### PR TITLE
chore: prepare for enabling CLICKHOUSE_USE_HTTP on backend test

### DIFF
--- a/posthog/async_migrations/test/test_0010_move_old_partitions.py
+++ b/posthog/async_migrations/test/test_0010_move_old_partitions.py
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.async_migrations
 
 MIGRATION_NAME = "0010_move_old_partitions"
 
-uuid1, uuid2, uuid3 = (UUIDT() for _ in range(3))
+uuid1, uuid2, uuid3, uuid4 = (UUIDT() for _ in range(4))
 
 
 MIGRATION_DEFINITION = get_async_migration_definition(MIGRATION_NAME)
@@ -26,6 +26,11 @@ def run_migration():
 
 
 class Test0010MoveOldPartitions(AsyncMigrationBaseTest):
+    """
+    If you end up here because your PR fails be warned that this test is flaky, it depends on many things
+    in unrelated code to work in a specific way (e.g. it needs some events to be inserted with exact timestamps).
+    """
+
     def setUp(self):
         MIGRATION_DEFINITION.parameters["OLDEST_PARTITION_TO_KEEP"] = (
             "202301",
@@ -58,6 +63,13 @@ class Test0010MoveOldPartitions(AsyncMigrationBaseTest):
             team=self.team,
             distinct_id="1",
             event="$pageview",
+            timestamp="2023-02-02T00:00:00Z",
+        )
+        create_event(
+            event_uuid=uuid4,
+            team=self.team,
+            distinct_id="1",
+            event="$pageview",
             timestamp="2045-02-02T00:00:00Z",
         )
 
@@ -70,4 +82,4 @@ class Test0010MoveOldPartitions(AsyncMigrationBaseTest):
         self.assertTrue(run_migration())
 
         # this test is not very helpful, but we will at least catch if this changes
-        self.assertEqual(len(MIGRATION_DEFINITION.operations), FuzzyInt(5, 6))
+        self.assertEqual(len(MIGRATION_DEFINITION.operations), FuzzyInt(5, 7))

--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -9,6 +9,8 @@ from clickhouse_driver import Client as SyncClient
 from clickhouse_pool import ChPool
 from django.conf import settings
 
+from posthog.utils import patchable
+
 
 class Workload(Enum):
     # Default workload
@@ -73,6 +75,7 @@ _clickhouse_http_pool_mgr = httputil.get_pool_manager(
 )
 
 
+@contextmanager
 def get_http_client(**overrides):
     kwargs = {
         "host": settings.QUERYSERVICE_HOST,
@@ -87,9 +90,10 @@ def get_http_client(**overrides):
         "pool_mgr": _clickhouse_http_pool_mgr,
         **overrides,
     }
-    return ProxyClient(get_client(**kwargs))
+    yield ProxyClient(get_client(**kwargs))
 
 
+@patchable
 def get_client_from_pool(workload: Workload = Workload.DEFAULT, team_id=None, readonly=False):
     """
     Returns the client for a given workload.

--- a/posthog/clickhouse/test/test_person_overrides.py
+++ b/posthog/clickhouse/test/test_person_overrides.py
@@ -128,7 +128,11 @@ def test_person_overrides_dict():
         "version": 1,
     }
 
-    sync_execute("INSERT INTO person_overrides (*) VALUES", [values])
+    insert_query = (
+        "INSERT INTO person_overrides (team_id, old_person_id, override_person_id, merged_at, oldest_event, created_at, version) "
+        "VALUES (%(team_id)s, %(old_person_id)s, %(override_person_id)s, %(merged_at)s, %(oldest_event)s, %(created_at)s, %(version)s)"
+    )
+    sync_execute(insert_query, values)
     sync_execute("SYSTEM RELOAD DICTIONARY person_overrides_dict")
     results = sync_execute(
         "SELECT dictGet(person_overrides_dict, 'override_person_id', (%(team_id)s, %(old_person_id)s))",
@@ -141,7 +145,7 @@ def test_person_overrides_dict():
     values["version"] = 2
     values["override_person_id"] = uuid4()
 
-    sync_execute("INSERT INTO person_overrides (*) VALUES", [values])
+    sync_execute(insert_query, values)
     sync_execute("SYSTEM RELOAD DICTIONARY person_overrides_dict")
     new_results = sync_execute(
         "SELECT dictGet(person_overrides_dict, 'override_person_id', (%(team_id)s, %(old_person_id)s))",


### PR DESCRIPTION
## Problem

PostHog tests failing when run against ClickHouse HTTP interface.

Many tests still fail when run with HTTP interface enabled, most of them because the clickhouse-connect does not apply the timezone if it is UTC. Need to think about some workaround.

## Changes

1. Fix `@patchable` to enable it be used with context
2. Make tapping into the executed queries easier
3. Make `sync_execute` to claim client only when it needs it
4. Fix `INSERT` statements

## Does this work well for both Cloud and self-hosted?

yes

## How did you test this code?

run tests with `CLICKHOUSE_USE_HTTP=1` and without it
