### PR TITLE
fix: add scope overrides for writing to a team

### DIFF
--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -570,6 +570,7 @@ class ProjectViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets
     @action(
         methods=["PATCH"],
         detail=True,
+        required_scopes=["team:read"],
     )
     def add_product_intent(self, request: request.Request, *args, **kwargs):
         project = self.get_object()
@@ -609,7 +610,17 @@ class ProjectViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets
 
         return response.Response(TeamSerializer(team, context=self.get_serializer_context()).data, status=201)
 
-    @action(methods=["PATCH"], detail=True)
+    # Override patch method to only require team:read scope - this is a temporary change until we
+    # split the patch requests into ones allowed vs ones not allowed
+    @action(required_scopes=["team:read"])
+    def patch(self, request, *args, **kwargs):
+        return super().patch(request, *args, **kwargs)
+
+    @action(
+        methods=["PATCH"],
+        detail=True,
+        required_scopes=["team:read"],
+    )
     def complete_product_onboarding(self, request: request.Request, *args, **kwargs):
         project = self.get_object()
         team = project.passthrough_team

--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -612,8 +612,8 @@ class ProjectViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets
 
     # Override patch method to only require team:read scope - this is a temporary change until we
     # split the patch requests into ones allowed vs ones not allowed
-    @action(required_scopes=["team:read"])
     def patch(self, request, *args, **kwargs):
+        self.required_scopes = ["team:read"]
         return super().patch(request, *args, **kwargs)
 
     @action(

--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -610,12 +610,6 @@ class ProjectViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets
 
         return response.Response(TeamSerializer(team, context=self.get_serializer_context()).data, status=201)
 
-    # Override patch method to only require team:read scope - this is a temporary change until we
-    # split the patch requests into ones allowed vs ones not allowed
-    def patch(self, request, *args, **kwargs):
-        self.required_scopes = ["team:read"]
-        return super().patch(request, *args, **kwargs)
-
     @action(
         methods=["PATCH"],
         detail=True,

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -593,8 +593,8 @@ class TeamViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.Mo
 
     # Override patch method to only require team:read scope - this is a temporary change until we
     # split the patch requests into ones allowed vs ones not allowed
-    @action(required_scopes=["team:read"])
     def patch(self, request, *args, **kwargs):
+        self.required_scopes = ["team:read"]
         return super().patch(request, *args, **kwargs)
 
     @action(

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -591,6 +591,12 @@ class TeamViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.Mo
         # TRICKY: We pass in `team` here as access to `user.current_team` can fail if it was deleted
         report_user_action(user, f"team deleted", team=team)
 
+    # Override patch method to only require team:read scope - this is a temporary change until we
+    # split the patch requests into ones allowed vs ones not allowed
+    @action(required_scopes=["team:read"])
+    def patch(self, request, *args, **kwargs):
+        return super().patch(request, *args, **kwargs)
+
     @action(
         methods=["PATCH"],
         detail=True,
@@ -630,6 +636,7 @@ class TeamViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.Mo
     @action(
         methods=["PATCH"],
         detail=True,
+        required_scopes=["team:read"],
     )
     def add_product_intent(self, request: request.Request, *args, **kwargs):
         team = self.get_object()
@@ -683,7 +690,11 @@ class TeamViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.Mo
 
         return response.Response(TeamSerializer(team, context=self.get_serializer_context()).data, status=201)
 
-    @action(methods=["PATCH"], detail=True)
+    @action(
+        methods=["PATCH"],
+        detail=True,
+        required_scopes=["team:read"],
+    )
     def complete_product_onboarding(self, request: request.Request, *args, **kwargs):
         team = self.get_object()
         product_type = request.data.get("product_type")

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -591,12 +591,6 @@ class TeamViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.Mo
         # TRICKY: We pass in `team` here as access to `user.current_team` can fail if it was deleted
         report_user_action(user, f"team deleted", team=team)
 
-    # Override patch method to only require team:read scope - this is a temporary change until we
-    # split the patch requests into ones allowed vs ones not allowed
-    def patch(self, request, *args, **kwargs):
-        self.required_scopes = ["team:read"]
-        return super().patch(request, *args, **kwargs)
-
     @action(
         methods=["PATCH"],
         detail=True,

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -1184,6 +1184,53 @@ def team_api_test_factory():
                 team=self.team,
             )
 
+        @patch("posthog.api.project.report_user_action")
+        @patch("posthog.api.team.report_user_action")
+        def test_can_complete_product_onboarding_as_member(
+            self, mock_report_user_action: MagicMock, mock_report_user_action_legacy_endpoint: MagicMock
+        ) -> None:
+            from ee.models import ExplicitTeamMembership
+
+            self.organization_membership.level = OrganizationMembership.Level.MEMBER
+            self.organization_membership.save()
+            self.team.access_control = True
+            self.team.save()
+            ExplicitTeamMembership.objects.create(
+                team=self.team,
+                parent_membership=self.organization_membership,
+                level=ExplicitTeamMembership.Level.MEMBER,
+            )
+
+            if self.client_class is EnvironmentToProjectRewriteClient:
+                mock_report_user_action = mock_report_user_action_legacy_endpoint
+            with freeze_time("2024-01-01T00:00:00Z"):
+                product_intent = ProductIntent.objects.create(team=self.team, product_type="product_analytics")
+            assert product_intent.created_at == datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+            assert product_intent.onboarding_completed_at is None
+            with freeze_time("2024-01-05T00:00:00Z"):
+                response = self.client.patch(
+                    f"/api/environments/{self.team.id}/complete_product_onboarding/",
+                    {"product_type": "product_analytics"},
+                    headers={"Referer": "https://posthogtest.com/my-url", "X-Posthog-Session-Id": "test_session_id"},
+                )
+            assert response.status_code == status.HTTP_200_OK
+            product_intent = ProductIntent.objects.get(team=self.team, product_type="product_analytics")
+            assert product_intent.onboarding_completed_at == datetime(2024, 1, 5, 0, 0, 0, tzinfo=UTC)
+            mock_report_user_action.assert_called_once_with(
+                self.user,
+                "product onboarding completed",
+                {
+                    "product_key": "product_analytics",
+                    "$current_url": "https://posthogtest.com/my-url",
+                    "$session_id": "test_session_id",
+                    "intent_context": None,
+                    "intent_created_at": datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC),
+                    "intent_updated_at": datetime(2024, 1, 5, 0, 0, 0, tzinfo=UTC),
+                    "realm": get_instance_realm(),
+                },
+                team=self.team,
+            )
+
         def _create_other_org_and_team(
             self, membership_level: OrganizationMembership.Level = OrganizationMembership.Level.ADMIN
         ):
@@ -1277,29 +1324,6 @@ def team_api_test_factory():
             response = self.client.patch("/api/environments/@current/", {"session_recording_linked_flag": config})
             assert response.status_code == expected_status, response.json()
             return response
-
-        def test_member_can_write_to_private_project_with_patch_access(self):
-            from ee.models import ExplicitTeamMembership
-
-            self.organization_membership.level = OrganizationMembership.Level.MEMBER
-            self.organization_membership.save()
-            self.team.access_control = True
-            self.team.save()
-            ExplicitTeamMembership.objects.create(
-                team=self.team,
-                parent_membership=self.organization_membership,
-                level=ExplicitTeamMembership.Level.MEMBER,
-            )
-
-            # Give the user explicit write access to the private project
-            response = self.client.patch(
-                f"/api/projects/{self.team.id}/",
-                {"name": "New Project Name"},
-                format="json",
-            )
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
-            self.team.refresh_from_db()
-            self.assertEqual(self.team.name, "New Project Name")
 
     return TestTeamAPI
 


### PR DESCRIPTION
## Changes

Reported by @joshsny (https://posthog.slack.com/archives/C07UWTB25S9/p1739355518463329)

Related to RBAC changes: https://github.com/PostHog/posthog/issues/24512

If projects are set to private (no access) then members with access to the project don't have permission to write to the team/project endpoints. This has been live for a while but not reported because it only affects a small number of users (0.292% of projects in the US and 1.38% in the EU are private). This is technically how it should be and RBAC fixed a whole that was previously present (I think).

This change allows write access to specific PATCH team endpoints if you have read access. This is not giving access to the team PATCH endpoint as that allows for too much access from a member. In the client, there are 57 instances where PATCH /api/team is called. Over the next few weeks, I'll review all of those and break out the ones where members should have access into more granular endpoints with better control of who can write to what fields on the team. 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

It doesn't have an impact.

## How did you test this code?

Added a test