### PR TITLE
WIP feat(cdp): hog property filter

### DIFF
--- a/plugin-server/src/cdp/templates/_transformations/property-filter/property-filter.template.test.ts
+++ b/plugin-server/src/cdp/templates/_transformations/property-filter/property-filter.template.test.ts
@@ -24,6 +24,8 @@ describe('property-filter.template', () => {
         const response = await tester.invoke(
             {
                 propertiesToFilter: 'distinct_id',
+                includeSetProperties: false,
+                includeSetOnceProperties: false,
             },
             mockGlobals
         )
@@ -35,15 +37,150 @@ describe('property-filter.template', () => {
         expect((response.execResult as any).properties.safe_property).toBe('keep-me')
     })
 
-    it('should filter out properties in event.properties', async () => {
+    it('should not filter properties from $set and $set_once when toggles are off', async () => {
         mockGlobals = tester.createGlobals({
             event: {
-                distinct_id: 'user123',
                 properties: {
-                    $ip: '127.0.0.1',
+                    sensitive: 'remove-me',
+                    safe_property: 'keep-me',
                     $set: {
-                        $ip: '192.168.1.1',
+                        sensitive: 'should-stay',
                         email: 'test@example.com',
+                    },
+                    $set_once: {
+                        sensitive: 'should-also-stay',
+                        username: 'test-user',
+                    },
+                },
+            },
+        })
+
+        const response = await tester.invoke(
+            {
+                propertiesToFilter: 'sensitive',
+                includeSetProperties: false,
+                includeSetOnceProperties: false,
+            },
+            mockGlobals
+        )
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect((response.execResult as any).properties.sensitive).toBeUndefined()
+        expect((response.execResult as any).properties.safe_property).toBe('keep-me')
+        expect((response.execResult as any).properties.$set.sensitive).toBe('should-stay')
+        expect((response.execResult as any).properties.$set_once.sensitive).toBe('should-also-stay')
+    })
+
+    it('should filter properties from $set when enabled', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    sensitive: 'remove-me',
+                    $set: {
+                        sensitive: 'should-be-removed',
+                        email: 'test@example.com',
+                    },
+                    $set_once: {
+                        sensitive: 'should-stay',
+                        username: 'test-user',
+                    },
+                },
+            },
+        })
+
+        const response = await tester.invoke(
+            {
+                propertiesToFilter: 'sensitive',
+                includeSetProperties: true,
+                includeSetOnceProperties: false,
+            },
+            mockGlobals
+        )
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect((response.execResult as any).properties.sensitive).toBeUndefined()
+        expect((response.execResult as any).properties.$set.sensitive).toBeUndefined()
+        expect((response.execResult as any).properties.$set.email).toBe('test@example.com')
+        expect((response.execResult as any).properties.$set_once.sensitive).toBe('should-stay')
+    })
+
+    it('should filter properties from $set_once when enabled', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    sensitive: 'remove-me',
+                    $set: {
+                        sensitive: 'should-stay',
+                        email: 'test@example.com',
+                    },
+                    $set_once: {
+                        sensitive: 'should-be-removed',
+                        username: 'test-user',
+                    },
+                },
+            },
+        })
+
+        const response = await tester.invoke(
+            {
+                propertiesToFilter: 'sensitive',
+                includeSetProperties: false,
+                includeSetOnceProperties: true,
+            },
+            mockGlobals
+        )
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect((response.execResult as any).properties.sensitive).toBeUndefined()
+        expect((response.execResult as any).properties.$set.sensitive).toBe('should-stay')
+        expect((response.execResult as any).properties.$set_once.sensitive).toBeUndefined()
+        expect((response.execResult as any).properties.$set_once.username).toBe('test-user')
+    })
+
+    it('should handle property names with special characters', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    '$feature/flag': true,
+                    '$experiment/variant': 'control',
+                    $geoip_city_name: 'London',
+                    'app/version': '1.2.3',
+                    safe_property: 'keep-me',
+                },
+            },
+        })
+
+        const response = await tester.invoke(
+            {
+                propertiesToFilter: '$feature/flag,$geoip_city_name',
+                includeSetProperties: false,
+                includeSetOnceProperties: false,
+            },
+            mockGlobals
+        )
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect((response.execResult as any).properties['$feature/flag']).toBeUndefined()
+        expect((response.execResult as any).properties['$experiment/variant']).toBe('control')
+        expect((response.execResult as any).properties.$geoip_city_name).toBeUndefined()
+        expect((response.execResult as any).properties['app/version']).toBe('1.2.3')
+        expect((response.execResult as any).properties.safe_property).toBe('keep-me')
+    })
+
+    it('should handle case-insensitive property matching', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    $IP: 'should-stay',
+                    ip: 'should-stay',
+                    $set: {
+                        IP: 'should-stay',
+                        $IP: 'should-stay',
+                        $ip: 'should-be-removed',
                     },
                     safe_property: 'keep-me',
                 },
@@ -52,17 +189,20 @@ describe('property-filter.template', () => {
 
         const response = await tester.invoke(
             {
-                propertiesToFilter: '$ip,$set.$ip',
+                propertiesToFilter: '$ip',
+                includeSetProperties: true,
+                includeSetOnceProperties: false,
             },
             mockGlobals
         )
 
         expect(response.finished).toBe(true)
         expect(response.error).toBeUndefined()
-        expect((response.execResult as any).distinct_id).toBe('user123')
-        expect((response.execResult as any).properties.$ip).toBeUndefined()
+        expect((response.execResult as any).properties.$IP).toBe('should-stay')
+        expect((response.execResult as any).properties.ip).toBe('should-stay')
+        expect((response.execResult as any).properties.$set.IP).toBe('should-stay')
+        expect((response.execResult as any).properties.$set.$IP).toBe('should-stay')
         expect((response.execResult as any).properties.$set.$ip).toBeUndefined()
-        expect((response.execResult as any).properties.$set.email).toBe('test@example.com')
         expect((response.execResult as any).properties.safe_property).toBe('keep-me')
     })
 
@@ -72,6 +212,9 @@ describe('property-filter.template', () => {
                 distinct_id: 'user123',
                 properties: {
                     $ip: '127.0.0.1',
+                    $set: {
+                        $ip: 'keep-me',
+                    },
                 },
             },
         })
@@ -79,6 +222,8 @@ describe('property-filter.template', () => {
         const response = await tester.invoke(
             {
                 propertiesToFilter: '',
+                includeSetProperties: true,
+                includeSetOnceProperties: true,
             },
             mockGlobals
         )
@@ -87,155 +232,106 @@ describe('property-filter.template', () => {
         expect(response.error).toBeUndefined()
         expect((response.execResult as any).distinct_id).toBe('user123')
         expect((response.execResult as any).properties.$ip).toBe('127.0.0.1')
+        expect((response.execResult as any).properties.$set.$ip).toBe('keep-me')
     })
 
-    it('should filter out deeply nested properties', async () => {
+    it('should handle exact property name matching', async () => {
         mockGlobals = tester.createGlobals({
             event: {
-                distinct_id: 'user123',
                 properties: {
-                    user: {
-                        profile: {
-                            settings: {
-                                email: 'test@example.com',
-                                api_key: 'secret-key',
-                                preferences: {
-                                    theme: 'dark',
-                                },
-                            },
-                        },
+                    $ip: 'should-be-removed',
+                    $IP: 'should-stay',
+                    ip: 'should-stay',
+                    IP: 'should-stay',
+                    $set: {
+                        $ip: 'should-be-removed',
+                        $IP: 'should-stay',
+                        ip: 'should-stay',
+                        IP: 'should-stay',
                     },
-                    safe_property: 'keep-me',
                 },
             },
         })
 
         const response = await tester.invoke(
             {
-                propertiesToFilter: 'user.profile.settings.api_key,user.profile.settings.preferences.theme',
+                propertiesToFilter: '$ip',
+                includeSetProperties: true,
+                includeSetOnceProperties: false,
             },
             mockGlobals
         )
 
         expect(response.finished).toBe(true)
         expect(response.error).toBeUndefined()
-        expect((response.execResult as any).distinct_id).toBe('user123')
-        expect((response.execResult as any).properties.user.profile.settings.email).toBe('test@example.com')
-        expect((response.execResult as any).properties.user.profile.settings.api_key).toBeUndefined()
-        expect((response.execResult as any).properties.user.profile.settings.preferences.theme).toBeUndefined()
-        expect((response.execResult as any).properties.safe_property).toBe('keep-me')
+        expect((response.execResult as any).properties.$ip).toBeUndefined()
+        expect((response.execResult as any).properties.$IP).toBe('should-stay')
+        expect((response.execResult as any).properties.ip).toBe('should-stay')
+        expect((response.execResult as any).properties.IP).toBe('should-stay')
+        expect((response.execResult as any).properties.$set.$ip).toBeUndefined()
+        expect((response.execResult as any).properties.$set.$IP).toBe('should-stay')
+        expect((response.execResult as any).properties.$set.ip).toBe('should-stay')
+        expect((response.execResult as any).properties.$set.IP).toBe('should-stay')
     })
 
-    it('should handle property paths with special characters and mixed casing', async () => {
+    it('should handle nested properties in $set and $set_once', async () => {
         mockGlobals = tester.createGlobals({
             event: {
                 properties: {
-                    user_data: {
-                        profile_info: {
-                            api_key: 'secret',
-                            userName: 'John',
-                        },
+                    $ip: 'should-be-removed',
+                    nested: {
+                        $ip: 'should-be-removed',
+                        other: 'should-stay',
                     },
                     $set: {
-                        last_login: '2024-01-01',
-                        UPPERCASE_PROP: 'test',
-                    },
-                },
-            },
-        })
-
-        const response = await tester.invoke(
-            {
-                propertiesToFilter: 'user_data.profile_info.api_key,$SET.last_login',
-            },
-            mockGlobals
-        )
-
-        expect(response.finished).toBe(true)
-        expect(response.error).toBeUndefined()
-        expect((response.execResult as any).properties.user_data.profile_info.api_key).toBeUndefined()
-        expect((response.execResult as any).properties.user_data.profile_info.userName).toBe('John')
-        expect((response.execResult as any).properties.$set.last_login).toBeUndefined()
-        expect((response.execResult as any).properties.$set.UPPERCASE_PROP).toBe('test')
-    })
-
-    it('should handle filtering non-existent properties while keeping siblings', async () => {
-        mockGlobals = tester.createGlobals({
-            event: {
-                properties: {
-                    parent: {
-                        child1: {
-                            value: 'keep-me',
-                        },
-                        child2: {
-                            value: 'also-keep-me',
-                        },
-                    },
-                },
-            },
-        })
-
-        const response = await tester.invoke(
-            {
-                propertiesToFilter: 'parent.child3.value,parent.child1.nonexistent,parent.child2.value',
-            },
-            mockGlobals
-        )
-
-        expect(response.finished).toBe(true)
-        expect(response.error).toBeUndefined()
-        expect((response.execResult as any).properties.parent.child1.value).toBe('keep-me')
-        expect((response.execResult as any).properties.parent.child2.value).toBeUndefined()
-        // These shouldn't exist but also shouldn't cause errors
-        expect((response.execResult as any).properties.parent.child3).toBeUndefined()
-        expect((response.execResult as any).properties.parent.child1.nonexistent).toBeUndefined()
-    })
-
-    it('should handle complex PostHog property paths', async () => {
-        mockGlobals = tester.createGlobals({
-            event: {
-                properties: {
-                    '$feature/onboarding/enable-new-flow': true,
-                    '$feature/billing/beta': false,
-                    '$experiment/checkout-test-001/variant': 'control',
-                    $geoip_city_name: 'London',
-                    'app/version': '1.2.3',
-                    $plugins: {
-                        'plugin/custom/sensitive-data': {
-                            'auth/api_key': 'secret-123',
-                            'user/metadata': {
-                                'session/device_id': 'test-device',
+                        user: {
+                            profile: {
+                                $ip: 'should-be-removed-if-set-enabled',
+                                email: 'keep@example.com',
+                            },
+                            settings: {
+                                $ip: 'should-be-removed-if-set-enabled',
+                                theme: 'dark',
                             },
                         },
                     },
-                    safe_property: 'keep-me',
+                    $set_once: {
+                        device: {
+                            info: {
+                                $ip: 'should-be-removed-if-set-once-enabled',
+                                id: 'device-123',
+                            },
+                        },
+                    },
                 },
             },
         })
 
         const response = await tester.invoke(
             {
-                propertiesToFilter:
-                    '$feature/onboarding/enable-new-flow,$plugins.plugin/custom/sensitive-data.auth/api_key,$geoip_city_name',
+                propertiesToFilter: '$ip',
+                includeSetProperties: true,
+                includeSetOnceProperties: true,
             },
             mockGlobals
         )
 
         expect(response.finished).toBe(true)
         expect(response.error).toBeUndefined()
-        expect((response.execResult as any).properties['$feature/onboarding/enable-new-flow']).toBeUndefined()
-        expect((response.execResult as any).properties['$feature/billing/beta']).toBe(false)
-        expect((response.execResult as any).properties['$experiment/checkout-test-001/variant']).toBe('control')
-        expect((response.execResult as any).properties.$geoip_city_name).toBeUndefined()
-        expect((response.execResult as any).properties['app/version']).toBe('1.2.3')
-        expect(
-            (response.execResult as any).properties.$plugins['plugin/custom/sensitive-data']['auth/api_key']
-        ).toBeUndefined()
-        expect(
-            (response.execResult as any).properties.$plugins['plugin/custom/sensitive-data']['user/metadata'][
-                'session/device_id'
-            ]
-        ).toBe('test-device')
-        expect((response.execResult as any).properties.safe_property).toBe('keep-me')
+
+        // Check top-level and nested properties
+        expect((response.execResult as any).properties.$ip).toBeUndefined()
+        expect((response.execResult as any).properties.nested.$ip).toBeUndefined()
+        expect((response.execResult as any).properties.nested.other).toBe('should-stay')
+
+        // Check deeply nested $set properties
+        expect((response.execResult as any).properties.$set.user.profile.$ip).toBeUndefined()
+        expect((response.execResult as any).properties.$set.user.profile.email).toBe('keep@example.com')
+        expect((response.execResult as any).properties.$set.user.settings.$ip).toBeUndefined()
+        expect((response.execResult as any).properties.$set.user.settings.theme).toBe('dark')
+
+        // Check deeply nested $set_once properties
+        expect((response.execResult as any).properties.$set_once.device.info.$ip).toBeUndefined()
+        expect((response.execResult as any).properties.$set_once.device.info.id).toBe('device-123')
     })
 })

--- a/plugin-server/src/cdp/templates/_transformations/property-filter/property-filter.template.test.ts
+++ b/plugin-server/src/cdp/templates/_transformations/property-filter/property-filter.template.test.ts
@@ -1,0 +1,241 @@
+import { HogFunctionInvocationGlobals } from '../../../types'
+import { TemplateTester } from '../../test/test-helpers'
+import { template } from './property-filter.template'
+
+describe('property-filter.template', () => {
+    const tester = new TemplateTester(template)
+    let mockGlobals: HogFunctionInvocationGlobals
+
+    beforeEach(async () => {
+        await tester.beforeEach()
+    })
+
+    it('should filter out top-level properties', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                distinct_id: 'user123',
+                event: 'test_event',
+                properties: {
+                    safe_property: 'keep-me',
+                },
+            },
+        })
+
+        const response = await tester.invoke(
+            {
+                propertiesToFilter: 'distinct_id',
+            },
+            mockGlobals
+        )
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect((response.execResult as any).distinct_id).toBeUndefined()
+        expect((response.execResult as any).event).toBe('test_event')
+        expect((response.execResult as any).properties.safe_property).toBe('keep-me')
+    })
+
+    it('should filter out properties in event.properties', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                distinct_id: 'user123',
+                properties: {
+                    $ip: '127.0.0.1',
+                    $set: {
+                        $ip: '192.168.1.1',
+                        email: 'test@example.com',
+                    },
+                    safe_property: 'keep-me',
+                },
+            },
+        })
+
+        const response = await tester.invoke(
+            {
+                propertiesToFilter: '$ip,$set.$ip',
+            },
+            mockGlobals
+        )
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect((response.execResult as any).distinct_id).toBe('user123')
+        expect((response.execResult as any).properties.$ip).toBeUndefined()
+        expect((response.execResult as any).properties.$set.$ip).toBeUndefined()
+        expect((response.execResult as any).properties.$set.email).toBe('test@example.com')
+        expect((response.execResult as any).properties.safe_property).toBe('keep-me')
+    })
+
+    it('should handle empty propertiesToFilter', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                distinct_id: 'user123',
+                properties: {
+                    $ip: '127.0.0.1',
+                },
+            },
+        })
+
+        const response = await tester.invoke(
+            {
+                propertiesToFilter: '',
+            },
+            mockGlobals
+        )
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect((response.execResult as any).distinct_id).toBe('user123')
+        expect((response.execResult as any).properties.$ip).toBe('127.0.0.1')
+    })
+
+    it('should filter out deeply nested properties', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                distinct_id: 'user123',
+                properties: {
+                    user: {
+                        profile: {
+                            settings: {
+                                email: 'test@example.com',
+                                api_key: 'secret-key',
+                                preferences: {
+                                    theme: 'dark',
+                                },
+                            },
+                        },
+                    },
+                    safe_property: 'keep-me',
+                },
+            },
+        })
+
+        const response = await tester.invoke(
+            {
+                propertiesToFilter: 'user.profile.settings.api_key,user.profile.settings.preferences.theme',
+            },
+            mockGlobals
+        )
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect((response.execResult as any).distinct_id).toBe('user123')
+        expect((response.execResult as any).properties.user.profile.settings.email).toBe('test@example.com')
+        expect((response.execResult as any).properties.user.profile.settings.api_key).toBeUndefined()
+        expect((response.execResult as any).properties.user.profile.settings.preferences.theme).toBeUndefined()
+        expect((response.execResult as any).properties.safe_property).toBe('keep-me')
+    })
+
+    it('should handle property paths with special characters and mixed casing', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    user_data: {
+                        profile_info: {
+                            api_key: 'secret',
+                            userName: 'John',
+                        },
+                    },
+                    $set: {
+                        last_login: '2024-01-01',
+                        UPPERCASE_PROP: 'test',
+                    },
+                },
+            },
+        })
+
+        const response = await tester.invoke(
+            {
+                propertiesToFilter: 'user_data.profile_info.api_key,$SET.last_login',
+            },
+            mockGlobals
+        )
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect((response.execResult as any).properties.user_data.profile_info.api_key).toBeUndefined()
+        expect((response.execResult as any).properties.user_data.profile_info.userName).toBe('John')
+        expect((response.execResult as any).properties.$set.last_login).toBeUndefined()
+        expect((response.execResult as any).properties.$set.UPPERCASE_PROP).toBe('test')
+    })
+
+    it('should handle filtering non-existent properties while keeping siblings', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    parent: {
+                        child1: {
+                            value: 'keep-me',
+                        },
+                        child2: {
+                            value: 'also-keep-me',
+                        },
+                    },
+                },
+            },
+        })
+
+        const response = await tester.invoke(
+            {
+                propertiesToFilter: 'parent.child3.value,parent.child1.nonexistent,parent.child2.value',
+            },
+            mockGlobals
+        )
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect((response.execResult as any).properties.parent.child1.value).toBe('keep-me')
+        expect((response.execResult as any).properties.parent.child2.value).toBeUndefined()
+        // These shouldn't exist but also shouldn't cause errors
+        expect((response.execResult as any).properties.parent.child3).toBeUndefined()
+        expect((response.execResult as any).properties.parent.child1.nonexistent).toBeUndefined()
+    })
+
+    it('should handle complex PostHog property paths', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    '$feature/onboarding/enable-new-flow': true,
+                    '$feature/billing/beta': false,
+                    '$experiment/checkout-test-001/variant': 'control',
+                    $geoip_city_name: 'London',
+                    'app/version': '1.2.3',
+                    $plugins: {
+                        'plugin/custom/sensitive-data': {
+                            'auth/api_key': 'secret-123',
+                            'user/metadata': {
+                                'session/device_id': 'test-device',
+                            },
+                        },
+                    },
+                    safe_property: 'keep-me',
+                },
+            },
+        })
+
+        const response = await tester.invoke(
+            {
+                propertiesToFilter:
+                    '$feature/onboarding/enable-new-flow,$plugins.plugin/custom/sensitive-data.auth/api_key,$geoip_city_name',
+            },
+            mockGlobals
+        )
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect((response.execResult as any).properties['$feature/onboarding/enable-new-flow']).toBeUndefined()
+        expect((response.execResult as any).properties['$feature/billing/beta']).toBe(false)
+        expect((response.execResult as any).properties['$experiment/checkout-test-001/variant']).toBe('control')
+        expect((response.execResult as any).properties.$geoip_city_name).toBeUndefined()
+        expect((response.execResult as any).properties['app/version']).toBe('1.2.3')
+        expect(
+            (response.execResult as any).properties.$plugins['plugin/custom/sensitive-data']['auth/api_key']
+        ).toBeUndefined()
+        expect(
+            (response.execResult as any).properties.$plugins['plugin/custom/sensitive-data']['user/metadata'][
+                'session/device_id'
+            ]
+        ).toBe('test-device')
+        expect((response.execResult as any).properties.safe_property).toBe('keep-me')
+    })
+})

--- a/plugin-server/src/cdp/templates/_transformations/property-filter/property-filter.template.ts
+++ b/plugin-server/src/cdp/templates/_transformations/property-filter/property-filter.template.ts
@@ -1,0 +1,135 @@
+import { HogFunctionTemplate } from '../../types'
+
+export const template: HogFunctionTemplate = {
+    free: false,
+    status: 'alpha',
+    type: 'transformation',
+    id: 'template-property-filter',
+    name: 'Property Filter',
+    description:
+        'This transformation removes properties from event object and nested properties from event.properties.',
+    icon_url: '/static/hedgehog/builder-hog-02.png',
+    category: ['Custom'],
+    hog: `
+// Get the properties to filter from inputs and split by comma
+let propertiesToFilter := []
+if (notEmpty(inputs.propertiesToFilter)) {
+    propertiesToFilter := splitByString(',', inputs.propertiesToFilter)
+}
+
+if (empty(propertiesToFilter)) {
+    return event
+}
+
+// Helper function to split path into parts
+fun splitPath(path) {
+    return splitByString('.', trim(path))
+}
+
+// Helper function to check if a path matches the start of another path
+fun pathStartsWith(path, prefix) {
+    let pathParts := splitPath(path)
+    let prefixParts := splitPath(prefix)
+    
+    if (length(prefixParts) > length(pathParts)) {
+        return false
+    }
+    
+    for (let i := 1; i <= length(prefixParts); i := i + 1) {
+        if (trim(pathParts[i]) != trim(prefixParts[i])) {
+            return false
+        }
+    }
+    
+    return true
+}
+
+// Helper function to get remaining path
+fun getRemainingPath(path, prefix) {
+    let pathParts := splitPath(path)
+    let prefixParts := splitPath(prefix)
+    let result := ''
+    
+    for (let i := length(prefixParts) + 1; i <= length(pathParts); i := i + 1) {
+        if (notEmpty(result)) {
+            result := concat(result, '.')
+        }
+        result := concat(result, pathParts[i])
+    }
+    
+    return result
+}
+
+// Helper function to filter properties from an object
+fun filterObject(obj, propertiesToRemove, currentPath) {
+    if (obj = null) {
+        return null
+    }
+    
+    if (typeof(obj) != 'object') {
+        return obj
+    }
+    
+    let result := {}
+    let objKeys := keys(obj)
+    
+    for (let key in objKeys) {
+        let shouldKeep := true
+        let fullPath := if(notEmpty(currentPath), concat(currentPath, '.', key), key)
+        
+        for (let propToFilter in propertiesToRemove) {
+            if (lower(trim(fullPath)) = lower(trim(propToFilter))) {
+                shouldKeep := false
+            }
+        }
+        
+        if (shouldKeep) {
+            let value := obj[key]
+            if (typeof(value) = 'object' and value != null) {
+                result[key] := filterObject(value, propertiesToRemove, fullPath)
+            } else {
+                result[key] := value
+            }
+        }
+    }
+    
+    return result
+}
+
+// Create a copy of the event
+let returnEvent := {}
+
+// Copy non-filtered top-level properties
+let eventKeys := keys(event)
+for (let key in eventKeys) {
+    let shouldKeep := true
+    for (let propToFilter in propertiesToFilter) {
+        if (position(propToFilter, '.') = 0 and trim(key) = trim(propToFilter)) {
+            shouldKeep := false
+        }
+    }
+    
+    if (shouldKeep) {
+        if (key = 'properties' and notEmpty(event.properties)) {
+            returnEvent.properties := filterObject(event.properties, propertiesToFilter, '')
+        } else {
+            returnEvent[key] := event[key]
+        }
+    }
+}
+
+return returnEvent
+`,
+    inputs_schema: [
+        {
+            key: 'propertiesToFilter',
+            type: 'string',
+            label: 'Properties to Filter',
+            description:
+                'Comma-separated list of properties to filter. For top-level properties use the property name (e.g. "distinct_id"), for nested properties use the full path (e.g. "user.profile.settings.api_key")',
+            default: '$ip',
+            secret: false,
+            required: true,
+        },
+    ],
+}

--- a/plugin-server/src/cdp/templates/index.ts
+++ b/plugin-server/src/cdp/templates/index.ts
@@ -5,6 +5,7 @@ import { template as defaultTransformationTemplate } from './_transformations/de
 import { template as geoipTemplate } from './_transformations/geoip/geoip.template'
 import { template as ipAnonymizationTemplate } from './_transformations/ip-anonymization/ip-anonymization.template'
 import { template as piiHashingTemplate } from './_transformations/pii-hashing/pii-hashing.template'
+import { template as propertyFilterTemplate } from './_transformations/property-filter/property-filter.template'
 import { template as removeNullPropertiesTemplate } from './_transformations/remove-null-properties/remove-null-properties.template'
 import { template as urlMaskingTemplate } from './_transformations/url-masking/url-masking.template'
 import { HogFunctionTemplate } from './types'
@@ -18,6 +19,7 @@ export const HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS: HogFunctionTemplate[] = [
     urlMaskingTemplate,
     piiHashingTemplate,
     botDetectionTemplate,
+    propertyFilterTemplate,
 ]
 
 export const HOG_FUNCTION_TEMPLATES_DESTINATIONS_DEPRECATED: HogFunctionTemplate[] = DESTINATION_PLUGINS.map(


### PR DESCRIPTION
## Problem

Currently the property filter does not exactly do what we anticipate it. instead of fixing it which would break current behaviour i build a new hog transformation that is filtering on all levels (optionally). 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<img width="1027" alt="Screenshot 2025-02-14 at 14 49 34" src="https://github.com/user-attachments/assets/25e0adba-1a89-4ad8-8898-06f20183b01c" />
<img width="1034" alt="Screenshot 2025-02-14 at 14 49 56" src="https://github.com/user-attachments/assets/83648179-2bcf-4a02-8691-f4bd63fd0c06" />

- customers can define all paths explicitly themselves 
- customers can opt into removing the properties also from $set and $set_once optionally

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- tests written 
- locally 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
