### PR TITLE
fix: ::placeholder for input and textarea lighter

### DIFF
--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -1338,7 +1338,7 @@ html {
 input::placeholder,
 textarea::placeholder {
     // Overrides Tailwind's default
-    color: var(--text-secondary);
+    color: var(--text-tertiary);
 }
 
 a {


### PR DESCRIPTION
## Problem
Placeholder color for input/textarea was too dark/too high contrast (people were confusing placeholder with a value)

## Changes
Made placeholder color lighter (less contrast)
AAA contrast => AA constrast (it's fine)

![2025-02-22 17 38 23](https://github.com/user-attachments/assets/ce7d0440-5aeb-4b56-a78c-b3f9902a2f24)

Text tertiary (in change) is the the lowest contrast we can have before it drops below AA WCAG ratings

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally