### PR TITLE
fix(flags): Fix broken "Add insight" button on embedded dashboards

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -17,6 +17,7 @@ import { urls } from 'scenes/urls'
 import { VariablesForDashboard } from '~/queries/nodes/DataVisualization/Components/Variables/Variables'
 import { DashboardMode, DashboardPlacement, DashboardType, DataColorThemeModel, QueryBasedInsightModel } from '~/types'
 
+import { AddInsightToDashboardModal } from './AddInsightToDashboardModal'
 import { DashboardHeader } from './DashboardHeader'
 import { EmptyDashboardComponent } from './EmptyDashboardComponent'
 
@@ -107,6 +108,7 @@ function DashboardScene(): JSX.Element {
     return (
         <div className="dashboard">
             {placement == DashboardPlacement.Dashboard && <DashboardHeader />}
+            {canEditDashboard && <AddInsightToDashboardModal />}
 
             {dashboardFailedToLoad ? (
                 <InsightErrorState title="There was an error loading this dashboard" />

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -35,7 +35,6 @@ import {
     QueryBasedInsightModel,
 } from '~/types'
 
-import { AddInsightToDashboardModal } from './AddInsightToDashboardModal'
 import { addInsightToDashboardLogic } from './addInsightToDashboardModalLogic'
 import { DASHBOARD_RESTRICTION_OPTIONS } from './DashboardCollaborators'
 import { dashboardCollaboratorsLogic } from './dashboardCollaboratorsLogic'
@@ -123,7 +122,6 @@ export function DashboardHeader(): JSX.Element | null {
                     )}
                     {canEditDashboard && <DeleteDashboardModal />}
                     {canEditDashboard && <DuplicateDashboardModal />}
-                    {canEditDashboard && <AddInsightToDashboardModal />}
                 </>
             )}
 


### PR DESCRIPTION
## Problem

In empty feature flag dashboards, the "Add Insight" button currently does nothing when clicked, due to the modal it controls not being rendered in the Feature flag scene

https://github.com/user-attachments/assets/a9ea71c7-6b9f-40e9-9ec0-01d21225c91a



## Changes

Move modal to same branch of react dom as the dashboard scene itself

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Validated dashboard modal works as expected in both embedded dashboards and the standard dashboard scene