### PR TITLE
feat(experiments): disable unsupported functionality

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -11,7 +11,7 @@ import { MetricSourceModal } from '../Metrics/MetricSourceModal'
 import { SharedMetricModal } from '../Metrics/SharedMetricModal'
 import { MetricsView } from '../MetricsView/MetricsView'
 import { VariantDeltaTimeseries } from '../MetricsView/VariantDeltaTimeseries'
-import { ExploreButton, LoadingState, PageHeaderCustom } from './components'
+import { ExploreButton, LoadingState, PageHeaderCustom, ResultsQuery } from './components'
 import { CumulativeExposuresChart } from './CumulativeExposuresChart'
 import { DataCollection } from './DataCollection'
 import { DistributionModal, DistributionTable } from './DistributionTable'
@@ -56,19 +56,19 @@ const ResultsTab = (): JSX.Element => {
                     <div className="pb-4">
                         <SummaryTable metric={firstPrimaryMetric} metricIndex={0} isSecondary={false} />
                     </div>
-                    <div className="flex justify-end">
-                        <ExploreButton result={metricResults?.[0] || null} size="xsmall" />
-                    </div>
-                    <div className="pb-4">
-                        {/* TODO: Insight display is not yet supported with the new query runner */}
-                        {/* <ResultsQuery result={metricResults?.[0] || null} showTable={true} /> */}
-                        <p>
-                            TODO: Insight display is not yet supported with the new query runner.
-                            <br />
-                            <br />
-                            <br />
-                        </p>
-                    </div>
+                    {/* TODO: Only show explore button results viz if the metric is a trends or funnels query. Not supported yet with new query runner */}
+                    {metricResults?.[0] &&
+                        (metricResults[0].kind === 'ExperimentTrendsQuery' ||
+                            metricResults[0].kind === 'ExperimentFunnelsQuery') && (
+                            <>
+                                <div className="flex justify-end">
+                                    <ExploreButton result={metricResults[0]} size="xsmall" />
+                                </div>
+                                <div className="pb-4">
+                                    <ResultsQuery result={metricResults?.[0] || null} showTable={true} />
+                                </div>
+                            </>
+                        )}
                 </div>
             )}
             <MetricsView isSecondary={true} />

--- a/frontend/src/scenes/experiments/ExperimentView/Overview.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Overview.tsx
@@ -1,6 +1,10 @@
 import { useValues } from 'kea'
 
-import { CachedExperimentFunnelsQueryResponse, CachedExperimentTrendsQueryResponse } from '~/queries/schema'
+import {
+    CachedExperimentFunnelsQueryResponse,
+    CachedExperimentQueryResponse,
+    CachedExperimentTrendsQueryResponse,
+} from '~/queries/schema'
 import { ExperimentIdType } from '~/types'
 
 import { experimentLogic } from '../experimentLogic'
@@ -10,7 +14,7 @@ export function WinningVariantText({
     result,
     experimentId,
 }: {
-    result: CachedExperimentFunnelsQueryResponse | CachedExperimentTrendsQueryResponse
+    result: CachedExperimentQueryResponse | CachedExperimentFunnelsQueryResponse | CachedExperimentTrendsQueryResponse
     experimentId: ExperimentIdType
 }): JSX.Element {
     const { getIndexForVariant, getHighestProbabilityVariant } = useValues(experimentLogic)

--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -216,7 +216,13 @@ export function ResultsHeader(): JSX.Element {
             </div>
 
             <div className="w-1/2 flex flex-col justify-end">
-                <div className="ml-auto">{result && <ExploreButton result={result} />}</div>
+                <div className="ml-auto">
+                    {/* TODO: Only show explore button if the metric is a trends or funnels query. Not supported yet with new query runner */}
+                    {result &&
+                        (result.kind === 'ExperimentTrendsQuery' || result.kind === 'ExperimentFunnelsQuery') && (
+                            <ExploreButton result={result} />
+                        )}
+                </div>
             </div>
         </div>
     )

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -845,9 +845,12 @@ export function DeltaChart({
                     </LemonButton>
                 }
             >
-                <div className="flex justify-end">
-                    <ExploreButton result={result} />
-                </div>
+                {/* TODO: Only show explore button if the metric is a trends or funnels query. Not supported yet with new query runner */}
+                {result && (result.kind === 'ExperimentTrendsQuery' || result.kind === 'ExperimentFunnelsQuery') && (
+                    <div className="flex justify-end">
+                        <ExploreButton result={result} />
+                    </div>
+                )}
                 <LemonBanner type={result?.significant ? 'success' : 'info'} className="mb-4">
                     <div className="items-center inline-flex flex-wrap">
                         <WinningVariantText result={result} experimentId={experimentId} />
@@ -855,7 +858,10 @@ export function DeltaChart({
                     </div>
                 </LemonBanner>
                 <SummaryTable metric={metric} metricIndex={metricIndex} isSecondary={isSecondary} />
-                <ResultsQuery result={result} showTable={true} />
+                {/* TODO: Only show results query if the metric is a trends or funnels query. Not supported yet with new query runner */}
+                {result && (result.kind === 'ExperimentTrendsQuery' || result.kind === 'ExperimentFunnelsQuery') && (
+                    <ResultsQuery result={result} showTable={true} />
+                )}
             </LemonModal>
         </div>
     )

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeExperiment.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeExperiment.tsx
@@ -82,7 +82,12 @@ const Component = ({ attributes }: NotebookNodeProps<NotebookNodeExperimentAttri
                                 <LemonDivider className="my-0" />
                                 <div className="p-2">
                                     <SummaryTable metric={experiment.metrics[0]} />
-                                    <ResultsQuery result={metricResults[0]} showTable={true} />
+                                    {/* TODO: Only show results if the metric is a trends or funnels query. Not supported yet with new query runner */}
+                                    {metricResults[0] &&
+                                        (metricResults[0].kind === 'ExperimentTrendsQuery' ||
+                                            metricResults[0].kind === 'ExperimentFunnelsQuery') && (
+                                            <ResultsQuery result={metricResults[0]} showTable={true} />
+                                        )}
                                 </div>
                             </>
                         )}


### PR DESCRIPTION
## Problem
It breaks a few places as we try to load components with the new metric format

## Changes
Only load components if the metric is of a supported kind.

Detail view for new metrics:
<img width="1282" alt="Screenshot 2025-02-13 at 19 13 06" src="https://github.com/user-attachments/assets/00f1962b-900c-4ce2-86d0-b6b7649e9b5c" />

Detail view for old metrics
<img width="1247" alt="Screenshot 2025-02-13 at 18 52 43" src="https://github.com/user-attachments/assets/4f3cd140-ec8a-4a29-80bd-494dc2c6402d" />

Overview for new metrics
<img width="1195" alt="Screenshot 2025-02-13 at 19 14 43" src="https://github.com/user-attachments/assets/863962ba-ecfa-42f3-a582-1c2341e5cb8d" />

Overview for old metrics
<img width="1185" alt="Screenshot 2025-02-13 at 19 14 51" src="https://github.com/user-attachments/assets/48bf1e93-2c63-4ef2-b729-88bd90bcd257" />


## How did you test this code?
* tests passes
* Looked at a new experiment with a single and two metrics
* Looked at an old experiment with with a single and two metrics
