### PR TITLE
fix: Add speed word to be aligned with other icons

### DIFF
--- a/frontend/src/scenes/session-recordings/player/controller/PlayerController.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/PlayerController.tsx
@@ -61,7 +61,7 @@ function SetPlaybackSpeed(): JSX.Element {
                 active: speed === speedToggle && speedToggle !== 1,
                 status: speed === speedToggle ? 'danger' : 'default',
             }))}
-            label={`${speed}x`}
+            label={`Speed ${speed}x`}
         />
     )
 }


### PR DESCRIPTION
The speed icon is different as it does not have text. Let's fix it

Before
<img width="563" alt="Screenshot 2025-02-11 at 22 35 04" src="https://github.com/user-attachments/assets/0394c04b-3138-4dca-b3ce-0af2b0cf5447" />

After
<img width="515" alt="Screenshot 2025-02-11 at 22 34 43" src="https://github.com/user-attachments/assets/68680bc8-b930-4584-b0fd-4ce6eec7ec9e" />
