### PR TITLE
feat(devex): turbo clean + vscode launch

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,10 +6,10 @@
     "configurations": [
         {
             "name": "Frontend",
-            "command": "pnpm start",
+            "command": "bin/turbo --filter=@posthog/frontend start",
             "request": "launch",
             "type": "node-terminal",
-            "cwd": "${workspaceFolder}/frontend",
+            "cwd": "${workspaceFolder}",
             "presentation": {
                 "group": "main"
             },
@@ -28,7 +28,7 @@
         },
         {
             "name": "Frontend (https)",
-            "command": "pnpm start",
+            "command": "bin/turbo --filter=@posthog/frontend start",
             "request": "launch",
             "type": "node-terminal",
             "cwd": "${workspaceFolder}/frontend",
@@ -143,10 +143,10 @@
         },
         {
             "name": "Plugin Server",
-            "command": "npm run start:dev",
+            "command": "bin/turbo --filter=@posthog/plugin-server start",
             "request": "launch",
             "type": "node-terminal",
-            "cwd": "${workspaceFolder}/plugin-server",
+            "cwd": "${workspaceFolder}",
             "env": {
                 "CLICKHOUSE_SECURE": "False",
                 "DATABASE_URL": "postgres://posthog:posthog@localhost:5432/posthog",

--- a/turbo.json
+++ b/turbo.json
@@ -27,6 +27,10 @@
             "dependsOn": ["^build"],
             "persistent": true,
             "cache": false
+        },
+        "clean": {
+            "dependsOn": ["^clean"],
+            "cache": false
         }
     }
 }


### PR DESCRIPTION
## Changes

- Update vscode launch configurations to launch the plugin server and frontend via turbo
- Add the "clean" script to turbo.json, so we can do `turbo --filter=@posthog/plugin-server clean` and it'll clean all the deps.

## How did you test this code?

Ran the scripts locally