### PR TITLE
perf: Add `person_properties_map_custom` property group

### DIFF
--- a/posthog/clickhouse/migrations/0098_events_person_properties_map_custom.py
+++ b/posthog/clickhouse/migrations/0098_events_person_properties_map_custom.py
@@ -1,0 +1,14 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.clickhouse.property_groups import property_groups
+
+operations = [
+    *[
+        run_sql_with_exceptions(statement, node_role=NodeRole.DATA)
+        for statement in property_groups.get_alter_create_statements("sharded_events", "person_properties", "custom")
+    ],
+    *[
+        run_sql_with_exceptions(statement, node_role=NodeRole.ALL)
+        for statement in property_groups.get_alter_create_statements("events", "person_properties", "custom")
+    ],
+]

--- a/posthog/clickhouse/property_groups.py
+++ b/posthog/clickhouse/property_groups.py
@@ -122,7 +122,13 @@ event_property_group_definitions = {
             "key like '$feature/%'",
             lambda key: key.startswith("$feature/"),
         ),
-    }
+    },
+    "person_properties": {
+        "custom": PropertyGroupDefinition(
+            f"key NOT LIKE '$%'",
+            lambda key: not key.startswith("$"),
+        ),
+    },
 }
 
 property_groups = PropertyGroupManager(

--- a/posthog/clickhouse/property_groups.py
+++ b/posthog/clickhouse/property_groups.py
@@ -25,10 +25,10 @@ class PropertyGroupDefinition:
         else:
             return self.key_filter_function(property_key)
 
-    def get_column_name(self, source_column: PropertySourceColumnName, group_name: PropertyGroupName):
+    def get_column_name(self, source_column: PropertySourceColumnName, group_name: PropertyGroupName) -> str:
         return f"{source_column}_{self.column_type_name}_{group_name}"
 
-    def get_column_definition(self, source_column: PropertySourceColumnName, group_name: PropertyGroupName):
+    def get_column_definition(self, source_column: PropertySourceColumnName, group_name: PropertyGroupName) -> str:
         column_definition = f"{self.get_column_name(source_column, group_name)} Map(String, String)"
         if not self.is_materialized:
             return column_definition

--- a/posthog/clickhouse/property_groups.py
+++ b/posthog/clickhouse/property_groups.py
@@ -16,12 +16,13 @@ class PropertyGroupDefinition:
     key_filter_function: Callable[[str], bool]
     codec: str = "ZSTD(1)"
     is_materialized: bool = True
+    column_type_name: str = "map"
 
     def contains(self, property_key: str) -> bool:
         return self.key_filter_function(property_key)
 
     def get_column_name(self, column: ColumnName, group_name: PropertyGroupName):
-        return f"{column}_group_{group_name}"
+        return f"{column}_{self.column_type_name}_{group_name}"
 
 
 class PropertyGroupManager:
@@ -137,10 +138,12 @@ event_property_group_definitions = {
         "custom": PropertyGroupDefinition(
             f"key NOT LIKE '$%' AND key NOT IN (" + f", ".join(f"'{name}'" for name in ignore_custom_properties) + f")",
             lambda key: not key.startswith("$") and key not in ignore_custom_properties,
+            column_type_name="group",
         ),
         "feature_flags": PropertyGroupDefinition(
             "key like '$feature/%'",
             lambda key: key.startswith("$feature/"),
+            column_type_name="group",
         ),
     },
     "person_properties": {

--- a/posthog/clickhouse/property_groups.py
+++ b/posthog/clickhouse/property_groups.py
@@ -17,9 +17,15 @@ class PropertyGroupDefinition:
     codec: str = "ZSTD(1)"
     is_materialized: bool = True
     column_type_name: str = "map"
+    hidden: bool = (
+        False  # whether or not this column should be returned when searching for groups containing a property key
+    )
 
     def contains(self, property_key: str) -> bool:
-        return self.key_filter_function(property_key)
+        if self.hidden:
+            return False
+        else:
+            return self.key_filter_function(property_key)
 
     def get_column_name(self, column: ColumnName, group_name: PropertyGroupName):
         return f"{column}_{self.column_type_name}_{group_name}"
@@ -150,6 +156,7 @@ event_property_group_definitions = {
         "custom": PropertyGroupDefinition(
             f"key NOT LIKE '$%'",
             lambda key: not key.startswith("$"),
+            hidden=True,
         ),
     },
 }

--- a/posthog/clickhouse/property_groups.py
+++ b/posthog/clickhouse/property_groups.py
@@ -74,11 +74,19 @@ class PropertyGroupManager:
                     yield f"INDEX {index_definition}"
 
     def get_alter_create_statements(
-        self, table: TableName, column: ColumnName, group_name: PropertyGroupName
+        self,
+        table: TableName,
+        column: ColumnName,
+        group_name: PropertyGroupName,
+        on_cluster: bool = False,
     ) -> Iterable[str]:
-        yield f"ALTER TABLE {table} ON CLUSTER {self.__cluster} ADD COLUMN IF NOT EXISTS {self.__get_column_definition(table, column, group_name)}"
+        prefix = f"ALTER TABLE {table}"
+        if on_cluster:
+            prefix += f" ON CLUSTER {self.__cluster}"
+
+        yield f"{prefix} ADD COLUMN IF NOT EXISTS {self.__get_column_definition(table, column, group_name)}"
         for index_definition in self.__get_index_definitions(table, column, group_name):
-            yield f"ALTER TABLE {table} ON CLUSTER {self.__cluster} ADD INDEX IF NOT EXISTS {index_definition}"
+            yield f"{prefix} ADD INDEX IF NOT EXISTS {index_definition}"
 
 
 ignore_custom_properties = [

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -749,7 +749,7 @@
       , elements_chain_texts Array(String) COMMENT 'column_materializer::elements_chain::texts'
       , elements_chain_ids Array(String) COMMENT 'column_materializer::elements_chain::ids'
       , elements_chain_elements Array(Enum('a', 'button', 'form', 'input', 'select', 'textarea', 'label')) COMMENT 'column_materializer::elements_chain::elements'
-      , properties_group_custom Map(String, String), properties_group_feature_flags Map(String, String)
+      , properties_group_custom Map(String, String), properties_group_feature_flags Map(String, String), person_properties_map_custom Map(String, String)
   
       
   , _timestamp DateTime
@@ -2547,19 +2547,25 @@
       , INDEX `minmax_$group_4` `$group_4` TYPE minmax GRANULARITY 1
       , INDEX `minmax_$window_id` `$window_id` TYPE minmax GRANULARITY 1
       , INDEX `minmax_$session_id` `$session_id` TYPE minmax GRANULARITY 1
-      ,                 properties_group_custom Map(String, String)
-                  MATERIALIZED mapSort(
-                      mapFilter((key, _) -> key NOT LIKE '$%' AND key NOT IN ('token', 'distinct_id', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term', 'gclid', 'gad_source', 'gclsrc', 'dclid', 'gbraid', 'wbraid', 'fbclid', 'msclkid', 'twclid', 'li_fat_id', 'mc_cid', 'igshid', 'ttclid', 'rdt_cid', 'irclid', '_kx'),
-                      CAST(JSONExtractKeysAndValues(properties, 'String'), 'Map(String, String)'))
-                  )
-                  CODEC(ZSTD(1))
-              , INDEX properties_group_custom_keys_bf mapKeys(properties_group_custom) TYPE bloom_filter, INDEX properties_group_custom_values_bf mapValues(properties_group_custom) TYPE bloom_filter,                 properties_group_feature_flags Map(String, String)
-                  MATERIALIZED mapSort(
-                      mapFilter((key, _) -> key like '$feature/%',
-                      CAST(JSONExtractKeysAndValues(properties, 'String'), 'Map(String, String)'))
-                  )
-                  CODEC(ZSTD(1))
-              , INDEX properties_group_feature_flags_keys_bf mapKeys(properties_group_feature_flags) TYPE bloom_filter, INDEX properties_group_feature_flags_values_bf mapValues(properties_group_feature_flags) TYPE bloom_filter
+      ,             properties_group_custom Map(String, String)
+              MATERIALIZED mapSort(
+                  mapFilter((key, _) -> key NOT LIKE '$%' AND key NOT IN ('token', 'distinct_id', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term', 'gclid', 'gad_source', 'gclsrc', 'dclid', 'gbraid', 'wbraid', 'fbclid', 'msclkid', 'twclid', 'li_fat_id', 'mc_cid', 'igshid', 'ttclid', 'rdt_cid', 'irclid', '_kx'),
+                  CAST(JSONExtractKeysAndValues(properties, 'String'), 'Map(String, String)'))
+              )
+              CODEC(ZSTD(1))
+          , INDEX properties_group_custom_keys_bf mapKeys(properties_group_custom) TYPE bloom_filter, INDEX properties_group_custom_values_bf mapValues(properties_group_custom) TYPE bloom_filter,             properties_group_feature_flags Map(String, String)
+              MATERIALIZED mapSort(
+                  mapFilter((key, _) -> key like '$feature/%',
+                  CAST(JSONExtractKeysAndValues(properties, 'String'), 'Map(String, String)'))
+              )
+              CODEC(ZSTD(1))
+          , INDEX properties_group_feature_flags_keys_bf mapKeys(properties_group_feature_flags) TYPE bloom_filter, INDEX properties_group_feature_flags_values_bf mapValues(properties_group_feature_flags) TYPE bloom_filter,             person_properties_map_custom Map(String, String)
+              MATERIALIZED mapSort(
+                  mapFilter((key, _) -> key NOT LIKE '$%',
+                  CAST(JSONExtractKeysAndValues(person_properties, 'String'), 'Map(String, String)'))
+              )
+              CODEC(ZSTD(1))
+          , INDEX person_properties_map_custom_keys_bf mapKeys(person_properties_map_custom) TYPE bloom_filter, INDEX person_properties_map_custom_values_bf mapValues(person_properties_map_custom) TYPE bloom_filter
   
       
   , _timestamp DateTime
@@ -3754,19 +3760,25 @@
       , INDEX `minmax_$group_4` `$group_4` TYPE minmax GRANULARITY 1
       , INDEX `minmax_$window_id` `$window_id` TYPE minmax GRANULARITY 1
       , INDEX `minmax_$session_id` `$session_id` TYPE minmax GRANULARITY 1
-      ,                 properties_group_custom Map(String, String)
-                  MATERIALIZED mapSort(
-                      mapFilter((key, _) -> key NOT LIKE '$%' AND key NOT IN ('token', 'distinct_id', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term', 'gclid', 'gad_source', 'gclsrc', 'dclid', 'gbraid', 'wbraid', 'fbclid', 'msclkid', 'twclid', 'li_fat_id', 'mc_cid', 'igshid', 'ttclid', 'rdt_cid', 'irclid', '_kx'),
-                      CAST(JSONExtractKeysAndValues(properties, 'String'), 'Map(String, String)'))
-                  )
-                  CODEC(ZSTD(1))
-              , INDEX properties_group_custom_keys_bf mapKeys(properties_group_custom) TYPE bloom_filter, INDEX properties_group_custom_values_bf mapValues(properties_group_custom) TYPE bloom_filter,                 properties_group_feature_flags Map(String, String)
-                  MATERIALIZED mapSort(
-                      mapFilter((key, _) -> key like '$feature/%',
-                      CAST(JSONExtractKeysAndValues(properties, 'String'), 'Map(String, String)'))
-                  )
-                  CODEC(ZSTD(1))
-              , INDEX properties_group_feature_flags_keys_bf mapKeys(properties_group_feature_flags) TYPE bloom_filter, INDEX properties_group_feature_flags_values_bf mapValues(properties_group_feature_flags) TYPE bloom_filter
+      ,             properties_group_custom Map(String, String)
+              MATERIALIZED mapSort(
+                  mapFilter((key, _) -> key NOT LIKE '$%' AND key NOT IN ('token', 'distinct_id', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term', 'gclid', 'gad_source', 'gclsrc', 'dclid', 'gbraid', 'wbraid', 'fbclid', 'msclkid', 'twclid', 'li_fat_id', 'mc_cid', 'igshid', 'ttclid', 'rdt_cid', 'irclid', '_kx'),
+                  CAST(JSONExtractKeysAndValues(properties, 'String'), 'Map(String, String)'))
+              )
+              CODEC(ZSTD(1))
+          , INDEX properties_group_custom_keys_bf mapKeys(properties_group_custom) TYPE bloom_filter, INDEX properties_group_custom_values_bf mapValues(properties_group_custom) TYPE bloom_filter,             properties_group_feature_flags Map(String, String)
+              MATERIALIZED mapSort(
+                  mapFilter((key, _) -> key like '$feature/%',
+                  CAST(JSONExtractKeysAndValues(properties, 'String'), 'Map(String, String)'))
+              )
+              CODEC(ZSTD(1))
+          , INDEX properties_group_feature_flags_keys_bf mapKeys(properties_group_feature_flags) TYPE bloom_filter, INDEX properties_group_feature_flags_values_bf mapValues(properties_group_feature_flags) TYPE bloom_filter,             person_properties_map_custom Map(String, String)
+              MATERIALIZED mapSort(
+                  mapFilter((key, _) -> key NOT LIKE '$%',
+                  CAST(JSONExtractKeysAndValues(person_properties, 'String'), 'Map(String, String)'))
+              )
+              CODEC(ZSTD(1))
+          , INDEX person_properties_map_custom_keys_bf mapKeys(person_properties_map_custom) TYPE bloom_filter, INDEX person_properties_map_custom_values_bf mapValues(person_properties_map_custom) TYPE bloom_filter
   
       
   , _timestamp DateTime

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -2053,7 +2053,7 @@
   FROM "posthog_cohort"
   INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
   WHERE (NOT "posthog_cohort"."deleted"
-         AND "posthog_team"."project_id" = 526)
+         AND "posthog_team"."project_id" = 525)
   '''
 # ---
 # name: TestFeatureFlagMatcher.test_numeric_operator_with_cohorts_and_nested_cohorts.1
@@ -2099,7 +2099,7 @@
          "posthog_grouptypemapping"."name_singular",
          "posthog_grouptypemapping"."name_plural"
   FROM "posthog_grouptypemapping"
-  WHERE "posthog_grouptypemapping"."project_id" = 526
+  WHERE "posthog_grouptypemapping"."project_id" = 525
   '''
 # ---
 # name: TestFeatureFlagMatcher.test_numeric_operator_with_groups_and_person_flags.1


### PR DESCRIPTION
## Problem

Customers with a lot of events report slowness when querying person properties, even when using the properties-on-events version of PoE.

## Changes

- Adds `person_properties_map_custom` column and indexes to `events` and `sharded_events` tables, containing non-`$`-prefixed person properties to reduce the amount of data scanned and JSON parsed
- Allows groups to be marked as "hidden" which prevents them from being used in querying while backfill is ongoing (not the ideal solution, but it should work for now)
- Refactors some other things that were annoying me and improves flexibility, also adds some short documentation strings to remind myself how everything works after being out of this headspace in a minute

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

See snapshots, also note lack of changed snapshots for read queries