### PR TITLE
fix(cdp): default event loading

### DIFF
--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionTest.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionTest.tsx
@@ -149,7 +149,7 @@ export function HogFunctionTest(): JSX.Element {
         testResultMode,
         sortedTestsResult,
         jsonError,
-        isGlobalLoadingCancelled,
+        fetchCancelled,
     } = useValues(hogFunctionTestLogic(logicProps))
     const {
         submitTestInvocation,
@@ -175,7 +175,7 @@ export function HogFunctionTest(): JSX.Element {
                     <div className="flex-1 space-y-2">
                         <h2 className="flex items-center gap-2 mb-0">
                             <span>Testing</span>
-                            {sampleGlobalsLoading ? <Spinner /> : null}
+                            {sampleGlobalsLoading && !fetchCancelled ? <Spinner /> : null}
                         </h2>
                         {!expanded && <p>Click here to test your function with an example event</p>}
                     </div>
@@ -231,7 +231,7 @@ export function HogFunctionTest(): JSX.Element {
                                                 <LemonButton
                                                     fullWidth
                                                     onClick={loadSampleGlobals}
-                                                    loading={sampleGlobalsLoading}
+                                                    loading={sampleGlobalsLoading && !fetchCancelled}
                                                     tooltip="Find the last event matching filters, and use it to populate the globals below."
                                                 >
                                                     Fetch new event
@@ -420,7 +420,7 @@ export function HogFunctionTest(): JSX.Element {
                                                         ? 'The provider will be tested with this sample data:'
                                                         : 'Here are all the global variables you can use in your code:'}
                                                 </div>
-                                                {sampleGlobalsLoading && !isGlobalLoadingCancelled && (
+                                                {sampleGlobalsLoading && !fetchCancelled && (
                                                     <div className="flex items-center gap-2 text-muted">
                                                         <Spinner />
                                                         <span>Fetching new event...</span>
@@ -440,7 +440,7 @@ export function HogFunctionTest(): JSX.Element {
                                             <HogFunctionTestEditor
                                                 value={value}
                                                 onChange={onChange}
-                                                readOnly={sampleGlobalsLoading && !isGlobalLoadingCancelled}
+                                                readOnly={sampleGlobalsLoading}
                                             />
                                         </>
                                     )}

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
@@ -1101,11 +1101,6 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                 actions.personsCountQueryChanged(personsCountQuery)
             }
         },
-        lastEventQuery: (lastEventQuery) => {
-            if (lastEventQuery) {
-                actions.loadSampleGlobals()
-            }
-        },
     })),
 
     beforeUnload(({ values, cache }) => ({

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionTestLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionTestLogic.tsx
@@ -32,6 +32,9 @@ export type HogTransformationEvent = {
 const convertToTransformationEvent = (result: any): HogTransformationEvent => {
     const properties = result.properties ?? {}
     properties.$ip = properties.$ip ?? '89.160.20.129'
+    // We don't want to use these values given they will change in the test invocation
+    delete properties.$transformations_failed
+    delete properties.$transformations_succeeded
     return {
         event: result.event,
         uuid: result.uuid,
@@ -42,6 +45,8 @@ const convertToTransformationEvent = (result: any): HogTransformationEvent => {
 }
 
 const convertFromTransformationEvent = (result: HogTransformationEvent): Record<string, any> => {
+    delete result.properties.$transformations_failed
+    delete result.properties.$transformations_succeeded
     return {
         event: result.event,
         uuid: result.uuid,

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionTestLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionTestLogic.tsx
@@ -32,10 +32,6 @@ export type HogTransformationEvent = {
 const convertToTransformationEvent = (result: any): HogTransformationEvent => {
     const properties = result.properties ?? {}
     properties.$ip = properties.$ip ?? '89.160.20.129'
-    // We don't want to use these values given they will change in the test invocation
-    delete properties.$transformations_failed
-    delete properties.$transformations_succeeded
-
     return {
         event: result.event,
         uuid: result.uuid,
@@ -46,8 +42,6 @@ const convertToTransformationEvent = (result: any): HogTransformationEvent => {
 }
 
 const convertFromTransformationEvent = (result: HogTransformationEvent): Record<string, any> => {
-    delete result.properties.$transformations_failed
-    delete result.properties.$transformations_succeeded
     return {
         event: result.event,
         uuid: result.uuid,
@@ -155,24 +149,13 @@ export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
             {
                 loadSampleGlobals: () => false,
                 cancelSampleGlobalsLoading: () => true,
-                // Reset when expanded changes to allow future fetches
                 toggleExpanded: () => false,
-            },
-        ],
-
-        isGlobalLoadingCancelled: [
-            false as boolean,
-            {
-                loadSampleGlobals: () => false,
-                cancelSampleGlobalsLoading: () => true,
-                loadSampleGlobalsSuccess: () => false,
             },
         ],
     }),
     listeners(({ values, actions }) => ({
         loadSampleGlobalsSuccess: () => {
-            // Only process the new globals if we're expanded and the fetch wasn't cancelled
-            if (values.expanded && !values.fetchCancelled) {
+            if (values.expanded && !values.fetchCancelled && values.sampleGlobals) {
                 actions.receiveExampleGlobals(values.sampleGlobals)
             }
         },

--- a/playwright/e2e/annotations.spec.ts
+++ b/playwright/e2e/annotations.spec.ts
@@ -1,5 +1,4 @@
 import { expect, test } from '../utils/playwright-test-base'
-import { Navigation } from '../utils/navigation'
 
 test.describe('Annotations', () => {
     test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
## Problem

Currently we still load events on mount when we visit a transformation or destination.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- prevent fetching events on mount for transformations and destinations 

![2025-02-17 10 29 25](https://github.com/user-attachments/assets/ffde7298-62f1-4072-a470-6004a64f3655)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- locally

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
