### PR TITLE
fix: make test_cluster output always same IP address

### DIFF
--- a/posthog/clickhouse/test/test_cluster.py
+++ b/posthog/clickhouse/test/test_cluster.py
@@ -30,18 +30,19 @@ def test_mutation_runner_rejects_invalid_parameters() -> None:
 
 
 def test_exception_summary(snapshot, cluster: ClickhouseCluster) -> None:
-    def replace_memory_addresses(value):
-        return re.sub(r"0x[0-9A-Fa-f]{16}", "0x0000000000000000", value)
+    def replace_memory_addresses_and_ips(value):
+        message = re.sub(r"0x[0-9A-Fa-f]{16}", "0x0000000000000000", value)
+        return re.sub(r"address='\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}'", "address='127.0.0.1'", message)
 
     with pytest.raises(ExceptionGroup) as e:
         cluster.map_all_hosts(Query("invalid query")).result()
 
-    assert replace_memory_addresses(e.value.message) == snapshot
+    assert replace_memory_addresses_and_ips(e.value.message) == snapshot
 
     with pytest.raises(ExceptionGroup) as e:
         cluster.map_all_hosts(Query("SELECT * FROM invalid_table_name")).result()
 
-    assert replace_memory_addresses(e.value.message) == snapshot
+    assert replace_memory_addresses_and_ips(e.value.message) == snapshot
 
     with pytest.raises(ExceptionGroup) as e:
 
@@ -50,7 +51,7 @@ def test_exception_summary(snapshot, cluster: ClickhouseCluster) -> None:
 
         cluster.map_all_hosts(explode).result()
 
-    assert e.value.message == snapshot
+    assert replace_memory_addresses_and_ips(e.value.message) == snapshot
 
 
 def test_mutations(cluster: ClickhouseCluster) -> None:


### PR DESCRIPTION
## Problem

`test_exception_summary` is flaky after merging https://github.com/PostHog/posthog/pull/29044

## Changes

Replace the IP address of the exception message to always use the same one.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Running the test locally
