### PR TITLE
feat(experiments): Properly translate event and action filters

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -6816,6 +6816,39 @@
             "required": ["columns", "hogql", "results", "types"],
             "type": "object"
         },
+        "ExperimentActionMetricConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "action": {
+                    "type": "number"
+                },
+                "kind": {
+                    "const": "ExperimentActionMetricConfig",
+                    "type": "string"
+                },
+                "math": {
+                    "$ref": "#/definitions/ExperimentMetricMath"
+                },
+                "math_hogql": {
+                    "type": "string"
+                },
+                "math_property": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "properties": {
+                    "description": "Properties configurable in the interface",
+                    "items": {
+                        "$ref": "#/definitions/AnyPropertyFilter"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["kind", "action"],
+            "type": "object"
+        },
         "ExperimentDataWarehouseMetricConfig": {
             "additionalProperties": false,
             "properties": {
@@ -6865,6 +6898,9 @@
                     "type": "string"
                 },
                 "math_property": {
+                    "type": "string"
+                },
+                "name": {
                     "type": "string"
                 },
                 "properties": {
@@ -6989,6 +7025,9 @@
                     "anyOf": [
                         {
                             "$ref": "#/definitions/ExperimentEventMetricConfig"
+                        },
+                        {
+                            "$ref": "#/definitions/ExperimentActionMetricConfig"
                         },
                         {
                             "$ref": "#/definitions/ExperimentDataWarehouseMetricConfig"
@@ -9731,6 +9770,7 @@
                 "ExperimentMetric",
                 "ExperimentQuery",
                 "ExperimentEventMetricConfig",
+                "ExperimentActionMetricConfig",
                 "ExperimentDataWarehouseMetricConfig",
                 "ExperimentTrendsQuery",
                 "ExperimentFunnelsQuery",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -102,6 +102,7 @@ export enum NodeKind {
     ExperimentMetric = 'ExperimentMetric',
     ExperimentQuery = 'ExperimentQuery',
     ExperimentEventMetricConfig = 'ExperimentEventMetricConfig',
+    ExperimentActionMetricConfig = 'ExperimentActionMetricConfig',
     ExperimentDataWarehouseMetricConfig = 'ExperimentDataWarehouseMetricConfig',
     ExperimentTrendsQuery = 'ExperimentTrendsQuery',
     ExperimentFunnelsQuery = 'ExperimentFunnelsQuery',
@@ -1803,12 +1804,24 @@ export interface ExperimentMetric {
     metric_type: ExperimentMetricType
     filterTestAccounts?: boolean
     inverse?: boolean
-    metric_config: ExperimentEventMetricConfig | ExperimentDataWarehouseMetricConfig
+    metric_config: ExperimentEventMetricConfig | ExperimentActionMetricConfig | ExperimentDataWarehouseMetricConfig
 }
 
 export interface ExperimentEventMetricConfig {
     kind: NodeKind.ExperimentEventMetricConfig
     event: string
+    name?: string
+    math?: ExperimentMetricMath
+    math_hogql?: string
+    math_property?: string
+    /** Properties configurable in the interface */
+    properties?: AnyPropertyFilter[]
+}
+
+export interface ExperimentActionMetricConfig {
+    kind: NodeKind.ExperimentActionMetricConfig
+    action: number
+    name?: string
     math?: ExperimentMetricMath
     math_hogql?: string
     math_property?: string

--- a/frontend/src/scenes/experiments/Metrics/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/Metrics/ExperimentMetricForm.tsx
@@ -5,11 +5,11 @@ import { useActions, useValues } from 'kea'
 import { ActionFilter } from 'scenes/insights/filters/ActionFilter/ActionFilter'
 import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
 
-import { ExperimentMetric, NodeKind } from '~/queries/schema/schema-general'
+import { ActionsNode, EventsNode, ExperimentMetric } from '~/queries/schema/schema-general'
 import { FilterType } from '~/types'
 
 import { experimentLogic } from '../experimentLogic'
-import { metricToFilter } from '../utils'
+import { filterToMetricConfig, metricConfigToFilter } from '../utils'
 import { commonActionFilterProps } from './Selectors'
 
 export function ExperimentMetricForm({ isSecondary = false }: { isSecondary?: boolean }): JSX.Element {
@@ -47,22 +47,17 @@ export function ExperimentMetricForm({ isSecondary = false }: { isSecondary?: bo
             </div>
             <ActionFilter
                 bordered
-                filters={metricToFilter(currentMetric)}
+                filters={metricConfigToFilter(currentMetric.metric_config)}
                 setFilters={({ actions, events }: Partial<FilterType>): void => {
                     // We only support one event/action for experiment metrics
                     const entity = events?.[0] || actions?.[0]
-                    if (entity) {
+                    const metricConfig = filterToMetricConfig(entity as EventsNode | ActionsNode)
+                    if (metricConfig) {
                         setMetric({
                             metricIdx,
                             metric: {
                                 ...currentMetric,
-                                metric_config: {
-                                    kind: NodeKind.ExperimentEventMetricConfig,
-                                    event: entity.id as string,
-                                    math: entity.math,
-                                    math_property: entity.math_property,
-                                    math_hogql: entity.math_hogql,
-                                },
+                                metric_config: metricConfig,
                             },
                             isSecondary,
                         })

--- a/frontend/src/scenes/experiments/Metrics/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/Metrics/ExperimentMetricForm.tsx
@@ -5,7 +5,7 @@ import { useActions, useValues } from 'kea'
 import { ActionFilter } from 'scenes/insights/filters/ActionFilter/ActionFilter'
 import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
 
-import { ActionsNode, EventsNode, ExperimentMetric } from '~/queries/schema/schema-general'
+import { ExperimentMetric } from '~/queries/schema/schema-general'
 import { FilterType } from '~/types'
 
 import { experimentLogic } from '../experimentLogic'
@@ -51,7 +51,7 @@ export function ExperimentMetricForm({ isSecondary = false }: { isSecondary?: bo
                 setFilters={({ actions, events }: Partial<FilterType>): void => {
                     // We only support one event/action for experiment metrics
                     const entity = events?.[0] || actions?.[0]
-                    const metricConfig = filterToMetricConfig(entity as EventsNode | ActionsNode)
+                    const metricConfig = filterToMetricConfig(entity)
                     if (metricConfig) {
                         setMetric({
                             metricIdx,

--- a/frontend/src/scenes/experiments/SharedMetrics/SharedExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/SharedExperimentMetricForm.tsx
@@ -3,11 +3,11 @@ import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { ActionFilter } from 'scenes/insights/filters/ActionFilter/ActionFilter'
 import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
 
-import { ExperimentMetric, ExperimentMetricType, NodeKind } from '~/queries/schema/schema-general'
+import { ActionsNode, EventsNode, ExperimentMetricType } from '~/queries/schema/schema-general'
 import { FilterType } from '~/types'
 
 import { commonActionFilterProps } from '../Metrics/Selectors'
-import { metricToFilter } from '../utils'
+import { filterToMetricConfig, metricConfigToFilter } from '../utils'
 import { sharedMetricLogic } from './sharedMetricLogic'
 
 export function SharedExperimentMetricForm(): JSX.Element {
@@ -42,24 +42,17 @@ export function SharedExperimentMetricForm(): JSX.Element {
             </div>
             <ActionFilter
                 bordered
-                filters={metricToFilter({
-                    ...sharedMetric.query,
-                } as ExperimentMetric)}
+                filters={metricConfigToFilter(sharedMetric.query.metric_config)}
                 setFilters={({ actions, events }: Partial<FilterType>): void => {
                     // We only support one event/action for experiment metrics
                     const entity = events?.[0] || actions?.[0]
-                    if (entity) {
+                    const metricConfig = filterToMetricConfig(entity as EventsNode | ActionsNode)
+                    if (metricConfig) {
                         setSharedMetric({
                             ...sharedMetric,
                             query: {
                                 ...sharedMetric.query,
-                                metric_config: {
-                                    kind: NodeKind.ExperimentEventMetricConfig,
-                                    event: entity.id as string,
-                                    math: entity.math,
-                                    math_property: entity.math_property,
-                                    math_hogql: entity.math_hogql,
-                                },
+                                metric_config: metricConfig,
                             },
                         })
                     }

--- a/frontend/src/scenes/experiments/SharedMetrics/SharedExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/SharedExperimentMetricForm.tsx
@@ -3,7 +3,7 @@ import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { ActionFilter } from 'scenes/insights/filters/ActionFilter/ActionFilter'
 import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
 
-import { ActionsNode, EventsNode, ExperimentMetricType } from '~/queries/schema/schema-general'
+import { ExperimentMetricType } from '~/queries/schema/schema-general'
 import { FilterType } from '~/types'
 
 import { commonActionFilterProps } from '../Metrics/Selectors'
@@ -46,7 +46,7 @@ export function SharedExperimentMetricForm(): JSX.Element {
                 setFilters={({ actions, events }: Partial<FilterType>): void => {
                     // We only support one event/action for experiment metrics
                     const entity = events?.[0] || actions?.[0]
-                    const metricConfig = filterToMetricConfig(entity as EventsNode | ActionsNode)
+                    const metricConfig = filterToMetricConfig(entity)
                     if (metricConfig) {
                         setSharedMetric({
                             ...sharedMetric,

--- a/frontend/src/scenes/experiments/utils.test.ts
+++ b/frontend/src/scenes/experiments/utils.test.ts
@@ -3,7 +3,14 @@ import metricFunnelEventsJson from '~/mocks/fixtures/api/experiments/_metric_fun
 import metricTrendActionJson from '~/mocks/fixtures/api/experiments/_metric_trend_action.json'
 import metricTrendCustomExposureJson from '~/mocks/fixtures/api/experiments/_metric_trend_custom_exposure.json'
 import metricTrendFeatureFlagCalledJson from '~/mocks/fixtures/api/experiments/_metric_trend_feature_flag_called.json'
-import { ExperimentFunnelsQuery, ExperimentMetric, ExperimentTrendsQuery } from '~/queries/schema/schema-general'
+import {
+    ExperimentActionMetricConfig,
+    ExperimentEventMetricConfig,
+    ExperimentFunnelsQuery,
+    ExperimentMetric,
+    ExperimentTrendsQuery,
+    NodeKind,
+} from '~/queries/schema/schema-general'
 import {
     EntityType,
     FeatureFlagFilters,
@@ -16,8 +23,10 @@ import {
 import { getNiceTickValues } from './MetricsView/MetricsView'
 import {
     featureFlagEligibleForExperiment,
+    filterToMetricConfig,
     getMinimumDetectableEffect,
     getViewRecordingFilters,
+    metricConfigToFilter,
     transformFiltersForWinningVariant,
 } from './utils'
 
@@ -508,5 +517,129 @@ describe('checkFeatureFlagEligibility', () => {
             },
         }
         expect(featureFlagEligibleForExperiment(featureFlag)).toEqual(true)
+    })
+})
+
+describe('metricConfigToFilter', () => {
+    it('returns the correct filter for an event', () => {
+        const metricConfig = {
+            kind: NodeKind.ExperimentEventMetricConfig,
+            event: '$pageview',
+            name: '$pageview',
+            math: 'total',
+            math_property: undefined,
+            math_hogql: undefined,
+            properties: [{ key: '$browser', value: ['Chrome'], operator: 'exact', type: 'event' }],
+        } as ExperimentEventMetricConfig
+        const filter = metricConfigToFilter(metricConfig)
+        expect(filter).toEqual({
+            events: [
+                {
+                    id: '$pageview',
+                    name: '$pageview',
+                    type: 'events',
+                    math: 'total',
+                    math_property: undefined,
+                    math_hogql: undefined,
+                    properties: [{ key: '$browser', value: ['Chrome'], operator: 'exact', type: 'event' }],
+                    kind: NodeKind.EventsNode,
+                },
+            ],
+            actions: [],
+        })
+    })
+    it('returns the correct filter for an action', () => {
+        const metricConfig = {
+            kind: NodeKind.ExperimentActionMetricConfig,
+            action: 8,
+            name: 'jan-16-running payment action',
+            math: 'total',
+            math_property: undefined,
+            math_hogql: undefined,
+            properties: [{ key: '$lib', type: 'event', value: ['python'], operator: 'exact' }],
+        } as ExperimentActionMetricConfig
+        const filter = metricConfigToFilter(metricConfig)
+        expect(filter).toEqual({
+            events: [],
+            actions: [
+                {
+                    id: 8,
+                    name: 'jan-16-running payment action',
+                    type: 'actions',
+                    math: 'total',
+                    math_property: undefined,
+                    math_hogql: undefined,
+                    properties: [{ key: '$lib', type: 'event', value: ['python'], operator: 'exact' }],
+                    kind: NodeKind.EventsNode,
+                },
+            ],
+        })
+    })
+})
+
+describe('filterToMetricConfig', () => {
+    it('returns the correct metric config for an event', () => {
+        const event = {
+            kind: NodeKind.EventsNode,
+            id: '$pageview',
+            name: '$pageview',
+            type: 'events',
+            order: 0,
+            uuid: 'b2aa47bc-c39b-4743-a2a2-ab88f78faf11',
+            properties: [
+                {
+                    key: '$browser',
+                    value: ['Chrome'],
+                    operator: 'exact',
+                    type: 'event',
+                },
+            ],
+        } as Record<string, any>
+        const metricConfig = filterToMetricConfig(event)
+        expect(metricConfig).toEqual({
+            kind: NodeKind.ExperimentEventMetricConfig,
+            event: '$pageview',
+            name: '$pageview',
+            math: 'total',
+            math_property: undefined,
+            math_hogql: undefined,
+            properties: [
+                {
+                    key: '$browser',
+                    value: ['Chrome'],
+                    operator: 'exact',
+                    type: 'event',
+                },
+            ],
+        })
+    })
+    it('returns the correct metric config for an action', () => {
+        const action = {
+            id: '8',
+            name: 'jan-16-running payment action',
+            kind: 'EventsNode',
+            type: 'actions',
+            math: 'total',
+            properties: [
+                {
+                    key: '$lib',
+                    type: 'event',
+                    value: ['python'],
+                    operator: 'exact',
+                },
+            ],
+            order: 0,
+            uuid: '29c01ac4-ebc3-4cb8-9d82-287c0487056e',
+        } as Record<string, any>
+        const metricConfig = filterToMetricConfig(action)
+        expect(metricConfig).toEqual({
+            kind: NodeKind.ExperimentActionMetricConfig,
+            action: '8',
+            name: 'jan-16-running payment action',
+            math: 'total',
+            math_property: undefined,
+            math_hogql: undefined,
+            properties: [{ key: '$lib', type: 'event', value: ['python'], operator: 'exact' }],
+        })
     })
 })

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1106,6 +1106,7 @@ class NodeKind(StrEnum):
     EXPERIMENT_METRIC = "ExperimentMetric"
     EXPERIMENT_QUERY = "ExperimentQuery"
     EXPERIMENT_EVENT_METRIC_CONFIG = "ExperimentEventMetricConfig"
+    EXPERIMENT_ACTION_METRIC_CONFIG = "ExperimentActionMetricConfig"
     EXPERIMENT_DATA_WAREHOUSE_METRIC_CONFIG = "ExperimentDataWarehouseMetricConfig"
     EXPERIMENT_TRENDS_QUERY = "ExperimentTrendsQuery"
     EXPERIMENT_FUNNELS_QUERY = "ExperimentFunnelsQuery"
@@ -4472,6 +4473,37 @@ class EventsQueryResponse(BaseModel):
     types: list[str]
 
 
+class ExperimentActionMetricConfig(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    action: float
+    kind: Literal["ExperimentActionMetricConfig"] = "ExperimentActionMetricConfig"
+    math: Optional[ExperimentMetricMath] = None
+    math_hogql: Optional[str] = None
+    math_property: Optional[str] = None
+    name: Optional[str] = None
+    properties: Optional[
+        list[
+            Union[
+                EventPropertyFilter,
+                PersonPropertyFilter,
+                ElementPropertyFilter,
+                SessionPropertyFilter,
+                CohortPropertyFilter,
+                RecordingPropertyFilter,
+                LogEntryPropertyFilter,
+                GroupPropertyFilter,
+                FeaturePropertyFilter,
+                HogQLPropertyFilter,
+                EmptyPropertyFilter,
+                DataWarehousePropertyFilter,
+                DataWarehousePersonPropertyFilter,
+            ]
+        ]
+    ] = Field(default=None, description="Properties configurable in the interface")
+
+
 class ExperimentEventMetricConfig(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -4481,6 +4513,7 @@ class ExperimentEventMetricConfig(BaseModel):
     math: Optional[ExperimentMetricMath] = None
     math_hogql: Optional[str] = None
     math_property: Optional[str] = None
+    name: Optional[str] = None
     properties: Optional[
         list[
             Union[
@@ -4509,7 +4542,7 @@ class ExperimentMetric(BaseModel):
     filterTestAccounts: Optional[bool] = None
     inverse: Optional[bool] = None
     kind: Literal["ExperimentMetric"] = "ExperimentMetric"
-    metric_config: Union[ExperimentEventMetricConfig, ExperimentDataWarehouseMetricConfig]
+    metric_config: Union[ExperimentEventMetricConfig, ExperimentActionMetricConfig, ExperimentDataWarehouseMetricConfig]
     metric_type: ExperimentMetricType
     name: Optional[str] = None
 


### PR DESCRIPTION
Merges into https://github.com/PostHog/posthog/pull/28347

## Changes

Properly translates event and action filters into their corresponding metric config objects.

**Event**

https://github.com/user-attachments/assets/c503feeb-77fd-4140-be60-9cfe47f01fe6

**Action**

https://github.com/user-attachments/assets/4bd55354-926d-41c1-9fe6-f0021ab17754

**Shared metric**

https://github.com/user-attachments/assets/8dceb205-3e34-4df7-a82a-abf40f3dcaac


## How did you test this code?

I added an event and an action to an experiment and verified they saved as expected.

I also created a shared metric for an action and a shared metric for a filter and verified they saved as expected.