### PR TITLE
perf: Use hogql to compute values

### DIFF
--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -294,7 +294,7 @@ class EventViewSet(
             date_from = relative_date_parse("-7d", team.timezone_info).strftime("%Y-%m-%d 00:00:00")
             date_to = timezone.now().strftime("%Y-%m-%d 23:59:59")
 
-            conditions = [
+            conditions: list[ast.Expr] = [
                 ast.CompareOperation(
                     op=ast.CompareOperationOp.GtEq,
                     left=ast.Field(chain=["timestamp"]),
@@ -313,7 +313,7 @@ class EventViewSet(
             ]
 
             if event_names and len(event_names) > 0:
-                event_conditions = [
+                event_conditions: list[ast.Expr] = [
                     ast.CompareOperation(
                         op=ast.CompareOperationOp.Eq,
                         left=ast.Field(chain=["event"]),

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -2,6 +2,11 @@ import json
 import urllib
 from datetime import datetime
 from typing import Any, List, Optional, Union  # noqa: UP035
+from posthog.hogql.query import execute_hogql_query
+from posthog.taxonomy.taxonomy import CORE_FILTER_DEFINITIONS_BY_GROUP
+from posthog.hogql import ast
+from django.utils import timezone
+from posthog.utils import relative_date_parse
 
 from django.db.models.query import Prefetch
 from drf_spectacular.types import OpenApiTypes
@@ -16,16 +21,15 @@ from posthog.exceptions_capture import capture_exception
 
 from posthog.api.documentation import PropertiesSerializer, extend_schema
 from posthog.api.routing import TeamAndOrgViewSetMixin
-from posthog.client import query_with_columns, sync_execute
+from posthog.client import query_with_columns
 from posthog.hogql.constants import DEFAULT_RETURNED_ROWS, MAX_SELECT_RETURNED_ROWS
 from posthog.models import Element, Filter, Person
 from posthog.models.event.query_event_list import query_events_list
-from posthog.models.event.sql import GET_CUSTOM_EVENTS, SELECT_ONE_EVENT_SQL
+from posthog.models.event.sql import SELECT_ONE_EVENT_SQL
 from posthog.models.event.util import ClickhouseEventSerializer
 from posthog.models.person.util import get_persons_by_distinct_ids
 from posthog.models.team import Team
 from posthog.models.utils import UUIDT
-from posthog.queries.property_values import get_property_values_for_key
 from posthog.rate_limit import (
     ClickHouseBurstRateThrottle,
     ClickHouseSustainedRateThrottle,
@@ -265,20 +269,101 @@ class EventViewSet(
         key = request.GET.get("key")
         event_names = request.GET.getlist("event_name", None)
 
-        flattened = []
         if key == "custom_event":
-            events = sync_execute(GET_CUSTOM_EVENTS, {"team_id": team.pk}, team_id=team.pk)
-            return response.Response([{"name": event[0]} for event in events])
-        elif key:
-            result = get_property_values_for_key(key, team, event_names, value=request.GET.get("value"))
+            system_events = [
+                event_name
+                for event_name in CORE_FILTER_DEFINITIONS_BY_GROUP["events"].keys()
+                if event_name != "All Events"  # Skip the wildcard
+            ]
 
-            for value in result:
+            query = ast.SelectQuery(
+                select=[ast.Field(chain=["event"])],
+                distinct=True,
+                select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+                where=ast.CompareOperation(
+                    op=ast.CompareOperationOp.NotIn,
+                    left=ast.Field(chain=["event"]),
+                    right=ast.Constant(value=system_events),
+                ),
+                order_by=[ast.OrderExpr(expr=ast.Field(chain=["event"]), order="ASC")],
+            )
+
+            result = execute_hogql_query(query, team=team)
+            return response.Response([{"name": event[0]} for event in result.results])
+        elif key:
+            date_from = relative_date_parse("-7d", team.timezone_info).strftime("%Y-%m-%d 00:00:00")
+            date_to = timezone.now().strftime("%Y-%m-%d 23:59:59")
+
+            conditions = [
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.GtEq,
+                    left=ast.Field(chain=["timestamp"]),
+                    right=ast.Constant(value=date_from),
+                ),
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.LtEq,
+                    left=ast.Field(chain=["timestamp"]),
+                    right=ast.Constant(value=date_to),
+                ),
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.NotEq,
+                    left=ast.Field(chain=["properties", key]),
+                    right=ast.Constant(value=None),
+                ),
+            ]
+
+            if event_names and len(event_names) > 0:
+                event_conditions = [
+                    ast.CompareOperation(
+                        op=ast.CompareOperationOp.Eq,
+                        left=ast.Field(chain=["event"]),
+                        right=ast.Constant(value=event_name),
+                    )
+                    for event_name in event_names
+                ]
+                if len(event_conditions) > 1:
+                    conditions.append(ast.Or(exprs=event_conditions))
+                else:
+                    conditions.append(event_conditions[0])
+
+            if request.GET.get("value"):
+                conditions.append(
+                    ast.CompareOperation(
+                        op=ast.CompareOperationOp.ILike,
+                        left=ast.Call(name="toString", args=[ast.Field(chain=["properties", key])]),
+                        right=ast.Constant(value=f"%{request.GET.get('value')}%"),
+                    )
+                )
+
+            order_by = []
+            if request.GET.get("value"):
+                order_by = [
+                    ast.OrderExpr(
+                        expr=ast.Call(
+                            name="length", args=[ast.Call(name="toString", args=[ast.Field(chain=["properties", key])])]
+                        ),
+                        order="ASC",
+                    )
+                ]
+
+            query = ast.SelectQuery(
+                select=[ast.Field(chain=["properties", key])],
+                distinct=True,
+                select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+                where=ast.And(exprs=conditions),
+                order_by=order_by,
+                limit=ast.Constant(value=10),
+            )
+
+            result = execute_hogql_query(query, team=team)
+            values = []
+            for value in result.results:
                 try:
-                    # Try loading as json for dicts or arrays
-                    flattened.append(json.loads(value[0]))
-                except json.decoder.JSONDecodeError:
-                    flattened.append(value[0])
-        return response.Response([{"name": convert_property_value(value)} for value in flatten(flattened)])
+                    values.append(json.loads(value[0]))
+                except json.JSONDecodeError:
+                    values.append(value[0])
+
+        return response.Response([{"name": convert_property_value(value)} for value in flatten(values)])
 
 
 class LegacyEventViewSet(EventViewSet):

--- a/posthog/api/test/__snapshots__/test_event.ambr
+++ b/posthog/api/test/__snapshots__/test_event.ambr
@@ -2,101 +2,112 @@
 # name: TestEvents.test_event_property_values
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
+  SELECT DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'random_prop'), ''), 'null'), '^"|"$', '') AS random_prop
   FROM events
-  WHERE team_id = 99999
-    AND JSONHas(properties, 'random_prop')
-    AND timestamp >= '2020-01-13 00:00:00'
-    AND timestamp <= '2020-01-20 23:59:59'
-  LIMIT 10
+  WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-13 00:00:00'), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-20 23:59:59'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'random_prop'), ''), 'null'), '^"|"$', '')))
+  LIMIT 10 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
   '''
 # ---
 # name: TestEvents.test_event_property_values.1
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
+  SELECT DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'random_prop'), ''), 'null'), '^"|"$', '') AS random_prop
   FROM events
-  WHERE team_id = 99999
-    AND JSONHas(properties, 'random_prop')
-    AND timestamp >= '2020-01-13 00:00:00'
-    AND timestamp <= '2020-01-20 23:59:59'
-    AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%qw%'
-  order by length(replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', ''))
-  LIMIT 10
+  WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-13 00:00:00'), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-20 23:59:59'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'random_prop'), ''), 'null'), '^"|"$', '')), ifNull(ilike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'random_prop'), ''), 'null'), '^"|"$', '')), '%qw%'), 0))
+  ORDER BY length(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'random_prop'), ''), 'null'), '^"|"$', ''))) ASC
+  LIMIT 10 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
   '''
 # ---
 # name: TestEvents.test_event_property_values.2
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
+  SELECT DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'random_prop'), ''), 'null'), '^"|"$', '') AS random_prop
   FROM events
-  WHERE team_id = 99999
-    AND JSONHas(properties, 'random_prop')
-    AND timestamp >= '2020-01-13 00:00:00'
-    AND timestamp <= '2020-01-20 23:59:59'
-    AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%QW%'
-  order by length(replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', ''))
-  LIMIT 10
+  WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-13 00:00:00'), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-20 23:59:59'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'random_prop'), ''), 'null'), '^"|"$', '')), ifNull(ilike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'random_prop'), ''), 'null'), '^"|"$', '')), '%QW%'), 0))
+  ORDER BY length(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'random_prop'), ''), 'null'), '^"|"$', ''))) ASC
+  LIMIT 10 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
   '''
 # ---
 # name: TestEvents.test_event_property_values.3
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
+  SELECT DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'random_prop'), ''), 'null'), '^"|"$', '') AS random_prop
   FROM events
-  WHERE team_id = 99999
-    AND JSONHas(properties, 'random_prop')
-    AND timestamp >= '2020-01-13 00:00:00'
-    AND timestamp <= '2020-01-20 23:59:59'
-    AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%6%'
-  order by length(replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', ''))
-  LIMIT 10
+  WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-13 00:00:00'), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-20 23:59:59'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'random_prop'), ''), 'null'), '^"|"$', '')), ifNull(ilike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'random_prop'), ''), 'null'), '^"|"$', '')), '%6%'), 0))
+  ORDER BY length(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'random_prop'), ''), 'null'), '^"|"$', ''))) ASC
+  LIMIT 10 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
   '''
 # ---
 # name: TestEvents.test_event_property_values.4
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
+  SELECT DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'random_prop'), ''), 'null'), '^"|"$', '') AS random_prop
   FROM events
-  WHERE team_id = 99999
-    AND JSONHas(properties, 'random_prop')
-    AND timestamp >= '2020-01-13 00:00:00'
-    AND timestamp <= '2020-01-20 23:59:59'
-    AND (event = 'random event')
-    AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%6%'
-  order by length(replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', ''))
-  LIMIT 10
+  WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-13 00:00:00'), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-20 23:59:59'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'random_prop'), ''), 'null'), '^"|"$', '')), equals(events.event, 'random event'), ifNull(ilike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'random_prop'), ''), 'null'), '^"|"$', '')), '%6%'), 0))
+  ORDER BY length(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'random_prop'), ''), 'null'), '^"|"$', ''))) ASC
+  LIMIT 10 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
   '''
 # ---
 # name: TestEvents.test_event_property_values.5
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
+  SELECT DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'random_prop'), ''), 'null'), '^"|"$', '') AS random_prop
   FROM events
-  WHERE team_id = 99999
-    AND JSONHas(properties, 'random_prop')
-    AND timestamp >= '2020-01-13 00:00:00'
-    AND timestamp <= '2020-01-20 23:59:59'
-    AND (event = 'foo'
-         OR event = 'random event')
-    AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%6%'
-  order by length(replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', ''))
-  LIMIT 10
+  WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-13 00:00:00'), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-20 23:59:59'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'random_prop'), ''), 'null'), '^"|"$', '')), or(equals(events.event, 'foo'), equals(events.event, 'random event')), ifNull(ilike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'random_prop'), ''), 'null'), '^"|"$', '')), '%6%'), 0))
+  ORDER BY length(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'random_prop'), ''), 'null'), '^"|"$', ''))) ASC
+  LIMIT 10 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
   '''
 # ---
 # name: TestEvents.test_event_property_values.6
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
+  SELECT DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'random_prop'), ''), 'null'), '^"|"$', '') AS random_prop
   FROM events
-  WHERE team_id = 99999
-    AND JSONHas(properties, 'random_prop')
-    AND timestamp >= '2020-01-13 00:00:00'
-    AND timestamp <= '2020-01-20 23:59:59'
-    AND (event = '404_i_dont_exist')
-    AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%qw%'
-  order by length(replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', ''))
-  LIMIT 10
+  WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-13 00:00:00'), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-20 23:59:59'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'random_prop'), ''), 'null'), '^"|"$', '')), equals(events.event, '404_i_dont_exist'), ifNull(ilike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'random_prop'), ''), 'null'), '^"|"$', '')), '%qw%'), 0))
+  ORDER BY length(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'random_prop'), ''), 'null'), '^"|"$', ''))) ASC
+  LIMIT 10 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
   '''
 # ---
 # name: TestEvents.test_event_property_values.7
@@ -117,101 +128,112 @@
 # name: TestEvents.test_event_property_values_materialized
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT DISTINCT "mat_random_prop"
+  SELECT DISTINCT nullIf(nullIf(events.mat_random_prop, ''), 'null') AS random_prop
   FROM events
-  WHERE team_id = 99999
-    AND notEmpty("mat_random_prop")
-    AND timestamp >= '2020-01-13 00:00:00'
-    AND timestamp <= '2020-01-20 23:59:59'
-  LIMIT 10
+  WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-13 00:00:00'), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-20 23:59:59'), isNotNull(nullIf(nullIf(events.mat_random_prop, ''), 'null')))
+  LIMIT 10 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
   '''
 # ---
 # name: TestEvents.test_event_property_values_materialized.1
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT DISTINCT "mat_random_prop"
+  SELECT DISTINCT nullIf(nullIf(events.mat_random_prop, ''), 'null') AS random_prop
   FROM events
-  WHERE team_id = 99999
-    AND notEmpty("mat_random_prop")
-    AND timestamp >= '2020-01-13 00:00:00'
-    AND timestamp <= '2020-01-20 23:59:59'
-    AND "mat_random_prop" ILIKE '%qw%'
-  order by length("mat_random_prop")
-  LIMIT 10
+  WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-13 00:00:00'), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-20 23:59:59'), isNotNull(nullIf(nullIf(events.mat_random_prop, ''), 'null')), ifNull(ilike(toString(nullIf(nullIf(events.mat_random_prop, ''), 'null')), '%qw%'), 0))
+  ORDER BY length(toString(nullIf(nullIf(events.mat_random_prop, ''), 'null'))) ASC
+  LIMIT 10 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
   '''
 # ---
 # name: TestEvents.test_event_property_values_materialized.2
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT DISTINCT "mat_random_prop"
+  SELECT DISTINCT nullIf(nullIf(events.mat_random_prop, ''), 'null') AS random_prop
   FROM events
-  WHERE team_id = 99999
-    AND notEmpty("mat_random_prop")
-    AND timestamp >= '2020-01-13 00:00:00'
-    AND timestamp <= '2020-01-20 23:59:59'
-    AND "mat_random_prop" ILIKE '%QW%'
-  order by length("mat_random_prop")
-  LIMIT 10
+  WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-13 00:00:00'), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-20 23:59:59'), isNotNull(nullIf(nullIf(events.mat_random_prop, ''), 'null')), ifNull(ilike(toString(nullIf(nullIf(events.mat_random_prop, ''), 'null')), '%QW%'), 0))
+  ORDER BY length(toString(nullIf(nullIf(events.mat_random_prop, ''), 'null'))) ASC
+  LIMIT 10 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
   '''
 # ---
 # name: TestEvents.test_event_property_values_materialized.3
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT DISTINCT "mat_random_prop"
+  SELECT DISTINCT nullIf(nullIf(events.mat_random_prop, ''), 'null') AS random_prop
   FROM events
-  WHERE team_id = 99999
-    AND notEmpty("mat_random_prop")
-    AND timestamp >= '2020-01-13 00:00:00'
-    AND timestamp <= '2020-01-20 23:59:59'
-    AND "mat_random_prop" ILIKE '%6%'
-  order by length("mat_random_prop")
-  LIMIT 10
+  WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-13 00:00:00'), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-20 23:59:59'), isNotNull(nullIf(nullIf(events.mat_random_prop, ''), 'null')), ifNull(ilike(toString(nullIf(nullIf(events.mat_random_prop, ''), 'null')), '%6%'), 0))
+  ORDER BY length(toString(nullIf(nullIf(events.mat_random_prop, ''), 'null'))) ASC
+  LIMIT 10 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
   '''
 # ---
 # name: TestEvents.test_event_property_values_materialized.4
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT DISTINCT "mat_random_prop"
+  SELECT DISTINCT nullIf(nullIf(events.mat_random_prop, ''), 'null') AS random_prop
   FROM events
-  WHERE team_id = 99999
-    AND notEmpty("mat_random_prop")
-    AND timestamp >= '2020-01-13 00:00:00'
-    AND timestamp <= '2020-01-20 23:59:59'
-    AND (event = 'random event')
-    AND "mat_random_prop" ILIKE '%6%'
-  order by length("mat_random_prop")
-  LIMIT 10
+  WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-13 00:00:00'), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-20 23:59:59'), isNotNull(nullIf(nullIf(events.mat_random_prop, ''), 'null')), equals(events.event, 'random event'), ifNull(ilike(toString(nullIf(nullIf(events.mat_random_prop, ''), 'null')), '%6%'), 0))
+  ORDER BY length(toString(nullIf(nullIf(events.mat_random_prop, ''), 'null'))) ASC
+  LIMIT 10 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
   '''
 # ---
 # name: TestEvents.test_event_property_values_materialized.5
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT DISTINCT "mat_random_prop"
+  SELECT DISTINCT nullIf(nullIf(events.mat_random_prop, ''), 'null') AS random_prop
   FROM events
-  WHERE team_id = 99999
-    AND notEmpty("mat_random_prop")
-    AND timestamp >= '2020-01-13 00:00:00'
-    AND timestamp <= '2020-01-20 23:59:59'
-    AND (event = 'foo'
-         OR event = 'random event')
-    AND "mat_random_prop" ILIKE '%6%'
-  order by length("mat_random_prop")
-  LIMIT 10
+  WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-13 00:00:00'), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-20 23:59:59'), isNotNull(nullIf(nullIf(events.mat_random_prop, ''), 'null')), or(equals(events.event, 'foo'), equals(events.event, 'random event')), ifNull(ilike(toString(nullIf(nullIf(events.mat_random_prop, ''), 'null')), '%6%'), 0))
+  ORDER BY length(toString(nullIf(nullIf(events.mat_random_prop, ''), 'null'))) ASC
+  LIMIT 10 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
   '''
 # ---
 # name: TestEvents.test_event_property_values_materialized.6
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT DISTINCT "mat_random_prop"
+  SELECT DISTINCT nullIf(nullIf(events.mat_random_prop, ''), 'null') AS random_prop
   FROM events
-  WHERE team_id = 99999
-    AND notEmpty("mat_random_prop")
-    AND timestamp >= '2020-01-13 00:00:00'
-    AND timestamp <= '2020-01-20 23:59:59'
-    AND (event = '404_i_dont_exist')
-    AND "mat_random_prop" ILIKE '%qw%'
-  order by length("mat_random_prop")
-  LIMIT 10
+  WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-13 00:00:00'), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), '2020-01-20 23:59:59'), isNotNull(nullIf(nullIf(events.mat_random_prop, ''), 'null')), equals(events.event, '404_i_dont_exist'), ifNull(ilike(toString(nullIf(nullIf(events.mat_random_prop, ''), 'null')), '%qw%'), 0))
+  ORDER BY length(toString(nullIf(nullIf(events.mat_random_prop, ''), 'null'))) ASC
+  LIMIT 10 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
   '''
 # ---
 # name: TestEvents.test_event_property_values_materialized.7


### PR DESCRIPTION
## Problem

We used plain Clickhouse SQL for values which meant we weren't benefiting from properties_group_custom and materialized columns (plus any other clever perf optimizations we come up with)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
