### PR TITLE
feat(cdp): add counter for transformEvent invocations

### DIFF
--- a/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -25,14 +25,21 @@ export const hogTransformationDroppedEvents = new Counter({
     help: 'Indicates how many events are dropped by hog transformations',
 })
 
-export const hogTransformationAndMessageInvocations = new Counter({
-    name: 'hog_transformation_and_message_invocations_total',
-    help: 'Number of times transformEventAndProduceMessages was called',
-})
-
 export const hogTransformationInvocations = new Counter({
     name: 'hog_transformation_invocations_total',
     help: 'Number of times transformEvent was called directly',
+})
+
+export const hogTransformationAttempts = new Counter({
+    name: 'hog_transformation_attempts_total',
+    help: 'Number of transformation attempts before any processing',
+    labelNames: ['type'],
+})
+
+export const hogTransformationCompleted = new Counter({
+    name: 'hog_transformation_completed_total',
+    help: 'Number of successfully completed transformations',
+    labelNames: ['type'],
 })
 
 export interface TransformationResultPure {
@@ -172,10 +179,10 @@ export class HogTransformerService {
         event: PluginEvent,
         runTestFunctions: boolean = false
     ): Promise<TransformationResult> {
-        hogTransformationAndMessageInvocations.inc()
         return runInstrumentedFunction({
             statsKey: `hogTransformer.transformEventAndProduceMessages`,
             func: async () => {
+                hogTransformationAttempts.inc({ type: 'with_messages' })
                 const transformationResult = await this.transformEvent(event, runTestFunctions)
                 const messagePromises: Promise<void>[] = []
 
@@ -183,6 +190,7 @@ export class HogTransformerService {
                     messagePromises.push(...this.processInvocationResult(result))
                 })
 
+                hogTransformationCompleted.inc({ type: 'with_messages' })
                 return {
                     ...transformationResult,
                     messagePromises,
@@ -192,11 +200,11 @@ export class HogTransformerService {
     }
 
     public transformEvent(event: PluginEvent, runTestFunctions: boolean = false): Promise<TransformationResultPure> {
-        hogTransformationInvocations.inc()
         return runInstrumentedFunction({
             statsKey: `hogTransformer.transformEvent`,
 
             func: async () => {
+                hogTransformationInvocations.inc()
                 const teamHogFunctions = this.hogFunctionManager.getTeamHogFunctions(event.team_id)
                 const results: HogFunctionInvocationResult[] = []
                 const transformationsSucceeded: string[] = event.properties?.$transformations_succeeded || []

--- a/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -25,6 +25,16 @@ export const hogTransformationDroppedEvents = new Counter({
     help: 'Indicates how many events are dropped by hog transformations',
 })
 
+export const hogTransformationAndMessageInvocations = new Counter({
+    name: 'hog_transformation_and_message_invocations_total',
+    help: 'Number of times transformEventAndProduceMessages was called',
+})
+
+export const hogTransformationInvocations = new Counter({
+    name: 'hog_transformation_invocations_total',
+    help: 'Number of times transformEvent was called directly',
+})
+
 export interface TransformationResultPure {
     event: PluginEvent | null
     invocationResults: HogFunctionInvocationResult[]
@@ -162,6 +172,7 @@ export class HogTransformerService {
         event: PluginEvent,
         runTestFunctions: boolean = false
     ): Promise<TransformationResult> {
+        hogTransformationAndMessageInvocations.inc()
         return runInstrumentedFunction({
             statsKey: `hogTransformer.transformEventAndProduceMessages`,
             func: async () => {
@@ -181,6 +192,7 @@ export class HogTransformerService {
     }
 
     public transformEvent(event: PluginEvent, runTestFunctions: boolean = false): Promise<TransformationResultPure> {
+        hogTransformationInvocations.inc()
         return runInstrumentedFunction({
             statsKey: `hogTransformer.transformEvent`,
 


### PR DESCRIPTION
## Problem

currently we experience a discrepancy between `transformEvent` invocations and `transformEventAndProduceMessages` invocations in terms of total processes events. we want to have just absolut counters to see if the actual invocations add up because the histograms are showing discrepancy. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- added counters for `transformEventAndProduceMessages` and `transformEvent`

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
