### PR TITLE
feat(experiments): Sort shared metrics alphabetically

### DIFF
--- a/ee/clickhouse/views/experiment_saved_metrics.py
+++ b/ee/clickhouse/views/experiment_saved_metrics.py
@@ -1,4 +1,5 @@
 import pydantic
+from django.db.models.functions import Lower
 from rest_framework import serializers, viewsets
 from rest_framework.exceptions import ValidationError
 
@@ -82,6 +83,5 @@ class ExperimentSavedMetricSerializer(TaggedItemSerializerMixin, serializers.Mod
 
 class ExperimentSavedMetricViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     scope_object = "experiment"
-    queryset = ExperimentSavedMetric.objects.prefetch_related("created_by").all()
+    queryset = ExperimentSavedMetric.objects.prefetch_related("created_by").order_by(Lower("name")).all()
     serializer_class = ExperimentSavedMetricSerializer
-    ordering = "-created_at"

--- a/frontend/src/scenes/experiments/SharedMetrics/SharedMetrics.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/SharedMetrics.tsx
@@ -39,6 +39,7 @@ export function SharedMetrics(): JSX.Element {
                     />
                 )
             },
+            sorter: (a, b) => a.name.localeCompare(b.name),
         },
         {
             key: 'description',


### PR DESCRIPTION
## Changes

It's much easier to find what you're looking for.

**Before**

![CleanShot 2025-02-10 at 11 57 29@2x](https://github.com/user-attachments/assets/816d2130-d75f-4216-a61a-6d677bcc4470)


**After**

![CleanShot 2025-02-10 at 11 56 51@2x](https://github.com/user-attachments/assets/e539a77c-dab4-4f93-b949-cc7f64560c20)

## How did you test this code?

Manual review.