### PR TITLE
fix(dev): Drop `-n` from `wait` in `bin/start-rust-service`

### DIFF
--- a/bin/start-rust-service
+++ b/bin/start-rust-service
@@ -92,7 +92,7 @@ while true; do
 
   # restart subprocess if it fails without bin/start shutdown
   set +e
-  wait -n $RS_PID
+  wait $RS_PID
   set -e
 
   sleep 3


### PR DESCRIPTION
From https://github.com/PostHog/posthog/pull/28681

## Problem

I'm seeing this error in my logs:

```
bin/start-rust-service: line 95: wait: -n: invalid option
wait: usage: wait [n]
```

Bash 3.2.57 on Mac.

## Changes

Drops the `-n` argument. I _think_ the `-n` argument means "wait for any child process", which means the `$PID` ignored anyway. 

## How did you test this code?

Warning no longer appears.

I also killed the child process and verified the process restarted as expected.
