### PR TITLE
fix: modal with pricing tiers for plans with one unlimited tier

### DIFF
--- a/frontend/src/scenes/billing/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.tsx
@@ -35,7 +35,9 @@ export const getTierDescription = (
     interval: string
 ): string => {
     return i === 0
-        ? `First ${summarizeUsage(tiers[i].up_to)} ${product.unit}s / ${interval}`
+        ? tiers[i].up_to
+            ? `First ${summarizeUsage(tiers[i].up_to)} ${product.unit}s / ${interval}`
+            : `All ${product.unit}s`
         : tiers[i].up_to
         ? `${summarizeUsage(tiers?.[i - 1].up_to || null)} - ${summarizeUsage(tiers[i].up_to)}`
         : `> ${summarizeUsage(tiers?.[i - 1].up_to || null)}`

--- a/frontend/src/scenes/billing/ProductPricingModal.tsx
+++ b/frontend/src/scenes/billing/ProductPricingModal.tsx
@@ -36,7 +36,9 @@ export const ProductPricingModal = ({
                         <span className="font-bold text-base">
                             $
                             {parseFloat(
-                                isFirstTierFree ? tiers?.[1]?.unit_amount_usd : tiers?.[0]?.unit_amount_usd
+                                isFirstTierFree && tiers?.[1]?.unit_amount_usd
+                                    ? tiers?.[1]?.unit_amount_usd
+                                    : tiers?.[0]?.unit_amount_usd
                             ).toFixed(numberOfSigFigs)}
                         </span>
                         {/* the product types we have are plural, so we need to singularlize them and this works for now */}


### PR DESCRIPTION
## Problem

The pricing modal that shows the price break down per tier was broken if the current plan had only one unlimited plan, as can be seen in the screenshot below:

<img width="438" alt="image" src="https://github.com/user-attachments/assets/10ee261b-0a23-4435-a81d-6b9e41afd2fa" />


## Changes

This is how it looks now after the fix:

<img width="513" alt="image" src="https://github.com/user-attachments/assets/cc2fe8df-a309-4713-a67e-9cd196d5f467" />

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Only cloud

## How did you test this code?

I tested locally with a customer, changing to different plans and see that it didn't break any of the current plans/pricing, and it fixed the problem with the plan that previously was broken.
