### PR TITLE
chore: add events for migration runs

### DIFF
--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -35,6 +35,7 @@ from posthog.rbac.migrations.rbac_team_migration import rbac_team_access_control
 from posthog.rbac.migrations.rbac_feature_flag_migration import rbac_feature_flag_role_access_migration
 from sentry_sdk import capture_exception
 from drf_spectacular.utils import extend_schema
+from posthog.event_usage import report_organization_action
 
 
 class PremiumMultiorganizationPermissions(permissions.BasePermission):
@@ -277,9 +278,18 @@ class OrganizationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         self.check_object_permissions(request, organization)
 
         try:
+            user = cast(User, request.user)
+            report_organization_action(organization, "rbac_team_migration_started", {"user": user.distinct_id})
+
             rbac_team_access_control_migration(organization.id)
             rbac_feature_flag_role_access_migration(organization.id)
+
+            report_organization_action(organization, "rbac_team_migration_completed", {"user": user.distinct_id})
+
         except Exception as e:
+            report_organization_action(
+                organization, "rbac_team_migration_failed", {"user": user.distinct_id, "error": str(e)}
+            )
             capture_exception(e)
             return Response({"status": False, "error": "An internal error has occurred."}, status=500)
 


### PR DESCRIPTION
## Changes

Follow along for RBAC changes: https://github.com/PostHog/posthog/issues/24512

Adding in event calls for actions 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

It doesn't have an impact.

## How did you test this code?

Update mocks for tests
