### PR TITLE
fix: fix wrong inputs in customerio migration

### DIFF
--- a/posthog/cdp/templates/customerio/template_customerio.py
+++ b/posthog/cdp/templates/customerio/template_customerio.py
@@ -259,9 +259,8 @@ class TemplateCustomerioMigrator(HogFunctionTemplateMigrator):
             "site_id": {"value": customerio_site_id},
             "token": {"value": token},
             "host": {"value": host},
-            "identifiers": {"value": {"email": "{person.properties.email}"}}
-            if identify_by_email
-            else {"value": {"id": "{event.distinct_id}"}},
+            "identifier_key": {"value": "email" if identify_by_email else "id"},
+            "identifier_value": {"value": "{person.properties.email}" if identify_by_email else "{event.distinct_id}"},
             "include_all_properties": {"value": True},
             "attributes": {"value": {}},
         }

--- a/posthog/cdp/templates/customerio/test_template_customerio.py
+++ b/posthog/cdp/templates/customerio/test_template_customerio.py
@@ -148,23 +148,13 @@ class TestTemplateMigration(BaseTest):
                 "site_id": {"value": "SITE_ID"},
                 "token": {"value": "TOKEN"},
                 "host": {"value": "track.customer.io"},
-                "identifiers": {"value": {"id": "{event.distinct_id}"}},
+                "identifier_key": {"value": "id"},
+                "identifier_value": {"value": "{event.distinct_id}"},
                 "include_all_properties": {"value": True},
                 "attributes": {"value": {}},
             }
         )
         assert template["filters"] == snapshot({})
-        assert template["inputs"] == snapshot(
-            {
-                "action": {"value": "automatic"},
-                "site_id": {"value": "SITE_ID"},
-                "token": {"value": "TOKEN"},
-                "host": {"value": "track.customer.io"},
-                "identifiers": {"value": {"id": "{event.distinct_id}"}},
-                "include_all_properties": {"value": True},
-                "attributes": {"value": {}},
-            }
-        )
 
     def test_anon_config_send_all(self):
         obj = self.get_plugin_config(
@@ -203,7 +193,8 @@ class TestTemplateMigration(BaseTest):
     def test_identify_by_email(self):
         obj = self.get_plugin_config({"identifyByEmail": "Yes"})
         template = TemplateCustomerioMigrator.migrate(obj)
-        assert template["inputs"]["identifiers"] == snapshot({"value": {"email": "{person.properties.email}"}})
+        assert template["inputs"]["identifier_key"] == {"value": "email"}
+        assert template["inputs"]["identifier_value"] == {"value": "{person.properties.email}"}
 
     def test_events_filters(self):
         obj = self.get_plugin_config({"eventsToSend": "event1,event2, $pageview"})


### PR DESCRIPTION
## Problem

The customer.io destination migration was passing inputs as a key-value dictionary instead of two separate keys for the key and the value.

## Changes

Changes the identifiers to use `identifier_key` and `identifier_value` input keys, as defined in the customer.io template.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Updated the tests.