### PR TITLE
feat(assistant): hard limits for tool calling

### DIFF
--- a/ee/hogai/assistant.py
+++ b/ee/hogai/assistant.py
@@ -163,7 +163,7 @@ class Assistant:
     def _get_config(self) -> RunnableConfig:
         callbacks = [self._callback_handler] if self._callback_handler else None
         config: RunnableConfig = {
-            "recursion_limit": 40,
+            "recursion_limit": 48,
             "callbacks": callbacks,
             "configurable": {"thread_id": self._conversation.id},
         }

--- a/ee/hogai/assistant.py
+++ b/ee/hogai/assistant.py
@@ -4,6 +4,7 @@ from typing import Any, Optional, cast
 from uuid import UUID, uuid4
 
 import posthoganalytics
+import structlog
 from langchain_core.callbacks.base import BaseCallbackHandler
 from langchain_core.messages import AIMessageChunk
 from langchain_core.runnables.config import RunnableConfig
@@ -62,6 +63,9 @@ STREAMING_NODES: set[AssistantNodeName] = {
 
 VERBOSE_NODES = STREAMING_NODES | {AssistantNodeName.MEMORY_INITIALIZER_INTERRUPT}
 """Nodes that can send messages to the client."""
+
+
+logger = structlog.get_logger(__name__)
 
 
 class Assistant:
@@ -146,7 +150,8 @@ class Assistant:
                 )
             else:
                 self._report_conversation_state(last_viz_message)
-        except:
+        except Exception as e:
+            logger.exception("Error in assistant stream", error=e)
             # This is an unhandled error, so we just stop further generation at this point
             yield self._serialize_message(FailureMessage())
             raise  # Re-raise, so that the error is printed or goes into Sentry

--- a/ee/hogai/root/nodes.py
+++ b/ee/hogai/root/nodes.py
@@ -45,6 +45,8 @@ root_tools_parser = PydanticToolsParser(tools=[create_and_query_insight])
 
 
 class RootNode(AssistantNode):
+    MAX_TOOL_CALLS = 4
+
     def run(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState:
         prompt = ChatPromptTemplate.from_messages(
             [
@@ -121,7 +123,7 @@ class RootNode(AssistantNode):
         return history
 
     def _is_hard_limit_reached(self, state: AssistantState) -> bool:
-        return state.root_tool_calls_count is not None and state.root_tool_calls_count >= 4
+        return state.root_tool_calls_count is not None and state.root_tool_calls_count >= self.MAX_TOOL_CALLS
 
 
 class RootNodeTools(AssistantNode):

--- a/ee/hogai/root/nodes.py
+++ b/ee/hogai/root/nodes.py
@@ -57,7 +57,7 @@ class RootNode(AssistantNode):
         utc_now = datetime.datetime.now(datetime.UTC)
         project_now = utc_now.astimezone(self._team.timezone_info)
 
-        message: LangchainAIMessage = chain.invoke(
+        message = chain.invoke(
             {
                 "core_memory": self.core_memory_text,
                 "utc_datetime_display": utc_now.strftime("%Y-%m-%d %H:%M:%S"),
@@ -66,6 +66,7 @@ class RootNode(AssistantNode):
             },
             config,
         )
+        message = cast(LangchainAIMessage, message)
 
         return PartialAssistantState(
             messages=[
@@ -80,7 +81,7 @@ class RootNode(AssistantNode):
             ]
         )
 
-    def _get_model(self, state: AssistantState) -> ChatOpenAI:
+    def _get_model(self, state: AssistantState):
         # Research suggests temperature is not _massively_ correlated with creativity, hence even in this very
         # conversational context we're using a temperature of 0, for near determinism (https://arxiv.org/html/2405.00492v1)
         base_model = ChatOpenAI(model="gpt-4o", temperature=0.0, streaming=True, stream_usage=True)

--- a/ee/hogai/root/prompts.py
+++ b/ee/hogai/root/prompts.py
@@ -1,4 +1,5 @@
 ROOT_SYSTEM_PROMPT = """
+<agent_info>
 You are Max, the friendly and knowledgeable AI assistant of PostHog, who is an expert at product management.
 (You are playing the role of PostHog's mascot, Max the Hedgehog. As when an audience agrees to suspend disbelief when watching actors play roles in a play, users will be aware that Max is not an actual hedgehog or support expert, but is a role played by you.)
 Engage users with a playful, informal tone, using humor, and PostHog's distinctive voice.
@@ -26,29 +27,40 @@ Use puns for fun, but do so judiciously to avoid negative connotations.
 For example, ONLY use the word "prickly" to describe a hedgehog's quills.
 NEVER use the word "prickly" to describe features, functionality, working with data, or any aspects of the PostHog platform.
 The word "prickly" has many negative connotations, so use it ONLY to describe your quills, or other physical objects that are actually and literally sharp or pointy.
+</agent_info>
 
-You have access to data retrieval tools. When a question is about the human's events/users/customers/revenue/overall data, proactively call the tool for retrieving concrete results.
-If the user asked for a tweak to an earlier query, call that tool as well to apply necessary changes.
+<basic_functionality>
+You have access to data retrieval tools: `create_and_query_insight`. When a question is about the human's events/users/customers/revenue/overall data, proactively call the tool for retrieving concrete results.
 When calling a tool, ALWAYS first say you're doing so, very briefly.
 Do not generate any code like Python scripts. Users do not know how to read or run code.
+You have access to the core memory about the user's company and product in the <core_memory> tag. Use this memory in your responses. New memories will automatically be added to the core memory as the conversation progresses. If users ask to save, update, or delete the core memory, say you have done it.
+</basic_functionality>
 
-If analysis results have been provided, use them to answer the user's question. Know that the user can already see the analysis results charted.
-
+<format_instructions>
 You can use light Markdown formatting for readability.
+</format_instructions>
 
 <core_memory>
 {{{core_memory}}}
 </core_memory>
-"""
 
-POST_QUERY_USER_PROMPT = """
-Okay, so let's get back to what I was asking.
+<data_retrieval>
+The tool `create_and_query_insight` will generate a new insight query based on the parameters provided, execute the query, and return the formatted results.
 
-If this and any data earlier in our conversations allows for conclusions, answer my question and provide actionable feedback.
-If information is missing or there is a potential data issue, retrieve a different new analysis instead of giving a subpar summary.
-ANY TIME you're about to retrieve more data, say so first. Important: NEVER retrieve data more than 3 times in a row.
-Avoid generic advice. Take into account what you know about the product. Your answer needs to be super high-impact, no more than a few sentences.
-"""
+Follow these guidelines when retrieving data:
+- If the user asked for a tweak to an earlier query, call the data retrieval tool as well to apply necessary changes.
+- If there is exactly the same insight already in the conversation history, reuse the retrieved data.
+- If analysis results have been provided, use them to answer the user's question. Know that the user can already see the analysis results charted, so you don't need to explain each data point.
+- If the retrieved data and any data earlier in the conversations allow for conclusions, answer the user's question and provide actionable feedback.
+= If there is a potential data issue, retrieve a different new analysis instead of giving a subpar summary. Note: empty data is NOT a potential data issue.
+
+IMPORTANT: Avoid generic advice. Take into account what you know about the product. Your answer needs to be super high-impact, no more than a few sentences.
+
+Remember: do NOT retrieve data for the same query more than 3 times in a row.
+</data_retrieval>
+
+Now begin.
+""".strip()
 
 
 ROOT_INSIGHT_DESCRIPTION_PROMPT = """
@@ -103,7 +115,7 @@ Examples of use cases include:
 - How many users come back and perform an action after their first visit.
 - How many users come back to perform action X after performing action Y.
 - How often users return to use a specific feature.
-"""
+""".strip()
 
 ROOT_VALIDATION_EXCEPTION_PROMPT = """
 The function call you previously provided didn't pass the validation and raised a Pydantic validation exception.
@@ -111,4 +123,8 @@ The function call you previously provided didn't pass the validation and raised 
 {{{exception}}}
 </pydantic_exception>
 You must fix the exception and try again.
-"""
+""".strip()
+
+ROOT_HARD_LIMIT_REACHED_PROMPT = """
+You have reached the maximum number of tool calls, a security measure to prevent infinite loops. Now, summarize the conversation so far and answer my question if you can. Then, ask me if I'd like to continue what you were doing.
+""".strip()

--- a/ee/hogai/root/prompts.py
+++ b/ee/hogai/root/prompts.py
@@ -126,5 +126,5 @@ You must fix the exception and try again.
 """.strip()
 
 ROOT_HARD_LIMIT_REACHED_PROMPT = """
-You have reached the maximum number of tool calls, a security measure to prevent infinite loops. Now, summarize the conversation so far and answer my question if you can. Then, ask me if I'd like to continue what you were doing.
+You have reached the maximum number of iterations, a security measure to prevent infinite loops. Now, summarize the conversation so far and answer my question if you can. Then, ask me if I'd like to continue what you were doing.
 """.strip()

--- a/ee/hogai/root/prompts.py
+++ b/ee/hogai/root/prompts.py
@@ -45,16 +45,16 @@ You can use light Markdown formatting for readability.
 </core_memory>
 
 <data_retrieval>
-The tool `create_and_query_insight` will generate a new insight query based on the parameters provided, execute the query, and return the formatted results.
+The tool `create_and_query_insight` generates a new insight query based on the provided parameters, executes the query, and returns the formatted results.
 
 Follow these guidelines when retrieving data:
-- If the user asked for a tweak to an earlier query, call the data retrieval tool as well to apply necessary changes.
-- If there is exactly the same insight already in the conversation history, reuse the retrieved data.
+- If the user asked for a tweak to an earlier query, call the data retrieval tool as well to apply the necessary changes.
+- If the same insight is already in the conversation history, reuse the retrieved data.
 - If analysis results have been provided, use them to answer the user's question. Know that the user can already see the analysis results charted, so you don't need to explain each data point.
 - If the retrieved data and any data earlier in the conversations allow for conclusions, answer the user's question and provide actionable feedback.
 = If there is a potential data issue, retrieve a different new analysis instead of giving a subpar summary. Note: empty data is NOT a potential data issue.
 
-IMPORTANT: Avoid generic advice. Take into account what you know about the product. Your answer needs to be super high-impact, no more than a few sentences.
+IMPORTANT: Avoid generic advice. Take into account what you know about the product. Your answer needs to be super high-impact and no more than a few sentences.
 
 Remember: do NOT retrieve data for the same query more than 3 times in a row.
 </data_retrieval>

--- a/ee/hogai/root/prompts.py
+++ b/ee/hogai/root/prompts.py
@@ -52,7 +52,7 @@ Follow these guidelines when retrieving data:
 - If the same insight is already in the conversation history, reuse the retrieved data.
 - If analysis results have been provided, use them to answer the user's question. Know that the user can already see the analysis results charted, so you don't need to explain each data point.
 - If the retrieved data and any data earlier in the conversations allow for conclusions, answer the user's question and provide actionable feedback.
-= If there is a potential data issue, retrieve a different new analysis instead of giving a subpar summary. Note: empty data is NOT a potential data issue.
+- If there is a potential data issue, retrieve a different new analysis instead of giving a subpar summary. Note: empty data is NOT a potential data issue.
 
 IMPORTANT: Avoid generic advice. Take into account what you know about the product. Your answer needs to be super high-impact and no more than a few sentences.
 

--- a/ee/hogai/root/test/test_nodes.py
+++ b/ee/hogai/root/test/test_nodes.py
@@ -17,7 +17,7 @@ from posthog.test.base import BaseTest, ClickhouseTestMixin
 class TestRootNode(ClickhouseTestMixin, BaseTest):
     def test_node_handles_plain_chat_response(self):
         with patch(
-            "ee.hogai.root.nodes.RootNode._model",
+            "ee.hogai.root.nodes.RootNode._get_model",
             return_value=RunnableLambda(
                 lambda _: LangchainAIMessage(content="Why did the chicken cross the road? To get to the other side!")
             ),
@@ -41,7 +41,7 @@ class TestRootNode(ClickhouseTestMixin, BaseTest):
     )
     def test_node_handles_insight_tool_call(self, insight_type):
         with patch(
-            "ee.hogai.root.nodes.RootNode._model",
+            "ee.hogai.root.nodes.RootNode._get_model",
             return_value=RunnableLambda(
                 lambda _: LangchainAIMessage(
                     content="Hang tight while I check this.",
@@ -83,7 +83,7 @@ class TestRootNode(ClickhouseTestMixin, BaseTest):
     )
     def test_node_handles_insight_tool_call_without_message(self, insight_type):
         with patch(
-            "ee.hogai.root.nodes.RootNode._model",
+            "ee.hogai.root.nodes.RootNode._get_model",
             return_value=RunnableLambda(
                 lambda _: LangchainAIMessage(
                     content="",
@@ -233,12 +233,7 @@ class TestRootNodeTools(BaseTest):
     def test_run_no_assistant_message(self):
         node = RootNodeTools(self.team)
         state = AssistantState(messages=[HumanMessage(content="Hello")])
-        self.assertIsNone(node.run(state, {}))
-
-    def test_run_assistant_message_no_tool_calls(self):
-        node = RootNodeTools(self.team)
-        state = AssistantState(messages=[AssistantMessage(content="Hello")])
-        self.assertIsNone(node.run(state, {}))
+        self.assertEqual(node.run(state, {}), PartialAssistantState(root_tool_calls_count=0))
 
     def test_run_validation_error(self):
         node = RootNodeTools(self.team)

--- a/ee/hogai/test/test_assistant.py
+++ b/ee/hogai/test/test_assistant.py
@@ -2,6 +2,7 @@ import json
 from itertools import cycle
 from typing import Any, Optional, cast
 from unittest.mock import patch
+from uuid import uuid4
 
 import pytest
 from langchain_core import messages
@@ -444,7 +445,7 @@ class TestAssistant(ClickhouseTestMixin, NonAtomicBaseTest):
 
     @patch("ee.hogai.schema_generator.nodes.SchemaGeneratorNode._model")
     @patch("ee.hogai.taxonomy_agent.nodes.TaxonomyAgentPlannerNode._model")
-    @patch("ee.hogai.root.nodes.RootNode._model")
+    @patch("ee.hogai.root.nodes.RootNode._get_model")
     @patch("ee.hogai.memory.nodes.MemoryCollectorNode._model", return_value=messages.AIMessage(content="[Done]"))
     def test_full_trends_flow(self, memory_collector_mock, root_mock, planner_mock, generator_mock):
         root_mock.side_effect = cycle(
@@ -507,7 +508,7 @@ class TestAssistant(ClickhouseTestMixin, NonAtomicBaseTest):
 
     @patch("ee.hogai.schema_generator.nodes.SchemaGeneratorNode._model")
     @patch("ee.hogai.taxonomy_agent.nodes.TaxonomyAgentPlannerNode._model")
-    @patch("ee.hogai.root.nodes.RootNode._model")
+    @patch("ee.hogai.root.nodes.RootNode._get_model")
     @patch("ee.hogai.memory.nodes.MemoryCollectorNode._model", return_value=messages.AIMessage(content="[Done]"))
     def test_full_funnel_flow(self, memory_collector_mock, root_mock, planner_mock, generator_mock):
         root_mock.side_effect = cycle(
@@ -710,3 +711,65 @@ class TestAssistant(ClickhouseTestMixin, NonAtomicBaseTest):
         # Verify memory was appended
         self.core_memory.refresh_from_db()
         self.assertIn("The product uses a subscription model.", self.core_memory.text)
+
+    @patch("ee.hogai.schema_generator.nodes.SchemaGeneratorNode._model")
+    @patch("ee.hogai.taxonomy_agent.nodes.TaxonomyAgentPlannerNode._model")
+    @patch("ee.hogai.root.nodes.RootNode._get_model")
+    @patch("ee.hogai.memory.nodes.MemoryCollectorNode._model", return_value=messages.AIMessage(content="[Done]"))
+    def test_exits_infinite_loop_after_fourth_attempt(
+        self, memory_collector_mock, get_model_mock, planner_mock, generator_mock
+    ):
+        """Test that the assistant exits an infinite loop of tool calls after the 4th attempt."""
+
+        # Track number of attempts
+        attempts = 0
+
+        # Mock the root node to keep making tool calls until 4th attempt
+        def make_tool_call(_):
+            nonlocal attempts
+            attempts += 1
+            if attempts <= 4:
+                return messages.AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "id": str(uuid4()),
+                            "name": "create_and_query_insight",
+                            "args": {"query_description": "Foobar", "query_kind": "trends"},
+                        }
+                    ],
+                )
+            return messages.AIMessage(content="No more tool calls after 4th attempt")
+
+        get_model_mock.return_value = RunnableLambda(make_tool_call)
+        planner_mock.return_value = RunnableLambda(
+            lambda _: messages.AIMessage(
+                content="""
+                Thought: Done.
+                Action:
+                ```
+                {
+                    "action": "final_answer",
+                    "action_input": "Plan"
+                }
+                ```
+                """
+            )
+        )
+        query = AssistantTrendsQuery(series=[])
+        generator_mock.return_value = RunnableLambda(lambda _: TrendsSchemaGeneratorOutput(query=query))
+
+        # Create a graph that only uses the root node
+        graph = AssistantGraph(self.team).compile_full_graph()
+
+        # Run the assistant and capture output
+        output = self._run_assistant_graph(graph)
+
+        # Verify the last message doesn't contain any tool calls and has our expected content
+        last_message = output[-1][1]
+        self.assertNotIn("tool_calls", last_message, "The final message should not contain any tool calls")
+        self.assertEqual(
+            last_message["content"],
+            "No more tool calls after 4th attempt",
+            "Final message should indicate no more tool calls",
+        )

--- a/ee/hogai/utils/types.py
+++ b/ee/hogai/utils/types.py
@@ -58,6 +58,10 @@ class _SharedAssistantState(BaseModel):
     """
     The type of insight to generate.
     """
+    root_tool_calls_count: Optional[int] = Field(default=None)
+    """
+    The number of tool calls made by the root node to limit the number of tool calls.
+    """
 
 
 class AssistantState(_SharedAssistantState):

--- a/ee/hogai/utils/types.py
+++ b/ee/hogai/utils/types.py
@@ -60,7 +60,7 @@ class _SharedAssistantState(BaseModel):
     """
     root_tool_calls_count: Optional[int] = Field(default=None)
     """
-    The number of tool calls made by the root node to limit the number of tool calls.
+    Tracks the number of tool calls made by the root node to terminate the loop.
     """
 
 


### PR DESCRIPTION
## Problem

The agent can now generate multiple insights in a single run, which presents us with a new challenge: infinite loops. Although LangGraph has a hard limit on the recursion limit, this limit only protects us from unexpected loops. If the request implies generating more than four insights, we want to provide a smooth interruption experience.

## Changes

- Bump the recursion limit to 48, so it should be enough to generate four insights.
- Better structure for the root prompt.
- Inject the user message when the hard limit of four insights is reached. The agent must terminate the conversation and provide feedback based on the insights it has built.
- Slightly change the prompt about the core memory to provide feedback instead of "I don't know how" messages.

#### Loops

Loop termination:
<img width="744" alt="Screenshot 2025-02-12 at 13 49 17" src="https://github.com/user-attachments/assets/22dd8095-45ad-451c-bed0-d6567d528305" />

Follow-up question with a soft rejection (users can actually continue if they want):
<img width="775" alt="Screenshot 2025-02-12 at 13 49 26" src="https://github.com/user-attachments/assets/2b69a671-6a61-45f4-a7ce-0571b2ac9d67" />

#### Memory

Core memory has a record:
<img width="802" alt="Screenshot 2025-02-12 at 14 16 14" src="https://github.com/user-attachments/assets/baed4a89-77b5-46bd-91db-1938a95dcd8d" />

No record in the memory:
<img width="797" alt="Screenshot 2025-02-12 at 14 16 48" src="https://github.com/user-attachments/assets/c5305cde-f2e8-4565-a555-bd10f314efcc" />


## Does this work well for both Cloud and self-hosted?

No

## How did you test this code?

Manual testing, unit tests
