### PR TITLE
fix: sanitize regex inputs

### DIFF
--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -134,7 +134,8 @@ def match_property(property: Property, override_property_values: dict[str, Any])
         pattern = sanitize_regex_pattern(str(value))
         try:
             # Make the pattern more flexible by using DOTALL flag to allow . to match newlines
-            compiled_pattern = re.compile(pattern)  # Added IGNORECASE for more flexibility
+            # Added IGNORECASE for more flexibility
+            compiled_pattern = re.compile(pattern, re.DOTALL | re.IGNORECASE)
             match = compiled_pattern.search(str(override_value))
 
             if operator == "regex":

--- a/posthog/queries/test/test_base.py
+++ b/posthog/queries/test/test_base.py
@@ -153,7 +153,7 @@ class TestMatchProperties(TestCase):
             mock_compile.return_value = pattern
             self.assertTrue(match_property(property_e, {"key": "5"}))
 
-        mock_compile.assert_called_once_with("5")
+        mock_compile.assert_called_once_with("5", re.IGNORECASE | re.DOTALL)
 
     def test_match_properties_math_operators(self):
         property_a = Property(key="key", value=1, operator="gt")

--- a/posthog/queries/test/test_base.py
+++ b/posthog/queries/test/test_base.py
@@ -366,7 +366,10 @@ class TestMatchProperties(TestCase):
         self.assertTrue(match_property(property_d, {"key": None}))
 
         property_d_lower_case = Property(key="key", value="no", operator="regex")
-        self.assertFalse(match_property(property_d_lower_case, {"key": None}))
+        self.assertTrue(match_property(property_d_lower_case, {"key": None}))
+
+        property_d_non_matching = Property(key="key", value="xyz", operator="regex")
+        self.assertFalse(match_property(property_d_non_matching, {"key": None}))
 
         property_e = Property(key="key", value=1, operator="gt")
         self.assertTrue(match_property(property_e, {"key": None}))

--- a/posthog/queries/test/test_base.py
+++ b/posthog/queries/test/test_base.py
@@ -678,3 +678,40 @@ class TestSanitizeRegexPattern(TestCase):
                 should_match,
                 f"Failed for pattern: {pattern}\nSanitized to: {sanitized}\nTesting against: {test_string}\nExpected match: {should_match}",
             )
+
+    def test_simple_regex_patterns(self):
+        test_cases = [
+            # Basic regex patterns
+            (r"^test$", "test", True),
+            (r"^test$", "test123", False),
+            (r"test\d+", "test123", True),
+            (r"test\d+", "test", False),
+            # Wildcards
+            (r".*\.com$", "example.com", True),
+            (r".*\.com$", "example.org", False),
+            # Character classes
+            (r"[a-z]+", "abc", True),
+            (r"[a-z]+", "123", False),
+            # Groups and alternation
+            (r"(foo|bar)", "foo", True),
+            (r"(foo|bar)", "bar", True),
+            (r"(foo|bar)", "baz", False),
+            # Quantifiers
+            (r"\d{3}-\d{2}-\d{4}", "123-45-6789", True),
+            (r"\d{3}-\d{2}-\d{4}", "12-34-567", False),
+            # Email-like pattern
+            (r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$", "test@example.com", True),
+            (r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$", "invalid-email", False),
+            # URL-like pattern
+            (r"^https?://[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$", "https://example.com", True),
+            (r"^https?://[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$", "not-a-url", False),
+        ]
+
+        for pattern, test_string, should_match in test_cases:
+            sanitized = sanitize_regex_pattern(pattern)
+            match = re.search(sanitized, test_string, re.DOTALL | re.IGNORECASE)
+            self.assertEqual(
+                bool(match),
+                should_match,
+                f"Failed for pattern: {pattern}\nSanitized to: {sanitized}\nTesting against: {test_string}\nExpected match: {should_match}",
+            )


### PR DESCRIPTION
## Problem

There are some regex patterns that have different outcomes depending on the environment they're executed.

Python, for instance, render JSON strings are dicts, which means they're converted to single quotation marks.

JS/Query engine, however, uses double quotation marks.

What this causes:

1. Stringfied JSON objects match correctly with a RegExp that uses double quotation marks on the Query engine
2. However, when we try to match them in the Python code, it doesn't work, as JSON's are converted to string like dicts

## Changes

This PR attempts to sanitize RegExp inputs in our BE so they always match, regardless of the quotation marks.
## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Lots and lots of [unit tests](https://github.com/PostHog/posthog/pull/28527/files#diff-0a17ad8db7751f804e57c3a701363e3fbb82c16975c8be901f2f33522ff86564)
