### PR TITLE
feat(cdp): add scroll to code editor

### DIFF
--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionTest.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionTest.tsx
@@ -23,6 +23,11 @@ import { useRef } from 'react'
 import { hogFunctionConfigurationLogic } from './hogFunctionConfigurationLogic'
 import { hogFunctionTestLogic } from './hogFunctionTestLogic'
 
+export interface HogFunctionTestProps {
+    id?: string
+    templateId?: string
+}
+
 const HogFunctionTestEditor = ({
     value,
     onChange,
@@ -135,7 +140,7 @@ const HogFunctionTestEditor = ({
     )
 }
 
-export function HogFunctionTest(): JSX.Element {
+export function HogFunctionTest({ id, templateId }: HogFunctionTestProps): JSX.Element {
     const { logicProps } = useValues(hogFunctionConfigurationLogic)
     const {
         isTestInvocationSubmitting,
@@ -163,9 +168,12 @@ export function HogFunctionTest(): JSX.Element {
         cancelSampleGlobalsLoading,
     } = useActions(hogFunctionTestLogic(logicProps))
 
+    const testResultsRef = useRef<HTMLDivElement>(null)
+
     return (
-        <Form logic={hogFunctionTestLogic} props={logicProps} formKey="testInvocation" enableFormOnSubmit>
+        <Form logic={hogFunctionTestLogic} props={{ id, templateId }} formKey="testInvocation" enableFormOnSubmit>
             <div
+                ref={testResultsRef}
                 className={clsx(
                     'border rounded p-3 space-y-2',
                     expanded ? 'bg-surface-secondary min-h-120' : 'bg-surface-primary'
@@ -181,7 +189,17 @@ export function HogFunctionTest(): JSX.Element {
                     </div>
 
                     {!expanded ? (
-                        <LemonButton data-attr="expand-hog-testing" type="secondary" onClick={() => toggleExpanded()}>
+                        <LemonButton
+                            data-attr="expand-hog-testing"
+                            type="secondary"
+                            onClick={() => {
+                                toggleExpanded()
+                                // Add a small delay to allow the content to expand
+                                setTimeout(() => {
+                                    testResultsRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+                                }, 100)
+                            }}
+                        >
                             Start testing
                         </LemonButton>
                     ) : (

--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionTest.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionTest.tsx
@@ -23,11 +23,6 @@ import { useRef } from 'react'
 import { hogFunctionConfigurationLogic } from './hogFunctionConfigurationLogic'
 import { hogFunctionTestLogic } from './hogFunctionTestLogic'
 
-export interface HogFunctionTestProps {
-    id?: string
-    templateId?: string
-}
-
 const HogFunctionTestEditor = ({
     value,
     onChange,
@@ -140,7 +135,7 @@ const HogFunctionTestEditor = ({
     )
 }
 
-export function HogFunctionTest({ id, templateId }: HogFunctionTestProps): JSX.Element {
+export function HogFunctionTest(): JSX.Element {
     const { logicProps } = useValues(hogFunctionConfigurationLogic)
     const {
         isTestInvocationSubmitting,
@@ -171,7 +166,7 @@ export function HogFunctionTest({ id, templateId }: HogFunctionTestProps): JSX.E
     const testResultsRef = useRef<HTMLDivElement>(null)
 
     return (
-        <Form logic={hogFunctionTestLogic} props={{ id, templateId }} formKey="testInvocation" enableFormOnSubmit>
+        <Form logic={hogFunctionTestLogic} props={logicProps} formKey="testInvocation" enableFormOnSubmit>
             <div
                 ref={testResultsRef}
                 className={clsx(


### PR DESCRIPTION
## Problem

little qol thing as it annoyed me that i needed to scroll down always once i clicked on start testing for a hog function. now we scroll automatically down to the editor. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

![2025-02-17 11 39 48](https://github.com/user-attachments/assets/0f7ea439-9860-4901-b470-ff207a070338)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- locally 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
