### PR TITLE
feat: Wait for all hosts in shard to complete when materializing partitions

### DIFF
--- a/dags/materialized_columns.py
+++ b/dags/materialized_columns.py
@@ -125,7 +125,7 @@ def run_materialize_mutations(
     # Step through the remaining partitions, materializing the column in any shards where the column hasn't already been
     # materialized.
     for partition in sorted(remaining_partitions, reverse=True):
-        cluster.map_any_host_in_shards(
+        shard_mutations = cluster.map_any_host_in_shards(
             {
                 shard_num: MutationRunner(
                     config.table,
@@ -135,6 +135,13 @@ def run_materialize_mutations(
                 for shard_num, remaining_partitions_for_shard in remaining_partitions_by_shard.items()
                 if partition in remaining_partitions_for_shard
             }
+        ).result()
+
+        # Wait for all hosts in the shard to finish the job before moving on to the next partition: this helps control
+        # the number of outstanding or in-progress mutations on clusters where some hosts are more resource constrained
+        # than others, as we want to wait for the slowest one to complete its tasks before giving it more work.
+        cluster.map_all_hosts_in_shards(
+            {shard_host.shard_num: mutation.wait for shard_host, mutation in shard_mutations.items()}
         ).result()
 
 

--- a/dags/materialized_columns.py
+++ b/dags/materialized_columns.py
@@ -125,16 +125,17 @@ def run_materialize_mutations(
     # Step through the remaining partitions, materializing the column in any shards where the column hasn't already been
     # materialized.
     for partition in sorted(remaining_partitions, reverse=True):
-        shard_tasks = {
-            shard_num: MutationRunner(
-                config.table,
-                f"MATERIALIZE COLUMN {config.column} IN PARTITION %(partition)s",
-                {"partition": partition},
-            )
-            for shard_num, remaining_partitions_for_shard in remaining_partitions_by_shard.items()
-            if partition in remaining_partitions_for_shard
-        }
-        cluster.map_any_host_in_shards(shard_tasks).result()
+        cluster.map_any_host_in_shards(
+            {
+                shard_num: MutationRunner(
+                    config.table,
+                    f"MATERIALIZE COLUMN {config.column} IN PARTITION %(partition)s",
+                    {"partition": partition},
+                ).enqueue
+                for shard_num, remaining_partitions_for_shard in remaining_partitions_by_shard.items()
+                if partition in remaining_partitions_for_shard
+            }
+        ).result()
 
 
 @dagster.job

--- a/dags/materialized_columns.py
+++ b/dags/materialized_columns.py
@@ -125,24 +125,16 @@ def run_materialize_mutations(
     # Step through the remaining partitions, materializing the column in any shards where the column hasn't already been
     # materialized.
     for partition in sorted(remaining_partitions, reverse=True):
-        shard_mutations = cluster.map_any_host_in_shards(
-            {
-                shard_num: MutationRunner(
-                    config.table,
-                    f"MATERIALIZE COLUMN {config.column} IN PARTITION %(partition)s",
-                    {"partition": partition},
-                ).enqueue
+        MutationRunner(
+            config.table, f"MATERIALIZE COLUMN {config.column} IN PARTITION %(partition)s", {"partition": partition}
+        ).run_on_shards(
+            cluster,
+            shards={
+                shard_num
                 for shard_num, remaining_partitions_for_shard in remaining_partitions_by_shard.items()
                 if partition in remaining_partitions_for_shard
-            }
-        ).result()
-
-        # Wait for all hosts in the shard to finish the job before moving on to the next partition: this helps control
-        # the number of outstanding or in-progress mutations on clusters where some hosts are more resource constrained
-        # than others, as we want to wait for the slowest one to complete its tasks before giving it more work.
-        cluster.map_all_hosts_in_shards(
-            {shard_host.shard_num: mutation.wait for shard_host, mutation in shard_mutations.items()}
-        ).result()
+            },
+        )
 
 
 @dagster.job

--- a/dags/person_overrides.py
+++ b/dags/person_overrides.py
@@ -2,7 +2,7 @@ import datetime
 import time
 import uuid
 from dataclasses import dataclass
-from functools import partial, reduce
+from functools import partial
 
 import dagster
 import pydantic
@@ -300,35 +300,13 @@ def load_and_verify_snapshot_dictionary(
 
 # Mutation Management
 
-ShardMutations = dict[int, Mutation]
-
 
 @dagster.op
-def start_person_id_update_mutations(
+def run_person_id_update_mutations(
     cluster: dagster.ResourceParam[ClickhouseCluster],
     dictionary: PersonOverridesSnapshotDictionary,
-) -> tuple[PersonOverridesSnapshotDictionary, ShardMutations]:
-    """Start the mutation to update `sharded_events.person_id` with the snapshot data on all shards."""
-    shard_mutations = {
-        host.shard_num: mutation
-        for host, mutation in (
-            cluster.map_one_host_per_shard(dictionary.person_id_update_mutation_runner.enqueue).result().items()
-        )
-    }
-    return (dictionary, shard_mutations)
-
-
-@dagster.op
-def wait_for_person_id_update_mutations(
-    cluster: dagster.ResourceParam[ClickhouseCluster],
-    inputs: tuple[PersonOverridesSnapshotDictionary, ShardMutations],
 ) -> PersonOverridesSnapshotDictionary:
-    """Wait for all hosts to complete the `sharded_events.person_id` update mutation."""
-    [dictionary, shard_mutations] = inputs
-    reduce(
-        lambda x, y: x.merge(y),
-        [cluster.map_all_hosts_in_shard(shard, mutation.wait) for shard, mutation in shard_mutations.items()],
-    ).result()
+    dictionary.person_id_update_mutation_runner.run_on_shards(cluster)
     return dictionary
 
 
@@ -382,9 +360,7 @@ def drop_snapshot_table(
 def squash_person_overrides():
     prepared_snapshot_table = wait_for_snapshot_table_replication(populate_snapshot_table(create_snapshot_table()))
     prepared_dictionary = load_and_verify_snapshot_dictionary(create_snapshot_dictionary(prepared_snapshot_table))
-    dictionary_after_person_id_update_mutations = wait_for_person_id_update_mutations(
-        start_person_id_update_mutations(prepared_dictionary)
-    )
+    dictionary_after_person_id_update_mutations = run_person_id_update_mutations(prepared_dictionary)
     dictionary_after_override_delete_mutations = wait_for_overrides_delete_mutations(
         start_overrides_delete_mutations(dictionary_after_person_id_update_mutations)
     )

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -340,12 +340,6 @@ class MutationRunner:
         if invalid_keys := {key for key in self.parameters.keys() if key.startswith("__")}:
             raise ValueError(f"invalid parameter names: {invalid_keys!r} (keys cannot start with double underscore)")
 
-    def __call__(self, client: Client) -> Mutation:
-        """Shorthand method to find or enqueue a mutation, and block until its completion."""
-        mutation = self.enqueue(client)
-        mutation.wait(client)
-        return mutation
-
     def find(self, client: Client) -> Mutation | None:
         """Find the running mutation task, if one exists."""
 


### PR DESCRIPTION
## Problem

The materialization job only waits for the host where the materialization was initially started on (or found on) before moving on to the next partition.

This isn't too big of a deal for homogenous clusters without workload routing since all hosts in the same shard should be able to generally process the mutation at the same speed, but in cases where some hosts in a shard have significantly different resource demands than others in the same shard, this will likely end up with many mutations queueing up on the slower hosts which is not ideal.

## Changes

Updated the job so that it waits for all mutations in all shards to complete before continuing.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Already covered (to the extent possible in single-node compose cluster, at least)