### PR TITLE
fix(experiments): Fix infinite credible intervals chart crash

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1723,9 +1723,6 @@ export const experimentLogic = kea<experimentLogicType>([
                         // This represents the range in which the true percentage change relative to the control is likely to fall.
                         const lowerBound = ((credibleInterval[0] - controlConversionRate) / controlConversionRate) * 100
                         const upperBound = ((credibleInterval[1] - controlConversionRate) / controlConversionRate) * 100
-                        if (lowerBound === Infinity || upperBound === Infinity) {
-                            return null
-                        }
                         return [lowerBound, upperBound]
                     }
 
@@ -1734,14 +1731,14 @@ export const experimentLogic = kea<experimentLogicType>([
                     ) as TrendExperimentVariant
 
                     const controlMean = controlVariant.count / controlVariant.absolute_exposure
+                    if (!controlMean) {
+                        return null
+                    }
 
                     // Calculate the percentage difference between the credible interval bounds of the variant and the control's mean.
                     // This represents the range in which the true percentage change relative to the control is likely to fall.
                     const relativeLowerBound = ((credibleInterval[0] - controlMean) / controlMean) * 100
                     const relativeUpperBound = ((credibleInterval[1] - controlMean) / controlMean) * 100
-                    if (relativeLowerBound === Infinity || relativeUpperBound === Infinity) {
-                        return null
-                    }
                     return [relativeLowerBound, relativeUpperBound]
                 },
         ],

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1723,6 +1723,9 @@ export const experimentLogic = kea<experimentLogicType>([
                         // This represents the range in which the true percentage change relative to the control is likely to fall.
                         const lowerBound = ((credibleInterval[0] - controlConversionRate) / controlConversionRate) * 100
                         const upperBound = ((credibleInterval[1] - controlConversionRate) / controlConversionRate) * 100
+                        if (lowerBound === Infinity || upperBound === Infinity) {
+                            return null
+                        }
                         return [lowerBound, upperBound]
                     }
 
@@ -1736,6 +1739,9 @@ export const experimentLogic = kea<experimentLogicType>([
                     // This represents the range in which the true percentage change relative to the control is likely to fall.
                     const relativeLowerBound = ((credibleInterval[0] - controlMean) / controlMean) * 100
                     const relativeUpperBound = ((credibleInterval[1] - controlMean) / controlMean) * 100
+                    if (relativeLowerBound === Infinity || relativeUpperBound === Infinity) {
+                        return null
+                    }
                     return [relativeLowerBound, relativeUpperBound]
                 },
         ],


### PR DESCRIPTION
## Changes

If the control doesn't have any successes yet, `controlMean = 0`. This causes our relative credible interval comparison to be a nonsensical value and crashes the delta chart.

So, similar to the funnel calculation, we need to bail early if `controlMean = 0`

**Before**

![CleanShot 2025-02-20 at 06 38 10@2x](https://github.com/user-attachments/assets/af2ad0ea-cd37-4505-bfab-b270323f116f)

**After**

![CleanShot 2025-02-20 at 06 37 26@2x](https://github.com/user-attachments/assets/1bce3e33-0a0c-4faa-8c81-b98a808760d2)

## How did you test this code?

I created an experiment where one of the metrics didn't have any results for control yet.