### PR TITLE
fix: reload available features upgraded

### DIFF
--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -60,12 +60,11 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             if org.billing.stripe_subscription_id:  # type: ignore
                 raise NotFound("Billing V1 is active for this organization")
 
-        plan_keys = request.query_params.get("plan_keys", None)
         billing_manager = self.get_billing_manager()
         query = {}
         if "include_forecasting" in request.query_params:
             query["include_forecasting"] = request.query_params.get("include_forecasting")
-        response = billing_manager.get_billing(org, plan_keys, query)
+        response = billing_manager.get_billing(org, query)
 
         return Response(response)
 

--- a/ee/api/test/test_billing.py
+++ b/ee/api/test/test_billing.py
@@ -987,7 +987,7 @@ class TestActivateBillingAPI(APILicensedTest):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         mock_deactivate_products.assert_called_once_with(self.organization, "product_1")
-        mock_get_billing.assert_called_once_with(self.organization, None, {})
+        mock_get_billing.assert_called_once_with(self.organization, {})
 
     def test_deactivate_failure(self):
         url = "/api/billing/deactivate"

--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -152,7 +152,7 @@ class BillingManager:
         organization.available_product_features = available_product_features
         organization.save()
 
-        return
+        return available_product_features
 
     def update_billing_organization_users(self, organization: Organization) -> None:
         try:
@@ -405,9 +405,9 @@ class BillingManager:
             json=data,
         )
 
-        self.update_available_product_features(organization)
-
         handle_billing_service_error(res)
+
+        self.update_available_product_features(organization)
 
         return res.json()
 
@@ -418,9 +418,9 @@ class BillingManager:
             json=data,
         )
 
-        self.update_available_product_features(organization)
-
         handle_billing_service_error(res)
+
+        self.update_available_product_features(organization)
 
     def authorize(self, organization: Organization):
         res = requests.post(

--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -77,7 +77,6 @@ class BillingManager:
     def get_billing(
         self,
         organization: Optional[Organization],
-        plan_keys: Optional[str],
         query_params: Optional[dict[str, Any]] = None,
     ) -> dict[str, Any]:
         if organization and self.license and self.license.is_v2_license:
@@ -140,6 +139,20 @@ class BillingManager:
         )
 
         handle_billing_service_error(res)
+
+    def update_available_product_features(self, organization: Organization) -> list[dict[str, Any]]:
+        res = requests.get(
+            f"{BILLING_SERVICE_URL}/api/billing/available_product_features",
+            headers=self.get_auth_headers(organization),
+        )
+
+        handle_billing_service_error(res)
+
+        available_product_features = res.json()
+        organization.available_product_features = available_product_features
+        organization.save()
+
+        return
 
     def update_billing_organization_users(self, organization: Organization) -> None:
         try:
@@ -392,6 +405,8 @@ class BillingManager:
             json=data,
         )
 
+        self.update_available_product_features(organization)
+
         handle_billing_service_error(res)
 
         return res.json()
@@ -402,6 +417,8 @@ class BillingManager:
             headers=self.get_auth_headers(organization),
             json=data,
         )
+
+        self.update_available_product_features(organization)
 
         handle_billing_service_error(res)
 

--- a/ee/billing/test/test_billing_manager.py
+++ b/ee/billing/test/test_billing_manager.py
@@ -50,9 +50,7 @@ class TestBillingManager(BaseTest):
 
         BillingManager(license=None).get_billing(organization, plan_keys=None)
         assert billing_patch_request_mock.call_count == 1
-        billing_patch_request_mock.assert_called_with(
-            "https://billing.posthog.com/api/products-v2", params={"plan": "standard"}, headers={}
-        )
+        billing_patch_request_mock.assert_called_with("https://billing.posthog.com/api/products-v2", headers={})
 
     @patch(
         "ee.billing.billing_manager.requests.patch",

--- a/ee/billing/test/test_billing_manager.py
+++ b/ee/billing/test/test_billing_manager.py
@@ -48,9 +48,11 @@ class TestBillingManager(BaseTest):
         organization = self.organization
         TEST_clear_instance_license_cache()
 
-        BillingManager(license=None).get_billing(organization, plan_keys=None)
+        BillingManager(license=None).get_billing(organization)
         assert billing_patch_request_mock.call_count == 1
-        billing_patch_request_mock.assert_called_with("https://billing.posthog.com/api/products-v2", headers={})
+        billing_patch_request_mock.assert_called_with(
+            "https://billing.posthog.com/api/products-v2", params={"plan": "standard"}, headers={}
+        )
 
     @patch(
         "ee.billing.billing_manager.requests.patch",

--- a/frontend/src/scenes/billing/billingLogic.tsx
+++ b/frontend/src/scenes/billing/billingLogic.tsx
@@ -13,6 +13,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { pluralize } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import posthog from 'posthog-js'
+import { organizationLogic } from 'scenes/organizationLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { userLogic } from 'scenes/userLogic'
 
@@ -105,6 +106,8 @@ export const billingLogic = kea<billingLogicType>([
         actions: [
             userLogic,
             ['loadUser'],
+            organizationLogic,
+            ['loadCurrentOrganization'],
             eventUsageLogic,
             ['reportProductUnsubscribed'],
             lemonBannerLogic({ dismissKey: 'usage-limit-exceeded' }),
@@ -723,6 +726,9 @@ export const billingLogic = kea<billingLogicType>([
                     title: 'Error',
                     message: _search.billing_error,
                 })
+            }
+            if (_search.upgraded) {
+                actions.loadCurrentOrganization()
             }
             actions.setRedirectPath()
             actions.setIsOnboarding()

--- a/frontend/src/scenes/billing/billingLogic.tsx
+++ b/frontend/src/scenes/billing/billingLogic.tsx
@@ -727,7 +727,7 @@ export const billingLogic = kea<billingLogicType>([
                     message: _search.billing_error,
                 })
             }
-            if (_search.upgraded) {
+            if (_search.upgraded || _search.success) {
                 actions.loadCurrentOrganization()
             }
             actions.setRedirectPath()


### PR DESCRIPTION
## Changes

Following up on https://github.com/PostHog/billing/pull/1121. 

After a user upgrades, this is meant to make sure the latest available features are loaded. 

Paths for when they need to be reloaded
- initially subscribing from onboarding or billing page
- adding an add-on
- adding a trial
- removing an add-on
- canceling a trial
- unsubscribing

This PR handles all of the above. There is much room to improve here how we sync avail features to organizations but this is a big improvement to the UX because right now the proper features are not loaded in until you refresh. 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
