### PR TITLE
fix(experiments): Ensure results modal displays correct data

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -211,8 +211,8 @@ class ExperimentSerializer(serializers.ModelSerializer):
         # Normalize query date ranges to the experiment's current range
         # Cribbed from ExperimentTrendsQuery
         new_date_range = {
-            "date_from": data["start_date"],
-            "date_to": data["end_date"],
+            "date_from": data["start_date"] if data["start_date"] else "",
+            "date_to": data["end_date"] if data["end_date"] else "",
             "explicitDate": True,
         }
         for metrics_list in [data.get("metrics", []), data.get("metrics_secondary", [])]:

--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -1,6 +1,5 @@
 from typing import Any, Optional
 from collections.abc import Callable
-from zoneinfo import ZoneInfo
 
 from django.utils.timezone import now
 from rest_framework import serializers, viewsets
@@ -211,16 +210,9 @@ class ExperimentSerializer(serializers.ModelSerializer):
         data = super().to_representation(instance)
         # Normalize query date ranges to the experiment's current range
         # Cribbed from ExperimentTrendsQuery
-        if instance.team.timezone:
-            tz = ZoneInfo(instance.team.timezone)
-            start_date = instance.start_date.astimezone(tz) if instance.start_date else None
-            end_date = instance.end_date.astimezone(tz) if instance.end_date else None
-        else:
-            start_date = instance.start_date
-            end_date = instance.end_date
         new_date_range = {
-            "date_from": start_date.strftime("%Y-%m-%dT%H:%M") if start_date else "",
-            "date_to": end_date.strftime("%Y-%m-%dT%H:%M") if end_date else "",
+            "date_from": data["start_date"],
+            "date_to": data["end_date"],
             "explicitDate": True,
         }
         for metrics_list in [data.get("metrics", []), data.get("metrics_secondary", [])]:

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -735,18 +735,22 @@ class TestExperimentCRUD(APILicensedTest):
 
         response = self.client.get(f"/api/projects/{self.team.id}/experiments/{experiment.id}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["metrics"][0]["funnels_query"]["dateRange"]["date_from"], "2025-02-01T00:00")
+        self.assertEqual(
+            response.json()["metrics"][0]["funnels_query"]["dateRange"]["date_from"], "2025-02-01T00:00:00Z"
+        )
         self.assertEqual(response.json()["metrics"][0]["funnels_query"]["dateRange"]["date_to"], "")
         self.assertEqual(
-            response.json()["metrics_secondary"][0]["count_query"]["dateRange"]["date_from"], "2025-02-01T00:00"
+            response.json()["metrics_secondary"][0]["count_query"]["dateRange"]["date_from"], "2025-02-01T00:00:00Z"
         )
         self.assertEqual(response.json()["metrics_secondary"][0]["count_query"]["dateRange"]["date_to"], "")
         self.assertEqual(
-            response.json()["saved_metrics"][0]["query"]["funnels_query"]["dateRange"]["date_from"], "2025-02-01T00:00"
+            response.json()["saved_metrics"][0]["query"]["funnels_query"]["dateRange"]["date_from"],
+            "2025-02-01T00:00:00Z",
         )
         self.assertEqual(response.json()["saved_metrics"][0]["query"]["funnels_query"]["dateRange"]["date_to"], "")
         self.assertEqual(
-            response.json()["saved_metrics"][1]["query"]["count_query"]["dateRange"]["date_from"], "2025-02-01T00:00"
+            response.json()["saved_metrics"][1]["query"]["count_query"]["dateRange"]["date_from"],
+            "2025-02-01T00:00:00Z",
         )
         self.assertEqual(response.json()["saved_metrics"][1]["query"]["count_query"]["dateRange"]["date_to"], "")
 

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -2053,7 +2053,7 @@
   FROM "posthog_cohort"
   INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
   WHERE (NOT "posthog_cohort"."deleted"
-         AND "posthog_team"."project_id" = 526)
+         AND "posthog_team"."project_id" = 525)
   '''
 # ---
 # name: TestFeatureFlagMatcher.test_numeric_operator_with_cohorts_and_nested_cohorts.1
@@ -2099,7 +2099,7 @@
          "posthog_grouptypemapping"."name_singular",
          "posthog_grouptypemapping"."name_plural"
   FROM "posthog_grouptypemapping"
-  WHERE "posthog_grouptypemapping"."project_id" = 526
+  WHERE "posthog_grouptypemapping"."project_id" = 525
   '''
 # ---
 # name: TestFeatureFlagMatcher.test_numeric_operator_with_groups_and_person_flags.1


### PR DESCRIPTION
See https://posthoghelp.zendesk.com/agent/tickets/25283 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/29154)

## Changes

Normalizes the funnel and trend queries to use the same date range as the experiment, thus preventing caching inconsistencies and stale results.

Previously, queries used whatever date range they were originally stored with:

![CleanShot 2025-02-13 at 12 38 40@2x](https://github.com/user-attachments/assets/de4bcd17-bed4-47ff-8d0e-9a65b5b25e97)

While the correct date was eventually applied in `ExperimentFunnelsQueryRunner` and `ExperimentTrendsQueryRunner`, the initial incorrect date caused the cache key to remain unchanged even when the experiment start date was modified. This led to stale results in the “Details” modal.

This fix normalizes the date range by ensuring that queries always reference the experiment’s start (and end) date:

![CleanShot 2025-02-13 at 12 37 01@2x](https://github.com/user-attachments/assets/a7ca7843-b34a-4074-9467-11da5679a515)

## How did you test this code?

I reproduced the original issue:
1. Visited an existing experiment with results.
2. Changed the start date to today.
3. Initially saw "Results not yet available" because it force-refreshed.
4. Refreshed the page.
5. Saw the stale experiment results because the stale cache was used.

Once I reproduced the original issue, I verified that this fix causes the expected results to be displayed whenever I change the experiment start date.

Also added some tests to verify the response object is modified as expected.