### PR TITLE
fix: Force all integrations to refresh every 5 mins

### DIFF
--- a/plugin-server/src/cdp/services/hog-function-manager.service.ts
+++ b/plugin-server/src/cdp/services/hog-function-manager.service.ts
@@ -279,7 +279,7 @@ export class HogFunctionManagerService {
             })
         })
 
-        if (!items.length) {
+        if (!integrationIds.length) {
             return
         }
 


### PR DESCRIPTION
## Problem

I'm not certain why but it seems integrations aren't always refreshing. 

## Changes

This makes a change to auto refresh every 5 mins as a stop gap until we can investigate further

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
