### PR TITLE
fix(local_evaluation): remove filter condition

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -760,7 +760,7 @@ class FeatureFlagViewSet(
     )
     def local_evaluation(self, request: request.Request, **kwargs):
         feature_flags: QuerySet[FeatureFlag] = FeatureFlag.objects.db_manager(DATABASE_FOR_LOCAL_EVALUATION).filter(
-            team__project_id=self.project_id, deleted=False, active=True
+            team__project_id=self.project_id, deleted=False
         )
 
         should_send_cohorts = "send_cohorts" in request.GET

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -4789,7 +4789,7 @@ class TestDecideUsesReadReplica(TransactionTestCase):
             self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
         self.assertTrue("flags" in response_data and "group_type_mapping" in response_data)
-        self.assertEqual(len(response_data["flags"]), 3)
+        self.assertEqual(len(response_data["flags"]), 4)
 
         sorted_flags = sorted(response_data["flags"], key=lambda x: x["key"])
 

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -4858,6 +4858,18 @@ class TestDecideUsesReadReplica(TransactionTestCase):
             sorted_flags[2],
         )
 
+        self.assertDictContainsSubset(
+            {
+                "name": "Inactive feature",
+                "key": "inactive-flag",
+                "filters": {"groups": [{"properties": [], "rollout_percentage": 100}]},
+                "deleted": False,
+                "active": False,
+                "ensure_experience_continuity": False,
+            },
+            sorted_flags[3],
+        )
+
         self.assertEqual(response_data["group_type_mapping"], {"0": "organization", "1": "company"})
 
     @patch("posthog.api.feature_flag.report_user_action")

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -2365,7 +2365,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
         self.assertTrue("flags" in response_data and "group_type_mapping" in response_data)
-        self.assertEqual(len(response_data["flags"]), 3)  # inactive flags not sent
+        self.assertEqual(len(response_data["flags"]), 4)
 
         sorted_flags = sorted(response_data["flags"], key=lambda x: x["key"])
 


### PR DESCRIPTION
## Problem

Here's the sitch: right now we omit disabled flags from the list returned via the /local_evaluation endpoint ([source](https://github.com/PostHog/posthog/blob/master/posthog/api/feature_flag.py#L762-L764)) – this creates a problem for users that disable flags but still call them.  Users expect the flag to be disabled and are fine with it evaluating to false, but since the flag is omitted from the /local_evaluation response, we fall back to the server to evaluate it.
This means that if someone is using local eval to save money on decide requests, but then they disable a flag in a hot path, they'll see their request count rise in an unexpected way.  No me gusta.  I feel like the fix here is to include disabled flags in the local eval response payload, especially since our SDKs already handle evaluating disabled (`!flag.active`) flags when computing flags locally.

Customer ticket about this: https://posthoghelp.zendesk.com/agent/tickets/25083 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/26633)