### PR TITLE
fix: load CH issue regardless

### DIFF
--- a/frontend/src/scenes/error-tracking/errorTrackingIssueSceneLogic.ts
+++ b/frontend/src/scenes/error-tracking/errorTrackingIssueSceneLogic.ts
@@ -130,7 +130,7 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
                 const issue = values.issue
                 if (!issue) {
                     actions.loadRelationalIssue()
-                } else if (!issue.last_seen) {
+                } else {
                     actions.loadClickHouseIssue(issue.first_seen)
                 }
             }


### PR DESCRIPTION
## Problem

Reported in https://posthoghelp.zendesk.com/agent/tickets/25111 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/26905)

## Changes

Always refresh the CH issue. Case being that you click through to the issue page from the list, previously it would not have refreshed because `last_seen` is set but we need to given the `earliest` isn't computed before this. This will change once we move to fetching the exception separately for latest / earliest / recommended views