### PR TITLE
fix(logging): tweak log line formatting

### DIFF
--- a/plugin-server/src/cdp/services/hog-function-manager.service.ts
+++ b/plugin-server/src/cdp/services/hog-function-manager.service.ts
@@ -259,13 +259,11 @@ export class HogFunctionManagerService {
                     const decrypted = this.hub.encryptedFields.decrypt(encryptedInputsString || '')
                     item.encrypted_inputs = decrypted ? JSON.parse(decrypted) : {}
                 } catch (error) {
-                    status.error(
-                        '🍿',
-                        'Error parsing encrypted inputs:',
-                        typeof encryptedInputsString,
-                        encryptedInputsString,
-                        error
-                    )
+                    status.error('🍿', 'Error parsing encrypted inputs:', {
+                        encStrTyoe: typeof encryptedInputsString,
+                        encStr: encryptedInputsString,
+                        cause: error,
+                    })
                     captureException(error)
                     // Quietly fail - not ideal but better then crashing out
                 }


### PR DESCRIPTION
## Problem
I held `status.error` wrong in [this PR](https://github.com/PostHog/posthog/pull/28876) 😆 let's fix it!

## Changes
Wrap detail KVs in an object

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally