### PR TITLE
chore: run playwright tests on larger depot instance

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -76,7 +76,7 @@ jobs:
 
     playwright:
         name: Playwright E2E tests
-        runs-on: ubuntu-latest
+        runs-on: depot-ubuntu-latest-4
         timeout-minutes: 60
         needs: [changes, container]
         permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,8 @@ yalc.lock
 .flox/env/manifest.lock
 
 playwright/.auth/
+playwright-report/
+test-results/
+playwright/playwright-report/
+playwright/test-results/
+

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
     /* Retry on CI only */
     retries: process.env.CI ? 8 : 2,
     /* Run one worker per core in GitHub Actions. */
-    // workers: process.env.CI ? 4 : undefined,
+    workers: process.env.CI ? 4 : undefined,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     reporter: [['html', { open: 'never' }]],
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
on a GH instance these run with 2 workers and already take ~25 minutes
let's time then on a depot 4