### PR TITLE
fix: require two members to complete invitation task

### DIFF
--- a/frontend/src/scenes/organization/membersLogic.tsx
+++ b/frontend/src/scenes/organization/membersLogic.tsx
@@ -169,7 +169,7 @@ export const membersLogic = kea<membersLogicType>([
             }
         },
         loadAllMembersSuccess: ({ members }) => {
-            if (members && members.length > 0) {
+            if (members && members.length > 1) {
                 activationLogic.findMounted()?.actions?.markTaskAsCompleted(ActivationTask.InviteTeamMember)
             }
         },


### PR DESCRIPTION
## Problem

We are checking off the task of inviting members if we find >0 members, but the current user is a member.

## Changes

Require two members to check off the task (in addition to the existing invitation checks)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manually
