### PR TITLE
fix: create database only in dev environment

### DIFF
--- a/posthog/management/commands/migrate_clickhouse.py
+++ b/posthog/management/commands/migrate_clickhouse.py
@@ -110,7 +110,8 @@ class Command(BaseCommand):
         return database._get_applied_migrations(MIGRATIONS_PACKAGE_NAME, replicated=True)
 
     def _create_database_if_not_exists(self, database: str, cluster: str):
-        with default_client() as client:
-            client.execute(
-                f"CREATE DATABASE IF NOT EXISTS {database} ON CLUSTER {cluster}",
-            )
+        if settings.TEST or settings.E2E_TESTING:
+            with default_client() as client:
+                client.execute(
+                    f"CREATE DATABASE IF NOT EXISTS {database} ON CLUSTER {cluster}",
+                )


### PR DESCRIPTION
## Problem

All pods are trying to create the database ON CLUSTER and are killing CH.


## Changes

The database it tries to create is the default one, that should already exist. Do it only for test.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

It should (migrations automatically create the database on just the server is connected to. Since hobby deployment only have one server, it will worl).
