### PR TITLE
fix: storybook command in mprocs.yaml

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -47,7 +47,7 @@ procs:
             bin/start-rust-service property-defs-rs
 
     storybook:
-        shell: 'pnpm storybook'
+        shell: 'pnpm --filter=@posthog/storybook start'
         autostart: false
 
 mouse_scroll_speed: 1


### PR DESCRIPTION
## Problem
Storybook launching in mprocs was broken

## Changes
Update mprocs.yaml with new workspace commad.

<img width="387" alt="image" src="https://github.com/user-attachments/assets/fd42dc07-6deb-4e63-95c9-830871a169a7" />

## Does this work well for both Cloud and self-hosted?
Yes?

## How did you test this code?
Ran ./bin/start and launches storybook correctly
