### PR TITLE
fix: make sure to capture errors and quit fast in /bin/migrate

### DIFF
--- a/bin/migrate
+++ b/bin/migrate
@@ -14,6 +14,8 @@ if [ -d "$SCRIPT_DIR/../rust/bin" ]; then
 fi
 
 # Create a temporary file for background process status
+# Ensure cleanup of temp file on script exit
+trap 'rm -f "$CLICKHOUSE_STATUS" 2>/dev/null' EXIT
 CLICKHOUSE_STATUS=$(mktemp)
 echo "0" > $CLICKHOUSE_STATUS
 

--- a/bin/migrate
+++ b/bin/migrate
@@ -1,28 +1,85 @@
 #!/bin/bash
-set -e
+set -e              # Exit on any command failure
+set -o pipefail     # Exit if any command in a pipeline fails
 
 SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 
 # NOTE when running in docker, rust might not exist so we need to check for it
 if [ -d "$SCRIPT_DIR/../rust/bin" ]; then
     bash $SCRIPT_DIR/../rust/bin/migrate-cyclotron
+    if [ $? -ne 0 ]; then
+        echo "Error in rust/bin/migrate-cyclotron, exiting."
+        exit 1
+    fi
 fi
 
-(
-    python manage.py migrate_clickhouse 
-    python manage.py sync_replicated_schema
-) & # ClickHouse migrations can run in parallel to Postgres ones
+# Create a temporary file for background process status
+CLICKHOUSE_STATUS=$(mktemp)
+echo "0" > $CLICKHOUSE_STATUS
 
+# Run ClickHouse migrations in the background but track their status
+(
+    # Run migrations and capture status
+    python manage.py migrate_clickhouse 
+    CH_MIGRATE_STATUS=$?
+    if [ $CH_MIGRATE_STATUS -ne 0 ]; then
+        echo "Error in migrate_clickhouse, setting error status."
+        echo "1" > $CLICKHOUSE_STATUS
+        exit $CH_MIGRATE_STATUS
+    fi
+    
+    python manage.py sync_replicated_schema
+    SYNC_STATUS=$?
+    if [ $SYNC_STATUS -ne 0 ]; then
+        echo "Error in sync_replicated_schema, setting error status."
+        echo "1" > $CLICKHOUSE_STATUS
+        exit $SYNC_STATUS
+    fi
+) & # ClickHouse migrations can run in parallel to Postgres ones
+CLICKHOUSE_PID=$!
+
+# Run postgres migrations
 python manage.py migrate
+if [ $? -ne 0 ]; then
+    echo "Error in postgres migrations, killing background process and exiting."
+    kill $CLICKHOUSE_PID 2>/dev/null || true
+    rm $CLICKHOUSE_STATUS
+    exit 1
+fi
 
 # NOTE: we do not apply any non-noop migrations here. Rather these are run
 # manually within the UI. See https://posthog.com/docs/runbook/async-migrations
 # for details.
 python manage.py run_async_migrations --complete-noop-migrations
+if [ $? -ne 0 ]; then
+    echo "Error in run_async_migrations, killing background process and exiting."
+    kill $CLICKHOUSE_PID 2>/dev/null || true
+    rm $CLICKHOUSE_STATUS
+    exit 1
+fi
 
 # NOTE: this check should not fail if a migration isn't complete but within the
 # given async migration posthog version range, thus this should not block e.g.
 # k8s pod deployments.
 python manage.py run_async_migrations --check
+if [ $? -ne 0 ]; then
+    echo "Error in run_async_migrations --check, killing background process and exiting."
+    kill $CLICKHOUSE_PID 2>/dev/null || true
+    rm $CLICKHOUSE_STATUS
+    exit 1
+fi
 
-wait $(jobs -p) # Make sure CH migrations are done before we exit
+# Wait for background ClickHouse migrations to complete
+wait $CLICKHOUSE_PID
+CLICKHOUSE_WAIT_STATUS=$?
+
+# Check the status of the ClickHouse migrations
+CH_STATUS=$(cat $CLICKHOUSE_STATUS)
+rm $CLICKHOUSE_STATUS
+
+if [ "$CH_STATUS" != "0" ] || [ $CLICKHOUSE_WAIT_STATUS -ne 0 ]; then
+    echo "Error in ClickHouse migrations, exiting."
+    exit 1
+fi
+
+echo "All migrations completed successfully."


### PR DESCRIPTION
## Problem

We don't fail fast on `/bin/migrate`

## Changes

Capture errors and fail fast with an error message in `/bin/migrate`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
