### PR TITLE
fix(err): Reverts #28793 - spawn a task per event in the batch

### DIFF
--- a/rust/cymbal/src/metric_consts.rs
+++ b/rust/cymbal/src/metric_consts.rs
@@ -35,4 +35,3 @@ pub const ISSUE_CREATED: &str = "cymbal_issue_created";
 pub const ISSUE_REOPENED: &str = "cymbal_issue_reopened";
 pub const FRAME_RESOLUTION_RESULTS_DELETED: &str = "cymbal_frame_resolution_results_deleted";
 pub const DROPPED_EVENTS: &str = "cymbal_dropped_events";
-pub const EVENT_BATCH_SIZE: &str = "cymbal_event_batch_size";


### PR DESCRIPTION
Reverts PostHog/posthog#28793

We're hitting concurrency issues in symbol set handling, need a more careful approach.