### PR TITLE
fix: Testing geoip doesnt work

### DIFF
--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -547,6 +547,8 @@ export async function startPluginsServer(
 
         if (capabilities.cdpApi) {
             const hub = await setupHub()
+            // NOTE: For silly reasons piscina is where the mmdb server is loaded which we need...
+            piscina = piscina ?? (await makePiscina(serverConfig, hub))
             const api = new CdpApi(hub)
             await api.start()
             services.push(api.service)


### PR DESCRIPTION
## Problem

For silly reasons this "piscina" thing is where the geoip mmdb gets loaded. This is all fixed in THE PURGE but needs to be added back in for now to keep it working

## Changes

* Adds it back in
* Tested it locally running only in cdp-api mode and it worked

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
