### PR TITLE
feat(loading-state-views): Improving messaging for long-running query mechanism.

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonDialog/LemonDialog.tsx
+++ b/frontend/src/lib/lemon-ui/LemonDialog/LemonDialog.tsx
@@ -29,10 +29,7 @@ export type LemonDialogProps = Pick<
     onAfterClose?: () => void
     closeOnNavigate?: boolean
     shouldAwaitSubmit?: boolean
-    isOpen: boolean
-    setIsOpen: (isOpen: boolean) => void
-    isLoading: boolean
-    setIsLoading: (isLoading: boolean) => void
+    isLoadingCallback?: (isLoading: boolean) => void
 }
 
 export function LemonDialog({
@@ -46,14 +43,13 @@ export function LemonDialog({
     closeOnNavigate = true,
     shouldAwaitSubmit = false,
     footer,
-    isOpen,
-    setIsOpen,
-    isLoading,
-    setIsLoading,
+    isLoadingCallback,
     ...props
 }: LemonDialogProps): JSX.Element {
     const { currentLocation } = useValues(router)
     const lastLocation = useRef(currentLocation.pathname)
+    const [isOpen, setIsOpen] = useState(true)
+    const [isLoading, setIsLoading] = useState(false)
 
     primaryButton =
         primaryButton ||
@@ -79,11 +75,13 @@ export function LemonDialog({
                 onClick={async (e) => {
                     if (button === primaryButton && shouldAwaitSubmit) {
                         setIsLoading(true)
+                        isLoadingCallback?.(true)
                         try {
                             // eslint-disable-next-line @typescript-eslint/await-thenable
                             await button.onClick?.(e)
                         } finally {
                             setIsLoading(false)
+                            isLoadingCallback?.(false)
                         }
                     } else {
                         button.onClick?.(e)
@@ -135,7 +133,6 @@ export const LemonFormDialog = ({
     const { form, isFormValid, formValidationErrors } = useValues(logic)
     const { setFormValues } = useActions(logic)
     const [isLoading, setIsLoading] = useState(false)
-    const [isOpen, setIsOpen] = useState(true)
 
     const firstError = useMemo(() => Object.values(formValidationErrors)[0] as string, [formValidationErrors])
 
@@ -175,11 +172,7 @@ export const LemonFormDialog = ({
                 content={resolvedContent}
                 primaryButton={primaryButton}
                 secondaryButton={secondaryButton}
-                isOpen={isOpen}
-                setIsOpen={setIsOpen}
-                isLoading={isLoading}
-                setIsLoading={setIsLoading}
-                onClose={() => setIsOpen(false)}
+                isLoadingCallback={setIsLoading}
             />
         </Form>
     )

--- a/frontend/src/scenes/data-warehouse/editor/ViewLoadingState.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/ViewLoadingState.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react'
+
+const VIEW_EMPTY_STATE_COPY = [
+    'Resolving joins between your tables…',
+    'Saving references to your tables…',
+    'Searching saved queries for references…',
+    'Fetching all references to optimize view…',
+    'Constructing HOGQL expressions…',
+]
+
+export function ViewEmptyState(): JSX.Element {
+    const [messageIndex, setMessageIndex] = useState(0)
+    const [isMessageVisible, setIsMessageVisible] = useState(true)
+
+    useEffect(() => {
+        const TOGGLE_INTERVAL = 3000
+        const FADE_OUT_DURATION = 300
+
+        const interval = setInterval(() => {
+            setIsMessageVisible(false)
+            setTimeout(() => {
+                setMessageIndex((current) => {
+                    let newIndex = Math.floor(Math.random() * VIEW_EMPTY_STATE_COPY.length)
+                    if (newIndex === current) {
+                        newIndex = (newIndex + 1) % VIEW_EMPTY_STATE_COPY.length
+                    }
+                    return newIndex
+                })
+                setIsMessageVisible(true)
+            }, FADE_OUT_DURATION)
+        }, TOGGLE_INTERVAL)
+
+        return () => clearInterval(interval)
+    }, [])
+
+    return (
+        <div data-attr="view-empty-state" className="flex flex-col flex-1 items-center justify-center">
+            <span
+                className={`text-center transition-opacity duration-300 ${
+                    isMessageVisible ? 'opacity-100' : 'opacity-0'
+                }`}
+            >
+                {VIEW_EMPTY_STATE_COPY[messageIndex]}
+            </span>
+        </div>
+    )
+}

--- a/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
@@ -19,6 +19,7 @@ import { DataWarehouseSavedQuery, ExportContext } from '~/types'
 import { DATAWAREHOUSE_EDITOR_ITEM_ID } from '../external/dataWarehouseExternalSceneLogic'
 import { dataWarehouseViewsLogic } from '../saved_queries/dataWarehouseViewsLogic'
 import type { multitabEditorLogicType } from './multitabEditorLogicType'
+import { ViewEmptyState } from './ViewLoadingState'
 
 export const dataNodeKey = insightVizDataNodeKey({
     dashboardItemId: DATAWAREHOUSE_EDITOR_ITEM_ID,
@@ -442,11 +443,20 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
                 title: 'Save as view',
                 initialValues: { viewName: values.activeModelUri?.name || '' },
                 description: `View names can only contain letters, numbers, '_', or '$'. Spaces are not allowed.`,
-                content: (
-                    <LemonField name="viewName">
-                        <LemonInput placeholder="Please enter the name of the view" autoFocus />
-                    </LemonField>
-                ),
+                content: (isLoading) =>
+                    isLoading ? (
+                        <div className="h-[37px] flex items-center">
+                            <ViewEmptyState />
+                        </div>
+                    ) : (
+                        <LemonField name="viewName">
+                            <LemonInput
+                                disabled={isLoading}
+                                placeholder="Please enter the name of the view"
+                                autoFocus
+                            />
+                        </LemonField>
+                    ),
                 errors: {
                     viewName: (name) =>
                         !name


### PR DESCRIPTION
## Problem
Since it's difficult to improve the query performance of our code that examines `s3_tables`, we will instead provide a better UX in the meantime to show that something is happening.

## Changes

- [x] Update dialog component to support providing `isLoading` state to the content.
- [x] Add messaging about what we're doing (and why it's taking time) 

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Submits and works as before w/ better messaging. It should not impact any existing dialogs, only add functionality.
