### PR TITLE
fix: set posthoganalytics key in asgi

### DIFF
--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -33,7 +33,7 @@ class PostHogConfig(AppConfig):
         elif settings.DEBUG:
             # In dev, analytics is by default turned to self-capture, i.e. data going into this very instance of PostHog
             # Due to ASGI's workings, we can't query for the right project API key in this `ready()` method
-            # Instead, we configure self-capture with `self_capture_wrapper()` - see posthog/asgi.py
+            # Instead, we configure self-capture with `self_capture_wrapper()` in posthog/asgi.py - see that file
             posthoganalytics.disabled = True
 
             # log development server launch to posthog

--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -2,15 +2,14 @@ import os
 
 import posthoganalytics
 import structlog
-from django.apps import AppConfig, apps
+from django.apps import AppConfig
 from django.conf import settings
 from posthoganalytics.client import Client
 from posthoganalytics.exception_capture import Integrations
 
 from posthog.git import get_git_branch, get_git_commit_short
-from posthog.settings import SELF_CAPTURE, SKIP_ASYNC_MIGRATIONS_SETUP
 from posthog.tasks.tasks import sync_all_organization_available_product_features
-from posthog.utils import get_machine_id, get_self_capture_api_token
+from posthog.utils import get_machine_id
 
 logger = structlog.get_logger(__name__)
 
@@ -32,7 +31,10 @@ class PostHogConfig(AppConfig):
         elif settings.TEST or os.environ.get("OPT_OUT_CAPTURE", False):
             posthoganalytics.disabled = True
         elif settings.DEBUG:
-            User = apps.get_model("posthog", "User")
+            # In dev, analytics is by default turned to self-capture, i.e. data going into this very instance of PostHog
+            # Due to ASGI's workings, we can't query for the right project API key in this `ready()` method
+            # Instead, we configure self-capture with `self_capture_wrapper()` - see posthog/asgi.py
+            posthoganalytics.disabled = True
 
             # log development server launch to posthog
             if os.getenv("RUN_MAIN") == "true":
@@ -48,25 +50,13 @@ class PostHogConfig(AppConfig):
                     {"git_rev": get_git_commit_short(), "git_branch": get_git_branch()},
                 )
 
-            try:
-                user = User.objects.filter(last_login__isnull=False).order_by("-last_login").first()
-                local_api_key = get_self_capture_api_token(user)
-            except:
-                local_api_key = None
-
-            if SELF_CAPTURE and local_api_key:
-                posthoganalytics.api_key = local_api_key
-                posthoganalytics.host = settings.SITE_URL
-            else:
-                posthoganalytics.disabled = True
-
         # load feature flag definitions if not already loaded
         if not posthoganalytics.disabled and posthoganalytics.feature_flag_definitions() is None:
             posthoganalytics.load_feature_flags()
 
         from posthog.async_migrations.setup import setup_async_migrations
 
-        if SKIP_ASYNC_MIGRATIONS_SETUP:
+        if settings.SKIP_ASYNC_MIGRATIONS_SETUP:
             logger.warning("Skipping async migrations setup. This is unsafe in production!")
         else:
             setup_async_migrations()

--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -35,7 +35,10 @@ class PostHogConfig(AppConfig):
             # In dev, analytics is by default turned to self-capture, i.e. data going into this very instance of PostHog
             # Due to ASGI's workings, we can't query for the right project API key in this `ready()` method
             # Instead, we configure self-capture with `self_capture_wrapper()` in posthog/asgi.py - see that file
+            # Self-capture for WSGI is initialized here
             posthoganalytics.disabled = True
+            if settings.SERVER_GATEWAY_INTERFACE == "WSGI":
+                async_to_sync(initialize_self_capture_api_token)()
 
             # log development server launch to posthog
             if os.getenv("RUN_MAIN") == "true":
@@ -50,8 +53,6 @@ class PostHogConfig(AppConfig):
                     "development server launched",
                     {"git_rev": get_git_commit_short(), "git_branch": get_git_branch()},
                 )
-            if settings.SERVER_GATEWAY_INTERFACE == "WSGI":
-                async_to_sync(initialize_self_capture_api_token)()
 
         # load feature flag definitions if not already loaded
         if not posthoganalytics.disabled and posthoganalytics.feature_flag_definitions() is None:

--- a/posthog/asgi.py
+++ b/posthog/asgi.py
@@ -29,7 +29,7 @@ def wrap_debug_analytics(func):
 
             await aset_debugging_analytics_key()
             # Set a flag to indicate that the analytics key has been set, so we don't run the code on every request.
-            inner.debug_analytics_initialized = True
+            inner.debug_analytics_initialized = True  # type: ignore
         return await func(scope, receive, send)
 
     return inner

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -13,7 +13,6 @@ import string
 import time
 import uuid
 import zlib
-from django.apps import apps
 from collections.abc import Generator, Mapping
 from enum import Enum
 from functools import lru_cache, wraps
@@ -31,8 +30,10 @@ from celery.result import AsyncResult
 from celery.schedules import crontab
 from dateutil import parser
 from dateutil.relativedelta import relativedelta
+from django.apps import apps
 from django.conf import settings
 from django.core.cache import cache
+from django.db import ProgrammingError
 from django.db.utils import DatabaseError
 from django.http import HttpRequest, HttpResponse
 from django.template.loader import get_template
@@ -519,7 +520,7 @@ async def initialize_self_capture_api_token():
         else:
             team = await Team.objects.only("api_token").aget()
         local_api_key = team.api_token
-    except (User.DoesNotExist, Team.DoesNotExist):
+    except (User.DoesNotExist, Team.DoesNotExist, ProgrammingError):
         local_api_key = None
 
     # This is running _after_ PostHogConfig.ready(), so we re-enable posthoganalytics while setting the params


### PR DESCRIPTION
## Problem

Django has been running on ASGI in debug mode for two days. Suddenly, local LLM traces stopped working somewhere around that time. The root problem is in the `posthog.apps.PostHogConfig.ready()` method, which now runs in an async context, so the ORM must also be called in async mode. However, the `ready()` method doesn't have an async alternative—[Detailed explanation](https://forum.djangoproject.com/t/orm-call-in-app-ready-in-asgi-mode/1348/9).

## Changes

Add a debug-only wrapper for the ASGI web server, which initializes the `posthoganalytics` package. @Twixes, you might have a better idea of how we can fix it.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manual and local testing.
