### PR TITLE
fix(hooks): Support firing hooks with not-in-cohort action filter

### DIFF
--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -1051,7 +1051,9 @@ export interface ElementPropertyFilter extends PropertyFilterWithOperator {
 export interface CohortPropertyFilter extends PropertyFilterBase {
     type: 'cohort'
     key: 'id'
-    value: number | string
+    value: number | 'all'
+    /** @default 'in' */
+    operator?: PropertyOperator
 }
 
 /** Sync with posthog/frontend/src/types.ts */

--- a/plugin-server/src/worker/ingestion/action-matcher.ts
+++ b/plugin-server/src/worker/ingestion/action-matcher.ts
@@ -383,7 +383,7 @@ export class ActionMatcher {
             return true
         }
         if (!event.person_id) {
-            return false // NO PERSON TO MATCH AGAINST COHORT
+            return filter.operator === PropertyOperator.IsNot // NO PERSON TO MATCH AGAINST COHORT
         }
         if (typeof cohortId !== 'number') {
             cohortId = parseInt(cohortId)
@@ -391,7 +391,15 @@ export class ActionMatcher {
         if (isNaN(cohortId)) {
             throw new Error(`Can't match against invalid cohort ID value "${filter.value}!"`)
         }
-        return await this.doesPersonBelongToCohort(Number(filter.value), event.person_id, event.teamId)
+        const doesPersonBelongToCohort = await this.doesPersonBelongToCohort(
+            Number(filter.value),
+            event.person_id,
+            event.teamId
+        )
+        if (filter.operator === PropertyOperator.IsNot) {
+            return !doesPersonBelongToCohort
+        }
+        return doesPersonBelongToCohort
     }
 
     public async doesPersonBelongToCohort(cohortId: number, personUuid: string, teamId: number): Promise<boolean> {

--- a/plugin-server/tests/worker/ingestion/action-matcher.test.ts
+++ b/plugin-server/tests/worker/ingestion/action-matcher.test.ts
@@ -718,9 +718,14 @@ describe('ActionMatcher', () => {
                 team_id: 2,
             })
 
-            const actionDefinition: Action = await createTestAction([
+            const actionDefinitionInCohort: Action = await createTestAction([
                 {
                     properties: [{ type: 'cohort', key: 'id', value: testCohort.id }],
+                },
+            ])
+            const actionDefinitionNotInCohort: Action = await createTestAction([
+                {
+                    properties: [{ type: 'cohort', key: 'id', operator: PropertyOperator.IsNot, value: testCohort.id }],
                 },
             ])
             const actionDefinitionAllUsers: Action = await createTestAction([
@@ -734,7 +739,7 @@ describe('ActionMatcher', () => {
                 {},
                 {},
                 {},
-                actionDefinition.team_id,
+                actionDefinitionInCohort.team_id,
                 null,
                 true,
                 new UUIDT().toString(),
@@ -746,7 +751,7 @@ describe('ActionMatcher', () => {
                 {},
                 {},
                 {},
-                actionDefinition.team_id,
+                actionDefinitionInCohort.team_id,
                 null,
                 true,
                 new UUIDT().toString(),
@@ -771,11 +776,17 @@ describe('ActionMatcher', () => {
             })
 
             expect(await actionMatcher.match(eventExamplePersonOk)).toEqual([
-                actionDefinition,
+                actionDefinitionInCohort,
                 actionDefinitionAllUsers,
             ])
-            expect(await actionMatcher.match(eventExamplePersonBad)).toEqual([actionDefinitionAllUsers])
-            expect(await actionMatcher.match(eventExamplePersonUnknown)).toEqual([actionDefinitionAllUsers])
+            expect(await actionMatcher.match(eventExamplePersonBad)).toEqual([
+                actionDefinitionNotInCohort,
+                actionDefinitionAllUsers,
+            ])
+            expect(await actionMatcher.match(eventExamplePersonUnknown)).toEqual([
+                actionDefinitionNotInCohort,
+                actionDefinitionAllUsers,
+            ])
         })
 
         it('returns a match in case of element href equals', async () => {


### PR DESCRIPTION
## Problem

I'm listed as the maintainer of PostHog's Zapier integration, hence I got involved in an email thread with a PostHog customer using Zapier + Zapier support, about the "action performed" trigger not working. After investigation, it turned out the action in question uses a user-not-in-cohort condition, and those did not receive the requisite support in the plugin server's `action-matcher.ts`.

## Changes

This adds support for user-not-in-cohort conditions to `action-matcher.ts`, hopefully resolving the PostHog customer's issue.

## How did you test this code?

Added unit tests.