### PR TITLE
feat(cdp): bump batch size of cyclotron-worker

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -193,7 +193,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         CDP_REDIS_HOST: '',
         CDP_REDIS_PORT: 6479,
         CDP_CYCLOTRON_BATCH_DELAY_MS: 50,
-        CDP_CYCLOTRON_BATCH_SIZE: 500,
+        CDP_CYCLOTRON_BATCH_SIZE: 1000,
 
         CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN: '',
 


### PR DESCRIPTION
## Problem

We see that cpu bound hpa is not kicking in fast enough for cyclotron-worker to scale properly with more load leading to backpressure and increasing lag on the cdp-processed-events consumer. batch utilization with high event load is maxed out while cpu and memory look super happy hence the scaling is not kicking in.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- With increasing the batch size to double we hope to utilize the CPU more (currently cpu is sitting pretty low) in order to trigger proper scaling.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
