### PR TITLE
fix: consider all nps iterations for calculating trend

### DIFF
--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -688,12 +688,6 @@ function SurveyNPSResults({
                                     operator: PropertyOperator.Exact,
                                     value: survey.id,
                                 },
-                                {
-                                    type: PropertyFilterType.Event,
-                                    key: '$survey_iteration',
-                                    operator: PropertyOperator.Exact,
-                                    value: survey.current_iteration,
-                                },
                             ],
                             trendsFilter: {
                                 formula: '(A / (A+B+C) * 100) - (C / (A+B+C) * 100)',


### PR DESCRIPTION
## Problem

similar to https://github.com/PostHog/posthog/pull/28643 but now for the NPS trend chart

in a follow up PR, i'll add a dedicated filter for survey iteration

necessary to fix https://posthoghelp.zendesk.com/agent/tickets/24307 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/27652)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

yes

## How did you test this code?

verified all tests are running + tested locally