### PR TITLE
chore: error tracking taxonomy

### DIFF
--- a/frontend/src/lib/taxonomy.tsx
+++ b/frontend/src/lib/taxonomy.tsx
@@ -169,7 +169,7 @@ export const CORE_FILTER_DEFINITIONS_BY_GROUP = {
         },
         $exception: {
             label: 'Exception',
-            description: 'Exceptions - an error or unexpected event in your application',
+            description: 'An unexpected error or unhandled exception in your application',
         },
         $web_vitals: {
             label: 'Web Vitals',
@@ -454,43 +454,35 @@ export const CORE_FILTER_DEFINITIONS_BY_GROUP = {
             description: 'The status of session recording at the time the event was captured',
         },
         // exception tracking
-        $cymbal_errors: {
-            label: 'Exception processing errors',
-            description: 'Errors encountered while trying to process exceptions',
-            system: true,
-        },
         $exception_list: {
             label: 'Exception list',
             description: 'List of one or more associated exceptions',
         },
-        // TODO - most of the rest of these are legacy, I think?
-        $sentry_exception: {
-            label: 'Sentry exception',
-            description: 'Raw Sentry exception data',
-            system: true,
-        },
-        $sentry_exception_message: {
-            label: 'Sentry exception message',
-        },
-        $sentry_exception_type: {
-            label: 'Sentry exception type',
-            description: 'Class name of the exception object',
-        },
-        $sentry_tags: {
-            label: 'Sentry tags',
-            description: 'Tags sent to Sentry along with the exception',
-        },
         $exception_type: {
             label: 'Exception type',
-            description: 'Exception categorized into types. E.g. "Error"',
+            description: 'Exception categorized into types',
+            examples: ['Error'],
         },
         $exception_message: {
             label: 'Exception Message',
-            description: 'The message detected on the error.',
+            description: 'The message detected on the error',
+        },
+        $exception_fingerprint: {
+            label: 'Exception fingerprint',
+            description: 'A fingerprint used to group issues, can be set clientside',
+        },
+        $exception_proposed_fingerprint: {
+            label: 'Exception proposed fingerprint',
+            description: 'The fingerprint used to group issues. Auto generated unless provided clientside',
+        },
+        $exception_issue_id: {
+            label: 'Exception issue ID',
+            description: 'The id of the issue the fingerprint was associated with at ingest time',
         },
         $exception_source: {
             label: 'Exception source',
-            description: 'The source of the exception. E.g. JS file.',
+            description: 'The source of the exception',
+            examples: ['JS file'],
         },
         $exception_lineno: {
             label: 'Exception source line number',
@@ -510,7 +502,7 @@ export const CORE_FILTER_DEFINITIONS_BY_GROUP = {
         },
         $exception_stack_trace_raw: {
             label: 'Exception raw stack trace',
-            description: "The exception's stack trace, as a string.",
+            description: 'The exceptions stack trace, as a string.',
         },
         $exception_handled: {
             label: 'Exception was handled',
@@ -519,6 +511,11 @@ export const CORE_FILTER_DEFINITIONS_BY_GROUP = {
         $exception_personURL: {
             label: 'Exception person URL',
             description: 'The PostHog person that experienced the exception',
+        },
+        $cymbal_errors: {
+            label: 'Exception processing errors',
+            description: 'Errors encountered while trying to process exceptions',
+            system: true,
         },
         $exception_capture_endpoint: {
             label: 'Exception capture endpoint',
@@ -533,6 +530,23 @@ export const CORE_FILTER_DEFINITIONS_BY_GROUP = {
         $exception_capture_enabled_server_side: {
             label: 'Exception capture enabled server side',
             description: 'Whether exception autocapture was enabled in remote config.',
+        },
+        // TODO - most of the rest of these are legacy, I think?
+        $sentry_exception: {
+            label: 'Sentry exception',
+            description: 'Raw Sentry exception data',
+            system: true,
+        },
+        $sentry_exception_message: {
+            label: 'Sentry exception message',
+        },
+        $sentry_exception_type: {
+            label: 'Sentry exception type',
+            description: 'Class name of the exception object',
+        },
+        $sentry_tags: {
+            label: 'Sentry tags',
+            description: 'Tags sent to Sentry along with the exception',
         },
 
         // GeoIP

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -178,7 +178,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         },
         "$exception": {
             "label": "Exception",
-            "description": "Automatically captured exceptions from the client Sentry integration",
+            "description": "An unexpected error or unhandled exception in your application",
         },
         "$web_vitals": {
             "label": "Web vitals",
@@ -370,34 +370,53 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "Sentry tags",
             "description": "Tags sent to Sentry along with the exception",
         },
-        "$exception_type": {
-            "label": "Exception type",
-            "description": 'Exception categorized into types. E.g. "Error"',
-        },
-        "$exception_message": {
-            "label": "Exception Message",
-            "description": "The message detected on the error.",
-        },
-        "$exception_source": {
-            "label": "Exception source",
-            "description": "The source of the exception. E.g. JS file.",
-        },
         "$exception_list": {
             "label": "Exception list",
             "description": "List of one or more associated exceptions",
             "system": True,
         },
+        "$exception_level": {
+            "label": "Exception level",
+            "description": "Exception categorized by severity",
+            "examples": ["error"],
+        },
+        "$exception_type": {
+            "label": "Exception type",
+            "description": "Exception categorized into types",
+            "examples": ["Error"],
+        },
+        "$exception_message": {
+            "label": "Exception message",
+            "description": "The message detected on the error",
+        },
+        "$exception_fingerprint": {
+            "label": "Exception fingerprint",
+            "description": "A fingerprint used to group issues, can be set clientside",
+        },
+        "$exception_proposed_fingerprint": {
+            "label": "Exception proposed fingerprint",
+            "description": "The fingerprint used to group issues. Auto generated unless provided clientside",
+        },
+        "$exception_issue_id": {
+            "label": "Exception issue ID",
+            "description": "The id of the issue the fingerprint was associated with at ingest time",
+        },
+        "$exception_source": {
+            "label": "Exception source",
+            "description": "The source of the exception",
+            "examples": ["JS file"],
+        },
         "$exception_lineno": {
             "label": "Exception source line number",
-            "description": "Which line in the exception source that caused the exception.",
+            "description": "Which line in the exception source that caused the exception",
         },
         "$exception_colno": {
             "label": "Exception source column number",
-            "description": "Which column of the line in the exception source that caused the exception.",
+            "description": "Which column of the line in the exception source that caused the exception",
         },
         "$exception_DOMException_code": {
             "label": "DOMException code",
-            "description": "If a DOMException was thrown, it also has a DOMException code.",
+            "description": "If a DOMException was thrown, it also has a DOMException code",
         },
         "$exception_is_synthetic": {
             "label": "Exception is synthetic",
@@ -405,7 +424,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         },
         "$exception_stack_trace_raw": {
             "label": "Exception raw stack trace",
-            "description": "The exception's stack trace, as a string.",
+            "description": "The exceptions stack trace, as a string",
         },
         "$exception_handled": {
             "label": "Exception was handled",
@@ -414,6 +433,25 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         "$exception_personURL": {
             "label": "Exception person URL",
             "description": "The PostHog person that experienced the exception",
+        },
+        "$cymbal_errors": {
+            "label": "Exception processing errors",
+            "description": "Errors encountered while trying to process exceptions",
+            "system": True,
+        },
+        "$exception_capture_endpoint": {
+            "label": "Exception capture endpoint",
+            "description": "Endpoint used by posthog-js exception autocapture.",
+            "examples": ["/e/"],
+        },
+        "$exception_capture_endpoint_suffix": {
+            "label": "Exception capture endpoint",
+            "description": "Endpoint used by posthog-js exception autocapture.",
+            "examples": ["/e/"],
+        },
+        "$exception_capture_enabled_server_side": {
+            "label": "Exception capture enabled server side",
+            "description": "Whether exception autocapture was enabled in remote config.",
         },
         "$ce_version": {
             "label": "$ce_version",


### PR DESCRIPTION
## Problem

Some exception properties are missing the associated taxonomy description

## Changes

- Add missing descriptions
- Formatting (no full stops, capitals, clearer, etc)
- Align both JS an PY files