### PR TITLE
fix(LemonSlider): change type of button in LemonSlider "button" instead of "submit"

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonSlider/LemonSlider.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSlider/LemonSlider.tsx
@@ -132,6 +132,7 @@ export function LemonSlider({ value = 0, onChange, min, max, step = 1, className
                     left: `calc(${proportion * 100}% - ${proportion}rem)`,
                 }}
                 role="slider"
+                type="button"
                 aria-valuemin={min}
                 aria-valuemax={max}
                 aria-valuenow={constrainedValue}


### PR DESCRIPTION
## Problem

I noticed that pressing on the button within Sliders submits a form if the slider is in one. I can't imagine we're relying on this behavior anywhere, and it feels buggy.

## Changes

Cause of bug: On most browsers, the default button `type` is `submit`. This simply overrides the type to `button`

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

https://github.com/user-attachments/assets/e6bc7fa2-ec30-4e42-a220-3ab53b6523b2



<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
