### PR TITLE
chore: wrap setFilters to avoid crash

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -17,6 +17,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { objectClean, objectsEqual } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { getCurrentTeamId } from 'lib/utils/getAppContext'
+import posthog from 'posthog-js'
 
 import { activationLogic, ActivationTask } from '~/layout/navigation-3000/sidepanel/panels/activation/activationLogic'
 import { NodeKind, RecordingOrder, RecordingsQuery, RecordingsQueryResponse } from '~/queries/schema/schema-general'
@@ -470,7 +471,9 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
                 setFilters: (state, { filters }) => {
                     try {
                         if (!isValidRecordingFilters(filters)) {
-                            console.error('Invalid filters provided:', filters)
+                            posthog.captureException(new Error('Invalid filters provided'), {
+                                filters,
+                            })
                             return getDefaultFilters(props.personUUID)
                         }
                         return {
@@ -478,7 +481,7 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
                             ...filters,
                         }
                     } catch (e) {
-                        console.error('Error setting filters:', e)
+                        posthog.captureException(e)
                         return getDefaultFilters(props.personUUID)
                     }
                 },

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -468,13 +468,18 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
             { persist: true, prefix: `${getCurrentTeamId()}__${key}` },
             {
                 setFilters: (state, { filters }) => {
-                    if (!isValidRecordingFilters(filters)) {
-                        console.error('Invalid filters provided:', filters)
-                        return state
-                    }
-                    return {
-                        ...state,
-                        ...filters,
+                    try {
+                        if (!isValidRecordingFilters(filters)) {
+                            console.error('Invalid filters provided:', filters)
+                            return getDefaultFilters(props.personUUID)
+                        }
+                        return {
+                            ...state,
+                            ...filters,
+                        }
+                    } catch (e) {
+                        console.error('Error setting filters:', e)
+                        return getDefaultFilters(props.personUUID)
                     }
                 },
                 resetFilters: () => getDefaultFilters(props.personUUID),


### PR DESCRIPTION
## Problem

Sometimes setFilters receive wrong object and it crashes the app. Also, as we saved the state it can be very difficult to get out of that deadloop.

## Changes

Wrap it in try catch and reset filters if something goes wrong.
