### PR TITLE
fix(err): spawn a task per event in the batch

### DIFF
--- a/rust/cymbal/src/main.rs
+++ b/rust/cymbal/src/main.rs
@@ -8,7 +8,9 @@ use cymbal::{
     app_context::AppContext,
     config::Config,
     handle_event,
-    metric_consts::{DROPPED_EVENTS, ERRORS, EVENT_PROCESSED, EVENT_RECEIVED, MAIN_LOOP_TIME},
+    metric_consts::{
+        DROPPED_EVENTS, ERRORS, EVENT_BATCH_SIZE, EVENT_PROCESSED, EVENT_RECEIVED, MAIN_LOOP_TIME,
+    },
 };
 use rdkafka::types::RDKafkaErrorCode;
 use tokio::task::JoinHandle;
@@ -71,6 +73,8 @@ async fn main() {
             .json_recv_batch(batch_size, batch_wait_time)
             .await;
 
+        metrics::gauge!(EVENT_BATCH_SIZE).set(received.len() as f64);
+
         let mut output = Vec::with_capacity(received.len());
         let mut offsets = Vec::with_capacity(received.len());
 
@@ -83,6 +87,8 @@ async fn main() {
                 panic!("Failed to start kafka transaction: {:?}", e);
             }
         };
+
+        let mut handles = Vec::with_capacity(received.len());
 
         for message in received {
             let (event, offset) = match message {
@@ -100,9 +106,13 @@ async fn main() {
             };
 
             metrics::counter!(EVENT_RECEIVED).increment(1);
+            handles.push(tokio::spawn(handle_event(context.clone(), event)));
+            offsets.push(offset);
+        }
 
-            let event = match handle_event(context.clone(), event).await {
-                Ok(e) => e,
+        for (handle, offset) in handles.into_iter().zip(offsets.iter()) {
+            match handle.await.expect("Spawn/join will not fail") {
+                Ok(e) => output.push(e),
                 Err(e) => {
                     error!("Error handling event: {:?}; offset: {:?}", e, offset);
                     // If we get an unhandled error, it means we have some logical error in the code, or a
@@ -110,11 +120,7 @@ async fn main() {
                     panic!("Unhandled error: {:?}; offset: {:?}", e, offset);
                 }
             };
-
             metrics::counter!(EVENT_PROCESSED).increment(1);
-
-            output.push(event);
-            offsets.push(offset);
         }
 
         let results = txn

--- a/rust/cymbal/src/metric_consts.rs
+++ b/rust/cymbal/src/metric_consts.rs
@@ -35,3 +35,4 @@ pub const ISSUE_CREATED: &str = "cymbal_issue_created";
 pub const ISSUE_REOPENED: &str = "cymbal_issue_reopened";
 pub const FRAME_RESOLUTION_RESULTS_DELETED: &str = "cymbal_frame_resolution_results_deleted";
 pub const DROPPED_EVENTS: &str = "cymbal_dropped_events";
+pub const EVENT_BATCH_SIZE: &str = "cymbal_event_batch_size";


### PR DESCRIPTION
I kind-of suspect we're hitting the limits of what one-at-a-time processing can handle when facing cache evictions. Lets see if this helps throughput at all.