### PR TITLE
fix(experiments): Hide delete button for a new shared metric

### DIFF
--- a/frontend/src/scenes/experiments/SharedMetrics/SharedMetric.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/SharedMetric.tsx
@@ -131,31 +131,34 @@ export function SharedMetric(): JSX.Element {
                 )}
             </div>
             <div className="flex justify-between mt-4">
+                {sharedMetricId !== 'new' && (
+                    <LemonButton
+                        size="medium"
+                        type="primary"
+                        status="danger"
+                        onClick={() => {
+                            LemonDialog.open({
+                                title: 'Delete this metric?',
+                                content: <div className="text-sm text-secondary">This action cannot be undone.</div>,
+                                primaryButton: {
+                                    children: 'Delete',
+                                    type: 'primary',
+                                    onClick: () => deleteSharedMetric(),
+                                    size: 'small',
+                                },
+                                secondaryButton: {
+                                    children: 'Cancel',
+                                    type: 'tertiary',
+                                    size: 'small',
+                                },
+                            })
+                        }}
+                    >
+                        Delete
+                    </LemonButton>
+                )}
                 <LemonButton
-                    size="medium"
-                    type="primary"
-                    status="danger"
-                    onClick={() => {
-                        LemonDialog.open({
-                            title: 'Delete this metric?',
-                            content: <div className="text-sm text-secondary">This action cannot be undone.</div>,
-                            primaryButton: {
-                                children: 'Delete',
-                                type: 'primary',
-                                onClick: () => deleteSharedMetric(),
-                                size: 'small',
-                            },
-                            secondaryButton: {
-                                children: 'Cancel',
-                                type: 'tertiary',
-                                size: 'small',
-                            },
-                        })
-                    }}
-                >
-                    Delete
-                </LemonButton>
-                <LemonButton
+                    className="ml-auto"
                     disabledReason={sharedMetric.name ? undefined : 'You must give your metric a name'}
                     size="medium"
                     type="primary"


### PR DESCRIPTION
## Changes

Hides the delete button for a new shared metric.

If it doesn't exist, it can't be deleted.

| Before | After |
|--------|--------|
| ![CleanShot 2025-02-12 at 05 43 10@2x](https://github.com/user-attachments/assets/4c15765d-b123-4ac3-89ee-733a77e952a2) | ![CleanShot 2025-02-12 at 05 42 42@2x](https://github.com/user-attachments/assets/497a39a6-6cd3-4a43-9ea9-cc681351aa81) | 

## How did you test this code?

Visual review.