### PR TITLE
feat: update links to go to traces rather than person modal

### DIFF
--- a/frontend/src/products.ts
+++ b/frontend/src/products.ts
@@ -78,7 +78,10 @@ export const productUrls = {
     earlyAccessFeature: (id: string): string => `/early_access_features/${id}`,
     llmObservabilityDashboard: (): string => '/llm-observability',
     llmObservabilityGenerations: (): string => '/llm-observability/generations',
-    llmObservabilityTraces: (): string => '/llm-observability/traces',
+    llmObservabilityTraces: (filters?: Record<string, any>[]): string => {
+        const filtersParam = filters ? `?filters=${JSON.stringify(filters)}` : ''
+        return `/llm-observability/traces${filtersParam}`
+    },
     llmObservabilityTrace: (
         id: string,
         params?: {

--- a/frontend/src/products.ts
+++ b/frontend/src/products.ts
@@ -78,10 +78,7 @@ export const productUrls = {
     earlyAccessFeature: (id: string): string => `/early_access_features/${id}`,
     llmObservabilityDashboard: (): string => '/llm-observability',
     llmObservabilityGenerations: (): string => '/llm-observability/generations',
-    llmObservabilityTraces: (filters?: Record<string, any>[]): string => {
-        const filtersParam = filters ? `?filters=${JSON.stringify(filters)}` : ''
-        return `/llm-observability/traces${filtersParam}`
-    },
+    llmObservabilityTraces: (): string => '/llm-observability/traces',
     llmObservabilityTrace: (
         id: string,
         params?: {

--- a/products/llm_observability/frontend/LLMObservabilityUsers.tsx
+++ b/products/llm_observability/frontend/LLMObservabilityUsers.tsx
@@ -1,10 +1,13 @@
 import { useActions, useValues } from 'kea'
+import { combineUrl } from 'kea-router'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 
 import { DataTable } from '~/queries/nodes/DataTable/DataTable'
 import { isHogQLQuery } from '~/queries/utils'
+import { PropertyFilterType } from '~/types'
 
 import { llmObservabilityLogic } from './llmObservabilityLogic'
+import { urls } from './urls'
 
 const mapPerson = (person: any): { distinct_id: string; created_at: string; properties: Record<string, any> } => {
     return {
@@ -38,7 +41,24 @@ export function LLMObservabilityUsers(): JSX.Element {
                         title: 'Person',
                         render: function RenderPerson(x) {
                             const person = mapPerson(x.value)
-                            return <PersonDisplay person={person} withIcon />
+                            return (
+                                <PersonDisplay
+                                    person={person}
+                                    withIcon
+                                    noPopover
+                                    href={
+                                        combineUrl(urls.llmObservabilityTraces(), {
+                                            filters: [
+                                                {
+                                                    type: PropertyFilterType.HogQL,
+                                                    key: `distinct_id == '${person.distinct_id}'`,
+                                                    value: null,
+                                                },
+                                            ],
+                                        }).url
+                                    }
+                                />
+                            )
                         },
                     },
                     first_seen: {

--- a/products/llm_observability/frontend/llmObservabilityLogic.tsx
+++ b/products/llm_observability/frontend/llmObservabilityLogic.tsx
@@ -513,7 +513,7 @@ export const llmObservabilityLogic = kea<llmObservabilityLogicType>([
                 s.propertyFilters,
                 groupsModel.selectors.groupsTaxonomicTypes,
             ],
-            (dateFilter, shouldFilterTestAccounts, propertyFilters): DataTableNode => ({
+            (dateFilter, shouldFilterTestAccounts, propertyFilters, groupsTaxonomicTypes): DataTableNode => ({
                 kind: NodeKind.DataTableNode,
                 source: {
                     kind: NodeKind.HogQLQuery,
@@ -556,6 +556,13 @@ export const llmObservabilityLogic = kea<llmObservabilityLogicType>([
                 showDateRange: true,
                 showReload: true,
                 showSearch: true,
+                showPropertyFilter: [
+                    TaxonomicFilterGroupType.EventProperties,
+                    TaxonomicFilterGroupType.PersonProperties,
+                    ...groupsTaxonomicTypes,
+                    TaxonomicFilterGroupType.Cohorts,
+                    TaxonomicFilterGroupType.HogQLExpression,
+                ],
                 showTestAccountFilters: true,
                 showExport: true,
                 showColumnConfigurator: true,
@@ -574,7 +581,7 @@ export const llmObservabilityLogic = kea<llmObservabilityLogicType>([
                 (date_from || INITIAL_EVENTS_DATE_FROM) !== values.dateFilter.dateFrom ||
                 (date_to || INITIAL_DATE_TO) !== values.dateFilter.dateTo
             ) {
-                actions.setDates(date_from, date_to)
+                actions.setDates(date_from || INITIAL_EVENTS_DATE_FROM, date_to || INITIAL_DATE_TO)
             }
             const filterTestAccountsValue = [true, 'true', 1, '1'].includes(filter_test_accounts)
             if (filterTestAccountsValue !== values.shouldFilterTestAccounts) {


### PR DESCRIPTION
## Problem
Frustrating ux when clicking on a user and getting the persons modal rather than just going to the traces of that user

## Changes
changed link to add hogql filter on person
added property filter on users tab