### PR TITLE
fix(experiments): Use experiment metrics if they already exist

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -2030,15 +2030,19 @@ export const experimentLogic = kea<experimentLogicType>([
         shouldUseExperimentMetrics: [
             (s) => [s.experiment, s.featureFlags],
             (experiment: Experiment, featureFlags: Record<string, boolean>): boolean => {
-                if (!featureFlags[FEATURE_FLAGS.EXPERIMENTS_NEW_QUERY_RUNNER]) {
-                    return false
-                }
                 const allMetrics = [...experiment.metrics, ...experiment.metrics_secondary, ...experiment.saved_metrics]
+                const hasExperimentMetrics = allMetrics.some((query) => query.kind === NodeKind.ExperimentMetric)
                 const hasLegacyMetrics = allMetrics.some(
                     (query) =>
                         query.kind === NodeKind.ExperimentTrendsQuery || query.kind === NodeKind.ExperimentFunnelsQuery
                 )
-                return !hasLegacyMetrics
+                if (hasExperimentMetrics) {
+                    return true
+                }
+                if (hasLegacyMetrics) {
+                    return false
+                }
+                return featureFlags[FEATURE_FLAGS.EXPERIMENTS_NEW_QUERY_RUNNER]
             },
         ],
     }),


### PR DESCRIPTION
See https://github.com/PostHog/posthog/pull/28644#discussion_r1954236132

## Changes

`shouldUseExperimentMetrics` should return true if the experiment already has an experiment metric.

## How did you test this code?

* I verified that an existing experiment with legacy metrics opened the legacy metric form as expected.
* I verified that an existing experiment with experiment metrics opened the experiment metric form as expected.
* On a brand new experiment, I verified the experiment metric form opened when the feature flag was enabled and the legacy form opened when the feature flag was disabled.