### PR TITLE
fix: billing limit must be above current usage

### DIFF
--- a/frontend/src/scenes/billing/billingProductLogic.ts
+++ b/frontend/src/scenes/billing/billingProductLogic.ts
@@ -474,19 +474,11 @@ export const billingProductLogic = kea<billingProductLogicType>([
 
                 if (props.product.current_usage && newAmountAsUsage < props.product.current_usage) {
                     LemonDialog.open({
-                        title: 'Billing limit warning',
+                        title: 'Billing limit not acceptable',
                         description:
-                            'Your new billing limit will be below your current usage. Your bill will not increase for this period but parts of the product will stop working and data may be lost.',
+                            'You cannot set a billing limit below your current usage. Please enter an amount greater than your current usage.',
                         primaryButton: {
-                            status: 'danger',
                             children: 'I understand',
-                            onClick: () =>
-                                actions.updateBillingLimits({
-                                    [props.product.type]: input,
-                                }),
-                        },
-                        secondaryButton: {
-                            children: 'I changed my mind',
                         },
                     })
                     return


### PR DESCRIPTION
## Problem

Users were able to set a billing limit lower than their current usage. Due how to `billing` works, that means they could have abused the system, reducing the charge of the current invoice.

## Changes

If the limit is lower than the current usage, a modal says the action is not allowed.

This is how it looked when you try to set a limit lower to the current usage:

![image](https://github.com/user-attachments/assets/05d75a84-b846-43b4-b7db-46dcf966edda)

And this is how it looks after the change:

![image](https://github.com/user-attachments/assets/28d33151-0aaa-41ab-95b7-e58ab3e76f5e)


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Only cloud.

## How did you test this code?

Locally.
