### PR TITLE
feat(assistant): Enable persons modal in chat

### DIFF
--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -260,10 +260,12 @@ function VisualizationAnswer({
             return {
                 kind: NodeKind.InsightVizNode,
                 source: castAssistantQuery(message.answer),
+                // We set `embedded` to `true` on `<Query>` for styling - but on the query we want `embedded: false`
+                // so that the persons modal is available
+                embedded: false,
                 showHeader: true,
             }
         }
-
         return null
     }, [message])
 


### PR DESCRIPTION
## Problem

Users haven't been able to click into persons in VisualizationMessages.

## Changes

Now the persons modal is available.
