### PR TITLE
fix(project-tree): split unfiled loading

### DIFF
--- a/frontend/src/layout/navigation-3000/components/projectTreeLogic.tsx
+++ b/frontend/src/layout/navigation-3000/components/projectTreeLogic.tsx
@@ -19,17 +19,12 @@ import {
     IconWarning,
 } from '@posthog/icons'
 import { Spinner } from '@posthog/lemon-ui'
-import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
+import { actions, afterMount, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { router } from 'kea-router'
 import api from 'lib/api'
 import { IconChevronRight } from 'lib/lemon-ui/icons'
 import { TreeDataItem } from 'lib/lemon-ui/LemonTree/LemonTree'
-import { dashboardsLogic } from 'scenes/dashboard/dashboards/dashboardsLogic'
-import { experimentsLogic } from 'scenes/experiments/experimentsLogic'
-import { featureFlagsLogic } from 'scenes/feature-flags/featureFlagsLogic'
-import { notebooksTableLogic } from 'scenes/notebooks/NotebooksTable/notebooksTableLogic'
-import { savedInsightsLogic } from 'scenes/saved-insights/savedInsightsLogic'
 import { urls } from 'scenes/urls'
 
 import { FileSystemEntry, FileSystemType } from '~/queries/schema'
@@ -264,24 +259,9 @@ export function iconForType(type?: FileSystemType): JSX.Element {
 
 export const projectTreeLogic = kea<projectTreeLogicType>([
     path(['layout', 'navigation-3000', 'components', 'projectTreeLogic']),
-    connect(() => ({
-        values: [
-            featureFlagsLogic,
-            ['featureFlags'],
-            savedInsightsLogic,
-            ['insights'],
-            experimentsLogic,
-            ['experiments'],
-            dashboardsLogic,
-            ['dashboards'],
-            notebooksTableLogic,
-            ['notebooks'],
-        ],
-        actions: [notebooksTableLogic, ['loadNotebooks']],
-    })),
     actions({
         loadSavedItems: true,
-        loadUnfiledItems: true,
+        loadUnfiledItems: (type?: FileSystemType) => ({ type }),
         addFolder: (folder: string) => ({ folder }),
         deleteItem: (item: FileSystemEntry) => ({ item }),
         moveItem: (oldPath: string, newPath: string) => ({ oldPath, newPath }),
@@ -298,16 +278,16 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
             {
                 loadSavedItems: async () => {
                     const response = await api.fileSystem.list()
-                    return response.results
+                    return [...values.savedItems, ...response.results]
                 },
             },
         ],
         allUnfiledItems: [
             [] as FileSystemEntry[],
             {
-                loadUnfiledItems: async () => {
-                    const response = await api.fileSystem.unfiled()
-                    return response.results
+                loadUnfiledItems: async ({ type }) => {
+                    const response = await api.fileSystem.unfiled(type)
+                    return [...values.allUnfiledItems, ...response.results]
                 },
             },
         ],
@@ -339,6 +319,14 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
         ],
     })),
     reducers({
+        unfiledLoadingCount: [
+            0,
+            {
+                loadUnfiledItems: (state) => state + 1,
+                loadUnfiledItemsSuccess: (state) => state - 1,
+                loadUnfiledItemsFailure: (state) => state - 1,
+            },
+        ],
         pendingActions: [
             [] as ProjectTreeAction[],
             {
@@ -357,6 +345,7 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
         ],
     }),
     selectors({
+        unfiledLoading: [(s) => [s.unfiledLoadingCount], (unfiledLoadingCount) => unfiledLoadingCount > 0],
         unfiledItems: [
             // Remove from unfiledItems the ones that are in "savedItems"
             (s) => [s.savedItems, s.allUnfiledItems],
@@ -424,10 +413,10 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
         ],
         loadingPaths: [
             // Paths that are currently being loaded
-            (s) => [s.allUnfiledItemsLoading, s.savedItemsLoading, s.pendingLoaderLoading, s.pendingActions],
-            (allUnfiledItemsLoading, savedItemsLoading, pendingLoaderLoading, pendingActions) => {
+            (s) => [s.unfiledLoading, s.savedItemsLoading, s.pendingLoaderLoading, s.pendingActions],
+            (unfiledLoading, savedItemsLoading, pendingLoaderLoading, pendingActions) => {
                 const loadingPaths: Record<string, boolean> = {}
-                if (allUnfiledItemsLoading) {
+                if (unfiledLoading) {
                     loadingPaths['Unfiled'] = true
                     loadingPaths[''] = true
                 }
@@ -591,7 +580,10 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
     })),
     afterMount(({ actions }) => {
         actions.loadSavedItems()
-        actions.loadUnfiledItems()
-        actions.loadNotebooks()
+        actions.loadUnfiledItems('feature_flag')
+        actions.loadUnfiledItems('experiment')
+        actions.loadUnfiledItems('insight')
+        actions.loadUnfiledItems('dashboard')
+        actions.loadUnfiledItems('notebook')
     }),
 ])

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -17,6 +17,7 @@ import {
     ErrorTrackingIssue,
     ErrorTrackingRelationalIssue,
     FileSystemEntry,
+    FileSystemType,
     HogCompileResponse,
     HogQLVariable,
     QuerySchema,
@@ -371,8 +372,12 @@ class ApiRequest {
     public fileSystem(teamId?: TeamType['id']): ApiRequest {
         return this.projectsDetail(teamId).addPathComponent('file_system')
     }
-    public fileSystemUnfiled(teamId?: TeamType['id']): ApiRequest {
-        return this.projectsDetail(teamId).addPathComponent('file_system').addPathComponent('unfiled')
+    public fileSystemUnfiled(type?: FileSystemType, teamId?: TeamType['id']): ApiRequest {
+        const path = this.projectsDetail(teamId).addPathComponent('file_system').addPathComponent('unfiled')
+        if (type) {
+            path.withQueryString({ type })
+        }
+        return path
     }
     public fileSystemDetail(id: FileSystemEntry['id'], teamId?: TeamType['id']): ApiRequest {
         return this.fileSystem(teamId).addPathComponent(id)
@@ -1179,8 +1184,8 @@ const api = {
         async list(): Promise<CountedPaginatedResponse<FileSystemEntry>> {
             return await new ApiRequest().fileSystem().get()
         },
-        async unfiled(): Promise<CountedPaginatedResponse<FileSystemEntry>> {
-            return await new ApiRequest().fileSystemUnfiled().get()
+        async unfiled(type?: FileSystemType): Promise<CountedPaginatedResponse<FileSystemEntry>> {
+            return await new ApiRequest().fileSystemUnfiled(type).get()
         },
         async create(data: FileSystemEntry): Promise<FileSystemEntry> {
             return await new ApiRequest().fileSystem().create({ data })

--- a/posthog/api/test/test_file_system.py
+++ b/posthog/api/test/test_file_system.py
@@ -105,7 +105,7 @@ class TestFileSystemAPI(APIBaseTest):
         feature_flag = FeatureFlag.objects.create(team=self.team, name="Beta Feature", created_by=self.user)
         Experiment.objects.create(team=self.team, name="Experiment #1", created_by=self.user, feature_flag=feature_flag)
         Dashboard.objects.create(team=self.team, name="User Dashboard", created_by=self.user)
-        Insight.objects.create(team=self.team, name="Marketing Insight", created_by=self.user)
+        Insight.objects.create(team=self.team, saved=True, name="Marketing Insight", created_by=self.user)
         Notebook.objects.create(team=self.team, title="Data Exploration", created_by=self.user)
 
         # Now call the endpoint
@@ -124,7 +124,17 @@ class TestFileSystemAPI(APIBaseTest):
         self.assertIn(FileSystemType.INSIGHT, types)
         self.assertIn(FileSystemType.NOTEBOOK, types)
 
-        # (Optional) You can do more detailed checks here, e.g. matching names, etc.
+    def test_unfiled_endpoint_with_type_filtering(self):
+        """
+        Ensure that the 'type' query parameter works as expected.
+        """
+        feature_flag = FeatureFlag.objects.create(team=self.team, name="Beta Feature", created_by=self.user)
+        Experiment.objects.create(team=self.team, name="Experiment #1", created_by=self.user, feature_flag=feature_flag)
+
+        # Check that the type filtering works
+        response = self.client.get(f"/api/projects/{self.team.id}/file_system/unfiled/?type=feature_flag")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        self.assertEqual(response.json()["count"], 1)
 
     def test_search_files_by_path(self):
         """

--- a/posthog/models/test/test_file_system.py
+++ b/posthog/models/test/test_file_system.py
@@ -28,7 +28,7 @@ class TestFileSystemModel(TestCase):
         ff = FeatureFlag.objects.create(team=self.team, name="Beta Feature", created_by=self.user, key="flaggy")
         Experiment.objects.create(team=self.team, name="Experiment #1", created_by=self.user, feature_flag=ff)
         Dashboard.objects.create(team=self.team, name="Main Dashboard", created_by=self.user)
-        Insight.objects.create(team=self.team, name="Traffic Insight", created_by=self.user)
+        Insight.objects.create(team=self.team, name="Traffic Insight", created_by=self.user, saved=True)
         Notebook.objects.create(team=self.team, title="Data Exploration", created_by=self.user)
 
         unfiled = get_unfiled_files(self.team, self.user)
@@ -69,8 +69,8 @@ class TestFileSystemModel(TestCase):
         """
         Insights with deleted=True should NOT appear as unfiled.
         """
-        Insight.objects.create(team=self.team, name="Active Insight", created_by=self.user, deleted=False)
-        Insight.objects.create(team=self.team, name="Deleted Insight", created_by=self.user, deleted=True)
+        Insight.objects.create(team=self.team, name="Active Insight", created_by=self.user, deleted=False, saved=True)
+        Insight.objects.create(team=self.team, name="Deleted Insight", created_by=self.user, deleted=True, saved=True)
         unfiled = get_unfiled_files(self.team, self.user)
         # Only the active insight is returned
         self.assertEqual(len(unfiled), 1)


### PR DESCRIPTION
## Problem

The `tree-view` flag doesn't load for our team as we have too many unsaved insights. 

## Changes

- Hide unsaved insights
- Split unfiled loading by type

Even this new approach is a temporary one. We should build this tree out beforehand, and integrate into the products.

This should however make _something_ load for our team in production.

## Does this work well for both Cloud and self-hosted?

Yep

## How did you test this code?

Added a test for API filtering, tested locally in the browser