### PR TITLE
chore: slow down timezone tooltips

### DIFF
--- a/frontend/src/lib/lemon-ui/Popover/Popover.tsx
+++ b/frontend/src/lib/lemon-ui/Popover/Popover.tsx
@@ -68,6 +68,8 @@ export interface PopoverProps {
     closeParentPopoverOnClickInside?: boolean
     /** Whether to show an arrow pointing to a reference element */
     showArrow?: boolean
+    /** An added delay before the floating overlay is shown */
+    delayMs?: number
 }
 
 /** Context for the popover overlay: parent popover visibility and parent popover level. */
@@ -106,6 +108,7 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(function P
         style,
         showArrow = false,
         overflowHidden = false,
+        delayMs = 50,
     },
     contentRef
 ): JSX.Element {
@@ -232,7 +235,14 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(function P
             )}
             {visible ? (
                 <FloatingPortal root={floatingContainer}>
-                    <CSSTransition in={visible} timeout={50} classNames="Popover-" appear mountOnEnter unmountOnExit>
+                    <CSSTransition
+                        in={visible}
+                        timeout={delayMs}
+                        classNames="Popover-"
+                        appear
+                        mountOnEnter
+                        unmountOnExit
+                    >
                         <PopoverReferenceContext.Provider
                             value={null /* Resetting the reference, since there's none */}
                         >

--- a/frontend/src/scenes/error-tracking/ErrorTrackingScene.tsx
+++ b/frontend/src/scenes/error-tracking/ErrorTrackingScene.tsx
@@ -179,10 +179,10 @@ const CustomGroupTitleColumn: QueryContextColumnComponent = (props) => {
                     <div className="space-y-1">
                         <div className="line-clamp-1">{record.description}</div>
                         <div className="space-x-1">
-                            <TZLabel time={record.first_seen} className="border-dotted border-b" />
+                            <TZLabel time={record.first_seen} className="border-dotted border-b" delayMs={750} />
                             <span>|</span>
                             {record.last_seen ? (
-                                <TZLabel time={record.last_seen} className="border-dotted border-b" />
+                                <TZLabel time={record.last_seen} className="border-dotted border-b" delayMs={750} />
                             ) : (
                                 <LemonSkeleton />
                             )}


### PR DESCRIPTION
## Problem

Timzone popovers are too noisy when you're mousing through the list

## Changes

Add a delay