### PR TITLE
fix: big filters button on surveys page

### DIFF
--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -500,17 +500,12 @@ export function SurveyResult({ disableEventsTable }: { disableEventsTable?: bool
             {survey.questions.map((question, i) => {
                 if (question.type === SurveyQuestionType.Rating) {
                     return (
-                        <>
+                        <div key={`survey-q-${i}`}>
                             {question.scale === 10 && (
-                                <div>
-                                    <div className="text-4xl font-bold">{surveyNPSScore}</div>
-                                    <div className="mb-2 font-semibold text-secondary">Latest NPS Score</div>
-                                    <SurveyNPSResults survey={survey as Survey} />
-                                </div>
+                                <SurveyNPSResults survey={survey as Survey} surveyNPSScore={surveyNPSScore} />
                             )}
 
                             <RatingQuestionBarChart
-                                key={`survey-q-${i}`}
                                 surveyRatingResults={surveyRatingResults}
                                 surveyRatingResultsReady={surveyRatingResultsReady}
                                 questionIndex={i}
@@ -531,7 +526,7 @@ export function SurveyResult({ disableEventsTable }: { disableEventsTable?: bool
                                         questionIndex={i}
                                     />
                                 )}
-                        </>
+                        </div>
                     )
                 } else if (question.type === SurveyQuestionType.SingleChoice) {
                     return (
@@ -577,9 +572,11 @@ export function SurveyResult({ disableEventsTable }: { disableEventsTable?: bool
     )
 }
 
-function SurveyNPSResults({ survey }: { survey: Survey }): JSX.Element {
+function SurveyNPSResults({ survey, surveyNPSScore }: { survey: Survey; surveyNPSScore?: string }): JSX.Element {
     return (
         <>
+            <div className="text-4xl font-bold">{surveyNPSScore}</div>
+            <div className="mb-2 font-semibold text-secondary">Latest NPS Score</div>
             <Query
                 query={{
                     kind: NodeKind.InsightVizNode,

--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -43,12 +43,14 @@ function SurveyResultsFilters(): JSX.Element {
     return (
         <div className="space-y-2">
             <h4 className="text-base font-semibold mb-2">Filter results</h4>
-            <PropertyFilters
-                propertyFilters={propertyFilters}
-                onChange={setPropertyFilters}
-                pageKey="survey-results"
-                buttonText="Add filter to survey results"
-            />
+            <div className="w-fit">
+                <PropertyFilters
+                    propertyFilters={propertyFilters}
+                    onChange={setPropertyFilters}
+                    pageKey="survey-results"
+                    buttonText="Add filter to survey results"
+                />
+            </div>
         </div>
     )
 }

--- a/frontend/src/scenes/surveys/surveyViewViz.tsx
+++ b/frontend/src/scenes/surveys/surveyViewViz.tsx
@@ -195,9 +195,13 @@ export function RatingQuestionBarChart({
     surveyRatingResultsReady: QuestionResultsReady
     iteration?: number | null | undefined
 }): JSX.Element {
+    const { loadSurveyRatingResults } = useActions(surveyLogic)
     const { survey } = useValues(surveyLogic)
     const barColor = '#1d4aff'
     const question = survey.questions[questionIndex]
+    useEffect(() => {
+        loadSurveyRatingResults({ questionIndex })
+    }, [questionIndex, loadSurveyRatingResults])
     if (question.type !== SurveyQuestionType.Rating) {
         throw new Error(`Question type must be ${SurveyQuestionType.Rating}`)
     }


### PR DESCRIPTION
## Problem

small UI fix on surveys' filters

## Changes

before:

![CleanShot 2025-02-14 at 15 17 20@2x](https://github.com/user-attachments/assets/d61d7dce-3e68-41aa-8e48-d392f048c35c)

after:

![CleanShot 2025-02-14 at 15 16 49@2x](https://github.com/user-attachments/assets/a00e6142-2783-4e0c-9f98-3c2d2f4e635e)


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

yes

## How did you test this code?

manually verified