### PR TITLE
chore(dw-scheduled-mat-view-capture): Scheduled Materialized View Event Capture

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/OutputPaneTabs/InfoTab.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPaneTabs/InfoTab.tsx
@@ -110,6 +110,7 @@ export function InfoTab({ codeEditorKey }: InfoTabProps): JSX.Element {
                                                     id: editingView.id,
                                                     sync_frequency: newValue,
                                                     types: [[]],
+                                                    lifecycle: 'update',
                                                 })
                                             }
                                         }}
@@ -125,14 +126,17 @@ export function InfoTab({ codeEditorKey }: InfoTabProps): JSX.Element {
                                     you to run queries faster and more efficiently.
                                 </p>
                                 <LemonButton
-                                    onClick={() =>
-                                        editingView &&
-                                        updateDataWarehouseSavedQuery({
-                                            id: editingView.id,
-                                            sync_frequency: '24hour',
-                                            types: [[]],
-                                        })
-                                    }
+                                    onClick={() => {
+                                        return (
+                                            editingView &&
+                                            updateDataWarehouseSavedQuery({
+                                                id: editingView.id,
+                                                sync_frequency: '24hour',
+                                                types: [[]],
+                                                lifecycle: 'insert',
+                                            })
+                                        )
+                                    }}
                                     type="primary"
                                     disabledReason={editingView ? undefined : 'You must save the view first'}
                                     loading={updatingDataWarehouseSavedQuery}

--- a/frontend/src/scenes/data-warehouse/editor/OutputPaneTabs/InfoTab.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPaneTabs/InfoTab.tsx
@@ -133,7 +133,7 @@ export function InfoTab({ codeEditorKey }: InfoTabProps): JSX.Element {
                                                 id: editingView.id,
                                                 sync_frequency: '24hour',
                                                 types: [[]],
-                                                lifecycle: 'insert',
+                                                lifecycle: 'create',
                                             })
                                         )
                                     }}

--- a/frontend/src/scenes/data-warehouse/saved_queries/dataWarehouseViewsLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/saved_queries/dataWarehouseViewsLogic.tsx
@@ -63,7 +63,7 @@ export const dataWarehouseViewsLogic = kea<dataWarehouseViewsLogicType>([
                         id: string
                         types: string[][]
                         sync_frequency?: string
-                        lifecycle?: 'insert' | 'update'
+                        lifecycle?: 'create' | 'update'
                     }
                 ) => {
                     // in the case where we are scheduling a materialized view, send an event

--- a/frontend/src/scenes/data-warehouse/saved_queries/dataWarehouseViewsLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/saved_queries/dataWarehouseViewsLogic.tsx
@@ -63,7 +63,7 @@ export const dataWarehouseViewsLogic = kea<dataWarehouseViewsLogicType>([
                         id: string
                         types: string[][]
                         sync_frequency?: string
-                        lifecycle?: 'create' | 'update'
+                        lifecycle?: string
                     }
                 ) => {
                     const newView = await api.dataWarehouseSavedQueries.update(view.id, view)


### PR DESCRIPTION
## Problem
Captures scheduled materialized view actions for endpoint that functions as an upsert operation.

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Emits a compressed payload once we issue this action.