### PR TITLE
fix(flags): Fix bug checking team project_id during scheduled change execution

### DIFF
--- a/posthog/models/feature_flag/feature_flag.py
+++ b/posthog/models/feature_flag/feature_flag.py
@@ -328,6 +328,7 @@ class FeatureFlag(models.Model):
         context = {
             "request": http_request,
             "team_id": self.team_id,
+            "project_id": self.team.project_id,
         }
 
         serializer_data = {}


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/24659 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/27384)

When we refactored [feature flag api code for environment suppor](https://github.com/PostHog/posthog/pull/26675/files#diff-901d485ec1a60127f907399dbbf514d89d3a99456190adfa242399d61749d3c5)t, we never added project id to the context created by the scheduled changes processor, resulting in this error: https://posthog.sentry.io/issues/6318258487/?alert_rule_id=15574993&alert_type=issue&notification_uuid=c37b9e47-d6c8-4d45-8b32-0e596f29208e&project=1899813&referrer=slack

Looking at where this error occurrs, scheduled changes were broken for flags that have cohort filters since that PR landed

## Changes

Provide project_id in the context as required

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added cohort filter flag and scheduled a change, confirmed this allows changes to execute successfully

<img width="1193" alt="Screenshot 2025-02-21 at 12 10 12 PM" src="https://github.com/user-attachments/assets/e8009cd6-043b-41cb-b2a2-4dd8bbf171fe" />

