### PR TITLE
fix: Migration uses templates

### DIFF
--- a/posthog/cdp/migrations.py
+++ b/posthog/cdp/migrations.py
@@ -94,10 +94,11 @@ def migrate_batch(legacy_plugins: Any, kind: str, test_mode: bool, dry_run: bool
                 "name": plugin_name,
                 "description": template.description,
                 "filters": template.filters,
+                "hog": template.hog,
                 "inputs": inputs,
                 "enabled": True,
-                "hog": template.hog,
                 "icon_url": template.icon_url,
+                "inputs_schema": template.inputs_schema,
                 "execution_order": plugin_config["order"],
             }
 

--- a/posthog/cdp/migrations.py
+++ b/posthog/cdp/migrations.py
@@ -1,6 +1,7 @@
 import json
 from typing import Any
 from posthog.api.hog_function import HogFunctionSerializer
+from posthog.api.hog_function_template import HogFunctionTemplates
 from posthog.constants import AvailableFeature
 from posthog.models.hog_functions.hog_function import HogFunction
 from posthog.models.plugin import PluginAttachment, PluginConfig
@@ -82,20 +83,21 @@ def migrate_batch(legacy_plugins: Any, kind: str, test_mode: bool, dry_run: bool
                 "is_create": True,
             }
 
-            icon_url = (
-                plugin_config["plugin__icon"] or f"https://raw.githubusercontent.com/PostHog/{plugin_id}/main/logo.png"
-            )
+            template = HogFunctionTemplates.template(f"plugin-{plugin_id}")
+
+            if not template:
+                raise Exception(f"Template not found for plugin {plugin_id}")
 
             data = {
-                "template_id": f"plugin-{plugin_id}",
+                "template_id": template.id,
                 "type": kind,
                 "name": plugin_name,
-                "description": "This is a legacy destination migrated from our old plugin system.",
-                "filters": {},
+                "description": template.description,
+                "filters": template.filters,
                 "inputs": inputs,
                 "enabled": True,
-                "hog": "return event",
-                "icon_url": icon_url,
+                "hog": template.hog,
+                "icon_url": template.icon_url,
                 "execution_order": plugin_config["order"],
             }
 


### PR DESCRIPTION
## Problem

Rather than having dummy content we can just use the template.

## Changes

Does that

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
