### PR TITLE
fix(hobby): use hostname in default clickhouse config

### DIFF
--- a/docker/clickhouse/config.d/default.xml
+++ b/docker/clickhouse/config.d/default.xml
@@ -5,7 +5,7 @@
         <posthog>
             <shard>
                 <replica>
-                    <host>localhost</host>
+                    <host>clickhouse</host>
                     <port>9000</port>
                 </replica>
             </shard>
@@ -13,7 +13,7 @@
         <posthog_single_shard>
             <shard>
                 <replica>
-                    <host>localhost</host>
+                    <host>clickhouse</host>
                     <port>9000</port>
                 </replica>
             </shard>
@@ -21,7 +21,7 @@
         <posthog_migrations>
             <shard>
                 <replica>
-                    <host>localhost</host>
+                    <host>clickhouse</host>
                     <port>9000</port>
                 </replica>
             </shard>


### PR DESCRIPTION
This was set to localhost, which worked for dev but caused the web container to go looking in the wrong place when trying to run migrations.