### PR TITLE
fix: reset preview page index on survey unmount

### DIFF
--- a/frontend/src/scenes/surveys/Survey.tsx
+++ b/frontend/src/scenes/surveys/Survey.tsx
@@ -28,14 +28,15 @@ export const scene: SceneExport = {
 }
 
 export function SurveyComponent({ id }: { id?: string } = {}): JSX.Element {
-    const { editingSurvey } = useActions(surveyLogic)
+    const { editingSurvey, setSelectedPageIndex } = useActions(surveyLogic)
     const { isEditingSurvey, surveyMissing } = useValues(surveyLogic)
 
     useEffect(() => {
         return () => {
             editingSurvey(false)
+            setSelectedPageIndex(0)
         }
-    }, [editingSurvey])
+    }, [editingSurvey, setSelectedPageIndex])
 
     if (surveyMissing) {
         return <NotFound object="survey" />


### PR DESCRIPTION
## Problem

if I create a survey, set to show the confirmation message, go back, create another survey, the preview starts in the confirmation message, which is unintended.

## Changes

this PR resets the preview page index back to 0 after unmounting the survey
## Does this work well for both Cloud and self-hosted?

N/A

## How did you test this code?

verified locally page index is back to the first one after creating a new survey