### PR TITLE
fix(data-warehouse): Check whether the timestamp field is not a datetime

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -384,7 +384,9 @@ def create_hogql_database(
                 expr=parse_expr(warehouse_modifier.id_field),
             )
 
-        if "timestamp" not in warehouse[warehouse_modifier.table_name].fields.keys():
+        if "timestamp" not in warehouse[warehouse_modifier.table_name].fields.keys() or not isinstance(
+            warehouse[warehouse_modifier.table_name].fields.get("timestamp"), DateTimeDatabaseField
+        ):
             table_model = get_table(team=team, warehouse_modifier=warehouse_modifier)
             timestamp_field_type = table_model.get_clickhouse_column_type(warehouse_modifier.timestamp_field)
 


### PR DESCRIPTION
## Problem
- Reported by Abigail [here](https://posthog.slack.com/archives/C075D3C5HST/p1739880400947539?thread_ts=1738750460.830599&cid=C075D3C5HST)
- If a table already has a `timestamp` field which isn't a datetime, then we skip using the UI defined timestamp field in product analytics

## Changes
- Check that the field defined is actually a datetime before skipping

## Does this work well for both Cloud and self-hosted?
Yep

## How did you test this code?
tested locally