### PR TITLE
fix: Fixed inconsistent colors in stickiness graph

### DIFF
--- a/frontend/src/scenes/trends/trendsDataLogic.ts
+++ b/frontend/src/scenes/trends/trendsDataLogic.ts
@@ -183,8 +183,6 @@ export const trendsDataLogic = kea<trendsDataLogicType>([
 
                 /** Unique series in the results, determined by `item.label` and `item.action.order`. */
                 const uniqSeries = Array.from(
-                    // :TRICKY: Stickiness insights don't have an `action` object, despite
-                    // types here not reflecting that.
                     new Set(
                         indexedResults.map((item) => `${item.label}_${item.action?.order}_${item?.breakdown_value}`)
                     )


### PR DESCRIPTION
## Problem

The stickiness graph was displaying inconsistent colors when viewing data of the same event type.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
Closes #28390
Closes #20404 

## Changes
<img width="1170" alt="Screenshot 2025-02-11 at 10 17 03 PM" src="https://github.com/user-attachments/assets/5e4e98a9-80cd-40aa-8ca5-932e38be7b74" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
Yep.

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Locally. Visual checks on the app.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
