### PR TITLE
feat: Improve exception group message summary

### DIFF
--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -36,12 +36,10 @@ V = TypeVar("V")
 
 
 def format_exception_summary(e: Exception, max_length: int = 256) -> str:
-    if isinstance(e, ServerException):
-        try:
-            if match := re.match(r"^DB::Exception:\s*(.*)\s*Stack trace:", e.message, re.MULTILINE):
-                value = match.group(1)
-        except Exception:
-            value = str(e)
+    if isinstance(e, ServerException) and (
+        match := re.match(r"^DB::Exception:\s*(.*)\s*Stack trace:", e.message, re.MULTILINE)
+    ):
+        value = match.group(1)
     else:
         value = str(e)
 
@@ -81,7 +79,6 @@ class FuturesMap(dict[K, Future[V]]):
                     errors[k] = e
 
         if errors:
-            # TODO: messaging could be improved here
             raise ExceptionGroup(
                 f"{len(errors)} future(s) did not return a result:\n\n"
                 + "\n".join([f"* {key}: {format_exception_summary(e)}" for key, e in errors.items()]),

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -176,8 +176,8 @@ class ClickhouseCluster:
                 self.__logger.info("Executing %r on %r...", fn, host)
                 try:
                     result = fn(client)
-                except Exception:
-                    self.__logger.warn("Failed to execute %r on %r!", fn, host, exc_info=True)
+                except Exception as e:
+                    self.__logger.warn("Failed to execute %r on %r: %s", fn, host, e, exc_info=True)
                     raise
                 else:
                     self.__logger.info("Successfully executed %r on %r.", fn, host)

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -18,7 +18,6 @@ from typing import Any, Literal, NamedTuple, TypeVar
 from collections.abc import Iterable
 
 from clickhouse_driver import Client
-from clickhouse_driver.errors import ServerException
 from clickhouse_pool import ChPool
 
 from posthog import settings
@@ -36,18 +35,9 @@ V = TypeVar("V")
 
 
 def format_exception_summary(e: Exception, max_length: int = 256) -> str:
-    if isinstance(e, ServerException) and (
-        match := re.match(r"^DB::Exception:\s*(.*)\s*Stack trace:", e.message, re.MULTILINE)
-    ):
-        value = match.group(1)
-    else:
-        value = str(e)
-
-    value = value.splitlines()[0]
-
+    value = repr(e).splitlines()[0]
     if len(value) > max_length:
         value = value[:max_length] + "..."
-
     return value
 
 

--- a/posthog/clickhouse/test/__snapshots__/test_cluster.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_cluster.ambr
@@ -1,0 +1,22 @@
+# serializer version: 1
+# name: test_exception_summary
+  '''
+  1 future(s) did not return a result:
+  
+  * HostInfo(connection_info=ConnectionInfo(address='127.0.0.1', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): Syntax error: failed at position 1 ('invalid'): invalid query. Expected one of: Query, Query with output, EXPLAIN, EXPLAIN, SELECT query, possibly with UNION, list of union elements, SELECT query, subquery, possibly with UNION, SELECT subquery, SELECT quer...
+  '''
+# ---
+# name: test_exception_summary.1
+  '''
+  1 future(s) did not return a result:
+  
+  * HostInfo(connection_info=ConnectionInfo(address='127.0.0.1', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): Unknown table expression identifier 'invalid_table_name' in scope SELECT * FROM invalid_table_name. 
+  '''
+# ---
+# name: test_exception_summary.2
+  '''
+  1 future(s) did not return a result:
+  
+  * HostInfo(connection_info=ConnectionInfo(address='127.0.0.1', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): custom error
+  '''
+# ---

--- a/posthog/clickhouse/test/__snapshots__/test_cluster.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_cluster.ambr
@@ -10,7 +10,7 @@
   '''
   1 future(s) did not return a result:
   
-  * HostInfo(connection_info=ConnectionInfo(address='127.0.0.1', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Unknown table expression identifier 'invalid_table_name' in scope SELECT * FROM invalid_table_name. Stack trace:\n\n0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000bc535e4\n1. DB::Exceptio...
+  * HostInfo(connection_info=ConnectionInfo(address='127.0.0.1', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Unknown table expression identifier 'invalid_table_name' in scope SELECT * FROM invalid_table_name. Stack trace:\n\n0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000d176d5b\n1. DB::Exceptio...
   '''
 # ---
 # name: test_exception_summary.2

--- a/posthog/clickhouse/test/__snapshots__/test_cluster.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_cluster.ambr
@@ -3,20 +3,20 @@
   '''
   1 future(s) did not return a result:
   
-  * HostInfo(connection_info=ConnectionInfo(address='127.0.0.1', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): Syntax error: failed at position 1 ('invalid'): invalid query. Expected one of: Query, Query with output, EXPLAIN, EXPLAIN, SELECT query, possibly with UNION, list of union elements, SELECT query, subquery, possibly with UNION, SELECT subquery, SELECT quer...
+  * HostInfo(connection_info=ConnectionInfo(address='127.0.0.1', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Syntax error: failed at position 1 ('invalid'): invalid query. Expected one of: Query, Query with output, EXPLAIN, EXPLAIN, SELECT query, possibly with UNION, list of union elements, SELECT query, subquery, possibly with UNI...
   '''
 # ---
 # name: test_exception_summary.1
   '''
   1 future(s) did not return a result:
   
-  * HostInfo(connection_info=ConnectionInfo(address='127.0.0.1', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): Unknown table expression identifier 'invalid_table_name' in scope SELECT * FROM invalid_table_name. 
+  * HostInfo(connection_info=ConnectionInfo(address='127.0.0.1', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Unknown table expression identifier 'invalid_table_name' in scope SELECT * FROM invalid_table_name. Stack trace:\n\n0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000bc535e4\n1. DB::Exceptio...
   '''
 # ---
 # name: test_exception_summary.2
   '''
   1 future(s) did not return a result:
   
-  * HostInfo(connection_info=ConnectionInfo(address='127.0.0.1', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): custom error
+  * HostInfo(connection_info=ConnectionInfo(address='127.0.0.1', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ValueError('custom error')
   '''
 # ---

--- a/posthog/clickhouse/test/__snapshots__/test_cluster.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_cluster.ambr
@@ -10,7 +10,7 @@
   '''
   1 future(s) did not return a result:
   
-  * HostInfo(connection_info=ConnectionInfo(address='127.0.0.1', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Unknown table expression identifier 'invalid_table_name' in scope SELECT * FROM invalid_table_name. Stack trace:\n\n0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000000d176d5b\n1. DB::Exceptio...
+  * HostInfo(connection_info=ConnectionInfo(address='127.0.0.1', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Unknown table expression identifier 'invalid_table_name' in scope SELECT * FROM invalid_table_name. Stack trace:\n\n0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x0000000000000000\n1. DB::Exceptio...
   '''
 # ---
 # name: test_exception_summary.2

--- a/posthog/clickhouse/test/test_cluster.py
+++ b/posthog/clickhouse/test/test_cluster.py
@@ -29,10 +29,18 @@ def test_mutation_runner_rejects_invalid_parameters() -> None:
 
 
 def test_exception_summary(cluster: ClickhouseCluster) -> None:
-    with pytest.raises(ExceptionGroup) as e:
+    with pytest.raises(ExceptionGroup):
         cluster.map_all_hosts(Query("invalid query")).result()
 
-    raise e.value  # todo
+    with pytest.raises(ExceptionGroup):
+        cluster.map_all_hosts(Query('SELECT throwIf(true, "Error")')).result()
+
+    with pytest.raises(ExceptionGroup):
+
+        def explode(_):
+            raise ValueError(1)
+
+        cluster.map_all_hosts(explode).result()
 
 
 def test_mutations(cluster: ClickhouseCluster) -> None:

--- a/posthog/clickhouse/test/test_cluster.py
+++ b/posthog/clickhouse/test/test_cluster.py
@@ -1,3 +1,4 @@
+import re
 import uuid
 from collections import defaultdict
 from collections.abc import Callable, Iterator
@@ -29,15 +30,18 @@ def test_mutation_runner_rejects_invalid_parameters() -> None:
 
 
 def test_exception_summary(snapshot, cluster: ClickhouseCluster) -> None:
+    def replace_memory_addresses(value):
+        return re.sub(r"0x[0-9A-Fa-f]{16}", "0x0000000000000000", value)
+
     with pytest.raises(ExceptionGroup) as e:
         cluster.map_all_hosts(Query("invalid query")).result()
 
-    assert e.value.message == snapshot
+    assert replace_memory_addresses(e.value.message) == snapshot
 
     with pytest.raises(ExceptionGroup) as e:
         cluster.map_all_hosts(Query("SELECT * FROM invalid_table_name")).result()
 
-    assert e.value.message == snapshot
+    assert replace_memory_addresses(e.value.message) == snapshot
 
     with pytest.raises(ExceptionGroup) as e:
 

--- a/posthog/clickhouse/test/test_cluster.py
+++ b/posthog/clickhouse/test/test_cluster.py
@@ -28,16 +28,16 @@ def test_mutation_runner_rejects_invalid_parameters() -> None:
         MutationRunner("table", "command", {"__invalid_key": True})
 
 
-def test_exception_summary(cluster: ClickhouseCluster) -> None:
+def test_exception_summary(snapshot, cluster: ClickhouseCluster) -> None:
     with pytest.raises(ExceptionGroup) as e:
         cluster.map_all_hosts(Query("invalid query")).result()
 
-    assert ": Syntax error: failed at position 1 ('invalid'):" in e.value.message
+    assert e.value.message == snapshot
 
     with pytest.raises(ExceptionGroup) as e:
         cluster.map_all_hosts(Query("SELECT * FROM invalid_table_name")).result()
 
-    assert ": Unknown table expression identifier 'invalid_table_name'" in e.value.message
+    assert e.value.message == snapshot
 
     with pytest.raises(ExceptionGroup) as e:
 
@@ -46,7 +46,7 @@ def test_exception_summary(cluster: ClickhouseCluster) -> None:
 
         cluster.map_all_hosts(explode).result()
 
-    assert ": custom error" in e.value.message
+    assert e.value.message == snapshot
 
 
 def test_mutations(cluster: ClickhouseCluster) -> None:

--- a/posthog/clickhouse/test/test_cluster.py
+++ b/posthog/clickhouse/test/test_cluster.py
@@ -1,13 +1,19 @@
-from collections import defaultdict
-from unittest.mock import Mock, patch
 import uuid
+from collections import defaultdict
 from collections.abc import Callable, Iterator
+from unittest.mock import Mock, patch
 
 import pytest
 from clickhouse_driver import Client
 
 from posthog.clickhouse.client.connection import NodeRole
-from posthog.clickhouse.cluster import T, ClickhouseCluster, HostInfo, MutationRunner, get_cluster
+from posthog.clickhouse.cluster import (
+    ClickhouseCluster,
+    HostInfo,
+    MutationRunner,
+    T,
+    get_cluster,
+)
 from posthog.models.event.sql import EVENTS_DATA_TABLE
 
 

--- a/posthog/clickhouse/test/test_cluster.py
+++ b/posthog/clickhouse/test/test_cluster.py
@@ -12,6 +12,7 @@ from posthog.clickhouse.cluster import (
     HostInfo,
     MutationRunner,
     T,
+    Query,
     get_cluster,
 )
 from posthog.models.event.sql import EVENTS_DATA_TABLE
@@ -25,6 +26,13 @@ def cluster(django_db_setup) -> Iterator[ClickhouseCluster]:
 def test_mutation_runner_rejects_invalid_parameters() -> None:
     with pytest.raises(ValueError):
         MutationRunner("table", "command", {"__invalid_key": True})
+
+
+def test_exception_summary(cluster: ClickhouseCluster) -> None:
+    with pytest.raises(ExceptionGroup) as e:
+        cluster.map_all_hosts(Query("invalid query")).result()
+
+    raise e.value  # todo
 
 
 def test_mutations(cluster: ClickhouseCluster) -> None:


### PR DESCRIPTION
## Problem

Dagster does not render the full exception group traceback tree when multiple exceptions are thrown during parallel query execution. This makes debugging failed jobs more tedious than necessary because getting any idea what actually happened requires going back to to the container logs.

## Changes

Adds a summary line for each exception that is part of the group to the exception message. See the test snapshots for examples. This does unfortunately end up duplicating what already exists in the full `ExceptionGroup` traceback so console logs get even more noisy, but it seems like a worthwhile tradeoff in this situation.

Also added the _full_ exception message to the warning log message on a failed (single) task. This will similarly be duplicated in console logs unfortunately, but should also help debugging via the UI.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added some tests to make sure summary rendering works well enough