### PR TITLE
feat(experiments): Clarify reset experiment behavior

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -498,8 +498,15 @@ export const ResetButton = ({ experimentId }: { experimentId: ExperimentIdType }
             title: 'Reset this experiment?',
             content: (
                 <>
-                    <div className="text-sm text-secondary">
-                        All data collected so far will be discarded and the experiment will go back to draft mode.
+                    <div className="text-sm text-secondary max-w-md">
+                        <p>
+                            The experiment start and end dates will be reset and the experiment will go back to draft
+                            mode.
+                        </p>
+                        <p>
+                            All events collected thus far will still exist, but won't be applied to the experiment
+                            unless you manually change the start date after launching the experiment again.
+                        </p>
                     </div>
                     {experiment.archived && (
                         <div className="text-sm text-secondary">Resetting will also unarchive the experiment.</div>


### PR DESCRIPTION
See https://posthoghelp.zendesk.com/agent/tickets/24918 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/26799)

## Changes

Clarifies the actual behavior when resetting an experiment.

**Before**

![CleanShot 2025-02-12 at 05 18 01@2x](https://github.com/user-attachments/assets/c0d0f2cf-fc89-46ff-8694-9845f0148453)

**After**

![CleanShot 2025-02-12 at 05 16 52@2x](https://github.com/user-attachments/assets/440f26c4-cddc-4d35-b60a-c278a3d05d2d)


## How did you test this code?

Visual review.