### PR TITLE
fix(data-warehouse): Dont need to error on binary types anymore

### DIFF
--- a/posthog/clickhouse/test/__snapshots__/test_cluster.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_cluster.ambr
@@ -3,20 +3,20 @@
   '''
   1 future(s) did not return a result:
   
-  * HostInfo(connection_info=ConnectionInfo(address='127.0.0.1', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Syntax error: failed at position 1 ('invalid'): invalid query. Expected one of: Query, Query with output, EXPLAIN, EXPLAIN, SELECT query, possibly with UNION, list of union elements, SELECT query, subquery, possibly with UNI...
+  * HostInfo(connection_info=ConnectionInfo(address='172.18.0.14', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Syntax error: failed at position 1 ('invalid'): invalid query. Expected one of: Query, Query with output, EXPLAIN, EXPLAIN, SELECT query, possibly with UNION, list of union elements, SELECT query, subquery, possibly with UNI...
   '''
 # ---
 # name: test_exception_summary.1
   '''
   1 future(s) did not return a result:
   
-  * HostInfo(connection_info=ConnectionInfo(address='127.0.0.1', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Unknown table expression identifier 'invalid_table_name' in scope SELECT * FROM invalid_table_name. Stack trace:\n\n0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x0000000000000000\n1. DB::Exceptio...
+  * HostInfo(connection_info=ConnectionInfo(address='172.18.0.14', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Unknown table expression identifier 'invalid_table_name' in scope SELECT * FROM invalid_table_name. Stack trace:\n\n0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x0000000000000000\n1. DB::Exceptio...
   '''
 # ---
 # name: test_exception_summary.2
   '''
   1 future(s) did not return a result:
   
-  * HostInfo(connection_info=ConnectionInfo(address='127.0.0.1', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ValueError('custom error')
+  * HostInfo(connection_info=ConnectionInfo(address='172.18.0.14', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ValueError('custom error')
   '''
 # ---

--- a/posthog/clickhouse/test/__snapshots__/test_cluster.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_cluster.ambr
@@ -3,20 +3,20 @@
   '''
   1 future(s) did not return a result:
   
-  * HostInfo(connection_info=ConnectionInfo(address='172.18.0.13', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Syntax error: failed at position 1 ('invalid'): invalid query. Expected one of: Query, Query with output, EXPLAIN, EXPLAIN, SELECT query, possibly with UNION, list of union elements, SELECT query, subquery, possibly with UNI...
+  * HostInfo(connection_info=ConnectionInfo(address='172.18.0.17', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Syntax error: failed at position 1 ('invalid'): invalid query. Expected one of: Query, Query with output, EXPLAIN, EXPLAIN, SELECT query, possibly with UNION, list of union elements, SELECT query, subquery, possibly with UNI...
   '''
 # ---
 # name: test_exception_summary.1
   '''
   1 future(s) did not return a result:
   
-  * HostInfo(connection_info=ConnectionInfo(address='172.18.0.13', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Unknown table expression identifier 'invalid_table_name' in scope SELECT * FROM invalid_table_name. Stack trace:\n\n0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x0000000000000000\n1. DB::Exceptio...
+  * HostInfo(connection_info=ConnectionInfo(address='172.18.0.17', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Unknown table expression identifier 'invalid_table_name' in scope SELECT * FROM invalid_table_name. Stack trace:\n\n0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x0000000000000000\n1. DB::Exceptio...
   '''
 # ---
 # name: test_exception_summary.2
   '''
   1 future(s) did not return a result:
   
-  * HostInfo(connection_info=ConnectionInfo(address='172.18.0.13', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ValueError('custom error')
+  * HostInfo(connection_info=ConnectionInfo(address='172.18.0.17', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ValueError('custom error')
   '''
 # ---

--- a/posthog/clickhouse/test/__snapshots__/test_cluster.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_cluster.ambr
@@ -3,20 +3,20 @@
   '''
   1 future(s) did not return a result:
   
-  * HostInfo(connection_info=ConnectionInfo(address='172.18.0.14', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Syntax error: failed at position 1 ('invalid'): invalid query. Expected one of: Query, Query with output, EXPLAIN, EXPLAIN, SELECT query, possibly with UNION, list of union elements, SELECT query, subquery, possibly with UNI...
+  * HostInfo(connection_info=ConnectionInfo(address='172.18.0.13', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Syntax error: failed at position 1 ('invalid'): invalid query. Expected one of: Query, Query with output, EXPLAIN, EXPLAIN, SELECT query, possibly with UNION, list of union elements, SELECT query, subquery, possibly with UNI...
   '''
 # ---
 # name: test_exception_summary.1
   '''
   1 future(s) did not return a result:
   
-  * HostInfo(connection_info=ConnectionInfo(address='172.18.0.14', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Unknown table expression identifier 'invalid_table_name' in scope SELECT * FROM invalid_table_name. Stack trace:\n\n0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x0000000000000000\n1. DB::Exceptio...
+  * HostInfo(connection_info=ConnectionInfo(address='172.18.0.13', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Unknown table expression identifier 'invalid_table_name' in scope SELECT * FROM invalid_table_name. Stack trace:\n\n0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x0000000000000000\n1. DB::Exceptio...
   '''
 # ---
 # name: test_exception_summary.2
   '''
   1 future(s) did not return a result:
   
-  * HostInfo(connection_info=ConnectionInfo(address='172.18.0.14', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ValueError('custom error')
+  * HostInfo(connection_info=ConnectionInfo(address='172.18.0.13', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ValueError('custom error')
   '''
 # ---

--- a/posthog/temporal/data_imports/pipelines/pipeline/hogql_schema.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/hogql_schema.py
@@ -27,6 +27,9 @@ class HogQLSchema:
         if existing_type is not None and existing_type != StringDatabaseField.__name__:
             return
 
+        if pa.types.is_binary(field.type):
+            return
+
         hogql_type: type[DatabaseField] = DatabaseField
 
         if pa.types.is_time(field.type):
@@ -43,8 +46,6 @@ class HogQLSchema:
             hogql_type = BooleanDatabaseField
         elif pa.types.is_integer(field.type):
             hogql_type = IntegerDatabaseField
-        elif pa.types.is_binary(field.type):
-            raise Exception("Type 'binary' is not a supported column type")
         elif pa.types.is_string(field.type):
             hogql_type = StringDatabaseField
 


### PR DESCRIPTION
## Problem
- A table can have a binary column for legacy reasons but they still cant sync the table because we throw an error when we create the hogql schema from the pyarrow table
  - legacy reasons: we'd need to resync any table that has a binary column. Instead we just fill any binary columns with `b""` for now
- Sentry error: https://posthog.sentry.io/issues/6188950191/?project=4508444747956225&query=&referrer=issue-stream&statsPeriod=30d&stream_index=2

## Changes
- Dont throw an error, just don't add the binary column to the hogql schema. This means that the column will never be queryable - ideal! 

