### PR TITLE
fix: Migration iteration

### DIFF
--- a/posthog/cdp/migrations.py
+++ b/posthog/cdp/migrations.py
@@ -156,7 +156,7 @@ def migrate_legacy_plugins(
     # Get all legacy plugin_configs that are active with their attachments and global values
     # Plugins are huge (JS and assets) so we only grab the bits we really need
 
-    legacy_plugin_ids = PluginConfig.objects.values("id").filter(enabled=True)
+    legacy_plugin_ids = PluginConfig.objects.values("id").filter(enabled=True).order_by("-id").all()
 
     if kind == "destination":
         legacy_plugin_ids = legacy_plugin_ids.filter(
@@ -175,7 +175,6 @@ def migrate_legacy_plugins(
     if limit:
         legacy_plugin_ids = legacy_plugin_ids[:limit]
 
-    legacy_plugin_ids = legacy_plugin_ids.order_by("-id").all()
     # Do this in batches of batch_size but loading the individual plugin configs as we are modfiying them in the loop
 
     for i in range(0, len(legacy_plugin_ids), batch_size):
@@ -191,6 +190,6 @@ def migrate_legacy_plugins(
             "plugin__icon",
             "order",
             # Order by order asc but with nulls last
-        ).filter(id__in=batch)
+        ).filter(id__in=[x["id"] for x in batch])
 
         migrate_batch(legacy_plugins, kind, test_mode, dry_run)

--- a/posthog/cdp/migrations.py
+++ b/posthog/cdp/migrations.py
@@ -8,7 +8,6 @@ from posthog.models.plugin import PluginAttachment, PluginConfig
 from posthog.models.team.team import Team
 from django.db import transaction
 from django.db.models import Q
-from django.core.paginator import Paginator
 
 # python manage.py migrate_plugins_to_hog_functions --dry-run --test-mode --kind=transformation
 


### PR DESCRIPTION
## Problem

The current script does a pagination query but when it runs for real it turns off the plugin config which means the next page is not correct as the original query has fewer results

## Changes

* Loads all the IDs first and then uses that to paginate


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?


Ran it on prod in dry run mode and it seemed legit
