### PR TITLE
fix: Use `host_name` instead of `host_address` for ClickhouseCluster node discovery

### DIFF
--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -41,9 +41,9 @@ runs:
               docker compose -f docker-compose.dev.yml down
               docker compose -f docker-compose.dev.yml up -d
 
-        - name: Add Kafka to /etc/hosts
+        - name: Add Kafka and ClickHouse to /etc/hosts
           shell: bash
-          run: echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts
+          run: echo "127.0.0.1 kafka clickhouse" | sudo tee -a /etc/hosts
 
         - name: Set up Python
           uses: actions/setup-python@v5

--- a/.github/workflows/ci-backend-update-test-timing.yml
+++ b/.github/workflows/ci-backend-update-test-timing.yml
@@ -7,7 +7,7 @@ env:
     SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da' # unsafe - for testing only
     DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
     REDIS_URL: 'redis://localhost'
-    CLICKHOUSE_HOST: 'clickhouse'
+    CLICKHOUSE_HOST: 'localhost'
     CLICKHOUSE_SECURE: 'False'
     CLICKHOUSE_VERIFY: 'False'
     TEST: 1

--- a/.github/workflows/ci-backend-update-test-timing.yml
+++ b/.github/workflows/ci-backend-update-test-timing.yml
@@ -7,7 +7,7 @@ env:
     SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da' # unsafe - for testing only
     DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
     REDIS_URL: 'redis://localhost'
-    CLICKHOUSE_HOST: 'localhost'
+    CLICKHOUSE_HOST: 'clickhouse'
     CLICKHOUSE_SECURE: 'False'
     CLICKHOUSE_VERIFY: 'False'
     TEST: 1

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -363,8 +363,8 @@ jobs:
               run: |
                   uv pip install --system -r requirements.txt -r requirements-dev.txt
 
-            - name: Add kafka host to /etc/hosts for kafka connectivity
-              run: sudo echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts
+            - name: Add Kafka and ClickHouse to /etc/hosts
+              run: sudo echo "127.0.0.1 kafka clickhouse" | sudo tee -a /etc/hosts
 
             - name: Set up needed files
               run: |

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -25,7 +25,7 @@ env:
     SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da' # unsafe - for testing only
     DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
     REDIS_URL: 'redis://localhost'
-    CLICKHOUSE_HOST: 'clickhouse'
+    CLICKHOUSE_HOST: 'localhost'
     CLICKHOUSE_SECURE: 'False'
     CLICKHOUSE_VERIFY: 'False'
     TEST: 1

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -25,7 +25,7 @@ env:
     SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da' # unsafe - for testing only
     DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
     REDIS_URL: 'redis://localhost'
-    CLICKHOUSE_HOST: 'localhost'
+    CLICKHOUSE_HOST: 'clickhouse'
     CLICKHOUSE_SECURE: 'False'
     CLICKHOUSE_VERIFY: 'False'
     TEST: 1

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -176,7 +176,7 @@ jobs:
                   mkdir -p /tmp/logs
 
                   echo "Starting PostHog using the container image ${{ needs.container.outputs.tag }}"
-                  DOCKER_RUN="docker run --rm --network host --add-host kafka:127.0.0.1 --env-file .env ${{ needs.container.outputs.tag }}"
+                  DOCKER_RUN="docker run --rm --network host --add-host kafka:127.0.0.1 --add-host clickhouse:127.0.0.1 --env-file .env ${{ needs.container.outputs.tag }}"
 
                   $DOCKER_RUN ./bin/migrate
                   $DOCKER_RUN python manage.py setup_dev

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -228,7 +228,7 @@ jobs:
                   mkdir -p /tmp/logs
 
                   echo "Starting PostHog using the container image ${{ needs.container.outputs.tag }}"
-                  DOCKER_RUN="docker run --rm --network host --add-host kafka:127.0.0.1 --env-file .env ${{ needs.container.outputs.tag }}"
+                  DOCKER_RUN="docker run --rm --network host --add-host kafka:127.0.0.1 --add-host clickhouse:127.0.0.1 --env-file .env ${{ needs.container.outputs.tag }}"
 
                   $DOCKER_RUN ./bin/migrate
                   $DOCKER_RUN python manage.py setup_dev

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -105,9 +105,9 @@ jobs:
                   docker compose -f docker-compose.dev.yml down
                   docker compose -f docker-compose.dev.yml up -d
 
-            - name: Add Kafka to /etc/hosts
+            - name: Add Kafka and ClickHouse to /etc/hosts
               if: needs.changes.outputs.plugin-server == 'true'
-              run: echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts
+              run: echo "127.0.0.1 kafka clickhouse" | sudo tee -a /etc/hosts
 
             - name: Set up Python
               if: needs.changes.outputs.plugin-server == 'true'
@@ -216,9 +216,9 @@ jobs:
                   docker compose -f docker-compose.dev.yml down
                   docker compose -f docker-compose.dev.yml up -d
 
-            - name: Add Kafka to /etc/hosts
+            - name: Add Kafka and ClickHouse to /etc/hosts
               if: needs.changes.outputs.plugin-server == 'true'
-              run: echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts
+              run: echo "127.0.0.1 kafka clickhouse" | sudo tee -a /etc/hosts
 
             - name: Set up Python
               if: needs.changes.outputs.plugin-server == 'true'

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -89,7 +89,7 @@ jobs:
 
         env:
             REDIS_URL: 'redis://localhost'
-            CLICKHOUSE_HOST: 'clickhouse'
+            CLICKHOUSE_HOST: 'localhost'
             CLICKHOUSE_DATABASE: 'posthog_test'
             KAFKA_HOSTS: 'kafka:9092'
 
@@ -198,7 +198,7 @@ jobs:
 
         env:
             REDIS_URL: 'redis://localhost'
-            CLICKHOUSE_HOST: 'clickhouse'
+            CLICKHOUSE_HOST: 'localhost'
             CLICKHOUSE_DATABASE: 'posthog_test'
             KAFKA_HOSTS: 'kafka:9092'
             DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -89,7 +89,7 @@ jobs:
 
         env:
             REDIS_URL: 'redis://localhost'
-            CLICKHOUSE_HOST: 'localhost'
+            CLICKHOUSE_HOST: 'clickhouse'
             CLICKHOUSE_DATABASE: 'posthog_test'
             KAFKA_HOSTS: 'kafka:9092'
 
@@ -198,7 +198,7 @@ jobs:
 
         env:
             REDIS_URL: 'redis://localhost'
-            CLICKHOUSE_HOST: 'localhost'
+            CLICKHOUSE_HOST: 'clickhouse'
             CLICKHOUSE_DATABASE: 'posthog_test'
             KAFKA_HOSTS: 'kafka:9092'
             DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -109,14 +109,14 @@ jobs:
               run: |
                   docker compose -f ../docker-compose.dev.yml down
                   docker compose -f ../docker-compose.dev.yml up -d
-                  echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts
+                  echo "127.0.0.1 kafka clickhouse" | sudo tee -a /etc/hosts
 
             - name: Setup dependencies
               if: needs.changes.outputs.rust == 'true' && matrix.package == 'others'
               run: |
                   docker compose up kafka redis db echo_server objectstorage -d --wait
                   docker compose up setup_test_db
-                  echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts
+                  echo "127.0.0.1 kafka clickhouse" | sudo tee -a /etc/hosts
 
             - name: Install rust
               if: needs.changes.outputs.rust == 'true'

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -79,11 +79,11 @@ class FuturesMap(dict[K, Future[V]]):
 
 
 class ConnectionInfo(NamedTuple):
-    host_name: str
+    host: str
     port: int | None
 
     def make_pool(self, client_settings: Mapping[str, str] | None = None) -> ChPool:
-        return _make_ch_pool(host=self.host_name, port=self.port, settings=client_settings)
+        return _make_ch_pool(host=self.host, port=self.port, settings=client_settings)
 
 
 class HostInfo(NamedTuple):

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -79,11 +79,11 @@ class FuturesMap(dict[K, Future[V]]):
 
 
 class ConnectionInfo(NamedTuple):
-    address: str
+    host_name: str
     port: int | None
 
     def make_pool(self, client_settings: Mapping[str, str] | None = None) -> ChPool:
-        return _make_ch_pool(host=self.address, port=self.port, settings=client_settings)
+        return _make_ch_pool(host=self.host_name, port=self.port, settings=client_settings)
 
 
 class HostInfo(NamedTuple):
@@ -114,7 +114,7 @@ class ClickhouseCluster:
 
         cluster_hosts = bootstrap_client.execute(
             """
-            SELECT host_address, port, shard_num, replica_num, getMacro('hostClusterType') as host_cluster_type, getMacro('hostClusterRole') as host_cluster_role
+            SELECT host_name, port, shard_num, replica_num, getMacro('hostClusterType') as host_cluster_type, getMacro('hostClusterRole') as host_cluster_role
             FROM clusterAllReplicas(%(name)s, system.clusters)
             WHERE name = %(name)s and is_local
             ORDER BY shard_num, replica_num
@@ -123,10 +123,10 @@ class ClickhouseCluster:
         )
 
         for row in cluster_hosts:
-            (host_address, port, shard_num, replica_num, host_cluster_type, host_cluster_role) = row
+            (host_name, port, shard_num, replica_num, host_cluster_type, host_cluster_role) = row
             host_info = HostInfo(
                 ConnectionInfo(
-                    host_address,
+                    host_name,
                     # We only use the port from system.clusters if we're running in E2E tests or debug mode,
                     # otherwise, we will use the default port.
                     port=port if (settings.E2E_TESTING or settings.DEBUG) else None,

--- a/posthog/clickhouse/test/__snapshots__/test_cluster.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_cluster.ambr
@@ -3,20 +3,20 @@
   '''
   1 future(s) did not return a result:
   
-  * HostInfo(connection_info=ConnectionInfo(host_name='clickhouse', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Syntax error: failed at position 1 ('invalid'): invalid query. Expected one of: Query, Query with output, EXPLAIN, EXPLAIN, SELECT query, possibly with UNION, list of union elements, SELECT query, subquery, possibly with UNI...
+  * HostInfo(connection_info=ConnectionInfo(host='clickhouse', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Syntax error: failed at position 1 ('invalid'): invalid query. Expected one of: Query, Query with output, EXPLAIN, EXPLAIN, SELECT query, possibly with UNION, list of union elements, SELECT query, subquery, possibly with UNI...
   '''
 # ---
 # name: test_exception_summary.1
   '''
   1 future(s) did not return a result:
   
-  * HostInfo(connection_info=ConnectionInfo(host_name='clickhouse', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Unknown table expression identifier 'invalid_table_name' in scope SELECT * FROM invalid_table_name. Stack trace:\n\n0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x0000000000000000\n1. DB::Exceptio...
+  * HostInfo(connection_info=ConnectionInfo(host='clickhouse', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Unknown table expression identifier 'invalid_table_name' in scope SELECT * FROM invalid_table_name. Stack trace:\n\n0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x0000000000000000\n1. DB::Exceptio...
   '''
 # ---
 # name: test_exception_summary.2
   '''
   1 future(s) did not return a result:
   
-  * HostInfo(connection_info=ConnectionInfo(host_name='clickhouse', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ValueError('custom error')
+  * HostInfo(connection_info=ConnectionInfo(host='clickhouse', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ValueError('custom error')
   '''
 # ---

--- a/posthog/clickhouse/test/__snapshots__/test_cluster.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_cluster.ambr
@@ -3,20 +3,20 @@
   '''
   1 future(s) did not return a result:
   
-  * HostInfo(connection_info=ConnectionInfo(address='127.0.0.1', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Syntax error: failed at position 1 ('invalid'): invalid query. Expected one of: Query, Query with output, EXPLAIN, EXPLAIN, SELECT query, possibly with UNION, list of union elements, SELECT query, subquery, possibly with UNI...
+  * HostInfo(connection_info=ConnectionInfo(host_name='clickhouse', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Syntax error: failed at position 1 ('invalid'): invalid query. Expected one of: Query, Query with output, EXPLAIN, EXPLAIN, SELECT query, possibly with UNION, list of union elements, SELECT query, subquery, possibly with UNI...
   '''
 # ---
 # name: test_exception_summary.1
   '''
   1 future(s) did not return a result:
   
-  * HostInfo(connection_info=ConnectionInfo(address='127.0.0.1', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Unknown table expression identifier 'invalid_table_name' in scope SELECT * FROM invalid_table_name. Stack trace:\n\n0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x0000000000000000\n1. DB::Exceptio...
+  * HostInfo(connection_info=ConnectionInfo(host_name='clickhouse', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ServerException("DB::Exception: Unknown table expression identifier 'invalid_table_name' in scope SELECT * FROM invalid_table_name. Stack trace:\n\n0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x0000000000000000\n1. DB::Exceptio...
   '''
 # ---
 # name: test_exception_summary.2
   '''
   1 future(s) did not return a result:
   
-  * HostInfo(connection_info=ConnectionInfo(address='127.0.0.1', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ValueError('custom error')
+  * HostInfo(connection_info=ConnectionInfo(host_name='clickhouse', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'): ValueError('custom error')
   '''
 # ---


### PR DESCRIPTION
## Problem

#29044 made it so that the `system.clusters` reported the IP address that is for the Docker network in local development, causing problems for tests and other things like migrations that use `ClickhouseCluster`.

## Changes

Use the hostname instead of IP address for connecting to cluster nodes. This works as long as hosts are configured as described here https://github.com/PostHog/posthog/pull/29044#pullrequestreview-2632678569

## Does this work well for both Cloud and self-hosted?

Cloud: yes
Self-hosted: yes
Development: yes

## How did you test this code?

Ran tests that were previously affected, they pass now