### PR TITLE
fix(flags): Fix bug preventing flag creation with analytics dashboards attached

### DIFF
--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -404,30 +404,10 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.json()["key"], "feature-with-analytics-dashboards")
-        self.assertEqual(response.json()["name"], "")
         self.assertEqual(len(response.json()["analytics_dashboards"]), 1)
         instance = FeatureFlag.objects.get(id=response.json()["id"])
         self.assertEqual(instance.key, "feature-with-analytics-dashboards")
-        self.assertEqual(instance.name, "")
         self.assertEqual(instance.analytics_dashboards.all()[0].id, dashboard.pk)
-
-        # Assert analytics are sent
-        mock_capture.assert_called_once_with(
-            self.user,
-            "feature flag created",
-            {
-                "groups_count": 1,  # 1 is always created by default
-                "has_variants": False,
-                "variants_count": 0,
-                "has_rollout_percentage": False,
-                "has_filters": False,
-                "filter_count": 0,
-                "created_at": instance.created_at,
-                "aggregating_by_groups": False,
-                "payload_count": 0,
-                "creation_context": "feature_flags",
-            },
-        )
 
     @patch("posthog.api.feature_flag.report_user_action")
     def test_create_multivariate_feature_flag(self, mock_capture):


### PR DESCRIPTION

## Problem

Context: https://posthoghelp.zendesk.com/agent/tickets/23578 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/27458)

[The region migration script](https://github.com/PostHog/posthog-migrate-meta/blob/main/index.ts#L221C77-L221C83) `POST`'s data from one project to another. If a new feature flag passed to the `POST ../feature_flags/` endpoint has analytics dashboards passed in via `analytics_dashboards`, we are not currently handling it correctly per Django rules, resulting in `TypeError('Direct assignment to the forward side of a many-to-many set is prohibited. Use analytics_dashboards.set() instead.')`

## Changes

This PR uses the same fix we have in the `PATCH` endpoint, popping `analytics_dashboards` out of the `validated_data`, handling it separately.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

I TDD'd a test for this exact error
