### PR TITLE
fix: form validation to link-type surveys questions

### DIFF
--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -1282,10 +1282,30 @@ export const surveyLogic = kea<surveyLogicType>([
                         }
 
                         if (question.type === SurveyQuestionType.Link) {
-                            if (!question.link?.startsWith('https://') && !question.link?.startsWith('mailto:')) {
-                                return {
-                                    ...questionErrors,
-                                    link: 'Please enter a valid link.',
+                            if (question.link) {
+                                if (question.link.startsWith('mailto:')) {
+                                    const emailRegex = /^mailto:[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/
+                                    if (!emailRegex.test(question.link)) {
+                                        return {
+                                            ...questionErrors,
+                                            link: 'Please enter a valid mailto link (e.g., mailto:example@domain.com).',
+                                        }
+                                    }
+                                } else {
+                                    try {
+                                        const url = new URL(question.link)
+                                        if (url.protocol !== 'https:') {
+                                            return {
+                                                ...questionErrors,
+                                                link: 'Only HTTPS links are supported for security reasons.',
+                                            }
+                                        }
+                                    } catch {
+                                        return {
+                                            ...questionErrors,
+                                            link: 'Please enter a valid HTTPS URL.',
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -673,7 +673,7 @@ export const surveyLogic = kea<surveyLogicType>([
             // When errors occur, scroll to the error, but wait for errors to be set in the DOM first
             if (hasFormErrors(values.flagPropertyErrors) || values.urlMatchTypeValidationError) {
                 actions.setSelectedSection(SurveyEditSection.DisplayConditions)
-            } else if (hasFormErrors(values.survey.appearance)) {
+            } else if (hasFormErrors(values.surveyValidationErrors.appearance)) {
                 actions.setSelectedSection(SurveyEditSection.Customization)
             } else {
                 actions.setSelectedSection(SurveyEditSection.Steps)
@@ -1279,6 +1279,15 @@ export const surveyLogic = kea<surveyLogicType>([
                     questions: questions.map((question) => {
                         const questionErrors = {
                             question: !question.question && 'Please enter a question label.',
+                        }
+
+                        if (question.type === SurveyQuestionType.Link) {
+                            if (!question.link?.startsWith('https://') && !question.link?.startsWith('mailto:')) {
+                                return {
+                                    ...questionErrors,
+                                    link: 'Please enter a valid link.',
+                                }
+                            }
                         }
 
                         if (question.type === SurveyQuestionType.Rating) {


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/27812

adds form validation to surveys

## Changes

![CleanShot 2025-02-15 at 03 04 12@2x](https://github.com/user-attachments/assets/add7283b-2c92-4c87-ab00-86f0b5b7b1a4)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

yes

## How did you test this code?

checked locally if form validation is working
