### PR TITLE
feat(syncs-status-reason): Latest error to syncs tab

### DIFF
--- a/frontend/src/scenes/data-warehouse/settings/source/Syncs.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/Syncs.tsx
@@ -2,7 +2,7 @@ import { LemonButton, LemonTable, LemonTag, LemonTagType, Tooltip } from '@posth
 import { useActions, useValues } from 'kea'
 import { TZLabel } from 'lib/components/TZLabel'
 
-import { ExternalDataJob } from '~/types'
+import { ExternalDataJob, ExternalDataJobStatus } from '~/types'
 
 import { dataWarehouseSourceSettingsLogic } from './dataWarehouseSourceSettingsLogic'
 import { LogsView } from './Logs'
@@ -41,7 +41,7 @@ export const Syncs = ({ id }: SyncsProps): JSX.Element => {
                         const tagContent = (
                             <LemonTag type={StatusTagSetting[job.status] || 'default'}>{job.status}</LemonTag>
                         )
-                        return job.latest_error && job.status === 'Failed' ? (
+                        return job.latest_error && job.status === ExternalDataJobStatus.Failed ? (
                             <Tooltip title={job.latest_error}>{tagContent}</Tooltip>
                         ) : (
                             tagContent

--- a/frontend/src/scenes/data-warehouse/settings/source/Syncs.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/Syncs.tsx
@@ -1,4 +1,4 @@
-import { LemonButton, LemonTable, LemonTag, LemonTagType } from '@posthog/lemon-ui'
+import { LemonButton, LemonTable, LemonTag, LemonTagType, Tooltip } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { TZLabel } from 'lib/components/TZLabel'
 
@@ -38,7 +38,14 @@ export const Syncs = ({ id }: SyncsProps): JSX.Element => {
                 {
                     title: 'Status',
                     render: (_, job) => {
-                        return <LemonTag type={StatusTagSetting[job.status]}>{job.status}</LemonTag>
+                        const tagContent = (
+                            <LemonTag type={StatusTagSetting[job.status] || 'default'}>{job.status}</LemonTag>
+                        )
+                        return job.latest_error && job.status === 'Failed' ? (
+                            <Tooltip title={job.latest_error}>{tagContent}</Tooltip>
+                        ) : (
+                            tagContent
+                        )
                     },
                 },
                 {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4218,10 +4218,17 @@ export interface ExternalDataSourceSchema extends SimpleExternalDataSourceSchema
     sync_frequency: DataWarehouseSyncInterval
 }
 
+export enum ExternalDataJobStatus {
+    Running = 'Running',
+    Completed = 'Completed',
+    Failed = 'Failed',
+    BillingLimits = 'Billing limits',
+}
+
 export interface ExternalDataJob {
     id: string
     created_at: string
-    status: 'Running' | 'Failed' | 'Completed' | 'Billing limits'
+    status: ExternalDataJobStatus
     schema: SimpleExternalDataSourceSchema
     rows_synced: number
     latest_error: string


### PR DESCRIPTION
## Problem

Users couldn't attribute errors to syncs previously: 
<img width="690" alt="image" src="https://github.com/user-attachments/assets/9f8fca58-e156-46d9-8b9b-bb848a4030c1" />

## Changes
- [x] Similar UI tooltip element to other source pages

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Tooltip on hover now.
