### PR TITLE
feat: Add Dagster job for managing column materializations

### DIFF
--- a/dags/definitions.py
+++ b/dags/definitions.py
@@ -12,6 +12,7 @@ from dagster import fs_io_manager
 from django.conf import settings
 
 from . import ch_examples, deletes, orm_examples
+from .materialized_columns import materialize_column
 from .person_overrides import ClickhouseClusterResource, squash_person_overrides
 
 all_assets = load_assets_from_modules([ch_examples, orm_examples])
@@ -58,7 +59,7 @@ def run_deletes_after_squash(context):
 
 defs = Definitions(
     assets=all_assets,
-    jobs=[squash_person_overrides, deletes.deletes_job],
+    jobs=[squash_person_overrides, deletes.deletes_job, materialize_column],
     schedules=[squash_schedule],
     sensors=[run_deletes_after_squash],
     resources=resources,

--- a/dags/materialized_columns.py
+++ b/dags/materialized_columns.py
@@ -1,8 +1,8 @@
-from dataclasses import dataclass
 import datetime
-from functools import reduce
 import itertools
 from collections.abc import Iterator
+from dataclasses import dataclass
+from functools import reduce
 from typing import ClassVar
 
 import dagster
@@ -40,7 +40,7 @@ class PartitionRange(dagster.Config):
     @pydantic.model_validator(mode="after")
     def validate_bounds(self):
         if not self.parse_date(self.lower) <= self.parse_date(self.upper):
-            raise ValueError("expected lower bound to be less (or equal to) upper bound")
+            raise ValueError("expected lower bound to be less than (or equal to) upper bound")
         return self
 
     @classmethod
@@ -131,7 +131,7 @@ def run_materialize_mutations(
     requested_partitions = set(config.partitions.iter_ids())
     remaining_partitions = reduce(lambda x, y: x | y, remaining_partitions_by_shard.values())
     context.log.info(
-        "Materializing %s of %s requested partitions (%s already materialized)",
+        "Materializing %s of %s requested partitions (%s already materialized in all shards)",
         len(remaining_partitions),
         len(requested_partitions),
         len(requested_partitions - remaining_partitions),

--- a/dags/materialized_columns.py
+++ b/dags/materialized_columns.py
@@ -110,7 +110,7 @@ class MaterializeColumnInPartitionTask:
             self.table,
             f"MATERIALIZE COLUMN {self.column} IN PARTITION %(partition)s",
             {"partition": self.partition},
-        ).enqueue(client).wait()
+        ).enqueue(client).wait(client)
 
 
 @dagster.op

--- a/dags/materialized_columns.py
+++ b/dags/materialized_columns.py
@@ -127,12 +127,13 @@ def run_materialize_mutations(
         mutation.wait()
 
     for partition in sorted(remaining_partitions, reverse=True):
-        # TODO: need a cluster function to target one host per shard based on key
-        _tasks = {
-            shard: partial(materialize_column_in_partition, partition)
-            for shard, partitions in remaining_partitions_by_shard.values()
-            if partition in partitions
-        }
+        cluster.map_any_host_in_shards(
+            {
+                shard: partial(materialize_column_in_partition, partition)
+                for shard, partitions in remaining_partitions_by_shard.values()
+                if partition in partitions
+            }
+        ).result()
 
 
 @dagster.job

--- a/dags/materialized_columns.py
+++ b/dags/materialized_columns.py
@@ -1,0 +1,84 @@
+from collections.abc import Iterable
+
+import concurrent.futures
+import dagster
+from clickhouse_driver import Client
+
+from posthog import settings
+from posthog.clickhouse.cluster import ClickhouseCluster, MutationRunner
+
+
+class MaterializeColumnConfig(dagster.Config):
+    table: str
+    column: str  # TODO: maybe make this a list/set so we can minimize the number of mutations?
+    from_partition: str
+    to_partition: str
+
+    def partitions(self) -> Iterable[str]:
+        raise NotImplementedError
+
+
+@dagster.op
+def run_materialize_mutations(config: MaterializeColumnConfig, cluster: dagster.ResourceParam[ClickhouseCluster]):
+    def materialize_column_for_shard(client: Client) -> None:
+        # The primary key column(s) should exist in all parts, so we can determine what parts (and partitions) do not
+        # have the target column materialized by finding parts where the key column exists but the target column does
+        # not. Since this is only being run on a single host in the shard, we're assuming that the other hosts either
+        # have the same set of partitions already materialized, or that a materialization mutation already exists (and
+        # is running) if they are lagging behind. (If _this_ host is lagging behind the others, the mutation runner
+        # should prevent us from scheduling duplicate mutations on the shard.)
+        [[key_column]] = client.execute(
+            """
+            SELECT name
+            FROM system.columns
+            WHERE
+                database = %(database)s
+                AND table = %(table)s
+                AND is_in_primary_key
+            ORDER BY position
+            LIMIT 1
+            """,
+            {"database": settings.CLICKHOUSE_DATABASE, "table": config.table},
+        )
+
+        remaining_partitions = client.execute(
+            """
+            SELECT partition
+            FROM system.parts_columns
+            WHERE
+                database = %(database)s
+                AND table = %(table)s
+                AND part_type != 'Compact'  -- can't get column sizes from compact parts; should be small enough to ignore anyway
+                AND active
+                AND column IN (%(key_column)s, %(column)s)
+                AND partition IN %(partitions)s
+            GROUP BY partition
+            HAVING countIf(column = %(key_column)s) > countIf(column = %(column)s)
+            ORDER BY partition DESC
+            """,
+            {
+                "database": settings.CLICKHOUSE_DATABASE,
+                "table": config.table,
+                "key_column": key_column,
+                "column": config.column,
+                "partitions": config.partitions,
+            },
+        )
+
+        for [partition] in remaining_partitions:
+            mutation = MutationRunner(
+                config.table,
+                "MATERIALIZE COLUMN %(column)s IN PARTITION %(partition)s",
+                {"column": settings.column, "partition": partition},
+            ).enqueue(client)
+            mutation.wait()
+
+    cluster.map_one_host_per_shard(materialize_column_for_shard).result(
+        # avoid getting into a situation where some shards stop making progress while others continue
+        return_when=concurrent.futures.FIRST_EXCEPTION,
+    )
+
+
+@dagster.job
+def materialize_column():
+    run_materialize_mutations()

--- a/dags/materialized_columns.py
+++ b/dags/materialized_columns.py
@@ -26,7 +26,7 @@ class PartitionRange(dagster.Config):
         while (cur_date := date_lower + relativedelta(months=next(seq))) <= date_upper:
             yield cur_date.strftime(self.FORMAT)
 
-    @validator("start", "stop")
+    @validator("lower", "upper")
     @classmethod
     def validate_format(cls, value: str) -> str:
         cls.parse_date(value)

--- a/dags/materialized_columns.py
+++ b/dags/materialized_columns.py
@@ -133,6 +133,8 @@ def run_materialize_mutations(
         len(requested_partitions - remaining_partitions),
     )
 
+    # Step through the remaining partitions, materializing the column in any shards where the column hasn't already been
+    # materialized.
     for partition in sorted(remaining_partitions, reverse=True):
         shard_tasks = {
             shard_num: MaterializeColumnInPartitionTask(config.table, config.column, partition).run

--- a/dags/tests/conftest.py
+++ b/dags/tests/conftest.py
@@ -2,3 +2,14 @@
 from posthog.conftest import django_db_setup
 
 __all__ = ["django_db_setup"]
+
+from collections.abc import Iterator
+
+import pytest
+
+from posthog.clickhouse.cluster import ClickhouseCluster, get_cluster
+
+
+@pytest.fixture
+def cluster(django_db_setup) -> Iterator[ClickhouseCluster]:
+    yield get_cluster()

--- a/dags/tests/test_deletes.py
+++ b/dags/tests/test_deletes.py
@@ -1,7 +1,5 @@
-from collections.abc import Iterator
 from datetime import datetime, timedelta
 from uuid import UUID
-
 
 import pytest
 from clickhouse_driver import Client
@@ -12,13 +10,8 @@ from dags.deletes import (
     PendingPersonEventDeletesTable,
     PendingDeletesDictionary,
 )
-from posthog.clickhouse.cluster import ClickhouseCluster, get_cluster
+from posthog.clickhouse.cluster import ClickhouseCluster
 from posthog.models.async_deletion import AsyncDeletion, DeletionType
-
-
-@pytest.fixture
-def cluster(django_db_setup) -> Iterator[ClickhouseCluster]:
-    yield get_cluster()
 
 
 @pytest.mark.django_db

--- a/dags/tests/test_materialized_columns.py
+++ b/dags/tests/test_materialized_columns.py
@@ -1,11 +1,12 @@
-from collections.abc import Iterator, Mapping
 import contextlib
+from collections.abc import Iterator, Mapping
 from datetime import datetime
 from uuid import UUID
-from clickhouse_driver import Client
+
 import dagster
 import pydantic
 import pytest
+from clickhouse_driver import Client
 
 from dags.materialized_columns import (
     MaterializeColumnConfig,
@@ -14,6 +15,7 @@ from dags.materialized_columns import (
     run_materialize_mutations,
 )
 from posthog.clickhouse.cluster import ClickhouseCluster
+from posthog.hogql.test.test_printer import materialized  # bad idea
 
 
 def test_partition_range_validation():
@@ -27,6 +29,15 @@ def test_partition_range_validation():
 
     with pytest.raises(pydantic.ValidationError):
         PartitionRange(lower="202401", upper="")
+
+
+@contextlib.contextmanager
+def stop_merges(cluster: ClickhouseCluster, table: str):
+    try:
+        cluster.map_all_hosts(lambda c: c.execute(f"SYSTEM STOP MERGES {table}")).result()
+        yield
+    finally:
+        cluster.map_all_hosts(lambda c: c.execute(f"SYSTEM START MERGES {table}")).result()
 
 
 @contextlib.contextmanager
@@ -45,14 +56,10 @@ def override_mergetree_settings(cluster: ClickhouseCluster, table: str, settings
 
 
 def test_sharded_table_job(cluster: ClickhouseCluster):
-    config = MaterializeColumnConfig(
-        table="sharded_events",
-        column="mat_$ip",  # TODO: create new materialized column
-        partitions=PartitionRange(lower="202401", upper="202412"),
-    )
+    partitions = PartitionRange(lower="202401", upper="202412")
 
     def populate_test_data(client: Client) -> None:
-        for date in config.partitions.iter_dates():
+        for date in partitions.iter_dates():
             dt = datetime(date.year, date.month, date.day)
             client.execute(
                 "INSERT INTO writable_events (timestamp, uuid) VALUES",
@@ -61,22 +68,29 @@ def test_sharded_table_job(cluster: ClickhouseCluster):
 
     with override_mergetree_settings(
         cluster,
-        config.table,
+        "sharded_events",
         {"min_bytes_for_wide_part": "1", "min_rows_for_wide_part": "1"},
     ):
         cluster.any_host(populate_test_data).result()
 
-    remaining_partitions_by_shard = cluster.map_one_host_per_shard(config.get_remaining_partitions).result()
-    for _shard_host, shard_partitions_remaining in remaining_partitions_by_shard.items():
-        assert shard_partitions_remaining == set(config.partitions.iter_ids())
+    with stop_merges(cluster, "sharded_events"), materialized("events", "$xyz") as column:
+        config = MaterializeColumnConfig(
+            table="sharded_events",
+            column=column.name,
+            partitions=partitions,
+        )
 
-    materialize_column.execute_in_process(
-        run_config=dagster.RunConfig(
-            {run_materialize_mutations.name: {"config": config.model_dump()}},
-        ),
-        resources={"cluster": cluster},
-    )
+        remaining_partitions_by_shard = cluster.map_one_host_per_shard(config.get_remaining_partitions).result()
+        for _shard_host, shard_partitions_remaining in remaining_partitions_by_shard.items():
+            assert shard_partitions_remaining == set(config.partitions.iter_ids())
 
-    remaining_partitions_by_shard = cluster.map_one_host_per_shard(config.get_remaining_partitions).result()
-    for _shard_host, shard_partitions_remaining in remaining_partitions_by_shard.items():
-        assert shard_partitions_remaining == set()
+        materialize_column.execute_in_process(
+            run_config=dagster.RunConfig(
+                {run_materialize_mutations.name: {"config": config.model_dump()}},
+            ),
+            resources={"cluster": cluster},
+        )
+
+        remaining_partitions_by_shard = cluster.map_one_host_per_shard(config.get_remaining_partitions).result()
+        for _shard_host, shard_partitions_remaining in remaining_partitions_by_shard.items():
+            assert shard_partitions_remaining == set()

--- a/dags/tests/test_materialized_columns.py
+++ b/dags/tests/test_materialized_columns.py
@@ -11,10 +11,11 @@ from dags.materialized_columns import (
 from posthog.clickhouse.cluster import ClickhouseCluster
 
 
-def test_partition_range():
+def test_partition_range_validation():
     assert set(PartitionRange(lower="202401", upper="202403").iter()) == {"202401", "202402", "202403"}
 
-    assert set(PartitionRange(lower="202403", upper="202401").iter()) == set()
+    with pytest.raises(pydantic.ValidationError):
+        PartitionRange(lower="202403", upper="202401")  # lower > upper
 
     with pytest.raises(pydantic.ValidationError):
         PartitionRange(lower="2024XX", upper="202403")

--- a/dags/tests/test_materialized_columns.py
+++ b/dags/tests/test_materialized_columns.py
@@ -14,3 +14,7 @@ def test_partition_range():
 
     with pytest.raises(pydantic.ValidationError):
         PartitionRange(lower="202401", upper="2024XX")
+
+
+def test_job():
+    raise NotImplementedError

--- a/dags/tests/test_materialized_columns.py
+++ b/dags/tests/test_materialized_columns.py
@@ -1,0 +1,16 @@
+import pydantic
+import pytest
+
+from dags.materialized_columns import PartitionRange
+
+
+def test_partition_range():
+    assert set(PartitionRange(lower="202401", upper="202403")) == {"202401", "202402", "202403"}
+
+    assert set(PartitionRange(lower="202403", upper="202401")) == set()
+
+    with pytest.raises(pydantic.ValidationError):
+        PartitionRange(lower="2024XX", upper="202403")
+
+    with pytest.raises(pydantic.ValidationError):
+        PartitionRange(lower="202401", upper="2024XX")

--- a/dags/tests/test_materialized_columns.py
+++ b/dags/tests/test_materialized_columns.py
@@ -21,10 +21,10 @@ def test_partition_range_validation():
         PartitionRange(lower="202403", upper="202401")  # lower > upper
 
     with pytest.raises(pydantic.ValidationError):
-        PartitionRange(lower="2024XX", upper="202403")
+        PartitionRange(lower="", upper="202403")
 
     with pytest.raises(pydantic.ValidationError):
-        PartitionRange(lower="202401", upper="2024XX")
+        PartitionRange(lower="202401", upper="")
 
 
 def test_sharded_table_job(cluster: ClickhouseCluster):

--- a/dags/tests/test_materialized_columns.py
+++ b/dags/tests/test_materialized_columns.py
@@ -1,7 +1,7 @@
 import contextlib
+import time
 from collections.abc import Iterator, Mapping
 from datetime import datetime
-import time
 from uuid import UUID
 
 import dagster
@@ -16,7 +16,7 @@ from dags.materialized_columns import (
     run_materialize_mutations,
 )
 from posthog.clickhouse.cluster import ClickhouseCluster
-from posthog.hogql.test.test_printer import materialized  # bad idea
+from posthog.test.base import materialized
 
 
 def test_partition_range_validation():

--- a/dags/tests/test_materialized_columns.py
+++ b/dags/tests/test_materialized_columns.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+from uuid import UUID
 from clickhouse_driver import Client
 import dagster
 import pydantic
@@ -13,7 +15,7 @@ from posthog.clickhouse.cluster import ClickhouseCluster
 
 
 def test_partition_range_validation():
-    assert set(PartitionRange(lower="202401", upper="202403").iter()) == {"202401", "202402", "202403"}
+    assert set(PartitionRange(lower="202401", upper="202403").iter_ids()) == {"202401", "202402", "202403"}
 
     with pytest.raises(pydantic.ValidationError):
         PartitionRange(lower="202403", upper="202401")  # lower > upper
@@ -35,20 +37,24 @@ def test_sharded_table_job(cluster: ClickhouseCluster):
     # make sure all parts are wide
     def setup_table_for_wide_part(client: Client) -> None:
         client.execute(
-            "ALTER TABLE %(table)s MODIFY SETTING min_bytes_for_wide_part = 1, min_rows_for_wide_part = 1",
-            {"table": config.table},
+            f"ALTER TABLE {config.table} MODIFY SETTING min_bytes_for_wide_part = 1, min_rows_for_wide_part = 1",
         )
 
     cluster.map_all_hosts(setup_table_for_wide_part).result()
 
     def populate_test_data(client: Client) -> None:
-        raise NotImplementedError
+        for date in config.partitions.iter_dates():
+            dt = datetime(date.year, date.month, date.day)
+            client.execute(
+                "INSERT INTO writable_events (timestamp, uuid) VALUES",
+                [(dt, UUID(int=i)) for i in range(100)],
+            )
 
-    cluster.any_host(populate_test_data)
+    cluster.any_host(populate_test_data).result()
 
     remaining_partitions_by_shard = cluster.map_one_host_per_shard(config.get_remaining_partitions).result()
     for _shard_host, shard_partitions_remaining in remaining_partitions_by_shard.items():
-        assert shard_partitions_remaining == set(config.partitions.iter())
+        assert shard_partitions_remaining == set(config.partitions.iter_ids())
 
     materialize_column.execute_in_process(
         run_config=dagster.RunConfig(

--- a/dags/tests/test_person_overrides.py
+++ b/dags/tests/test_person_overrides.py
@@ -1,9 +1,7 @@
-from collections.abc import Iterator
 from datetime import datetime, timedelta
 from uuid import UUID
 
 import dagster
-import pytest
 from clickhouse_driver import Client
 
 from dags.person_overrides import (
@@ -13,12 +11,7 @@ from dags.person_overrides import (
     populate_snapshot_table,
     squash_person_overrides,
 )
-from posthog.clickhouse.cluster import ClickhouseCluster, get_cluster
-
-
-@pytest.fixture
-def cluster(django_db_setup) -> Iterator[ClickhouseCluster]:
-    yield get_cluster()
+from posthog.clickhouse.cluster import ClickhouseCluster
 
 
 def test_full_job(cluster: ClickhouseCluster):

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -128,7 +128,7 @@ class ClickhouseCluster:
             (self.__shards[shard_num] if host_info.shard_num is not None else self.__extra_hosts).add(host_info)
 
         if extra_hosts is not None and len(extra_hosts) > 0:
-            self.__extra_hosts.extend(
+            self.__extra_hosts.update(
                 [
                     HostInfo(
                         connection_info,

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import logging
-import time
 import re
+import time
+from collections import defaultdict
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from concurrent.futures import (
     ALL_COMPLETED,
@@ -97,6 +98,9 @@ class ClickhouseCluster:
         if logger is None:
             logger = logging.getLogger(__name__)
 
+        self.__shards: dict[int, set[HostInfo]] = defaultdict(set)
+        self.__extra_hosts: set[HostInfo] = set()
+
         cluster_hosts = bootstrap_client.execute(
             """
             SELECT host_address, port, shard_num, replica_num, getMacro('hostClusterType') as host_cluster_type, getMacro('hostClusterRole') as host_cluster_role
@@ -107,12 +111,13 @@ class ClickhouseCluster:
             {"name": cluster or settings.CLICKHOUSE_CLUSTER},
         )
 
-        self.__hosts = [
-            # We only use the port from system.clusters if we're running in E2E tests or debug mode,
-            # otherwise, we will use the default port.
-            HostInfo(
+        for row in cluster_hosts:
+            (host_address, port, shard_num, replica_num, host_cluster_type, host_cluster_role) = row
+            host_info = HostInfo(
                 ConnectionInfo(
                     host_address,
+                    # We only use the port from system.clusters if we're running in E2E tests or debug mode,
+                    # otherwise, we will use the default port.
                     port=port if (settings.E2E_TESTING or settings.DEBUG) else None,
                 ),
                 shard_num if host_cluster_role != "coordinator" else None,
@@ -120,18 +125,10 @@ class ClickhouseCluster:
                 host_cluster_type,
                 host_cluster_role,
             )
-            for (
-                host_address,
-                port,
-                shard_num,
-                replica_num,
-                host_cluster_type,
-                host_cluster_role,
-            ) in cluster_hosts
-        ]
+            (self.__shards[shard_num] if host_info.shard_num is not None else self.__extra_hosts).add(host_info)
 
         if extra_hosts is not None and len(extra_hosts) > 0:
-            self.__hosts.extend(
+            self.__extra_hosts.extend(
                 [
                     HostInfo(
                         connection_info,
@@ -143,13 +140,10 @@ class ClickhouseCluster:
                     for connection_info in extra_hosts
                 ]
             )
+
         self.__pools: dict[HostInfo, ChPool] = {}
         self.__logger = logger
         self.__client_settings = client_settings
-
-    @property
-    def shards(self) -> list[int]:
-        return list({host.shard_num for host in self.__hosts if host.shard_num is not None})
 
     def __get_task_function(self, host: HostInfo, fn: Callable[[Client], T]) -> Callable[[], T]:
         pool = self.__pools.get(host)
@@ -170,9 +164,17 @@ class ClickhouseCluster:
 
         return task
 
+    @property
+    def __hosts(self) -> set[HostInfo]:
+        """Set containing all hosts in the cluster."""
+        hosts = set(self.__extra_hosts)
+        for shard_hosts in self.__shards.values():
+            hosts.update(shard_hosts)
+        return hosts
+
     def any_host(self, fn: Callable[[Client], T]) -> Future[T]:
         with ThreadPoolExecutor() as executor:
-            host = self.__hosts[0]
+            host = next(iter(self.__hosts))
             return executor.submit(self.__get_task_function(host, fn))
 
     def any_host_by_role(self, fn: Callable[[Client], T], node_role: NodeRole) -> Future[T]:
@@ -227,11 +229,7 @@ class ClickhouseCluster:
         """
         with ThreadPoolExecutor(max_workers=concurrency) as executor:
             return FuturesMap(
-                {
-                    host: executor.submit(self.__get_task_function(host, fn))
-                    for host in self.__hosts
-                    if host.shard_num == shard_num
-                }
+                {host: executor.submit(self.__get_task_function(host, fn)) for host in self.__shards[shard_num]}
             )
 
     def map_all_hosts_in_shards(
@@ -245,18 +243,33 @@ class ClickhouseCluster:
 
         Wait for all to return before returning upon ``.values()``
         """
-
         shard_host_fn = {}
         for shard, fn in shard_fns.items():
-            if shard not in self.shards:
-                raise ValueError(f"Shard {shard} not found in cluster")
-            for host in self.__hosts:
-                if host.shard_num == shard:
-                    shard_host_fn[host] = fn
+            for host in self.__shards[shard]:
+                shard_host_fn[host] = fn
 
         with ThreadPoolExecutor(max_workers=concurrency) as executor:
             return FuturesMap(
                 {host: executor.submit(self.__get_task_function(host, fn)) for host, fn in shard_host_fn.items()}
+            )
+
+    def map_any_host_in_shards(
+        self, shard_fns: dict[int, Callable[[Client], T]], concurrency: int | None = None
+    ) -> FuturesMap[HostInfo, T]:
+        """
+        Execute the callable on one host for each of the specified shards.
+
+        The number of concurrent queries can limited with the ``concurrency`` parameter, or set to ``None`` to use the
+        default limit of the executor.
+        """
+        shard_host_fns = {}
+        for shard, fn in shard_fns.items():
+            host = next(iter(self.__shards[shard]))
+            shard_host_fns[host] = fn
+
+        with ThreadPoolExecutor(max_workers=concurrency) as executor:
+            return FuturesMap(
+                {host: executor.submit(self.__get_task_function(host, fn)) for host, fn in shard_host_fns.items()}
             )
 
     def map_one_host_per_shard(
@@ -268,15 +281,9 @@ class ClickhouseCluster:
         The number of concurrent queries can limited with the ``concurrency`` parameter, or set to ``None`` to use the
         default limit of the executor.
         """
-        shard_hosts: dict[int, HostInfo] = {}
-        for host in self.__hosts:
-            if host.shard_num is not None and host.shard_num not in shard_hosts:
-                shard_hosts[host.shard_num] = host
-
+        hosts = {next(iter(shard_hosts)) for shard_hosts in self.__shards.values()}
         with ThreadPoolExecutor(max_workers=concurrency) as executor:
-            return FuturesMap(
-                {host: executor.submit(self.__get_task_function(host, fn)) for host in shard_hosts.values()}
-            )
+            return FuturesMap({host: executor.submit(self.__get_task_function(host, fn)) for host in hosts})
 
 
 def get_cluster(

--- a/posthog/clickhouse/test/test_cluster.py
+++ b/posthog/clickhouse/test/test_cluster.py
@@ -16,6 +16,11 @@ def cluster(django_db_setup) -> Iterator[ClickhouseCluster]:
     yield get_cluster()
 
 
+def test_mutation_runner_rejects_invalid_parameters() -> None:
+    with pytest.raises(ValueError):
+        MutationRunner("table", "command", {"__invalid_key": True})
+
+
 def test_mutations(cluster: ClickhouseCluster) -> None:
     table = EVENTS_DATA_TABLE()
     count = 100

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -36,8 +36,7 @@ def materialized(table, property):
         pytest.xfail(str(e))
 
     try:
-        materialize(table, property)
-        yield
+        yield materialize(table, property)
     finally:
         cleanup_materialized_columns()
 

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -1,6 +1,5 @@
 import json
 from collections.abc import Mapping
-from contextlib import contextmanager
 from typing import Any, Literal, Optional, cast
 
 import pytest
@@ -24,21 +23,7 @@ from posthog.schema import (
     PersonsOnEventsMode,
     PropertyGroupsMode,
 )
-from posthog.test.base import BaseTest, _create_event, cleanup_materialized_columns
-
-
-@contextmanager
-def materialized(table, property):
-    """Materialize a property within the managed block, removing it on exit."""
-    try:
-        from ee.clickhouse.materialized_columns.analyze import materialize
-    except ModuleNotFoundError as e:
-        pytest.xfail(str(e))
-
-    try:
-        yield materialize(table, property)
-    finally:
-        cleanup_materialized_columns()
+from posthog.test.base import BaseTest, _create_event, materialized
 
 
 class TestPrinter(BaseTest):

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -10,6 +10,7 @@ from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from functools import wraps
 from typing import Any, Optional, Union
+from collections.abc import Iterator
 from unittest.mock import patch
 
 import freezegun
@@ -30,6 +31,7 @@ from rest_framework.test import APITestCase as DRFTestCase
 from posthog import rate_limit, redis
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.connection import ch_pool
+from posthog.clickhouse.materialized_columns import MaterializedColumn
 from posthog.clickhouse.plugin_log_entries import TRUNCATE_PLUGIN_LOG_ENTRIES_TABLE_SQL
 from posthog.cloud_utils import TEST_clear_instance_license_cache
 from posthog.models import Dashboard, DashboardTile, Insight, Organization, Team, User
@@ -621,6 +623,20 @@ def cleanup_materialized_columns():
     optionally_drop("events", lambda name: name not in default_column_names)
     optionally_drop("person")
     optionally_drop("groups")
+
+
+@contextmanager
+def materialized(table, property) -> Iterator[MaterializedColumn]:
+    """Materialize a property within the managed block, removing it on exit."""
+    try:
+        from ee.clickhouse.materialized_columns.analyze import materialize
+    except ModuleNotFoundError as e:
+        pytest.xfail(str(e))
+
+    try:
+        yield materialize(table, property)
+    finally:
+        cleanup_materialized_columns()
 
 
 def also_test_with_materialized_columns(

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -610,6 +610,8 @@ def cleanup_materialized_columns():
         )
         if drops:
             sync_execute(f"ALTER TABLE {table} {drops} SETTINGS mutations_sync = 2")
+            if table == "events":
+                sync_execute(f"ALTER TABLE sharded_events {drops} SETTINGS mutations_sync = 2")
 
     default_column_names = {
         get_materialized_columns("events")[(prop, "properties")].name


### PR DESCRIPTION
## Problem

Very large materializations can be hard to manage, especially if they are performed over multiple shards and need to be paused and resumed during operation.

## Changes

Adds a materialization job to Dagster for managing materializations. Mutations are run partition-by-partition in reverse chronological order on all shards where the column hasn't already been materialized in all parts within the partition and there is not already an existing mutation for that partition.

There are currently some rough edges: this job currently only works with tables that are sharded and month partitioned (i.e. it is designed to work with `sharded_events`), and it can only materialize a single column at a time — but it should be relatively straightforward to extend this to support more types of materializations in the future, eventually allowing us to replace the existing management command logic for all materialized columns.

This also:

- Moves `cluster` fixture into [a location where it can be autodiscovered](https://docs.pytest.org/en/stable/reference/fixtures.html#conftest-py-sharing-fixtures-across-multiple-files)
- Updates `ClickhouseCluster` to deduplicate hosts (noticed this with PostHog/charts#3362), simplify some shard operations, and adds a method that can be used to invoke a callback function on one host per shard for a set of shards.
- Fixes support for non-`UPDATE` commands in `MutationRunner` and cleans up parameter validation
- Moves column materialization test helper from `posthog/hogql/test/test_printer.py` into a more obviously shared location
- Fixes a bug in test teardown where materialized columns were only being dropped from the `events` distributed table, not the `sharded_events` data table(s)

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added test