### PR TITLE
chore(err): re-work handle_event to be handle_events

### DIFF
--- a/rust/cymbal/src/error.rs
+++ b/rust/cymbal/src/error.rs
@@ -28,6 +28,8 @@ pub enum UnhandledError {
     ByteStreamError(#[from] ByteStreamError), // AWS specific bytestream error. Idk
     #[error("Unhandled serde error: {0}")]
     SerdeError(#[from] serde_json::Error),
+    #[error("Unhandled error: {0}")]
+    Other(String),
 }
 
 // These are errors that occur during frame resolution. This excludes e.g. network errors,

--- a/rust/cymbal/src/issue_resolution.rs
+++ b/rust/cymbal/src/issue_resolution.rs
@@ -5,7 +5,6 @@ use uuid::Uuid;
 use crate::{
     error::UnhandledError,
     metric_consts::{ISSUE_CREATED, ISSUE_REOPENED},
-    types::{FingerprintedErrProps, OutputErrProps},
 };
 
 pub struct IssueFingerprintOverride {
@@ -118,6 +117,11 @@ impl Issue {
     where
         E: sqlx::Executor<'c, Database = sqlx::Postgres>,
     {
+        // If this issue is already active, we don't need to do anything
+        if self.status == "active" {
+            return Ok(false);
+        }
+
         let res = sqlx::query_scalar!(
             r#"
             UPDATE posthog_errortrackingissue
@@ -195,37 +199,33 @@ impl IssueFingerprintOverride {
 pub async fn resolve_issue<'c, A>(
     con: A,
     team_id: i32,
-    fingerprinted: FingerprintedErrProps,
+    fingerprint: &str,
+    name: String,
+    description: String,
     event_timestamp: DateTime<Utc>,
-) -> Result<OutputErrProps, UnhandledError>
+) -> Result<Uuid, UnhandledError>
 where
     A: sqlx::Acquire<'c, Database = sqlx::Postgres>,
 {
     let mut conn = con.acquire().await?;
 
     // Fast path - just fetch the issue directly, and then reopen it if needed
-    let existing_issue =
-        Issue::load_by_fingerprint(&mut *conn, team_id, &fingerprinted.fingerprint).await?;
+    let existing_issue = Issue::load_by_fingerprint(&mut *conn, team_id, fingerprint).await?;
     if let Some(issue) = existing_issue {
         // TODO - we should use the bool here to determine if we need to notify a user
         // that the issue was reopened
         issue.maybe_reopen(&mut *conn).await?;
-        return Ok(fingerprinted.to_output(issue.id));
+        return Ok(issue.id);
     }
 
     // Slow path - insert a new issue, and then insert the fingerprint override, rolling
     // back the transaction if the override insert fails (since that indicates someone else
     // beat us to creating this new issue). Then, possibly reopen the issue.
 
-    // UNWRAP: We never resolve an issue for an exception with no exception list
-    let first = fingerprinted.exception_list.first().unwrap();
-    let new_name = first.exception_type.clone();
-    let new_description = first.exception_message.clone();
-
     // Start a transaction, so we can roll it back on override insert failure
     conn.begin().await?;
     // Insert a new issue
-    let issue = Issue::new(team_id, new_name, new_description);
+    let issue = Issue::new(team_id, name.to_string(), description.to_string());
     // We don't actually care if we insert the issue here or not - conflicts aren't possible at
     // this stage.
     issue.insert(&mut *conn).await?;
@@ -233,7 +233,7 @@ where
     let issue_override = IssueFingerprintOverride::create_or_load(
         &mut *conn,
         team_id,
-        &fingerprinted.fingerprint,
+        fingerprint,
         &issue,
         event_timestamp,
     )
@@ -260,7 +260,7 @@ where
         issue.maybe_reopen(&mut *conn).await?;
     }
 
-    Ok(fingerprinted.to_output(issue_override.issue_id))
+    Ok(issue_override.issue_id)
 }
 
 #[cfg(test)]

--- a/rust/cymbal/src/lib.rs
+++ b/rust/cymbal/src/lib.rs
@@ -100,6 +100,10 @@ pub async fn handle_events(
                 });
                 frame_resolve_handles.insert(id, handle);
             }
+
+            // Put the frames back on the exception, now that we're done mutating them until we've
+            // gathered our lookup table.
+            exception.stack = Some(Stacktrace::Raw { frames });
         }
     }
 

--- a/rust/cymbal/src/lib.rs
+++ b/rust/cymbal/src/lib.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use app_context::AppContext;
 use chrono::{DateTime, NaiveDateTime, Utc};
@@ -9,7 +9,7 @@ use issue_resolution::resolve_issue;
 use metric_consts::FRAME_RESOLUTION;
 use serde_json::Value;
 use tracing::{error, warn};
-use types::{Exception, RawErrProps, Stacktrace};
+use types::{FingerprintedErrProps, RawErrProps, Stacktrace};
 use uuid::Uuid;
 
 pub mod app_context;
@@ -24,66 +24,179 @@ pub mod metric_consts;
 pub mod symbol_store;
 pub mod types;
 
-pub async fn handle_event(
+pub async fn handle_events(
     context: Arc<AppContext>,
-    mut event: ClickHouseEvent,
-) -> Result<ClickHouseEvent, UnhandledError> {
-    let mut props = match get_props(&event) {
-        Ok(r) => r,
-        Err(e) => {
-            warn!(team = event.team_id, "Failed to get props: {}", e);
-
-            if let Err(e) = add_error_to_event(&mut event, e) {
-                // If we fail to add an error to an event, we just log it.
-                // This can happen if we failed to read the properties
-                // of the event in /any/ way, e.g. due to a serde recursion limit.
-                // If that's the case, we will fail to add a new element to the
-                // event properties storing the error message, so there's not much
-                // we can do. We should consider whether we want to drop these events.
-                error!(team = event.team_id, "Failed to add error to event: {}", e);
+    mut events: Vec<ClickHouseEvent>,
+) -> Result<Vec<ClickHouseEvent>, (usize, UnhandledError)> {
+    // First pass through the event list, to get all the exception property sets
+    // we'll process. Events we don't get exception properties from will be skipped
+    // in all the following passes
+    let mut indexed_props = Vec::new();
+    for (index, event) in events.iter_mut().enumerate() {
+        match get_props(event) {
+            Ok(r) => indexed_props.push((index, r)),
+            Err(e) => {
+                warn!(team = event.team_id, "Failed to get props: {}", e);
+                if let Err(e) = add_error_to_event(event, e) {
+                    // If we fail to add an error to an event, we just log it.
+                    // This can happen if we failed to read the properties
+                    // of the event at all, e.g. due to a serde recursion limit.
+                    error!(team = event.team_id, "Failed to add error to event: {}", e);
+                }
+                continue;
             }
-            return Ok(event);
+        };
+    }
+
+    // Freeze the events list as immutable until the final stage, to ensure we don't
+    // accidentally mutate or drop an event during processing.
+    let events = events;
+
+    // Second pass, to spawn the relevant tokio tasks to resolve the frames
+    let mut frame_resolve_handles = HashMap::new();
+    for (index, props) in indexed_props.iter_mut() {
+        let team_id = events[*index].team_id;
+        for exception in props.exception_list.iter_mut() {
+            let frames = match exception.stack.take() {
+                Some(Stacktrace::Raw { frames }) => frames,
+                Some(Stacktrace::Resolved { frames }) => {
+                    // This stack trace is already resolved, we have no work to do.
+                    exception.stack = Some(Stacktrace::Resolved { frames });
+                    continue;
+                }
+                None => {
+                    continue; // It was None before and it's none after the take
+                }
+            };
+
+            if frames.is_empty() {
+                // If the frame list was empty, we effectively just remove the stack from the exception,
+                // making it stackless.
+                exception.stack = None;
+                continue;
+            }
+
+            for frame in frames.iter() {
+                let id = frame.frame_id();
+                if frame_resolve_handles.contains_key(&id) {
+                    // We've already spawned a task to resolve this frame, so we don't need to do it again.
+                    continue;
+                }
+
+                // We need a cloned frame to move into the closure below
+                let frame = frame.clone();
+
+                let context = context.clone();
+                // Spawn a concurrent task for resolving every frame
+                let handle = tokio::spawn(async move {
+                    context.worker_liveness.report_healthy().await;
+                    metrics::counter!(FRAME_RESOLUTION).increment(1);
+                    let res = context
+                        .resolver
+                        .resolve(&frame, team_id, &context.pool, &context.catalog)
+                        .await;
+                    context.worker_liveness.report_healthy().await;
+                    res
+                });
+                frame_resolve_handles.insert(id, handle);
+            }
         }
-    };
-
-    let exceptions = std::mem::take(&mut props.exception_list);
-
-    if exceptions.is_empty() {
-        props.add_error_message("No exceptions found on exception event");
-        event.properties = Some(serde_json::to_string(&props).unwrap());
-        return Ok(event);
     }
 
-    let mut results = Vec::new();
-    for exception in exceptions.into_iter() {
-        // If we get an unhandled error during exception processing, we return an error, which should
-        // cause the caller to drop the offset without storing it - unhandled exceptions indicate
-        // a dependency is down, or some bug, adn we want to take lag in those situations.
-        results.push(process_exception(context.clone(), event.team_id, exception).await?);
+    // Collect the results of frame resolution
+    let mut frame_lookup_table = HashMap::new();
+    for (id, handle) in frame_resolve_handles.into_iter() {
+        let res = match handle.await.expect("Frame resolve task didn't panic") {
+            Ok(r) => r,
+            Err(e) => {
+                let index = find_index_with_matching_frame_id(&id, &indexed_props);
+                return Err((index, e));
+            }
+        };
+        frame_lookup_table.insert(id, res);
     }
 
-    let fingerprint = generate_fingerprint(&results);
-    props.exception_list = results;
-    let fingerprinted = props.to_fingerprinted(fingerprint.clone());
+    // Third pass, to map the unresolved frames into resolved ones, fingerprint them, and kick
+    // off issue resolution for any new fingerprints. This time we consume the RawErrorProps list,
+    // converting each entry into a fingerprinted one.
+    let mut indexed_fingerprinted = Vec::new();
+    let mut issue_handles = HashMap::new();
+    for (index, mut props) in indexed_props.into_iter() {
+        let event = &events[index];
+        let team_id = event.team_id;
+        for exception in props.exception_list.iter_mut() {
+            exception.stack = exception
+                .stack
+                .take()
+                .map(|s| {
+                    s.resolve(&frame_lookup_table).ok_or(UnhandledError::Other(
+                        "Stacktrace::resolve returned None".to_string(),
+                    ))
+                })
+                .transpose()
+                .map_err(|e| (index, e))?
+        }
 
-    let event_timestamp = get_event_timestamp(&event).unwrap_or_else(|| {
-        warn!(
-            event = event.uuid.to_string(),
-            "Failed to get event timestamp, using current time"
-        );
-        Utc::now()
-    });
+        let fingerprint = generate_fingerprint(&props.exception_list);
+        if !issue_handles.contains_key(&fingerprint) {
+            let name = props.exception_list[0].exception_type.clone();
+            let description = props.exception_list[0].exception_message.clone();
+            let event_timestamp = get_event_timestamp(event).unwrap_or_else(|| {
+                warn!(
+                    event = event.uuid.to_string(),
+                    "Failed to get event timestamp, using current time"
+                );
+                Utc::now()
+            });
 
-    let mut output =
-        resolve_issue(&context.pool, event.team_id, fingerprinted, event_timestamp).await?;
+            let m_fingerprint = fingerprint.clone();
+            let m_context = context.clone();
+            let handle = tokio::spawn(async move {
+                resolve_issue(
+                    &m_context.pool,
+                    team_id,
+                    &m_fingerprint,
+                    name,
+                    description,
+                    event_timestamp,
+                )
+                .await
+            });
+            issue_handles.insert(fingerprint.clone(), handle);
+        }
 
-    // TODO - I'm not sure we actually want to do this? Maybe junk drawer stuff should end up in clickhouse, and
-    // be directly queryable by users? Stripping it for now, so it only ends up in postgres
-    output.strip_frame_junk();
+        let fingerprinted = props.to_fingerprinted(fingerprint);
+        indexed_fingerprinted.push((index, fingerprinted));
+    }
 
-    event.properties = Some(serde_json::to_string(&output).unwrap());
+    // Collect the results of issue resolution
+    let mut resolved_issues = HashMap::new();
+    for (fingerprint, handle) in issue_handles.into_iter() {
+        let issue_id = match handle.await.expect("issue resolution task did not panic") {
+            Ok(id) => id,
+            Err(e) => {
+                let index =
+                    find_index_with_matching_fingerprint(&fingerprint, &indexed_fingerprinted);
+                return Err((index, e));
+            }
+        };
+        resolved_issues.insert(fingerprint, issue_id);
+    }
 
-    Ok(event)
+    // Fourth pass, to update the events with the resolved issues
+    // Unfreeze the events list, since now we have to modify the events we processed
+    let mut events = events;
+    for (index, fingerprinted) in indexed_fingerprinted.into_iter() {
+        let event = &mut events[index];
+        let issue_id = resolved_issues
+            .get(&fingerprinted.fingerprint)
+            .cloned()
+            .expect("Issue was resolved");
+        let output = fingerprinted.to_output(issue_id);
+        event.properties = Some(serde_json::to_string(&output).map_err(|e| (index, e.into()))?);
+    }
+
+    Ok(events)
 }
 
 pub fn get_props(event: &ClickHouseEvent) -> Result<RawErrProps, EventError> {
@@ -164,63 +277,6 @@ pub fn needs_sanitization(s: &str) -> bool {
     s.contains('\u{0000}')
 }
 
-async fn process_exception(
-    context: Arc<AppContext>,
-    team_id: i32,
-    mut e: Exception,
-) -> Result<Exception, UnhandledError> {
-    let stack = std::mem::take(&mut e.stack);
-    let Some(Stacktrace::Raw { frames }) = stack else {
-        // This stack trace is already resolved, we have no work to do.
-        e.stack = stack;
-        return Ok(e);
-    };
-
-    if frames.is_empty() {
-        // If the frame list was empty, we effectively just remove the stack from the exception,
-        // making it stackless.
-        return Ok(e);
-    }
-
-    let mut handles = Vec::with_capacity(frames.len());
-    let mut resolved_frames = Vec::with_capacity(frames.len());
-
-    for frame in frames.into_iter() {
-        let context = context.clone();
-        // Spawn a concurrent task for resolving every frame - we're careful elsewhere to
-        // ensure this kind of concurrency is fine, although this "throw it at the wall"
-        // data flow structure is pretty questionable. Once we switch to handling more than
-        // 1 event at a time, we should re-group frames into associated groups and then
-        // process those groups in-order (but the individual frames in them can still be
-        // thrown at the wall), with some cross-group concurrency.
-        handles.push(tokio::spawn(async move {
-            context.worker_liveness.report_healthy().await;
-            metrics::counter!(FRAME_RESOLUTION).increment(1);
-            let res = context
-                .resolver
-                .resolve(&frame, team_id, &context.pool, &context.catalog)
-                .await;
-            context.worker_liveness.report_healthy().await;
-            res
-        }));
-    }
-
-    // Collect the results
-    for handle in handles {
-        // Joinhandles wrap the returned type in a Result, because if the task panics,
-        // tokio catches it and returns an error. If any of our tasks panicked, we want
-        // to propogate that panic, so we unwrap the outer Result here.
-        let res = handle.await.unwrap()?;
-        resolved_frames.push(res)
-    }
-
-    e.stack = Some(Stacktrace::Resolved {
-        frames: resolved_frames,
-    });
-
-    Ok(e)
-}
-
 // This is expensive, since it round-trips the event through JSON.
 // We could maybe change ClickhouseEvent to only do serde at the edges
 pub fn add_error_to_event(
@@ -249,6 +305,33 @@ pub fn get_event_timestamp(event: &ClickHouseEvent) -> Option<DateTime<Utc>> {
     NaiveDateTime::parse_from_str(&event.timestamp, "%Y-%m-%d %H:%M:%S%.f")
         .map(|ndt| ndt.and_utc())
         .ok()
+}
+
+fn find_index_with_matching_frame_id(id: &str, list: &[(usize, RawErrProps)]) -> usize {
+    for (index, props) in list.iter() {
+        for exception in props.exception_list.iter() {
+            if let Some(Stacktrace::Raw { frames }) = &exception.stack {
+                for frame in frames {
+                    if frame.frame_id() == id {
+                        return *index;
+                    }
+                }
+            }
+        }
+    }
+    0
+}
+
+fn find_index_with_matching_fingerprint(
+    fingerprint: &str,
+    list: &[(usize, FingerprintedErrProps)],
+) -> usize {
+    for (index, props) in list.iter() {
+        if props.fingerprint == fingerprint {
+            return *index;
+        }
+    }
+    0
 }
 
 #[cfg(test)]

--- a/rust/cymbal/src/main.rs
+++ b/rust/cymbal/src/main.rs
@@ -105,7 +105,7 @@ async fn main() {
         }
 
         let processed = match handle_events(context.clone(), to_process).await {
-            Ok(event) => event,
+            Ok(events) => events,
             Err((index, e)) => {
                 let offset = &offsets[index];
                 error!("Error handling event: {:?}; offset: {:?}", e, offset);

--- a/rust/cymbal/src/main.rs
+++ b/rust/cymbal/src/main.rs
@@ -7,7 +7,7 @@ use common_types::ClickHouseEvent;
 use cymbal::{
     app_context::AppContext,
     config::Config,
-    handle_event,
+    handle_events,
     metric_consts::{DROPPED_EVENTS, ERRORS, EVENT_PROCESSED, EVENT_RECEIVED, MAIN_LOOP_TIME},
 };
 use rdkafka::types::RDKafkaErrorCode;
@@ -71,9 +71,6 @@ async fn main() {
             .json_recv_batch(batch_size, batch_wait_time)
             .await;
 
-        let mut output = Vec::with_capacity(received.len());
-        let mut offsets = Vec::with_capacity(received.len());
-
         let mut producer = context.kafka_producer.lock().await;
 
         let txn = match producer.begin() {
@@ -84,9 +81,15 @@ async fn main() {
             }
         };
 
+        let mut to_process = Vec::with_capacity(received.len());
+        let mut offsets = Vec::with_capacity(received.len());
+
         for message in received {
-            let (event, offset) = match message {
-                Ok(r) => r,
+            match message {
+                Ok((event, offset)) => {
+                    to_process.push(event);
+                    offsets.push(offset);
+                }
                 Err(RecvErr::Kafka(e)) => {
                     panic!("Kafka error: {}", e)
                 }
@@ -98,30 +101,25 @@ async fn main() {
                     continue;
                 }
             };
-
             metrics::counter!(EVENT_RECEIVED).increment(1);
-
-            let event = match handle_event(context.clone(), event).await {
-                Ok(e) => e,
-                Err(e) => {
-                    error!("Error handling event: {:?}; offset: {:?}", e, offset);
-                    // If we get an unhandled error, it means we have some logical error in the code, or a
-                    // dependency is down, and we should just fall over.
-                    panic!("Unhandled error: {:?}; offset: {:?}", e, offset);
-                }
-            };
-
-            metrics::counter!(EVENT_PROCESSED).increment(1);
-
-            output.push(event);
-            offsets.push(offset);
         }
+
+        let processed = match handle_events(context.clone(), to_process).await {
+            Ok(event) => event,
+            Err((index, e)) => {
+                let offset = &offsets[index];
+                error!("Error handling event: {:?}; offset: {:?}", e, offset);
+                panic!("Unhandled error: {:?}; offset: {:?}", e, offset);
+            }
+        };
+
+        metrics::counter!(EVENT_PROCESSED).increment(processed.len() as u64);
 
         let results = txn
             .send_keyed_iter_to_kafka(
                 &context.config.events_topic,
                 |ev| Some(ev.uuid.to_string()),
-                &output,
+                &processed,
             )
             .await;
 

--- a/rust/cymbal/src/types/mod.rs
+++ b/rust/cymbal/src/types/mod.rs
@@ -170,6 +170,26 @@ impl OutputErrProps {
     }
 }
 
+impl Stacktrace {
+    pub fn resolve(&self, lookup_table: &HashMap<String, Frame>) -> Option<Self> {
+        let Stacktrace::Raw { frames } = self else {
+            return Some(self.clone());
+        };
+
+        let mut resolved_frames = Vec::with_capacity(frames.len());
+        for frame in frames {
+            match lookup_table.get(&frame.frame_id()) {
+                Some(resolved_frame) => resolved_frames.push(resolved_frame.clone()),
+                None => return None,
+            }
+        }
+
+        Some(Stacktrace::Resolved {
+            frames: resolved_frames,
+        })
+    }
+}
+
 #[cfg(test)]
 mod test {
     use common_types::ClickHouseEvent;


### PR DESCRIPTION
I _think_ this should be a significant improvement, most notably because it only resolves the issue once per fingerprint, instead of running issue resolution _on every event_. It also tries to be more cleverer about frame resolution, but that might turn out to be a mistake, I'm not sure yet. 

If this does actually improve throughput notably, I'll refactor it to be a bit more composable, but since this might have no impact and be immediately reverted, I'd rather merge and see.