### PR TITLE
fix: skip datetime parsing optimization if time zone provided

### DIFF
--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -1148,8 +1148,10 @@ class _Printer(Visitor):
                         and isinstance(node.args[0].type, StringType)
                     ):
                         try:
-                            _ = parser.isoparse(node.args[0].value)
-                            relevant_clickhouse_name = "toDateTime64"
+                            t = parser.isoparse(node.args[0].value)
+                            # if we have timezone info, toDateTime64 cannot handle
+                            if t.tzinfo is None:
+                                relevant_clickhouse_name = "toDateTime64"
                         except ValueError:
                             pass
 


### PR DESCRIPTION
## Problem

toDateTime64 cannot handle timezones properly 

## Changes

Skip replacement of parseDateTimeBestEffortOrNull => toDateTime if a literal has time zone info.

![image](https://github.com/user-attachments/assets/a3e14eb9-c8c6-4c7a-b676-097fcc710187)


## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

tested manually
