### PR TITLE
fix(data-warehouse): Get the actual primary keys of a mysql table

### DIFF
--- a/posthog/temporal/data_imports/pipelines/mysql/mysql.py
+++ b/posthog/temporal/data_imports/pipelines/mysql/mysql.py
@@ -61,18 +61,11 @@ def _build_query(
 
 def _get_primary_keys(cursor: Cursor, schema: str, table_name: str) -> list[str] | None:
     query = """
-        SELECT
-            kcu.column_name
-        FROM
-            information_schema.table_constraints tc
-        JOIN
-            information_schema.key_column_usage kcu
-            ON tc.constraint_name = kcu.constraint_name
-            AND tc.table_schema = kcu.table_schema
-        WHERE
-            tc.table_schema = %(schema)s
-            AND tc.table_name = %(table_name)s
-            AND tc.constraint_type = 'PRIMARY KEY'"""
+        SELECT COLUMN_NAME
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = %(schema)s
+        AND TABLE_NAME = %(table_name)s
+        AND COLUMN_KEY = 'PRI'"""
 
     cursor.execute(
         query,

--- a/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -110,7 +110,11 @@ class DeltaTableHelper:
             if not primary_keys or len(primary_keys) == 0:
                 raise Exception("Primary key required for incremental syncs")
 
-            normalized_primary_keys = [normalize_column_name(x) for x in primary_keys]
+            # Normalize keys and check the keys actually exist in the dataset
+            py_table_column_names = data.column_names
+            normalized_primary_keys = [
+                normalize_column_name(x) for x in primary_keys if normalize_column_name(x) in py_table_column_names
+            ]
 
             delta_table.merge(
                 source=data,

--- a/posthog/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/utils.py
@@ -173,7 +173,7 @@ def _evolve_pyarrow_schema(table: pa.Table, delta_schema: deltalake.Schema | Non
                     new_column_data = pa.array([None] * table.num_rows, type=field.type)
                 else:
                     new_column_data = pa.array(
-                        [_get_default_value_from_pyarrow_type(field.type)] * table.num_rows, type=field.type
+                        [get_default_value_for_pyarrow_type(field.type)] * table.num_rows, type=field.type
                     )
                 table = table.append_column(field, new_column_data)
 
@@ -255,30 +255,6 @@ def _append_debug_column_to_pyarrows_table(table: pa.Table, load_id: int) -> pa.
 
     column = pa.array([debug_info] * table.num_rows, type=pa.string())
     return table.append_column("_ph_debug", column)
-
-
-def _get_default_value_from_pyarrow_type(pyarrow_type: pa.DataType):
-    """
-    Returns a default value for the given PyArrow type.
-    """
-    if pa.types.is_integer(pyarrow_type):
-        return 0
-    elif pa.types.is_floating(pyarrow_type):
-        return 0.0
-    elif pa.types.is_string(pyarrow_type):
-        return ""
-    elif pa.types.is_boolean(pyarrow_type):
-        return False
-    elif pa.types.is_binary(pyarrow_type):
-        return b""
-    elif pa.types.is_timestamp(pyarrow_type):
-        return pa.scalar(0, type=pyarrow_type).as_py()
-    elif pa.types.is_date(pyarrow_type):
-        return pa.scalar(0, type=pyarrow_type).as_py()
-    elif pa.types.is_time(pyarrow_type):
-        return pa.scalar(0, type=pyarrow_type).as_py()
-    else:
-        raise ValueError(f"No default value defined for type: {pyarrow_type}")
 
 
 def _update_incremental_state(schema: ExternalDataSchema | None, table: pa.Table, logger: FilteringBoundLogger) -> None:


### PR DESCRIPTION
## Problem
- What I thought was a universally standard SQL query for getting primary keys is actually not in MySQL
- Causing deltalake to try to merge on primary keys that don't exist

## Changes
- Use a better query to get a tables primary keys
- Also removed some duplicate code

## How did you test this code?
We need some mock MySQL tests in the codebase