### PR TITLE
fix: constrain width of funnel step editor

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
@@ -337,7 +337,7 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
                     })}
                 >
                     {filterGroupsGroups.map(({ title, editorFilterGroups }) => (
-                        <div key={title} className="flex-1 flex flex-col gap-4">
+                        <div key={title} className="flex-1 flex flex-col gap-4 max-w-full">
                             {editorFilterGroups.map((editorFilterGroup) => (
                                 <EditorFilterGroup
                                     key={editorFilterGroup.title}


### PR DESCRIPTION
## Problem

<img width="498" alt="Arc 2025-02-15 13 58 02" src="https://github.com/user-attachments/assets/be7207b9-0f79-407f-968c-06d94cadb6d7" />


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Constrain the width

<img width="441" alt="Arc 2025-02-15 13 57 54" src="https://github.com/user-attachments/assets/37358046-fdcf-4005-a0b0-7242bdeb0b47" />


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

👀 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
