### PR TITLE
fix: side panel missing x

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
@@ -33,10 +33,10 @@ import { urls } from 'scenes/urls'
 import { AvailableFeature, ProductKey, SidePanelTab } from '~/types'
 
 import AlgoliaSearch from '../../components/AlgoliaSearch'
+import { SidePanelPaneHeader } from '../components/SidePanelPaneHeader'
 import { sidePanelStateLogic } from '../sidePanelStateLogic'
 import { MaxChatInterface } from './sidePanelMaxChatInterface'
 import { sidePanelStatusLogic } from './sidePanelStatusLogic'
-
 const PRODUCTS = [
     {
         name: 'Product OS',
@@ -212,6 +212,7 @@ export const SidePanelSupport = (): JSX.Element => {
     return (
         <>
             <div className="overflow-y-auto" data-attr="side-panel-support-container">
+                <SidePanelPaneHeader title="Help" />
                 <div className="p-3 max-w-160 w-full mx-auto">
                     {isEmailFormOpen ? (
                         <SupportFormBlock onCancel={() => closeEmailForm()} />


### PR DESCRIPTION
## Problem

You cannot close "Help" side panel atm as it's missing the X. 
Let's add it.

## Before
<img width="585" alt="Screenshot 2025-02-24 at 10 04 39" src="https://github.com/user-attachments/assets/0bee7f32-9832-40d4-b614-e8c3e005a6e1" />

##After
<img width="534" alt="Screenshot 2025-02-24 at 10 06 03" src="https://github.com/user-attachments/assets/010b92f2-4fba-4a4b-9312-178d6d70ce4d" />
