### PR TITLE
chore(flags): Add sentry exception capture when error occurs during processing feature flag scheduled changes

### DIFF
--- a/posthog/tasks/process_scheduled_changes.py
+++ b/posthog/tasks/process_scheduled_changes.py
@@ -1,12 +1,10 @@
-import structlog
 from posthog.models import ScheduledChange
 from django.utils import timezone
+from posthog.exceptions_capture import capture_exception
 from posthog.models import FeatureFlag
 from django.db import transaction, OperationalError
 
 models = {"FeatureFlag": FeatureFlag}
-
-logger = structlog.get_logger(__name__)
 
 
 def process_scheduled_changes() -> None:
@@ -37,7 +35,7 @@ def process_scheduled_changes() -> None:
                     scheduled_change.failure_reason = str(e)
                     scheduled_change.executed_at = timezone.now()
                     scheduled_change.save()
-                    logger.exception("Failed to process scheduled change", exc_info=e)
+                    capture_exception(e)
     except OperationalError:
         # Failed to obtain the lock
         pass

--- a/posthog/tasks/process_scheduled_changes.py
+++ b/posthog/tasks/process_scheduled_changes.py
@@ -33,11 +33,11 @@ def process_scheduled_changes() -> None:
                     scheduled_change.save()
 
                 except Exception as e:
-                    logger.exception("Failed to process scheduled change", exc_info=e)
                     # Store the failure reason
                     scheduled_change.failure_reason = str(e)
                     scheduled_change.executed_at = timezone.now()
                     scheduled_change.save()
+                    logger.exception("Failed to process scheduled change", exc_info=e)
     except OperationalError:
         # Failed to obtain the lock
         pass

--- a/posthog/tasks/process_scheduled_changes.py
+++ b/posthog/tasks/process_scheduled_changes.py
@@ -1,9 +1,12 @@
+import structlog
 from posthog.models import ScheduledChange
 from django.utils import timezone
 from posthog.models import FeatureFlag
 from django.db import transaction, OperationalError
 
 models = {"FeatureFlag": FeatureFlag}
+
+logger = structlog.get_logger(__name__)
 
 
 def process_scheduled_changes() -> None:
@@ -30,6 +33,7 @@ def process_scheduled_changes() -> None:
                     scheduled_change.save()
 
                 except Exception as e:
+                    logger.exception("Failed to process scheduled change", exc_info=e)
                     # Store the failure reason
                     scheduled_change.failure_reason = str(e)
                     scheduled_change.executed_at = timezone.now()


### PR DESCRIPTION
## Problem

We have some intermittent scheduled changes failures whose `failure_reason` is simply `'project_id'`: 

https://metabase.prod-us.posthog.dev/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJkYXRhYmFzZSI6MzQsIm5hdGl2ZSI6eyJxdWVyeSI6InNlbGVjdCAqIGZyb20gcG9zdGhvZ19zY2hlZHVsZWRjaGFuZ2Ugd2hlcmUgZmFpbHVyZV9yZWFzb24gPSAnJydwcm9qZWN0X2lkJycnO1xuXG5zZWxlY3QgKiBmcm9tIHBvc3Rob2dfdGVhbSB3aGVyZSBpZCA9IDEwNTA4NDtcbnNlbGVjdCAqIGZyb20gcG9zdGhvZ19wcm9qZWN0IHdoZXJlIGlkID0gMTA1MDg0OyIsInRlbXBsYXRlLXRhZ3MiOnt9fX0sImRpc3BsYXkiOiJ0YWJsZSIsInBhcmFtZXRlcnMiOltdLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fX0=

## Changes

Do a `capture_exception` to try and collect more info about this issue in Sentry

These scheduled changes errors are [not common in general](https://metabase.prod-us.posthog.dev/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJkYXRhYmFzZSI6MzQsIm5hdGl2ZSI6eyJxdWVyeSI6InNlbGVjdCAqIGZyb20gcG9zdGhvZ19zY2hlZHVsZWRjaGFuZ2Ugd2hlcmUgZmFpbHVyZV9yZWFzb24gaXMgbm90IG51bGw7XG5cbnNlbGVjdCAqIGZyb20gcG9zdGhvZ190ZWFtIHdoZXJlIGlkID0gMTA1MDg0O1xuc2VsZWN0ICogZnJvbSBwb3N0aG9nX3Byb2plY3Qgd2hlcmUgaWQgPSAxMDUwODQ7IiwidGVtcGxhdGUtdGFncyI6e319fSwiZGlzcGxheSI6InRhYmxlIiwicGFyYW1ldGVycyI6W10sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnt9fQ==) and shouldn't eat up Sentry quotas

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

n/a