### PR TITLE
feat: add ability to run migrations from admin

### DIFF
--- a/posthog/admin/admins/organization_admin.py
+++ b/posthog/admin/admins/organization_admin.py
@@ -15,6 +15,8 @@ from django.urls import path
 from django.shortcuts import render, redirect
 from django.contrib import messages
 from django import forms
+from posthog.rbac.migrations.rbac_team_migration import rbac_team_access_control_migration
+from posthog.rbac.migrations.rbac_feature_flag_migration import rbac_feature_flag_role_access_migration
 
 
 class UsageReportForm(forms.Form):
@@ -94,6 +96,16 @@ class OrganizationAdmin(admin.ModelAdmin):
             path(
                 "send-usage-report/", self.admin_site.admin_view(self.send_usage_report_view), name="send-usage-report"
             ),
+            path(
+                "<str:organization_id>/run-rbac-team-migration/",
+                self.admin_site.admin_view(self.run_rbac_team_migration),
+                name="run-rbac-team-migration",
+            ),
+            path(
+                "<str:organization_id>/run-rbac-feature-flag-migration/",
+                self.admin_site.admin_view(self.run_rbac_feature_flag_migration),
+                name="run-rbac-feature-flag-migration",
+            ),
         ]
         return custom_urls + urls
 
@@ -118,3 +130,26 @@ class OrganizationAdmin(admin.ModelAdmin):
         extra_context = extra_context or {}
         extra_context["show_usage_report_button"] = True
         return super().changelist_view(request, extra_context=extra_context)
+
+    def run_rbac_team_migration(self, request, organization_id):
+        try:
+            organization = Organization.objects.get(id=organization_id)
+            rbac_team_access_control_migration(organization.id)
+            messages.success(request, f"RBAC team migration completed successfully for {organization.name}")
+        except Exception as e:
+            messages.error(request, f"Error running RBAC team migration: {str(e)}")
+        return redirect(reverse("admin:posthog_organization_change", args=[organization_id]))
+
+    def run_rbac_feature_flag_migration(self, request, organization_id):
+        try:
+            organization = Organization.objects.get(id=organization_id)
+            rbac_feature_flag_role_access_migration(organization.id)
+            messages.success(request, f"RBAC feature flag migration completed successfully for {organization.name}")
+        except Exception as e:
+            messages.error(request, f"Error running RBAC feature flag migration: {str(e)}")
+        return redirect(reverse("admin:posthog_organization_change", args=[organization_id]))
+
+    def change_view(self, request, object_id, form_url="", extra_context=None):
+        extra_context = extra_context or {}
+        extra_context["show_rbac_migration_buttons"] = True
+        return super().change_view(request, object_id, form_url, extra_context=extra_context)

--- a/posthog/admin/admins/organization_admin.py
+++ b/posthog/admin/admins/organization_admin.py
@@ -151,5 +151,7 @@ class OrganizationAdmin(admin.ModelAdmin):
 
     def change_view(self, request, object_id, form_url="", extra_context=None):
         extra_context = extra_context or {}
-        extra_context["show_rbac_migration_buttons"] = True
+        if not request.user.groups.filter(name="Billing Team").exists():
+            extra_context["show_rbac_migration_buttons"] = True
+
         return super().change_view(request, object_id, form_url, extra_context=extra_context)

--- a/posthog/admin/admins/organization_admin.py
+++ b/posthog/admin/admins/organization_admin.py
@@ -132,6 +132,10 @@ class OrganizationAdmin(admin.ModelAdmin):
         return super().changelist_view(request, extra_context=extra_context)
 
     def run_rbac_team_migration(self, request, organization_id):
+        if not request.user.groups.filter(name="Billing Team").exists():
+            messages.error(request, "You are not authorized to run RBAC team migrations.")
+            return redirect(reverse("admin:posthog_organization_changelist"))
+
         try:
             organization = Organization.objects.get(id=organization_id)
             rbac_team_access_control_migration(organization.id)
@@ -141,6 +145,10 @@ class OrganizationAdmin(admin.ModelAdmin):
         return redirect(reverse("admin:posthog_organization_change", args=[organization_id]))
 
     def run_rbac_feature_flag_migration(self, request, organization_id):
+        if not request.user.groups.filter(name="Billing Team").exists():
+            messages.error(request, "You are not authorized to run RBAC feature flag migrations.")
+            return redirect(reverse("admin:posthog_organization_changelist"))
+
         try:
             organization = Organization.objects.get(id=organization_id)
             rbac_feature_flag_role_access_migration(organization.id)

--- a/posthog/templates/admin/posthog/organization/change_form.html
+++ b/posthog/templates/admin/posthog/organization/change_form.html
@@ -1,0 +1,17 @@
+{% extends "admin/change_form.html" %}
+{% load i18n %}
+
+{% block submit_buttons_bottom %}
+    {{ block.super }}
+    {% if show_rbac_migration_buttons %}
+        <div class="submit-row" style="margin-top: 20px;">
+            <input type="button" value="Run RBAC Team Migration" 
+                onclick="if(confirm('Are you sure you want to run the RBAC team migration?')) { window.location.href='{% url 'admin:run-rbac-team-migration' object_id %}'; }"
+                style="background: #79aec8; padding: 10px 15px; border: none; border-radius: 4px; color: #fff; cursor: pointer;">
+            
+            <input type="button" value="Run RBAC Feature Flag Migration"
+                onclick="if(confirm('Are you sure you want to run the RBAC feature flag migration?')) { window.location.href='{% url 'admin:run-rbac-feature-flag-migration' object_id %}'; }"
+                style="background: #79aec8; padding: 10px 15px; border: none; border-radius: 4px; color: #fff; cursor: pointer;">
+        </div>
+    {% endif %}
+{% endblock %} 


### PR DESCRIPTION
## Changes

Follow along for RBAC: https://github.com/PostHog/posthog/issues/24512

I want to be able to run these migrations for companies quicker without logging into their account. This will only show for the growth team in admin. 

![Screenshot 2025-02-12 at 3 21 43 PM](https://github.com/user-attachments/assets/04c75c35-b6b9-4f2b-8f03-bb2482743792)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
