### PR TITLE
fix: Multiple y axes for stickiness

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -78,6 +78,7 @@ export function InsightDisplayConfig(): JSX.Element {
     const showSmoothing =
         isTrends && !isValidBreakdown(breakdownFilter) && (!display || display === ChartDisplayType.ActionsLineGraph)
     const showMultipleYAxesConfig = isTrends || isStickiness
+    const showAlertThresholdLinesConfig = isTrends
 
     const { showValuesOnSeries, mightContainFractionalNumbers } = useValues(trendsDataLogic(insightProps))
 
@@ -90,7 +91,9 @@ export function InsightDisplayConfig(): JSX.Element {
                           ...(supportsValueOnSeries ? [{ label: () => <ValueOnSeriesFilter /> }] : []),
                           ...(supportsPercentStackView ? [{ label: () => <PercentStackViewFilter /> }] : []),
                           ...(hasLegend ? [{ label: () => <ShowLegendFilter /> }] : []),
-                          { label: () => <ShowAlertThresholdLinesFilter /> },
+                          ...(showAlertThresholdLinesConfig
+                              ? [{ label: () => <ShowAlertThresholdLinesFilter /> }]
+                              : []),
                           ...(showMultipleYAxesConfig ? [{ label: () => <ShowMultipleYAxesFilter /> }] : []),
                       ],
                   },

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -77,6 +77,7 @@ export function InsightDisplayConfig(): JSX.Element {
         ((isTrends || isStickiness) && !(display && NON_TIME_SERIES_DISPLAY_TYPES.includes(display)))
     const showSmoothing =
         isTrends && !isValidBreakdown(breakdownFilter) && (!display || display === ChartDisplayType.ActionsLineGraph)
+    const showMultipleYAxesConfig = isTrends || isStickiness
 
     const { showValuesOnSeries, mightContainFractionalNumbers } = useValues(trendsDataLogic(insightProps))
 
@@ -90,7 +91,7 @@ export function InsightDisplayConfig(): JSX.Element {
                           ...(supportsPercentStackView ? [{ label: () => <PercentStackViewFilter /> }] : []),
                           ...(hasLegend ? [{ label: () => <ShowLegendFilter /> }] : []),
                           { label: () => <ShowAlertThresholdLinesFilter /> },
-                          { label: () => <ShowMultipleYAxesFilter /> },
+                          ...(showMultipleYAxesConfig ? [{ label: () => <ShowMultipleYAxesFilter /> }] : []),
                       ],
                   },
               ]

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -13304,6 +13304,9 @@
                 "showLegend": {
                     "type": "boolean"
                 },
+                "showMultipleYAxes": {
+                    "type": "boolean"
+                },
                 "showValuesOnSeries": {
                     "type": "boolean"
                 },
@@ -13350,6 +13353,9 @@
                     "type": "object"
                 },
                 "show_legend": {
+                    "type": "boolean"
+                },
+                "show_multiple_y_axes": {
                     "type": "boolean"
                 },
                 "show_values_on_series": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1178,6 +1178,7 @@ export type StickinessFilter = {
     display?: StickinessFilterLegacy['display']
     showLegend?: StickinessFilterLegacy['show_legend']
     showValuesOnSeries?: StickinessFilterLegacy['show_values_on_series']
+    showMultipleYAxes?: StickinessFilterLegacy['show_multiple_y_axes']
     hiddenLegendIndexes?: integer[]
     stickinessCriteria?: {
         operator: StickinessOperator

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -366,6 +366,8 @@ export const getYAxisScaleType = (query: InsightQueryNode): string | undefined =
 export const getShowMultipleYAxes = (query: InsightQueryNode): boolean | undefined => {
     if (isTrendsQuery(query)) {
         return query.trendsFilter?.showMultipleYAxes
+    } else if (isStickinessQuery(query)) {
+        return query.stickinessFilter?.showMultipleYAxes
     }
     return undefined
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2348,6 +2348,7 @@ export interface StickinessFilterType extends FilterType {
     show_legend?: boolean // used to show/hide legend next to insights graph
     hidden_legend_keys?: Record<string, boolean | undefined> // used to toggle visibilities in table and legend
     show_values_on_series?: boolean
+    show_multiple_y_axes?: boolean
 
     // persons only
     stickiness_days?: number

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1352,6 +1352,7 @@ class StickinessFilterLegacy(BaseModel):
     display: Optional[ChartDisplayType] = None
     hidden_legend_keys: Optional[dict[str, Union[bool, Any]]] = None
     show_legend: Optional[bool] = None
+    show_multiple_y_axes: Optional[bool] = None
     show_values_on_series: Optional[bool] = None
 
 
@@ -2633,6 +2634,7 @@ class StickinessFilter(BaseModel):
     display: Optional[ChartDisplayType] = None
     hiddenLegendIndexes: Optional[list[int]] = None
     showLegend: Optional[bool] = None
+    showMultipleYAxes: Optional[bool] = None
     showValuesOnSeries: Optional[bool] = None
     stickinessCriteria: Optional[StickinessCriteria] = None
 


### PR DESCRIPTION
## Problem
After adding the multiple Y-axes config for the trends filter, we weren't hiding the config option from the dropdown for the other insights. This caused the other insights to break if the user selected the showMuultipleYAxes config option from the dropdown.

This PR adds the functionality to showMultipleYaxes for the stickiness insight and also only display the config option in the dropdown for stickiness and trends insights.

We also weren't hiding the show alert threshold lines option for other insights that didn't support it which caused a similar type of familiar. I've updated the FE to only display that config for trends insights.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Updated the stickiness schema to support showMultipleYaxes.
- Hide showMultipleYaxes and showAlertThresholdLines for insights that don't support it.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Tested locally 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
