### PR TITLE
fix(experiments): Only load exposures if experiment is running

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -2123,7 +2123,9 @@ export const experimentLogic = kea<experimentLogicType>([
                 }
                 if (parsedId !== 'new' && parsedId === values.experimentId) {
                     actions.loadExperiment()
-                    actions.loadExposures()
+                    if (values.isExperimentRunning) {
+                        actions.loadExposures()
+                    }
                 }
             }
         },


### PR DESCRIPTION
## Changes

Prevents this error from appearing when the experiment isn't yet started:

![CleanShot 2025-02-19 at 11 39 51@2x](https://github.com/user-attachments/assets/270fe2a8-7260-4595-b0ae-6193c3ac0720)

Still loads as expected for a running experiment:

![CleanShot 2025-02-19 at 11 40 33@2x](https://github.com/user-attachments/assets/5420f076-64d0-4250-bfc6-73a2801d4302)

## How did you test this code?

Manual review.