### PR TITLE
feat: Fix UI colors for Web Vitals

### DIFF
--- a/frontend/src/queries/nodes/WebVitals/WebVitalsContent.tsx
+++ b/frontend/src/queries/nodes/WebVitals/WebVitalsContent.tsx
@@ -1,6 +1,5 @@
 import { IconInfo } from '@posthog/icons'
 import { LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
-import clsx from 'clsx'
 import { useValues } from 'kea'
 import { useMemo } from 'react'
 import { webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
@@ -87,7 +86,7 @@ export const WebVitalsContent = ({ webVitalsQueryResponse }: WebVitalsContentPro
                 </Tooltip>
 
                 <span>
-                    <Icon className={clsx('inline-block mr-1', `text-${color}`)} />
+                    <Icon className="inline-block mr-1" style={{ color }} />
                     {positioning} {values}
                 </span>
             </div>

--- a/frontend/src/queries/nodes/WebVitals/WebVitalsProgressBar.tsx
+++ b/frontend/src/queries/nodes/WebVitals/WebVitalsProgressBar.tsx
@@ -1,8 +1,12 @@
-import clsx from 'clsx'
-
 import { WebVitalsMetric, WebVitalsMetricBand } from '~/queries/schema'
 
-import { computePositionInBand, getMetricBand, getThresholdColor, WEB_VITALS_THRESHOLDS } from './definitions'
+import {
+    computePositionInBand,
+    getMetricBand,
+    getThresholdColor,
+    WEB_VITALS_COLORS,
+    WEB_VITALS_THRESHOLDS,
+} from './definitions'
 
 interface WebVitalsProgressBarProps {
     value?: number
@@ -21,30 +25,38 @@ export function WebVitalsProgressBar({ value, metric }: WebVitalsProgressBarProp
         <div className="w-full h-1 rounded-full relative">
             {/* Green segment up to "good" threshold */}
             <div
-                className={clsx('absolute h-full rounded-full', band === 'good' ? 'bg-success' : 'bg-surface-tooltip')}
                 // eslint-disable-next-line react/forbid-dom-props
-                style={{ width: `${goodWidth}%` }}
+                style={{
+                    width: `${goodWidth}%`,
+                    backgroundColor: band === 'good' ? WEB_VITALS_COLORS.good : undefined,
+                }}
+                className="absolute h-full rounded-full bg-surface-tooltip"
             >
                 <IndicatorLine value={value} metric={metric} band="good" />
             </div>
 
             {/* Yellow segment up to "poor" threshold */}
             <div
-                className={clsx(
-                    'absolute h-full rounded-full',
-                    band === 'needs_improvements' ? 'bg-warning' : 'bg-surface-tooltip'
-                )}
                 // eslint-disable-next-line react/forbid-dom-props
-                style={{ left: `${goodWidth + 1}%`, width: `${improvementsWidth - 1}%` }}
+                style={{
+                    left: `${goodWidth + 1}%`,
+                    width: `${improvementsWidth - 1}%`,
+                    backgroundColor: band === 'needs_improvements' ? WEB_VITALS_COLORS.needs_improvements : undefined,
+                }}
+                className="absolute h-full rounded-full bg-surface-tooltip"
             >
                 <IndicatorLine value={value} metric={metric} band="needs_improvements" />
             </div>
 
             {/* Red segment after "poor" threshold */}
             <div
-                className={clsx('absolute h-full rounded-full', band === 'poor' ? 'bg-danger' : 'bg-surface-tooltip')}
                 // eslint-disable-next-line react/forbid-dom-props
-                style={{ left: `${goodWidth + improvementsWidth + 1}%`, width: `${poorWidth - 1}%` }}
+                style={{
+                    left: `${goodWidth + improvementsWidth + 1}%`,
+                    width: `${poorWidth - 1}%`,
+                    backgroundColor: band === 'poor' ? WEB_VITALS_COLORS.poor : undefined,
+                }}
+                className="absolute h-full rounded-full bg-surface-tooltip"
             >
                 <IndicatorLine value={value} metric={metric} band="poor" />
             </div>
@@ -69,13 +81,13 @@ const IndicatorLine = ({ value, metric, band }: IndicatorLineProps): JSX.Element
     }
 
     const positionInBand = computePositionInBand(value, metric)
-    const color = getThresholdColor(value, metric)
+    const backgroundColor = getThresholdColor(value, metric)
 
     return (
         <div
             // eslint-disable-next-line react/forbid-dom-props
-            style={{ left: `${positionInBand * 100}%` }}
-            className={clsx('absolute w-0.5 h-3 -top-1', `bg-${color}`)}
+            style={{ left: `${positionInBand * 100}%`, backgroundColor }}
+            className="absolute w-0.5 h-3 -top-1"
         />
     )
 }

--- a/frontend/src/queries/nodes/WebVitals/WebVitalsTab.tsx
+++ b/frontend/src/queries/nodes/WebVitals/WebVitalsTab.tsx
@@ -2,7 +2,6 @@ import './WebVitalsTab.scss'
 
 import { IconInfo } from '@posthog/icons'
 import { LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
-import clsx from 'clsx'
 
 import { WebVitalsMetric } from '~/queries/schema'
 
@@ -20,7 +19,7 @@ export function WebVitalsTab({ value, metric, isActive, setTab }: WebVitalsTabPr
     const label = LONG_METRIC_NAME[metric]
 
     const { value: parsedValue, unit } = getValueWithUnit(value, metric)
-    const thresholdColor = getThresholdColor(value, metric)
+    const color = getThresholdColor(value, metric)
 
     return (
         <div
@@ -39,7 +38,11 @@ export function WebVitalsTab({ value, metric, isActive, setTab }: WebVitalsTabPr
             </span>
 
             <div className="flex flex-row items-end">
-                <span className={clsx('text-2xl', `text-${thresholdColor}`)}>
+                <span
+                    // eslint-disable-next-line react/forbid-dom-props
+                    style={{ color }}
+                    className="text-2xl"
+                >
                     {parsedValue || <LemonSkeleton fade className="w-20 h-8" />}
                 </span>
                 <span className="text-xs ml-1 mb-1">{unit}</span>

--- a/frontend/src/queries/nodes/WebVitals/definitions.ts
+++ b/frontend/src/queries/nodes/WebVitals/definitions.ts
@@ -104,23 +104,22 @@ export const getValueWithUnit = (value: number | undefined, tab: WebVitalsMetric
     return { value: value.toFixed(2), unit: undefined }
 }
 
-type Color = 'muted' | 'success' | 'warning' | 'danger'
-export const getThresholdColor = (value: number | undefined, metric: WebVitalsMetric): Color => {
+export const getThresholdColor = (value: number | undefined, metric: WebVitalsMetric): string => {
     const threshold = WEB_VITALS_THRESHOLDS[metric]
 
     if (value === undefined) {
-        return 'muted'
+        return 'var(--color-gray-500)'
     }
 
     if (value <= threshold.good) {
-        return 'success'
+        return WEB_VITALS_COLORS.good
     }
 
     if (value <= threshold.poor) {
-        return 'warning'
+        return WEB_VITALS_COLORS.needs_improvements
     }
 
-    return 'danger'
+    return WEB_VITALS_COLORS.poor
 }
 
 // Returns a value between 0 and 1 that represents the position of the value inside that band
@@ -152,7 +151,7 @@ export const WEB_VITALS_THRESHOLDS: Record<WebVitalsMetric, WebVitalsThreshold> 
 }
 
 export const WEB_VITALS_COLORS = {
-    good: 'rgb(45, 200, 100)',
-    needs_improvements: 'rgb(255, 160, 0)',
-    poor: 'rgb(220, 53, 69)',
+    good: 'var(--color-green-700)',
+    needs_improvements: 'var(--color-amber-500)',
+    poor: 'var(--color-red-700)',
 } as const

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -71,6 +71,19 @@ function truncateString(str: string, num: number): string {
     return str
 }
 
+function resolveVariableColor(color: string | undefined): string | undefined {
+    if (!color) {
+        return color
+    }
+
+    if (color.startsWith('var(--')) {
+        const replaced = color.replace('var(', '').replace(')', '')
+        return getComputedStyle(document.documentElement).getPropertyValue(replaced)
+    }
+
+    return color
+}
+
 export function onChartClick(
     event: ChartEvent,
     chart: Chart,
@@ -450,7 +463,7 @@ export function LineGraph_({
                     if (context.tick) {
                         for (const annotation of goalLinesWithColor) {
                             if (context.tick.value === annotation.value) {
-                                return annotation.borderColor
+                                return resolveVariableColor(annotation.borderColor)
                             }
                         }
                     }
@@ -609,7 +622,7 @@ export function LineGraph_({
                             type: 'line',
                             yMin: annotation.value,
                             yMax: annotation.value,
-                            borderColor: annotation.borderColor || 'rgb(255, 99, 132)',
+                            borderColor: resolveVariableColor(annotation.borderColor) || 'rgb(255, 99, 132)',
                             label: {
                                 content: annotation.label,
                                 display: annotation.displayLabel ?? true,

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -71,15 +71,26 @@ function truncateString(str: string, num: number): string {
     return str
 }
 
+const RESOLVED_COLOR_MAP = new Map<string, string>()
 function resolveVariableColor(color: string | undefined): string | undefined {
     if (!color) {
         return color
     }
 
+    if (RESOLVED_COLOR_MAP.has(color)) {
+        return RESOLVED_COLOR_MAP.get(color)
+    }
+
+    // Cache complex variables to avoid the `getComputedStyle` call on every call
     if (color.startsWith('var(--')) {
         const replaced = color.replace('var(', '').replace(')', '')
-        return getComputedStyle(document.documentElement).getPropertyValue(replaced)
+        const computedColor = getComputedStyle(document.documentElement).getPropertyValue(replaced)
+        RESOLVED_COLOR_MAP.set(color, computedColor)
+        return computedColor
     }
+
+    // Optimize to avoid the `startsWith` check on every call
+    RESOLVED_COLOR_MAP.set(color, color)
 
     return color
 }

--- a/frontend/src/toolbar/web-vitals/WebVitalsToolbarMenu.tsx
+++ b/frontend/src/toolbar/web-vitals/WebVitalsToolbarMenu.tsx
@@ -1,5 +1,4 @@
 import { LemonBanner, Link, Spinner, Tooltip } from '@posthog/lemon-ui'
-import clsx from 'clsx'
 import { useValues } from 'kea'
 import { inStorybook, inStorybookTestRunner } from 'lib/utils'
 import { urls } from 'scenes/urls'
@@ -126,7 +125,11 @@ const MetricCard = ({ metric, value }: { metric: WebVitalsMetric; value: number 
             >
                 {metric}:
             </DottedTooltip>
-            <span className={clsx('text-sm', `text-${color}`)}>
+            <span
+                // eslint-disable-next-line react/forbid-dom-props
+                style={{ color }}
+                className="text-sm"
+            >
                 {' '}
                 {value === undefined ? <WebVitalsToolbarSpinner /> : value === null ? 'N/A' : `${valueWithUnit}${unit}`}
             </span>


### PR DESCRIPTION
Rather than using hardcoded colors for Web Vitals, let's use variables inheriting from our theme

![image](https://github.com/user-attachments/assets/dd98ce67-9645-4b67-9d8b-564fe5ab3557)
![image](https://github.com/user-attachments/assets/6fc7b15a-4227-45c8-bed0-21eea4fdae28)
![image](https://github.com/user-attachments/assets/c6a30bc2-5682-4032-af32-b20e8913a920)
