### PR TITLE
fix: alter the distributed table in coord, instead of the sharded one

### DIFF
--- a/posthog/clickhouse/migrations/0100_sessions_v2_irclid_kx.py
+++ b/posthog/clickhouse/migrations/0100_sessions_v2_irclid_kx.py
@@ -18,7 +18,7 @@ operations = [
     run_sql_with_exceptions(BASE_RAW_SESSIONS_ADD_IRCLID_KX_COLUMNS_SQL()),
     run_sql_with_exceptions(DISTRIBUTED_RAW_SESSIONS_ADD_IRCLID_KX_COLUMNS_SQL()),
     run_sql_with_exceptions(
-        DISTRIBUTED_RAW_SESSIONS_ADD_IRCLID_KX_COLUMNS_SQL(on_cluster=False), node_role=NodeRole.COORDINATOR
+        BASE_RAW_SESSIONS_ADD_IRCLID_KX_COLUMNS_SQL(on_cluster=False), node_role=NodeRole.COORDINATOR
     ),
     run_sql_with_exceptions(WRITABLE_RAW_SESSIONS_ADD_IRCLID_KX_COLUMNS_SQL()),
     # and then recreate the materialized view and view


### PR DESCRIPTION
## Problem

The naming is a bit misleading, so we were updating the sharded table instead of the distributed one.

## Changes

This actually alters the distributed table.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
Yes

