### PR TITLE
fix: remove terminate=True on query cancel

### DIFF
--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -263,11 +263,14 @@ def get_query_status(team_id: int, query_id: str, show_progress: bool = False) -
     return manager.get_query_status(show_progress=show_progress)
 
 
-def cancel_query(team_id: int, query_id: str) -> bool:
+def cancel_query(team_id: int, query_id: str):
     manager = QueryStatusManager(query_id, team_id)
 
     try:
         query_status = manager.get_query_status()
+
+        if query_status.complete:
+            return
 
         if query_status.task_id:
             logger.info("Got task id %s, attempting to revoke", query_status.task_id)
@@ -283,5 +286,3 @@ def cancel_query(team_id: int, query_id: str) -> bool:
     cancel_query_on_cluster(team_id, query_id)
 
     manager.delete_query_status()
-
-    return True

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -271,7 +271,7 @@ def cancel_query(team_id: int, query_id: str) -> bool:
 
         if query_status.task_id:
             logger.info("Got task id %s, attempting to revoke", query_status.task_id)
-            celery.app.control.revoke(query_status.task_id, terminate=True)
+            celery.app.control.revoke(query_status.task_id)
 
             logger.info("Revoked task id %s", query_status.task_id)
     except QueryNotFoundError:


### PR DESCRIPTION
## Problem

There are 3 places in the code where we revoke celery tasks:
- Here in execute_async
- In explicitely unsafe code in `async_migrations/force_stop_migration`
- In `wait_for_parallel_celery_group`, which is used for Exports.

This code is called every time a user changes anything on the front-end, and currently seems like it might be terminating a random celery process if the current job has already finished.

## Changes
Make this not terminate on revoke.

This means that if the job has started, the revoke will not do anything. This means we will be relying on the logic in `cancel_query_on_cluster` to kill queries

If this helps, I will then look into making process_query_taks an [`AbortableTask`](https://docs.celeryq.dev/en/stable/reference/celery.contrib.abortable.html) so that we can cancel it.


## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Deploying it is the test - hard to test locally.