### PR TITLE
fix(data-modeling): saved query limit being overridden

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -330,7 +330,6 @@ ee/billing/billing_manager.py:0: error: Module has no attribute "utc"  [attr-def
 ee/billing/billing_manager.py:0: error: Incompatible types in assignment (expression has type "object", variable has type "bool | Combinable | None")  [assignment]
 posthog/hogql/query.py:0: error: Incompatible types in assignment (expression has type "None", variable has type "str | SelectQuery | SelectSetQuery")  [assignment]
 posthog/hogql/query.py:0: error: Incompatible types in assignment (expression has type "Expr", variable has type "SelectQuery | SelectSetQuery")  [assignment]
-posthog/hogql/query.py:0: error: Argument 1 to "get_default_limit_for_context" has incompatible type "LimitContext | None"; expected "LimitContext"  [arg-type]
 posthog/hogql/query.py:0: error: Subclass of "SelectQuery" and "SelectSetQuery" cannot exist: would have incompatible method signatures  [unreachable]
 posthog/api/organization.py:0: error: Incompatible return value type (got "int | None", expected "Level | None")  [return-value]
 posthog/api/capture.py:0: error: Module has no attribute "utc"  [attr-defined]

--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -115,7 +115,10 @@ class HogQLQueryExecutor:
         with self.timings.measure("max_limit"):
             for one_query in extract_select_queries(self.select_query):
                 if one_query.limit is None:
-                    one_query.limit = ast.Constant(value=get_default_limit_for_context(self.limit_context))
+                    if self.limit_context == LimitContext.SAVED_QUERY:
+                        self.context.limit_top_select = False
+                    else:
+                        one_query.limit = ast.Constant(value=get_default_limit_for_context(self.limit_context))
 
     def _generate_hogql(self):
         with self.timings.measure("hogql"):
@@ -165,7 +168,12 @@ class HogQLQueryExecutor:
 
     def _generate_clickhouse_sql(self):
         settings = self.settings or HogQLGlobalSettings()
-        if self.limit_context in (LimitContext.EXPORT, LimitContext.COHORT_CALCULATION, LimitContext.QUERY_ASYNC):
+        if self.limit_context in (
+            LimitContext.EXPORT,
+            LimitContext.COHORT_CALCULATION,
+            LimitContext.QUERY_ASYNC,
+            LimitContext.SAVED_QUERY,
+        ):
             settings.max_execution_time = HOGQL_INCREASED_MAX_EXECUTION_TIME
         try:
             self.clickhouse_context = dataclasses.replace(

--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -118,7 +118,9 @@ class HogQLQueryExecutor:
                     if self.limit_context == LimitContext.SAVED_QUERY:
                         self.context.limit_top_select = False
                     else:
-                        one_query.limit = ast.Constant(value=get_default_limit_for_context(self.limit_context))
+                        one_query.limit = ast.Constant(
+                            value=get_default_limit_for_context(self.limit_context or LimitContext.QUERY)
+                        )
 
     def _generate_hogql(self):
         with self.timings.measure("hogql"):


### PR DESCRIPTION
## Problem

- saved query limit is set at max int but it's being min'd in the printer

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- use the overriding flag in the hogql executor when limit context is saved query

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
