### PR TITLE
chore(editor-3001): save view without running

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
@@ -478,15 +478,27 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
         saveAsViewSubmit: async ({ name }) => {
             const query: HogQLQuery = values.sourceQuery.source
 
+            const queryToSave = {
+                ...query,
+                query: values.queryInput,
+            }
+
             const logic = dataNodeLogic({
                 key: dataNodeKey,
-                query,
+                query: queryToSave,
             })
 
             const types = logic.values.response?.types ?? []
-
-            await dataWarehouseViewsLogic.asyncActions.createDataWarehouseSavedQuery({ name, query, types })
-            actions.updateState()
+            try {
+                await dataWarehouseViewsLogic.asyncActions.createDataWarehouseSavedQuery({
+                    name,
+                    query: queryToSave,
+                    types,
+                })
+                actions.updateState()
+            } catch (e) {
+                lemonToast.error('Failed to save view')
+            }
         },
         saveAsInsight: async () => {
             LemonDialog.openForm({


### PR DESCRIPTION
## Problem

- right now you need to run the query before you can save the view

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- just save directly

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
