### PR TITLE
fix: Fixed PNG insight exports

### DIFF
--- a/frontend/src/exporter/ExportedInsight/ExportedInsight.scss
+++ b/frontend/src/exporter/ExportedInsight/ExportedInsight.scss
@@ -33,8 +33,10 @@
 
         html.export-type-image & .InsightCard__viz {
             // We can't use the viewport height, as the screenshotter will resize the height of the window to capture the full content
-            // Instead we try to make it roughly rectangular
-            min-height: 50vw;
+            // Instead we ensure a good aspect ratio for visualizations
+            min-height: 75vw;
+            max-height: 100vw;
+            aspect-ratio: 4/3;
         }
     }
 

--- a/frontend/src/exporter/ExportedInsight/ExportedInsight.scss
+++ b/frontend/src/exporter/ExportedInsight/ExportedInsight.scss
@@ -36,7 +36,6 @@
             // Instead we ensure a good aspect ratio for visualizations
             min-height: 75vw;
             max-height: 100vw;
-            aspect-ratio: 4/3;
         }
     }
 

--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -142,10 +142,8 @@ def _screenshot_asset(
     driver: Optional[webdriver.Chrome] = None
     try:
         driver = get_driver()
-        # Note: When the content height is smaller than the height set here,
-        # elements with `h-full` can expand the scroll height we read
-        # further below. This can lead to a screenshot that is too tall.
-        driver.set_window_size(screenshot_width, 200)
+        # Set initial window size with a more reasonable height to prevent initial rendering issues
+        driver.set_window_size(screenshot_width, 600)
         driver.get(url_to_render)
         WebDriverWait(driver, 20).until(lambda x: x.find_element(By.CSS_SELECTOR, wait_for_css_selector))
         # Also wait until nothing is loading
@@ -166,6 +164,17 @@ def _screenshot_asset(
                 except Exception:
                     pass
                 capture_exception()
+
+        # Get the height of the visualization container specifically
+        height = driver.execute_script("""
+            const element = document.querySelector('.InsightCard__viz') || document.querySelector('.ExportedInsight__content');
+            if (element) {
+                const rect = element.getBoundingClientRect();
+                return Math.max(rect.height, document.body.scrollHeight);
+            }
+            return document.body.scrollHeight;
+        """)
+
         # For example funnels use a table that can get very wide, so try to get its width
         width = driver.execute_script(
             """
@@ -175,15 +184,33 @@ def _screenshot_asset(
             }
         """
         )
-        height = driver.execute_script("return document.body.scrollHeight")
         if isinstance(width, int):
             width = max(int(screenshot_width), min(1800, width or screenshot_width))
         else:
             width = screenshot_width
+
+        # Ensure minimum height for visualizations
+        min_height = int(width * 0.75)  # 4:3 aspect ratio
+        height = max(int(height), min_height)
+
+        # Set window size with the calculated dimensions
         driver.set_window_size(width, height + HEIGHT_OFFSET)
-        # The needed height might have changed when setting width, so we need to get it again
-        height = driver.execute_script("return document.body.scrollHeight")
-        driver.set_window_size(width, height + HEIGHT_OFFSET)
+
+        # Allow a moment for any dynamic resizing
+        driver.execute_script("return new Promise(resolve => setTimeout(resolve, 500))")
+
+        # Get the final height after any dynamic adjustments
+        final_height = driver.execute_script("""
+            const element = document.querySelector('.InsightCard__viz') || document.querySelector('.ExportedInsight__content');
+            if (element) {
+                const rect = element.getBoundingClientRect();
+                return Math.max(rect.height, document.body.scrollHeight);
+            }
+            return document.body.scrollHeight;
+        """)
+
+        # Set final window size
+        driver.set_window_size(width, final_height + HEIGHT_OFFSET)
         driver.save_screenshot(image_path)
     except Exception as e:
         # To help with debugging, add a screenshot and any chrome logs

--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -189,10 +189,6 @@ def _screenshot_asset(
         else:
             width = screenshot_width
 
-        # Ensure minimum height for visualizations
-        min_height = int(width * 0.75)  # 4:3 aspect ratio
-        height = max(int(height), min_height)
-
         # Set window size with the calculated dimensions
         driver.set_window_size(width, height + HEIGHT_OFFSET)
 


### PR DESCRIPTION
## Problem

The heights on the PNG exports were causing some images to be vertically compressed. [Slack thread](https://posthog.slack.com/archives/C0368RPHLQH/p1739548746807439)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

### Before
![export-weekly-file-volume (2)](https://github.com/user-attachments/assets/71ddc8d5-d424-418c-bd20-2d793553d971)

### After
![export-weekly-file-volume (1)](https://github.com/user-attachments/assets/e4f75576-eb39-4374-89d8-bf8a613b012b)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Manually tested exports locally.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
