### PR TITLE
fix: show tier table for mobile replay addon when on temporal free plan

### DIFF
--- a/frontend/src/scenes/billing/BillingProductPricingTable.tsx
+++ b/frontend/src/scenes/billing/BillingProductPricingTable.tsx
@@ -195,7 +195,7 @@ export const BillingProductPricingTable = ({
 
     return (
         <div className="pl-16 pb-8">
-            {product.tiered && tableTierData ? (
+            {(product.tiered || product.type === 'mobile_replay') && tableTierData ? (
                 <>
                     <LemonTable
                         stealth
@@ -212,7 +212,7 @@ export const BillingProductPricingTable = ({
                         }}
                     />
                     <FeatureFlagUsageNotice product={product as BillingProductV2Type} />
-                    <LemonBanner type="warning" className="text-sm pt-2">
+                    <LemonBanner type="warning" className="text-sm pt-2 mt-2">
                         Tier breakdowns are updated once daily and may differ from the gauge above.
                     </LemonBanner>
                 </>


### PR DESCRIPTION
## Problem

If you are in the granfathered plan for `Mobile Replay`, it only has one tier so we weren't showing the table with usage per tier in the billing page. This will be removed once we migrate all the customers out of this plan. Also minor fix with the top margin in the warning text.

## Changes

![image](https://github.com/user-attachments/assets/98bd8d13-7979-471e-aab9-36732a899ecd)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Cloud

## How did you test this code?

Tested locally.
