### PR TITLE
fix: HogQL expression to SQL

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -487,11 +487,11 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         getIcon: getPropertyDefinitionIcon,
                     },
                     {
-                        name: 'HogQL expression',
+                        name: 'SQL expression',
                         searchPlaceholder: null,
                         type: TaxonomicFilterGroupType.HogQLExpression,
                         render: InlineHogQLEditor,
-                        getPopoverHeader: () => 'HogQL expression',
+                        getPopoverHeader: () => 'SQL expression',
                         componentProps: { metadataSource },
                     },
                     {


### PR DESCRIPTION
## Problem

HogQL expression label still shows on filters, but it should be SQL for consistency

![CleanShot 2025-02-12 at 13 20 56@2x](https://github.com/user-attachments/assets/4fd953e1-dd00-4c48-a05e-b62030527e6d)

To match: https://github.com/PostHog/posthog/pull/28471

## Changes

Change HogQL label to SQL in filters

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Automated tests take the wheel

(Please merge for me because it will take me like one whole day to get local dev working)
