### PR TITLE
feat(cdp): set batch size to meaningful level

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -193,7 +193,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         CDP_REDIS_HOST: '',
         CDP_REDIS_PORT: 6479,
         CDP_CYCLOTRON_BATCH_DELAY_MS: 50,
-        CDP_CYCLOTRON_BATCH_SIZE: 1000,
+        CDP_CYCLOTRON_BATCH_SIZE: 1500,
 
         CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN: '',
 

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -193,7 +193,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         CDP_REDIS_HOST: '',
         CDP_REDIS_PORT: 6479,
         CDP_CYCLOTRON_BATCH_DELAY_MS: 50,
-        CDP_CYCLOTRON_BATCH_SIZE: 1500,
+        CDP_CYCLOTRON_BATCH_SIZE: 300,
 
         CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN: '',
 


### PR DESCRIPTION
## Problem

Seems like someone by hand overwrote the batch_size in k8s meaning this config never applied. The batch_size was set to `50` thats why the cpu ultilization of cyclotron was so low. We currently bumped it and gradually will increase it to 300 which should utilize 1s per batch. This will also help cyclotron to scale up. we will also add it back to the helm charts so the config from plugin server will only be a default we fall back to.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- set batch_size to 300

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
