### PR TITLE
fix(experiments): count users once in exposure query runner

### DIFF
--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -158,7 +158,7 @@ class ExperimentQueryRunner(QueryRunner):
             ]
 
         # First exposure query: One row per user-variant combination
-        # Columns: distinct_id, variant, first_exposure_time
+        # Columns: entity_id, variant, first_exposure_time
         # Finds when each user was first exposed to each experiment variant
         exposure_query = ast.SelectQuery(
             select=exposure_query_select,
@@ -206,7 +206,7 @@ class ExperimentQueryRunner(QueryRunner):
         match self.metric.metric_config:
             case ExperimentDataWarehouseMetricConfig() as metric_config:
                 # Events after exposure query: One row per event after exposure
-                # Columns: timestamp, distinct_id, variant, value
+                # Columns: timestamp, after_exposure_identifier, variant, value
                 # Joins data warehouse events with exposure data to get all relevant events
                 # that occurred after a user was exposed to a variant
                 events_after_exposure_query = ast.SelectQuery(
@@ -270,7 +270,7 @@ class ExperimentQueryRunner(QueryRunner):
                         op=ast.CompareOperationOp.Eq,
                     )
                 # Events after exposure query: One row per PostHog event after exposure
-                # Columns: timestamp, distinct_id, variant, event, value
+                # Columns: timestamp, entity_id, variant, event, value
                 # Finds all matching events that occurred after a user was exposed to a variant
                 events_after_exposure_query = ast.SelectQuery(
                     select=[
@@ -312,7 +312,7 @@ class ExperimentQueryRunner(QueryRunner):
                 )
 
         # User metrics aggregation: One row per user
-        # Columns: variant, distinct_id, value (sum of all event values)
+        # Columns: variant, entity_id, value (sum of all event values)
         # Aggregates all events per user to get their total contribution to the metric
         metrics_aggregated_per_user_query = ast.SelectQuery(
             select=[

--- a/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_exposures_query_runner.ambr
+++ b/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_exposures_query_runner.ambr
@@ -1,0 +1,85 @@
+# serializer version: 1
+# name: TestExperimentExposuresQueryRunner.test_exposure_query_counts_users_only_on_first_exposure
+  '''
+  SELECT subq.day AS day,
+         subq.variant AS variant,
+         count(subq.person_id) AS exposed_count
+  FROM
+    (SELECT toDateOrNull(toString(min(toTimeZone(events.timestamp, 'UTC')))) AS day,
+            replaceAll(JSONExtractRaw(events.properties, '$feature_flag_response'), '"', '') AS variant,
+            if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id
+     FROM events
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     LEFT JOIN
+       (SELECT person.id AS id,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+        FROM person
+        WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                             (SELECT person.id AS id, max(person.version) AS version
+                                                              FROM person
+                                                              WHERE equals(person.team_id, 99999)
+                                                              GROUP BY person.id
+                                                              HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+     WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceAll(JSONExtractRaw(events.properties, '$feature_flag'), '"', ''), 'test-experiment'), 0), ifNull(in(replaceAll(JSONExtractRaw(events.properties, '$feature_flag_response'), '"', ''), ['control', 'test']), 0)), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1))
+     GROUP BY if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id),
+              replaceAll(JSONExtractRaw(events.properties, '$feature_flag_response'), '"', '')) AS subq
+  GROUP BY subq.day,
+           subq.variant
+  ORDER BY subq.day ASC
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestExperimentExposuresQueryRunner.test_exposure_query_returns_correct_timeseries
+  '''
+  SELECT subq.day AS day,
+         subq.variant AS variant,
+         count(subq.person_id) AS exposed_count
+  FROM
+    (SELECT toDateOrNull(toString(min(toTimeZone(events.timestamp, 'UTC')))) AS day,
+            replaceAll(JSONExtractRaw(events.properties, '$feature_flag_response'), '"', '') AS variant,
+            if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id
+     FROM events
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     LEFT JOIN
+       (SELECT person.id AS id,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+        FROM person
+        WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                             (SELECT person.id AS id, max(person.version) AS version
+                                                              FROM person
+                                                              WHERE equals(person.team_id, 99999)
+                                                              GROUP BY person.id
+                                                              HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+     WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceAll(JSONExtractRaw(events.properties, '$feature_flag'), '"', ''), 'test-experiment'), 0), ifNull(in(replaceAll(JSONExtractRaw(events.properties, '$feature_flag_response'), '"', ''), ['control', 'test']), 0)), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1))
+     GROUP BY if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id),
+              replaceAll(JSONExtractRaw(events.properties, '$feature_flag_response'), '"', '')) AS subq
+  GROUP BY subq.day,
+           subq.variant
+  ORDER BY subq.day ASC
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0
+  '''
+# ---

--- a/posthog/hogql_queries/experiments/test/test_experiment_exposures_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_exposures_query_runner.py
@@ -228,3 +228,111 @@ class TestExperimentExposuresQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(response.total_exposures["control"], 4)
         self.assertEqual(response.total_exposures["test"], 5)
+
+    @freeze_time("2024-01-07T12:00:00Z")
+    def test_exposure_query_counts_users_only_on_first_exposure(self):
+        ff_property = f"$feature/{self.feature_flag.key}"
+
+        journeys_for(
+            {
+                "user_control_1": [
+                    # First exposure on Jan 2
+                    {
+                        "event": "$feature_flag_called",
+                        "timestamp": "2024-01-02",
+                        "properties": {
+                            "$feature_flag_response": "control",
+                            ff_property: "control",
+                            "$feature_flag": self.feature_flag.key,
+                        },
+                    },
+                    # Second exposure on Jan 3 - should not be counted
+                    {
+                        "event": "$feature_flag_called",
+                        "timestamp": "2024-01-03",
+                        "properties": {
+                            "$feature_flag_response": "control",
+                            ff_property: "control",
+                            "$feature_flag": self.feature_flag.key,
+                        },
+                    },
+                ],
+                "user_test_1": [
+                    # First exposure on Jan 2
+                    {
+                        "event": "$feature_flag_called",
+                        "timestamp": "2024-01-02",
+                        "properties": {
+                            "$feature_flag_response": "test",
+                            ff_property: "test",
+                            "$feature_flag": self.feature_flag.key,
+                        },
+                    },
+                    # Later exposures on Jan 3 and 4 - should not be counted
+                    {
+                        "event": "$feature_flag_called",
+                        "timestamp": "2024-01-03",
+                        "properties": {
+                            "$feature_flag_response": "test",
+                            ff_property: "test",
+                            "$feature_flag": self.feature_flag.key,
+                        },
+                    },
+                    {
+                        "event": "$feature_flag_called",
+                        "timestamp": "2024-01-04",
+                        "properties": {
+                            "$feature_flag_response": "test",
+                            ff_property: "test",
+                            "$feature_flag": self.feature_flag.key,
+                        },
+                    },
+                ],
+                "user_test_2": [
+                    # Only exposure on Jan 3
+                    {
+                        "event": "$feature_flag_called",
+                        "timestamp": "2024-01-03",
+                        "properties": {
+                            "$feature_flag_response": "test",
+                            ff_property: "test",
+                            "$feature_flag": self.feature_flag.key,
+                        },
+                    },
+                ],
+            },
+            self.team,
+        )
+
+        flush_persons_and_events()
+
+        query = ExperimentExposureQuery(
+            kind="ExperimentExposureQuery",
+            experiment_id=self.experiment.id,
+        )
+
+        query_runner = ExperimentExposuresQueryRunner(
+            team=self.team,
+            query=query,
+        )
+
+        response = query_runner.calculate()
+
+        control_series = next(series for series in response.timeseries if series.variant == "control")
+        test_series = next(series for series in response.timeseries if series.variant == "test")
+
+        # Daily cumulative exposures for control variant:
+        # Day 0 (Jan 1): 0 exposures
+        # Day 1 (Jan 2): 1 new user exposed
+        # Days 2-6: No new exposures (second exposure of user_control_1 not counted)
+        self.assertEqual(control_series.exposure_counts, [0, 1, 1, 1, 1, 1, 1])
+
+        # Daily cumulative exposures for test variant:
+        # Day 0 (Jan 1): 0 exposures
+        # Day 1 (Jan 2): 1 new user exposed
+        # Day 2 (Jan 3): 1 more user exposed (user_test_2), total 2
+        # Days 3-6: No new exposures (additional exposures of user_test_1 not counted)
+        self.assertEqual(test_series.exposure_counts, [0, 1, 2, 2, 2, 2, 2])
+
+        self.assertEqual(response.total_exposures["control"], 1)
+        self.assertEqual(response.total_exposures["test"], 2)

--- a/posthog/hogql_queries/experiments/test/test_experiment_exposures_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_exposures_query_runner.py
@@ -13,6 +13,7 @@ from posthog.test.base import (
     APIBaseTest,
     ClickhouseTestMixin,
     flush_persons_and_events,
+    snapshot_clickhouse_queries,
 )
 from posthog.test.test_journeys import journeys_for
 
@@ -82,6 +83,7 @@ class TestExperimentExposuresQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
 
     @freeze_time("2024-01-07T12:00:00Z")
+    @snapshot_clickhouse_queries
     def test_exposure_query_returns_correct_timeseries(self):
         ff_property = f"$feature/{self.feature_flag.key}"
 
@@ -230,6 +232,7 @@ class TestExperimentExposuresQueryRunner(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.total_exposures["test"], 5)
 
     @freeze_time("2024-01-07T12:00:00Z")
+    @snapshot_clickhouse_queries
     def test_exposure_query_counts_users_only_on_first_exposure(self):
         ff_property = f"$feature/{self.feature_flag.key}"
 


### PR DESCRIPTION
## Problem
In `ExperimentExposureQueryRunner`, we're currently counting users multiple times if they have multiple exposure events on different days. This causes inflated exposure counts to be returned.

## Changes
Modified the exposure query to only count each user once, on the day of their first exposure to a variant. We do this by:
1. Using a window function (`min(toDate(timestamp)) OVER (PARTITION BY distinct_id, variant)`) to identify each user's first exposure date
2. Only counting users when the event date matches their first exposure date

## How did you test this code?
Added a test case.