### PR TITLE
chore(experiments): Person on events tests for funnels

### DIFF
--- a/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_funnels_query_runner.ambr
+++ b/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_funnels_query_runner.ambr
@@ -86,7 +86,7 @@
                           WHERE equals(person_distinct_id_overrides.team_id, 99999)
                           GROUP BY person_distinct_id_overrides.distinct_id
                           HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(nullIf(nullIf(e.mat_pp_email, ''), 'null')), '%@posthog.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
+                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@posthog.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
               WHERE ifNull(equals(step_0, 1), 0)))
         GROUP BY aggregation_target,
                  steps,
@@ -192,7 +192,7 @@
                           WHERE equals(person_distinct_id_overrides.team_id, 99999)
                           GROUP BY person_distinct_id_overrides.distinct_id
                           HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(nullIf(nullIf(e.mat_pp_email, ''), 'null')), '%@earlierevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
+                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@earlierevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
               WHERE ifNull(equals(step_0, 1), 0)))
         GROUP BY aggregation_target,
                  steps,
@@ -298,7 +298,7 @@
                           WHERE equals(person_distinct_id_overrides.team_id, 99999)
                           GROUP BY person_distinct_id_overrides.distinct_id
                           HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(nullIf(nullIf(e.mat_pp_email, ''), 'null')), '%@laterevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
+                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@laterevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
               WHERE ifNull(equals(step_0, 1), 0)))
         GROUP BY aggregation_target,
                  steps,
@@ -406,7 +406,7 @@
                           HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
                        LEFT JOIN
                          (SELECT person.id AS id,
-                                 nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
+                                 replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
                           FROM person
                           WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
                                                                                (SELECT person.id AS id, max(person.version) AS version
@@ -522,7 +522,7 @@
                           HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
                        LEFT JOIN
                          (SELECT person.id AS id,
-                                 nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
+                                 replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
                           FROM person
                           WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
                                                                                (SELECT person.id AS id, max(person.version) AS version
@@ -638,7 +638,7 @@
                           HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
                        LEFT JOIN
                          (SELECT person.id AS id,
-                                 nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
+                                 replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
                           FROM person
                           WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
                                                                                (SELECT person.id AS id, max(person.version) AS version
@@ -745,7 +745,7 @@
                               prop_basic AS prop,
                               argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
                        FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-31 00:00:00.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(nullIf(nullIf(e.mat_pp_email, ''), 'null')), '%@posthog.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
+                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-31 00:00:00.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@posthog.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
               WHERE ifNull(equals(step_0, 1), 0)))
         GROUP BY aggregation_target,
                  steps,
@@ -844,7 +844,7 @@
                               prop_basic AS prop,
                               argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
                        FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-31 00:00:00.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(nullIf(nullIf(e.mat_pp_email, ''), 'null')), '%@earlierevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
+                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-31 00:00:00.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@earlierevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
               WHERE ifNull(equals(step_0, 1), 0)))
         GROUP BY aggregation_target,
                  steps,
@@ -943,7 +943,7 @@
                               prop_basic AS prop,
                               argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
                        FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-31 00:00:00.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(nullIf(nullIf(e.mat_pp_email, ''), 'null')), '%@laterevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
+                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-31 00:00:00.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@laterevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
               WHERE ifNull(equals(step_0, 1), 0)))
         GROUP BY aggregation_target,
                  steps,

--- a/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_funnels_query_runner.ambr
+++ b/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_funnels_query_runner.ambr
@@ -105,7 +105,7 @@
                     allow_experimental_analyzer=1
   '''
 # ---
-# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_1_person_id_override_properties_on_events_filter_laterevent
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_1_person_id_override_properties_on_events_filter_earlierevent
   '''
   
   SELECT DISTINCT person_id
@@ -114,113 +114,7 @@
     AND distinct_id = 'person_id_1_distinct_id_2'
   '''
 # ---
-# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_1_person_id_override_properties_on_events_filter_laterevent.1
-  '''
-  SELECT sum(step_1) AS step_1,
-         sum(step_2) AS step_2,
-         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
-         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
-         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
-  FROM
-    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
-            prop AS prop,
-            row_number() OVER (
-                               ORDER BY step_2 DESC) AS row_number
-     FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time
-        FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  prop AS prop
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     prop AS prop
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                           prop AS prop
-                 FROM
-                   (SELECT timestamp AS timestamp,
-                           aggregation_target AS aggregation_target,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           prop_basic AS prop_basic,
-                           prop,
-                           prop_vals AS prop_vals,
-                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'purchase'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
-                              prop_basic AS prop,
-                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(nullIf(nullIf(e.mat_pp_email, ''), 'null')), '%@laterevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     GROUP BY prop)
-  GROUP BY final_prop
-  LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    format_csv_allow_double_quotes=0,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=23622320128,
-                    allow_experimental_analyzer=1
-  '''
-# ---
-# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_2_person_id_override_properties_on_events_filter_earlierevent
-  '''
-  
-  SELECT DISTINCT person_id
-  FROM events
-  WHERE team_id = 99999
-    AND distinct_id = 'person_id_1_distinct_id_2'
-  '''
-# ---
-# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_2_person_id_override_properties_on_events_filter_earlierevent.1
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_1_person_id_override_properties_on_events_filter_earlierevent.1
   '''
   SELECT sum(step_1) AS step_1,
          sum(step_2) AS step_2,
@@ -299,6 +193,112 @@
                           GROUP BY person_distinct_id_overrides.distinct_id
                           HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
                        WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(nullIf(nullIf(e.mat_pp_email, ''), 'null')), '%@earlierevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
+              WHERE ifNull(equals(step_0, 1), 0)))
+        GROUP BY aggregation_target,
+                 steps,
+                 prop
+        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
+                      and isNull(max(max_steps))))
+     GROUP BY prop)
+  GROUP BY final_prop
+  LIMIT 26 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=23622320128,
+                    allow_experimental_analyzer=1
+  '''
+# ---
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_2_person_id_override_properties_on_events_filter_laterevent
+  '''
+  
+  SELECT DISTINCT person_id
+  FROM events
+  WHERE team_id = 99999
+    AND distinct_id = 'person_id_1_distinct_id_2'
+  '''
+# ---
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_2_person_id_override_properties_on_events_filter_laterevent.1
+  '''
+  SELECT sum(step_1) AS step_1,
+         sum(step_2) AS step_2,
+         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
+         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
+         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
+  FROM
+    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
+            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
+            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
+            prop AS prop,
+            row_number() OVER (
+                               ORDER BY step_2 DESC) AS row_number
+     FROM
+       (SELECT aggregation_target AS aggregation_target,
+               steps AS steps,
+               prop AS prop,
+               prop AS prop,
+               min(step_1_conversion_time) AS step_1_conversion_time
+        FROM
+          (SELECT aggregation_target AS aggregation_target,
+                  steps AS steps,
+                  prop AS prop,
+                  max(steps) OVER (PARTITION BY aggregation_target,
+                                                prop) AS max_steps,
+                                  step_1_conversion_time AS step_1_conversion_time,
+                                  prop AS prop
+           FROM
+             (SELECT aggregation_target AS aggregation_target,
+                     timestamp AS timestamp,
+                     step_0 AS step_0,
+                     latest_0 AS latest_0,
+                     step_1 AS step_1,
+                     latest_1 AS latest_1,
+                     prop AS prop,
+                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
+                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
+                     prop AS prop
+              FROM
+                (SELECT aggregation_target AS aggregation_target,
+                        timestamp AS timestamp,
+                        step_0 AS step_0,
+                        latest_0 AS latest_0,
+                        step_1 AS step_1,
+                        min(latest_1) OVER (PARTITION BY aggregation_target,
+                                                         prop
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
+                                           prop AS prop
+                 FROM
+                   (SELECT timestamp AS timestamp,
+                           aggregation_target AS aggregation_target,
+                           step_0 AS step_0,
+                           latest_0 AS latest_0,
+                           step_1 AS step_1,
+                           latest_1 AS latest_1,
+                           prop_basic AS prop_basic,
+                           prop,
+                           prop_vals AS prop_vals,
+                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
+                    FROM
+                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
+                              if(equals(e.event, 'purchase'), 1, 0) AS step_1,
+                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
+                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                              prop_basic AS prop,
+                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+                       FROM events AS e
+                       LEFT OUTER JOIN
+                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                                 person_distinct_id_overrides.distinct_id AS distinct_id
+                          FROM person_distinct_id_overrides
+                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                          GROUP BY person_distinct_id_overrides.distinct_id
+                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(nullIf(nullIf(e.mat_pp_email, ''), 'null')), '%@laterevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
               WHERE ifNull(equals(step_0, 1), 0)))
         GROUP BY aggregation_target,
                  steps,
@@ -433,7 +433,7 @@
                     allow_experimental_analyzer=1
   '''
 # ---
-# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_4_person_id_override_properties_joined_filter_laterevent
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_4_person_id_override_properties_joined_filter_earlierevent
   '''
   
   SELECT DISTINCT person_id
@@ -442,123 +442,7 @@
     AND distinct_id = 'person_id_1_distinct_id_2'
   '''
 # ---
-# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_4_person_id_override_properties_joined_filter_laterevent.1
-  '''
-  SELECT sum(step_1) AS step_1,
-         sum(step_2) AS step_2,
-         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
-         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
-         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
-  FROM
-    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
-            prop AS prop,
-            row_number() OVER (
-                               ORDER BY step_2 DESC) AS row_number
-     FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time
-        FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  prop AS prop
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     prop AS prop
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                           prop AS prop
-                 FROM
-                   (SELECT timestamp AS timestamp,
-                           aggregation_target AS aggregation_target,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           prop_basic AS prop_basic,
-                           prop,
-                           prop_vals AS prop_vals,
-                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'purchase'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
-                              prop_basic AS prop,
-                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       LEFT JOIN
-                         (SELECT person.id AS id,
-                                 nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
-                          FROM person
-                          WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
-                                                                               (SELECT person.id AS id, max(person.version) AS version
-                                                                                FROM person
-                                                                                WHERE equals(person.team_id, 99999)
-                                                                                GROUP BY person.id
-                                                                                HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(e__person.properties___email), '%@laterevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     GROUP BY prop)
-  GROUP BY final_prop
-  LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    format_csv_allow_double_quotes=0,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=23622320128,
-                    allow_experimental_analyzer=1
-  '''
-# ---
-# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_5_person_id_override_properties_joined_filter_earlierevent
-  '''
-  
-  SELECT DISTINCT person_id
-  FROM events
-  WHERE team_id = 99999
-    AND distinct_id = 'person_id_1_distinct_id_2'
-  '''
-# ---
-# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_5_person_id_override_properties_joined_filter_earlierevent.1
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_4_person_id_override_properties_joined_filter_earlierevent.1
   '''
   SELECT sum(step_1) AS step_1,
          sum(step_2) AS step_2,
@@ -647,6 +531,122 @@
                                                                                 GROUP BY person.id
                                                                                 HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
                        WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(e__person.properties___email), '%@earlierevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
+              WHERE ifNull(equals(step_0, 1), 0)))
+        GROUP BY aggregation_target,
+                 steps,
+                 prop
+        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
+                      and isNull(max(max_steps))))
+     GROUP BY prop)
+  GROUP BY final_prop
+  LIMIT 26 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=23622320128,
+                    allow_experimental_analyzer=1
+  '''
+# ---
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_5_person_id_override_properties_joined_filter_laterevent
+  '''
+  
+  SELECT DISTINCT person_id
+  FROM events
+  WHERE team_id = 99999
+    AND distinct_id = 'person_id_1_distinct_id_2'
+  '''
+# ---
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_5_person_id_override_properties_joined_filter_laterevent.1
+  '''
+  SELECT sum(step_1) AS step_1,
+         sum(step_2) AS step_2,
+         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
+         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
+         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
+  FROM
+    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
+            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
+            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
+            prop AS prop,
+            row_number() OVER (
+                               ORDER BY step_2 DESC) AS row_number
+     FROM
+       (SELECT aggregation_target AS aggregation_target,
+               steps AS steps,
+               prop AS prop,
+               prop AS prop,
+               min(step_1_conversion_time) AS step_1_conversion_time
+        FROM
+          (SELECT aggregation_target AS aggregation_target,
+                  steps AS steps,
+                  prop AS prop,
+                  max(steps) OVER (PARTITION BY aggregation_target,
+                                                prop) AS max_steps,
+                                  step_1_conversion_time AS step_1_conversion_time,
+                                  prop AS prop
+           FROM
+             (SELECT aggregation_target AS aggregation_target,
+                     timestamp AS timestamp,
+                     step_0 AS step_0,
+                     latest_0 AS latest_0,
+                     step_1 AS step_1,
+                     latest_1 AS latest_1,
+                     prop AS prop,
+                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
+                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
+                     prop AS prop
+              FROM
+                (SELECT aggregation_target AS aggregation_target,
+                        timestamp AS timestamp,
+                        step_0 AS step_0,
+                        latest_0 AS latest_0,
+                        step_1 AS step_1,
+                        min(latest_1) OVER (PARTITION BY aggregation_target,
+                                                         prop
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
+                                           prop AS prop
+                 FROM
+                   (SELECT timestamp AS timestamp,
+                           aggregation_target AS aggregation_target,
+                           step_0 AS step_0,
+                           latest_0 AS latest_0,
+                           step_1 AS step_1,
+                           latest_1 AS latest_1,
+                           prop_basic AS prop_basic,
+                           prop,
+                           prop_vals AS prop_vals,
+                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
+                    FROM
+                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
+                              if(equals(e.event, 'purchase'), 1, 0) AS step_1,
+                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
+                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                              prop_basic AS prop,
+                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+                       FROM events AS e
+                       LEFT OUTER JOIN
+                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                                 person_distinct_id_overrides.distinct_id AS distinct_id
+                          FROM person_distinct_id_overrides
+                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                          GROUP BY person_distinct_id_overrides.distinct_id
+                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+                       LEFT JOIN
+                         (SELECT person.id AS id,
+                                 nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
+                          FROM person
+                          WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                                               (SELECT person.id AS id, max(person.version) AS version
+                                                                                FROM person
+                                                                                WHERE equals(person.team_id, 99999)
+                                                                                GROUP BY person.id
+                                                                                HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(e__person.properties___email), '%@laterevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
               WHERE ifNull(equals(step_0, 1), 0)))
         GROUP BY aggregation_target,
                  steps,
@@ -764,7 +764,7 @@
                     allow_experimental_analyzer=1
   '''
 # ---
-# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_7_person_id_no_override_properties_on_events_filter_laterevent
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_7_person_id_no_override_properties_on_events_filter_earlierevent
   '''
   
   SELECT DISTINCT person_id
@@ -773,106 +773,7 @@
     AND distinct_id = 'person_id_1_distinct_id_2'
   '''
 # ---
-# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_7_person_id_no_override_properties_on_events_filter_laterevent.1
-  '''
-  SELECT sum(step_1) AS step_1,
-         sum(step_2) AS step_2,
-         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
-         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
-         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
-  FROM
-    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
-            prop AS prop,
-            row_number() OVER (
-                               ORDER BY step_2 DESC) AS row_number
-     FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time
-        FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  prop AS prop
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     prop AS prop
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                           prop AS prop
-                 FROM
-                   (SELECT timestamp AS timestamp,
-                           aggregation_target AS aggregation_target,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           prop_basic AS prop_basic,
-                           prop,
-                           prop_vals AS prop_vals,
-                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.person_id AS aggregation_target,
-                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'purchase'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
-                              prop_basic AS prop,
-                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-31 00:00:00.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(nullIf(nullIf(e.mat_pp_email, ''), 'null')), '%@laterevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     GROUP BY prop)
-  GROUP BY final_prop
-  LIMIT 26 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    format_csv_allow_double_quotes=0,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=23622320128,
-                    allow_experimental_analyzer=1
-  '''
-# ---
-# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_8_person_id_no_override_properties_on_events_filter_earlierevent
-  '''
-  
-  SELECT DISTINCT person_id
-  FROM events
-  WHERE team_id = 99999
-    AND distinct_id = 'person_id_1_distinct_id_2'
-  '''
-# ---
-# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_8_person_id_no_override_properties_on_events_filter_earlierevent.1
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_7_person_id_no_override_properties_on_events_filter_earlierevent.1
   '''
   SELECT sum(step_1) AS step_1,
          sum(step_2) AS step_2,
@@ -944,6 +845,105 @@
                               argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
                        FROM events AS e
                        WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-31 00:00:00.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(nullIf(nullIf(e.mat_pp_email, ''), 'null')), '%@earlierevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
+              WHERE ifNull(equals(step_0, 1), 0)))
+        GROUP BY aggregation_target,
+                 steps,
+                 prop
+        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
+                      and isNull(max(max_steps))))
+     GROUP BY prop)
+  GROUP BY final_prop
+  LIMIT 26 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=23622320128,
+                    allow_experimental_analyzer=1
+  '''
+# ---
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_8_person_id_no_override_properties_on_events_filter_laterevent
+  '''
+  
+  SELECT DISTINCT person_id
+  FROM events
+  WHERE team_id = 99999
+    AND distinct_id = 'person_id_1_distinct_id_2'
+  '''
+# ---
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_8_person_id_no_override_properties_on_events_filter_laterevent.1
+  '''
+  SELECT sum(step_1) AS step_1,
+         sum(step_2) AS step_2,
+         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
+         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
+         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
+  FROM
+    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
+            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
+            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
+            prop AS prop,
+            row_number() OVER (
+                               ORDER BY step_2 DESC) AS row_number
+     FROM
+       (SELECT aggregation_target AS aggregation_target,
+               steps AS steps,
+               prop AS prop,
+               prop AS prop,
+               min(step_1_conversion_time) AS step_1_conversion_time
+        FROM
+          (SELECT aggregation_target AS aggregation_target,
+                  steps AS steps,
+                  prop AS prop,
+                  max(steps) OVER (PARTITION BY aggregation_target,
+                                                prop) AS max_steps,
+                                  step_1_conversion_time AS step_1_conversion_time,
+                                  prop AS prop
+           FROM
+             (SELECT aggregation_target AS aggregation_target,
+                     timestamp AS timestamp,
+                     step_0 AS step_0,
+                     latest_0 AS latest_0,
+                     step_1 AS step_1,
+                     latest_1 AS latest_1,
+                     prop AS prop,
+                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
+                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
+                     prop AS prop
+              FROM
+                (SELECT aggregation_target AS aggregation_target,
+                        timestamp AS timestamp,
+                        step_0 AS step_0,
+                        latest_0 AS latest_0,
+                        step_1 AS step_1,
+                        min(latest_1) OVER (PARTITION BY aggregation_target,
+                                                         prop
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
+                                           prop AS prop
+                 FROM
+                   (SELECT timestamp AS timestamp,
+                           aggregation_target AS aggregation_target,
+                           step_0 AS step_0,
+                           latest_0 AS latest_0,
+                           step_1 AS step_1,
+                           latest_1 AS latest_1,
+                           prop_basic AS prop_basic,
+                           prop,
+                           prop_vals AS prop_vals,
+                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
+                    FROM
+                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                              e.person_id AS aggregation_target,
+                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
+                              if(equals(e.event, 'purchase'), 1, 0) AS step_1,
+                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
+                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                              prop_basic AS prop,
+                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+                       FROM events AS e
+                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-31 00:00:00.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(nullIf(nullIf(e.mat_pp_email, ''), 'null')), '%@laterevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
               WHERE ifNull(equals(step_0, 1), 0)))
         GROUP BY aggregation_target,
                  steps,

--- a/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_funnels_query_runner.ambr
+++ b/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_funnels_query_runner.ambr
@@ -1,0 +1,964 @@
+# serializer version: 1
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_0_person_id_override_properties_on_events_no_filter
+  '''
+  
+  SELECT DISTINCT person_id
+  FROM events
+  WHERE team_id = 99999
+    AND distinct_id = 'person_id_1_distinct_id_2'
+  '''
+# ---
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_0_person_id_override_properties_on_events_no_filter.1
+  '''
+  SELECT sum(step_1) AS step_1,
+         sum(step_2) AS step_2,
+         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
+         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
+         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
+  FROM
+    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
+            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
+            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
+            prop AS prop,
+            row_number() OVER (
+                               ORDER BY step_2 DESC) AS row_number
+     FROM
+       (SELECT aggregation_target AS aggregation_target,
+               steps AS steps,
+               prop AS prop,
+               prop AS prop,
+               min(step_1_conversion_time) AS step_1_conversion_time
+        FROM
+          (SELECT aggregation_target AS aggregation_target,
+                  steps AS steps,
+                  prop AS prop,
+                  max(steps) OVER (PARTITION BY aggregation_target,
+                                                prop) AS max_steps,
+                                  step_1_conversion_time AS step_1_conversion_time,
+                                  prop AS prop
+           FROM
+             (SELECT aggregation_target AS aggregation_target,
+                     timestamp AS timestamp,
+                     step_0 AS step_0,
+                     latest_0 AS latest_0,
+                     step_1 AS step_1,
+                     latest_1 AS latest_1,
+                     prop AS prop,
+                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
+                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
+                     prop AS prop
+              FROM
+                (SELECT aggregation_target AS aggregation_target,
+                        timestamp AS timestamp,
+                        step_0 AS step_0,
+                        latest_0 AS latest_0,
+                        step_1 AS step_1,
+                        min(latest_1) OVER (PARTITION BY aggregation_target,
+                                                         prop
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
+                                           prop AS prop
+                 FROM
+                   (SELECT timestamp AS timestamp,
+                           aggregation_target AS aggregation_target,
+                           step_0 AS step_0,
+                           latest_0 AS latest_0,
+                           step_1 AS step_1,
+                           latest_1 AS latest_1,
+                           prop_basic AS prop_basic,
+                           prop,
+                           prop_vals AS prop_vals,
+                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
+                    FROM
+                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
+                              if(equals(e.event, 'purchase'), 1, 0) AS step_1,
+                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
+                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                              prop_basic AS prop,
+                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+                       FROM events AS e
+                       LEFT OUTER JOIN
+                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                                 person_distinct_id_overrides.distinct_id AS distinct_id
+                          FROM person_distinct_id_overrides
+                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                          GROUP BY person_distinct_id_overrides.distinct_id
+                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(nullIf(nullIf(e.mat_pp_email, ''), 'null')), '%@posthog.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
+              WHERE ifNull(equals(step_0, 1), 0)))
+        GROUP BY aggregation_target,
+                 steps,
+                 prop
+        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
+                      and isNull(max(max_steps))))
+     GROUP BY prop)
+  GROUP BY final_prop
+  LIMIT 26 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=23622320128,
+                    allow_experimental_analyzer=1
+  '''
+# ---
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_1_person_id_override_properties_on_events_filter_laterevent
+  '''
+  
+  SELECT DISTINCT person_id
+  FROM events
+  WHERE team_id = 99999
+    AND distinct_id = 'person_id_1_distinct_id_2'
+  '''
+# ---
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_1_person_id_override_properties_on_events_filter_laterevent.1
+  '''
+  SELECT sum(step_1) AS step_1,
+         sum(step_2) AS step_2,
+         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
+         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
+         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
+  FROM
+    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
+            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
+            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
+            prop AS prop,
+            row_number() OVER (
+                               ORDER BY step_2 DESC) AS row_number
+     FROM
+       (SELECT aggregation_target AS aggregation_target,
+               steps AS steps,
+               prop AS prop,
+               prop AS prop,
+               min(step_1_conversion_time) AS step_1_conversion_time
+        FROM
+          (SELECT aggregation_target AS aggregation_target,
+                  steps AS steps,
+                  prop AS prop,
+                  max(steps) OVER (PARTITION BY aggregation_target,
+                                                prop) AS max_steps,
+                                  step_1_conversion_time AS step_1_conversion_time,
+                                  prop AS prop
+           FROM
+             (SELECT aggregation_target AS aggregation_target,
+                     timestamp AS timestamp,
+                     step_0 AS step_0,
+                     latest_0 AS latest_0,
+                     step_1 AS step_1,
+                     latest_1 AS latest_1,
+                     prop AS prop,
+                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
+                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
+                     prop AS prop
+              FROM
+                (SELECT aggregation_target AS aggregation_target,
+                        timestamp AS timestamp,
+                        step_0 AS step_0,
+                        latest_0 AS latest_0,
+                        step_1 AS step_1,
+                        min(latest_1) OVER (PARTITION BY aggregation_target,
+                                                         prop
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
+                                           prop AS prop
+                 FROM
+                   (SELECT timestamp AS timestamp,
+                           aggregation_target AS aggregation_target,
+                           step_0 AS step_0,
+                           latest_0 AS latest_0,
+                           step_1 AS step_1,
+                           latest_1 AS latest_1,
+                           prop_basic AS prop_basic,
+                           prop,
+                           prop_vals AS prop_vals,
+                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
+                    FROM
+                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
+                              if(equals(e.event, 'purchase'), 1, 0) AS step_1,
+                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
+                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                              prop_basic AS prop,
+                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+                       FROM events AS e
+                       LEFT OUTER JOIN
+                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                                 person_distinct_id_overrides.distinct_id AS distinct_id
+                          FROM person_distinct_id_overrides
+                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                          GROUP BY person_distinct_id_overrides.distinct_id
+                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(nullIf(nullIf(e.mat_pp_email, ''), 'null')), '%@laterevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
+              WHERE ifNull(equals(step_0, 1), 0)))
+        GROUP BY aggregation_target,
+                 steps,
+                 prop
+        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
+                      and isNull(max(max_steps))))
+     GROUP BY prop)
+  GROUP BY final_prop
+  LIMIT 26 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=23622320128,
+                    allow_experimental_analyzer=1
+  '''
+# ---
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_2_person_id_override_properties_on_events_filter_earlierevent
+  '''
+  
+  SELECT DISTINCT person_id
+  FROM events
+  WHERE team_id = 99999
+    AND distinct_id = 'person_id_1_distinct_id_2'
+  '''
+# ---
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_2_person_id_override_properties_on_events_filter_earlierevent.1
+  '''
+  SELECT sum(step_1) AS step_1,
+         sum(step_2) AS step_2,
+         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
+         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
+         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
+  FROM
+    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
+            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
+            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
+            prop AS prop,
+            row_number() OVER (
+                               ORDER BY step_2 DESC) AS row_number
+     FROM
+       (SELECT aggregation_target AS aggregation_target,
+               steps AS steps,
+               prop AS prop,
+               prop AS prop,
+               min(step_1_conversion_time) AS step_1_conversion_time
+        FROM
+          (SELECT aggregation_target AS aggregation_target,
+                  steps AS steps,
+                  prop AS prop,
+                  max(steps) OVER (PARTITION BY aggregation_target,
+                                                prop) AS max_steps,
+                                  step_1_conversion_time AS step_1_conversion_time,
+                                  prop AS prop
+           FROM
+             (SELECT aggregation_target AS aggregation_target,
+                     timestamp AS timestamp,
+                     step_0 AS step_0,
+                     latest_0 AS latest_0,
+                     step_1 AS step_1,
+                     latest_1 AS latest_1,
+                     prop AS prop,
+                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
+                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
+                     prop AS prop
+              FROM
+                (SELECT aggregation_target AS aggregation_target,
+                        timestamp AS timestamp,
+                        step_0 AS step_0,
+                        latest_0 AS latest_0,
+                        step_1 AS step_1,
+                        min(latest_1) OVER (PARTITION BY aggregation_target,
+                                                         prop
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
+                                           prop AS prop
+                 FROM
+                   (SELECT timestamp AS timestamp,
+                           aggregation_target AS aggregation_target,
+                           step_0 AS step_0,
+                           latest_0 AS latest_0,
+                           step_1 AS step_1,
+                           latest_1 AS latest_1,
+                           prop_basic AS prop_basic,
+                           prop,
+                           prop_vals AS prop_vals,
+                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
+                    FROM
+                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
+                              if(equals(e.event, 'purchase'), 1, 0) AS step_1,
+                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
+                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                              prop_basic AS prop,
+                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+                       FROM events AS e
+                       LEFT OUTER JOIN
+                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                                 person_distinct_id_overrides.distinct_id AS distinct_id
+                          FROM person_distinct_id_overrides
+                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                          GROUP BY person_distinct_id_overrides.distinct_id
+                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(nullIf(nullIf(e.mat_pp_email, ''), 'null')), '%@earlierevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
+              WHERE ifNull(equals(step_0, 1), 0)))
+        GROUP BY aggregation_target,
+                 steps,
+                 prop
+        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
+                      and isNull(max(max_steps))))
+     GROUP BY prop)
+  GROUP BY final_prop
+  LIMIT 26 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=23622320128,
+                    allow_experimental_analyzer=1
+  '''
+# ---
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_3_person_id_override_properties_joined_no_filter
+  '''
+  
+  SELECT DISTINCT person_id
+  FROM events
+  WHERE team_id = 99999
+    AND distinct_id = 'person_id_1_distinct_id_2'
+  '''
+# ---
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_3_person_id_override_properties_joined_no_filter.1
+  '''
+  SELECT sum(step_1) AS step_1,
+         sum(step_2) AS step_2,
+         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
+         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
+         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
+  FROM
+    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
+            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
+            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
+            prop AS prop,
+            row_number() OVER (
+                               ORDER BY step_2 DESC) AS row_number
+     FROM
+       (SELECT aggregation_target AS aggregation_target,
+               steps AS steps,
+               prop AS prop,
+               prop AS prop,
+               min(step_1_conversion_time) AS step_1_conversion_time
+        FROM
+          (SELECT aggregation_target AS aggregation_target,
+                  steps AS steps,
+                  prop AS prop,
+                  max(steps) OVER (PARTITION BY aggregation_target,
+                                                prop) AS max_steps,
+                                  step_1_conversion_time AS step_1_conversion_time,
+                                  prop AS prop
+           FROM
+             (SELECT aggregation_target AS aggregation_target,
+                     timestamp AS timestamp,
+                     step_0 AS step_0,
+                     latest_0 AS latest_0,
+                     step_1 AS step_1,
+                     latest_1 AS latest_1,
+                     prop AS prop,
+                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
+                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
+                     prop AS prop
+              FROM
+                (SELECT aggregation_target AS aggregation_target,
+                        timestamp AS timestamp,
+                        step_0 AS step_0,
+                        latest_0 AS latest_0,
+                        step_1 AS step_1,
+                        min(latest_1) OVER (PARTITION BY aggregation_target,
+                                                         prop
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
+                                           prop AS prop
+                 FROM
+                   (SELECT timestamp AS timestamp,
+                           aggregation_target AS aggregation_target,
+                           step_0 AS step_0,
+                           latest_0 AS latest_0,
+                           step_1 AS step_1,
+                           latest_1 AS latest_1,
+                           prop_basic AS prop_basic,
+                           prop,
+                           prop_vals AS prop_vals,
+                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
+                    FROM
+                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
+                              if(equals(e.event, 'purchase'), 1, 0) AS step_1,
+                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
+                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                              prop_basic AS prop,
+                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+                       FROM events AS e
+                       LEFT OUTER JOIN
+                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                                 person_distinct_id_overrides.distinct_id AS distinct_id
+                          FROM person_distinct_id_overrides
+                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                          GROUP BY person_distinct_id_overrides.distinct_id
+                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+                       LEFT JOIN
+                         (SELECT person.id AS id,
+                                 nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
+                          FROM person
+                          WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                                               (SELECT person.id AS id, max(person.version) AS version
+                                                                                FROM person
+                                                                                WHERE equals(person.team_id, 99999)
+                                                                                GROUP BY person.id
+                                                                                HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(e__person.properties___email), '%@posthog.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
+              WHERE ifNull(equals(step_0, 1), 0)))
+        GROUP BY aggregation_target,
+                 steps,
+                 prop
+        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
+                      and isNull(max(max_steps))))
+     GROUP BY prop)
+  GROUP BY final_prop
+  LIMIT 26 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=23622320128,
+                    allow_experimental_analyzer=1
+  '''
+# ---
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_4_person_id_override_properties_joined_filter_laterevent
+  '''
+  
+  SELECT DISTINCT person_id
+  FROM events
+  WHERE team_id = 99999
+    AND distinct_id = 'person_id_1_distinct_id_2'
+  '''
+# ---
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_4_person_id_override_properties_joined_filter_laterevent.1
+  '''
+  SELECT sum(step_1) AS step_1,
+         sum(step_2) AS step_2,
+         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
+         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
+         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
+  FROM
+    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
+            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
+            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
+            prop AS prop,
+            row_number() OVER (
+                               ORDER BY step_2 DESC) AS row_number
+     FROM
+       (SELECT aggregation_target AS aggregation_target,
+               steps AS steps,
+               prop AS prop,
+               prop AS prop,
+               min(step_1_conversion_time) AS step_1_conversion_time
+        FROM
+          (SELECT aggregation_target AS aggregation_target,
+                  steps AS steps,
+                  prop AS prop,
+                  max(steps) OVER (PARTITION BY aggregation_target,
+                                                prop) AS max_steps,
+                                  step_1_conversion_time AS step_1_conversion_time,
+                                  prop AS prop
+           FROM
+             (SELECT aggregation_target AS aggregation_target,
+                     timestamp AS timestamp,
+                     step_0 AS step_0,
+                     latest_0 AS latest_0,
+                     step_1 AS step_1,
+                     latest_1 AS latest_1,
+                     prop AS prop,
+                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
+                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
+                     prop AS prop
+              FROM
+                (SELECT aggregation_target AS aggregation_target,
+                        timestamp AS timestamp,
+                        step_0 AS step_0,
+                        latest_0 AS latest_0,
+                        step_1 AS step_1,
+                        min(latest_1) OVER (PARTITION BY aggregation_target,
+                                                         prop
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
+                                           prop AS prop
+                 FROM
+                   (SELECT timestamp AS timestamp,
+                           aggregation_target AS aggregation_target,
+                           step_0 AS step_0,
+                           latest_0 AS latest_0,
+                           step_1 AS step_1,
+                           latest_1 AS latest_1,
+                           prop_basic AS prop_basic,
+                           prop,
+                           prop_vals AS prop_vals,
+                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
+                    FROM
+                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
+                              if(equals(e.event, 'purchase'), 1, 0) AS step_1,
+                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
+                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                              prop_basic AS prop,
+                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+                       FROM events AS e
+                       LEFT OUTER JOIN
+                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                                 person_distinct_id_overrides.distinct_id AS distinct_id
+                          FROM person_distinct_id_overrides
+                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                          GROUP BY person_distinct_id_overrides.distinct_id
+                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+                       LEFT JOIN
+                         (SELECT person.id AS id,
+                                 nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
+                          FROM person
+                          WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                                               (SELECT person.id AS id, max(person.version) AS version
+                                                                                FROM person
+                                                                                WHERE equals(person.team_id, 99999)
+                                                                                GROUP BY person.id
+                                                                                HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(e__person.properties___email), '%@laterevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
+              WHERE ifNull(equals(step_0, 1), 0)))
+        GROUP BY aggregation_target,
+                 steps,
+                 prop
+        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
+                      and isNull(max(max_steps))))
+     GROUP BY prop)
+  GROUP BY final_prop
+  LIMIT 26 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=23622320128,
+                    allow_experimental_analyzer=1
+  '''
+# ---
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_5_person_id_override_properties_joined_filter_earlierevent
+  '''
+  
+  SELECT DISTINCT person_id
+  FROM events
+  WHERE team_id = 99999
+    AND distinct_id = 'person_id_1_distinct_id_2'
+  '''
+# ---
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_5_person_id_override_properties_joined_filter_earlierevent.1
+  '''
+  SELECT sum(step_1) AS step_1,
+         sum(step_2) AS step_2,
+         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
+         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
+         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
+  FROM
+    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
+            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
+            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
+            prop AS prop,
+            row_number() OVER (
+                               ORDER BY step_2 DESC) AS row_number
+     FROM
+       (SELECT aggregation_target AS aggregation_target,
+               steps AS steps,
+               prop AS prop,
+               prop AS prop,
+               min(step_1_conversion_time) AS step_1_conversion_time
+        FROM
+          (SELECT aggregation_target AS aggregation_target,
+                  steps AS steps,
+                  prop AS prop,
+                  max(steps) OVER (PARTITION BY aggregation_target,
+                                                prop) AS max_steps,
+                                  step_1_conversion_time AS step_1_conversion_time,
+                                  prop AS prop
+           FROM
+             (SELECT aggregation_target AS aggregation_target,
+                     timestamp AS timestamp,
+                     step_0 AS step_0,
+                     latest_0 AS latest_0,
+                     step_1 AS step_1,
+                     latest_1 AS latest_1,
+                     prop AS prop,
+                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
+                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
+                     prop AS prop
+              FROM
+                (SELECT aggregation_target AS aggregation_target,
+                        timestamp AS timestamp,
+                        step_0 AS step_0,
+                        latest_0 AS latest_0,
+                        step_1 AS step_1,
+                        min(latest_1) OVER (PARTITION BY aggregation_target,
+                                                         prop
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
+                                           prop AS prop
+                 FROM
+                   (SELECT timestamp AS timestamp,
+                           aggregation_target AS aggregation_target,
+                           step_0 AS step_0,
+                           latest_0 AS latest_0,
+                           step_1 AS step_1,
+                           latest_1 AS latest_1,
+                           prop_basic AS prop_basic,
+                           prop,
+                           prop_vals AS prop_vals,
+                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
+                    FROM
+                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
+                              if(equals(e.event, 'purchase'), 1, 0) AS step_1,
+                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
+                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                              prop_basic AS prop,
+                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+                       FROM events AS e
+                       LEFT OUTER JOIN
+                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                                 person_distinct_id_overrides.distinct_id AS distinct_id
+                          FROM person_distinct_id_overrides
+                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                          GROUP BY person_distinct_id_overrides.distinct_id
+                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+                       LEFT JOIN
+                         (SELECT person.id AS id,
+                                 nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
+                          FROM person
+                          WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                                               (SELECT person.id AS id, max(person.version) AS version
+                                                                                FROM person
+                                                                                WHERE equals(person.team_id, 99999)
+                                                                                GROUP BY person.id
+                                                                                HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(e__person.properties___email), '%@earlierevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
+              WHERE ifNull(equals(step_0, 1), 0)))
+        GROUP BY aggregation_target,
+                 steps,
+                 prop
+        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
+                      and isNull(max(max_steps))))
+     GROUP BY prop)
+  GROUP BY final_prop
+  LIMIT 26 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=23622320128,
+                    allow_experimental_analyzer=1
+  '''
+# ---
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_6_person_id_no_override_properties_on_events_no_filter
+  '''
+  
+  SELECT DISTINCT person_id
+  FROM events
+  WHERE team_id = 99999
+    AND distinct_id = 'person_id_1_distinct_id_2'
+  '''
+# ---
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_6_person_id_no_override_properties_on_events_no_filter.1
+  '''
+  SELECT sum(step_1) AS step_1,
+         sum(step_2) AS step_2,
+         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
+         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
+         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
+  FROM
+    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
+            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
+            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
+            prop AS prop,
+            row_number() OVER (
+                               ORDER BY step_2 DESC) AS row_number
+     FROM
+       (SELECT aggregation_target AS aggregation_target,
+               steps AS steps,
+               prop AS prop,
+               prop AS prop,
+               min(step_1_conversion_time) AS step_1_conversion_time
+        FROM
+          (SELECT aggregation_target AS aggregation_target,
+                  steps AS steps,
+                  prop AS prop,
+                  max(steps) OVER (PARTITION BY aggregation_target,
+                                                prop) AS max_steps,
+                                  step_1_conversion_time AS step_1_conversion_time,
+                                  prop AS prop
+           FROM
+             (SELECT aggregation_target AS aggregation_target,
+                     timestamp AS timestamp,
+                     step_0 AS step_0,
+                     latest_0 AS latest_0,
+                     step_1 AS step_1,
+                     latest_1 AS latest_1,
+                     prop AS prop,
+                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
+                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
+                     prop AS prop
+              FROM
+                (SELECT aggregation_target AS aggregation_target,
+                        timestamp AS timestamp,
+                        step_0 AS step_0,
+                        latest_0 AS latest_0,
+                        step_1 AS step_1,
+                        min(latest_1) OVER (PARTITION BY aggregation_target,
+                                                         prop
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
+                                           prop AS prop
+                 FROM
+                   (SELECT timestamp AS timestamp,
+                           aggregation_target AS aggregation_target,
+                           step_0 AS step_0,
+                           latest_0 AS latest_0,
+                           step_1 AS step_1,
+                           latest_1 AS latest_1,
+                           prop_basic AS prop_basic,
+                           prop,
+                           prop_vals AS prop_vals,
+                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
+                    FROM
+                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                              e.person_id AS aggregation_target,
+                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
+                              if(equals(e.event, 'purchase'), 1, 0) AS step_1,
+                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
+                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                              prop_basic AS prop,
+                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+                       FROM events AS e
+                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-31 00:00:00.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(nullIf(nullIf(e.mat_pp_email, ''), 'null')), '%@posthog.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
+              WHERE ifNull(equals(step_0, 1), 0)))
+        GROUP BY aggregation_target,
+                 steps,
+                 prop
+        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
+                      and isNull(max(max_steps))))
+     GROUP BY prop)
+  GROUP BY final_prop
+  LIMIT 26 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=23622320128,
+                    allow_experimental_analyzer=1
+  '''
+# ---
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_7_person_id_no_override_properties_on_events_filter_laterevent
+  '''
+  
+  SELECT DISTINCT person_id
+  FROM events
+  WHERE team_id = 99999
+    AND distinct_id = 'person_id_1_distinct_id_2'
+  '''
+# ---
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_7_person_id_no_override_properties_on_events_filter_laterevent.1
+  '''
+  SELECT sum(step_1) AS step_1,
+         sum(step_2) AS step_2,
+         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
+         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
+         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
+  FROM
+    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
+            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
+            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
+            prop AS prop,
+            row_number() OVER (
+                               ORDER BY step_2 DESC) AS row_number
+     FROM
+       (SELECT aggregation_target AS aggregation_target,
+               steps AS steps,
+               prop AS prop,
+               prop AS prop,
+               min(step_1_conversion_time) AS step_1_conversion_time
+        FROM
+          (SELECT aggregation_target AS aggregation_target,
+                  steps AS steps,
+                  prop AS prop,
+                  max(steps) OVER (PARTITION BY aggregation_target,
+                                                prop) AS max_steps,
+                                  step_1_conversion_time AS step_1_conversion_time,
+                                  prop AS prop
+           FROM
+             (SELECT aggregation_target AS aggregation_target,
+                     timestamp AS timestamp,
+                     step_0 AS step_0,
+                     latest_0 AS latest_0,
+                     step_1 AS step_1,
+                     latest_1 AS latest_1,
+                     prop AS prop,
+                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
+                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
+                     prop AS prop
+              FROM
+                (SELECT aggregation_target AS aggregation_target,
+                        timestamp AS timestamp,
+                        step_0 AS step_0,
+                        latest_0 AS latest_0,
+                        step_1 AS step_1,
+                        min(latest_1) OVER (PARTITION BY aggregation_target,
+                                                         prop
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
+                                           prop AS prop
+                 FROM
+                   (SELECT timestamp AS timestamp,
+                           aggregation_target AS aggregation_target,
+                           step_0 AS step_0,
+                           latest_0 AS latest_0,
+                           step_1 AS step_1,
+                           latest_1 AS latest_1,
+                           prop_basic AS prop_basic,
+                           prop,
+                           prop_vals AS prop_vals,
+                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
+                    FROM
+                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                              e.person_id AS aggregation_target,
+                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
+                              if(equals(e.event, 'purchase'), 1, 0) AS step_1,
+                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
+                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                              prop_basic AS prop,
+                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+                       FROM events AS e
+                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-31 00:00:00.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(nullIf(nullIf(e.mat_pp_email, ''), 'null')), '%@laterevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
+              WHERE ifNull(equals(step_0, 1), 0)))
+        GROUP BY aggregation_target,
+                 steps,
+                 prop
+        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
+                      and isNull(max(max_steps))))
+     GROUP BY prop)
+  GROUP BY final_prop
+  LIMIT 26 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=23622320128,
+                    allow_experimental_analyzer=1
+  '''
+# ---
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_8_person_id_no_override_properties_on_events_filter_earlierevent
+  '''
+  
+  SELECT DISTINCT person_id
+  FROM events
+  WHERE team_id = 99999
+    AND distinct_id = 'person_id_1_distinct_id_2'
+  '''
+# ---
+# name: TestExperimentFunnelsQueryRunner.test_query_runner_with_persons_on_events_mode_8_person_id_no_override_properties_on_events_filter_earlierevent.1
+  '''
+  SELECT sum(step_1) AS step_1,
+         sum(step_2) AS step_2,
+         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
+         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
+         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
+  FROM
+    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
+            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
+            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
+            prop AS prop,
+            row_number() OVER (
+                               ORDER BY step_2 DESC) AS row_number
+     FROM
+       (SELECT aggregation_target AS aggregation_target,
+               steps AS steps,
+               prop AS prop,
+               prop AS prop,
+               min(step_1_conversion_time) AS step_1_conversion_time
+        FROM
+          (SELECT aggregation_target AS aggregation_target,
+                  steps AS steps,
+                  prop AS prop,
+                  max(steps) OVER (PARTITION BY aggregation_target,
+                                                prop) AS max_steps,
+                                  step_1_conversion_time AS step_1_conversion_time,
+                                  prop AS prop
+           FROM
+             (SELECT aggregation_target AS aggregation_target,
+                     timestamp AS timestamp,
+                     step_0 AS step_0,
+                     latest_0 AS latest_0,
+                     step_1 AS step_1,
+                     latest_1 AS latest_1,
+                     prop AS prop,
+                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
+                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
+                     prop AS prop
+              FROM
+                (SELECT aggregation_target AS aggregation_target,
+                        timestamp AS timestamp,
+                        step_0 AS step_0,
+                        latest_0 AS latest_0,
+                        step_1 AS step_1,
+                        min(latest_1) OVER (PARTITION BY aggregation_target,
+                                                         prop
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
+                                           prop AS prop
+                 FROM
+                   (SELECT timestamp AS timestamp,
+                           aggregation_target AS aggregation_target,
+                           step_0 AS step_0,
+                           latest_0 AS latest_0,
+                           step_1 AS step_1,
+                           latest_1 AS latest_1,
+                           prop_basic AS prop_basic,
+                           prop,
+                           prop_vals AS prop_vals,
+                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
+                    FROM
+                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                              e.person_id AS aggregation_target,
+                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
+                              if(equals(e.event, 'purchase'), 1, 0) AS step_1,
+                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
+                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                              prop_basic AS prop,
+                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+                       FROM events AS e
+                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-31 00:00:00.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(nullIf(nullIf(e.mat_pp_email, ''), 'null')), '%@earlierevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
+              WHERE ifNull(equals(step_0, 1), 0)))
+        GROUP BY aggregation_target,
+                 steps,
+                 prop
+        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
+                      and isNull(max(max_steps))))
+     GROUP BY prop)
+  GROUP BY final_prop
+  LIMIT 26 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=23622320128,
+                    allow_experimental_analyzer=1
+  '''
+# ---

--- a/posthog/hogql_queries/experiments/test/test_experiment_funnels_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_funnels_query_runner.py
@@ -8,12 +8,21 @@ from posthog.schema import (
     ExperimentFunnelsQuery,
     ExperimentSignificanceCode,
     FunnelsQuery,
+    PersonsOnEventsMode,
 )
-from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, _create_person, flush_persons_and_events
+from posthog.test.base import (
+    APIBaseTest,
+    ClickhouseTestMixin,
+    _create_event,
+    _create_person,
+    create_person_id_override_by_distinct_id,
+    flush_persons_and_events,
+    snapshot_clickhouse_queries,
+)
 from freezegun import freeze_time
 from parameterized import parameterized
 from django.utils import timezone
-from datetime import timedelta
+from datetime import datetime, timedelta
 from rest_framework.exceptions import ValidationError
 from posthog.constants import ExperimentNoResultsErrorKeys
 import json
@@ -47,15 +56,23 @@ class TestExperimentFunnelsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             created_by=self.user,
         )
 
-    def create_experiment(self, name="test-experiment", feature_flag=None):
+    def create_experiment(self, name="test-experiment", feature_flag=None, start_date=None, end_date=None):
         if feature_flag is None:
             feature_flag = self.create_feature_flag(name)
+        if start_date is None:
+            start_date = timezone.now()
+        else:
+            start_date = timezone.make_aware(start_date)  # Make naive datetime timezone-aware
+        if end_date is None:
+            end_date = timezone.now() + timedelta(days=14)
+        elif end_date is not None:
+            end_date = timezone.make_aware(end_date)  # Make naive datetime timezone-aware
         return Experiment.objects.create(
             name=name,
             team=self.team,
             feature_flag=feature_flag,
-            start_date=timezone.now(),
-            end_date=timezone.now() + timedelta(days=14),
+            start_date=start_date,
+            end_date=end_date,
         )
 
     def create_holdout_for_experiment(self, experiment):
@@ -443,6 +460,249 @@ class TestExperimentFunnelsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(control_variant.failure_count, expected_counts["control_failure"])
         self.assertEqual(test_variant.success_count, expected_counts["test_success"])
         self.assertEqual(test_variant.failure_count, expected_counts["test_failure"])
+
+    @parameterized.expand(
+        [
+            ###
+            # PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS
+            ###
+            [
+                "person_id_override_properties_on_events_no_filter",
+                PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS,
+                None,
+                {
+                    "control_success": 1,
+                    "control_failure": 0,
+                    "test_success": 1,
+                    "test_failure": 0,
+                },
+            ],
+            [
+                "person_id_override_properties_on_events_filter_laterevent",
+                PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS,
+                {
+                    "key": "email",
+                    "value": "@laterevent.com",
+                    "operator": "not_icontains",
+                    "type": "person",
+                },
+                {
+                    "control_success": 1,
+                    "control_failure": 0,
+                    "test_success": 0,
+                    "test_failure": 1,
+                },
+            ],
+            [
+                "person_id_override_properties_on_events_filter_earlierevent",
+                PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS,
+                {
+                    "key": "email",
+                    "value": "@earlierevent.com",
+                    "operator": "not_icontains",
+                    "type": "person",
+                },
+                {
+                    "control_success": 1,
+                    "control_failure": 0,
+                    "test_success": 1,
+                    "test_failure": 0,
+                },
+            ],
+            ###
+            # PERSON_ID_OVERRIDE_PROPERTIES_JOINED
+            ###
+            [
+                "person_id_override_properties_joined_no_filter",
+                PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED,
+                None,
+                {
+                    "control_success": 1,
+                    "control_failure": 0,
+                    "test_success": 1,
+                    "test_failure": 0,
+                },
+            ],
+            [
+                "person_id_override_properties_joined_filter_laterevent",
+                PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED,
+                {
+                    "key": "email",
+                    "value": "@laterevent.com",
+                    "operator": "not_icontains",
+                    "type": "person",
+                },
+                None,
+            ],
+            [
+                "person_id_override_properties_joined_filter_earlierevent",
+                PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED,
+                {
+                    "key": "email",
+                    "value": "@earlierevent.com",
+                    "operator": "not_icontains",
+                    "type": "person",
+                },
+                {
+                    "control_success": 1,
+                    "control_failure": 0,
+                    "test_success": 1,
+                    "test_failure": 0,
+                },
+            ],
+            ###
+            # PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS
+            ###
+            [
+                "person_id_no_override_properties_on_events_no_filter",
+                PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS,
+                None,
+                {
+                    "control_success": 1,
+                    "control_failure": 0,
+                    "test_success": 1,
+                    "test_failure": 1,
+                },
+            ],
+            [
+                "person_id_no_override_properties_on_events_filter_laterevent",
+                PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS,
+                {
+                    "key": "email",
+                    "value": "@laterevent.com",
+                    "operator": "not_icontains",
+                    "type": "person",
+                },
+                {
+                    "control_success": 1,
+                    "control_failure": 0,
+                    "test_success": 0,
+                    "test_failure": 1,
+                },
+            ],
+            [
+                "person_id_no_override_properties_on_events_filter_earlierevent",
+                PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS,
+                {
+                    "key": "email",
+                    "value": "@earlierevent.com",
+                    "operator": "not_icontains",
+                    "type": "person",
+                },
+                {
+                    "control_success": 1,
+                    "control_failure": 0,
+                    "test_success": 1,
+                    "test_failure": 0,
+                },
+            ],
+        ]
+    )
+    @snapshot_clickhouse_queries
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_query_runner_with_persons_on_events_mode(self, name, persons_on_events_mode, filters, expected_results):
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(
+            feature_flag=feature_flag, start_date=datetime(2020, 1, 1), end_date=datetime(2020, 1, 31)
+        )
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        funnels_query = FunnelsQuery(
+            series=[EventsNode(event="$pageview"), EventsNode(event="purchase")],
+            dateRange={"date_from": "2020-01-01", "date_to": "2020-01-31"},
+            filterTestAccounts=True,
+        )
+
+        experiment_query = ExperimentFunnelsQuery(
+            experiment_id=experiment.id,
+            kind="ExperimentFunnelsQuery",
+            funnels_query=funnels_query,
+        )
+
+        experiment.metrics = [{"type": "primary", "query": experiment_query.model_dump()}]
+        experiment.save()
+
+        ## Control isn't affected by the filter
+        _create_person(distinct_ids=["user_control_1"], team_id=self.team.pk)
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="user_control_1",
+            timestamp="2020-01-02T12:00:00Z",
+            properties={feature_flag_property: "control"},
+        )
+        _create_event(
+            team=self.team,
+            event="purchase",
+            distinct_id="user_control_1",
+            timestamp="2020-01-02T12:01:00Z",
+            properties={feature_flag_property: "control"},
+        )
+
+        ## Test is tied to person on events mode
+        _create_person(
+            distinct_ids=["person_id_1_distinct_id_1"],
+            properties={"email": "person_id_1@earlierevent.com"},
+            team_id=self.team.pk,
+        )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="person_id_1_distinct_id_1",
+            timestamp="2020-01-02T12:00:00Z",
+            properties={feature_flag_property: "test"},
+        )
+        _create_person(
+            distinct_ids=["person_id_1_distinct_id_2"],
+            properties={"email": "person_id_1@laterevent.com"},
+            team_id=self.team.pk,
+        )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="person_id_1_distinct_id_2",
+            timestamp="2020-01-02T12:01:00Z",
+            properties={feature_flag_property: "test"},
+        )
+        _create_event(
+            team=self.team,
+            event="purchase",
+            distinct_id="person_id_1_distinct_id_2",
+            timestamp="2020-01-02T12:02:00Z",
+            properties={feature_flag_property: "test"},
+        )
+        create_person_id_override_by_distinct_id("person_id_1_distinct_id_1", "person_id_1_distinct_id_2", self.team.pk)
+
+        flush_persons_and_events()
+
+        self.team.modifiers = {"personsOnEventsMode": persons_on_events_mode}
+        if filters:
+            self.team.test_account_filters = [filters]
+        self.team.save()
+
+        query_runner = ExperimentFunnelsQueryRunner(
+            query=ExperimentFunnelsQuery(**experiment.metrics[0]["query"]), team=self.team
+        )
+        if expected_results is None:
+            with self.assertRaises(ValidationError):
+                query_runner.calculate()
+        else:
+            result = query_runner.calculate()
+
+            self.assertEqual(len(result.variants), 2)
+            control_variant = next(v for v in result.variants if v.key == "control")
+            test_variant = next(v for v in result.variants if v.key == "test")
+
+            self.assertEqual(
+                {
+                    "control_success": int(control_variant.success_count),
+                    "control_failure": int(control_variant.failure_count),
+                    "test_success": int(test_variant.success_count),
+                    "test_failure": int(test_variant.failure_count),
+                },
+                expected_results,
+            )
 
     @freeze_time("2020-01-01T12:00:00Z")
     def test_query_runner_with_holdout(self):

--- a/posthog/hogql_queries/experiments/test/test_experiment_funnels_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_funnels_query_runner.py
@@ -478,22 +478,6 @@ class TestExperimentFunnelsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                 },
             ],
             [
-                "person_id_override_properties_on_events_filter_laterevent",
-                PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS,
-                {
-                    "key": "email",
-                    "value": "@laterevent.com",
-                    "operator": "not_icontains",
-                    "type": "person",
-                },
-                {
-                    "control_success": 1,
-                    "control_failure": 0,
-                    "test_success": 0,
-                    "test_failure": 1,
-                },
-            ],
-            [
                 "person_id_override_properties_on_events_filter_earlierevent",
                 PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS,
                 {
@@ -509,6 +493,22 @@ class TestExperimentFunnelsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                     "test_failure": 0,
                 },
             ],
+            [
+                "person_id_override_properties_on_events_filter_laterevent",
+                PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS,
+                {
+                    "key": "email",
+                    "value": "@laterevent.com",
+                    "operator": "not_icontains",
+                    "type": "person",
+                },
+                {
+                    "control_success": 1,
+                    "control_failure": 0,
+                    "test_success": 0,
+                    "test_failure": 1,
+                },
+            ],
             ###
             # PERSON_ID_OVERRIDE_PROPERTIES_JOINED
             ###
@@ -516,6 +516,22 @@ class TestExperimentFunnelsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                 "person_id_override_properties_joined_no_filter",
                 PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED,
                 None,
+                {
+                    "control_success": 1,
+                    "control_failure": 0,
+                    "test_success": 1,
+                    "test_failure": 0,
+                },
+            ],
+            [
+                "person_id_override_properties_joined_filter_earlierevent",
+                PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED,
+                {
+                    "key": "email",
+                    "value": "@earlierevent.com",
+                    "operator": "not_icontains",
+                    "type": "person",
+                },
                 {
                     "control_success": 1,
                     "control_failure": 0,
@@ -534,22 +550,6 @@ class TestExperimentFunnelsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                 },
                 None,
             ],
-            [
-                "person_id_override_properties_joined_filter_earlierevent",
-                PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED,
-                {
-                    "key": "email",
-                    "value": "@earlierevent.com",
-                    "operator": "not_icontains",
-                    "type": "person",
-                },
-                {
-                    "control_success": 1,
-                    "control_failure": 0,
-                    "test_success": 1,
-                    "test_failure": 0,
-                },
-            ],
             ###
             # PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS
             ###
@@ -561,22 +561,6 @@ class TestExperimentFunnelsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                     "control_success": 1,
                     "control_failure": 0,
                     "test_success": 1,
-                    "test_failure": 1,
-                },
-            ],
-            [
-                "person_id_no_override_properties_on_events_filter_laterevent",
-                PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS,
-                {
-                    "key": "email",
-                    "value": "@laterevent.com",
-                    "operator": "not_icontains",
-                    "type": "person",
-                },
-                {
-                    "control_success": 1,
-                    "control_failure": 0,
-                    "test_success": 0,
                     "test_failure": 1,
                 },
             ],
@@ -594,6 +578,22 @@ class TestExperimentFunnelsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                     "control_failure": 0,
                     "test_success": 1,
                     "test_failure": 0,
+                },
+            ],
+            [
+                "person_id_no_override_properties_on_events_filter_laterevent",
+                PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS,
+                {
+                    "key": "email",
+                    "value": "@laterevent.com",
+                    "operator": "not_icontains",
+                    "type": "person",
+                },
+                {
+                    "control_success": 1,
+                    "control_failure": 0,
+                    "test_success": 0,
+                    "test_failure": 1,
                 },
             ],
         ]

--- a/posthog/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/test/__snapshots__/test_feature_flag.ambr
@@ -2069,7 +2069,7 @@
   FROM "posthog_cohort"
   INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
   WHERE (NOT "posthog_cohort"."deleted"
-         AND "posthog_team"."project_id" = 523)
+         AND "posthog_team"."project_id" = 521)
   '''
 # ---
 # name: TestFeatureFlagMatcher.test_numeric_operator_with_cohorts_and_nested_cohorts.1
@@ -2115,7 +2115,7 @@
          "posthog_grouptypemapping"."name_singular",
          "posthog_grouptypemapping"."name_plural"
   FROM "posthog_grouptypemapping"
-  WHERE "posthog_grouptypemapping"."project_id" = 523
+  WHERE "posthog_grouptypemapping"."project_id" = 521
   '''
 # ---
 # name: TestFeatureFlagMatcher.test_numeric_operator_with_groups_and_person_flags.1


### PR DESCRIPTION
## Changes

Adds tests and query snapshots for person on events mode applied to a funnel. I tried to write the tests in a way that prioritizes readability. The intent is to document the current behavior (it may actually be undesirable in certain scenarios). Feel free to review my analysis too.

The basic setup is:
* `person_id_1_distinct_id_1` with `email=person_id_1@earlierevent.com` fires:
	* `$pageview` at `12:00`
* `person_id_1_distinct_id_2` with `email=person_id_1@laterevent.com` fires:
	* `$pageview` at `12:01`
	* `purchase` at `12:02`
* The two persons are combined with with `create_person_id_override_by_distinct_id("person_id_1_distinct_id_1", "person_id_1_distinct_id_2", self.team.pk)`

### `PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS`
_Use person properties from the time of the event.
Fast queries. If the person property is updated, query results on past data won't change._

Results explained:
* The `no_filter` scenario produces `test_success=1, test_failure=0`. Both sets of events have the same `distinct_id`, so only one funnel completion is captured.
* The `email!=@earlierevent.com` scenario produces `test_success=1, test_failure=0`. The `person_id_1_distinct_id_1` pageview event is filtered out, but `person_id_1_distinct_id_2` is able to complete the funnel.
* The `email!=@laterevent.com` scenario produces `test_success=0, test_failure=1` because the events from `person_id_1_distinct_id_2` are filtered out, leaving the single event from `person_id_1_distinct_id_1`.

Relevant part of the query:

```sql
SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
       if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,  -- Key part: uses override when available
       if(equals(e.event, '$pageview'), 1, 0) AS step_0,
       /* ... other fields ... */
FROM events AS e
LEFT OUTER JOIN
  (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
          person_distinct_id_overrides.distinct_id AS distinct_id
   FROM person_distinct_id_overrides
   WHERE equals(person_distinct_id_overrides.team_id, 99999)
   GROUP BY person_distinct_id_overrides.distinct_id
   HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0)
   SETTINGS optimize_aggregation_in_order=1) AS e__override 
ON equals(e.distinct_id, e__override.distinct_id)
```

### `PERSON_ID_OVERRIDE_PROPERTIES_JOINED`
_Use person properties as of running the query
Slower queries. If the person property is updated, query results on past data will change accordingly._

Results explained:
* The `no_filter` scenario produces `test_success=1, test_failure=0`. `person_id_1_distinct_id_2` is applied to all three events, and only one funnel completion is applied.
* The `email!=@earlierevent.com` scenario produces `test_success=1, test_failure=0`. Ditto `no_filter` scenario.
* The `email!=@laterevent.com` scenario returns no data. `person_id_1_distinct_id_2` is applied to all three events, causing all three events to be filtered out.

Relevant part of the query:

```sql
SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
       if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
       /* ... other fields ... */
FROM events AS e
LEFT OUTER JOIN
  (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
          person_distinct_id_overrides.distinct_id AS distinct_id
   FROM person_distinct_id_overrides
   WHERE equals(person_distinct_id_overrides.team_id, 99999)
   GROUP BY person_distinct_id_overrides.distinct_id
   HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0)
   SETTINGS optimize_aggregation_in_order=1) AS e__override 
ON equals(e.distinct_id, e__override.distinct_id)
LEFT JOIN
  (SELECT person.id AS id,
          nullIf(nullIf(person.pmat_email, ''), 'null') AS properties___email
   FROM person
   WHERE /* ... conditions ... */
   ) AS e__person 
ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
```

### `PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS`
_Use person IDs and person properties from the time of the event
Fastest queries, but funnels and unique user counts will be inaccurate. If the person property is updated, query results on past data won't change._

Results explained:
* The `no_filter` scenario produces `test_success=1, test_failure=1`. The person isn't normalized and all three events are counted.
* The `email!=@earlierevent.com` scenario produces `test_success=1, test_failure=0`. The person isn't normalized, `person_id_1_distinct_id_1` is filtered out, and the journey from `person_id_1_distinct_id_2` is counted.
* The `email!=@laterevent.com` scenario returns `test_success=0, test_failure=1`. The person isn't normalized, `person_id_1_distinct_id_2` is filtered out, and the failure from `person_id_1_distinct_id_1` is counted.

Relevant part of the query:

```sql
SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
       e.person_id AS aggregation_target,  -- Key part: directly uses e.person_id without overrides
       if(equals(e.event, '$pageview'), 1, 0) AS step_0,
       if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
       if(equals(e.event, 'purchase'), 1, 0) AS step_1,
       if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
       [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
       prop_basic AS prop,
       argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
FROM events AS e
WHERE /* ... conditions ... */
```

## How did you test this code?

Tests should pass.
