### PR TITLE
refactor: Move `ClickhouseCluster` resource to common location

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -70,6 +70,7 @@ jobs:
                         - 'ee/**/*'
                         - 'common/hogvm/**/*'
                         - 'posthog/**/*'
+                        - 'dags/**'
                         - 'bin/*.py'
                         - requirements.txt
                         - requirements-dev.txt

--- a/dags/common.py
+++ b/dags/common.py
@@ -1,0 +1,23 @@
+import dagster
+
+from posthog.clickhouse.cluster import (
+    ClickhouseCluster,
+    get_cluster,
+)
+
+
+class ClickhouseClusterResource(dagster.ConfigurableResource):
+    """
+    The ClickHouse cluster used to run the job.
+    """
+
+    client_settings: dict[str, str] = {
+        "lightweight_deletes_sync": "0",
+        "max_execution_time": "0",
+        "max_memory_usage": "0",
+        "mutations_sync": "0",
+        "receive_timeout": f"{10 * 60}",  # some queries like dictionary checksumming can be very slow
+    }
+
+    def create_resource(self, context: dagster.InitResourceContext) -> ClickhouseCluster:
+        return get_cluster(context.log, client_settings=self.client_settings)

--- a/dags/common.py
+++ b/dags/common.py
@@ -16,7 +16,7 @@ class ClickhouseClusterResource(dagster.ConfigurableResource):
         "max_execution_time": "0",
         "max_memory_usage": "0",
         "mutations_sync": "0",
-        "receive_timeout": f"{10 * 60}",  # some queries like dictionary checksumming can be very slow
+        "receive_timeout": f"{10 * 60}",  # some synchronous queries like dictionary checksumming can be very slow to return
     }
 
     def create_resource(self, context: dagster.InitResourceContext) -> ClickhouseCluster:

--- a/dags/definitions.py
+++ b/dags/definitions.py
@@ -12,8 +12,9 @@ from dagster import fs_io_manager
 from django.conf import settings
 
 from . import ch_examples, deletes, orm_examples
+from .common import ClickhouseClusterResource
 from .materialized_columns import materialize_column
-from .person_overrides import ClickhouseClusterResource, squash_person_overrides
+from .person_overrides import squash_person_overrides
 
 all_assets = load_assets_from_modules([ch_examples, orm_examples])
 

--- a/dags/deletes.py
+++ b/dags/deletes.py
@@ -256,7 +256,7 @@ def get_oldest_person_override_timestamp(
     query = f"""
     SELECT min(_timestamp) FROM {PERSON_DISTINCT_ID_OVERRIDES_TABLE}
     """
-    [[result]] = cluster.any_host_by_role(lambda client: client.execute(query), NodeRole.WORKER).result()
+    [[result]] = cluster.any_host_by_role(lambda client: client.execute(query), NodeRole.DATA).result()
     return result
 
 

--- a/dags/deletes.py
+++ b/dags/deletes.py
@@ -9,9 +9,7 @@ from dagster import (
     OpExecutionContext,
     Config,
     MetadataValue,
-    InitResourceContext,
     ResourceParam,
-    ConfigurableResource,
 )
 from django.conf import settings
 from functools import partial
@@ -22,27 +20,9 @@ from posthog.clickhouse.cluster import (
     Mutation,
     MutationRunner,
     NodeRole,
-    get_cluster,
 )
 from posthog.models.event.sql import EVENTS_DATA_TABLE
 from posthog.models.async_deletion import AsyncDeletion, DeletionType
-
-
-class ClickhouseClusterResource(ConfigurableResource):
-    """
-    The ClickHouse cluster used to run the job.
-    """
-
-    client_settings: dict[str, str] = {
-        "max_execution_time": "0",
-        "max_memory_usage": "0",
-        "receive_timeout": f"{24 * 60 * 60}",  # wait 24 hours for a response from CH
-        "mutations_sync": "0",
-        "lightweight_deletes_sync": "0",
-    }
-
-    def create_resource(self, context: InitResourceContext) -> ClickhouseCluster:
-        return get_cluster(context.log, client_settings=self.client_settings)
 
 
 class DeleteConfig(Config):

--- a/dags/person_overrides.py
+++ b/dags/person_overrides.py
@@ -13,25 +13,9 @@ from posthog.clickhouse.cluster import (
     ClickhouseCluster,
     Mutation,
     MutationRunner,
-    get_cluster,
 )
 from posthog.models.event.sql import EVENTS_DATA_TABLE
 from posthog.models.person.sql import PERSON_DISTINCT_ID_OVERRIDES_TABLE
-
-
-class ClickhouseClusterResource(dagster.ConfigurableResource):
-    """
-    The ClickHouse cluster used to run the job.
-    """
-
-    client_settings: dict[str, str] = {
-        "max_execution_time": "0",
-        "max_memory_usage": "0",
-        "receive_timeout": f"{10 * 60}",  # some queries like dictionary checksumming can be very slow
-    }
-
-    def create_resource(self, context: dagster.InitResourceContext) -> ClickhouseCluster:
-        return get_cluster(context.log, client_settings=self.client_settings)
 
 
 @dataclass

--- a/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_query_runner.ambr
+++ b/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_query_runner.ambr
@@ -198,7 +198,7 @@
                replaceAll(JSONExtractRaw(events.properties, '$feature_flag_response'), '"', '') AS variant,
                min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time
         FROM events
-        WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceAll(JSONExtractRaw(events.properties, '$feature_flag'), '"', ''), 'test-experiment'), 0)), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-01 12:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-15 12:00:00.000000', 6, 'UTC')))
+        WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceAll(JSONExtractRaw(events.properties, '$feature_flag'), '"', ''), 'test-experiment'), 0), ifNull(in(replaceAll(JSONExtractRaw(events.properties, '$feature_flag_response'), '"', ''), ['control', 'test']), 0)), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-01 12:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-15 12:00:00.000000', 6, 'UTC')))
         GROUP BY variant,
                  events.distinct_id) AS exposure_data
      LEFT JOIN
@@ -213,7 +213,7 @@
                   replaceAll(JSONExtractRaw(events.properties, '$feature_flag_response'), '"', '') AS variant,
                   min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time
            FROM events
-           WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceAll(JSONExtractRaw(events.properties, '$feature_flag'), '"', ''), 'test-experiment'), 0)), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-01 12:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-15 12:00:00.000000', 6, 'UTC')))
+           WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceAll(JSONExtractRaw(events.properties, '$feature_flag'), '"', ''), 'test-experiment'), 0), ifNull(in(replaceAll(JSONExtractRaw(events.properties, '$feature_flag_response'), '"', ''), ['control', 'test']), 0)), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-01 12:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-15 12:00:00.000000', 6, 'UTC')))
            GROUP BY variant,
                     events.distinct_id) AS exposure_data ON equals(events.distinct_id, exposure_data.distinct_id)
         WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), exposure_data.first_exposure_time), equals(events.event, 'purchase'))) AS events_after_exposure ON and(equals(exposure_data.distinct_id, events_after_exposure.distinct_id), equals(exposure_data.variant, events_after_exposure.variant))


### PR DESCRIPTION
## Problem

The delete job is not using the client configuration defined in `dags/deletes.py`. This is because the `ClickhouseCluster` resource is defined at the application/package level and was using the implementation defined in `dags/person_overrides.py` [as seen by the `receive_timeout` setting used in the query log](https://metabase.prod-eu.posthog.dev/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJkYXRhYmFzZSI6MiwibmF0aXZlIjp7InF1ZXJ5Ijoic2VsZWN0IHF1ZXJ5LCBTZXR0aW5nc1xuZnJvbSBjbHVzdGVyQWxsUmVwbGljYXMocG9zdGhvZywgc3lzdGVtLnF1ZXJ5X2xvZylcbndoZXJlIFxuICAgIGV2ZW50X2RhdGUgPSAnMjAyNS0wMi0xNydcbiAgICBhbmQgdHlwZSA-IDFcbiAgICBhbmQgcXVlcnlfa2luZCA9ICdEZWxldGUnIiwidGVtcGxhdGUtdGFncyI6e319fSwiZGlzcGxheSI6InRhYmxlIiwicGFyYW1ldGVycyI6W10sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnt9fQ==). The lack of the `lightweight_deletes_sync` setting being passed through causes failed mutations due to transient issues (disk space, memory limits, etc.) to be reported back as errors to the client and leads to op/job failures requiring manual restarts that would otherwise be more robustly handled by the mutation runner.

## Changes

- Moves `ClickhouseClusterResource` to a more obviously common location to reduce confusion and unnecessary duplication
- Combines both sets of settings into reasonable defaults for all long-running jobs
- Makes delete jobs more failure tolerant

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Sort of covered by existing tests