### PR TITLE
fix(data-warehouse): Change how we connect with psycopg

### DIFF
--- a/posthog/temporal/data_imports/pipelines/postgres/postgres.py
+++ b/posthog/temporal/data_imports/pipelines/postgres/postgres.py
@@ -185,7 +185,16 @@ def postgres_source(
         raise ValueError("Table name is missing")
 
     with psycopg.connect(
-        f"postgresql://{user}:{password}@{host}:{port}/{database}?sslmode={sslmode}&connect_timeout=5",
+        host=host,
+        port=port,
+        dbname=database,
+        user=user,
+        password=password,
+        sslmode=sslmode,
+        connect_timeout=5,
+        sslrootcert="/tmp/no.txt",
+        sslcert="/tmp/no.txt",
+        sslkey="/tmp/no.txt",
     ) as connection:
         with connection.cursor() as cursor:
             primary_keys = _get_primary_keys(cursor, schema, table_name)
@@ -200,7 +209,16 @@ def postgres_source(
         arrow_schema = _get_arrow_schema_from_type_name(table_structure)
 
         with psycopg.connect(
-            f"postgresql://{user}:{password}@{host}:{port}/{database}?sslmode={sslmode}&connect_timeout=5",
+            host=host,
+            port=port,
+            dbname=database,
+            user=user,
+            password=password,
+            sslmode=sslmode,
+            connect_timeout=5,
+            sslrootcert="/tmp/no.txt",
+            sslcert="/tmp/no.txt",
+            sslkey="/tmp/no.txt",
             cursor_factory=psycopg.ServerCursor,
         ) as connection:
             with connection.cursor(name=f"posthog_{team_id}_{schema}.{table_name}") as cursor:


### PR DESCRIPTION
## Problem
- Supabase connections dont like the connection string approach for some reason

## Changes
- Use keyword args for making `psycopg` connections instead
- Make sure to use the correct SSL cert params too

## How did you test this code?
Tested the approach in a pod on a supabase db