### PR TITLE
fix: make NPS-rating question consider all survey iterations

### DIFF
--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -512,7 +512,6 @@ export function SurveyResult({ disableEventsTable }: { disableEventsTable?: bool
                                 surveyRatingResults={surveyRatingResults}
                                 surveyRatingResultsReady={surveyRatingResultsReady}
                                 questionIndex={i}
-                                iteration={survey.current_iteration}
                             />
 
                             {survey.iteration_count &&

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -316,10 +316,8 @@ export const surveyLogic = kea<surveyLogicType>([
         surveyRatingResults: {
             loadSurveyRatingResults: async ({
                 questionIndex,
-                iteration,
             }: {
                 questionIndex: number
-                iteration?: number | null | undefined
             }): Promise<SurveyRatingResults> => {
                 const question = values.survey.questions[questionIndex]
                 if (question.type !== SurveyQuestionType.Rating) {
@@ -341,7 +339,6 @@ export const surveyLogic = kea<surveyLogicType>([
                         FROM events
                         WHERE event = 'survey sent'
                             AND properties.$survey_id = '${props.id}'
-                            ${iteration && iteration > 0 ? ` AND properties.$survey_iteration='${iteration}' ` : ''}
                             AND timestamp >= '${startDate}'
                             AND timestamp <= '${endDate}'
                             AND {filters}

--- a/frontend/src/scenes/surveys/surveyViewViz.tsx
+++ b/frontend/src/scenes/surveys/surveyViewViz.tsx
@@ -189,24 +189,18 @@ export function RatingQuestionBarChart({
     questionIndex,
     surveyRatingResults,
     surveyRatingResultsReady,
-    iteration,
 }: {
     questionIndex: number
     surveyRatingResults: SurveyRatingResults
     surveyRatingResultsReady: QuestionResultsReady
     iteration?: number | null | undefined
 }): JSX.Element {
-    const { loadSurveyRatingResults } = useActions(surveyLogic)
     const { survey } = useValues(surveyLogic)
     const barColor = '#1d4aff'
     const question = survey.questions[questionIndex]
     if (question.type !== SurveyQuestionType.Rating) {
         throw new Error(`Question type must be ${SurveyQuestionType.Rating}`)
     }
-    useEffect(() => {
-        loadSurveyRatingResults({ questionIndex, iteration })
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [questionIndex])
 
     return (
         <div>


### PR DESCRIPTION
## Problem

right now, if you have a recurring NPS survey, but you're past the first iteration, you no longer get data from the first iteration.

Instead, we should always query for all the data, as it can happen where the current iteration has no data available, and their NPS result will be "No data available", even though there is data.

Will fix this support ticket: https://posthoghelp.zendesk.com/agent/tickets/24307 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/27652)

## Changes

Remove forced iteration filter on Survey Rating Results Chart.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

All tests still running; manually tested if nps survey now includes all data