### PR TITLE
fix(data-warehouse): Allow dashes in the identifier logic

### DIFF
--- a/posthog/temporal/data_imports/pipelines/mysql/mysql.py
+++ b/posthog/temporal/data_imports/pipelines/mysql/mysql.py
@@ -24,10 +24,10 @@ from dlt.common.normalizers.naming.snake_case import NamingConvention
 def _sanitize_identifier(identifier: str) -> str:
     if not identifier.isidentifier():
         if identifier.startswith("$") or (len(identifier) > 0 and identifier[0].isdigit()):
-            if not identifier[1:].isidentifier():
+            if not identifier[1:].replace(".", "").replace("_", "").replace("-", "").isidentifier():
                 raise ValueError(f"Invalid SQL identifier: {identifier}")
 
-    if not identifier.replace(".", "").replace("_", "").replace("$", "").isalnum():
+    if not identifier.replace(".", "").replace("_", "").replace("-", "").replace("$", "").isalnum():
         raise ValueError(f"Invalid SQL identifier: {identifier}")
 
     return f"`{identifier}`"


### PR DESCRIPTION
## Problem
- A table is trying to sync with a dash in its name - this was working before we added stricter identifier logic
- Sentry error: https://posthog.sentry.io/issues/6318573788/events/be5c56e6b1ec4bb19c3ef23c9e281cf7/

## Changes
Allow dashes in the identifier names for mysql
