### PR TITLE
feat(experiments): improve default metric title

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.test.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.test.tsx
@@ -150,3 +150,98 @@ describe('generateViolinPath', () => {
         expect(path).toContain('Z')
     })
 })
+import { ExperimentMetric, ExperimentMetricType, NodeKind } from '~/queries/schema/schema-general'
+
+import { getDefaultMetricTitle } from './DeltaChart'
+
+describe('getDefaultMetricTitle', () => {
+    it('handles ExperimentEventMetricConfig correctly', () => {
+        const metric: ExperimentMetric = {
+            kind: NodeKind.ExperimentMetric,
+            metric_type: ExperimentMetricType.COUNT,
+            metric_config: {
+                kind: NodeKind.ExperimentEventMetricConfig,
+                math: 'total',
+                math_property: 'revenue',
+                event: 'purchase',
+            },
+        }
+
+        expect(getDefaultMetricTitle(metric)).toBe('Total Revenue Purchase')
+    })
+
+    it('handles ExperimentEventMetricConfig without math_property', () => {
+        const metric: ExperimentMetric = {
+            kind: NodeKind.ExperimentMetric,
+            metric_type: ExperimentMetricType.COUNT,
+            metric_config: {
+                kind: NodeKind.ExperimentEventMetricConfig,
+                math: 'total',
+                event: 'signup',
+            },
+        }
+
+        expect(getDefaultMetricTitle(metric)).toBe('Total Signup')
+    })
+
+    it('handles ExperimentActionMetricConfig with name', () => {
+        const metric: ExperimentMetric = {
+            kind: NodeKind.ExperimentMetric,
+            metric_type: ExperimentMetricType.COUNT,
+            metric_config: {
+                kind: NodeKind.ExperimentActionMetricConfig,
+                math: 'avg',
+                math_property: 'value',
+                name: 'Completed Purchase',
+                action: 123,
+            },
+        }
+
+        expect(getDefaultMetricTitle(metric)).toBe('Average Value Completed Purchase')
+    })
+
+    it('handles ExperimentActionMetricConfig without name', () => {
+        const metric: ExperimentMetric = {
+            kind: NodeKind.ExperimentMetric,
+            metric_type: ExperimentMetricType.COUNT,
+            metric_config: {
+                kind: NodeKind.ExperimentActionMetricConfig,
+                math: 'avg',
+                math_property: 'value',
+                action: 123,
+            },
+        }
+
+        expect(getDefaultMetricTitle(metric)).toBe('Average Value Action 123')
+    })
+
+    it('handles snake_case conversion correctly', () => {
+        const metric: ExperimentMetric = {
+            kind: NodeKind.ExperimentMetric,
+            metric_type: ExperimentMetricType.COUNT,
+            metric_config: {
+                kind: NodeKind.ExperimentEventMetricConfig,
+                math: 'total',
+                math_property: 'user_revenue',
+                event: 'completed_purchase',
+            },
+        }
+
+        expect(getDefaultMetricTitle(metric)).toBe('Total User Revenue Completed Purchase')
+    })
+
+    it('handles camelCase conversion correctly', () => {
+        const metric: ExperimentMetric = {
+            kind: NodeKind.ExperimentMetric,
+            metric_type: ExperimentMetricType.COUNT,
+            metric_config: {
+                kind: NodeKind.ExperimentEventMetricConfig,
+                math: 'total',
+                math_property: 'userRevenue',
+                event: 'completedPurchase',
+            },
+        }
+
+        expect(getDefaultMetricTitle(metric)).toBe('Total User Revenue Completed Purchase')
+    })
+})

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.test.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.test.tsx
@@ -162,12 +162,12 @@ describe('getDefaultMetricTitle', () => {
             metric_config: {
                 kind: NodeKind.ExperimentEventMetricConfig,
                 math: 'total',
-                math_property: 'revenue',
-                event: 'purchase',
+                math_property: undefined,
+                event: 'purchase completed',
             },
         }
 
-        expect(getDefaultMetricTitle(metric)).toBe('Total Revenue Purchase')
+        expect(getDefaultMetricTitle(metric)).toBe('Total purchase completed')
     })
 
     it('handles ExperimentEventMetricConfig without math_property', () => {
@@ -181,7 +181,7 @@ describe('getDefaultMetricTitle', () => {
             },
         }
 
-        expect(getDefaultMetricTitle(metric)).toBe('Total Signup')
+        expect(getDefaultMetricTitle(metric)).toBe('Total signup')
     })
 
     it('handles ExperimentActionMetricConfig with name', () => {
@@ -197,7 +197,7 @@ describe('getDefaultMetricTitle', () => {
             },
         }
 
-        expect(getDefaultMetricTitle(metric)).toBe('Average Value Completed Purchase')
+        expect(getDefaultMetricTitle(metric)).toBe('Avg value completed purchase')
     })
 
     it('handles ExperimentActionMetricConfig without name', () => {
@@ -212,7 +212,7 @@ describe('getDefaultMetricTitle', () => {
             },
         }
 
-        expect(getDefaultMetricTitle(metric)).toBe('Average Value Action 123')
+        expect(getDefaultMetricTitle(metric)).toBe('Avg value action 123')
     })
 
     it('handles snake_case conversion correctly', () => {
@@ -227,7 +227,7 @@ describe('getDefaultMetricTitle', () => {
             },
         }
 
-        expect(getDefaultMetricTitle(metric)).toBe('Total User Revenue Completed Purchase')
+        expect(getDefaultMetricTitle(metric)).toBe('Total user revenue completed purchase')
     })
 
     it('handles camelCase conversion correctly', () => {
@@ -242,6 +242,6 @@ describe('getDefaultMetricTitle', () => {
             },
         }
 
-        expect(getDefaultMetricTitle(metric)).toBe('Total User Revenue Completed Purchase')
+        expect(getDefaultMetricTitle(metric)).toBe('Total user revenue completed purchase')
     })
 })

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.test.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.test.tsx
@@ -1,3 +1,11 @@
+import {
+    ExperimentFunnelsQuery,
+    ExperimentMetric,
+    ExperimentMetricType,
+    ExperimentTrendsQuery,
+    NodeKind,
+} from '~/queries/schema/schema-general'
+
 import { generateViolinPath } from './DeltaChart'
 
 /**
@@ -150,98 +158,67 @@ describe('generateViolinPath', () => {
         expect(path).toContain('Z')
     })
 })
-import { ExperimentMetric, ExperimentMetricType, NodeKind } from '~/queries/schema/schema-general'
 
-import { getDefaultMetricTitle } from './DeltaChart'
+import { getDefaultMetricTitle, getMetricTag } from './DeltaChart'
 
 describe('getDefaultMetricTitle', () => {
-    it('handles ExperimentEventMetricConfig correctly', () => {
+    it('handles ExperimentEventMetricConfig with math and math_property', () => {
         const metric: ExperimentMetric = {
             kind: NodeKind.ExperimentMetric,
             metric_type: ExperimentMetricType.COUNT,
             metric_config: {
                 kind: NodeKind.ExperimentEventMetricConfig,
-                math: 'total',
-                math_property: undefined,
                 event: 'purchase completed',
             },
         }
-
-        expect(getDefaultMetricTitle(metric)).toBe('Total purchase completed')
+        expect(getDefaultMetricTitle(metric)).toBe('purchase completed')
     })
 
-    it('handles ExperimentEventMetricConfig without math_property', () => {
-        const metric: ExperimentMetric = {
-            kind: NodeKind.ExperimentMetric,
-            metric_type: ExperimentMetricType.COUNT,
-            metric_config: {
-                kind: NodeKind.ExperimentEventMetricConfig,
-                math: 'total',
-                event: 'signup',
-            },
-        }
-
-        expect(getDefaultMetricTitle(metric)).toBe('Total signup')
-    })
-
-    it('handles ExperimentActionMetricConfig with name', () => {
+    it('returns action name for ExperimentActionMetricConfig', () => {
         const metric: ExperimentMetric = {
             kind: NodeKind.ExperimentMetric,
             metric_type: ExperimentMetricType.COUNT,
             metric_config: {
                 kind: NodeKind.ExperimentActionMetricConfig,
-                math: 'avg',
-                math_property: 'value',
-                name: 'Completed Purchase',
-                action: 123,
+                action: 1,
+                name: 'purchase',
             },
         }
 
-        expect(getDefaultMetricTitle(metric)).toBe('Avg value completed purchase')
+        expect(getDefaultMetricTitle(metric)).toBe('purchase')
     })
+})
 
-    it('handles ExperimentActionMetricConfig without name', () => {
-        const metric: ExperimentMetric = {
-            kind: NodeKind.ExperimentMetric,
-            metric_type: ExperimentMetricType.COUNT,
-            metric_config: {
-                kind: NodeKind.ExperimentActionMetricConfig,
-                math: 'avg',
-                math_property: 'value',
-                action: 123,
-            },
-        }
-
-        expect(getDefaultMetricTitle(metric)).toBe('Avg value action 123')
-    })
-
-    it('handles snake_case conversion correctly', () => {
-        const metric: ExperimentMetric = {
+describe('getMetricTag', () => {
+    it('handles different metric types correctly', () => {
+        const experimentMetric: ExperimentMetric = {
             kind: NodeKind.ExperimentMetric,
             metric_type: ExperimentMetricType.COUNT,
             metric_config: {
                 kind: NodeKind.ExperimentEventMetricConfig,
                 math: 'total',
-                math_property: 'user_revenue',
-                event: 'completed_purchase',
+                event: 'purchase',
             },
         }
 
-        expect(getDefaultMetricTitle(metric)).toBe('Total user revenue completed purchase')
-    })
-
-    it('handles camelCase conversion correctly', () => {
-        const metric: ExperimentMetric = {
-            kind: NodeKind.ExperimentMetric,
-            metric_type: ExperimentMetricType.COUNT,
-            metric_config: {
-                kind: NodeKind.ExperimentEventMetricConfig,
-                math: 'total',
-                math_property: 'userRevenue',
-                event: 'completedPurchase',
+        const funnelMetric: ExperimentFunnelsQuery = {
+            kind: NodeKind.ExperimentFunnelsQuery,
+            funnels_query: {
+                kind: NodeKind.FunnelsQuery,
+                series: [],
             },
         }
 
-        expect(getDefaultMetricTitle(metric)).toBe('Total user revenue completed purchase')
+        const trendMetric: ExperimentTrendsQuery = {
+            kind: NodeKind.ExperimentTrendsQuery,
+            count_query: {
+                kind: NodeKind.TrendsQuery,
+                series: [],
+            },
+        }
+
+        expect(getMetricTag(experimentMetric)).toBe('Count')
+        expect(getMetricTag(funnelMetric)).toBe('Funnel')
+        expect(getMetricTag(trendMetric)).toBe('Trend')
     })
 })

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -43,10 +43,13 @@ export function getDefaultMetricTitle(metric: ExperimentMetric): string {
             .join(' ')
             // replace underscores with spaces
             .replace(/_/g, ' ')
-            // add spaces before capital letters
+            // add spaces before capital letters and convert to lowercase
             .replace(/([A-Z])/g, ' $1')
+            .toLowerCase()
             // capitalize first letter
             .replace(/^./, (str) => str.toUpperCase())
+            // normalize spaces (remove double spaces)
+            .replace(/\s+/g, ' ')
             .trim()
     )
 }

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -17,7 +17,12 @@ import { humanFriendlyNumber } from 'lib/utils'
 import { useEffect, useRef, useState } from 'react'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
-import { ExperimentMetric, NodeKind } from '~/queries/schema/schema-general'
+import {
+    ExperimentFunnelsQuery,
+    ExperimentMetric,
+    ExperimentTrendsQuery,
+    NodeKind,
+} from '~/queries/schema/schema-general'
 import { InsightType, TrendExperimentVariant } from '~/types'
 
 import { experimentLogic } from '../experimentLogic'
@@ -25,6 +30,15 @@ import { ExploreButton, ResultsQuery, VariantTag } from '../ExperimentView/compo
 import { SignificanceText, WinningVariantText } from '../ExperimentView/Overview'
 import { SummaryTable } from '../ExperimentView/SummaryTable'
 import { NoResultEmptyState } from './NoResultEmptyState'
+
+export function getMetricTag(metric: ExperimentMetric | ExperimentTrendsQuery | ExperimentFunnelsQuery): string {
+    if (metric.kind === NodeKind.ExperimentMetric) {
+        return metric.metric_type.charAt(0).toUpperCase() + metric.metric_type.slice(1).toLowerCase()
+    } else if (metric.kind === NodeKind.ExperimentFunnelsQuery) {
+        return 'Funnel'
+    }
+    return 'Trend'
+}
 
 export function getDefaultMetricTitle(metric: ExperimentMetric): string {
     if (metric.metric_config.kind === NodeKind.ExperimentEventMetricConfig) {
@@ -317,12 +331,7 @@ export function DeltaChart({
                             </div>
                             <div className="space-x-1">
                                 <LemonTag type="muted" size="small">
-                                    {(metric.kind === NodeKind.ExperimentMetric
-                                        ? metric.metric_config.math
-                                        : metric.kind === NodeKind.ExperimentFunnelsQuery
-                                        ? 'Funnel'
-                                        : 'Total'
-                                    ).toUpperCase()}
+                                    {getMetricTag(metric)}
                                 </LemonTag>
                                 {metric.isSharedMetric && (
                                     <LemonTag type="option" size="small">

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -17,7 +17,7 @@ import { humanFriendlyNumber } from 'lib/utils'
 import { useEffect, useRef, useState } from 'react'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
-import { ExperimentMetric } from '~/queries/schema/schema-general'
+import { ExperimentMetric, NodeKind } from '~/queries/schema/schema-general'
 import { InsightType, TrendExperimentVariant } from '~/types'
 
 import { experimentLogic } from '../experimentLogic'
@@ -28,9 +28,9 @@ import { NoResultEmptyState } from './NoResultEmptyState'
 
 export function getDefaultMetricTitle(metric: ExperimentMetric): string {
     let parts: (string | undefined)[] = []
-    if (metric.metric_config.kind === 'ExperimentEventMetricConfig') {
+    if (metric.metric_config.kind === NodeKind.ExperimentEventMetricConfig) {
         parts = [metric.metric_config.math || 'Total', metric.metric_config.math_property, metric.metric_config.event]
-    } else if (metric.metric_config.kind === 'ExperimentActionMetricConfig') {
+    } else if (metric.metric_config.kind === NodeKind.ExperimentActionMetricConfig) {
         parts = [
             metric.metric_config.math || 'Total',
             metric.metric_config.math_property,
@@ -80,7 +80,7 @@ const getMetricTitle = (metric: any, metricType: InsightType): JSX.Element => {
         return <span className="truncate">{metric.name}</span>
     }
 
-    if (metric.kind === 'ExperimentMetric') {
+    if (metric.kind === NodeKind.ExperimentMetric) {
         return <span className="truncate">{getDefaultMetricTitle(metric)}</span>
     }
 
@@ -336,7 +336,7 @@ export function DeltaChart({
                             </div>
                             <div className="space-x-1">
                                 <LemonTag type="muted" size="small">
-                                    {metric.kind === 'ExperimentFunnelsQuery' ? 'Funnel' : 'Trend'}
+                                    {metric.kind === NodeKind.ExperimentFunnelsQuery ? 'Funnel' : 'Trend'}
                                 </LemonTag>
                                 {metric.isSharedMetric && (
                                     <LemonTag type="option" size="small">
@@ -898,11 +898,13 @@ export function DeltaChart({
                 }
             >
                 {/* TODO: Only show explore button if the metric is a trends or funnels query. Not supported yet with new query runner */}
-                {result && (result.kind === 'ExperimentTrendsQuery' || result.kind === 'ExperimentFunnelsQuery') && (
-                    <div className="flex justify-end">
-                        <ExploreButton result={result} />
-                    </div>
-                )}
+                {result &&
+                    (result.kind === NodeKind.ExperimentTrendsQuery ||
+                        result.kind === NodeKind.ExperimentFunnelsQuery) && (
+                        <div className="flex justify-end">
+                            <ExploreButton result={result} />
+                        </div>
+                    )}
                 <LemonBanner type={result?.significant ? 'success' : 'info'} className="mb-4">
                     <div className="items-center inline-flex flex-wrap">
                         <WinningVariantText result={result} experimentId={experimentId} />
@@ -911,9 +913,11 @@ export function DeltaChart({
                 </LemonBanner>
                 <SummaryTable metric={metric} metricIndex={metricIndex} isSecondary={isSecondary} />
                 {/* TODO: Only show results query if the metric is a trends or funnels query. Not supported yet with new query runner */}
-                {result && (result.kind === 'ExperimentTrendsQuery' || result.kind === 'ExperimentFunnelsQuery') && (
-                    <ResultsQuery result={result} showTable={true} />
-                )}
+                {result &&
+                    (result.kind === NodeKind.ExperimentTrendsQuery ||
+                        result.kind === NodeKind.ExperimentFunnelsQuery) && (
+                        <ResultsQuery result={result} showTable={true} />
+                    )}
             </LemonModal>
         </div>
     )

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -67,7 +67,11 @@ const getMetricTitle = (metric: any, metricType: InsightType): JSX.Element => {
         if (metric.metric_config?.kind === 'ExperimentEventMetricConfig') {
             const mathName = getMathDisplayName(metric.metric_config.math)
             const eventName = metric.metric_config.event
-            return <span className="truncate">{`${mathName} ${eventName}`}</span>
+            return (
+                <span className="truncate">{`${mathName} ${
+                    metric.metric_config.math_property ? `${metric.metric_config.math_property} ` : ''
+                }${eventName}`}</span>
+            )
         }
     }
 

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -25,6 +25,18 @@ import { SignificanceText, WinningVariantText } from '../ExperimentView/Overview
 import { SummaryTable } from '../ExperimentView/SummaryTable'
 import { NoResultEmptyState } from './NoResultEmptyState'
 
+function getMathDisplayName(math?: string): string {
+    if (!math) {
+        return 'Total'
+    }
+    // Capitalize first letter and add spaces before capital letters
+    return math
+        .toString()
+        .replace(/([A-Z])/g, ' $1')
+        .replace(/^./, (str) => str.toUpperCase())
+        .trim()
+}
+
 function formatTickValue(value: number): string {
     if (value === 0) {
         return '0%'
@@ -49,6 +61,14 @@ function formatTickValue(value: number): string {
 const getMetricTitle = (metric: any, metricType: InsightType): JSX.Element => {
     if (metric.name) {
         return <span className="truncate">{metric.name}</span>
+    }
+
+    if (metric.kind === 'ExperimentMetric') {
+        if (metric.metric_config?.kind === 'ExperimentEventMetricConfig') {
+            const mathName = getMathDisplayName(metric.metric_config.math)
+            const eventName = metric.metric_config.event
+            return <span className="truncate">{`${mathName} ${eventName}`}</span>
+        }
     }
 
     if (metricType === InsightType.TRENDS && metric.count_query?.series?.[0]?.name) {

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -27,31 +27,12 @@ import { SummaryTable } from '../ExperimentView/SummaryTable'
 import { NoResultEmptyState } from './NoResultEmptyState'
 
 export function getDefaultMetricTitle(metric: ExperimentMetric): string {
-    let parts: (string | undefined)[] = []
     if (metric.metric_config.kind === NodeKind.ExperimentEventMetricConfig) {
-        parts = [metric.metric_config.math || 'Total', metric.metric_config.math_property, metric.metric_config.event]
+        return metric.metric_config.event
     } else if (metric.metric_config.kind === NodeKind.ExperimentActionMetricConfig) {
-        parts = [
-            metric.metric_config.math || 'Total',
-            metric.metric_config.math_property,
-            metric.metric_config.name || `Action ${metric.metric_config.action}`,
-        ]
+        return metric.metric_config.name || `Action ${metric.metric_config.action}`
     }
-    return (
-        parts
-            .filter(Boolean)
-            .join(' ')
-            // replace underscores with spaces
-            .replace(/_/g, ' ')
-            // add spaces before capital letters and convert to lowercase
-            .replace(/([A-Z])/g, ' $1')
-            .toLowerCase()
-            // capitalize first letter
-            .replace(/^./, (str) => str.toUpperCase())
-            // normalize spaces (remove double spaces)
-            .replace(/\s+/g, ' ')
-            .trim()
-    )
+    return 'Untitled metric'
 }
 
 function formatTickValue(value: number): string {
@@ -336,7 +317,12 @@ export function DeltaChart({
                             </div>
                             <div className="space-x-1">
                                 <LemonTag type="muted" size="small">
-                                    {metric.kind === NodeKind.ExperimentFunnelsQuery ? 'Funnel' : 'Trend'}
+                                    {(metric.kind === NodeKind.ExperimentMetric
+                                        ? metric.metric_config.math
+                                        : metric.kind === NodeKind.ExperimentFunnelsQuery
+                                        ? 'Funnel'
+                                        : 'Total'
+                                    ).toUpperCase()}
                                 </LemonTag>
                                 {metric.isSharedMetric && (
                                     <LemonTag type="option" size="small">

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -26,7 +26,7 @@ import { SignificanceText, WinningVariantText } from '../ExperimentView/Overview
 import { SummaryTable } from '../ExperimentView/SummaryTable'
 import { NoResultEmptyState } from './NoResultEmptyState'
 
-function getDefaultMetricTitle(metric: ExperimentMetric): string {
+export function getDefaultMetricTitle(metric: ExperimentMetric): string {
     let parts: (string | undefined)[] = []
     if (metric.metric_config.kind === 'ExperimentEventMetricConfig') {
         parts = [metric.metric_config.math || 'Total', metric.metric_config.math_property, metric.metric_config.event]


### PR DESCRIPTION
## Problem
<img width="294" alt="Screenshot 2025-02-19 at 13 19 48" src="https://github.com/user-attachments/assets/2232ad05-fc4f-4769-a9b4-1022f17746b5" />


## Changes
Use raw event / action name as fallback. Set tag to be metric type.
<img width="282" alt="Screenshot 2025-02-19 at 13 17 11" src="https://github.com/user-attachments/assets/1d02a289-e3fa-4bc6-b660-a5e06943cba1" />


## How did you test this code?
* added some tests
* 👀 