### PR TITLE
feat(trends): cap breakdown limit at 1000

### DIFF
--- a/frontend/src/scenes/insights/filters/BreakdownFilter/GlobalBreakdownOptionsMenu.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/GlobalBreakdownOptionsMenu.tsx
@@ -49,8 +49,10 @@ export const GlobalBreakdownOptionsMenu = (): JSX.Element => {
                 <LemonInput
                     id="breakdown-limit"
                     min={1}
+                    max={1000}
                     value={breakdownLimit}
-                    onChange={setBreakdownLimit}
+                    // :HACKY: We cap the breakdown limit in the `onChange` handler, as the `max` prop doesn't enforce anything.
+                    onChange={(value) => setBreakdownLimit(value !== undefined ? Math.min(value, 1000) : undefined)}
                     fullWidth={false}
                     className="w-20 ml-2"
                     type="number"


### PR DESCRIPTION
## Problem

Setting a large enough breakdown value results in the "sad face" icon on charts (canvas elements running out of memory). See this thread for a customer running into the issue: https://posthog.slack.com/archives/C0368RPHLQH/p1739445669014909

## Changes

- Enforces a limit of 1000 in the UI. 
- We likely don't want to limit the backend, as there's still a valid use case for large breakdown limits in exports.
- I thought about doing the validation with `kea-forms`, but it isn't worth the effort for this minor issue IMO.

## How did you test this code?

Tried locally