### PR TITLE
fix(retention): remove `cumulative` from frontend-only properties

### DIFF
--- a/frontend/src/scenes/insights/utils/queryUtils.ts
+++ b/frontend/src/scenes/insights/utils/queryUtils.ts
@@ -142,7 +142,6 @@ const cleanInsightQuery = (query: InsightQueryNode, opts?: CompareQueryOpts): In
             toggledLifecycles: undefined,
             showLabelsOnSeries: undefined,
             showMean: undefined,
-            cumulative: undefined,
             yAxisScaleType: undefined,
             hiddenLegendIndexes: undefined,
             hiddenLegendBreakdowns: undefined,

--- a/posthog/schema_helpers.py
+++ b/posthog/schema_helpers.py
@@ -71,7 +71,6 @@ def to_dict(query: BaseModel) -> dict:
                                 "toggledLifecycles",
                                 "showLabelsOnSeries",
                                 "showMean",
-                                "cumulative",
                                 "yAxisScaleType",
                                 "hiddenLegendIndexes",
                                 "hiddenLegendBreakdowns",


### PR DESCRIPTION
## Problem

When fixing another issue with rolling retention queries https://github.com/PostHog/posthog/pull/24926, the `cumulative` key now is a backend side setting as well. We're still considering it as a frontend only setting however.

## Changes

Removes the `cumulative` key from frontend-only settings to allow computation of rolling retention insights without a refresh. Reported by a customer here: https://posthoghelp.zendesk.com/agent/tickets/25544. (moved to PostHog: https://us.posthog.com/project/2/support/tickets/27786)

## How did you test this code?

Tried locally