### PR TITLE
fix(alerts): navigation from alerts page

### DIFF
--- a/frontend/src/lib/components/Alerts/alertFormLogic.ts
+++ b/frontend/src/lib/components/Alerts/alertFormLogic.ts
@@ -66,7 +66,10 @@ export const alertFormLogic = kea<alertFormLogicType>([
     key(({ alert }) => alert?.id ?? 'new'),
 
     connect((props: AlertFormLogicProps) => ({
-        values: [trendsDataLogic(props.insightVizDataLogicProps ?? { dashboardId: undefined }), ['goalLines']],
+        values: [
+            trendsDataLogic({ dashboardId: undefined, dashboardItemId: undefined, ...props.insightVizDataLogicProps }),
+            ['goalLines'],
+        ],
     })),
 
     actions({

--- a/frontend/src/lib/components/Alerts/views/Alerts.tsx
+++ b/frontend/src/lib/components/Alerts/views/Alerts.tsx
@@ -1,7 +1,6 @@
 import { LemonTag, Tooltip } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
-import { FeedbackNotice } from 'lib/components/FeedbackNotice'
 import { DetectiveHog } from 'lib/components/hedgehogs'
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { TZLabel } from 'lib/components/TZLabel'
@@ -111,8 +110,6 @@ export function Alerts({ alertId }: AlertsProps): JSX.Element {
     // TODO: add info here to sign up for alerts early access
     return (
         <>
-            <FeedbackNotice text="Alerts are in closed alpha. Thanks for taking part! We'd love to hear what you think." />
-
             {alertsSortedByState.length === 0 && !alertsLoading && (
                 <ProductIntroduction
                     productName="Alerts"

--- a/frontend/src/lib/components/Alerts/views/ManageAlertsModal.tsx
+++ b/frontend/src/lib/components/Alerts/views/ManageAlertsModal.tsx
@@ -77,16 +77,13 @@ export function ManageAlertsModal(props: ManageAlertsModalProps): JSX.Element {
     return (
         <LemonModal onClose={props.onClose} isOpen={props.isOpen} width={600} simple title="">
             <LemonModal.Header>
-                <div className="flex items-center gap-2">
-                    <h3 className="!m-0">Manage Alerts</h3>
-                    <LemonTag type="warning">ALPHA</LemonTag>
-                </div>
+                <h3 className="!m-0">Manage Alerts</h3>
             </LemonModal.Header>
             <LemonModal.Content>
                 <div className="mb-4">
                     With alerts, PostHog will monitor your insight and notify you when certain conditions are met. We do
-                    not evaluate alerts in real-time, but rather on a schedule (hourly, daily...). Please note that
-                    alerts are in alpha and may not be fully reliable. <br />
+                    not evaluate alerts in real-time, but rather on a schedule (hourly, daily...).
+                    <br />
                     <Link to={urls.alerts()} target="_blank">
                         View all your alerts here
                     </Link>

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -22,7 +22,7 @@ import {
     IconVideoCamera,
     IconWarning,
 } from '@posthog/icons'
-import { LemonSelectOptions, LemonTag } from '@posthog/lemon-ui'
+import { LemonSelectOptions } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { AccessControlledLemonButton } from 'lib/components/AccessControlledLemonButton'
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
@@ -678,11 +678,7 @@ export function SavedInsights(): JSX.Element {
                         ? [
                               {
                                   key: SavedInsightsTabs.Alerts,
-                                  label: (
-                                      <div className="flex items-center gap-2">
-                                          Alerts <LemonTag type="highlight">ALPHA</LemonTag>
-                                      </div>
-                                  ),
+                                  label: <div className="flex items-center gap-2">Alerts</div>,
                               },
                           ]
                         : []),

--- a/playwright/e2e/annotations.spec.ts
+++ b/playwright/e2e/annotations.spec.ts
@@ -1,5 +1,4 @@
 import { expect, test } from '../utils/playwright-test-base'
-import { Navigation } from '../utils/navigation'
 
 test.describe('Annotations', () => {
     test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
## Problem
#28461 broke navigation for alerts from the main alerts page. Clicking any alert on there leads to this page.
<img width="864" alt="image" src="https://github.com/user-attachments/assets/e19d6f6d-e7a8-4b94-b190-a22170ebc72f" />
<img width="854" alt="image" src="https://github.com/user-attachments/assets/4945fa16-ec2f-468b-bbee-023cb22e410d" />


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- Passing defaults for the insight props fixes this but ideally we should be getting the insight short id from a different connected logic and passing it here instead of undefined. @rafaeelaudibert will let you handle this, have just seen your changes + you'll have more context around what you want to achieve in this scenario :) 
- also removed the alpha tags.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Tested locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
