### PR TITLE
fix: nps trend chart on Suveys

### DIFF
--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -500,9 +500,13 @@ export function SurveyResult({ disableEventsTable }: { disableEventsTable?: bool
             {survey.questions.map((question, i) => {
                 if (question.type === SurveyQuestionType.Rating) {
                     return (
-                        <div key={`survey-q-${i}`}>
+                        <div key={`survey-q-${i}`} className="space-y-2">
                             {question.scale === 10 && (
-                                <SurveyNPSResults survey={survey as Survey} surveyNPSScore={surveyNPSScore} />
+                                <SurveyNPSResults
+                                    survey={survey as Survey}
+                                    surveyNPSScore={surveyNPSScore}
+                                    questionIndex={i}
+                                />
                             )}
 
                             <RatingQuestionBarChart
@@ -572,9 +576,17 @@ export function SurveyResult({ disableEventsTable }: { disableEventsTable?: bool
     )
 }
 
-function SurveyNPSResults({ survey, surveyNPSScore }: { survey: Survey; surveyNPSScore?: string }): JSX.Element {
+function SurveyNPSResults({
+    survey,
+    surveyNPSScore,
+    questionIndex,
+}: {
+    survey: Survey
+    surveyNPSScore?: string
+    questionIndex: number
+}): JSX.Element {
     return (
-        <>
+        <div>
             <div className="text-4xl font-bold">{surveyNPSScore}</div>
             <div className="mb-2 font-semibold text-secondary">Latest NPS Score</div>
             <Query
@@ -596,7 +608,10 @@ function SurveyNPSResults({ survey, surveyNPSScore }: { survey: Survey; surveyNP
                                 properties: [
                                     {
                                         type: PropertyFilterType.Event,
-                                        key: '$survey_response',
+                                        key:
+                                            questionIndex === 0
+                                                ? '$survey_response'
+                                                : `$survey_response_${questionIndex}`,
                                         operator: PropertyOperator.Exact,
                                         value: ['9', '10'],
                                     },
@@ -609,7 +624,10 @@ function SurveyNPSResults({ survey, surveyNPSScore }: { survey: Survey; surveyNP
                                 properties: [
                                     {
                                         type: PropertyFilterType.Event,
-                                        key: '$survey_response',
+                                        key:
+                                            questionIndex === 0
+                                                ? '$survey_response'
+                                                : `$survey_response_${questionIndex}`,
                                         operator: PropertyOperator.Exact,
                                         value: ['7', '8'],
                                     },
@@ -622,7 +640,10 @@ function SurveyNPSResults({ survey, surveyNPSScore }: { survey: Survey; surveyNP
                                 properties: [
                                     {
                                         type: PropertyFilterType.Event,
-                                        key: '$survey_response',
+                                        key:
+                                            questionIndex === 0
+                                                ? '$survey_response'
+                                                : `$survey_response_${questionIndex}`,
                                         operator: PropertyOperator.Exact,
                                         value: ['0', '1', '2', '3', '4', '5', '6'],
                                     },
@@ -651,6 +672,6 @@ function SurveyNPSResults({ survey, surveyNPSScore }: { survey: Survey; surveyNP
                 }}
                 readOnly={true}
             />
-        </>
+        </div>
     )
 }

--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -16,6 +16,7 @@ import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { capitalizeFirstLetter, pluralize } from 'lib/utils'
 import { useEffect, useState } from 'react'
 import { LinkedHogFunctions } from 'scenes/pipeline/hogfunctions/list/LinkedHogFunctions'
+import { getSurveyResponseKey } from 'scenes/surveys/utils'
 
 import { Query } from '~/queries/Query/Query'
 import { NodeKind } from '~/queries/schema/schema-general'
@@ -608,10 +609,7 @@ function SurveyNPSResults({
                                 properties: [
                                     {
                                         type: PropertyFilterType.Event,
-                                        key:
-                                            questionIndex === 0
-                                                ? '$survey_response'
-                                                : `$survey_response_${questionIndex}`,
+                                        key: getSurveyResponseKey(questionIndex),
                                         operator: PropertyOperator.Exact,
                                         value: ['9', '10'],
                                     },
@@ -624,10 +622,7 @@ function SurveyNPSResults({
                                 properties: [
                                     {
                                         type: PropertyFilterType.Event,
-                                        key:
-                                            questionIndex === 0
-                                                ? '$survey_response'
-                                                : `$survey_response_${questionIndex}`,
+                                        key: getSurveyResponseKey(questionIndex),
                                         operator: PropertyOperator.Exact,
                                         value: ['7', '8'],
                                     },
@@ -640,10 +635,7 @@ function SurveyNPSResults({
                                 properties: [
                                     {
                                         type: PropertyFilterType.Event,
-                                        key:
-                                            questionIndex === 0
-                                                ? '$survey_response'
-                                                : `$survey_response_${questionIndex}`,
+                                        key: getSurveyResponseKey(questionIndex),
                                         operator: PropertyOperator.Exact,
                                         value: ['0', '1', '2', '3', '4', '5', '6'],
                                     },

--- a/frontend/src/scenes/surveys/surveyViewViz.tsx
+++ b/frontend/src/scenes/surveys/surveyViewViz.tsx
@@ -23,6 +23,7 @@ import { PieChart } from 'scenes/insights/views/LineGraph/PieChart'
 import { maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 import { AIConsentPopoverWrapper } from 'scenes/settings/organization/AIConsentPopoverWrapper'
+import { getSurveyResponseKey } from 'scenes/surveys/utils'
 
 import { GraphType, InsightLogicProps, SurveyQuestionType } from '~/types'
 
@@ -574,7 +575,7 @@ export function OpenTextViz({
 }): JSX.Element {
     const { loadSurveyOpenTextResults } = useActions(surveyLogic)
     const { survey } = useValues(surveyLogic)
-    const surveyResponseField = questionIndex === 0 ? '$survey_response' : `$survey_response_${questionIndex}`
+    const surveyResponseKey = getSurveyResponseKey(questionIndex)
 
     const question = survey.questions[questionIndex]
     if (question.type !== SurveyQuestionType.Open) {
@@ -617,9 +618,9 @@ export function OpenTextViz({
                             return (
                                 <div key={`open-text-${questionIndex}-${i}`} className="masonry-item border rounded">
                                     <div className="max-h-80 overflow-y-auto text-center italic font-semibold px-5 py-4">
-                                        {typeof event.properties[surveyResponseField] !== 'string'
-                                            ? JSON.stringify(event.properties[surveyResponseField])
-                                            : event.properties[surveyResponseField]}
+                                        {typeof event.properties[surveyResponseKey] !== 'string'
+                                            ? JSON.stringify(event.properties[surveyResponseKey])
+                                            : event.properties[surveyResponseKey]}
                                     </div>
                                     <div className="bg-surface-primary items-center px-5 py-4 border-t rounded-b truncate w-full">
                                         <PersonDisplay

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -30,6 +30,10 @@ export function validateColor(color: string | undefined, fieldName: string): str
     return !isValidColor ? `Invalid color value for ${fieldName}. Please use a valid CSS color.` : undefined
 }
 
+export function getSurveyResponseKey(questionIndex: number): string {
+    return questionIndex === 0 ? '$survey_response' : `$survey_response_${questionIndex}`
+}
+
 export function sanitizeSurveyAppearance(appearance: SurveyAppearance | null): SurveyAppearance | null {
     if (!appearance) {
         return null


### PR DESCRIPTION
## Problem

the current NPS trend chart on surveys has a fixed `survey_response` for the property, which means that, if the survey doesn't have the NPS question in the first one, it'll not work, as it'll never have the correct data.

fixes https://posthoghelp.zendesk.com/agent/tickets/24307 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/27652)

## Changes

properly changes the survey response based on the question index

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

checked if the visualization now loads as expected