### PR TITLE
fix: don't need to clone history when installing self-host

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -80,7 +80,7 @@ sudo apt update
 echo "Installing PostHog 🦔 from Github"
 sudo apt install -y git
 # try to clone - if folder is already there pull latest for that branch
-git clone https://github.com/PostHog/posthog.git &> /dev/null || true
+git clone --depth=1  https://github.com/PostHog/posthog.git &> /dev/null || true
 cd posthog
 
 if [[ "$POSTHOG_APP_TAG" = "latest-release" ]]

--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -88,6 +88,7 @@ then
     git fetch --tags
     latestReleaseTag=$(git describe --tags `git rev-list --tags --max-count=1`)
     echo "Checking out latest PostHog release: $latestReleaseTag"
+    echo "Warning PostHog don't create tagged releases anymore. It's way better to use 'latest' than 'latest-release'"
     git checkout $latestReleaseTag
 elif [[ "$POSTHOG_APP_TAG" = "latest" ]]
 then

--- a/bin/upgrade-hobby
+++ b/bin/upgrade-hobby
@@ -81,7 +81,7 @@ fi
 export POSTHOG_APP_TAG="${POSTHOG_APP_TAG:-latest-release}"
 
 cd posthog
-git pull
+git pull --depth=2 --prune
 cd ../
 
 # Upgrade Docker Compose to version 2.13.0

--- a/bin/upgrade-hobby
+++ b/bin/upgrade-hobby
@@ -138,4 +138,5 @@ else
     exit
 fi
 
+echo "Consider running 'docker system prune -a' to clean up old images and free disk space"
 echo "PostHog upgraded successfully!"


### PR DESCRIPTION
Just had to do surgery on my self-hosted install because the git dir filled the disk 😅 

let's

* not clone the entire history
* prune as we upgrade
* prompt people to prune docker
* fly-by: warn people not to use `latest-release` when installing