### PR TITLE
perf: Add `person_properties_map_custom` property group

### DIFF
--- a/posthog/clickhouse/client/migration_tools.py
+++ b/posthog/clickhouse/client/migration_tools.py
@@ -22,8 +22,10 @@ def run_sql_with_exceptions(sql: str, node_role: NodeRole = NodeRole.DATA):
         if node_role == NodeRole.ALL:
             logger.info("       Running migration on coordinators and data nodes")
             return cluster.map_all_hosts(query).result()
-        else:
+        elif node_role == NodeRole.DATA:
             logger.info(f"       Running migration on {node_role.value.lower()}s")
             return cluster.map_hosts_by_role(query, node_role=node_role).result()
+        else:
+            raise NotImplementedError
 
     return migrations.RunPython(lambda _: run_migration())

--- a/posthog/clickhouse/client/migration_tools.py
+++ b/posthog/clickhouse/client/migration_tools.py
@@ -11,11 +11,13 @@ logger = logging.getLogger("migrations")
 cluster = get_cluster(cluster=CLICKHOUSE_MIGRATIONS_CLUSTER)
 
 
-def run_sql_with_exceptions(sql: str, node_role: NodeRole = NodeRole.DATA):
+def run_sql_with_exceptions(sql: str, node_role: NodeRole = NodeRole.DATA, sharded: bool = False):
     """
     migrations.RunSQL does not raise exceptions, so we need to wrap it in a function that does.
     node_role is set to DATA by default to keep compatibility with the old migrations.
     """
+    if sharded:
+        assert node_role == NodeRole.DATA
 
     def run_migration():
         query = Query(sql)
@@ -23,8 +25,12 @@ def run_sql_with_exceptions(sql: str, node_role: NodeRole = NodeRole.DATA):
             logger.info("       Running migration on coordinators and data nodes")
             return cluster.map_all_hosts(query).result()
         elif node_role == NodeRole.DATA:
-            logger.info(f"       Running migration on {node_role.value.lower()}s")
-            return cluster.map_hosts_by_role(query, node_role=node_role).result()
+            logger.info("       Running migration on %ss (sharded: %s)", node_role.value.lower(), sharded)
+            if sharded:
+                futures = cluster.map_one_host_per_shard(query)
+            else:
+                futures = cluster.map_hosts_by_role(query, node_role=node_role)
+            return futures.result()
         else:
             raise NotImplementedError
 

--- a/posthog/clickhouse/client/migration_tools.py
+++ b/posthog/clickhouse/client/migration_tools.py
@@ -16,22 +16,20 @@ def run_sql_with_exceptions(sql: str, node_role: NodeRole = NodeRole.DATA, shard
     migrations.RunSQL does not raise exceptions, so we need to wrap it in a function that does.
     node_role is set to DATA by default to keep compatibility with the old migrations.
     """
-    if sharded:
-        assert node_role == NodeRole.DATA
 
     def run_migration():
         query = Query(sql)
         if node_role == NodeRole.ALL:
+            assert not sharded
             logger.info("       Running migration on coordinators and data nodes")
             return cluster.map_all_hosts(query).result()
-        elif node_role == NodeRole.DATA:
-            logger.info("       Running migration on %ss (sharded: %s)", node_role.value.lower(), sharded)
+        else:
+            logger.info("       Running migration on %ss", node_role.value.lower())
             if sharded:
+                assert node_role == NodeRole.DATA
                 futures = cluster.map_one_host_per_shard(query)
             else:
                 futures = cluster.map_hosts_by_role(query, node_role=node_role)
             return futures.result()
-        else:
-            raise NotImplementedError
 
     return migrations.RunPython(lambda _: run_migration())

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -299,6 +299,15 @@ def get_cluster(
 
 
 @dataclass
+class Query:
+    query: str
+    parameters: Any | None = None
+
+    def __call__(self, client: Client):
+        return client.execute(self.query, self.parameters)
+
+
+@dataclass
 class Mutation:
     table: str
     mutation_id: str

--- a/posthog/clickhouse/migrations/0099_events_person_properties_map_custom.py
+++ b/posthog/clickhouse/migrations/0099_events_person_properties_map_custom.py
@@ -1,0 +1,14 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.clickhouse.property_groups import property_groups
+
+operations = [
+    *[
+        run_sql_with_exceptions(statement, node_role=NodeRole.DATA)
+        for statement in property_groups.get_alter_create_statements("sharded_events", "person_properties", "custom")
+    ],
+    *[
+        run_sql_with_exceptions(statement, node_role=NodeRole.ALL)
+        for statement in property_groups.get_alter_create_statements("events", "person_properties", "custom")
+    ],
+]

--- a/posthog/clickhouse/migrations/0099_events_person_properties_map_custom.py
+++ b/posthog/clickhouse/migrations/0099_events_person_properties_map_custom.py
@@ -4,7 +4,7 @@ from posthog.clickhouse.property_groups import property_groups
 
 operations = [
     *[
-        run_sql_with_exceptions(statement, node_role=NodeRole.DATA)
+        run_sql_with_exceptions(statement, node_role=NodeRole.DATA, sharded=True)
         for statement in property_groups.get_alter_create_statements("sharded_events", "person_properties", "custom")
     ],
     *[

--- a/posthog/clickhouse/property_groups.py
+++ b/posthog/clickhouse/property_groups.py
@@ -102,9 +102,12 @@ class PropertyGroupManager:
             prefix += f" ON CLUSTER {cluster}"
 
         group_definition = self.__groups[table][source_column][group_name]
-        yield f"{prefix} ADD COLUMN IF NOT EXISTS {group_definition.get_column_definition(source_column, group_name)}"
+
+        commands = [f"ADD COLUMN IF NOT EXISTS {group_definition.get_column_definition(source_column, group_name)}"]
         for index_definition in group_definition.get_index_definitions(source_column, group_name):
-            yield f"{prefix} ADD INDEX IF NOT EXISTS {index_definition}"
+            commands.append(f"ADD INDEX IF NOT EXISTS {index_definition}")
+
+        yield f"{prefix} " + ", ".join(commands)
 
 
 ignore_custom_properties = [

--- a/posthog/clickhouse/property_groups.py
+++ b/posthog/clickhouse/property_groups.py
@@ -2,7 +2,10 @@ import dataclasses
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 
-from posthog import settings
+
+TableName = str
+PropertySourceColumnName = str
+PropertyGroupName = str
 
 
 @dataclass
@@ -11,74 +14,97 @@ class PropertyGroupDefinition:
     key_filter_function: Callable[[str], bool]
     codec: str = "ZSTD(1)"
     is_materialized: bool = True
+    column_type_name: str = "map"
+    hidden: bool = (
+        False  # whether or not this column should be returned when searching for groups containing a property key
+    )
 
     def contains(self, property_key: str) -> bool:
-        return self.key_filter_function(property_key)
+        if self.hidden:
+            return False
+        else:
+            return self.key_filter_function(property_key)
 
+    def get_column_name(self, source_column: PropertySourceColumnName, group_name: PropertyGroupName) -> str:
+        return f"{source_column}_{self.column_type_name}_{group_name}"
 
-TableName = str
-ColumnName = str
-PropertyGroupName = str
+    def get_column_definition(self, source_column: PropertySourceColumnName, group_name: PropertyGroupName) -> str:
+        column_definition = f"{self.get_column_name(source_column, group_name)} Map(String, String)"
+        if not self.is_materialized:
+            return column_definition
+
+        return f"""\
+            {column_definition}
+            MATERIALIZED mapSort(
+                mapFilter((key, _) -> {self.key_filter_expression},
+                CAST(JSONExtractKeysAndValues({source_column}, 'String'), 'Map(String, String)'))
+            )
+            CODEC({self.codec})
+        """
+
+    def get_index_definitions(
+        self, source_column: PropertySourceColumnName, group_name: PropertyGroupName
+    ) -> Iterable[str]:
+        if not self.is_materialized:
+            return
+
+        map_column_name = self.get_column_name(source_column, group_name)
+        yield f"{map_column_name}_keys_bf mapKeys({map_column_name}) TYPE bloom_filter"
+        yield f"{map_column_name}_values_bf mapValues({map_column_name}) TYPE bloom_filter"
 
 
 class PropertyGroupManager:
     def __init__(
         self,
-        cluster: str,
-        groups: Mapping[TableName, Mapping[ColumnName, Mapping[PropertyGroupName, PropertyGroupDefinition]]],
+        groups: Mapping[
+            TableName, Mapping[PropertySourceColumnName, Mapping[PropertyGroupName, PropertyGroupDefinition]]
+        ],
     ) -> None:
-        self.__cluster = cluster
         self.__groups = groups
 
-    def __get_map_column_name(self, column: ColumnName, group_name: PropertyGroupName) -> str:
-        return f"{column}_group_{group_name}"
-
-    def get_property_group_columns(self, table: TableName, column: ColumnName, property_key: str) -> Iterable[str]:
-        if (table_groups := self.__groups.get(table)) and (column_groups := table_groups.get(column)):
+    def get_property_group_columns(
+        self, table: TableName, source_column: PropertySourceColumnName, property_key: str
+    ) -> Iterable[str]:
+        """
+        Returns an iterable of column names for the map columns responsible for the provided property key and source
+        column. The iterable may contain zero items if no maps contain the property key, or multiple items if more than
+        one map if the keyspaces of the defined groups for that source column are overlapping.
+        """
+        if (table_groups := self.__groups.get(table)) and (column_groups := table_groups.get(source_column)):
             for group_name, group_definition in column_groups.items():
                 if group_definition.contains(property_key):
-                    yield self.__get_map_column_name(column, group_name)
-
-    def __get_column_definition(self, table: TableName, column: ColumnName, group_name: PropertyGroupName) -> str:
-        group_definition = self.__groups[table][column][group_name]
-        map_column_name = self.__get_map_column_name(column, group_name)
-        column_definition = f"{map_column_name} Map(String, String)"
-        if not group_definition.is_materialized:
-            return column_definition
-        else:
-            return f"""\
-                {column_definition}
-                MATERIALIZED mapSort(
-                    mapFilter((key, _) -> {group_definition.key_filter_expression},
-                    CAST(JSONExtractKeysAndValues({column}, 'String'), 'Map(String, String)'))
-                )
-                CODEC({group_definition.codec})
-            """
-
-    def __get_index_definitions(
-        self, table: TableName, column: ColumnName, group_name: PropertyGroupName
-    ) -> Iterable[str]:
-        group_definition = self.__groups[table][column][group_name]
-        if not group_definition.is_materialized:
-            return
-
-        map_column_name = self.__get_map_column_name(column, group_name)
-        yield f"{map_column_name}_keys_bf mapKeys({map_column_name}) TYPE bloom_filter"
-        yield f"{map_column_name}_values_bf mapValues({map_column_name}) TYPE bloom_filter"
+                    yield group_definition.get_column_name(source_column, group_name)
 
     def get_create_table_pieces(self, table: TableName) -> Iterable[str]:
-        for column, groups in self.__groups[table].items():
-            for group_name in groups:
-                yield self.__get_column_definition(table, column, group_name)
-                for index_definition in self.__get_index_definitions(table, column, group_name):
+        """
+        Returns an iterable of SQL DDL chunks that can be used to define all property groups for the provided table as
+        part of a CREATE TABLE statement.
+        """
+        for source_column, groups in self.__groups[table].items():
+            for group_name, group_definition in groups.items():
+                yield group_definition.get_column_definition(source_column, group_name)
+                for index_definition in group_definition.get_index_definitions(source_column, group_name):
                     yield f"INDEX {index_definition}"
 
     def get_alter_create_statements(
-        self, table: TableName, column: ColumnName, group_name: PropertyGroupName
+        self,
+        table: TableName,
+        source_column: PropertySourceColumnName,
+        group_name: PropertyGroupName,
+        cluster: str | None = None,
     ) -> Iterable[str]:
-        yield f"ALTER TABLE {table} ON CLUSTER {self.__cluster} ADD COLUMN IF NOT EXISTS {self.__get_column_definition(table, column, group_name)}"
-        for index_definition in self.__get_index_definitions(table, column, group_name):
-            yield f"ALTER TABLE {table} ON CLUSTER {self.__cluster} ADD INDEX IF NOT EXISTS {index_definition}"
+        """
+        Returns an iterable of ALTER TABLE statements that can be used to create the property group (e.g. as part of a
+        migration) if it doesn't already exist.
+        """
+        prefix = f"ALTER TABLE {table}"
+        if cluster is not None:
+            prefix += f" ON CLUSTER {cluster}"
+
+        group_definition = self.__groups[table][source_column][group_name]
+        yield f"{prefix} ADD COLUMN IF NOT EXISTS {group_definition.get_column_definition(source_column, group_name)}"
+        for index_definition in group_definition.get_index_definitions(source_column, group_name):
+            yield f"{prefix} ADD INDEX IF NOT EXISTS {index_definition}"
 
 
 ignore_custom_properties = [
@@ -117,24 +143,34 @@ event_property_group_definitions = {
         "custom": PropertyGroupDefinition(
             f"key NOT LIKE '$%' AND key NOT IN (" + f", ".join(f"'{name}'" for name in ignore_custom_properties) + f")",
             lambda key: not key.startswith("$") and key not in ignore_custom_properties,
+            column_type_name="group",
         ),
         "feature_flags": PropertyGroupDefinition(
             "key like '$feature/%'",
             lambda key: key.startswith("$feature/"),
+            column_type_name="group",
         ),
-    }
+    },
+    "person_properties": {
+        "custom": PropertyGroupDefinition(
+            f"key NOT LIKE '$%'",
+            lambda key: not key.startswith("$"),
+            hidden=True,
+        ),
+    },
 }
 
 property_groups = PropertyGroupManager(
-    settings.CLICKHOUSE_CLUSTER,
     {
         "sharded_events": event_property_group_definitions,
         "events": {
+            # the events distributed table shares the same property group names and types as the sharded_events table,
+            # just without the materialize statements
             column_name: {
                 group_name: dataclasses.replace(group_definition, is_materialized=False)
                 for group_name, group_definition in column_group_definitions.items()
             }
             for column_name, column_group_definitions in event_property_group_definitions.items()
         },
-    },
+    }
 )

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -749,7 +749,7 @@
       , elements_chain_texts Array(String) COMMENT 'column_materializer::elements_chain::texts'
       , elements_chain_ids Array(String) COMMENT 'column_materializer::elements_chain::ids'
       , elements_chain_elements Array(Enum('a', 'button', 'form', 'input', 'select', 'textarea', 'label')) COMMENT 'column_materializer::elements_chain::elements'
-      , properties_group_custom Map(String, String), properties_group_feature_flags Map(String, String)
+      , properties_group_custom Map(String, String), properties_group_feature_flags Map(String, String), person_properties_map_custom Map(String, String)
   
       
   , _timestamp DateTime
@@ -2547,19 +2547,25 @@
       , INDEX `minmax_$group_4` `$group_4` TYPE minmax GRANULARITY 1
       , INDEX `minmax_$window_id` `$window_id` TYPE minmax GRANULARITY 1
       , INDEX `minmax_$session_id` `$session_id` TYPE minmax GRANULARITY 1
-      ,                 properties_group_custom Map(String, String)
-                  MATERIALIZED mapSort(
-                      mapFilter((key, _) -> key NOT LIKE '$%' AND key NOT IN ('token', 'distinct_id', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term', 'gclid', 'gad_source', 'gclsrc', 'dclid', 'gbraid', 'wbraid', 'fbclid', 'msclkid', 'twclid', 'li_fat_id', 'mc_cid', 'igshid', 'ttclid', 'rdt_cid', 'irclid', '_kx'),
-                      CAST(JSONExtractKeysAndValues(properties, 'String'), 'Map(String, String)'))
-                  )
-                  CODEC(ZSTD(1))
-              , INDEX properties_group_custom_keys_bf mapKeys(properties_group_custom) TYPE bloom_filter, INDEX properties_group_custom_values_bf mapValues(properties_group_custom) TYPE bloom_filter,                 properties_group_feature_flags Map(String, String)
-                  MATERIALIZED mapSort(
-                      mapFilter((key, _) -> key like '$feature/%',
-                      CAST(JSONExtractKeysAndValues(properties, 'String'), 'Map(String, String)'))
-                  )
-                  CODEC(ZSTD(1))
-              , INDEX properties_group_feature_flags_keys_bf mapKeys(properties_group_feature_flags) TYPE bloom_filter, INDEX properties_group_feature_flags_values_bf mapValues(properties_group_feature_flags) TYPE bloom_filter
+      ,             properties_group_custom Map(String, String)
+              MATERIALIZED mapSort(
+                  mapFilter((key, _) -> key NOT LIKE '$%' AND key NOT IN ('token', 'distinct_id', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term', 'gclid', 'gad_source', 'gclsrc', 'dclid', 'gbraid', 'wbraid', 'fbclid', 'msclkid', 'twclid', 'li_fat_id', 'mc_cid', 'igshid', 'ttclid', 'rdt_cid', 'irclid', '_kx'),
+                  CAST(JSONExtractKeysAndValues(properties, 'String'), 'Map(String, String)'))
+              )
+              CODEC(ZSTD(1))
+          , INDEX properties_group_custom_keys_bf mapKeys(properties_group_custom) TYPE bloom_filter, INDEX properties_group_custom_values_bf mapValues(properties_group_custom) TYPE bloom_filter,             properties_group_feature_flags Map(String, String)
+              MATERIALIZED mapSort(
+                  mapFilter((key, _) -> key like '$feature/%',
+                  CAST(JSONExtractKeysAndValues(properties, 'String'), 'Map(String, String)'))
+              )
+              CODEC(ZSTD(1))
+          , INDEX properties_group_feature_flags_keys_bf mapKeys(properties_group_feature_flags) TYPE bloom_filter, INDEX properties_group_feature_flags_values_bf mapValues(properties_group_feature_flags) TYPE bloom_filter,             person_properties_map_custom Map(String, String)
+              MATERIALIZED mapSort(
+                  mapFilter((key, _) -> key NOT LIKE '$%',
+                  CAST(JSONExtractKeysAndValues(person_properties, 'String'), 'Map(String, String)'))
+              )
+              CODEC(ZSTD(1))
+          , INDEX person_properties_map_custom_keys_bf mapKeys(person_properties_map_custom) TYPE bloom_filter, INDEX person_properties_map_custom_values_bf mapValues(person_properties_map_custom) TYPE bloom_filter
   
       
   , _timestamp DateTime
@@ -3754,19 +3760,25 @@
       , INDEX `minmax_$group_4` `$group_4` TYPE minmax GRANULARITY 1
       , INDEX `minmax_$window_id` `$window_id` TYPE minmax GRANULARITY 1
       , INDEX `minmax_$session_id` `$session_id` TYPE minmax GRANULARITY 1
-      ,                 properties_group_custom Map(String, String)
-                  MATERIALIZED mapSort(
-                      mapFilter((key, _) -> key NOT LIKE '$%' AND key NOT IN ('token', 'distinct_id', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term', 'gclid', 'gad_source', 'gclsrc', 'dclid', 'gbraid', 'wbraid', 'fbclid', 'msclkid', 'twclid', 'li_fat_id', 'mc_cid', 'igshid', 'ttclid', 'rdt_cid', 'irclid', '_kx'),
-                      CAST(JSONExtractKeysAndValues(properties, 'String'), 'Map(String, String)'))
-                  )
-                  CODEC(ZSTD(1))
-              , INDEX properties_group_custom_keys_bf mapKeys(properties_group_custom) TYPE bloom_filter, INDEX properties_group_custom_values_bf mapValues(properties_group_custom) TYPE bloom_filter,                 properties_group_feature_flags Map(String, String)
-                  MATERIALIZED mapSort(
-                      mapFilter((key, _) -> key like '$feature/%',
-                      CAST(JSONExtractKeysAndValues(properties, 'String'), 'Map(String, String)'))
-                  )
-                  CODEC(ZSTD(1))
-              , INDEX properties_group_feature_flags_keys_bf mapKeys(properties_group_feature_flags) TYPE bloom_filter, INDEX properties_group_feature_flags_values_bf mapValues(properties_group_feature_flags) TYPE bloom_filter
+      ,             properties_group_custom Map(String, String)
+              MATERIALIZED mapSort(
+                  mapFilter((key, _) -> key NOT LIKE '$%' AND key NOT IN ('token', 'distinct_id', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term', 'gclid', 'gad_source', 'gclsrc', 'dclid', 'gbraid', 'wbraid', 'fbclid', 'msclkid', 'twclid', 'li_fat_id', 'mc_cid', 'igshid', 'ttclid', 'rdt_cid', 'irclid', '_kx'),
+                  CAST(JSONExtractKeysAndValues(properties, 'String'), 'Map(String, String)'))
+              )
+              CODEC(ZSTD(1))
+          , INDEX properties_group_custom_keys_bf mapKeys(properties_group_custom) TYPE bloom_filter, INDEX properties_group_custom_values_bf mapValues(properties_group_custom) TYPE bloom_filter,             properties_group_feature_flags Map(String, String)
+              MATERIALIZED mapSort(
+                  mapFilter((key, _) -> key like '$feature/%',
+                  CAST(JSONExtractKeysAndValues(properties, 'String'), 'Map(String, String)'))
+              )
+              CODEC(ZSTD(1))
+          , INDEX properties_group_feature_flags_keys_bf mapKeys(properties_group_feature_flags) TYPE bloom_filter, INDEX properties_group_feature_flags_values_bf mapValues(properties_group_feature_flags) TYPE bloom_filter,             person_properties_map_custom Map(String, String)
+              MATERIALIZED mapSort(
+                  mapFilter((key, _) -> key NOT LIKE '$%',
+                  CAST(JSONExtractKeysAndValues(person_properties, 'String'), 'Map(String, String)'))
+              )
+              CODEC(ZSTD(1))
+          , INDEX person_properties_map_custom_keys_bf mapKeys(person_properties_map_custom) TYPE bloom_filter, INDEX person_properties_map_custom_values_bf mapValues(person_properties_map_custom) TYPE bloom_filter
   
       
   , _timestamp DateTime


### PR DESCRIPTION
## Problem

> Customers with a lot of events report slowness when querying person properties, even when using the properties-on-events version of PoE.

Second attempt of #28697 which was reverted with #28704 due to stalled mutations:

```
DB::Exception: Metadata on replica is not up to date with common metadata in Zookeeper. It means that this replica still not applied some of previous alters. Probably too many alters executing concurrently (highly not recommended). You can retry this error.
```

## Changes

> - Adds `person_properties_map_custom` column and indexes to `events` and `sharded_events` tables, containing non-`$`-prefixed person properties to reduce the amount of data scanned and JSON parsed
> - Allows groups to be marked as "hidden" which prevents them from being used in querying while backfill is ongoing (not the ideal solution, but it should work for now)
> - Refactors some other things that were annoying me and improves flexibility, also adds some short documentation strings to remind myself how everything works after being out of this headspace in a minute

- Reduces the number of `ALTER TABLE` statements executed to only one per table
- Runs migrations only on one host per shard when possible

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Snapshots; migrations are run in existing tests