### PR TITLE
fix(devex): more ram for turbo compile

### DIFF
--- a/.github/workflows/ci-turbo.yml
+++ b/.github/workflows/ci-turbo.yml
@@ -1,0 +1,101 @@
+name: Turbo CI
+
+on:
+    push:
+        branches:
+            - master
+    pull_request:
+
+jobs:
+    turbo-affected-4:
+        timeout-minutes: 30
+        name: Turbo Affected
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                # os: [depot-ubuntu-22.04, depot-ubuntu-22.04-4]
+                os: [depot-ubuntu-22.04-4]
+
+        steps:
+            - name: Check out code
+              uses: actions/checkout@v3
+              with:
+                  # Just fetch the current commit/PR head
+                  fetch-depth: 1
+
+            - name: Detect architecture
+              if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
+              run: |
+                  ARCH=$(uname -m)
+                  echo "ARCH=$ARCH" >> $GITHUB_ENV
+
+            # Conditionally fetch the base branch so Turborepo can compare against it
+            - name: Fetch base branch
+              run: |
+                  if [ "${{ github.event_name }}" = "pull_request" ]; then
+                    git fetch origin refs/heads/${GITHUB_BASE_REF}:refs/heads/${GITHUB_BASE_REF} --depth=1
+                    echo "TURBO_SCM_BASE=${GITHUB_BASE_REF}" >> $GITHUB_ENV
+                  else
+                    git fetch origin refs/heads/master:refs/heads/master --depth=1
+                    echo "TURBO_SCM_BASE=master" >> $GITHUB_ENV
+                  fi
+
+            - name: Set up Python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: 3.11.9
+                  cache: 'pip'
+                  cache-dependency-path: '**/requirements*.txt'
+                  token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
+
+            - run: pip install uv
+
+            - name: Install pnpm
+              uses: pnpm/action-setup@v4
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 18
+                  cache: 'pnpm'
+
+            - name: Cache node-gyp artifacts
+              uses: actions/cache@v3
+              with:
+                  path: ~/.cache/node-gyp
+                  key: ${{ runner.os }}-${{ env.ARCH }}-node-gyp-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+                  restore-keys: |
+                      ${{ runner.os }}-${{ env.ARCH }}-node-gyp-node-${{ matrix.node-version }}-
+
+            - name: Run Python and Node setup in parallel
+              run: |
+                  set -e
+                  set -m
+
+                  (
+                    echo ">>> [Python] Installing SAML (python3-saml) dependencies..."
+                    sudo apt-get update
+                    sudo apt-get install -y libxml2-dev libxmlsec1 libxmlsec1-dev libxmlsec1-openssl
+
+                    echo ">>> [Python] Installing dependencies..."
+                    uv pip install --system -r requirements.txt -r requirements-dev.txt
+                  ) &
+                  PY_PID=$!
+
+                  (
+                    echo ">>> [Node] Installing dependencies..."
+                    pnpm install --frozen-lockfile
+                  ) &
+                  NODE_PID=$!
+
+                  wait -n || (echo ">>> One of the parallel tasks failed, killing the other..." && kill $PY_PID $NODE_PID 2>/dev/null && exit 1)
+                  wait -n || (echo ">>> The second parallel task failed" && exit 1)
+
+                  echo ">>> Both parallel tasks completed successfully!"
+
+            - name: Turbo Affected
+              run: |
+                  bin/turbo build --affected --dry-run
+              env:
+                  NODE_OPTIONS: --max-old-space-size=8192
+                  TURBO_SCM_BASE: ${{ env.TURBO_SCM_BASE }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,10 +86,10 @@ COPY ./plugin-server/src/ ./plugin-server/src/
 COPY ./plugin-server/tests/ ./plugin-server/tests/
 
 # Build cyclotron first with increased memory
-RUN NODE_OPTIONS="--max-old-space-size=4096" bin/turbo --filter=@posthog/cyclotron build
+RUN NODE_OPTIONS="--max-old-space-size=6144" bin/turbo --filter=@posthog/cyclotron build
 
 # Then build the plugin server with increased memory
-RUN NODE_OPTIONS="--max-old-space-size=4096" bin/turbo --filter=@posthog/plugin-server build
+RUN NODE_OPTIONS="--max-old-space-size=6144" bin/turbo --filter=@posthog/plugin-server build
 
 # only prod dependencies in the node_module folder
 # as we will copy it to the last image.


### PR DESCRIPTION
## Changes

- Spins up a new CI pipeline that runs `turbo build test --affected`, listing the scripts it would run
- Increases memory in Docker for plugin server compilation by 2GB

## How did you test this code?

- This adds tests.
- Hoping the docker images compile