### PR TITLE
fix(experiments): Use consistent sort order for variant results

### DIFF
--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -415,6 +415,8 @@ class ExperimentQueryRunner(QueryRunner):
             modifiers=create_default_modifiers_for_team(self.team),
         )
 
+        sorted_results = sorted(response.results, key=lambda x: self.variants.index(x[0]))
+
         if self.metric.metric_type == ExperimentMetricType.BINOMIAL:
             return [
                 ExperimentVariantFunnelsBaseStats(
@@ -422,7 +424,7 @@ class ExperimentQueryRunner(QueryRunner):
                     key=result[0],
                     success_count=result[2],
                 )
-                for result in response.results
+                for result in sorted_results
             ]
 
         return [
@@ -432,7 +434,7 @@ class ExperimentQueryRunner(QueryRunner):
                 exposure=result[1],
                 key=result[0],
             )
-            for result in response.results
+            for result in sorted_results
         ]
 
     def calculate(self) -> ExperimentQueryResponse:


### PR DESCRIPTION
## Changes

Ensures variant results are always returned in a consistent order so they're always displayed in a consistent order.

**Before**

![CleanShot 2025-02-20 at 05 49 39@2x](https://github.com/user-attachments/assets/5af2e888-67ce-43b6-bdac-f78dc6cd7865)

**After**

![CleanShot 2025-02-20 at 05 48 34@2x](https://github.com/user-attachments/assets/9a7ec124-3875-4e61-b116-ce59d905ade8)

## How did you test this code?

Manual review.