### PR TITLE
feat(cdp): allow downsampling only some events

### DIFF
--- a/plugin-server/src/cdp/legacy-plugins/_transformations/downsampling-plugin/index.test.ts
+++ b/plugin-server/src/cdp/legacy-plugins/_transformations/downsampling-plugin/index.test.ts
@@ -76,3 +76,30 @@ test('processEvent filters same events at different increasing percent', () => {
         expect(event1).toEqual(event0)
     }
 })
+
+test('processEvent filters events based on triggering events', () => {
+    // create an event. Hash generates 0.42
+    const event0 = createEvent({ event: 'blah', distinct_id: '1' })
+
+    for (let i = 0; i < 5; i++) {
+        meta.config.percentage = (i * 10).toString()
+        meta.config.triggeringEvents = 'blah,$pageview'
+
+        // Setup Plugin
+        setupPlugin(meta)
+
+        const event1 = processEvent(event0, meta)
+        expect(event1).toBeNull()
+    }
+
+    for (let i = 0; i < 5; i++) {
+        meta.config.percentage = (i * 10).toString()
+        meta.config.triggeringEvents = '$pageview'
+
+        // Setup Plugin
+        setupPlugin(meta)
+
+        const event1 = processEvent(event0, meta)
+        expect(event1).toEqual(event0)
+    }
+})

--- a/plugin-server/src/cdp/legacy-plugins/_transformations/downsampling-plugin/template.ts
+++ b/plugin-server/src/cdp/legacy-plugins/_transformations/downsampling-plugin/template.ts
@@ -35,6 +35,16 @@ export const downsamplingPlugin: LegacyTransformationPlugin = {
                 default: 'Distinct ID aware sampling',
                 required: false,
             },
+            {
+                type: 'string',
+                templating: false,
+                key: 'triggeringEvents',
+                description:
+                    "A comma-separated list of PostHog events you want to downsample (e.g.: '$identify,mycustomevent' ). If empty, all events will be downsampled.",
+                label: 'Triggering events.',
+                default: '',
+                required: false,
+            },
         ],
     },
 }

--- a/plugin-server/src/cdp/legacy-plugins/_transformations/downsampling-plugin/template.ts
+++ b/plugin-server/src/cdp/legacy-plugins/_transformations/downsampling-plugin/template.ts
@@ -40,7 +40,7 @@ export const downsamplingPlugin: LegacyTransformationPlugin = {
                 templating: false,
                 key: 'triggeringEvents',
                 description:
-                    "A comma-separated list of PostHog events you want to downsample (e.g.: '$identify,mycustomevent' ). If empty, all events will be downsampled.",
+                    "A comma-separated list of PostHog events you want to downsample (e.g.: '$identify,mycustomevent'). If empty, all events will be downsampled.",
                 label: 'Triggering events',
                 default: '',
                 required: false,

--- a/plugin-server/src/cdp/legacy-plugins/_transformations/downsampling-plugin/template.ts
+++ b/plugin-server/src/cdp/legacy-plugins/_transformations/downsampling-plugin/template.ts
@@ -41,7 +41,7 @@ export const downsamplingPlugin: LegacyTransformationPlugin = {
                 key: 'triggeringEvents',
                 description:
                     "A comma-separated list of PostHog events you want to downsample (e.g.: '$identify,mycustomevent' ). If empty, all events will be downsampled.",
-                label: 'Triggering events.',
+                label: 'Triggering events',
                 default: '',
                 required: false,
             },


### PR DESCRIPTION
## Problem

Customers want to downsample some events, but not the others.
https://posthoghelp.zendesk.com/agent/tickets/25190 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/27201)

For some reason, transformations aren't working for ingested events in my local environments, but the behavior is as expected in the testing panel + tests are passing.

## Changes

- Added the `triggeringEvents` option to the downsampling transformation

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- added test