### PR TITLE
fix(insight-variables): variable calendar component using stale value

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/NewVariableModal.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/NewVariableModal.tsx
@@ -7,6 +7,7 @@ import {
     LemonSelect,
 } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
+import { dayjs } from 'lib/dayjs'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 
 import { Variable, VariableType } from '../../types'
@@ -97,8 +98,7 @@ const renderVariableSpecificFields = (
         return (
             <LemonField.Pure label="Default value" className="gap-1">
                 <VariableCalendar
-                    showDefault={true}
-                    variable={variable}
+                    value={dayjs(variable.default_value)}
                     updateVariable={(date) => {
                         updateVariable({ ...variable, default_value: date })
                         // calendar is a special case to reuse LemonCalendarSelect

--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/VariableCalendar.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/VariableCalendar.tsx
@@ -10,9 +10,6 @@ export const VariableCalendar = ({
     updateVariable: (date: string) => void
 }): JSX.Element => {
     const [calendarTime, setCalendarTime] = useState(() => {
-        if (!value) {
-            return false
-        }
         // Check if the date string contains time information (HH:mm or HH:mm:ss)
         return /\d{2}:\d{2}(:\d{2})?/.test(value.format('YYYY-MM-DD HH:mm:00'))
     })

--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/VariableCalendar.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/VariableCalendar.tsx
@@ -2,33 +2,25 @@ import { LemonCalendarSelect } from '@posthog/lemon-ui'
 import { dayjs } from 'lib/dayjs'
 import { useState } from 'react'
 
-import { DateVariable } from '../../types'
-
 export const VariableCalendar = ({
-    variable,
+    value,
     updateVariable,
-    showDefault = false,
 }: {
-    variable: DateVariable
+    value: dayjs.Dayjs
     updateVariable: (date: string) => void
-    showDefault?: boolean
 }): JSX.Element => {
     const [calendarTime, setCalendarTime] = useState(() => {
-        const dateToCheck = showDefault || !variable.value ? variable.default_value : variable.value
-        if (!dateToCheck) {
+        if (!value) {
             return false
         }
         // Check if the date string contains time information (HH:mm or HH:mm:ss)
-        return /\d{2}:\d{2}(:\d{2})?/.test(dateToCheck)
+        return /\d{2}:\d{2}(:\d{2})?/.test(value.format('YYYY-MM-DD HH:mm:00'))
     })
-
-    const [date, setDate] = useState(showDefault ? dayjs(variable.default_value) : dayjs(variable.value))
 
     return (
         <LemonCalendarSelect
-            value={date}
+            value={value}
             onChange={(date) => {
-                setDate(date)
                 updateVariable(
                     calendarTime ? date?.format('YYYY-MM-DD HH:mm:00') ?? '' : date?.format('YYYY-MM-DD') ?? ''
                 )

--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
@@ -179,7 +179,7 @@ const VariableInput = ({
                 )}
                 {variable.type === 'Date' && (
                     <VariableCalendar
-                        variable={variable}
+                        value={dayjs(localInputValue)}
                         updateVariable={(date) => {
                             onChange(variable.id, date)
                             closePopover()


### PR DESCRIPTION
## Problem

- calendar component using var directly which means null values are wrongly applied

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- use localinputvalue which runs through null checks

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
