### PR TITLE
chore(insights) support normalizing all pathname and current_url props in breakdown

### DIFF
--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.ts
@@ -8,10 +8,8 @@ export const isCohort = (t: number | string): t is number => typeof t === 'numbe
 export const isCohortBreakdown = (t: number | string): t is number | string => isAllCohort(t) || isCohort(t)
 
 export const isURLNormalizeable = (propertyName: string): boolean => {
-    const normalizablePathMatches = ['current_url', 'pathname']
-    return propertyName.startsWith('$') && 
-        normalizablePathMatches.some(term => propertyName.includes(term)) &&
-        normalizablePathMatches.some(term => propertyName.endsWith(term))
+    const propertyMatchTerms = ['current_url', 'pathname']
+    return propertyName.startsWith('$') && propertyMatchTerms.some(term => propertyName.endsWith(term))
     
 }
 

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.ts
@@ -8,7 +8,11 @@ export const isCohort = (t: number | string): t is number => typeof t === 'numbe
 export const isCohortBreakdown = (t: number | string): t is number | string => isAllCohort(t) || isCohort(t)
 
 export const isURLNormalizeable = (propertyName: string): boolean => {
-    return ['current_url', 'pathname'].some(term => propertyName.includes(term))
+    const normalizablePathMatches = ['current_url', 'pathname']
+    return propertyName.startsWith('$') && 
+        normalizablePathMatches.some(term => propertyName.includes(term)) &&
+        normalizablePathMatches.some(term => propertyName.endsWith(term))
+    
 }
 
 export function isMultipleBreakdownType(breakdownType?: BreakdownType | null): breakdownType is MultipleBreakdownType {

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.ts
@@ -8,7 +8,7 @@ export const isCohort = (t: number | string): t is number => typeof t === 'numbe
 export const isCohortBreakdown = (t: number | string): t is number | string => isAllCohort(t) || isCohort(t)
 
 export const isURLNormalizeable = (propertyName: string): boolean => {
-    return ['$current_url', '$pathname'].includes(propertyName)
+    return ['current_url', 'pathname'].some(term => propertyName.includes(term))
 }
 
 export function isMultipleBreakdownType(breakdownType?: BreakdownType | null): breakdownType is MultipleBreakdownType {


### PR DESCRIPTION
breakdown filter only offered to normalize event properties $current_url and $pathname, but there are many other attribution properties with similar names that should also have this option. New behavior offers to normalize property starting with $ and ending with `pathname` or `current_url`.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

untested

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
