### PR TITLE
feat(dashboard): animate preview button

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -147,6 +147,7 @@ export function DashboardHeader(): JSX.Element | null {
                                     type="primary"
                                     size="small"
                                     tooltip="Preview filter changes on dashboard"
+                                    className={filtersUpdated ? 'animate-bounce' : undefined}
                                 >
                                     Preview
                                 </LemonButton>

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -147,7 +147,7 @@ export function DashboardHeader(): JSX.Element | null {
                                     type="primary"
                                     size="small"
                                     tooltip="Preview filter changes on dashboard"
-                                    className={filtersUpdated ? 'animate-bounce' : undefined}
+                                    className={filtersUpdated ? 'animate-[bounce_1s_ease-in-out_2]' : undefined}
                                 >
                                     Preview
                                 </LemonButton>


### PR DESCRIPTION
## Problem
'Preview' button can be hard to notice when dashboard filters are added

## Changes
Add a bounce animation whenever preview button becomes active

https://github.com/user-attachments/assets/4a97e685-342d-4b7b-89e6-3738360b8381


## Does this work well for both Cloud and self-hosted?
Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
👀 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
