### PR TITLE
feat(capture): don't quota limit capturing events for which we don't charge

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -362,7 +362,6 @@ def drop_events_over_quota(token: str, events: list[Any]) -> EventsOverQuotaResu
     from ee.billing.quota_limiting import QuotaResource, list_limited_team_attributes
 
     results = []
-
     limited_tokens_events = list_limited_team_attributes(
         QuotaResource.EVENTS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
     )
@@ -372,7 +371,6 @@ def drop_events_over_quota(token: str, events: list[Any]) -> EventsOverQuotaResu
 
     recordings_were_limited = False
     events_were_limited = False
-
     for event in events:
         if event.get("event") in SESSION_RECORDING_EVENT_NAMES:
             EVENTS_RECEIVED_COUNTER.labels(resource_type="recordings").inc()

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -23,7 +23,7 @@ from statshog.defaults.django import statsd
 from token_bucket import Limiter, MemoryStorage
 from typing import Any, Optional, Literal
 
-from ee.billing.quota_limiting import QuotaLimitingCaches, QuotaResource, list_limited_team_attributes
+from ee.billing.quota_limiting import QuotaLimitingCaches
 from posthog.api.utils import get_data, get_token, safe_clickhouse_string
 from posthog.cache_utils import cache_for
 from posthog.exceptions import generate_exception_response
@@ -359,7 +359,10 @@ def drop_events_over_quota(token: str, events: list[Any]) -> EventsOverQuotaResu
     if not settings.EE_AVAILABLE:
         return EventsOverQuotaResult(events, False, False)
 
-    # Get lists of limited tokens from Redis
+    from ee.billing.quota_limiting import QuotaResource, list_limited_team_attributes
+
+    results = []
+
     limited_tokens_events = list_limited_team_attributes(
         QuotaResource.EVENTS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
     )
@@ -367,7 +370,6 @@ def drop_events_over_quota(token: str, events: list[Any]) -> EventsOverQuotaResu
         QuotaResource.RECORDINGS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
     )
 
-    results = []
     recordings_were_limited = False
     events_were_limited = False
 


### PR DESCRIPTION
## Problem

Per a [customer request](https://posthoghelp.zendesk.com/agent/tickets/23071), I'm proposing don't drop free events, even if a user is generally at their event quota limit.  More context: https://posthog.slack.com/archives/C075D3C5HST/p1740384418248519

## Changes

Made it so that capture checks for free events and doesn't drop them in the event that a capture request is quota limit for that token:id combo.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

New unit tests.
