### PR TITLE
chore: only log self hosted success on success

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -218,18 +218,22 @@ sudo -E docker-compose -f docker-compose.yml up -d --no-build --pull always
 echo "We will need to wait ~5-10 minutes for things to settle down, migrations to finish, and TLS certs to be issued"
 echo ""
 echo "⏳ Waiting for PostHog web to boot (this will take a few minutes)"
-bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost/_health)" != "200" ]]; do sleep 5; done'
-echo "⌛️ PostHog looks up!"
-echo ""
-echo "🎉🎉🎉  Done! 🎉🎉🎉"
-# send log of this install for continued support!
-curl -o /dev/null -L --header "Content-Type: application/json" -d "{
-    \"api_key\": \"sTMFPsFhdP1Ssg\",
-    \"distinct_id\": \"${DOMAIN}\",
-    \"properties\": {\"domain\": \"${DOMAIN}\"},
-    \"type\": \"capture\",
-    \"event\": \"magic_curl_install_complete\"
-}" https://us.i.posthog.com/batch/ &> /dev/null
+if bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost/_health)" != "200" ]]; do sleep 5; done'; then
+    echo "⌛️ PostHog looks up!"
+    echo ""
+    echo "🎉🎉🎉  Done! 🎉🎉🎉"
+    # send log of this install for continued support!
+    curl -o /dev/null -L --header "Content-Type: application/json" -d "{
+        \"api_key\": \"sTMFPsFhdP1Ssg\",
+        \"distinct_id\": \"${DOMAIN}\",
+        \"properties\": {\"domain\": \"${DOMAIN}\"},
+        \"type\": \"capture\",
+        \"event\": \"magic_curl_install_complete\"
+    }" https://us.i.posthog.com/batch/ &> /dev/null
+else
+    echo "Failed to detect PostHog web boot. Please check the logs for more details."
+fi
+
 echo ""
 echo "To stop the stack run 'docker-compose stop'"
 echo "To start the stack again run 'docker-compose start'"

--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -231,7 +231,7 @@ if bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost/_heal
         \"event\": \"magic_curl_install_complete\"
     }" https://us.i.posthog.com/batch/ &> /dev/null
 else
-    echo "Failed to detect PostHog web boot. Please check the logs for more details."
+    echo "Failed to detect PostHog web boot. Please check the logs with 'docker-compose logs' for more details."
 fi
 
 echo ""


### PR DESCRIPTION
the self-hosted install was completely broken

but our metrics for installs didn't change

my guess is that we were sending the success event whether it succeeds or not

so, let's not

https://us.posthog.com/project/2/insights/xqeYhvHD