### PR TITLE
fix: make survey spacing consistent between visualizations

### DIFF
--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -474,77 +474,75 @@ export function SurveyResult({ disableEventsTable }: { disableEventsTable?: bool
     } = useValues(surveyLogic)
 
     return (
-        <>
-            <>
-                <Summary surveyUserStatsLoading={surveyUserStatsLoading} surveyUserStats={surveyUserStats} />
-                {survey.questions.map((question, i) => {
-                    if (question.type === SurveyQuestionType.Rating) {
-                        return (
-                            <>
-                                {question.scale === 10 && (
-                                    <>
-                                        <div className="text-4xl font-bold">{surveyNPSScore}</div>
-                                        <div className="mb-2 font-semibold text-secondary">Latest NPS Score</div>
-                                        <SurveyNPSResults survey={survey as Survey} />
-                                    </>
+        <div className="space-y-4">
+            <Summary surveyUserStatsLoading={surveyUserStatsLoading} surveyUserStats={surveyUserStats} />
+            {survey.questions.map((question, i) => {
+                if (question.type === SurveyQuestionType.Rating) {
+                    return (
+                        <>
+                            {question.scale === 10 && (
+                                <div>
+                                    <div className="text-4xl font-bold">{surveyNPSScore}</div>
+                                    <div className="mb-2 font-semibold text-secondary">Latest NPS Score</div>
+                                    <SurveyNPSResults survey={survey as Survey} />
+                                </div>
+                            )}
+
+                            <RatingQuestionBarChart
+                                key={`survey-q-${i}`}
+                                surveyRatingResults={surveyRatingResults}
+                                surveyRatingResultsReady={surveyRatingResultsReady}
+                                questionIndex={i}
+                                iteration={survey.current_iteration}
+                            />
+
+                            {survey.iteration_count &&
+                                survey.iteration_count > 0 &&
+                                survey.current_iteration &&
+                                survey.current_iteration > 1 &&
+                                survey.iteration_start_dates &&
+                                survey.iteration_start_dates.length > 0 && (
+                                    <NPSSurveyResultsBarChart
+                                        key={`nps-survey-results-q-${i}`}
+                                        surveyRecurringNPSResults={surveyRecurringNPSResults}
+                                        surveyRecurringNPSResultsReady={surveyRecurringNPSResultsReady}
+                                        iterationStartDates={survey.iteration_start_dates}
+                                        currentIteration={survey.current_iteration}
+                                        questionIndex={i}
+                                    />
                                 )}
-
-                                <RatingQuestionBarChart
-                                    key={`survey-q-${i}`}
-                                    surveyRatingResults={surveyRatingResults}
-                                    surveyRatingResultsReady={surveyRatingResultsReady}
-                                    questionIndex={i}
-                                    iteration={survey.current_iteration}
-                                />
-
-                                {survey.iteration_count &&
-                                    survey.iteration_count > 0 &&
-                                    survey.current_iteration &&
-                                    survey.current_iteration > 1 &&
-                                    survey.iteration_start_dates &&
-                                    survey.iteration_start_dates.length > 0 && (
-                                        <NPSSurveyResultsBarChart
-                                            key={`nps-survey-results-q-${i}`}
-                                            surveyRecurringNPSResults={surveyRecurringNPSResults}
-                                            surveyRecurringNPSResultsReady={surveyRecurringNPSResultsReady}
-                                            iterationStartDates={survey.iteration_start_dates}
-                                            currentIteration={survey.current_iteration}
-                                            questionIndex={i}
-                                        />
-                                    )}
-                            </>
-                        )
-                    } else if (question.type === SurveyQuestionType.SingleChoice) {
-                        return (
-                            <SingleChoiceQuestionPieChart
-                                key={`survey-q-${i}`}
-                                surveySingleChoiceResults={surveySingleChoiceResults}
-                                surveySingleChoiceResultsReady={surveySingleChoiceResultsReady}
-                                questionIndex={i}
-                            />
-                        )
-                    } else if (question.type === SurveyQuestionType.MultipleChoice) {
-                        return (
-                            <MultipleChoiceQuestionBarChart
-                                key={`survey-q-${i}`}
-                                surveyMultipleChoiceResults={surveyMultipleChoiceResults}
-                                surveyMultipleChoiceResultsReady={surveyMultipleChoiceResultsReady}
-                                questionIndex={i}
-                            />
-                        )
-                    } else if (question.type === SurveyQuestionType.Open) {
-                        return (
-                            <OpenTextViz
-                                key={`survey-q-${i}`}
-                                surveyOpenTextResults={surveyOpenTextResults}
-                                surveyOpenTextResultsReady={surveyOpenTextResultsReady}
-                                questionIndex={i}
-                            />
-                        )
-                    }
-                })}
-            </>
-            <div className="mb-4 max-w-40">
+                        </>
+                    )
+                } else if (question.type === SurveyQuestionType.SingleChoice) {
+                    return (
+                        <SingleChoiceQuestionPieChart
+                            key={`survey-q-${i}`}
+                            surveySingleChoiceResults={surveySingleChoiceResults}
+                            surveySingleChoiceResultsReady={surveySingleChoiceResultsReady}
+                            questionIndex={i}
+                        />
+                    )
+                } else if (question.type === SurveyQuestionType.MultipleChoice) {
+                    return (
+                        <MultipleChoiceQuestionBarChart
+                            key={`survey-q-${i}`}
+                            surveyMultipleChoiceResults={surveyMultipleChoiceResults}
+                            surveyMultipleChoiceResultsReady={surveyMultipleChoiceResultsReady}
+                            questionIndex={i}
+                        />
+                    )
+                } else if (question.type === SurveyQuestionType.Open) {
+                    return (
+                        <OpenTextViz
+                            key={`survey-q-${i}`}
+                            surveyOpenTextResults={surveyOpenTextResults}
+                            surveyOpenTextResultsReady={surveyOpenTextResultsReady}
+                            questionIndex={i}
+                        />
+                    )
+                }
+            })}
+            <div className="max-w-40">
                 <LemonButton
                     type="primary"
                     data-attr="survey-results-explore"
@@ -555,7 +553,7 @@ export function SurveyResult({ disableEventsTable }: { disableEventsTable?: bool
                 </LemonButton>
             </div>
             {!disableEventsTable && (surveyLoading ? <LemonSkeleton /> : <Query query={dataTableQuery} />)}
-        </>
+        </div>
     )
 }
 

--- a/frontend/src/scenes/surveys/surveyViewViz.tsx
+++ b/frontend/src/scenes/surveys/surveyViewViz.tsx
@@ -24,8 +24,7 @@ import { maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 import { AIConsentPopoverWrapper } from 'scenes/settings/organization/AIConsentPopoverWrapper'
 
-import { GraphType } from '~/types'
-import { InsightLogicProps, SurveyQuestionType } from '~/types'
+import { GraphType, InsightLogicProps, SurveyQuestionType } from '~/types'
 
 import {
     QuestionResultsReady,
@@ -86,7 +85,7 @@ export function UsersStackedBar({ surveyUserStats }: { surveyUserStats: SurveyUs
     return (
         <>
             {total > 0 && (
-                <div className="mb-8">
+                <div>
                     <div className="relative w-full mx-auto h-10 mb-4">
                         {[
                             {
@@ -169,7 +168,7 @@ export function Summary({
     surveyUserStatsLoading: boolean
 }): JSX.Element {
     return (
-        <div className="mb-4 mt-2">
+        <div>
             {surveyUserStatsLoading ? (
                 <LemonTable dataSource={[]} columns={[]} loading={true} />
             ) : (
@@ -210,13 +209,13 @@ export function RatingQuestionBarChart({
     }, [questionIndex])
 
     return (
-        <div className="mb-4">
+        <div>
             {!surveyRatingResultsReady[questionIndex] ? (
                 <LemonTable dataSource={[]} columns={[]} loading={true} />
             ) : !surveyRatingResults[questionIndex]?.total ? (
                 <></>
             ) : (
-                <div className="mb-8">
+                <div>
                     <div className="font-semibold text-secondary">{`${
                         question.scale === 10
                             ? '0 - 10'
@@ -305,13 +304,13 @@ export function NPSSurveyResultsBarChart({
     }, [questionIndex])
 
     return (
-        <div className="mb-4">
+        <div>
             {!surveyRecurringNPSResultsReady[questionIndex] ? (
                 <LemonTable dataSource={[]} columns={[]} loading={true} />
             ) : !surveyRecurringNPSResults[questionIndex]?.total ? (
                 <></>
             ) : (
-                <div className="mb-8">
+                <div>
                     <div className="font-semibold text-secondary">{`${
                         question.scale === 10 ? '0 - 10' : '1 - 5'
                     } rating`}</div>
@@ -402,13 +401,13 @@ export function SingleChoiceQuestionPieChart({
     }, [questionIndex])
 
     return (
-        <div className="mb-4">
+        <div>
             {!surveySingleChoiceResultsReady[questionIndex] ? (
                 <LemonTable dataSource={[]} columns={[]} loading={true} />
             ) : !surveySingleChoiceResults[questionIndex]?.data.length ? (
                 <></>
             ) : (
-                <div className="mb-8">
+                <div>
                     <div className="font-semibold text-secondary">Single choice</div>
                     <div className="text-xl font-bold mb-2">{question.question}</div>
                     <div className="h-80 overflow-y-auto border rounded pt-4 pb-2 flex">
@@ -513,7 +512,7 @@ export function MultipleChoiceQuestionBarChart({
     }, [surveyMultipleChoiceResults])
 
     return (
-        <div className="mb-4">
+        <div>
             {!surveyMultipleChoiceResultsReady[questionIndex] ? (
                 <LemonTable dataSource={[]} columns={[]} loading={true} />
             ) : !surveyMultipleChoiceResults[questionIndex]?.data.length ? (
@@ -590,7 +589,7 @@ export function OpenTextViz({
     }, [questionIndex])
 
     return (
-        <div className="mb-4">
+        <div>
             {!surveyOpenTextResultsReady[questionIndex] ? (
                 <LemonTable dataSource={[]} columns={[]} loading={true} />
             ) : !surveyOpenTextResults[questionIndex]?.events.length ? (


### PR DESCRIPTION
## Problem

all components define space by themselves, which makes it harder to add new ones.

instead, move the spacing rule between each section to the parent component.

also, make the spacing consistent between the charts. instead of being `mb-4` or `mb-8`, makes everything size 4 (`space-y-4`)

## Changes

no functionality nor UI changes, it's just a code refactor

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

yes

## How did you test this code?

checked if tests are still running as expected