### PR TITLE
fix: fix self capture posthog host serialization

### DIFF
--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -368,7 +368,7 @@ def render_template(
 
         if api_token:
             context["js_posthog_api_key"] = api_token
-            context["js_posthog_host"] = None
+            context["js_posthog_host"] = ""
     else:
         context["js_posthog_api_key"] = "sTMFPsFhdP1Ssg"
         context["js_posthog_host"] = "https://internal-t.posthog.com"


### PR DESCRIPTION
## Problem

When set to `None`, `js_posthog_host` serializes to `"None"`, breaking the JS loading for self capture on localhost and dev. 

See https://github.com/PostHog/posthog/pull/28207/files#diff-83e1564f93aa8bbe220b6e93a740cd80e32f6ab81a13346a2a6310ea41e69a8bR371

## Changes

Changes the self capture `js_posthog_host` value to an empty string.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Tested locally.
