### PR TITLE
fix: Use the full transformEvent flow when testing events

### DIFF
--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionTestLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionTestLogic.tsx
@@ -32,6 +32,10 @@ export type HogTransformationEvent = {
 const convertToTransformationEvent = (result: any): HogTransformationEvent => {
     const properties = result.properties ?? {}
     properties.$ip = properties.$ip ?? '89.160.20.129'
+    // We don't want to use these values given they will change in the test invocation
+    delete properties.$transformations_failed
+    delete properties.$transformations_succeeded
+
     return {
         event: result.event,
         uuid: result.uuid,
@@ -42,6 +46,8 @@ const convertToTransformationEvent = (result: any): HogTransformationEvent => {
 }
 
 const convertFromTransformationEvent = (result: HogTransformationEvent): Record<string, any> => {
+    delete result.properties.$transformations_failed
+    delete result.properties.$transformations_succeeded
     return {
         event: result.event,
         uuid: result.uuid,

--- a/plugin-server/src/cdp/cdp-api.test.ts
+++ b/plugin-server/src/cdp/cdp-api.test.ts
@@ -486,7 +486,7 @@ describe('CDP API', () => {
                   "elements_chain": "",
                   "event": "$pageview",
                   "ip": null,
-                  "now": "2025-02-14T13:37:49.509+01:00",
+                  "now": "",
                   "properties": {
                     "$lib_version": "1.0.0",
                     "$transformations_failed": [],

--- a/plugin-server/src/cdp/cdp-api.test.ts
+++ b/plugin-server/src/cdp/cdp-api.test.ts
@@ -482,12 +482,18 @@ describe('CDP API', () => {
             expect(res.body.result).toMatchInlineSnapshot(`
                 {
                   "distinct_id": "123",
+                  "elements_chain": "",
                   "event": "$pageview",
+                  "ip": null,
                   "properties": {
                     "$lib_version": "1.0.0",
+                    "$transformations_failed": [],
+                    "$transformations_succeeded": [
+                      "Filter Out Plugin (0194ffe6-0905-0000-24a6-f984696287bb)",
+                    ],
                   },
-                  "team_id": 2,
                   "timestamp": "2021-09-28T14:00:00Z",
+                  "url": "https://example.com/events/b3a1fe86-b10c-43cc-acaf-d208977608d0/2021-09-28T14:00:00Z",
                   "uuid": "b3a1fe86-b10c-43cc-acaf-d208977608d0",
                 }
             `)

--- a/plugin-server/src/cdp/cdp-api.test.ts
+++ b/plugin-server/src/cdp/cdp-api.test.ts
@@ -5,6 +5,7 @@ import supertest from 'supertest'
 
 import { HOG_EXAMPLES, HOG_FILTERS_EXAMPLES, HOG_INPUTS_EXAMPLES } from '../../tests/cdp/examples'
 import { createHogFunction, insertHogFunction as _insertHogFunction } from '../../tests/cdp/fixtures'
+import { forSnapshot } from '../../tests/helpers/snapshots'
 import { getFirstTeam, resetTestDatabase } from '../../tests/helpers/sql'
 import { Hub, Team } from '../types'
 import { closeHub, createHub } from '../utils/db/hub'
@@ -479,22 +480,25 @@ describe('CDP API', () => {
                 ]
             `)
 
-            expect(res.body.result).toMatchInlineSnapshot(`
+            expect(forSnapshot(res.body.result)).toMatchInlineSnapshot(`
                 {
                   "distinct_id": "123",
                   "elements_chain": "",
                   "event": "$pageview",
                   "ip": null,
+                  "now": "2025-02-14T13:37:49.509+01:00",
                   "properties": {
                     "$lib_version": "1.0.0",
                     "$transformations_failed": [],
                     "$transformations_succeeded": [
-                      "Filter Out Plugin (0194ffe6-0905-0000-24a6-f984696287bb)",
+                      "Filter Out Plugin (<REPLACED-UUID-1>)",
                     ],
                   },
+                  "site_url": "http://localhost:8000/project/2",
+                  "team_id": 2,
                   "timestamp": "2021-09-28T14:00:00Z",
-                  "url": "https://example.com/events/b3a1fe86-b10c-43cc-acaf-d208977608d0/2021-09-28T14:00:00Z",
-                  "uuid": "b3a1fe86-b10c-43cc-acaf-d208977608d0",
+                  "url": "https://example.com/events/<REPLACED-UUID-1>/2021-09-28T14:00:00Z",
+                  "uuid": "<REPLACED-UUID-0>",
                 }
             `)
         })

--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -239,12 +239,15 @@ export class CdpApi {
                 // NOTE: We override the ID so that the transformer doesn't cache the result
                 // TODO: We could do this with a "special" ID to indicate no caching...
                 compoundConfiguration.id = new UUIDT().toString()
-                const response = await this.hogTransformer.executeHogFunction(compoundConfiguration, triggerGlobals)
-                logs = logs.concat(response.logs)
-                result = response.execResult ?? null
+                const response = await this.hogTransformer.transformEvent(triggerGlobals, [compoundConfiguration])
 
-                if (response.error) {
-                    errors.push(response.error)
+                result = response.event
+
+                for (const result of response.invocationResults) {
+                    logs = logs.concat(result.logs)
+                    if (result.error) {
+                        errors.push(result.error)
+                    }
                 }
             }
 

--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -251,7 +251,7 @@ export class CdpApi {
                     ip: triggerGlobals.event.properties.$ip,
                     site_url: triggerGlobals.project.url,
                     team_id: triggerGlobals.project.id,
-                    now: DateTime.now().toISO(),
+                    now: '',
                 }
                 const response = await this.hogTransformer.transformEvent(pluginEvent, [compoundConfiguration])
 

--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -246,16 +246,21 @@ export class CdpApi {
                 // NOTE: We override the ID so that the transformer doesn't cache the result
                 // TODO: We could do this with a "special" ID to indicate no caching...
                 compoundConfiguration.id = new UUIDT().toString()
-                const response = await this.hogTransformer.transformEvent(triggerGlobals.event as PluginEvent, [
-                    compoundConfiguration,
-                ])
+                const pluginEvent: PluginEvent = {
+                    ...triggerGlobals.event,
+                    ip: triggerGlobals.event.properties.$ip,
+                    site_url: triggerGlobals.project.url,
+                    team_id: triggerGlobals.project.id,
+                    now: DateTime.now().toISO(),
+                }
+                const response = await this.hogTransformer.transformEvent(pluginEvent, [compoundConfiguration])
 
                 result = response.event
 
-                for (const result of response.invocationResults) {
-                    logs = logs.concat(result.logs)
-                    if (result.error) {
-                        errors.push(result.error)
+                for (const invocationResult of response.invocationResults) {
+                    logs = logs.concat(invocationResult.logs)
+                    if (invocationResult.error) {
+                        errors.push(invocationResult.error)
                     }
                 }
             }

--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -1,3 +1,4 @@
+import { PluginEvent } from '@posthog/plugin-scaffold'
 import express from 'express'
 import { DateTime } from 'luxon'
 
@@ -11,7 +12,13 @@ import { HogExecutorService, MAX_ASYNC_STEPS } from './services/hog-executor.ser
 import { HogFunctionManagerService } from './services/hog-function-manager.service'
 import { HogWatcherService, HogWatcherState } from './services/hog-watcher.service'
 import { HOG_FUNCTION_TEMPLATES } from './templates'
-import { HogFunctionInvocationResult, HogFunctionQueueParametersFetchRequest, HogFunctionType, LogEntry } from './types'
+import {
+    HogFunctionInvocationGlobals,
+    HogFunctionInvocationResult,
+    HogFunctionQueueParametersFetchRequest,
+    HogFunctionType,
+    LogEntry,
+} from './types'
 
 export class CdpApi {
     private hogExecutor: HogExecutorService
@@ -147,7 +154,7 @@ export class CdpApi {
             let result: any = null
             const errors: any[] = []
 
-            const triggerGlobals = {
+            const triggerGlobals: HogFunctionInvocationGlobals = {
                 ...globals,
                 project: {
                     id: team.id,
@@ -239,7 +246,9 @@ export class CdpApi {
                 // NOTE: We override the ID so that the transformer doesn't cache the result
                 // TODO: We could do this with a "special" ID to indicate no caching...
                 compoundConfiguration.id = new UUIDT().toString()
-                const response = await this.hogTransformer.transformEvent(triggerGlobals, [compoundConfiguration])
+                const response = await this.hogTransformer.transformEvent(triggerGlobals.event as PluginEvent, [
+                    compoundConfiguration,
+                ])
 
                 result = response.event
 

--- a/plugin-server/src/cdp/hog-transformations/__snapshots__/hog-transformer.service.test.ts.snap
+++ b/plugin-server/src/cdp/hog-transformations/__snapshots__/hog-transformer.service.test.ts.snap
@@ -1,0 +1,136 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HogTransformer transformEvent should execute multiple transformations and produce messages 1`] = `
+[
+  {
+    "key": "<REPLACED-UUID-0>",
+    "topic": "clickhouse_app_metrics2_test",
+    "value": {
+      "app_source": "hog_function",
+      "app_source_id": "<REPLACED-UUID-1>",
+      "count": 1,
+      "metric_kind": "success",
+      "metric_name": "succeeded",
+      "team_id": 2,
+      "timestamp": "2025-01-01 00:00:00.000",
+    },
+  },
+  {
+    "key": "<REPLACED-UUID-1>",
+    "topic": "log_entries_test",
+    "value": {
+      "instance_id": "<REPLACED-UUID-2>",
+      "level": "debug",
+      "log_source": "hog_function",
+      "log_source_id": "<REPLACED-UUID-2>",
+      "message": "Executing function",
+      "team_id": 2,
+      "timestamp": "2025-01-01 00:00:00.000",
+    },
+  },
+  {
+    "key": "<REPLACED-UUID-2>",
+    "topic": "log_entries_test",
+    "value": {
+      "instance_id": "<REPLACED-UUID-2>",
+      "level": "info",
+      "log_source": "hog_function",
+      "log_source_id": "<REPLACED-UUID-2>",
+      "message": "geoip location data for ip:, {"city_name":"Linköping","country_name":"Sweden","country_code":"SE","continent_name":"Europe","continent_code":"EU","latitude":58.4167,"longitude":15.6167,"accuracy_radius":76,"time_zone":"Europe/Stockholm","subdivision_1_code":"E","subdivision_1_name":"Östergötland County"}",
+      "team_id": 2,
+      "timestamp": "2025-01-01 00:00:00.001",
+    },
+  },
+  {
+    "key": "<REPLACED-UUID-2>",
+    "topic": "log_entries_test",
+    "value": {
+      "instance_id": "<REPLACED-UUID-2>",
+      "level": "debug",
+      "log_source": "hog_function",
+      "log_source_id": "<REPLACED-UUID-2>",
+      "message": "Function completed in [REPLACED]",
+      "team_id": 2,
+      "timestamp": "2025-01-01 00:00:00.002",
+    },
+  },
+  {
+    "key": "<REPLACED-UUID-2>",
+    "topic": "clickhouse_app_metrics2_test",
+    "value": {
+      "app_source": "hog_function",
+      "app_source_id": "<REPLACED-UUID-3>",
+      "count": 1,
+      "metric_kind": "success",
+      "metric_name": "succeeded",
+      "team_id": 2,
+      "timestamp": "2025-01-01 00:00:00.000",
+    },
+  },
+  {
+    "key": "<REPLACED-UUID-3>",
+    "topic": "log_entries_test",
+    "value": {
+      "instance_id": "<REPLACED-UUID-4>",
+      "level": "debug",
+      "log_source": "hog_function",
+      "log_source_id": "<REPLACED-UUID-4>",
+      "message": "Executing function",
+      "team_id": 2,
+      "timestamp": "2025-01-01 00:00:00.000",
+    },
+  },
+  {
+    "key": "<REPLACED-UUID-4>",
+    "topic": "log_entries_test",
+    "value": {
+      "instance_id": "<REPLACED-UUID-4>",
+      "level": "debug",
+      "log_source": "hog_function",
+      "log_source_id": "<REPLACED-UUID-4>",
+      "message": "Function completed in [REPLACED]",
+      "team_id": 2,
+      "timestamp": "2025-01-01 00:00:00.001",
+    },
+  },
+  {
+    "key": "<REPLACED-UUID-4>",
+    "topic": "clickhouse_app_metrics2_test",
+    "value": {
+      "app_source": "hog_function",
+      "app_source_id": "<REPLACED-UUID-5>",
+      "count": 1,
+      "metric_kind": "success",
+      "metric_name": "succeeded",
+      "team_id": 2,
+      "timestamp": "2025-01-01 00:00:00.000",
+    },
+  },
+  {
+    "key": "<REPLACED-UUID-5>",
+    "topic": "log_entries_test",
+    "value": {
+      "instance_id": "<REPLACED-UUID-6>",
+      "level": "debug",
+      "log_source": "hog_function",
+      "log_source_id": "<REPLACED-UUID-6>",
+      "message": "Executing function",
+      "team_id": 2,
+      "timestamp": "2025-01-01 00:00:00.000",
+    },
+  },
+  {
+    "key": "<REPLACED-UUID-6>",
+    "topic": "log_entries_test",
+    "value": {
+      "instance_id": "<REPLACED-UUID-6>",
+      "level": "debug",
+      "log_source": "hog_function",
+      "log_source_id": "<REPLACED-UUID-6>",
+      "message": "Function completed in [REPLACED]",
+      "team_id": 2,
+      "timestamp": "2025-01-01 00:00:00.001",
+    },
+  },
+]
+`;

--- a/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -8,7 +8,7 @@ import {
     HogFunctionType,
     HogFunctionTypeType,
 } from '../../cdp/types'
-import { CDP_TEST_ID, createInvocation, fixLogDeduplication, isLegacyPluginHogFunction } from '../../cdp/utils'
+import { createInvocation, fixLogDeduplication, isLegacyPluginHogFunction } from '../../cdp/utils'
 import { KAFKA_APP_METRICS_2, KAFKA_LOG_ENTRIES } from '../../config/kafka-topics'
 import { runInstrumentedFunction } from '../../main/utils'
 import { AppMetric2Type, Hub, TimestampFormat } from '../../types'
@@ -175,15 +175,13 @@ export class HogTransformerService {
         return promises
     }
 
-    public transformEventAndProduceMessages(
-        event: PluginEvent,
-        runTestFunctions: boolean = false
-    ): Promise<TransformationResult> {
+    public transformEventAndProduceMessages(event: PluginEvent): Promise<TransformationResult> {
         return runInstrumentedFunction({
             statsKey: `hogTransformer.transformEventAndProduceMessages`,
             func: async () => {
                 hogTransformationAttempts.inc({ type: 'with_messages' })
-                const transformationResult = await this.transformEvent(event, runTestFunctions)
+                const teamHogFunctions = this.hogFunctionManager.getTeamHogFunctions(event.team_id)
+                const transformationResult = await this.transformEvent(event, teamHogFunctions)
                 const messagePromises: Promise<void>[] = []
 
                 transformationResult.invocationResults.forEach((result) => {
@@ -199,23 +197,18 @@ export class HogTransformerService {
         })
     }
 
-    public transformEvent(event: PluginEvent, runTestFunctions: boolean = false): Promise<TransformationResultPure> {
+    public transformEvent(event: PluginEvent, teamHogFunctions: HogFunctionType[]): Promise<TransformationResultPure> {
         return runInstrumentedFunction({
             statsKey: `hogTransformer.transformEvent`,
 
             func: async () => {
                 hogTransformationInvocations.inc()
-                const teamHogFunctions = this.hogFunctionManager.getTeamHogFunctions(event.team_id)
                 const results: HogFunctionInvocationResult[] = []
                 const transformationsSucceeded: string[] = event.properties?.$transformations_succeeded || []
                 const transformationsFailed: string[] = event.properties?.$transformations_failed || []
 
                 // For now, execute each transformation function in sequence
                 for (const hogFunction of teamHogFunctions) {
-                    if (hogFunction.name.includes(CDP_TEST_ID) && !runTestFunctions) {
-                        // Skip test functions if we're not running in test mode
-                        continue
-                    }
                     const transformationIdentifier = `${hogFunction.name} (${hogFunction.id})`
                     const result = await this.executeHogFunction(hogFunction, this.createInvocationGlobals(event))
 
@@ -307,7 +300,7 @@ export class HogTransformerService {
         })
     }
 
-    public async executeHogFunction(
+    private async executeHogFunction(
         hogFunction: HogFunctionType,
         globals: HogFunctionInvocationGlobals
     ): Promise<HogFunctionInvocationResult> {


### PR DESCRIPTION
## Problem

Would be really useful to use the full transform code to catch any specific things it does or does not do

## Changes

- [x] Does that
- [x] Makes sure we don't show the transform meta properties in the diff
- [ ] Also adds a snapshot test for the message production

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Tests