### PR TITLE
feat(cdp): improve ux for testing hogFunctions

### DIFF
--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionTest.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionTest.tsx
@@ -299,7 +299,7 @@ export function HogFunctionTest(): JSX.Element {
                 {expanded && (
                     <>
                         {testResult ? (
-                            <div className="space-y-2">
+                            <div className="space-y-2" data-attr="test-results">
                                 <LemonBanner type={testResult.status === 'success' ? 'success' : 'error'}>
                                     {testResult.status === 'success' ? 'Success' : 'Error'}
                                 </LemonBanner>

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionTestLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionTestLogic.tsx
@@ -214,9 +214,34 @@ export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
         setTestResult: ({ result }) => {
             if (result) {
                 setTimeout(() => {
+                    // First try to scroll the test results container into view
                     const testResults = document.querySelector('[data-attr="test-results"]')
                     if (testResults) {
                         testResults.scrollIntoView({ behavior: 'smooth', block: 'start' })
+                    }
+
+                    // Find the Monaco editor and scroll to the first difference
+                    const editors = document.querySelectorAll('[data-attr="test-results"] .monaco-editor')
+                    if (editors.length > 0 && values.sortedTestsResult?.hasDiff) {
+                        const lastEditor = editors[editors.length - 1]
+                        const monacoEditor = lastEditor.querySelector('.monaco-scrollable-element')
+                        if (monacoEditor) {
+                            const inputLines = values.sortedTestsResult.input.split('\n')
+                            const outputLines = values.sortedTestsResult.output.split('\n')
+
+                            // Find the first line that differs
+                            let diffLineIndex = 0
+                            for (let i = 0; i < Math.max(inputLines.length, outputLines.length); i++) {
+                                if (inputLines[i] !== outputLines[i]) {
+                                    diffLineIndex = i
+                                    break
+                                }
+                            }
+
+                            // Calculate approximate scroll position for the diff, showing 2 lines of context above
+                            const lineHeight = 19 // Default Monaco line height
+                            monacoEditor.scrollTop = Math.max(0, (diffLineIndex - 2) * lineHeight)
+                        }
                     }
                 }, 100)
             }

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionTestLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionTestLogic.tsx
@@ -210,6 +210,17 @@ export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
                 editor.revealLineInCenter(pos.lineNumber)
             }
         },
+
+        setTestResult: ({ result }) => {
+            if (result) {
+                setTimeout(() => {
+                    const testResults = document.querySelector('[data-attr="test-results"]')
+                    if (testResults) {
+                        testResults.scrollIntoView({ behavior: 'smooth', block: 'start' })
+                    }
+                }, 100)
+            }
+        },
     })),
 
     forms(({ props, actions, values }) => ({


### PR DESCRIPTION
## Problem

Currently when Testing a HogFunction (Transformation, Destination) the test executes and everything stays as is. It makes it hard to see if there is an actual diff and you need to start scrolling and doing things to actually come to the result. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- upon receiving the test result we scroll to the `test-result` container automatically 
- once the diff is calculated we scroll to the actual diff in the editor 

![2025-02-12 12 38 58](https://github.com/user-attachments/assets/d2824543-3936-4be5-895a-66ea3cbbd49f)


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- locally 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
