### PR TITLE
feat(cdp): mask url props transformation

### DIFF
--- a/plugin-server/src/cdp/templates/_transformations/url-masking/url-masking.template.test.ts
+++ b/plugin-server/src/cdp/templates/_transformations/url-masking/url-masking.template.test.ts
@@ -1,0 +1,156 @@
+import { HogFunctionInvocationGlobals } from '../../../types'
+import { TemplateTester } from '../../test/test-helpers'
+import { template } from './url-masking.template'
+
+describe('url-masking.template', () => {
+    const tester = new TemplateTester(template)
+    let mockGlobals: HogFunctionInvocationGlobals
+
+    beforeEach(async () => {
+        await tester.beforeEach()
+    })
+
+    it('should mask sensitive parameters in URLs', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    $current_url: 'https://example.com?email=test@example.com&password=secret&name=john',
+                    $referrer: 'https://other.com?token=12345&email=test@example.com',
+                },
+            },
+        })
+
+        const response = await tester.invoke(
+            {
+                urlProperties: {
+                    $current_url: 'email, password',
+                    $referrer: 'email, token',
+                },
+                maskWith: '[REDACTED]',
+            },
+            mockGlobals
+        )
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect(response.execResult).toMatchObject({
+            properties: {
+                $current_url: 'https://example.com?email=[REDACTED]&password=[REDACTED]&name=john',
+                $referrer: 'https://other.com?token=[REDACTED]&email=[REDACTED]',
+            },
+        })
+    })
+
+    it('should handle URLs without query parameters', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    $current_url: 'https://example.com',
+                },
+            },
+        })
+
+        const response = await tester.invoke(
+            {
+                urlProperties: {
+                    $current_url: 'email, password',
+                },
+                maskWith: '[REDACTED]',
+            },
+            mockGlobals
+        )
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect(response.execResult).toMatchObject({
+            properties: {
+                $current_url: 'https://example.com',
+            },
+        })
+    })
+
+    it('should handle malformed URLs', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    $current_url: 'not-a-url?email=test@example.com',
+                },
+            },
+        })
+
+        const response = await tester.invoke(
+            {
+                urlProperties: {
+                    $current_url: 'email',
+                },
+                maskWith: '[REDACTED]',
+            },
+            mockGlobals
+        )
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect(response.execResult).toMatchObject({
+            properties: {
+                $current_url: 'not-a-url?email=[REDACTED]',
+            },
+        })
+    })
+
+    it('should handle missing properties', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    $current_url: 'https://example.com?email=test@example.com',
+                },
+            },
+        })
+
+        const response = await tester.invoke(
+            {
+                urlProperties: {
+                    $current_url: 'email',
+                    $referrer: 'email', // $referrer doesn't exist in properties
+                },
+                maskWith: '[REDACTED]',
+            },
+            mockGlobals
+        )
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect(response.execResult).toMatchObject({
+            properties: {
+                $current_url: 'https://example.com?email=[REDACTED]',
+            },
+        })
+    })
+
+    it('should handle empty parameter values', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    $current_url: 'https://example.com?email=&token=123',
+                },
+            },
+        })
+
+        const response = await tester.invoke(
+            {
+                urlProperties: {
+                    $current_url: 'email, token',
+                },
+                maskWith: '[REDACTED]',
+            },
+            mockGlobals
+        )
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect(response.execResult).toMatchObject({
+            properties: {
+                $current_url: 'https://example.com?email=[REDACTED]&token=[REDACTED]',
+            },
+        })
+    })
+})

--- a/plugin-server/src/cdp/templates/_transformations/url-masking/url-masking.template.test.ts
+++ b/plugin-server/src/cdp/templates/_transformations/url-masking/url-masking.template.test.ts
@@ -69,11 +69,11 @@ describe('url-masking.template', () => {
         })
     })
 
-    it('should handle malformed URLs', async () => {
+    it('should handle malformed URLs starting with question mark', async () => {
         mockGlobals = tester.createGlobals({
             event: {
                 properties: {
-                    $current_url: 'not-a-url?email=test@example.com',
+                    $current_url: '?email=test@example.com',
                 },
             },
         })
@@ -92,7 +92,7 @@ describe('url-masking.template', () => {
         expect(response.error).toBeUndefined()
         expect(response.execResult).toMatchObject({
             properties: {
-                $current_url: 'not-a-url?email=[REDACTED]',
+                $current_url: '?email=test@example.com',
             },
         })
     })
@@ -122,6 +122,34 @@ describe('url-masking.template', () => {
         expect(response.execResult).toMatchObject({
             properties: {
                 $current_url: 'https://example.com?email=[REDACTED]',
+            },
+        })
+    })
+
+    it('should handle parameters without values', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    $current_url: 'https://example.com?email&token=123&password',
+                },
+            },
+        })
+
+        const response = await tester.invoke(
+            {
+                urlProperties: {
+                    $current_url: 'email, password, token',
+                },
+                maskWith: '[REDACTED]',
+            },
+            mockGlobals
+        )
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect(response.execResult).toMatchObject({
+            properties: {
+                $current_url: 'https://example.com?email=[REDACTED]&token=[REDACTED]&password=[REDACTED]',
             },
         })
     })

--- a/plugin-server/src/cdp/templates/_transformations/url-masking/url-masking.template.ts
+++ b/plugin-server/src/cdp/templates/_transformations/url-masking/url-masking.template.ts
@@ -1,0 +1,110 @@
+import { HogFunctionTemplate } from '../../types'
+
+export const template: HogFunctionTemplate = {
+    free: false,
+    status: 'alpha',
+    type: 'transformation',
+    id: 'template-url-masking',
+    name: 'URL Parameter Masking',
+    description: 'Masks sensitive information in URL parameters (query strings) of specified properties',
+    icon_url: '/static/hedgehog/builder-hog-01.png',
+    category: ['Custom'],
+    hog: `
+// Function to check if parameter matches any mask pattern
+fun isParameterInList(paramName, paramsString) {
+    let paramsList := splitByString(',', paramsString)
+    for (let pattern in paramsList) {
+        if (lower(paramName) =~ lower(trim(pattern))) {
+            return true
+        }
+    }
+    return false
+}
+
+// Function to mask URL parameters
+fun maskURLParameters(url, paramsToMask, maskValue) {
+    // If URL is empty or not a string, return as is
+    if (empty(url) or typeof(url) != 'string') {
+        return url
+    }
+
+    try {
+        // Split URL into base and query string
+        let parts := splitByString('?', url, 2)
+        if (length(parts) < 2) {
+            return url
+        }
+        
+        let baseUrl := parts[1]
+        let queryString := parts[2]
+        
+        // Split query string into parameters
+        let params := splitByString('&', queryString)
+        let maskedParams := []
+        
+        // Process each parameter
+        for (let param in params) {
+            let keyValue := splitByString('=', param, 2)
+            if (length(keyValue) < 2) {
+                maskedParams := arrayPushBack(maskedParams, param)
+                continue
+            }
+            
+            let paramName := keyValue[1]
+            
+            if (isParameterInList(paramName, paramsToMask)) {
+                maskedParams := arrayPushBack(maskedParams, concat(paramName, '=', maskValue))
+            } else {
+                maskedParams := arrayPushBack(maskedParams, param)
+            }
+        }
+        
+        // Reconstruct URL with masked parameters
+        return concat(baseUrl, '?', arrayStringConcat(maskedParams, '&'))
+    } catch (error) {
+        print('Error masking URL parameters:', error)
+        return url
+    }
+}
+
+// Create a copy of the event to modify
+let maskedEvent := event
+
+// Process each URL property
+for (let propName, paramsToMask in inputs.urlProperties) {
+    if (not empty(event.properties?.[propName])) {
+        maskedEvent.properties[propName] := maskURLParameters(
+            event.properties[propName],
+            paramsToMask,
+            inputs.maskWith
+        )
+    }
+}
+
+return maskedEvent
+    `,
+    inputs_schema: [
+        {
+            key: 'urlProperties',
+            type: 'dictionary',
+            label: 'URL Properties to Mask',
+            description:
+                "Map of event properties containing URLs and their parameters to mask. Example: {'$current_url': 'email, password'}",
+            default: {
+                $current_url: 'email, password, token',
+                $referrer: 'email, password, token',
+            },
+            secret: false,
+            required: true,
+        },
+        {
+            key: 'maskWith',
+            type: 'string',
+            label: 'Mask Value',
+            description: 'The value to replace sensitive parameters with',
+            default: '[REDACTED]',
+            secret: false,
+            required: true,
+        },
+    ],
+}

--- a/plugin-server/src/cdp/templates/_transformations/url-masking/url-masking.template.ts
+++ b/plugin-server/src/cdp/templates/_transformations/url-masking/url-masking.template.ts
@@ -38,24 +38,35 @@ fun maskURLParameters(url, paramsToMask, maskValue) {
         let baseUrl := parts[1]
         let queryString := parts[2]
         
+        // Handle malformed URLs that start with ?
+        if (empty(baseUrl)) {
+            return url
+        }
+        
         // Split query string into parameters
         let params := splitByString('&', queryString)
         let maskedParams := []
         
         // Process each parameter
         for (let param in params) {
-            let keyValue := splitByString('=', param, 2)
-            if (length(keyValue) < 2) {
-                maskedParams := arrayPushBack(maskedParams, param)
-                continue
-            }
-            
-            let paramName := keyValue[1]
-            
-            if (isParameterInList(paramName, paramsToMask)) {
-                maskedParams := arrayPushBack(maskedParams, concat(paramName, '=', maskValue))
-            } else {
-                maskedParams := arrayPushBack(maskedParams, param)
+            if (not empty(param)) {
+                let keyValue := splitByString('=', param, 2)
+                let paramName := keyValue[1]
+                
+                // Handle parameters without values (e.g., ?key&foo=bar)
+                if (length(keyValue) < 2) {
+                    if (isParameterInList(paramName, paramsToMask)) {
+                        maskedParams := arrayPushBack(maskedParams, concat(paramName, '=', maskValue))
+                    } else {
+                        maskedParams := arrayPushBack(maskedParams, paramName)
+                    }
+                } else {
+                    if (isParameterInList(paramName, paramsToMask)) {
+                        maskedParams := arrayPushBack(maskedParams, concat(paramName, '=', maskValue))
+                    } else {
+                        maskedParams := arrayPushBack(maskedParams, param)
+                    }
+                }
             }
         }
         

--- a/plugin-server/src/cdp/templates/index.ts
+++ b/plugin-server/src/cdp/templates/index.ts
@@ -6,6 +6,7 @@ import { template as geoipTemplate } from './_transformations/geoip/geoip.templa
 import { template as ipAnonymizationTemplate } from './_transformations/ip-anonymization/ip-anonymization.template'
 import { template as piiHashingTemplate } from './_transformations/pii-hashing/pii-hashing.template'
 import { template as removeNullPropertiesTemplate } from './_transformations/remove-null-properties/remove-null-properties.template'
+import { template as urlMaskingTemplate } from './_transformations/url-masking/url-masking.template'
 import { HogFunctionTemplate } from './types'
 export const HOG_FUNCTION_TEMPLATES_DESTINATIONS: HogFunctionTemplate[] = [webhookTemplate]
 
@@ -14,6 +15,7 @@ export const HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS: HogFunctionTemplate[] = [
     geoipTemplate,
     ipAnonymizationTemplate,
     removeNullPropertiesTemplate,
+    urlMaskingTemplate,
     piiHashingTemplate,
     botDetectionTemplate,
 ]


### PR DESCRIPTION
## Problem

Customers want to mask potential user info in URL properties as they come in

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- define the property you want to mask (top level only, e.g. `$current_url`, `referrer`)
- define the query params you want to mask e.g. `email` `token` etc. 
- define how you want to mask it e.g. `[MASKED]` `REDACTED` as examples

<img width="1107" alt="Screenshot 2025-02-12 at 14 57 55" src="https://github.com/user-attachments/assets/473c5950-af26-4c7a-9920-28a00d33fa29" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- written tests 
- tested locally

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
