### PR TITLE
fix: surveys' device type formatting

### DIFF
--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -35,12 +35,12 @@ import { useState } from 'react'
 import { featureFlagLogic } from 'scenes/feature-flags/featureFlagLogic'
 import { FeatureFlagReleaseConditions } from 'scenes/feature-flags/FeatureFlagReleaseConditions'
 import { SurveyRepeatSchedule } from 'scenes/surveys/SurveyRepeatSchedule'
+import { getSurveyMatchTypeToPropertyOperator } from 'scenes/surveys/utils'
 
 import {
     ActionType,
     LinkSurveyQuestion,
     PropertyFilterType,
-    PropertyOperator,
     RatingSurveyQuestion,
     SurveyMatchType,
     SurveyQuestion,
@@ -824,13 +824,17 @@ export default function SurveyEdit(): JSX.Element {
                                                                         TaxonomicFilterGroupType.EventProperties
                                                                     )}
                                                                     type={PropertyFilterType.Event}
-                                                                    onSet={(deviceTypes: string[]) =>
+                                                                    onSet={(deviceTypes: string | string[]) => {
                                                                         onChange({
                                                                             ...value,
-                                                                            deviceTypes: deviceTypes,
+                                                                            deviceTypes: Array.isArray(deviceTypes)
+                                                                                ? deviceTypes
+                                                                                : [deviceTypes],
                                                                         })
-                                                                    }
-                                                                    operator={PropertyOperator.Exact}
+                                                                    }}
+                                                                    operator={getSurveyMatchTypeToPropertyOperator(
+                                                                        survey.conditions?.deviceTypesMatchType
+                                                                    )}
                                                                     value={value?.deviceTypes}
                                                                     inputClassName="flex-1"
                                                                 />

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -1,6 +1,6 @@
 import DOMPurify from 'dompurify'
 
-import { SurveyAppearance } from '~/types'
+import { PropertyOperator, SurveyAppearance, SurveyMatchType } from '~/types'
 
 const sanitizeConfig = { ADD_ATTR: ['target'] }
 
@@ -47,5 +47,28 @@ export function sanitizeSurveyAppearance(appearance: SurveyAppearance | null): S
         ratingButtonColor: sanitizeColor(appearance.ratingButtonColor),
         submitButtonColor: sanitizeColor(appearance.submitButtonColor),
         submitButtonTextColor: sanitizeColor(appearance.submitButtonTextColor),
+    }
+}
+
+export function getSurveyMatchTypeToPropertyOperator(surveyMatchType?: SurveyMatchType): PropertyOperator {
+    if (!surveyMatchType) {
+        return PropertyOperator.IContains
+    }
+
+    switch (surveyMatchType) {
+        case SurveyMatchType.Contains:
+            return PropertyOperator.IContains
+        case SurveyMatchType.NotIContains:
+            return PropertyOperator.NotIContains
+        case SurveyMatchType.Regex:
+            return PropertyOperator.Regex
+        case SurveyMatchType.NotRegex:
+            return PropertyOperator.NotRegex
+        case SurveyMatchType.Exact:
+            return PropertyOperator.Exact
+        case SurveyMatchType.IsNot:
+            return PropertyOperator.IsNot
+        default:
+            return PropertyOperator.IContains
     }
 }


### PR DESCRIPTION
## Problem

fixes RegExp validation for device match type, and also fixes operators so it's only multi-select as supported

## Changes

![CleanShot 2025-02-17 at 19 09 29@2x](https://github.com/user-attachments/assets/73718f22-10e5-4c39-88af-3cef813044a2)


<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

verified locally; checked if tests are still running