### PR TITLE
feat(cdp) http request recordings for destinations

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/http-recording/patch-fetch.test.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/http-recording/patch-fetch.test.ts
@@ -1,0 +1,83 @@
+import { patchTrackedFetch, restoreTrackedFetch } from './patch-fetch'
+import { DestinationHttpRecorder } from './recorder'
+
+describe('patchTrackedFetch', () => {
+    let mockFetchModule: any
+    let mockRecorder: DestinationHttpRecorder
+    let originalFetch: jest.Mock
+    let mockResponse: any
+
+    beforeEach(() => {
+        // Mock response
+        mockResponse = {
+            status: 200,
+            headers: new Map([['content-type', 'application/json']]),
+            clone: jest.fn().mockReturnThis(),
+            json: jest.fn().mockResolvedValue({ success: true }),
+            text: jest.fn().mockResolvedValue('{"success":true}'),
+        }
+
+        // Mock fetch function
+        originalFetch = jest.fn().mockResolvedValue(mockResponse)
+
+        // Mock fetch module
+        mockFetchModule = {
+            trackedFetch: originalFetch,
+        }
+
+        // Mock recorder
+        mockRecorder = {
+            startRecording: jest.fn(),
+            recordInteraction: jest.fn(),
+            stopRecording: jest.fn(),
+            compareRecordings: jest.fn(),
+        } as unknown as DestinationHttpRecorder
+    })
+
+    it('should patch the trackedFetch function', () => {
+        patchTrackedFetch(mockFetchModule, mockRecorder)
+
+        expect(mockFetchModule.trackedFetch).not.toBe(originalFetch)
+    })
+
+    it('should restore the original trackedFetch function', () => {
+        patchTrackedFetch(mockFetchModule, mockRecorder)
+        restoreTrackedFetch(mockFetchModule)
+
+        expect(mockFetchModule.trackedFetch).toBe(originalFetch)
+    })
+
+    it('should record successful HTTP interactions', async () => {
+        patchTrackedFetch(mockFetchModule, mockRecorder)
+
+        await mockFetchModule.trackedFetch('https://api.example.com', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ data: 'test' }),
+        })
+
+        expect(mockRecorder.recordInteraction).toHaveBeenCalledTimes(1)
+
+        const recordedInteraction = (mockRecorder.recordInteraction as jest.Mock).mock.calls[0][0]
+        expect(recordedInteraction.request.method).toBe('POST')
+        expect(recordedInteraction.request.url).toBe('https://api.example.com')
+        expect(recordedInteraction.response.status).toBe(200)
+    })
+
+    it('should record failed HTTP interactions', async () => {
+        patchTrackedFetch(mockFetchModule, mockRecorder)
+
+        const error = new Error('Network error')
+        originalFetch.mockRejectedValueOnce(error)
+
+        await expect(mockFetchModule.trackedFetch('https://api.example.com')).rejects.toThrow('Network error')
+
+        expect(mockRecorder.recordInteraction).toHaveBeenCalledTimes(1)
+
+        const recordedInteraction = (mockRecorder.recordInteraction as jest.Mock).mock.calls[0][0]
+        expect(recordedInteraction.request.method).toBe('GET')
+        expect(recordedInteraction.request.url).toBe('https://api.example.com')
+        expect(recordedInteraction.response.status).toBe(0)
+        expect(recordedInteraction.response.body.error).toBe('Network error')
+    })
+})

--- a/plugin-server/src/worker/ingestion/event-pipeline/http-recording/patch-fetch.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/http-recording/patch-fetch.ts
@@ -1,0 +1,114 @@
+import { v4 as uuidv4 } from 'uuid'
+
+import { DestinationHttpRecorder } from './recorder'
+import { HttpInteraction } from './types'
+
+/**
+ * Patches the trackedFetch function to record HTTP interactions
+ */
+export function patchTrackedFetch(trackedFetchModule: any, recorder: DestinationHttpRecorder): void {
+    // Save the original function directly on the module
+    if (!trackedFetchModule.__originalTrackedFetch) {
+        trackedFetchModule.__originalTrackedFetch = trackedFetchModule.trackedFetch
+    }
+
+    // Replace the trackedFetch function with our recording version
+    trackedFetchModule.trackedFetch = async (url: string, options: any = {}) => {
+        const requestId = uuidv4()
+        const startTime = Date.now()
+
+        // Extract request details
+        const method = options.method || 'GET'
+        const headers = options.headers || {}
+        const body = options.body
+            ? typeof options.body === 'string'
+                ? options.body.startsWith('{')
+                    ? JSON.parse(options.body)
+                    : options.body
+                : options.body
+            : undefined
+
+        // Create request part of the interaction
+        const interaction: Partial<HttpInteraction> = {
+            id: requestId,
+            timestamp: startTime,
+            request: {
+                method,
+                url,
+                headers,
+                body,
+            },
+        }
+
+        try {
+            // Make the actual request using the original function
+            const response = await trackedFetchModule.__originalTrackedFetch(url, options)
+            const endTime = Date.now()
+
+            // Extract response details
+            const responseHeaders: Record<string, string> = {}
+            response.headers.forEach((value: string, key: string) => {
+                responseHeaders[key] = value
+            })
+
+            // Try to parse response body based on content type
+            let responseBody
+            const contentType = response.headers.get('content-type')
+
+            // Clone the response to read the body without consuming it
+            const clonedResponse = response.clone()
+
+            if (contentType?.includes('application/json')) {
+                try {
+                    responseBody = await clonedResponse.json()
+                } catch (e) {
+                    // If we can't parse as JSON, get as text
+                    responseBody = await clonedResponse.text()
+                }
+            } else if (contentType?.includes('text/')) {
+                responseBody = await clonedResponse.text()
+            }
+
+            // Complete the interaction with response data
+            interaction.response = {
+                status: response.status,
+                headers: responseHeaders,
+                body: responseBody,
+                timing: {
+                    duration: endTime - startTime,
+                },
+            }
+
+            // Record the complete interaction
+            recorder.recordInteraction(interaction as HttpInteraction)
+
+            return response
+        } catch (error) {
+            const endTime = Date.now()
+
+            // Record failed request
+            interaction.response = {
+                status: 0,
+                headers: {},
+                body: { error: error.message },
+                timing: {
+                    duration: endTime - startTime,
+                },
+            }
+
+            recorder.recordInteraction(interaction as HttpInteraction)
+
+            throw error
+        }
+    }
+}
+
+/**
+ * Restores the original trackedFetch function
+ */
+export function restoreTrackedFetch(trackedFetchModule: any): void {
+    if (trackedFetchModule.__originalTrackedFetch) {
+        trackedFetchModule.trackedFetch = trackedFetchModule.__originalTrackedFetch
+        delete trackedFetchModule.__originalTrackedFetch
+    }
+}

--- a/plugin-server/src/worker/ingestion/event-pipeline/http-recording/recorder.test.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/http-recording/recorder.test.ts
@@ -1,0 +1,192 @@
+import { DestinationHttpRecorder } from './recorder'
+import { HttpInteraction } from './types'
+
+describe('DestinationHttpRecorder', () => {
+    let recorder: DestinationHttpRecorder
+
+    beforeEach(() => {
+        recorder = new DestinationHttpRecorder()
+    })
+
+    describe('recording lifecycle', () => {
+        it('should start a new recording', () => {
+            recorder.startRecording('event-123', 1, 'destination-1')
+            const recording = recorder.stopRecording()
+
+            expect(recording.metadata).toEqual(
+                expect.objectContaining({
+                    eventUuid: 'event-123',
+                    teamId: 1,
+                    destinationId: 'destination-1',
+                })
+            )
+            expect(recording.interactions).toEqual([])
+        })
+
+        it('should throw when starting a recording while one is in progress', () => {
+            recorder.startRecording('event-123', 1, 'destination-1')
+            expect(() => recorder.startRecording('event-456', 1, 'destination-1')).toThrow(
+                'Recording already in progress'
+            )
+        })
+
+        it('should throw when stopping a recording when none is in progress', () => {
+            expect(() => recorder.stopRecording()).toThrow('No recording in progress')
+        })
+
+        it('should throw when recording interaction when no recording is in progress', () => {
+            const interaction = createMockInteraction()
+            expect(() => recorder.recordInteraction(interaction)).toThrow('No recording in progress')
+        })
+    })
+
+    describe('recording interactions', () => {
+        it('should record interactions in sequence', () => {
+            recorder.startRecording('event-123', 1, 'destination-1')
+
+            const interaction1 = createMockInteraction({ id: '1' })
+            const interaction2 = createMockInteraction({ id: '2' })
+
+            recorder.recordInteraction(interaction1)
+            recorder.recordInteraction(interaction2)
+
+            const recording = recorder.stopRecording()
+            expect(recording.interactions).toEqual([interaction1, interaction2])
+        })
+    })
+
+    describe('comparing recordings', () => {
+        it('should identify identical recordings', () => {
+            const interaction = createMockInteraction()
+            const recording1 = createMockRecording([interaction])
+            const recording2 = createMockRecording([interaction])
+
+            const comparison = recorder.compareRecordings(recording1, recording2)
+            expect(comparison.matches).toBe(true)
+            expect(comparison.differences).toBeUndefined()
+        })
+
+        it('should identify missing interactions', () => {
+            const interaction1 = createMockInteraction({ id: '1' })
+            const interaction2 = createMockInteraction({ id: '2' })
+
+            const recording1 = createMockRecording([interaction1, interaction2])
+            const recording2 = createMockRecording([interaction1])
+
+            const comparison = recorder.compareRecordings(recording1, recording2)
+            expect(comparison.matches).toBe(false)
+            expect(comparison.differences?.missing).toEqual([interaction2])
+        })
+
+        it('should identify additional interactions', () => {
+            const interaction1 = createMockInteraction({ id: '1' })
+            const interaction2 = createMockInteraction({ id: '2' })
+
+            const recording1 = createMockRecording([interaction1])
+            const recording2 = createMockRecording([interaction1, interaction2])
+
+            const comparison = recorder.compareRecordings(recording1, recording2)
+            expect(comparison.matches).toBe(false)
+            expect(comparison.differences?.additional).toEqual([interaction2])
+        })
+
+        it('should identify differences in interactions', () => {
+            const interaction1 = createMockInteraction({
+                id: '1',
+                request: {
+                    method: 'GET',
+                    url: 'https://api.example.com',
+                    headers: {},
+                },
+            })
+
+            const interaction2 = createMockInteraction({
+                id: '1',
+                request: {
+                    method: 'POST',
+                    url: 'https://api.example.com',
+                    headers: {},
+                },
+            })
+
+            const recording1 = createMockRecording([interaction1])
+            const recording2 = createMockRecording([interaction2])
+
+            const comparison = recorder.compareRecordings(recording1, recording2)
+            expect(comparison.matches).toBe(false)
+            expect(comparison.differences?.different[0].differences).toContain('Method mismatch: GET != POST')
+        })
+
+        it('should handle case-insensitive header comparison', () => {
+            const interaction1 = createMockInteraction({
+                id: '1',
+                request: {
+                    method: 'GET',
+                    url: 'https://api.example.com',
+                    headers: { 'Content-Type': 'application/json' },
+                },
+            })
+
+            const interaction2 = createMockInteraction({
+                id: '1',
+                request: {
+                    method: 'GET',
+                    url: 'https://api.example.com',
+                    headers: { 'content-type': 'application/json' },
+                },
+            })
+
+            const recording1 = createMockRecording([interaction1])
+            const recording2 = createMockRecording([interaction2])
+
+            const comparison = recorder.compareRecordings(recording1, recording2)
+            expect(comparison.matches).toBe(true)
+            expect(comparison.differences).toBeUndefined()
+        })
+    })
+})
+
+// Helper functions to create test data
+function createMockInteraction(overrides: Partial<HttpInteraction> = {}): HttpInteraction {
+    const defaultInteraction: HttpInteraction = {
+        id: 'test-id',
+        timestamp: Date.now(),
+        request: {
+            method: 'GET',
+            url: 'https://api.example.com',
+            headers: {},
+            ...(overrides.request || {}),
+        },
+        response: {
+            status: 200,
+            headers: {},
+            body: { success: true },
+            ...(overrides.response || {}),
+        },
+    }
+
+    return {
+        ...defaultInteraction,
+        ...overrides,
+        request: {
+            ...defaultInteraction.request,
+            ...(overrides.request || {}),
+        },
+        response: {
+            ...defaultInteraction.response,
+            ...(overrides.response || {}),
+        },
+    }
+}
+
+function createMockRecording(interactions: HttpInteraction[]) {
+    return {
+        metadata: {
+            eventUuid: 'test-event',
+            teamId: 1,
+            destinationId: 'test-destination',
+            timestamp: Date.now(),
+        },
+        interactions,
+    }
+}

--- a/plugin-server/src/worker/ingestion/event-pipeline/http-recording/recorder.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/http-recording/recorder.ts
@@ -1,0 +1,143 @@
+import { DestinationHttpRecording, HttpInteraction, HttpRecorder, HttpRecordingComparison } from './types'
+
+export class DestinationHttpRecorder implements HttpRecorder {
+    private currentRecording: DestinationHttpRecording | null = null
+
+    public startRecording(eventUuid: string, teamId: number, destinationId: string): void {
+        if (this.currentRecording) {
+            throw new Error('Recording already in progress')
+        }
+
+        this.currentRecording = {
+            metadata: {
+                eventUuid,
+                teamId,
+                destinationId,
+                timestamp: Date.now(),
+            },
+            interactions: [],
+        }
+    }
+
+    public recordInteraction(interaction: HttpInteraction): void {
+        if (!this.currentRecording) {
+            throw new Error('No recording in progress')
+        }
+        this.currentRecording.interactions.push(interaction)
+    }
+
+    public stopRecording(): DestinationHttpRecording {
+        if (!this.currentRecording) {
+            throw new Error('No recording in progress')
+        }
+        const recording = this.currentRecording
+        this.currentRecording = null
+        return recording
+    }
+
+    public compareRecordings(
+        oldRecording: DestinationHttpRecording,
+        newRecording: DestinationHttpRecording
+    ): HttpRecordingComparison {
+        const differences: HttpRecordingComparison['differences'] = {
+            missing: [],
+            additional: [],
+            different: [],
+        }
+
+        // Create maps for faster lookup of parent-child relationships
+        const oldInteractionMap = new Map(oldRecording.interactions.map((i) => [i.id, i]))
+        const newInteractionMap = new Map(newRecording.interactions.map((i) => [i.id, i]))
+
+        // Check for missing interactions in new recording
+        for (const oldInteraction of oldRecording.interactions) {
+            if (!newInteractionMap.has(oldInteraction.id)) {
+                differences.missing.push(oldInteraction)
+                continue
+            }
+
+            const newInteraction = newInteractionMap.get(oldInteraction.id)!
+            const interactionDifferences = this.compareInteractions(oldInteraction, newInteraction)
+
+            if (interactionDifferences.length > 0) {
+                differences.different.push({
+                    old: oldInteraction,
+                    new: newInteraction,
+                    differences: interactionDifferences,
+                })
+            }
+        }
+
+        // Check for additional interactions in new recording
+        for (const newInteraction of newRecording.interactions) {
+            if (!oldInteractionMap.has(newInteraction.id)) {
+                differences.additional.push(newInteraction)
+            }
+        }
+
+        return {
+            matches:
+                differences.missing.length === 0 &&
+                differences.additional.length === 0 &&
+                differences.different.length === 0,
+            differences:
+                differences.missing.length === 0 &&
+                differences.additional.length === 0 &&
+                differences.different.length === 0
+                    ? undefined
+                    : differences,
+        }
+    }
+
+    private compareInteractions(oldInteraction: HttpInteraction, newInteraction: HttpInteraction): string[] {
+        const differences: string[] = []
+
+        // Compare request fields
+        if (oldInteraction.request.method !== newInteraction.request.method) {
+            differences.push(`Method mismatch: ${oldInteraction.request.method} != ${newInteraction.request.method}`)
+        }
+        if (oldInteraction.request.url !== newInteraction.request.url) {
+            differences.push(`URL mismatch: ${oldInteraction.request.url} != ${newInteraction.request.url}`)
+        }
+        if (JSON.stringify(oldInteraction.request.body) !== JSON.stringify(newInteraction.request.body)) {
+            differences.push('Request body mismatch')
+        }
+        if (oldInteraction.request.parentRequestId !== newInteraction.request.parentRequestId) {
+            differences.push(
+                `Parent request ID mismatch: ${oldInteraction.request.parentRequestId} != ${newInteraction.request.parentRequestId}`
+            )
+        }
+
+        // Compare response fields
+        if (oldInteraction.response.status !== newInteraction.response.status) {
+            differences.push(
+                `Status code mismatch: ${oldInteraction.response.status} != ${newInteraction.response.status}`
+            )
+        }
+        if (JSON.stringify(oldInteraction.response.body) !== JSON.stringify(newInteraction.response.body)) {
+            differences.push('Response body mismatch')
+        }
+
+        // Compare headers (ignoring case)
+        const oldRequestHeaders = this.normalizeHeaders(oldInteraction.request.headers)
+        const newRequestHeaders = this.normalizeHeaders(newInteraction.request.headers)
+        if (JSON.stringify(oldRequestHeaders) !== JSON.stringify(newRequestHeaders)) {
+            differences.push('Request headers mismatch')
+        }
+
+        const oldResponseHeaders = this.normalizeHeaders(oldInteraction.response.headers)
+        const newResponseHeaders = this.normalizeHeaders(newInteraction.response.headers)
+        if (JSON.stringify(oldResponseHeaders) !== JSON.stringify(newResponseHeaders)) {
+            differences.push('Response headers mismatch')
+        }
+
+        return differences
+    }
+
+    private normalizeHeaders(headers: Record<string, string>): Record<string, string> {
+        return Object.entries(headers).reduce((acc, [key, value]) => {
+            acc[key.toLowerCase()] = value
+            return acc
+        }, {} as Record<string, string>)
+    }
+}

--- a/plugin-server/src/worker/ingestion/event-pipeline/http-recording/types.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/http-recording/types.ts
@@ -12,6 +12,9 @@ export interface HttpInteraction {
         status: number
         headers: Record<string, string>
         body?: any
+        timing?: {
+            duration?: number
+        }
     }
 }
 

--- a/plugin-server/src/worker/ingestion/event-pipeline/http-recording/types.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/http-recording/types.ts
@@ -1,0 +1,49 @@
+export interface HttpInteraction {
+    id: string
+    timestamp: number
+    request: {
+        method: string
+        url: string
+        headers: Record<string, string>
+        body?: any
+        parentRequestId?: string
+    }
+    response: {
+        status: number
+        headers: Record<string, string>
+        body?: any
+    }
+}
+
+export interface DestinationHttpRecording {
+    metadata: {
+        eventUuid: string
+        teamId: number
+        destinationId: string
+        timestamp: number
+    }
+    interactions: HttpInteraction[]
+}
+
+export interface HttpRecordingComparison {
+    matches: boolean
+    differences?: {
+        missing: HttpInteraction[]
+        additional: HttpInteraction[]
+        different: Array<{
+            old: HttpInteraction
+            new: HttpInteraction
+            differences: string[]
+        }>
+    }
+}
+
+export interface HttpRecorder {
+    startRecording(eventUuid: string, teamId: number, destinationId: string): void
+    recordInteraction(interaction: HttpInteraction): void
+    stopRecording(): DestinationHttpRecording
+    compareRecordings(
+        oldRecording: DestinationHttpRecording,
+        newRecording: DestinationHttpRecording
+    ): HttpRecordingComparison
+}

--- a/plugin-server/src/worker/ingestion/event-pipeline/pluginsProcessEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/pluginsProcessEventStep.ts
@@ -2,18 +2,20 @@ import { PluginEvent } from '@posthog/plugin-scaffold'
 
 import { runInstrumentedFunction } from '../../../main/utils'
 import { runProcessEvent } from '../../plugins/run'
+import { DestinationHttpRecorder } from './http-recording/recorder'
 import { droppedEventCounter } from './metrics'
 import { EventPipelineRunner } from './runner'
 
 export async function pluginsProcessEventStep(
     runner: EventPipelineRunner,
-    event: PluginEvent
+    event: PluginEvent,
+    recorder?: DestinationHttpRecorder
 ): Promise<PluginEvent | null> {
     const processedEvent = await runInstrumentedFunction({
         timeoutContext: () => ({
             event: JSON.stringify(event),
         }),
-        func: () => runProcessEvent(runner.hub, event),
+        func: () => runProcessEvent(runner.hub, event, recorder),
         statsKey: 'kafka_queue.single_event',
         timeoutMessage: 'Still running plugins on event. Timeout warning after 30 sec!',
         teamId: event.team_id,


### PR DESCRIPTION
## Problem

Just as we migrated the old JavaScript transformations running in VM2 to inlined JavaScript transformations, we want to apply the same approach to destinations. Given the challenges we encountered with transformations, we need to take a more structured approach. The key aspects of destinations are HTTP calls and their responses, so we need a solution that records outgoing HTTP requests and their corresponding responses. By comparing these, we can ensure confidence in the migration.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

I built an HTTP recorder combined with a patched version of `fetch` to capture HTTP requests and their responses for later comparison. This PR focuses solely on recording HTTP requests and responses from the existing plugin step, which includes the execution of destinations.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- unit tests for the single components 
- [ ] TODO: write an integration test 
- [ ] TODO: test it out locally 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
