### PR TITLE
chore(editor-3001): add resizeable and expandable columns with default width

### DIFF
--- a/frontend/src/lib/components/ExportButton/ExportButton.tsx
+++ b/frontend/src/lib/components/ExportButton/ExportButton.tsx
@@ -16,7 +16,8 @@ export interface ExportButtonItem {
     insight?: number
 }
 
-export interface ExportButtonProps extends Pick<LemonButtonProps, 'disabledReason' | 'icon' | 'type' | 'fullWidth'> {
+export interface ExportButtonProps
+    extends Pick<LemonButtonProps, 'disabledReason' | 'icon' | 'type' | 'fullWidth' | 'size'> {
     items: ExportButtonItem[]
 }
 

--- a/frontend/src/scenes/data-warehouse/editor/DataGrid.scss
+++ b/frontend/src/scenes/data-warehouse/editor/DataGrid.scss
@@ -1,4 +1,5 @@
 .rdg-cell {
+    font-size: 0.75rem;
     border-block-end: 1px solid var(--border);
     border-inline-end: 1px solid var(--border);
 }


### PR DESCRIPTION

## Problem

- when columns have length content they take up all the space

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- add defaults

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
