### PR TITLE
feat(cdp): load example event as default for transformations

### DIFF
--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionTest.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionTest.tsx
@@ -221,14 +221,25 @@ export function HogFunctionTest(): JSX.Element {
                                                     )}
                                                 </LemonField>
                                                 <LemonDivider />
-                                                <LemonButton
-                                                    fullWidth
-                                                    onClick={loadSampleGlobals}
-                                                    loading={sampleGlobalsLoading}
-                                                    tooltip="Find the last event matching filters, and use it to populate the globals below."
-                                                >
-                                                    Fetch new event
-                                                </LemonButton>
+                                                {type === 'transformation' ? (
+                                                    <LemonButton
+                                                        fullWidth
+                                                        onClick={loadSampleGlobals}
+                                                        loading={sampleGlobalsLoading}
+                                                        tooltip="Load a real event from your system to test the transformation."
+                                                    >
+                                                        Fetch real event
+                                                    </LemonButton>
+                                                ) : (
+                                                    <LemonButton
+                                                        fullWidth
+                                                        onClick={loadSampleGlobals}
+                                                        loading={sampleGlobalsLoading}
+                                                        tooltip="Find the last event matching filters, and use it to populate the globals below."
+                                                    >
+                                                        Fetch new event
+                                                    </LemonButton>
+                                                )}
                                                 <LemonDivider />
                                                 {savedGlobals.map(({ name, globals }, index) => (
                                                     <div className="flex justify-between w-full" key={index}>

--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionTest.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionTest.tsx
@@ -26,9 +26,13 @@ import { hogFunctionTestLogic } from './hogFunctionTestLogic'
 const HogFunctionTestEditor = ({
     value,
     onChange,
+    options,
+    disabled = false,
 }: {
     value: string
     onChange?: (value?: string) => void
+    options?: monacoEditor.IStandaloneEditorConstructionOptions
+    disabled?: boolean
 }): JSX.Element => {
     const editorRef = useRef<monacoEditor.IStandaloneCodeEditor | null>(null)
     const decorationsRef = useRef<string[]>([]) // Track decoration IDs
@@ -98,14 +102,18 @@ const HogFunctionTestEditor = ({
             value={value}
             height={400}
             onChange={(newValue) => {
-                onChange?.(newValue)
-                handleValidation(newValue ?? '')
+                if (!disabled) {
+                    onChange?.(newValue)
+                    handleValidation(newValue ?? '')
+                }
             }}
             onMount={(editor) => {
                 editorRef.current = editor
                 handleValidation(value)
             }}
             options={{
+                ...options,
+                readOnly: disabled,
                 lineNumbers: 'on',
                 minimap: {
                     enabled: false,
@@ -144,6 +152,7 @@ export function HogFunctionTest(): JSX.Element {
         testResultMode,
         sortedTestsResult,
         jsonError,
+        isFetchingEvent,
     } = useValues(hogFunctionTestLogic(logicProps))
     const {
         submitTestInvocation,
@@ -154,6 +163,7 @@ export function HogFunctionTest(): JSX.Element {
         setSampleGlobals,
         saveGlobals,
         setTestResultMode,
+        cancelSampleGlobalsLoad,
     } = useActions(hogFunctionTestLogic(logicProps))
 
     return (
@@ -416,8 +426,49 @@ export function HogFunctionTest(): JSX.Element {
                                                 {sampleGlobalsError ? (
                                                     <div className="text-warning">{sampleGlobalsError}</div>
                                                 ) : null}
+                                                {isFetchingEvent && (
+                                                    <LemonBanner type="info">
+                                                        <div className="flex items-center gap-2">
+                                                            <Spinner />
+                                                            <span>Fetching event data...</span>
+                                                            <LemonButton
+                                                                type="secondary"
+                                                                size="small"
+                                                                onClick={() => cancelSampleGlobalsLoad()}
+                                                            >
+                                                                Cancel
+                                                            </LemonButton>
+                                                        </div>
+                                                    </LemonBanner>
+                                                )}
                                             </div>
-                                            <HogFunctionTestEditor value={value} onChange={onChange} />
+                                            <HogFunctionTestEditor
+                                                value={value}
+                                                onChange={onChange}
+                                                disabled={isFetchingEvent}
+                                                options={{
+                                                    readOnly: isFetchingEvent,
+                                                    lineNumbers: 'on',
+                                                    minimap: {
+                                                        enabled: false,
+                                                    },
+                                                    quickSuggestions: {
+                                                        other: true,
+                                                        strings: true,
+                                                    },
+                                                    suggest: {
+                                                        showWords: false,
+                                                        showFields: false,
+                                                        showKeywords: false,
+                                                    },
+                                                    scrollbar: {
+                                                        vertical: 'auto',
+                                                        verticalScrollbarSize: 14,
+                                                    },
+                                                    folding: true,
+                                                    glyphMargin: true,
+                                                }}
+                                            />
                                         </>
                                     )}
                                 </LemonField>

--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionTest.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionTest.tsx
@@ -221,25 +221,14 @@ export function HogFunctionTest(): JSX.Element {
                                                     )}
                                                 </LemonField>
                                                 <LemonDivider />
-                                                {type === 'transformation' ? (
-                                                    <LemonButton
-                                                        fullWidth
-                                                        onClick={loadSampleGlobals}
-                                                        loading={sampleGlobalsLoading}
-                                                        tooltip="Load a real event from your system to test the transformation."
-                                                    >
-                                                        Fetch real event
-                                                    </LemonButton>
-                                                ) : (
-                                                    <LemonButton
-                                                        fullWidth
-                                                        onClick={loadSampleGlobals}
-                                                        loading={sampleGlobalsLoading}
-                                                        tooltip="Find the last event matching filters, and use it to populate the globals below."
-                                                    >
-                                                        Fetch new event
-                                                    </LemonButton>
-                                                )}
+                                                <LemonButton
+                                                    fullWidth
+                                                    onClick={loadSampleGlobals}
+                                                    loading={sampleGlobalsLoading}
+                                                    tooltip="Find the last event matching filters, and use it to populate the globals below."
+                                                >
+                                                    Fetch new event
+                                                </LemonButton>
                                                 <LemonDivider />
                                                 {savedGlobals.map(({ name, globals }, index) => (
                                                     <div className="flex justify-between w-full" key={index}>

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionTestLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionTestLogic.tsx
@@ -96,6 +96,8 @@ export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
         validateJson: (value: string, editor: editor.IStandaloneCodeEditor, decorations: string[]) =>
             ({ value, editor, decorations } as CodeEditorValidation),
         setDecorationIds: (decorationIds: string[]) => ({ decorationIds }),
+        cancelSampleGlobalsLoad: true,
+        setIsFetchingEvent: (isFetching: boolean) => ({ isFetching }),
     }),
     reducers({
         expanded: [
@@ -142,11 +144,28 @@ export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
                 setJsonError: () => [], // Clear decorations when error state changes
             },
         ],
+
+        isFetchingEvent: [
+            false as boolean,
+            {
+                setIsFetchingEvent: (_, { isFetching }) => isFetching,
+                cancelSampleGlobalsLoad: () => false,
+            },
+        ],
     }),
     listeners(({ values, actions }) => ({
-        loadSampleGlobalsSuccess: () => {
-            actions.receiveExampleGlobals(values.sampleGlobals)
+        loadSampleGlobals: () => {
+            actions.setIsFetchingEvent(true)
         },
+
+        loadSampleGlobalsSuccess: () => {
+            actions.setIsFetchingEvent(false)
+        },
+
+        cancelSampleGlobalsLoad: () => {
+            actions.setIsFetchingEvent(false)
+        },
+
         setSampleGlobals: ({ sampleGlobals }) => {
             actions.receiveExampleGlobals(sampleGlobals)
         },
@@ -295,6 +314,7 @@ export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
 
     afterMount(({ actions, values }) => {
         if (values.type === 'transformation') {
+            // Use example/default event on initial load
             actions.receiveExampleGlobals(values.exampleInvocationGlobals)
         }
     }),

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionTestLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionTestLogic.tsx
@@ -57,33 +57,6 @@ export interface CodeEditorValidation {
     decorations: string[]
 }
 
-const DUMMY_EVENT_DATA = {
-    event: '$web_vitals',
-    uuid: '0194f039-940d-787d-a6a2-9a3dafdd717a',
-    distinct_id: 'nXtTAAkoBZjuN0tYeuHe69od3oYa1ASx4GITyQjwR5U',
-    timestamp: '2025-02-10T14:18:12.884Z',
-    properties: {
-        $browser: 'Chrome',
-        $browser_version: 132,
-        $os_version: '10.15.7',
-        $device_type: 'Desktop',
-        $screen_width: 1512,
-        $screen_height: 982,
-        $viewport_width: 1321,
-        $viewport_height: 884,
-        $timezone: 'Europe/Berlin',
-        '$feature/web-vitals': true,
-        $web_vitals_LCP_value: 967.6,
-        $session_id: '0194f02e-733f-7efb-ba17-84d7928094a1',
-        $lib: 'web',
-        $lib_version: '1.215.6',
-        $host: 'localhost:8010',
-        $is_identified: true,
-        $user_id: 'nXtTAAkoBZjuN0tYeuHe69od3oYa1ASx4GITyQjwR5X',
-        $ip: '192.168.97.1',
-    },
-}
-
 export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
     props({} as HogFunctionConfigurationLogicProps),
     key(({ id, templateId }: HogFunctionConfigurationLogicProps) => {
@@ -172,14 +145,7 @@ export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
     }),
     listeners(({ values, actions }) => ({
         loadSampleGlobalsSuccess: () => {
-            if (values.type === 'transformation') {
-                if (values.expanded) {
-                    const event = convertToTransformationEvent(values.sampleGlobals?.event)
-                    actions.setTestInvocationValue('globals', JSON.stringify(event, null, 2))
-                }
-            } else {
-                actions.receiveExampleGlobals(values.sampleGlobals)
-            }
+            actions.receiveExampleGlobals(values.sampleGlobals)
         },
         setSampleGlobals: ({ sampleGlobals }) => {
             actions.receiveExampleGlobals(sampleGlobals)
@@ -191,12 +157,9 @@ export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
             }
 
             if (values.type === 'transformation') {
-                if (globals === values.exampleInvocationGlobals) {
-                    const event = convertToTransformationEvent(globals.event)
-                    actions.setTestInvocationValue('globals', JSON.stringify(event, null, 2))
-                } else {
-                    actions.setTestInvocationValue('globals', JSON.stringify(DUMMY_EVENT_DATA, null, 2))
-                }
+                const event = convertToTransformationEvent(globals.event)
+                // Strip down to just the real values
+                actions.setTestInvocationValue('globals', JSON.stringify(event, null, 2))
             } else {
                 actions.setTestInvocationValue('globals', JSON.stringify(globals, null, 2))
             }
@@ -332,8 +295,6 @@ export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
 
     afterMount(({ actions, values }) => {
         if (values.type === 'transformation') {
-            actions.setTestInvocationValue('globals', JSON.stringify(DUMMY_EVENT_DATA, null, 2))
-        } else {
             actions.receiveExampleGlobals(values.exampleInvocationGlobals)
         }
     }),

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionTestLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionTestLogic.tsx
@@ -57,6 +57,33 @@ export interface CodeEditorValidation {
     decorations: string[]
 }
 
+const DUMMY_EVENT_DATA = {
+    event: '$web_vitals',
+    uuid: '0194f039-940d-787d-a6a2-9a3dafdd717a',
+    distinct_id: 'nXtTAAkoBZjuN0tYeuHe69od3oYa1ASx4GITyQjwR5U',
+    timestamp: '2025-02-10T14:18:12.884Z',
+    properties: {
+        $browser: 'Chrome',
+        $browser_version: 132,
+        $os_version: '10.15.7',
+        $device_type: 'Desktop',
+        $screen_width: 1512,
+        $screen_height: 982,
+        $viewport_width: 1321,
+        $viewport_height: 884,
+        $timezone: 'Europe/Berlin',
+        '$feature/web-vitals': true,
+        $web_vitals_LCP_value: 967.6,
+        $session_id: '0194f02e-733f-7efb-ba17-84d7928094a1',
+        $lib: 'web',
+        $lib_version: '1.215.6',
+        $host: 'localhost:8010',
+        $is_identified: true,
+        $user_id: 'nXtTAAkoBZjuN0tYeuHe69od3oYa1ASx4GITyQjwR5X',
+        $ip: '192.168.97.1',
+    },
+}
+
 export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
     props({} as HogFunctionConfigurationLogicProps),
     key(({ id, templateId }: HogFunctionConfigurationLogicProps) => {
@@ -145,7 +172,14 @@ export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
     }),
     listeners(({ values, actions }) => ({
         loadSampleGlobalsSuccess: () => {
-            actions.receiveExampleGlobals(values.sampleGlobals)
+            if (values.type === 'transformation') {
+                if (values.expanded) {
+                    const event = convertToTransformationEvent(values.sampleGlobals?.event)
+                    actions.setTestInvocationValue('globals', JSON.stringify(event, null, 2))
+                }
+            } else {
+                actions.receiveExampleGlobals(values.sampleGlobals)
+            }
         },
         setSampleGlobals: ({ sampleGlobals }) => {
             actions.receiveExampleGlobals(sampleGlobals)
@@ -157,9 +191,12 @@ export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
             }
 
             if (values.type === 'transformation') {
-                const event = convertToTransformationEvent(globals.event)
-                // Strip down to just the real values
-                actions.setTestInvocationValue('globals', JSON.stringify(event, null, 2))
+                if (globals === values.exampleInvocationGlobals) {
+                    const event = convertToTransformationEvent(globals.event)
+                    actions.setTestInvocationValue('globals', JSON.stringify(event, null, 2))
+                } else {
+                    actions.setTestInvocationValue('globals', JSON.stringify(DUMMY_EVENT_DATA, null, 2))
+                }
             } else {
                 actions.setTestInvocationValue('globals', JSON.stringify(globals, null, 2))
             }
@@ -295,6 +332,8 @@ export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
 
     afterMount(({ actions, values }) => {
         if (values.type === 'transformation') {
+            actions.setTestInvocationValue('globals', JSON.stringify(DUMMY_EVENT_DATA, null, 2))
+        } else {
             actions.receiveExampleGlobals(values.exampleInvocationGlobals)
         }
     }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15180,8 +15180,8 @@ packages:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
 
-  unlayer-types@1.219.0:
-    resolution: {integrity: sha512-hMjlu7cQqZF8CdPggPJ3kfl/djDOhS+YM7R8Y+NLqfqtFxNtejr5ym9NcG94wL3wVnXgTYy07NFS9ICxHqVZYQ==}
+  unlayer-types@1.218.0:
+    resolution: {integrity: sha512-86opZGOx5+weMRzUkIzdaAaV1+IUQf3MwUTWF5kfD99ZHxPD0JFMB+50DAPNi+8TnEZ2gzBQ0R5D+Ykc5ZjwyQ==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -32684,7 +32684,7 @@ snapshots:
   react-email-editor@1.7.11(react@18.2.0):
     dependencies:
       react: 18.2.0
-      unlayer-types: 1.219.0
+      unlayer-types: 1.218.0
 
   react-error-boundary@3.1.4(react@18.2.0):
     dependencies:
@@ -34751,7 +34751,7 @@ snapshots:
 
   universalify@2.0.0: {}
 
-  unlayer-types@1.219.0: {}
+  unlayer-types@1.218.0: {}
 
   unpipe@1.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15180,8 +15180,8 @@ packages:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
 
-  unlayer-types@1.218.0:
-    resolution: {integrity: sha512-86opZGOx5+weMRzUkIzdaAaV1+IUQf3MwUTWF5kfD99ZHxPD0JFMB+50DAPNi+8TnEZ2gzBQ0R5D+Ykc5ZjwyQ==}
+  unlayer-types@1.219.0:
+    resolution: {integrity: sha512-hMjlu7cQqZF8CdPggPJ3kfl/djDOhS+YM7R8Y+NLqfqtFxNtejr5ym9NcG94wL3wVnXgTYy07NFS9ICxHqVZYQ==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -32684,7 +32684,7 @@ snapshots:
   react-email-editor@1.7.11(react@18.2.0):
     dependencies:
       react: 18.2.0
-      unlayer-types: 1.218.0
+      unlayer-types: 1.219.0
 
   react-error-boundary@3.1.4(react@18.2.0):
     dependencies:
@@ -34751,7 +34751,7 @@ snapshots:
 
   universalify@2.0.0: {}
 
-  unlayer-types@1.218.0: {}
+  unlayer-types@1.219.0: {}
 
   unpipe@1.0.0: {}
 


### PR DESCRIPTION
## Problem

Currently we always load a real event from CH for testing which is taking pretty long a lot of times. Let"s load a default example event and folks can fetch a real event if they need one. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- load example event by default for transformations 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
