### PR TITLE
fix: restore tailwind jit rescan

### DIFF
--- a/common/esbuilder/utils.mjs
+++ b/common/esbuilder/utils.mjs
@@ -30,6 +30,12 @@ export function copyPublicFolder(srcDir, destDir) {
     })
 }
 
+/** Update the file's modified and accessed times to now. */
+async function touchFile(file) {
+    const now = new Date()
+    await fs.utimes(file, now, now)
+}
+
 export function copyIndexHtml(
     absWorkingDir = '.',
     from = 'src/index.html',
@@ -384,6 +390,11 @@ export async function buildOrWatch(config) {
                 }
 
                 if (inputFiles.has(filePath) || filePath === tailwindConfigJsPath) {
+                    if (filePath.match(/\.tsx?$/) || filePath === tailwindConfigJsPath) {
+                        // For changed TS/TSX files, we need to initiate a Tailwind JIT rescan
+                        // in case any new utility classes are used. `touch`ing `base.scss` (or the file that imports tailwind.css) achieves this.
+                        await touchFile(path.resolve(absWorkingDir, 'src/styles/base.scss'))
+                    }
                     void debouncedBuild()
                 }
             })


### PR DESCRIPTION
## Problem
Tailwind wasn't watching for changes in our files and wasn't registering new classes. 

**How it is now**:
building a class such as `<div className="w-[22px]">` didn't build the class into our tailwind output (you would have to rebuild the frontend)

I removed the 'touching' file condition by accident, which enabled tailwind to do a rescan, this PR restores that functionality.

## Changes
* add back the touching of the `.scss` file that imports tailwind css

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
it should

## How did you test this code?
Added in some arbitrary tailwind classes and re-scanning functions as intended.