### PR TITLE
fix: group nps trend by hour if survey is < 2 days old

### DIFF
--- a/frontend/src/scenes/surveys/surveyLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveyLogic.test.ts
@@ -1629,6 +1629,13 @@ describe('surveyLogic filters for surveys responses', () => {
         })
 
         it('calculates default interval based on survey dates', async () => {
+            // Test for survey <= 2 days old
+            await expectLogic(logic, () => {
+                logic.actions.setSurveyValue('created_at', dayjs().subtract(1, 'day').format('YYYY-MM-DD'))
+            }).toMatchValues({
+                defaultInterval: 'hour',
+            })
+
             // Test for survey <= 4 weeks old
             await expectLogic(logic, () => {
                 logic.actions.setSurveyValue('created_at', dayjs().subtract(3, 'weeks').format('YYYY-MM-DD'))

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -1422,16 +1422,15 @@ export const surveyLogic = kea<surveyLogicType>([
                 const start = getSurveyStartDateForQuery(survey)
                 const end = getSurveyEndDateForQuery(survey)
                 const diffInDays = dayjs(end).diff(dayjs(start), 'days')
+                const diffInWeeks = dayjs(end).diff(dayjs(start), 'weeks')
 
                 if (diffInDays < 2) {
                     return 'hour'
                 }
-                // less than a month
-                if (diffInDays < 30) {
+                if (diffInWeeks <= 4) {
                     return 'day'
                 }
-                // more than a month, less than 3 months
-                if (diffInDays < 90) {
+                if (diffInWeeks <= 12) {
                     return 'week'
                 }
                 return 'month'

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -1257,7 +1257,6 @@ export const surveyLogic = kea<surveyLogicType>([
                     }
 
                     const data: number[] = questionResults.data
-
                     if (data.length === 11) {
                         const promoters = data.slice(9, 11).reduce((a, b) => a + b, 0)
                         const passives = data.slice(7, 9).reduce((a, b) => a + b, 0)

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -1257,6 +1257,7 @@ export const surveyLogic = kea<surveyLogicType>([
                     }
 
                     const data: number[] = questionResults.data
+
                     if (data.length === 11) {
                         const promoters = data.slice(9, 11).reduce((a, b) => a + b, 0)
                         const passives = data.slice(7, 9).reduce((a, b) => a + b, 0)
@@ -1421,11 +1422,17 @@ export const surveyLogic = kea<surveyLogicType>([
             (survey: Survey): IntervalType => {
                 const start = getSurveyStartDateForQuery(survey)
                 const end = getSurveyEndDateForQuery(survey)
-                const diffInWeeks = dayjs(end).diff(dayjs(start), 'weeks')
+                const diffInDays = dayjs(end).diff(dayjs(start), 'days')
 
-                if (diffInWeeks <= 4) {
+                if (diffInDays < 2) {
+                    return 'hour'
+                }
+                // less than a month
+                if (diffInDays < 30) {
                     return 'day'
-                } else if (diffInWeeks <= 12) {
+                }
+                // more than a month, less than 3 months
+                if (diffInDays < 90) {
                     return 'week'
                 }
                 return 'month'


### PR DESCRIPTION
## Problem

no sense in grouping by day if there's not enough days the survey is live

## Changes

before:

![CleanShot 2025-02-22 at 16 15 21@2x](https://github.com/user-attachments/assets/5da5d229-a4d4-435b-a77f-8ec2afc84f18)


after:

![CleanShot 2025-02-22 at 16 15 02@2x](https://github.com/user-attachments/assets/1c54bc51-c84a-4df4-b25c-4593ad2c07c7)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

yes

## How did you test this code?

verified locally; updated unit tests
