### PR TITLE
chore: upgrade minio

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -122,7 +122,7 @@ services:
             DYNAMIC_CONFIG_ENABLED: 'true'
 
     objectstorage:
-        image: minio/minio:RELEASE.2022-06-25T15-50-16Z
+        image: minio/minio:RELEASE.2025-02-18T16-25-55Z
         restart: on-failure
         environment:
             MINIO_ROOT_USER: object_storage_root_user


### PR DESCRIPTION
we're using a really old minio in self hosted replay
AWS has changed how they handle checksums and so minio was erroring

https://github.com/minio/minio/issues/20845

locally i ingested a recording, made sure it was in object storage, then upgraded minio and could still play it back