### PR TITLE
fix(experiments): Restore ability to manually edit a selector

### DIFF
--- a/frontend/src/toolbar/actions/SelectorCount.tsx
+++ b/frontend/src/toolbar/actions/SelectorCount.tsx
@@ -1,23 +1,11 @@
-import { IconPencil } from '@posthog/icons'
-import { LemonButton, LemonInput, LemonModal } from '@posthog/lemon-ui'
-import { useActions } from 'kea'
 import { querySelectorAllDeep } from 'query-selector-shadow-dom'
-import { useMemo, useState } from 'react'
-
-import { experimentsTabLogic } from '../experiments/experimentsTabLogic'
+import { useMemo } from 'react'
 
 interface SelectorCountProps {
     selector: string | null
-    variant: string
-    transformIndex: number
 }
 
-export function SelectorCount({ selector, variant, transformIndex }: SelectorCountProps): JSX.Element | null {
-    const { inspectElementSelected } = useActions(experimentsTabLogic)
-
-    const [editSelectorOpen, setEditSelectorOpen] = useState(false)
-    const [editSelectorValue, setEditSelectorValue] = useState('')
-
+export function SelectorCount({ selector }: SelectorCountProps): JSX.Element | null {
     const [matches, selectorError] = useMemo(() => {
         let _selectorError = false
         let _matches = 0
@@ -31,62 +19,11 @@ export function SelectorCount({ selector, variant, transformIndex }: SelectorCou
         return [_matches, _selectorError]
     }, [selector])
 
-    const isValidSelector = useMemo(() => {
-        if (!editSelectorValue) {
-            return false
-        }
-        try {
-            return !!document.querySelector(editSelectorValue)
-        } catch {
-            return false
-        }
-    }, [editSelectorValue])
-
     return selector === null ? null : (
         <>
-            <small className={`float-right flex items-center gap-1 ${selectorError && 'text-danger'}`}>
+            <small className={`float-right ${selectorError && 'text-danger'}`}>
                 {selectorError ? 'Invalid selector' : `Matches ${matches} element${matches === 1 ? '' : 's'}`}
-                <LemonButton
-                    size="xsmall"
-                    icon={<IconPencil />}
-                    onClick={(e) => {
-                        e.stopPropagation()
-                        setEditSelectorValue(selector)
-                        setEditSelectorOpen(true)
-                    }}
-                />
             </small>
-            <LemonModal
-                isOpen={editSelectorOpen}
-                onClose={() => setEditSelectorOpen(false)}
-                title="Edit selector"
-                footer={
-                    <>
-                        <LemonButton onClick={() => setEditSelectorOpen(false)}>Cancel</LemonButton>
-                        <LemonButton
-                            type="primary"
-                            onClick={() => {
-                                setEditSelectorOpen(false)
-                                inspectElementSelected(
-                                    document.querySelector(editSelectorValue) as HTMLElement,
-                                    variant,
-                                    transformIndex,
-                                    editSelectorValue
-                                )
-                            }}
-                            disabledReason={
-                                !isValidSelector
-                                    ? 'Please enter a valid selector. Element not found on page.'
-                                    : undefined
-                            }
-                        >
-                            Save
-                        </LemonButton>
-                    </>
-                }
-            >
-                <LemonInput value={editSelectorValue} onChange={(value) => setEditSelectorValue(value)} />
-            </LemonModal>
         </>
     )
 }

--- a/frontend/src/toolbar/actions/SelectorCount.tsx
+++ b/frontend/src/toolbar/actions/SelectorCount.tsx
@@ -1,11 +1,23 @@
+import { IconPencil } from '@posthog/icons'
+import { LemonButton, LemonInput, LemonModal } from '@posthog/lemon-ui'
+import { useActions } from 'kea'
 import { querySelectorAllDeep } from 'query-selector-shadow-dom'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
+
+import { experimentsTabLogic } from '../experiments/experimentsTabLogic'
 
 interface SelectorCountProps {
     selector: string | null
+    variant: string
+    transformIndex: number
 }
 
-export function SelectorCount({ selector }: SelectorCountProps): JSX.Element | null {
+export function SelectorCount({ selector, variant, transformIndex }: SelectorCountProps): JSX.Element | null {
+    const { inspectElementSelected } = useActions(experimentsTabLogic)
+
+    const [editSelectorOpen, setEditSelectorOpen] = useState(false)
+    const [editSelectorValue, setEditSelectorValue] = useState('')
+
     const [matches, selectorError] = useMemo(() => {
         let _selectorError = false
         let _matches = 0
@@ -19,9 +31,62 @@ export function SelectorCount({ selector }: SelectorCountProps): JSX.Element | n
         return [_matches, _selectorError]
     }, [selector])
 
+    const isValidSelector = useMemo(() => {
+        if (!editSelectorValue) {
+            return false
+        }
+        try {
+            return !!document.querySelector(editSelectorValue)
+        } catch {
+            return false
+        }
+    }, [editSelectorValue])
+
     return selector === null ? null : (
-        <small className={`float-right ${selectorError && 'text-danger'}`}>
-            {selectorError ? 'Invalid selector' : `Matches ${matches} element${matches === 1 ? '' : 's'}`}
-        </small>
+        <>
+            <small className={`float-right flex items-center gap-1 ${selectorError && 'text-danger'}`}>
+                {selectorError ? 'Invalid selector' : `Matches ${matches} element${matches === 1 ? '' : 's'}`}
+                <LemonButton
+                    size="xsmall"
+                    icon={<IconPencil />}
+                    onClick={(e) => {
+                        e.stopPropagation()
+                        setEditSelectorValue(selector)
+                        setEditSelectorOpen(true)
+                    }}
+                />
+            </small>
+            <LemonModal
+                isOpen={editSelectorOpen}
+                onClose={() => setEditSelectorOpen(false)}
+                title="Edit selector"
+                footer={
+                    <>
+                        <LemonButton onClick={() => setEditSelectorOpen(false)}>Cancel</LemonButton>
+                        <LemonButton
+                            type="primary"
+                            onClick={() => {
+                                setEditSelectorOpen(false)
+                                inspectElementSelected(
+                                    document.querySelector(editSelectorValue) as HTMLElement,
+                                    variant,
+                                    transformIndex,
+                                    editSelectorValue
+                                )
+                            }}
+                            disabledReason={
+                                !isValidSelector
+                                    ? 'Please enter a valid selector. Element not found on page.'
+                                    : undefined
+                            }
+                        >
+                            Save
+                        </LemonButton>
+                    </>
+                }
+            >
+                <LemonInput value={editSelectorValue} onChange={(value) => setEditSelectorValue(value)} />
+            </LemonModal>
+        </>
     )
 }

--- a/frontend/src/toolbar/experiments/SelectorEditor.tsx
+++ b/frontend/src/toolbar/experiments/SelectorEditor.tsx
@@ -1,0 +1,77 @@
+import { IconPencil } from '@posthog/icons'
+import { useActions } from 'kea'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonInput } from 'lib/lemon-ui/LemonInput'
+import { LemonModal } from 'lib/lemon-ui/LemonModal'
+import { useMemo, useState } from 'react'
+
+import { experimentsTabLogic } from './experimentsTabLogic'
+
+interface SelectorEditorProps {
+    selector: string | null
+    variant: string
+    transformIndex: number
+}
+
+export function SelectorEditor({ selector, variant, transformIndex }: SelectorEditorProps): JSX.Element {
+    const { inspectElementSelected } = useActions(experimentsTabLogic)
+
+    const [editSelectorOpen, setEditSelectorOpen] = useState(false)
+    const [editSelectorValue, setEditSelectorValue] = useState('')
+
+    const isValidSelector = useMemo(() => {
+        if (!editSelectorValue) {
+            return false
+        }
+        try {
+            return !!document.querySelector(editSelectorValue)
+        } catch {
+            return false
+        }
+    }, [editSelectorValue])
+
+    return (
+        <>
+            <LemonButton
+                size="xsmall"
+                icon={<IconPencil />}
+                onClick={(e) => {
+                    e.stopPropagation()
+                    setEditSelectorValue(selector ?? '')
+                    setEditSelectorOpen(true)
+                }}
+            />
+            <LemonModal
+                isOpen={editSelectorOpen}
+                onClose={() => setEditSelectorOpen(false)}
+                title="Edit selector"
+                footer={
+                    <>
+                        <LemonButton onClick={() => setEditSelectorOpen(false)}>Cancel</LemonButton>
+                        <LemonButton
+                            type="primary"
+                            onClick={() => {
+                                setEditSelectorOpen(false)
+                                inspectElementSelected(
+                                    document.querySelector(editSelectorValue) as HTMLElement,
+                                    variant,
+                                    transformIndex,
+                                    editSelectorValue
+                                )
+                            }}
+                            disabledReason={
+                                !isValidSelector
+                                    ? 'Please enter a valid selector. Element not found on page.'
+                                    : undefined
+                            }
+                        >
+                            Save
+                        </LemonButton>
+                    </>
+                }
+            >
+                <LemonInput value={editSelectorValue} onChange={(value) => setEditSelectorValue(value)} />
+            </LemonModal>
+        </>
+    )
+}

--- a/frontend/src/toolbar/experiments/WebExperimentTransformHeader.tsx
+++ b/frontend/src/toolbar/experiments/WebExperimentTransformHeader.tsx
@@ -33,7 +33,9 @@ export function WebExperimentTransformHeader({
                 )}
             </div>
 
-            {transform.selector && <SelectorCount selector={transform.selector} />}
+            {transform.selector && (
+                <SelectorCount selector={transform.selector} variant={variant} transformIndex={transformIndex} />
+            )}
 
             {experimentForm?.variants && (
                 <LemonButton

--- a/frontend/src/toolbar/experiments/WebExperimentTransformHeader.tsx
+++ b/frontend/src/toolbar/experiments/WebExperimentTransformHeader.tsx
@@ -7,6 +7,8 @@ import { SelectorCount } from '~/toolbar/actions/SelectorCount'
 import { experimentsTabLogic } from '~/toolbar/experiments/experimentsTabLogic'
 import { WebExperimentTransform } from '~/toolbar/types'
 
+import { SelectorEditor } from './SelectorEditor'
+
 interface WebExperimentTransformHeaderProps {
     variant: string
     transformIndex: number
@@ -34,7 +36,10 @@ export function WebExperimentTransformHeader({
             </div>
 
             {transform.selector && (
-                <SelectorCount selector={transform.selector} variant={variant} transformIndex={transformIndex} />
+                <div className="float-right flex items-center gap-2">
+                    <SelectorCount selector={transform.selector} />
+                    <SelectorEditor selector={transform.selector} variant={variant} transformIndex={transformIndex} />
+                </div>
             )}
 
             {experimentForm?.variants && (

--- a/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
+++ b/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
@@ -78,10 +78,16 @@ export const experimentsTabLogic = kea<experimentsTabLogicType>([
             index,
         }),
         editSelectorWithIndex: (variant: string, index: number | null) => ({ variant, index }),
-        inspectElementSelected: (element: HTMLElement, variant: string, index: number | null) => ({
+        inspectElementSelected: (
+            element: HTMLElement,
+            variant: string,
+            index: number | null,
+            selector: string | null
+        ) => ({
             element,
             variant,
             index,
+            selector,
         }),
         saveExperiment: (formValues: WebExperimentForm) => ({ formValues }),
         showButtonExperiments: true,
@@ -293,11 +299,13 @@ export const experimentsTabLogic = kea<experimentsTabLogicType>([
             actions.showButtonExperiments()
             toolbarLogic.actions.setVisibleMenu('experiments')
         },
-        inspectElementSelected: ({ element, variant, index }) => {
+        inspectElementSelected: ({ element, variant, index, selector }) => {
             if (values.experimentForm?.variants) {
                 const currentVariant = values.experimentForm.variants[variant]
                 if (currentVariant && index !== null && currentVariant.transforms.length > index) {
-                    const selector = element.id ? `#${element.id}` : elementToQuery(element, [])
+                    if (!selector) {
+                        selector = element.id ? `#${element.id}` : elementToQuery(element, [])
+                    }
                     if (!selector) {
                         return
                     }

--- a/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
+++ b/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
@@ -315,10 +315,10 @@ export const experimentsTabLogic = kea<experimentsTabLogicType>([
                     if (previousSelector) {
                         const originalHtmlState = values.experimentForm.original_html_state?.[previousSelector]
                         if (originalHtmlState) {
-                            const element = document.querySelector(previousSelector) as HTMLElement
-                            element.innerHTML = originalHtmlState.html
+                            const previousElement = document.querySelector(previousSelector) as HTMLElement
+                            previousElement.innerHTML = originalHtmlState.html
                             if (originalHtmlState.css) {
-                                element.setAttribute('style', originalHtmlState.css)
+                                previousElement.setAttribute('style', originalHtmlState.css)
                             }
                         }
                     }

--- a/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
+++ b/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
@@ -82,7 +82,7 @@ export const experimentsTabLogic = kea<experimentsTabLogicType>([
             element: HTMLElement,
             variant: string,
             index: number | null,
-            selector: string | null
+            selector?: string | null
         ) => ({
             element,
             variant,


### PR DESCRIPTION
Related https://posthoghelp.zendesk.com/agent/tickets/24670 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/27093)

## Changes

Restores the ability to manually edit a selector, which was removed in https://github.com/PostHog/posthog/pull/28440

https://github.com/user-attachments/assets/31ecc27f-9296-41ca-b264-0c347b38bd09

Also prevents `element` from being overridden by the previous element when calling `inspectElementSelected( element, variant, index, selector )`

Unfortunately, clicking in the `<input>` causes the transformation to toggle because we have a button within a button. 

## How did you test this code?

1. I clicked on the pencil icon, entered an invalid selector, and verified I couldn't save.
2. I clicked on the pencil icon, entered a new, valid selector, and verified I could save.
3. I verified that I could select a new element when using "Select element"