### PR TITLE
fix(routing): Improve project switching for insights pages

### DIFF
--- a/frontend/src/layout/navigation/EnvironmentSwitcher.tsx
+++ b/frontend/src/layout/navigation/EnvironmentSwitcher.tsx
@@ -151,21 +151,23 @@ export function EnvironmentSwitcherOverlay({ onClickInside }: { onClickInside?: 
 }
 
 function determineProjectSwitchUrl(pathname: string, newTeamId: number): string {
-    // NOTE: There is a tradeoff here - because we choose keep the whole path it could be that the
-    // project switch lands on something like insight/abc that won't exist.
-    // On the other hand, if we remove the ID, it could be that someone opens a page, realizes they're in the wrong project
-    // and after switching is on a different page than before.
     let route = removeProjectIdIfPresent(pathname)
     route = removeFlagIdIfPresent(route)
 
     // List of routes that should redirect to project home
-    // instead of keeping the current path.
     const redirectToHomeRoutes = ['/products', '/onboarding']
+
+    // Check if we're on an insights page
+    const isInsightsPage = route.includes('/insights/')
 
     const shouldRedirectToHome = redirectToHomeRoutes.some((redirectRoute) => route.includes(redirectRoute))
 
     if (shouldRedirectToHome) {
         return urls.project(newTeamId) // Go to project home
+    }
+
+    if (isInsightsPage) {
+        return urls.project(newTeamId, '/insights') // Go to insights list instead of specific insight
     }
 
     return urls.project(newTeamId, route)

--- a/frontend/src/layout/navigation/EnvironmentSwitcher.tsx
+++ b/frontend/src/layout/navigation/EnvironmentSwitcher.tsx
@@ -152,15 +152,14 @@ export function EnvironmentSwitcherOverlay({ onClickInside }: { onClickInside?: 
 
 function determineProjectSwitchUrl(pathname: string, newTeamId: number): string {
     const { currentTeam } = teamLogic.values
-    const { sortedProjectsMap } = environmentSwitcherLogic.values
+    const { currentOrganization } = organizationLogic.values
 
     // Find the target team's project ID
     let targetTeamProjectId: number | null = null
-    for (const [_, [, teams]] of sortedProjectsMap.entries()) {
-        const targetTeam = teams.find((team) => team.id === newTeamId)
+    if (currentOrganization?.teams) {
+        const targetTeam = currentOrganization.teams.find((team) => team.id === newTeamId)
         if (targetTeam) {
             targetTeamProjectId = targetTeam.project_id
-            break
         }
     }
 

--- a/frontend/src/layout/navigation/ProjectSwitcher.tsx
+++ b/frontend/src/layout/navigation/ProjectSwitcher.tsx
@@ -7,13 +7,12 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { LemonSnack } from 'lib/lemon-ui/LemonSnack/LemonSnack'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { removeFlagIdIfPresent, removeProjectIdIfPresent } from 'lib/utils/router-utils'
+import { getProjectSwitchTargetUrl } from 'lib/utils/router-utils'
 import { useMemo } from 'react'
 import { organizationLogic } from 'scenes/organizationLogic'
 import { isAuthenticatedTeam, teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
-import { breadcrumbsLogic } from '~/layout/navigation/Breadcrumbs/breadcrumbsLogic'
 import { AvailableFeature, TeamBasicType } from '~/types'
 
 import { globalModalsLogic } from '../GlobalModals'
@@ -95,34 +94,10 @@ function CurrentProjectButton({ onClickInside }: { onClickInside?: () => void })
 function OtherProjectButton({ team }: { team: TeamBasicType; onClickInside?: () => void }): JSX.Element {
     const { location } = useValues(router)
     const { currentTeam } = useValues(teamLogic)
-    const { breadcrumbs } = useValues(breadcrumbsLogic)
 
     const relativeOtherProjectPath = useMemo(() => {
-        let route = removeProjectIdIfPresent(location.pathname)
-        route = removeFlagIdIfPresent(route)
-
-        // List of routes that should redirect to project home
-        const redirectToHomeRoutes = ['/products', '/onboarding']
-
-        const shouldRedirectToHome = redirectToHomeRoutes.some((redirectRoute) => route.includes(redirectRoute))
-
-        if (shouldRedirectToHome) {
-            return urls.project(team.id) // Go to project home
-        }
-
-        // If switching between projects (not just environments), redirect to parent path
-        if (currentTeam && currentTeam.project_id !== team.project_id) {
-            // Get the parent breadcrumb's path if it exists
-            const parentBreadcrumb = breadcrumbs.length > 1 ? breadcrumbs[breadcrumbs.length - 2] : null
-            if (parentBreadcrumb?.path) {
-                return urls.project(team.id, parentBreadcrumb.path)
-            }
-            // If no parent path found, go to project home
-            return urls.project(team.id)
-        }
-
-        return urls.project(team.id, route)
-    }, [location.pathname, team.id, team.project_id, breadcrumbs, currentTeam])
+        return getProjectSwitchTargetUrl(location.pathname, team.id, currentTeam?.project_id, team.project_id)
+    }, [location.pathname, team.id, team.project_id, currentTeam?.project_id])
 
     return (
         <LemonButton

--- a/frontend/src/layout/navigation/ProjectSwitcher.tsx
+++ b/frontend/src/layout/navigation/ProjectSwitcher.tsx
@@ -95,21 +95,23 @@ function OtherProjectButton({ team }: { team: TeamBasicType; onClickInside?: () 
     const { location } = useValues(router)
 
     const relativeOtherProjectPath = useMemo(() => {
-        // NOTE: There is a tradeoff here - because we choose keep the whole path it could be that the
-        // project switch lands on something like insight/abc that won't exist.
-        // On the other hand, if we remove the ID, it could be that someone opens a page, realizes they're in the wrong project
-        // and after switching is on a different page than before.
         let route = removeProjectIdIfPresent(location.pathname)
         route = removeFlagIdIfPresent(route)
 
         // List of routes that should redirect to project home
-        // instead of keeping the current path.
         const redirectToHomeRoutes = ['/products', '/onboarding']
+
+        // Check if we're on an insights page
+        const isInsightsPage = route.includes('/insights/')
 
         const shouldRedirectToHome = redirectToHomeRoutes.some((redirectRoute) => route.includes(redirectRoute))
 
         if (shouldRedirectToHome) {
             return urls.project(team.id) // Go to project home
+        }
+
+        if (isInsightsPage) {
+            return urls.project(team.id, '/insights') // Go to insights list instead of specific insight
         }
 
         return urls.project(team.id, route)

--- a/frontend/src/lib/utils/router-utils.ts
+++ b/frontend/src/lib/utils/router-utils.ts
@@ -58,3 +58,44 @@ export function addProjectIdIfMissing(path: string, teamId?: TeamType['id']): st
         ? removeProjectIdIfPresent(path)
         : addProjectIdUnlessPresent(path, teamId)
 }
+
+const STAY_ON_SAME_PAGE_PATHS = ['settings']
+const REDIRECT_TO_PROJECT_ROOT_PATHS = ['products', 'onboarding']
+
+export function getProjectSwitchTargetUrl(
+    currentPath: string,
+    newTeamId: number,
+    currentProjectId?: number | null,
+    newProjectId?: number | null
+): string {
+    // Remove project ID and flag ID from the path
+    let route = removeProjectIdIfPresent(currentPath)
+    route = removeFlagIdIfPresent(route)
+
+    // Extract the resource path (first part after removing project ID)
+    const resourcePath = route.split('/')[1]
+
+    // If it's a path that should redirect to project root
+    if (REDIRECT_TO_PROJECT_ROOT_PATHS.includes(resourcePath)) {
+        return `/project/${newTeamId}`
+    }
+
+    // If it's a path where we should stay on the same page (like settings)
+    if (STAY_ON_SAME_PAGE_PATHS.includes(resourcePath)) {
+        return `/project/${newTeamId}${route}`
+    }
+
+    // For other paths with subresources (like /insights/abc123)
+    const pathParts = route.split('/')
+    if (pathParts.length > 2) {
+        // If switching between teams in the same project, keep the resource ID
+        if (currentProjectId && newProjectId && currentProjectId === newProjectId) {
+            return `/project/${newTeamId}${route}`
+        }
+        // Otherwise, go to the parent resource
+        return `/project/${newTeamId}/${pathParts[1]}`
+    }
+
+    // Default: keep the same route structure but with new project ID
+    return `/project/${newTeamId}${route}`
+}


### PR DESCRIPTION
## Problem

Right now, when switching a project while being inside an insight, it just updates the project id:
e.g: from 
`https://us.posthog.com/project/80848/insights/rwQGkcYU` to
`https://us.posthog.com/project/19618/insights/rwQGkcYU`

but since the insight is not there, it shows "Insight not found".
![image](https://github.com/user-attachments/assets/cda6556b-38b2-4430-a1a6-660ae0446532)


<!-- Who are we building for, what are their needs, why is this important? -->

General UX improvement

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

When changing the project from the project switcher, check if it's in the insight page and in that case, route to the `[new project id]/insights` page instead of `[new project id]/insights/ [old insight id/`

This changes the #25009 PR by @Twixes. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Locally by creating a new project and switching between them while being inside an insight. 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

[Slack thread](https://posthog.slack.com/archives/C0368RPHLQH/p1739522928079419)