### PR TITLE
chore(remove-source-update-block): Allow editing for all sources

### DIFF
--- a/frontend/src/scenes/data-warehouse/settings/source/SourceConfiguration.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/SourceConfiguration.tsx
@@ -1,9 +1,7 @@
-import { LemonBanner, LemonButton, LemonSkeleton } from '@posthog/lemon-ui'
+import { LemonButton, LemonSkeleton } from '@posthog/lemon-ui'
 import { BindLogic, useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { SourceFormComponent, SourceFormProps } from 'scenes/data-warehouse/external/forms/SourceForm'
-
-import { ExternalDataSourceType } from '~/types'
 
 import { dataWarehouseSourceSettingsLogic } from './dataWarehouseSourceSettingsLogic'
 
@@ -28,23 +26,9 @@ interface UpdateSourceConnectionFormContainerProps extends SourceFormProps {
     id: string
 }
 
-const supportedEditingSourceTypes: ExternalDataSourceType[] = ['MSSQL', 'MySQL', 'Postgres', 'Stripe']
-
 function UpdateSourceConnectionFormContainer(props: UpdateSourceConnectionFormContainerProps): JSX.Element {
     const { source, sourceLoading } = useValues(dataWarehouseSourceSettingsLogic({ id: props.id }))
     const { setSourceConfigValue } = useActions(dataWarehouseSourceSettingsLogic)
-
-    if (!source?.source_type || !supportedEditingSourceTypes.includes(source?.source_type)) {
-        return (
-            <LemonBanner type="warning" className="mt-2">
-                <p>
-                    Only {supportedEditingSourceTypes.slice(0, -1).join(', ')}, and {supportedEditingSourceTypes.at(-1)}{' '}
-                    are configurable. Please delete and recreate your source if you need to connect to a new source of
-                    the same type.
-                </p>
-            </LemonBanner>
-        )
-    }
 
     return (
         <>


### PR DESCRIPTION
## Problem

Since we've added a few workflows to both allow updates for sources and whitelist a series of non-sensitive credentials, it has come time to allow users to update all their sources.

> Note: Not all have been tested, so worth keeping an eye out here.

## Changes
- [x] Drop UI element blocking access.

## Does this work well for both Cloud and self-hosted?
Yes
