### PR TITLE
fix: missing activity tab in sidepanel

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
@@ -64,6 +64,7 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
                 if (isCloudOrDev) {
                     tabs.push(SidePanelTab.Support)
                 }
+                tabs.push(SidePanelTab.Activity)
 
                 if (currentTeam?.created_at) {
                     const teamCreatedAt = dayjs(currentTeam.created_at)


### PR DESCRIPTION
## Problem

Accidentally removed this from the side panel

## Changes

Brings it back

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Ran it locally
