### PR TITLE
fix: Debugging why uuids are not uuid's in delete reporting table

### DIFF
--- a/dags/deletes.py
+++ b/dags/deletes.py
@@ -251,7 +251,7 @@ class PendingDeletesDictionary:
 def get_oldest_person_override_timestamp(
     cluster: ResourceParam[ClickhouseCluster],
 ) -> datetime:
-    """Get the oldest person override timestamp from the person_distinct_id_overrides_snapshot table."""
+    """Get the oldest person override timestamp from the person_distinct_id_overrides table."""
 
     query = f"""
     SELECT min(_timestamp) FROM {PERSON_DISTINCT_ID_OVERRIDES_TABLE}

--- a/dags/deletes.py
+++ b/dags/deletes.py
@@ -306,7 +306,13 @@ def load_pending_person_deletions(
     """Query postgres using django ORM to get pending person deletions and insert directly into ClickHouse."""
 
     if create_pending_person_deletions_table.is_reporting:
-        pending_deletions = AsyncDeletion.objects.all().values("team_id", "key", "created_at").iterator()
+        pending_deletions = (
+            AsyncDeletion.objects.filter(
+                deletion_type=DeletionType.Person,
+            )
+            .values("team_id", "key", "created_at")
+            .iterator()
+        )
     else:
         if not create_pending_person_deletions_table.team_id:
             pending_deletions = (


### PR DESCRIPTION
## Problem

Keys in the deletion reporting table are not UUIDs, they are integers. This is because of a broken predicate on the reporting table fill job.

## Changes

- fix the broken predicate on the fill job

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
