### PR TITLE
fix: Added missing template ID to default geoip

### DIFF
--- a/posthog/models/plugin.py
+++ b/posthog/models/plugin.py
@@ -590,10 +590,11 @@ def enable_preinstalled_plugins_for_new_team(sender, instance: Team, created: bo
                 name="GeoIP",
                 description="Enrich events with GeoIP data",
                 icon_url="/static/transformations/geoip.png",
-                hog=geoip_template.hog,
-                inputs_schema=geoip_template.inputs_schema,
                 enabled=True,
                 execution_order=1,
+                hog=geoip_template.hog,
+                inputs_schema=geoip_template.inputs_schema,
+                template_id=geoip_template.id,
             )
     else:
         # Old way: Enable all preinstalled plugins including GeoIP

--- a/posthog/test/test_plugin.py
+++ b/posthog/test/test_plugin.py
@@ -201,6 +201,7 @@ class TestPlugin(BaseTest):
             self.assertEqual(geoip.icon_url, "/static/transformations/geoip.png")
             self.assertEqual(geoip.enabled, True)
             self.assertEqual(geoip.execution_order, 1)
+            self.assertEqual(geoip.template_id, "plugin-posthog-plugin-geoip")
 
         # Verify no plugins were enabled
         plugin_configs = PluginConfig.objects.filter(team=team)


### PR DESCRIPTION
## Problem

We didn't include the template_id which means the runner isn't able to use the legacy plugin value...

## Changes

* Fixes it
* Need to add a test

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
