### PR TITLE
fix: Fix self-capture initialization when multiple users

### DIFF
--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -511,7 +511,7 @@ async def initialize_self_capture_api_token():
             await User.objects.filter(last_login__isnull=False)
             .order_by("-last_login")
             .select_related("current_team")
-            .aget()
+            .afirst()
         )
         # Get the current user's team (or first team in the instance) to set self capture configs
         team = None


### PR DESCRIPTION
Fixes https://posthog.slack.com/archives/C0113360FFV/p1739489263187629

From https://github.com/PostHog/posthog/pull/28627