### PR TITLE
fix(experiments): Allow multiple errored results to display

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -132,6 +132,8 @@ const loadMetrics = async ({
         | null
     )[] = []
 
+    const currentErrors = new Array(metrics.length).fill(null)
+
     return await Promise.all(
         metrics.map(async (metric, index) => {
             try {
@@ -150,7 +152,6 @@ const loadMetrics = async ({
                 const errorDetailMatch = error.detail?.match(/\{.*\}/)
                 const errorDetail = errorDetailMatch ? JSON.parse(errorDetailMatch[0]) : error.detail || error.message
 
-                const currentErrors = new Array(metrics.length).fill(null)
                 currentErrors[index] = {
                     detail: errorDetail,
                     statusCode: error.status,


### PR DESCRIPTION
Follow up from https://github.com/PostHog/posthog/pull/28387

## Changes

Allows multiple errored results to display as expected, instead of having the last result error overwrite all of the prior errors.

**Before**

![CleanShot 2025-02-13 at 13 39 16@2x](https://github.com/user-attachments/assets/067468cf-770f-4bb0-b26b-fac5a8a4a662)

**After**

![CleanShot 2025-02-13 at 13 38 37@2x](https://github.com/user-attachments/assets/6f642ba2-06e8-4343-8b6a-7470ca72df12)

## How did you test this code?

Manual review.