### PR TITLE
fix(err): move search into events list

### DIFF
--- a/frontend/src/scenes/error-tracking/ErrorTrackingFilters.tsx
+++ b/frontend/src/scenes/error-tracking/ErrorTrackingFilters.tsx
@@ -17,12 +17,10 @@ export const ErrorTrackingFilters = (): JSX.Element => {
     return (
         <div className="space-y-1">
             <div className="flex gap-2 items-center">
-                <UniversalSearch />
-                <InternalAccounts />
-            </div>
-            <div className="flex gap-2">
                 <DateRange />
                 <FilterGroup />
+                <UniversalSearch />
+                <InternalAccounts />
             </div>
         </div>
     )

--- a/frontend/src/scenes/error-tracking/ErrorTrackingIssueScene.tsx
+++ b/frontend/src/scenes/error-tracking/ErrorTrackingIssueScene.tsx
@@ -10,7 +10,6 @@ import { SceneExport } from 'scenes/sceneTypes'
 import { ErrorTrackingIssue } from '~/queries/schema/schema-general'
 
 import { AssigneeSelect } from './AssigneeSelect'
-import { ErrorTrackingFilters } from './ErrorTrackingFilters'
 import { errorTrackingIssueSceneLogic } from './errorTrackingIssueSceneLogic'
 import { ErrorTrackingSetupPrompt } from './ErrorTrackingSetupPrompt'
 import { Events } from './issue/Events'
@@ -88,7 +87,6 @@ export function ErrorTrackingIssueScene(): JSX.Element {
                         <LemonDivider className="my-4" />
                         <PanelLayout>
                             <PanelLayout.Container column primary>
-                                <ErrorTrackingFilters />
                                 <SparklinePanel />
                                 <PanelLayout.Panel primary>
                                     <Events />

--- a/frontend/src/scenes/error-tracking/issue/Events.tsx
+++ b/frontend/src/scenes/error-tracking/issue/Events.tsx
@@ -3,6 +3,7 @@ import { useActions, useValues } from 'kea'
 import PanelLayout, { SettingsButton } from 'lib/components/PanelLayout/PanelLayout'
 import { useState } from 'react'
 
+import { ErrorTrackingFilters } from '../ErrorTrackingFilters'
 import { errorTrackingIssueSceneLogic, EventsMode } from '../errorTrackingIssueSceneLogic'
 import { getExceptionAttributes, hasStacktrace } from '../utils'
 import { Overview } from './Overview'
@@ -73,7 +74,11 @@ export const Events = (): JSX.Element => {
                 />
             </PanelLayout.PanelSettings>
             {eventsMode === EventsMode.All ? (
-                <EventsTab />
+                <div className="m-4">
+                    <ErrorTrackingFilters />
+                    <LemonDivider thick className="mt-2 mb-0" />
+                    <EventsTab />
+                </div>
             ) : (
                 <>
                     <Overview />


### PR DESCRIPTION
Old placement was confusing with the "overview" panel state. Also inlined filters - I think we generally expect people to use few of them, and this scans easier for me.

<img width="2224" alt="image" src="https://github.com/user-attachments/assets/4ff69e92-164a-48a3-b464-d4fdd4618d6d" />
