### PR TITLE
fix: Collapse multiple commands into single statement when creating property group

### DIFF
--- a/posthog/clickhouse/property_groups.py
+++ b/posthog/clickhouse/property_groups.py
@@ -102,9 +102,12 @@ class PropertyGroupManager:
             prefix += f" ON CLUSTER {cluster}"
 
         group_definition = self.__groups[table][source_column][group_name]
-        yield f"{prefix} ADD COLUMN IF NOT EXISTS {group_definition.get_column_definition(source_column, group_name)}"
+
+        commands = [f"ADD COLUMN IF NOT EXISTS {group_definition.get_column_definition(source_column, group_name)}"]
         for index_definition in group_definition.get_index_definitions(source_column, group_name):
-            yield f"{prefix} ADD INDEX IF NOT EXISTS {index_definition}"
+            commands.append(f"ADD INDEX IF NOT EXISTS {index_definition}")
+
+        yield f"{prefix} " + ", ".join(commands)
 
 
 ignore_custom_properties = [


### PR DESCRIPTION
## Problem

The number of separate statements generated here probably contribute to the "too many alters executing concurrently" error from #28697.

## Changes

Combines commands into a single statement where possible.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Ran `bin/migrate` on a clean sheet database, checked schemas and query log, saw multi-command statements like (after formatting):

```sql
ALTER TABLE sharded_events
    ADD COLUMN IF NOT EXISTS `person_properties_map_custom` Map(String, String) MATERIALIZED mapSort(mapFilter((key, _) -> (key NOT LIKE '$%'), CAST(JSONExtractKeysAndValues(person_properties, 'String'), 'Map(String, String)'))) CODEC(ZSTD(1)),
    ADD INDEX IF NOT EXISTS person_properties_map_custom_keys_bf mapKeys(person_properties_map_custom) TYPE bloom_filter GRANULARITY 1,
    ADD INDEX IF NOT EXISTS person_properties_map_custom_values_bf mapValues(person_properties_map_custom) TYPE bloom_filter GRANULARITY 1

```
