### PR TITLE
chore: Enforce min rust version in cyclotron-core Cargo.toml

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -120,7 +120,7 @@ jobs:
 
             - name: Install rust
               if: needs.changes.outputs.rust == 'true'
-              uses: dtolnay/rust-toolchain@1.82
+              uses: dtolnay/rust-toolchain@1.82 # please keep this in sync with rust-version in rust/Cargo.toml
 
             - uses: actions/cache@v4
               if: needs.changes.outputs.rust == 'true'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -120,7 +120,7 @@ jobs:
 
             - name: Install rust
               if: needs.changes.outputs.rust == 'true'
-              uses: dtolnay/rust-toolchain@1.82 # please keep this in sync with rust-version in rust/Cargo.toml
+              uses: dtolnay/rust-toolchain@1.82 # please keep this in sync with rust-version in rust/*/Cargo.toml
 
             - uses: actions/cache@v4
               if: needs.changes.outputs.rust == 'true'

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -101,4 +101,3 @@ posthog-rs = { version = "0.3.5", features = ["async-client"] }
 
 # Used for decrypting django encrypted fields
 fernet = "0.2"
-

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 resolver = "2"
+rust-version = "1.82.0" # please keep in sync with the version in .github/workflows/rust.yml
 
 members = [
     "property-defs-rs",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,5 @@
 [workspace]
 resolver = "2"
-rust-version = "1.82.0" # please keep in sync with the version in .github/workflows/rust.yml
 
 members = [
     "property-defs-rs",
@@ -102,3 +101,4 @@ posthog-rs = { version = "0.3.5", features = ["async-client"] }
 
 # Used for decrypting django encrypted fields
 fernet = "0.2"
+

--- a/rust/cyclotron-core/Cargo.toml
+++ b/rust/cyclotron-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cyclotron-core"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.82.0" # please keep in sync with the version in .github/workflows/rust.yml
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Problem

I had some pain trying to get plugin-server to build with an older version of rust, so I thought I'd make life easier for the next guy.

## Changes

Add a minimum rust version in Cargo.toml, and made it the same as the rust version used in CI. Both contain a comment to stay in sync with the other.

Sadly there's no workspace-level minimum rust, so I just set this on cyclotron-core

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
Let's see if the rust build works in CI


<img width="572" alt="Screenshot 2025-02-20 at 17 46 46" src="https://github.com/user-attachments/assets/ba1a6062-df99-41cf-8360-29663df1686e" />
