### PR TITLE
fix: Turn off debug logs for legacy plugins

### DIFF
--- a/plugin-server/src/cdp/services/legacy-plugin-executor.service.ts
+++ b/plugin-server/src/cdp/services/legacy-plugin-executor.service.ts
@@ -160,8 +160,6 @@ export class LegacyPluginExecutorService {
                       | LegacyDestinationPlugin)
                 : null
 
-            addLog('debug', `Executing plugin ${pluginId}`)
-
             if (!pluginId || !plugin) {
                 throw new Error(`Plugin ${pluginId} not found`)
             }
@@ -292,7 +290,6 @@ export class LegacyPluginExecutorService {
                 }
             }
 
-            addLog('debug', `Execution successful`)
             pluginExecutionDuration.observe(performance.now() - start)
         } catch (e) {
             if (e instanceof RetryError) {


### PR DESCRIPTION
## Problem

We don't need these logs and they take up a lot of space

## Changes

* Turns them off

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
