### PR TITLE
fix(experiments): Show 'Details' for all shared primary metrics

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -133,14 +133,15 @@ export function DeltaChart({
         credibleIntervalForVariant,
         conversionRateForVariant,
         experimentId,
+        experiment,
         countDataForVariant,
         exposureCountDataForVariant,
         metricResultsLoading,
         secondaryMetricResultsLoading,
         featureFlags,
+        primaryMetricsLengthWithSharedMetrics,
     } = useValues(experimentLogic)
 
-    const { experiment } = useValues(experimentLogic)
     const {
         openPrimaryMetricModal,
         openSecondaryMetricModal,
@@ -346,7 +347,7 @@ export function DeltaChart({
                         <div className="absolute top-2 left-2" style={{ zIndex: 102 }}>
                             <SignificanceHighlight metricIndex={metricIndex} isSecondary={isSecondary} />
                         </div>
-                        {(isSecondary || (!isSecondary && experiment.metrics.length > 1)) && (
+                        {(isSecondary || (!isSecondary && primaryMetricsLengthWithSharedMetrics > 1)) && (
                             <div
                                 className="absolute bottom-2 left-2 flex justify-center bg-[var(--bg-table)]"
                                 // Chart is z-index 100, so we need to be above it


### PR DESCRIPTION
## Changes

Ensures the 'Details' button shows when all primary metrics are shared metrics.

**Before**

![CleanShot 2025-02-11 at 14 24 59@2x](https://github.com/user-attachments/assets/945ec680-cf80-4955-8dcd-fe28f2a0ea9d)

**After**

![CleanShot 2025-02-11 at 14 24 39@2x](https://github.com/user-attachments/assets/98df7de8-0aca-4bb9-b050-95328c97f3b6)

## How did you test this code?

Manual review.