### PR TITLE
fix: datatypes when using http CH client

### DIFF
--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -52,7 +52,7 @@ class ProxyClient:
         if written_rows > 0:
             return written_rows
         if with_column_types:
-            column_types_driver_format = list(zip(result.column_names, result.column_types))
+            column_types_driver_format = [(a, b.name) for (a, b) in zip(result.column_names, result.column_types)]
             return result.result_set, column_types_driver_format
         return result.result_set
 


### PR DESCRIPTION
## Problem

Datatypes were parsed, we must keep them as string names. This is a problem only if CLICKHOUSE_USE_HTTP=1

## Changes

Downcast datatypes to string.

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Local tests.