### PR TITLE
feat: create a limit of async queries made through API

### DIFF
--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -11,7 +11,7 @@ from rest_framework.exceptions import APIException, NotFound
 
 from posthog import celery, redis
 from posthog.clickhouse.client.async_task_chain import add_task_to_on_commit
-from posthog.clickhouse.query_tagging import tag_queries
+from posthog.clickhouse.query_tagging import tag_queries, get_query_tag_value
 from posthog.errors import CHQueryErrorTooManySimultaneousQueries, ExposedCHQueryError
 from posthog.hogql.constants import LimitContext
 from posthog.hogql.errors import ExposedHogQLError
@@ -246,7 +246,8 @@ def enqueue_process_query_task(
     )
     manager.store_query_status(query_status)
 
-    task_signature = process_query_task.si(team.id, user_id, query_id, query_json, LimitContext.QUERY_ASYNC)
+    is_api = get_query_tag_value("access_method") == "personal_api_key"
+    task_signature = process_query_task.si(team.id, user_id, query_id, query_json, is_api, LimitContext.QUERY_ASYNC)
 
     if _test_only_bypass_celery:
         task_signature()

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -59,11 +59,18 @@ def redis_heartbeat() -> None:
     key=lambda *args, **kwargs: kwargs.get("team_id") or args[0],
     limit_name="per_team",
 )  # Do not run too many queries at once for the same team
+@limit_concurrency(
+    5,
+    key=lambda *args, **kwargs: kwargs.get("team_id") or args[0],
+    applicable=lambda *args, **kwargs: (kwargs.get("is_api") or args[4]),
+    limit_name="api_per_team",
+)  # Do not run too many queries at once for the same team
 def process_query_task(
     team_id: int,
     user_id: Optional[int],
     query_id: str,
     query_json: dict,
+    is_api: bool,
     limit_context: Optional[LimitContext] = None,
 ) -> None:
     """


### PR DESCRIPTION
## Problem

Some heavy API users overload ClickHouse

## Changes

Add is_api to concurrency limiter.

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Run it.