### PR TITLE
fix(data-warehouse): Adjust the loading state of data viz nodes

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
@@ -164,7 +164,7 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
     // TODO(@Gilbert09): Better loading support for all components - e.g. using the `loading` param of `Table`
     if (!showEditingUI && (!response || responseLoading)) {
         component = (
-            <div className="flex flex-col flex-1 justify-center items-center border rounded bg-surface-primary">
+            <div className="flex flex-col flex-1 justify-center items-center bg-surface-primary h-full">
                 <LoadingBar />
             </div>
         )

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -256,7 +256,7 @@ function InternalDataTableVisualization(
     // TODO(@Gilbert09): Better loading support for all components - e.g. using the `loading` param of `Table`
     if (!showEditingUI && (!response || responseLoading)) {
         component = (
-            <div className="flex flex-col flex-1 justify-center items-center border rounded bg-surface-primary">
+            <div className="flex flex-col flex-1 justify-center items-center bg-surface-primary h-full">
                 <LoadingBar />
             </div>
         )


### PR DESCRIPTION
## Problem
- The loading state of data viz nodes is small and looks weird - it has an extra rounded border and doesn't fill the whole container

<img width="629" alt="image" src="https://github.com/user-attachments/assets/734f473c-dfb0-46b5-80d9-b970c0d4087a" />


## Changes
Fixes ^^