### PR TITLE
feat: move action buttons from app header to page header

### DIFF
--- a/frontend/src/lib/components/PageHeader.tsx
+++ b/frontend/src/lib/components/PageHeader.tsx
@@ -1,10 +1,6 @@
 import clsx from 'clsx'
-import { useValues } from 'kea'
 import { WithinPageHeaderContext } from 'lib/lemon-ui/LemonButton/LemonButton'
-import { createPortal } from 'react-dom'
 import { DraggableToNotebookProps } from 'scenes/notebooks/AddToNotebook/DraggableToNotebook'
-
-import { breadcrumbsLogic } from '~/layout/navigation/Breadcrumbs/breadcrumbsLogic'
 
 interface PageHeaderProps {
     caption?: string | JSX.Element | null | false
@@ -15,19 +11,27 @@ interface PageHeaderProps {
 }
 
 export function PageHeader({ caption, buttons, tabbedPage }: PageHeaderProps): JSX.Element | null {
-    const { actionsContainer } = useValues(breadcrumbsLogic)
+    if (!caption && !buttons) {
+        return null
+    }
 
     return (
-        <>
-            {buttons &&
-                actionsContainer &&
-                createPortal(
-                    <WithinPageHeaderContext.Provider value={true}>{buttons}</WithinPageHeaderContext.Provider>,
-                    actionsContainer
+        <div className="page-header">
+            <div
+                className={clsx(
+                    'page-header-content',
+                    'flex items-center gap-2',
+                    caption ? 'justify-between' : 'justify-end'
                 )}
-
-            {caption && <div className={clsx('page-caption', tabbedPage && 'tabbed')}>{caption}</div>}
-        </>
+            >
+                {caption && <div className={clsx('page-caption', tabbedPage && 'tabbed')}>{caption}</div>}
+                {buttons && (
+                    <div className="page-buttons flex items-center gap-2">
+                        <WithinPageHeaderContext.Provider value={true}>{buttons}</WithinPageHeaderContext.Provider>
+                    </div>
+                )}
+            </div>
+        </div>
     )
 }
 


### PR DESCRIPTION
## Problem

Action buttons are not in easily reachable area. 

[Example discussion](https://posthog.slack.com/archives/C0368RPHLQH/p1740069258444419?thread_ts=1739861954.785259&cid=C0368RPHLQH)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

This PR moves action buttons from app header to page header. 

<img width="1912" alt="image" src="https://github.com/user-attachments/assets/75242db7-0d59-40ab-afea-8f70b92382c8" />
<img width="1912" alt="image" src="https://github.com/user-attachments/assets/459482e2-aeb1-45d4-bbe0-ef42572b9dd0" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Locally 👀 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
