### PR TITLE
fix(dashboard): bring back preview popover

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardEditBar.tsx
+++ b/frontend/src/scenes/dashboard/DashboardEditBar.tsx
@@ -41,7 +41,7 @@ export function DashboardEditBar(): JSX.Element {
             overlay={
                 <div className="flex items-center gap-2 m-1">
                     <LemonButton
-                        onClick={() => setDashboardMode(null, DashboardEventSource.DashboardHeaderSaveDashboard)}
+                        onClick={() => setDashboardMode(null, DashboardEventSource.DashboardHeaderDiscardChanges)}
                         type="secondary"
                         size="small"
                     >

--- a/frontend/src/scenes/dashboard/DashboardEditBar.tsx
+++ b/frontend/src/scenes/dashboard/DashboardEditBar.tsx
@@ -1,9 +1,11 @@
 import { IconCalendar } from '@posthog/icons'
+import { LemonButton, Popover } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { TaxonomicBreakdownFilter } from 'scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -13,8 +15,9 @@ import { BreakdownFilter, NodeKind } from '~/queries/schema/schema-general'
 import { DashboardMode, InsightLogicProps } from '~/types'
 
 export function DashboardEditBar(): JSX.Element {
-    const { dashboard, temporaryFilters, dashboardMode } = useValues(dashboardLogic)
-    const { setDates, setProperties, setBreakdownFilter, setDashboardMode } = useActions(dashboardLogic)
+    const { canAutoPreview, dashboard, temporaryFilters, dashboardMode, filtersUpdated } = useValues(dashboardLogic)
+    const { setDates, setProperties, setBreakdownFilter, setDashboardMode, previewTemporaryFilters } =
+        useActions(dashboardLogic)
     const { groupsTaxonomicTypes } = useValues(groupsModel)
 
     const insightProps: InsightLogicProps = {
@@ -31,71 +34,93 @@ export function DashboardEditBar(): JSX.Element {
     }
 
     return (
-        <div
-            className={clsx(
-                'flex gap-2 items-center justify-between flex-wrap border md:[&>*]:grow-0 [&>*]:grow',
-                dashboardMode === DashboardMode.Edit
-                    ? '-m-1.5 p-1.5 border-border-bold border-dashed rounded-lg'
-                    : 'border-transparent'
-            )}
+        // Only show preview button for large dashboards where we don't automatically preview filter changes */
+        <Popover
+            visible={!canAutoPreview && filtersUpdated}
+            className="z-1" // So that Cancel/Apply isn't above filter popovers
+            overlay={
+                <div className="flex items-center gap-2 m-1">
+                    <LemonButton
+                        onClick={() => setDashboardMode(null, DashboardEventSource.DashboardHeaderSaveDashboard)}
+                        type="secondary"
+                        size="small"
+                    >
+                        Cancel
+                    </LemonButton>
+                    <LemonButton onClick={previewTemporaryFilters} type="primary" size="small">
+                        Apply filters and preview
+                    </LemonButton>
+                </div>
+            }
+            placement="top"
+            showArrow
         >
-            <DateFilter
-                showCustom
-                dateFrom={temporaryFilters.date_from}
-                dateTo={temporaryFilters.date_to}
-                onChange={(from_date, to_date) => {
-                    if (dashboardMode !== DashboardMode.Edit) {
-                        setDashboardMode(DashboardMode.Edit, null)
-                    }
-                    setDates(from_date, to_date)
-                }}
-                makeLabel={(key) => (
-                    <>
-                        <IconCalendar />
-                        <span className="hide-when-small"> {key}</span>
-                    </>
+            <div
+                className={clsx(
+                    'flex gap-2 items-center justify-between flex-wrap border md:[&>*]:grow-0 [&>*]:grow',
+                    dashboardMode === DashboardMode.Edit
+                        ? '-m-1.5 p-1.5 border-border-bold border-dashed rounded-lg'
+                        : 'border-transparent'
                 )}
-            />
-            <PropertyFilters
-                onChange={(properties) => {
-                    if (dashboardMode !== DashboardMode.Edit) {
-                        setDashboardMode(DashboardMode.Edit, null)
-                    }
-                    setProperties(properties)
-                }}
-                pageKey={'dashboard_' + dashboard?.id}
-                propertyFilters={temporaryFilters.properties}
-                taxonomicGroupTypes={[
-                    TaxonomicFilterGroupType.EventProperties,
-                    TaxonomicFilterGroupType.PersonProperties,
-                    TaxonomicFilterGroupType.EventFeatureFlags,
-                    ...groupsTaxonomicTypes,
-                    TaxonomicFilterGroupType.Cohorts,
-                    TaxonomicFilterGroupType.Elements,
-                    TaxonomicFilterGroupType.HogQLExpression,
-                ]}
-            />
-            <BindLogic logic={insightLogic} props={insightProps}>
-                <TaxonomicBreakdownFilter
-                    insightProps={insightProps}
-                    breakdownFilter={temporaryFilters.breakdown_filter}
-                    isTrends={false}
-                    showLabel={false}
-                    updateBreakdownFilter={(breakdown_filter) => {
+            >
+                <DateFilter
+                    showCustom
+                    dateFrom={temporaryFilters.date_from}
+                    dateTo={temporaryFilters.date_to}
+                    onChange={(from_date, to_date) => {
                         if (dashboardMode !== DashboardMode.Edit) {
                             setDashboardMode(DashboardMode.Edit, null)
                         }
-                        let saved_breakdown_filter: BreakdownFilter | null = breakdown_filter
-                        // taxonomicBreakdownFilterLogic can generate an empty breakdown_filter object
-                        if (breakdown_filter && !breakdown_filter.breakdown_type && !breakdown_filter.breakdowns) {
-                            saved_breakdown_filter = null
-                        }
-                        setBreakdownFilter(saved_breakdown_filter)
+                        setDates(from_date, to_date)
                     }}
-                    updateDisplay={() => {}}
-                    size="small"
+                    makeLabel={(key) => (
+                        <>
+                            <IconCalendar />
+                            <span className="hide-when-small"> {key}</span>
+                        </>
+                    )}
                 />
-            </BindLogic>
-        </div>
+                <PropertyFilters
+                    onChange={(properties) => {
+                        if (dashboardMode !== DashboardMode.Edit) {
+                            setDashboardMode(DashboardMode.Edit, null)
+                        }
+                        setProperties(properties)
+                    }}
+                    pageKey={'dashboard_' + dashboard?.id}
+                    propertyFilters={temporaryFilters.properties}
+                    taxonomicGroupTypes={[
+                        TaxonomicFilterGroupType.EventProperties,
+                        TaxonomicFilterGroupType.PersonProperties,
+                        TaxonomicFilterGroupType.EventFeatureFlags,
+                        ...groupsTaxonomicTypes,
+                        TaxonomicFilterGroupType.Cohorts,
+                        TaxonomicFilterGroupType.Elements,
+                        TaxonomicFilterGroupType.HogQLExpression,
+                    ]}
+                />
+                <BindLogic logic={insightLogic} props={insightProps}>
+                    <TaxonomicBreakdownFilter
+                        insightProps={insightProps}
+                        breakdownFilter={temporaryFilters.breakdown_filter}
+                        isTrends={false}
+                        showLabel={false}
+                        updateBreakdownFilter={(breakdown_filter) => {
+                            if (dashboardMode !== DashboardMode.Edit) {
+                                setDashboardMode(DashboardMode.Edit, null)
+                            }
+                            let saved_breakdown_filter: BreakdownFilter | null = breakdown_filter
+                            // taxonomicBreakdownFilterLogic can generate an empty breakdown_filter object
+                            if (breakdown_filter && !breakdown_filter.breakdown_type && !breakdown_filter.breakdowns) {
+                                saved_breakdown_filter = null
+                            }
+                            setBreakdownFilter(saved_breakdown_filter)
+                        }}
+                        updateDisplay={() => {}}
+                        size="small"
+                    />
+                </BindLogic>
+            </div>
+        </Popover>
     )
 }

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -57,8 +57,8 @@ export function DashboardHeader(): JSX.Element | null {
         showTextTileModal,
         textTileId,
     } = useValues(dashboardLogic)
-    const { previewTemporaryFilters, setDashboardMode, triggerDashboardUpdate } = useActions(dashboardLogic)
-    const { asDashboardTemplate, canAutoPreview, filtersUpdated } = useValues(dashboardLogic)
+    const { setDashboardMode, triggerDashboardUpdate } = useActions(dashboardLogic)
+    const { asDashboardTemplate } = useValues(dashboardLogic)
     const { updateDashboard, pinDashboard, unpinDashboard } = useActions(dashboardsModel)
     const { createNotebookFromDashboard } = useActions(notebooksModel)
     const { showAddInsightToDashboardModal } = useActions(addInsightToDashboardLogic)
@@ -139,19 +139,6 @@ export function DashboardHeader(): JSX.Element | null {
                             >
                                 Cancel
                             </LemonButton>
-                            {/* Only show preview button for large dashboards where we don't automatically preview filter changes */}
-                            {!canAutoPreview && (
-                                <LemonButton
-                                    disabledReason={!filtersUpdated && 'No changes to apply'}
-                                    onClick={previewTemporaryFilters}
-                                    type="primary"
-                                    size="small"
-                                    tooltip="Preview filter changes on dashboard"
-                                    className={filtersUpdated ? 'animate-[bounce_1s_ease-in-out_2]' : undefined}
-                                >
-                                    Preview
-                                </LemonButton>
-                            )}
                             <LemonButton
                                 data-attr="dashboard-edit-mode-save"
                                 type="primary"


### PR DESCRIPTION
## Problem
Preview button in dashboard was hard to notice for filter changes.

## Changes
Showing a popup now to make it easier to notice

https://github.com/user-attachments/assets/6a553e6c-74bf-4116-bf80-6dc09e48aac3


## Does this work well for both Cloud and self-hosted?
Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
👀 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
