### PR TITLE
fix: Fix timings wiring up and dedup db creation

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14853,8 +14853,8 @@ packages:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
 
-  unlayer-types@1.225.0:
-    resolution: {integrity: sha512-lWwAoP6nqRaxae25KYUgY3dSCKQMzh2KPxNth/+qJp2CQcqePyC41IeJiimCzC8y9etIqUYlJiM2CnahwBR1eQ==}
+  unlayer-types@1.226.0:
+    resolution: {integrity: sha512-7idQSgPCFx8/IhujudcrQImPPrv4mDoYRSghN7n6aSpD57KN6ddD8M72bHMhL+CJxNN8aQekrWG6FML+125NbQ==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -30468,7 +30468,7 @@ snapshots:
   react-email-editor@1.7.11(react@18.2.0):
     dependencies:
       react: 18.2.0
-      unlayer-types: 1.225.0
+      unlayer-types: 1.226.0
 
   react-error-boundary@3.1.4(react@18.2.0):
     dependencies:
@@ -32556,7 +32556,7 @@ snapshots:
 
   universalify@2.0.0: {}
 
-  unlayer-types@1.225.0: {}
+  unlayer-types@1.226.0: {}
 
   unpipe@1.0.0: {}
 

--- a/posthog/hogql/autocomplete.py
+++ b/posthog/hogql/autocomplete.py
@@ -372,9 +372,9 @@ def get_hogql_autocomplete(
     if database_arg is not None:
         database = database_arg
     else:
-        database = create_hogql_database(team_id=team.pk, team_arg=team)
+        database = create_hogql_database(team_id=team.pk, team_arg=team, timings=timings)
 
-    context = HogQLContext(team_id=team.pk, team=team, database=database)
+    context = HogQLContext(team_id=team.pk, team=team, database=database, timings=timings)
     if query.sourceQuery:
         if query.sourceQuery.kind == "HogQLQuery" and (
             query.sourceQuery.query is None or query.sourceQuery.query == ""

--- a/posthog/hogql/hogql.py
+++ b/posthog/hogql/hogql.py
@@ -32,7 +32,7 @@ def translate_hogql(
         if context.database is None:
             if context.team_id is None:
                 raise ValueError("Cannot translate HogQL for a filter with no team specified")
-            context.database = create_hogql_database(context.team_id, context.modifiers)
+            context.database = create_hogql_database(context.team_id, context.modifiers, timings=context.timings)
         node = parse_expr(query, placeholders=placeholders)
         select_query = ast.SelectQuery(select=[node], select_from=ast.JoinExpr(table=ast.Field(chain=["events"])))
 

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -117,7 +117,9 @@ def prepare_ast_for_printing(
 ) -> _T_AST | None:
     if context.database is None:
         with context.timings.measure("create_hogql_database"):
-            context.database = create_hogql_database(context.team_id, context.modifiers, context.team)
+            context.database = create_hogql_database(
+                context.team_id, context.modifiers, context.team, timings=context.timings
+            )
 
     context.modifiers = set_default_in_cohort_via(context.modifiers)
 

--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -33,6 +33,7 @@ from posthog.schema import (
     HogQLVariable,
 )
 from posthog.settings import HOGQL_INCREASED_MAX_EXECUTION_TIME
+import functools
 
 
 @dataclasses.dataclass
@@ -52,6 +53,7 @@ class HogQLQueryExecutor:
     pretty: Optional[bool] = True
     context: HogQLContext = dataclasses.field(default_factory=lambda: HogQLQueryExecutor.__uninitialized_context)
 
+    _cached_clickhouse_context: Optional[HogQLContext] = None
     __uninitialized_context: ClassVar[HogQLContext] = HogQLContext()
 
     def __post_init__(self):
@@ -123,29 +125,19 @@ class HogQLQueryExecutor:
                     )
 
     def _generate_hogql(self):
-        with self.timings.measure("hogql"):
-            with self.timings.measure("prepare_ast"):
-                hogql_query_context = dataclasses.replace(
-                    self.context,
-                    team_id=self.team.pk,
-                    team=self.team,
-                    enable_select_queries=True,
-                    timings=self.timings,
-                    modifiers=self.query_modifiers,
-                )
+        with self.timings.measure("clone"):
+            cloned_query = clone_expr(self.select_query, True)
 
-            with self.timings.measure("clone"):
-                cloned_query = clone_expr(self.select_query, True)
-
+        with self.timings.measure("prepare_ast_for_printing"):
             select_query_hogql = cast(
                 ast.SelectQuery,
-                prepare_ast_for_printing(node=cloned_query, context=hogql_query_context, dialect="hogql"),
+                prepare_ast_for_printing(node=cloned_query, context=self.context, dialect="hogql"),
             )
 
-        with self.timings.measure("print_ast"):
+        with self.timings.measure("print_prepared_ast"):
             self.hogql = print_prepared_ast(
                 select_query_hogql,
-                hogql_query_context,
+                self.clickhouse_context,
                 "hogql",
                 pretty=self.pretty if self.pretty is not None else True,
             )
@@ -162,7 +154,7 @@ class HogQLQueryExecutor:
                     self.print_columns.append(
                         print_prepared_ast(
                             node=node,
-                            context=hogql_query_context,
+                            context=self.clickhouse_context,
                             dialect="hogql",
                             stack=[select_query_hogql],
                         )
@@ -178,21 +170,14 @@ class HogQLQueryExecutor:
         ):
             settings.max_execution_time = HOGQL_INCREASED_MAX_EXECUTION_TIME
         try:
-            self.clickhouse_context = dataclasses.replace(
-                self.context,
-                team_id=self.team.pk,
-                team=self.team,
-                enable_select_queries=True,
-                timings=self.timings,
-                modifiers=self.query_modifiers,
-            )
-            self.clickhouse_sql = print_ast(
-                self.select_query,
-                context=self.clickhouse_context,
-                dialect="clickhouse",
-                settings=settings,
-                pretty=self.pretty if self.pretty is not None else True,
-            )
+            with self.timings.measure("print_ast"):
+                self.clickhouse_sql = print_ast(
+                    self.select_query,
+                    context=self.clickhouse_context,
+                    dialect="clickhouse",
+                    settings=settings,
+                    pretty=self.pretty if self.pretty is not None else True,
+                )
         except Exception as e:
             if self.debug:
                 self.clickhouse_sql = ""
@@ -254,13 +239,27 @@ class HogQLQueryExecutor:
                     HogQLMetadata(language=HogLanguage.HOG_QL, query=self.hogql, debug=True), self.team
                 )
 
+    @functools.cached_property
+    def clickhouse_context(self):
+        return dataclasses.replace(
+            self.context,
+            team_id=self.team.pk,
+            team=self.team,
+            enable_select_queries=True,
+            timings=self.timings,
+            modifiers=self.query_modifiers,
+            database=None,  # we're overriding the modifiers, so need to recreate the DB
+        )
+
     def generate_clickhouse_sql(self) -> tuple[str, HogQLContext]:
         self._parse_query()
         self._process_variables()
         self._process_placeholders()
         self._apply_limit()
-        self._generate_hogql()
-        self._generate_clickhouse_sql()
+        with self.timings.measure("_generate_hogql"):
+            self._generate_hogql()
+        with self.timings.measure("_generate_clickhouse_sql"):
+            self._generate_clickhouse_sql()
         return self.clickhouse_sql, self.clickhouse_context
 
     def execute(self) -> HogQLQueryResponse:

--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -53,7 +53,6 @@ class HogQLQueryExecutor:
     pretty: Optional[bool] = True
     context: HogQLContext = dataclasses.field(default_factory=lambda: HogQLQueryExecutor.__uninitialized_context)
 
-    _cached_clickhouse_context: Optional[HogQLContext] = None
     __uninitialized_context: ClassVar[HogQLContext] = HogQLContext()
 
     def __post_init__(self):

--- a/posthog/hogql/transforms/test/__snapshots__/test_in_cohort.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_in_cohort.ambr
@@ -15,11 +15,13 @@
   -- HogQL
   
   SELECT event 
-  FROM events LEFT JOIN (
-  SELECT person_id AS cohort_person_id, 1 AS matched, cohort_id 
+  FROM events 
+  WHERE and(in(person_id, (
+  SELECT person_id 
   FROM raw_cohort_people 
-  WHERE and(equals(cohort_id, XX), equals(version, 0))) AS __in_cohort ON equals(__in_cohort.cohort_person_id, person_id) 
-  WHERE and(and(1, equals(event, 'RANDOM_TEST_ID::UUID')), equals(__in_cohort.matched, 1)) 
+  WHERE equals(cohort_id, XX) 
+  GROUP BY person_id, cohort_id, version 
+  HAVING greater(sum(sign), 0))), equals(event, 'RANDOM_TEST_ID::UUID')) 
   LIMIT 100
   '''
 # ---
@@ -39,11 +41,11 @@
   -- HogQL
   
   SELECT event 
-  FROM events LEFT JOIN (
-  SELECT person_id AS cohort_person_id, 1 AS matched, cohort_id 
+  FROM events 
+  WHERE in(person_id, (
+  SELECT person_id 
   FROM static_cohort_people 
-  WHERE in(cohort_id, [1, 2, 3, 4, 5 /* ... */])) AS __in_cohort ON equals(__in_cohort.cohort_person_id, person_id) 
-  WHERE and(1, equals(__in_cohort.matched, 1)) 
+  WHERE equals(cohort_id, XX))) 
   LIMIT 100
   '''
 # ---
@@ -63,11 +65,11 @@
   -- HogQL
   
   SELECT event 
-  FROM events LEFT JOIN (
-  SELECT person_id AS cohort_person_id, 1 AS matched, cohort_id 
+  FROM events 
+  WHERE in(person_id, (
+  SELECT person_id 
   FROM static_cohort_people 
-  WHERE in(cohort_id, [1, 2, 3, 4, 5 /* ... */])) AS __in_cohort ON equals(__in_cohort.cohort_person_id, person_id) 
-  WHERE and(1, equals(__in_cohort.matched, 1)) 
+  WHERE equals(cohort_id, XX))) 
   LIMIT 100
   '''
 # ---
@@ -89,13 +91,13 @@
   -- HogQL
   
   SELECT event 
-  FROM events LEFT JOIN (
-  SELECT person_id, 1 AS matched 
+  FROM events 
+  WHERE and(in(person_id, (
+  SELECT person_id 
   FROM raw_cohort_people 
   WHERE equals(cohort_id, XX) 
   GROUP BY person_id, cohort_id, version 
-  HAVING greater(sum(sign), 0)) AS in_cohort__XX ON equals(in_cohort__XX.person_id, person_id) 
-  WHERE and(equals(in_cohort__XX.matched, 1), equals(event, 'RANDOM_TEST_ID::UUID')) 
+  HAVING greater(sum(sign), 0))), equals(event, 'RANDOM_TEST_ID::UUID')) 
   LIMIT 100
   '''
 # ---
@@ -115,11 +117,11 @@
   -- HogQL
   
   SELECT event 
-  FROM events LEFT JOIN (
-  SELECT person_id, 1 AS matched 
+  FROM events 
+  WHERE in(person_id, (
+  SELECT person_id 
   FROM static_cohort_people 
-  WHERE equals(cohort_id, XX)) AS in_cohort__XX ON equals(in_cohort__XX.person_id, person_id) 
-  WHERE equals(in_cohort__XX.matched, 1) 
+  WHERE equals(cohort_id, XX))) 
   LIMIT 100
   '''
 # ---
@@ -139,11 +141,11 @@
   -- HogQL
   
   SELECT event 
-  FROM events LEFT JOIN (
-  SELECT person_id, 1 AS matched 
+  FROM events 
+  WHERE in(person_id, (
+  SELECT person_id 
   FROM static_cohort_people 
-  WHERE equals(cohort_id, XX)) AS in_cohort__XX ON equals(in_cohort__XX.person_id, person_id) 
-  WHERE equals(in_cohort__XX.matched, 1) 
+  WHERE equals(cohort_id, XX))) 
   LIMIT 100
   '''
 # ---


### PR DESCRIPTION
## Problem

We don't always wire up the timings object, so don't always have info on the slow parts of `create_hogql_database`.

I found a case where we create_hogql_database twice when running `SELECT 1`

## Changes
Use `context.timings` a lot more liberally.

Cache the context on the `HogQLQueryExecutor`.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Existing tests pass.

Also here's what `SELECT 1`'s timings look like now (local dev, so no dw tables). I wouldn't trust the absolute timings (it's local dev, I have stuff running in a debugger, but there's more info in the former.

```json
[
                {
                    "k": "./parse_select/parse_select_cpp",
                    "t": 0.0022889580577611923
                },
                {
                    "k": "./parse_select",
                    "t": 0.0026869168505072594
                },
                {
                    "k": "./filters",
                    "t": 0.0002491660416126251
                },
                {
                    "k": "./query",
                    "t": 4.437495954334736e-05
                },
                {
                    "k": "./variables",
                    "t": 2.5957822799682617e-05
                },
                {
                    "k": "./replace_placeholders",
                    "t": 9.112502448260784e-05
                },
                {
                    "k": "./max_limit",
                    "t": 2.950010821223259e-05
                },
                {
                    "k": "./_generate_hogql/clone",
                    "t": 0.00030554202385246754
                },
                {
                    "k": "./_generate_hogql/prepare_ast_for_printing",
                    "t": 0.049202042166143656
                },
                {
                    "k": "./_generate_hogql/print_prepared_ast/printer",
                    "t": 0.005009832791984081
                },
                {
                    "k": "./_generate_hogql/print_prepared_ast",
                    "t": 0.005723415873944759
                },
                {
                    "k": "./_generate_hogql",
                    "t": 0.05528875021263957
                },
                {
                    "k": "./_generate_clickhouse_sql/print_ast/create_hogql_database/modifiers",
                    "t": 0.019441792042925954
                },
                {
                    "k": "./_generate_clickhouse_sql/print_ast/create_hogql_database/session_table",
                    "t": 0.00039862492121756077
                },
                {
                    "k": "./_generate_clickhouse_sql/print_ast/create_hogql_database/initial_domain_type/initial_domain_type_expr",
                    "t": 9.082956239581108e-06
                },
                {
                    "k": "./_generate_clickhouse_sql/print_ast/create_hogql_database/initial_domain_type",
                    "t": 6.545800715684891e-05
                },
                {
                    "k": "./_generate_clickhouse_sql/print_ast/create_hogql_database/initial_channel_type/custom_channel_rules",
                    "t": 7.833121344447136e-06
                },
                {
                    "k": "./_generate_clickhouse_sql/print_ast/create_hogql_database/initial_channel_type/default_channel_rules_parse",
                    "t": 7.666880264878273e-06
                },
                {
                    "k": "./_generate_clickhouse_sql/print_ast/create_hogql_database/initial_channel_type/default_channel_rules_replace",
                    "t": 0.00019770790822803974
                },
                {
                    "k": "./_generate_clickhouse_sql/print_ast/create_hogql_database/initial_channel_type",
                    "t": 0.00023941602557897568
                },
                {
                    "k": "./_generate_clickhouse_sql/print_ast/create_hogql_database/group_type_mapping",
                    "t": 0.001329708145931363
                },
                {
                    "k": "./_generate_clickhouse_sql/print_ast/create_hogql_database/data_warehouse_saved_query",
                    "t": 0.001139041967689991
                },
                {
                    "k": "./_generate_clickhouse_sql/print_ast/create_hogql_database/data_warehouse_tables",
                    "t": 0.0019408329389989376
                },
                {
                    "k": "./_generate_clickhouse_sql/print_ast/create_hogql_database/data_warehouse_joins",
                    "t": 0.0009727920405566692
                },
                {
                    "k": "./_generate_clickhouse_sql/print_ast/create_hogql_database",
                    "t": 0.025588833028450608
                },
                {
                    "k": "./_generate_clickhouse_sql/print_ast/resolve_types",
                    "t": 6.79579097777605e-05
                },
                {
                    "k": "./_generate_clickhouse_sql/print_ast/resolve_property_types",
                    "t": 0.00012129195965826511
                },
                {
                    "k": "./_generate_clickhouse_sql/print_ast/resolve_lazy_tables",
                    "t": 6.720796227455139e-05
                },
                {
                    "k": "./_generate_clickhouse_sql/print_ast/swap_properties",
                    "t": 2.150004729628563e-05
                },
                {
                    "k": "./_generate_clickhouse_sql/print_ast/printer",
                    "t": 8.40828288346529e-05
                },
                {
                    "k": "./_generate_clickhouse_sql/print_ast",
                    "t": 0.025995166040956974
                },
                {
                    "k": "./_generate_clickhouse_sql",
                    "t": 0.026062707882374525
                },
                {
                    "k": "./clickhouse_execute",
                    "t": 0.0034568330738693476
                },
                {
                    "k": ".",
                    "t": 0.10163762490265071
                }
            ]
```

compared to
```json
[
                {
                    "k": "./parse_select/parse_select_cpp",
                    "t": 0.004829083103686571
                },
                {
                    "k": "./parse_select",
                    "t": 0.005888042040169239
                },
                {
                    "k": "./filters",
                    "t": 0.0007879168260842562
                },
                {
                    "k": "./query",
                    "t": 7.829186506569386e-05
                },
                {
                    "k": "./variables",
                    "t": 1.5666009858250618e-05
                },
                {
                    "k": "./replace_placeholders",
                    "t": 2.8999987989664078e-05
                },
                {
                    "k": "./max_limit",
                    "t": 9.612506255507469e-05
                },
                {
                    "k": "./hogql/prepare_ast",
                    "t": 7.737497799098492e-05
                },
                {
                    "k": "./hogql/clone",
                    "t": 0.0006638749036937952
                },
                {
                    "k": "./hogql/create_hogql_database",
                    "t": 0.3042102500330657
                },
                {
                    "k": "./hogql/resolve_types",
                    "t": 0.003296332899481058
                },
                {
                    "k": "./hogql",
                    "t": 0.30876941699534655
                },
                {
                    "k": "./print_ast/printer",
                    "t": 0.0017555828671902418
                },
                {
                    "k": "./print_ast",
                    "t": 0.0019913329742848873
                },
                {
                    "k": "./create_hogql_database",
                    "t": 0.08035433292388916
                },
                {
                    "k": "./resolve_types",
                    "t": 0.00018541701138019562
                },
                {
                    "k": "./resolve_property_types",
                    "t": 0.00021187495440244675
                },
                {
                    "k": "./resolve_lazy_tables",
                    "t": 0.00012895790860056877
                },
                {
                    "k": "./swap_properties",
                    "t": 5.4208096116781235e-05
                },
                {
                    "k": "./printer",
                    "t": 0.00022141705267131329
                },
                {
                    "k": "./clickhouse_execute",
                    "t": 0.0644365418702364
                },
                {
                    "k": ".",
                    "t": 0.500723792007193
                }
            ]
```