### PR TITLE
fix(no-code experiments): refactor toolbar (7)

### DIFF
--- a/frontend/src/toolbar/bar/Toolbar.tsx
+++ b/frontend/src/toolbar/bar/Toolbar.tsx
@@ -122,8 +122,6 @@ export function ToolbarInfoMenu(): JSX.Element | null {
         <WebVitalsToolbarMenu />
     ) : null
 
-    // const content = <ExperimentsToolbarMenu />
-
     useEffect(() => {
         setMenu(ref.current)
         return () => setMenu(null)

--- a/frontend/src/toolbar/bar/Toolbar.tsx
+++ b/frontend/src/toolbar/bar/Toolbar.tsx
@@ -122,6 +122,8 @@ export function ToolbarInfoMenu(): JSX.Element | null {
         <WebVitalsToolbarMenu />
     ) : null
 
+    // const content = <ExperimentsToolbarMenu />
+
     useEffect(() => {
         setMenu(ref.current)
         return () => setMenu(null)

--- a/frontend/src/toolbar/experiments/ExperimentsEditingToolbarMenu.tsx
+++ b/frontend/src/toolbar/experiments/ExperimentsEditingToolbarMenu.tsx
@@ -48,11 +48,22 @@ export const ExperimentsEditingToolbarMenu = (): JSX.Element => {
                 className="flex flex-col overflow-hidden flex-1"
             >
                 <ToolbarMenu.Header className="border-b">
-                    <h1 className="p-1 font-bold text-sm mb-0">
-                        {selectedExperimentId === 'new' ? 'New ' : 'Edit '}
-                        experiment
-                        {selectedVariant && `  variant : ${selectedVariant}`}
-                    </h1>
+                    {selectedExperimentId === 'new' ? (
+                        <div className="w-full p-4">
+                            <LemonLabel>Experiment name</LemonLabel>
+                            <LemonInput
+                                className="w-2/3"
+                                placeholder="Example: Pricing page conversion"
+                                onChange={(newName: string) => {
+                                    setExperimentFormValue('name', newName)
+                                }}
+                                value={experimentForm.name}
+                                status={experimentFormErrors.name ? 'danger' : 'default'}
+                            />
+                        </div>
+                    ) : (
+                        <h2 className="p-2 font-bold">{experimentForm.name}</h2>
+                    )}
                     <div id="errorcontainer">
                         {Object.keys(experimentFormErrors).length > 0 &&
                             !Object.values(experimentFormErrors).every((el) => el === undefined) && (
@@ -67,25 +78,6 @@ export const ExperimentsEditingToolbarMenu = (): JSX.Element => {
                 </ToolbarMenu.Header>
                 <ToolbarMenu.Body>
                     <div className="space-y-6 p-2">
-                        <div className="flex w-full">
-                            {selectedExperimentId === 'new' ? (
-                                <div className="w-full">
-                                    <LemonLabel>Name</LemonLabel>
-                                    <LemonInput
-                                        className="w-2/3"
-                                        placeholder="Example: Pricing page conversion"
-                                        onChange={(newName: string) => {
-                                            experimentForm.name = newName
-                                            setExperimentFormValue('name', experimentForm.name)
-                                        }}
-                                        value={experimentForm.name}
-                                        status={experimentFormErrors.name ? 'danger' : 'default'}
-                                    />
-                                </div>
-                            ) : (
-                                <h4 className="col-span-2">{experimentForm.name}</h4>
-                            )}
-                        </div>
                         <div>
                             <div className="flex items-center justify-between mb-2">
                                 <LemonLabel>Variants</LemonLabel>

--- a/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
+++ b/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
@@ -265,12 +265,37 @@ export const experimentsTabLogic = kea<experimentsTabLogicType>([
             if (!selectedExperiment) {
                 actions.setExperimentFormValues({ name: '', variants: {} })
             } else {
+                // Build original_html_state from existing selectors
+                const original_html_state: Record<string, { html: string; css?: string }> = {}
+
+                if ((selectedExperiment as WebExperiment).variants) {
+                    Object.values((selectedExperiment as WebExperiment).variants).forEach((variant) => {
+                        variant.transforms?.forEach((transform) => {
+                            if (transform.selector) {
+                                const element = document.querySelector(transform.selector) as HTMLElement
+                                if (element) {
+                                    const style = element.getAttribute('style')
+                                    original_html_state[transform.selector] = {
+                                        html: element.innerHTML,
+                                        ...(style && { css: style }),
+                                    }
+                                }
+                            }
+                        })
+                    })
+                }
+
                 actions.setExperimentFormValues({
                     name: selectedExperiment.name,
                     variants: (selectedExperiment as WebExperiment).variants
                         ? (selectedExperiment as WebExperiment).variants
                         : {},
+                    original_html_state,
                 })
+
+                // TODO: refactor into a single actions to select + apply changes
+                actions.applyVariant('control')
+                actions.selectVariant('control')
             }
         },
     })),


### PR DESCRIPTION
## Changes
- Build original HTML state when an existing experiment is selected. This ensures that preview of changes works for existing experiments, not only new ones.
- Made the toolbar header nicer, put the experiment name there.
- Automatically select control variant and apply its changes.

![image](https://github.com/user-attachments/assets/67e6a096-ed52-4914-925a-75492e79d953)

https://www.loom.com/share/0443e40c2e2846c5b11afdc2cebd8e27

## How did you test this code?
👀 