### PR TITLE
chore: open player full width when sidebar is open

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/Playlist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/Playlist.tsx
@@ -14,6 +14,7 @@ import { AiFilter } from 'scenes/session-recordings/components/AiFilter/AiFilter
 
 import { SessionRecordingType } from '~/types'
 
+import { playerSettingsLogic } from '../player/playerSettingsLogic'
 import { playlistLogic } from './playlistLogic'
 
 const SCROLL_TRIGGER_OFFSET = 100
@@ -91,6 +92,7 @@ export function Playlist({
 
     const { isExpanded } = useValues(playlistLogic)
     const { setIsExpanded } = useActions(playlistLogic)
+    const { sidebarOpen } = useValues(playerSettingsLogic)
 
     const onChangeActiveItem = (item: SessionRecordingType): void => {
         setControlledActiveItemId(item.id)
@@ -161,10 +163,10 @@ export function Playlist({
 
             <div
                 className={clsx('flex flex-col w-full gap-2 h-full', {
-                    'xl:flex-row': true,
+                    'xl:flex-row': !sidebarOpen,
                 })}
             >
-                <div className="flex flex-col gap-2 xl:max-w-80">
+                <div className="flex flex-col gap-2">
                     <DraggableToNotebook href={notebooksHref}>{filterActions}</DraggableToNotebook>
                     <div
                         ref={playlistRef}
@@ -235,13 +237,12 @@ export function Playlist({
                     </div>
                 </div>
                 <div
-                    className={clsx(
-                        'Playlist h-full min-h-96 w-full min-w-96 lg:min-w-[560px] order-first xl:order-none',
-                        {
-                            'Playlist--wide': size !== 'small',
-                            'Playlist--embedded': embedded,
-                        }
-                    )}
+                    className={clsx('Playlist h-full min-h-full w-full min-w-96 lg:min-w-[560px]', {
+                        'Playlist--wide': size !== 'small',
+                        'Playlist--embedded': embedded,
+                        'order-first xl:order-none': !sidebarOpen,
+                        'order-first': sidebarOpen,
+                    })}
                 >
                     {content && (
                         <div className="Playlist__main h-full">


### PR DESCRIPTION
## Problem

When you open the sidebar the player becomes way too small so it's very difficult to follow actions. 

## Solution

Make the player full width when the sidebar is open

###Before
<img width="1216" alt="Screenshot 2025-02-24 at 14 24 22" src="https://github.com/user-attachments/assets/48354cc9-ba2e-49dd-8ee8-d7183036a359" />


###AFter
<img width="1203" alt="Screenshot 2025-02-24 at 14 23 36" src="https://github.com/user-attachments/assets/7ad0f2df-34a2-4dca-91e1-40385bccaa6f" />
