### PR TITLE
fix(experiments): Fix conversion rate reporting in summary

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1669,7 +1669,9 @@ export const experimentLogic = kea<experimentLogicType>([
                             return null
                         }
                         return (
-                            variantResults.success_count / (variantResults.success_count + variantResults.failure_count)
+                            (variantResults.success_count /
+                                (variantResults.success_count + variantResults.failure_count)) *
+                            100
                         )
                     } else if (metricResult.kind === NodeKind.ExperimentFunnelsQuery && metricResult.insight) {
                         const variantResults = (metricResult.insight as FunnelStep[][]).find(
@@ -1683,7 +1685,7 @@ export const experimentLogic = kea<experimentLogicType>([
                             return null
                         }
 
-                        return variantResults[variantResults.length - 1].count / variantResults[0].count
+                        return (variantResults[variantResults.length - 1].count / variantResults[0].count) * 100
                     }
 
                     return null


### PR DESCRIPTION
Regression from https://github.com/PostHog/posthog/pull/28892
Reported in https://posthoghelp.zendesk.com/agent/tickets/25686 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/27712)

## Changes

Multiplies the conversion rate by 100 so it's reported correctly in the summary table.

| Before | After |
|--------|--------|
| ![CleanShot 2025-02-20 at 03 50 14@2x](https://github.com/user-attachments/assets/16480a25-6968-4e74-8cf7-b8a54301d52e) | ![CleanShot 2025-02-20 at 03 48 53@2x](https://github.com/user-attachments/assets/b35ca074-228c-4e61-bd12-fa3f9edae944) | 

## How did you test this code?

Manual review.