### PR TITLE
fix(batch-exports): Fix check for earliest start date

### DIFF
--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -576,32 +576,35 @@ def create_backfill(
         end_at = None
 
     if (start_at is not None or end_at is not None) and batch_export.model is not None:
-        earliest_backfill_start_at = fetch_earliest_backfill_start_at(
-            team_id=team.pk,
-            model=batch_export.model,
-            interval_time_delta=batch_export.interval_time_delta,
-            exclude_events=batch_export.destination.config.get("exclude_events", []),
-            include_events=batch_export.destination.config.get("include_events", []),
-        )
-        if earliest_backfill_start_at is None:
-            raise ValidationError("There is no data to backfill for this model.")
-
-        earliest_backfill_start_at = earliest_backfill_start_at.astimezone(team.timezone_info)
-
-        if end_at is not None and end_at < earliest_backfill_start_at:
-            raise ValidationError(
-                "The provided backfill date range contains no data. The earliest possible backfill start date is "
-                f"{earliest_backfill_start_at.strftime('%Y-%m-%d %H:%M:%S')}",
+        try:
+            earliest_backfill_start_at = fetch_earliest_backfill_start_at(
+                team_id=team.pk,
+                model=batch_export.model,
+                interval_time_delta=batch_export.interval_time_delta,
+                exclude_events=batch_export.destination.config.get("exclude_events", []),
+                include_events=batch_export.destination.config.get("include_events", []),
             )
+            if earliest_backfill_start_at is None:
+                raise ValidationError("There is no data to backfill for this model.")
 
-        if start_at is not None and start_at < earliest_backfill_start_at:
-            logger.info(
-                "Backfill start_at '%s' is before the earliest possible backfill start_at '%s', setting start_at "
-                "to earliest_backfill_start_at",
-                start_at,
-                earliest_backfill_start_at,
-            )
-            start_at = earliest_backfill_start_at
+            earliest_backfill_start_at = earliest_backfill_start_at.astimezone(team.timezone_info)
+
+            if end_at is not None and end_at < earliest_backfill_start_at:
+                raise ValidationError(
+                    "The provided backfill date range contains no data. The earliest possible backfill start date is "
+                    f"{earliest_backfill_start_at.strftime('%Y-%m-%d %H:%M:%S')}",
+                )
+
+            if start_at is not None and start_at < earliest_backfill_start_at:
+                logger.info(
+                    "Backfill start_at '%s' is before the earliest possible backfill start_at '%s', setting start_at "
+                    "to earliest_backfill_start_at",
+                    start_at,
+                    earliest_backfill_start_at,
+                )
+                start_at = earliest_backfill_start_at
+        except NotImplementedError:
+            logger.warning("No backfill check implemented for model: '%s'; skipping", batch_export.model)
 
     if start_at is None or end_at is None:
         return backfill_export(temporal, str(batch_export.pk), team.pk, start_at, end_at)

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -877,9 +877,10 @@ def fetch_earliest_backfill_start_at(
         exclude_events = exclude_events or []
         include_events = include_events or []
         query = """
-            SELECT toStartOfInterval(MIN(timestamp), INTERVAL %(interval_seconds)s SECONDS)
+            SELECT MIN(toStartOfInterval(timestamp, INTERVAL %(interval_seconds)s SECONDS))
             FROM events
             WHERE team_id = %(team_id)s
+            AND timestamp > '2000-01-01'
             AND (length(%(include_events)s::Array(String)) = 0 OR event IN %(include_events)s::Array(String))
             AND (length(%(exclude_events)s::Array(String)) = 0 OR event NOT IN %(exclude_events)s::Array(String))
         """
@@ -925,7 +926,7 @@ def fetch_earliest_backfill_start_at(
             return None
         return min(results)
     else:
-        raise ValueError(f"Invalid model: {model}")
+        raise NotImplementedError(f"Invalid model: {model}")
 
 
 @dataclass(kw_only=True)


### PR DESCRIPTION
## Problem

There are a couple of issues with the check for the earliest possible backfill date:
1. If we haven't implemented a check for a given model (eg sessions) we raise an error
2. If the earliest event timestamp is way in the past (eg 1900) then calling `toStartOfInterval` on this can cause an unexpected underflow and actually return a date in the future

## Changes

1. Don't run the check if one hasn't been implemented for a given model
2. Add a lower bound for the timestamp filter and also change the ordering of the `min` and `toStartOfInterval`

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Existing tests
