### PR TITLE
feat(experiments): only show supported math types

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
@@ -1,13 +1,18 @@
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
 import { ActionFilter } from 'scenes/insights/filters/ActionFilter/ActionFilter'
-import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
 
 import { Query } from '~/queries/Query/Query'
 import { ExperimentMetric, ExperimentMetricType, NodeKind } from '~/queries/schema/schema-general'
 import { FilterType } from '~/types'
 
 import { commonActionFilterProps } from './Metrics/Selectors'
-import { filterToMetricConfig, metricConfigToFilter, metricToQuery } from './utils'
+import {
+    filterToMetricConfig,
+    getAllowedMathTypes,
+    getMathAvailability,
+    metricConfigToFilter,
+    metricToQuery,
+} from './utils'
 
 export function ExperimentMetricForm({
     metric,
@@ -16,6 +21,9 @@ export function ExperimentMetricForm({
     metric: ExperimentMetric
     handleSetMetric: any
 }): JSX.Element {
+    const mathAvailability = getMathAvailability(metric.metric_type)
+    const allowedMathTypes = getAllowedMathTypes(metric.metric_type)
+
     return (
         <div className="space-y-4">
             <div>
@@ -24,10 +32,15 @@ export function ExperimentMetricForm({
                     data-attr="metrics-selector"
                     value={metric.metric_type}
                     onChange={(newMetricType: ExperimentMetricType) => {
+                        const newAllowedMathTypes = getAllowedMathTypes(newMetricType)
                         handleSetMetric({
                             newMetric: {
                                 ...metric,
                                 metric_type: newMetricType,
+                                metric_config: {
+                                    ...metric.metric_config,
+                                    math: newAllowedMathTypes[0],
+                                },
                             },
                         })
                     }}
@@ -68,7 +81,8 @@ export function ExperimentMetricForm({
                 hideRename={true}
                 entitiesLimit={1}
                 showNumericalPropsOnly={true}
-                mathAvailability={MathAvailability.All}
+                mathAvailability={mathAvailability}
+                allowedMathTypes={allowedMathTypes}
                 {...commonActionFilterProps}
             />
             <Query

--- a/frontend/src/scenes/experiments/Metrics/TrendsMetricForm.tsx
+++ b/frontend/src/scenes/experiments/Metrics/TrendsMetricForm.tsx
@@ -18,7 +18,7 @@ import { Query } from '~/queries/Query/Query'
 import { ExperimentTrendsQuery, InsightQueryNode, NodeKind } from '~/queries/schema/schema-general'
 import { BaseMathType, ChartDisplayType, FilterType } from '~/types'
 
-import { EXPERIMENT_ALLOWED_MATH_TYPES } from '../constants'
+import { LEGACY_EXPERIMENT_ALLOWED_MATH_TYPES } from '../constants'
 import { experimentLogic } from '../experimentLogic'
 import { commonActionFilterProps } from './Selectors'
 
@@ -99,7 +99,7 @@ export function TrendsMetricForm({ isSecondary = false }: { isSecondary?: boolea
                                     showSeriesIndicator={true}
                                     entitiesLimit={1}
                                     showNumericalPropsOnly={true}
-                                    allowedMathTypes={EXPERIMENT_ALLOWED_MATH_TYPES}
+                                    allowedMathTypes={LEGACY_EXPERIMENT_ALLOWED_MATH_TYPES}
                                     {...commonActionFilterProps}
                                 />
                                 <div className="mt-4 space-y-4">

--- a/frontend/src/scenes/experiments/SharedMetrics/LegacySharedTrendsMetricForm.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/LegacySharedTrendsMetricForm.tsx
@@ -15,7 +15,7 @@ import { Query } from '~/queries/Query/Query'
 import { ExperimentTrendsQuery, InsightQueryNode, NodeKind } from '~/queries/schema/schema-general'
 import { BaseMathType, ChartDisplayType, FilterType } from '~/types'
 
-import { EXPERIMENT_ALLOWED_MATH_TYPES } from '../constants'
+import { LEGACY_EXPERIMENT_ALLOWED_MATH_TYPES } from '../constants'
 import { commonActionFilterProps } from '../Metrics/Selectors'
 import { sharedMetricLogic } from './sharedMetricLogic'
 
@@ -67,7 +67,7 @@ export function LegacySharedTrendsMetricForm(): JSX.Element {
                                     showSeriesIndicator={true}
                                     entitiesLimit={1}
                                     showNumericalPropsOnly={true}
-                                    allowedMathTypes={EXPERIMENT_ALLOWED_MATH_TYPES}
+                                    allowedMathTypes={LEGACY_EXPERIMENT_ALLOWED_MATH_TYPES}
                                     {...commonActionFilterProps}
                                 />
                                 <div className="mt-4 space-y-4">
@@ -225,7 +225,7 @@ export function LegacySharedTrendsMetricForm(): JSX.Element {
                                             showSeriesIndicator={true}
                                             entitiesLimit={1}
                                             showNumericalPropsOnly={true}
-                                            allowedMathTypes={EXPERIMENT_ALLOWED_MATH_TYPES}
+                                            allowedMathTypes={LEGACY_EXPERIMENT_ALLOWED_MATH_TYPES}
                                             {...commonActionFilterProps}
                                         />
                                         <div className="mt-4 space-y-4">

--- a/frontend/src/scenes/experiments/constants.ts
+++ b/frontend/src/scenes/experiments/constants.ts
@@ -8,7 +8,7 @@ export enum MetricInsightId {
     SecondaryFunnels = 'new-experiment-secondary-funnels',
 }
 
-export const EXPERIMENT_ALLOWED_MATH_TYPES = [
+export const LEGACY_EXPERIMENT_ALLOWED_MATH_TYPES = [
     BaseMathType.TotalCount,
     BaseMathType.UniqueUsers,
     BaseMathType.UniqueSessions,

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -501,8 +501,6 @@ export function getMathAvailability(metricType: ExperimentMetricType): MathAvail
     switch (metricType) {
         case ExperimentMetricType.COUNT:
             return MathAvailability.None
-        case ExperimentMetricType.FUNNEL:
-            return MathAvailability.None
         case ExperimentMetricType.CONTINUOUS:
             return MathAvailability.All
         default:

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -515,7 +515,7 @@ export function getAllowedMathTypes(metricType: ExperimentMetricType): string[] 
         case ExperimentMetricType.COUNT:
             return [BaseMathType.TotalCount]
         case ExperimentMetricType.CONTINUOUS:
-            return [PropertyMathType.Sum, PropertyMathType.Average]
+            return [PropertyMathType.Sum]
         default:
             return [BaseMathType.TotalCount]
     }

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -2,6 +2,7 @@ import { getSeriesColor } from 'lib/colors'
 import { EXPERIMENT_DEFAULT_DURATION, FunnelLayout } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import merge from 'lodash.merge'
+import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
 
 import {
     AnyEntityNode,
@@ -20,6 +21,7 @@ import {
 } from '~/queries/schema/schema-general'
 import { isFunnelsQuery, isNodeWithSource, isTrendsQuery, isValidQueryForExperiment } from '~/queries/utils'
 import {
+    BaseMathType,
     ChartDisplayType,
     FeatureFlagFilters,
     FeatureFlagType,
@@ -493,4 +495,30 @@ export function metricToQuery(metric: ExperimentMetric): TrendsQuery | undefined
     }
 
     return undefined
+}
+
+export function getMathAvailability(metricType: ExperimentMetricType): MathAvailability {
+    switch (metricType) {
+        case ExperimentMetricType.COUNT:
+            return MathAvailability.None
+        case ExperimentMetricType.FUNNEL:
+            return MathAvailability.None
+        case ExperimentMetricType.CONTINUOUS:
+            return MathAvailability.All
+        default:
+            return MathAvailability.None
+    }
+}
+
+export function getAllowedMathTypes(metricType: ExperimentMetricType): string[] {
+    switch (metricType) {
+        case ExperimentMetricType.COUNT:
+            return [BaseMathType.TotalCount]
+        case ExperimentMetricType.CONTINUOUS:
+            return [PropertyMathType.Sum, PropertyMathType.Average]
+        case ExperimentMetricType.FUNNEL:
+            return [BaseMathType.TotalCount]
+        default:
+            return [BaseMathType.TotalCount]
+    }
 }

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -516,8 +516,6 @@ export function getAllowedMathTypes(metricType: ExperimentMetricType): string[] 
             return [BaseMathType.TotalCount]
         case ExperimentMetricType.CONTINUOUS:
             return [PropertyMathType.Sum, PropertyMathType.Average]
-        case ExperimentMetricType.FUNNEL:
-            return [BaseMathType.TotalCount]
         default:
             return [BaseMathType.TotalCount]
     }

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -660,6 +660,20 @@ function isCountPerActorMath(math: string | undefined): math is CountPerActorMat
 
 const TRAILING_MATH_TYPES = new Set<string>([BaseMathType.WeeklyActiveUsers, BaseMathType.MonthlyActiveUsers])
 
+function getDefaultPropertyMathType(
+    math: string | undefined,
+    allowedMathTypes: readonly string[] | undefined
+): PropertyMathType {
+    if (isPropertyValueMath(math)) {
+        return math
+    }
+    if (allowedMathTypes?.length) {
+        const propertyMathTypes = allowedMathTypes.filter(isPropertyValueMath)
+        return (propertyMathTypes[0] as PropertyMathType) || PropertyMathType.Average
+    }
+    return PropertyMathType.Average
+}
+
 function useMathSelectorOptions({
     math,
     index,
@@ -681,16 +695,9 @@ function useMathSelectorOptions({
         staticActorsOnlyMathDefinitions,
     } = useValues(mathsLogic)
 
-    const [propertyMathTypeShown, setPropertyMathTypeShown] = useState<PropertyMathType>(() => {
-        if (isPropertyValueMath(math)) {
-            return math
-        }
-        if (allowedMathTypes?.length) {
-            // filter out non-property math types
-            return allowedMathTypes.filter(isPropertyValueMath)[0] as PropertyMathType
-        }
-        return PropertyMathType.Average
-    })
+    const [propertyMathTypeShown, setPropertyMathTypeShown] = useState<PropertyMathType>(
+        getDefaultPropertyMathType(math, allowedMathTypes)
+    )
 
     const [countPerActorMathTypeShown, setCountPerActorMathTypeShown] = useState<CountPerActorMathType>(
         isCountPerActorMath(math) ? math : CountPerActorMathType.Average


### PR DESCRIPTION
## Problem
In the new metric form, we currently show unsupported math types.

## Changes
Only show the math types we currently support. For the `count` metric type, hide the drop down completely as only "Total count" is allowed. The idea is to only show what we currently support, then add more math types as we update the backend to support it.
<img width="1021" alt="Screenshot 2025-02-19 at 12 47 50" src="https://github.com/user-attachments/assets/e3ebf597-c053-41f7-8ef0-142098751712" />

For continuous, only show `sum` for now.
<img width="1024" alt="Screenshot 2025-02-19 at 12 51 07" src="https://github.com/user-attachments/assets/6a84eeb8-f415-4ede-a63f-77f52f7bc0d3" />

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## How did you test this code?
👀 
