### PR TITLE
chore: only show one pay gate at a time for access control

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/AccessControlObject.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/AccessControlObject.tsx
@@ -55,12 +55,13 @@ export function AccessControlObject(props: AccessControlLogicProps): JSX.Element
                     <AccessControlObjectDefaults />
                 </div>
 
-                <PayGateMini feature={AvailableFeature.ADVANCED_PERMISSIONS}>
+                <PayGateMini feature={AvailableFeature.ADVANCED_PERMISSIONS} className="space-y-6">
                     <AccessControlObjectUsers />
-                </PayGateMini>
 
-                <PayGateMini feature={AvailableFeature.ROLE_BASED_ACCESS}>
-                    <AccessControlObjectRoles />
+                    {/* Put this inside of Advanced Permissions so two aren't shown at once */}
+                    <PayGateMini feature={AvailableFeature.ROLE_BASED_ACCESS}>
+                        <AccessControlObjectRoles />
+                    </PayGateMini>
                 </PayGateMini>
             </div>
         </BindLogic>


### PR DESCRIPTION
## Changes

Right now we show two pay gates on the access control sidebar and this makes sure only one is shown:
- advanced permission if free / paid
  - ![Screenshot 2025-02-17 at 2 13 07 PM](https://github.com/user-attachments/assets/4d8fd7f3-d191-4b14-87ef-ed5ed4c1e7c1) 
- rbac if teams
  - ![Screenshot 2025-02-17 at 2 13 25 PM](https://github.com/user-attachments/assets/25fd59f3-0e63-44f7-b732-cd3aa62e9acd)
- no paygates - if enterprise

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manually
