### PR TITLE
fix(prop-defs): Fix leftover `team_id` prop def lookup in API

### DIFF
--- a/posthog/api/test/test_property_definition.py
+++ b/posthog/api/test/test_property_definition.py
@@ -451,6 +451,61 @@ class TestPropertyDefinitionAPI(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {"custom_event": False, "$pageview": False}
 
+    def test_property_definition_project_id_coalesce(self):
+        # Create legacy property with only team_id (old style)
+        PropertyDefinition.objects.create(team=self.team, name="legacy_team_prop", property_type="String")
+        # Create property with explicit project_id set (new style)
+        PropertyDefinition.objects.create(
+            team=self.team,
+            project_id=self.team.pk,  # Explicitly set project_id
+            name="newer_prop",
+            property_type="String",
+        )
+        # Create property for another team to verify isolation
+        other_team = Team.objects.create(organization=self.organization)
+        PropertyDefinition.objects.create(team=other_team, name="other_team_prop", property_type="String")
+
+        response = self.client.get(f"/api/projects/{self.team.pk}/property_definitions/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Should return properties with either project_id or team_id matching
+        property_names = {p["name"] for p in response.json()["results"]}
+        self.assertIn("legacy_team_prop", property_names)  # Found via team_id
+        self.assertIn("newer_prop", property_names)  # Found via project_id
+        self.assertNotIn("other_team_prop", property_names)  # Different team, should not be found
+
+    def test_property_definition_project_id_coalesce_detail(self):
+        # Create legacy property with only team_id (old style)
+        legacy_prop = PropertyDefinition.objects.create(team=self.team, name="legacy_team_prop", property_type="String")
+
+        # Create property with explicit project_id set (new style)
+        newer_prop = PropertyDefinition.objects.create(
+            team=self.team,
+            project_id=self.team.pk,  # Explicitly set project_id
+            name="newer_prop",
+            property_type="String",
+        )
+
+        # Create property for another team to verify isolation
+        other_team = Team.objects.create(organization=self.organization)
+        other_team_prop = PropertyDefinition.objects.create(
+            team=other_team, name="other_team_prop", property_type="String"
+        )
+
+        # Test retrieving legacy property
+        response = self.client.get(f"/api/projects/{self.team.pk}/property_definitions/{legacy_prop.id}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["name"], "legacy_team_prop")
+
+        # Test retrieving newer property
+        response = self.client.get(f"/api/projects/{self.team.pk}/property_definitions/{newer_prop.id}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["name"], "newer_prop")
+
+        # Test retrieving other team's property should fail
+        response = self.client.get(f"/api/projects/{self.team.pk}/property_definitions/{other_team_prop.id}")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
 
 class TestPropertyDefinitionQuerySerializer(BaseTest):
     def test_validation(self):

--- a/posthog/api/test/test_property_definition.py
+++ b/posthog/api/test/test_property_definition.py
@@ -465,7 +465,7 @@ class TestPropertyDefinitionAPI(APIBaseTest):
         other_team = Team.objects.create(organization=self.organization)
         PropertyDefinition.objects.create(team=other_team, name="other_team_prop", property_type="String")
 
-        response = self.client.get(f"/api/projects/{self.team.pk}/property_definitions/")
+        response = self.client.get(f"/api/projects/{self.project.id}/property_definitions/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # Should return properties with either project_id or team_id matching
@@ -493,17 +493,17 @@ class TestPropertyDefinitionAPI(APIBaseTest):
         )
 
         # Test retrieving legacy property
-        response = self.client.get(f"/api/projects/{self.team.pk}/property_definitions/{legacy_prop.id}")
+        response = self.client.get(f"/api/projects/{self.project.id}/property_definitions/{legacy_prop.id}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["name"], "legacy_team_prop")
 
         # Test retrieving newer property
-        response = self.client.get(f"/api/projects/{self.team.pk}/property_definitions/{newer_prop.id}")
+        response = self.client.get(f"/api/projects/{self.project.id}/property_definitions/{newer_prop.id}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["name"], "newer_prop")
 
         # Test retrieving other team's property should fail
-        response = self.client.get(f"/api/projects/{self.team.pk}/property_definitions/{other_team_prop.id}")
+        response = self.client.get(f"/api/projects/{self.project.id}/property_definitions/{other_team_prop.id}")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
 

--- a/posthog/taxonomy/property_definition_api.py
+++ b/posthog/taxonomy/property_definition_api.py
@@ -570,7 +570,7 @@ class PropertyDefinitionViewSet(
                     EnterprisePropertyDefinition.objects.alias(
                         effective_project_id=Coalesce("project_id", "team_id", output_field=models.BigIntegerField())
                     )
-                    .filter(id=id, effective_project_id=self.project_id)
+                    .filter(id=id, effective_project_id=self.project_id)  # type: ignore
                     .first()
                 )
                 if enterprise_property:

--- a/posthog/taxonomy/property_definition_api.py
+++ b/posthog/taxonomy/property_definition_api.py
@@ -4,6 +4,7 @@ from django.db.models.functions import Coalesce
 from typing import Any, Optional, cast, Self
 
 from django.db import connection, models
+from django.shortcuts import get_object_or_404
 from loginas.utils import is_impersonated_session
 from rest_framework import mixins, request, response, serializers, status, viewsets
 from posthog.api.utils import action
@@ -551,6 +552,13 @@ class PropertyDefinitionViewSet(
 
     def safely_get_object(self, queryset):
         id = self.kwargs["id"]
+        non_enterprise_property = get_object_or_404(
+            PropertyDefinition.objects.alias(
+                effective_project_id=Coalesce("project_id", "team_id", output_field=models.BigIntegerField())
+            ),
+            id=id,
+            effective_project_id=self.project_id,
+        )
         if self.request.user.organization.is_feature_available(AvailableFeature.INGESTION_TAXONOMY):
             try:
                 # noinspection PyUnresolvedReferences
@@ -558,17 +566,22 @@ class PropertyDefinitionViewSet(
             except ImportError:
                 pass
             else:
-                enterprise_property = EnterprisePropertyDefinition.objects.filter(id=id, team_id=self.team_id).first()
+                enterprise_property = (
+                    EnterprisePropertyDefinition.objects.alias(
+                        effective_project_id=Coalesce("project_id", "team_id", output_field=models.BigIntegerField())
+                    )
+                    .filter(id=id, effective_project_id=self.project_id)
+                    .first()
+                )
                 if enterprise_property:
                     return enterprise_property
-                non_enterprise_property = PropertyDefinition.objects.get(id=id, team_id=self.team_id)
                 new_enterprise_property = EnterprisePropertyDefinition(
                     propertydefinition_ptr_id=non_enterprise_property.id, description=""
                 )
                 new_enterprise_property.__dict__.update(non_enterprise_property.__dict__)
                 new_enterprise_property.save()
                 return new_enterprise_property
-        return PropertyDefinition.objects.get(id=id, team_id=self.team_id)
+        return non_enterprise_property
 
     @extend_schema(parameters=[PropertyDefinitionQuerySerializer])
     def list(self, request, *args, **kwargs):


### PR DESCRIPTION
## Problem

We still had one call site filtering `PropertyDefinition.objects` on `team_id=`, instead of `effective_project_id=` (which is project_id and team_id coalesced). This resulted in some 500s.

## Changes

Fixed property definition filtering to coalesce project_id and team_id.

## How did you test this code?

Added API tests.