### PR TITLE
fix: person popover position in replay

### DIFF
--- a/frontend/src/scenes/persons/PersonDisplay.tsx
+++ b/frontend/src/scenes/persons/PersonDisplay.tsx
@@ -27,6 +27,7 @@ export interface PersonDisplayProps {
     isCentered?: boolean
     children?: React.ReactChild
     withCopyButton?: boolean
+    placement?: 'top' | 'bottom' | 'left' | 'right'
 }
 
 export function PersonIcon({
@@ -64,6 +65,7 @@ export function PersonDisplay({
     href = asLink(person),
     children,
     withCopyButton,
+    placement,
 }: PersonDisplayProps): JSX.Element {
     const display = asDisplay(person)
     const [visible, setVisible] = useState(false)
@@ -125,7 +127,7 @@ export function PersonDisplay({
                 }
                 visible={visible}
                 onClickOutside={() => setVisible(false)}
-                placement="top"
+                placement={placement || 'top'}
                 fallbackPlacements={['bottom', 'right']}
                 showArrow
             >

--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarOverviewTab.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarOverviewTab.tsx
@@ -12,7 +12,7 @@ export function PlayerSidebarOverviewTab(): JSX.Element {
 
     return (
         <div className="flex flex-col overflow-auto bg-primary px-2 py-1 h-full space-y-1">
-            <PersonDisplay person={sessionPerson} withIcon withCopyButton />
+            <PersonDisplay person={sessionPerson} withIcon withCopyButton placement="bottom" />
             <PlayerSidebarOverviewGrid />
             <PlayerSidebarSessionSummary />
         </div>


### PR DESCRIPTION
see: https://posthoghelp.zendesk.com/agent/tickets/25205 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/26825)

The person popover opens above the click target by default. In replay that means it opens with not much space... this has got worse as we've reclaimed vertical space for the player.

I spent a while fighting the positioning hook before I realised we can just default to opening below the click target in replay 🙈 

| before | after |
| - | - | 
| ![Screenshot 2025-02-12 at 16 49 19](https://github.com/user-attachments/assets/3f49b7df-cc2e-4180-a042-a64234503712)| ![Screenshot 2025-02-12 at 17 46 18](https://github.com/user-attachments/assets/3329246c-2668-4f7d-bc19-335e8fa20db0)|
