### PR TITLE
fix: don't preview confirmation message if it's not configured

### DIFF
--- a/frontend/src/scenes/surveys/SurveyFormAppearance.tsx
+++ b/frontend/src/scenes/surveys/SurveyFormAppearance.tsx
@@ -26,6 +26,9 @@ export function SurveyFormAppearance({
                 previewPageIndex={previewPageIndex}
                 onPreviewSubmit={(response) => {
                     const nextStep = getNextSurveyStep(survey, previewPageIndex, response)
+                    if (nextStep === SurveyQuestionBranchingType.End && !survey.appearance?.displayThankYouMessage) {
+                        return
+                    }
                     handleSetSelectedPageIndex(
                         nextStep === SurveyQuestionBranchingType.End ? survey.questions.length : nextStep
                     )


### PR DESCRIPTION
## Problem

dont preview confirmation message if there's no one added.

behavior on the actual survey: once you press submit, the survey disappears

## Does this work well for both Cloud and self-hosted?

yes

## How did you test this code?

tested if the preview no longer displays a preview message if no confirmation message is added
