### PR TITLE
fix: return an error on invalid type

### DIFF
--- a/plugin-server/src/cdp/cdp-api.test.ts
+++ b/plugin-server/src/cdp/cdp-api.test.ts
@@ -144,7 +144,7 @@ describe('CDP API', () => {
             .post(`/api/projects/${hogFunction.team_id}/hog_functions/new/invocations`)
             .send({ globals })
 
-        expect(res.status).toEqual(200)
+        expect(res.status).toEqual(400)
     })
 
     it('can invoke a function via the API with mocks', async () => {

--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -263,6 +263,8 @@ export class CdpApi {
                         errors.push(invocationResult.error)
                     }
                 }
+            } else {
+                return res.status(400).json({ error: 'Invalid function type' })
             }
 
             res.json({


### PR DESCRIPTION
Testing internal events doesn't work at all but returns a 200 implying it does