### PR TITLE
fix(cdp): accept url with /v1/batch

### DIFF
--- a/posthog/cdp/templates/rudderstack/template_rudderstack.py
+++ b/posthog/cdp/templates/rudderstack/template_rudderstack.py
@@ -96,7 +96,7 @@ fun getPayload() {
     }
 }
 
-fetch(f'{inputs.host}/v1/batch', getPayload())
+fetch(f'{replaceAll(inputs.host, '/v1/batch', '')}/v1/batch', getPayload())
 """.strip(),
     inputs_schema=[
         {

--- a/posthog/cdp/templates/rudderstack/test_template_rudderstack.py
+++ b/posthog/cdp/templates/rudderstack/test_template_rudderstack.py
@@ -76,6 +76,24 @@ class TestTemplateRudderstack(BaseHogFunctionTemplateTest):
             )
         )
 
+    def test_accepts_wrong_url(self):
+        self.run_function(
+            inputs=self._inputs(host="https://hosted.rudderlabs.com/v1/batch"),
+            globals={
+                "event": {
+                    "uuid": "96a04bdc-6021-4120-a3e3-f1988f59ba5f",
+                    "timestamp": "2024-08-29T13:40:22.713Z",
+                    "distinct_id": "85bcd2e4-d10d-4a99-9dc8-43789b7226a1",
+                    "event": "$pageview",
+                    "properties": {"$current_url": "https://example.com", "$browser": "Chrome"},
+                },
+                "person": {"uuid": "a08ff8e1-a5ee-49cc-99e9-564e455c33f0"},
+            },
+        )
+
+        res = self.get_mock_fetch_calls()[0]
+        assert res[0] == "https://hosted.rudderlabs.com/v1/batch"
+
     def test_automatic_action_mapping(self):
         for event_name, expected_action in [
             ("$identify", "identify"),


### PR DESCRIPTION
## Problem

Currently, you have to supply the Rudderstack dataplane URL without the `/v1/batch` at the end. That is confusing.
https://posthoghelp.zendesk.com/agent/tickets/25142 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/26815)

## Changes

- Make sure it work with both the URLs supplied:
  - https://hosted.rudderlabs.com/v1/batch
  - https://hosted.rudderlabs.com

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

added test