### PR TITLE
fix(funnels): hide correlation analysis for non-steps funnels

### DIFF
--- a/frontend/src/scenes/insights/views/Funnels/FunnelCorrelation.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelCorrelation.tsx
@@ -15,10 +15,10 @@ import { FunnelPropertyCorrelationTable } from './FunnelPropertyCorrelationTable
 
 export const FunnelCorrelation = (): JSX.Element | null => {
     const { insightProps } = useValues(insightLogic)
-    const { steps } = useValues(funnelDataLogic(insightProps))
+    const { steps, isStepsFunnel } = useValues(funnelDataLogic(insightProps))
     useMountedLogic(funnelCorrelationUsageLogic(insightProps))
 
-    if (steps.length <= 1) {
+    if (!isStepsFunnel || steps.length <= 1) {
         return null
     }
 


### PR DESCRIPTION
## Problem

We were deciding wether to show the correlation analysis based on wether there are multiple steps. This would usually hide it from trend and time-to-convert funnels. Adding a breakdown to those would however erroneously show the analysis.

See https://posthoghelp.zendesk.com/agent/tickets/24455 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/27556)

## Changes

Adds a check for the viz type as well.

## How did you test this code?

:eyes: