### PR TITLE
fix(cdp): fix unwanted caching of integrations

### DIFF
--- a/plugin-server/src/cdp/services/hog-function-manager.service.test.ts
+++ b/plugin-server/src/cdp/services/hog-function-manager.service.test.ts
@@ -440,3 +440,96 @@ describe('Hogfunction Manager - Execution Order', () => {
         ])
     })
 })
+
+describe('HogFunctionManager - Integration Updates', () => {
+    let hub: Hub
+    let manager: HogFunctionManagerService
+    let teamId: number
+    let integration: IntegrationType
+
+    beforeEach(async () => {
+        hub = await createHub()
+        await resetTestDatabase()
+        manager = new HogFunctionManagerService(hub)
+
+        const team = await hub.db.fetchTeam(2)
+        teamId = await createTeam(hub.db.postgres, team!.organization_id)
+
+        // Create an integration
+        integration = await insertIntegration(hub.postgres, teamId, {
+            kind: 'slack',
+            config: { team: 'initial-team' },
+            sensitive_config: {
+                access_token: hub.encryptedFields.encrypt('initial-token'),
+            },
+        })
+
+        // Create a hog function that uses this integration
+        await insertHogFunction(hub.postgres, teamId, {
+            name: 'Test Integration Updates',
+            inputs_schema: [
+                {
+                    type: 'integration',
+                    key: 'slack',
+                },
+            ],
+            inputs: {
+                slack: {
+                    value: integration.id,
+                },
+            },
+        })
+
+        await manager.start(['destination'])
+    })
+
+    afterEach(async () => {
+        await manager.stop()
+        await closeHub(hub)
+    })
+
+    it('updates cached integration data when integration changes', async () => {
+        // First check - initial state
+        const functions = manager.getTeamHogFunctions(teamId)
+        expect(functions[0]?.inputs?.slack.value).toEqual({
+            team: 'initial-team',
+            access_token: 'initial-token',
+        })
+
+        // Update the integration in the database
+        await hub.db.postgres.query(
+            PostgresUse.COMMON_WRITE,
+            `UPDATE posthog_integration 
+             SET config = jsonb_set(config, '{team}', '"updated-team"'::jsonb),
+                 sensitive_config = jsonb_set(sensitive_config, '{access_token}', $1::jsonb)
+             WHERE id = $2`,
+            [JSON.stringify(hub.encryptedFields.encrypt('updated-token')), integration.id],
+            'updateIntegration'
+        )
+
+        await manager.reloadIntegrations(teamId, [integration.id])
+
+        // Verify the database update worked
+        const updatedIntegration = await hub.db.postgres.query(
+            PostgresUse.COMMON_READ,
+            `SELECT config, sensitive_config FROM posthog_integration WHERE id = $1`,
+            [integration.id],
+            'fetchUpdatedIntegration'
+        )
+
+        // assert the integration was updated
+        expect(updatedIntegration.rows[0].config).toEqual({ team: 'updated-team' })
+        expect(hub.encryptedFields.decrypt(updatedIntegration.rows[0].sensitive_config.access_token)).toEqual(
+            'updated-token'
+        )
+
+        // Trigger integration reload
+        await manager.reloadAllIntegrations()
+        // Check if the cached data was updated
+        const newFunctions = manager.getTeamHogFunctions(teamId)
+        expect(newFunctions[0]?.inputs?.slack.value).toEqual({
+            team: 'updated-team',
+            access_token: 'updated-token',
+        })
+    })
+})


### PR DESCRIPTION
## Problem

The HogFunctionManager service was not properly handling integration updates, leading to stale data in the cache. When an integration's configuration was updated, the cached hog functions would still show the old integration data because:

1. We were only mutating copies of objects during enrichment, not updating the base cache
2. We weren't properly invalidating and refreshing caches when integration data changed
3. The ordered cache for teams wasn't being cleared when integration data changed

This could lead to outdated integration configurations being used in hog functions until the next full reload.

## Changes

Implemented a robust caching strategy for integration updates:

1. In `reloadIntegrations`:
   - Find all hog functions that depend on the updated integrations
   - Delete them from `this.hogFunctions` cache
   - Clear the `orderedHogFunctionsCache` for affected teams
   - Fetch fresh copies from the database
   - Update caches with fresh data
   - Re-enrich with latest integration data

2. Similar improvements for `reloadAllIntegrations`:
   - Clear all affected functions from cache
   - Clear all team caches (since we don't know which teams are affected)
   - Fetch fresh copies of all functions
   - Update caches with fresh data
   - Re-enrich with latest integration data

The key insight was that we needed to fetch fresh copies of hog functions from the database when integrations change, rather than trying to update the cached copies in place.

Risk: we fetch all related hogFunctions fresh that depend on integrations which will increase db load every 5 minutes since we reload all integrations every 5 minutes.

## How did you test this code?

1. Added comprehensive test that:
   - Creates an integration and hog function
   - Updates the integration's config and sensitive_config
   - Verifies the database update worked
   - Checks that the cached hog function data is updated
   - Ensures the changes persist after cache invalidation