### PR TITLE
feat: allow control of replay inspector tab state from URL for debugging

### DIFF
--- a/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
@@ -1,4 +1,5 @@
 import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
+import { actionToUrl, router, urlToAction } from 'kea-router'
 import { subscriptions } from 'kea-subscriptions'
 import posthog from 'posthog-js'
 import { teamLogic } from 'scenes/teamLogic'
@@ -162,6 +163,32 @@ export const playerSettingsLogic = kea<playerSettingsLogicType>([
             if (hideViewedRecordings === true) {
                 actions.setHideViewedRecordings('current-user')
             }
+        },
+    })),
+
+    urlToAction(({ actions, values }) => ({
+        // intentionally locked to replay/* to prevent other pages from setting the tab
+        // this is a debug affordance
+        ['**/replay/*']: (_, searchParams) => {
+            // this is a debug affordance, so we only listen to whether it should be open, not also closed
+            const inspectorSideBarOpen = searchParams.inspectorSideBar === true
+            if (inspectorSideBarOpen && inspectorSideBarOpen !== values.sidebarOpen) {
+                actions.setSidebarOpen(inspectorSideBarOpen)
+            }
+        },
+    })),
+
+    actionToUrl(() => ({
+        setSidebarOpen: ({ open }) => {
+            const { currentLocation } = router.values
+            return [
+                currentLocation.pathname,
+                {
+                    ...currentLocation.searchParams,
+                    inspectorSideBar: open,
+                },
+                currentLocation.hashParams,
+            ]
         },
     })),
 ])

--- a/frontend/src/scenes/session-recordings/player/sidebar/playerSidebarLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sidebar/playerSidebarLogic.ts
@@ -1,4 +1,5 @@
 import { actions, kea, path, props, reducers } from 'kea'
+import { actionToUrl, router, urlToAction } from 'kea-router'
 
 import { SessionRecordingSidebarTab } from '~/types'
 
@@ -18,5 +19,31 @@ export const playerSidebarLogic = kea<playerSidebarLogicType>([
             SessionRecordingSidebarTab.INSPECTOR as SessionRecordingSidebarTab,
             { setTab: (_, { tab }) => tab },
         ],
+    })),
+
+    actionToUrl(() => ({
+        setTab: ({ tab }) => {
+            const { currentLocation } = router.values
+            return [
+                currentLocation.pathname,
+                {
+                    ...currentLocation.searchParams,
+                    tab,
+                },
+                currentLocation.hashParams,
+            ]
+        },
+    })),
+
+    urlToAction(({ actions, values }) => ({
+        ['**/replay/home*']: (_, searchParams) => {
+            const urlTab = Object.values(SessionRecordingSidebarTab).includes(searchParams.tab)
+                ? (searchParams.tab as SessionRecordingSidebarTab)
+                : SessionRecordingSidebarTab.INSPECTOR
+
+            if (!!urlTab && urlTab !== values.activeTab) {
+                actions.setTab(urlTab)
+            }
+        },
     })),
 ])

--- a/frontend/src/scenes/session-recordings/player/sidebar/playerSidebarLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sidebar/playerSidebarLogic.ts
@@ -43,7 +43,7 @@ export const playerSidebarLogic = kea<playerSidebarLogicType>([
                 ? (searchParams.tab as SessionRecordingSidebarTab)
                 : SessionRecordingSidebarTab.INSPECTOR
 
-            if (!!urlTab && urlTab !== values.activeTab) {
+            if (urlTab !== values.activeTab) {
                 actions.setTab(urlTab)
             }
         },

--- a/frontend/src/scenes/session-recordings/player/sidebar/playerSidebarLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sidebar/playerSidebarLogic.ts
@@ -36,7 +36,9 @@ export const playerSidebarLogic = kea<playerSidebarLogicType>([
     })),
 
     urlToAction(({ actions, values }) => ({
-        ['**/replay/home*']: (_, searchParams) => {
+        // intentionally locked to replay/* to prevent other pages from setting the tab
+        // this is a debug affordance
+        ['**/replay/*']: (_, searchParams) => {
             const urlTab = Object.values(SessionRecordingSidebarTab).includes(searchParams.tab)
                 ? (searchParams.tab as SessionRecordingSidebarTab)
                 : SessionRecordingSidebarTab.INSPECTOR


### PR DESCRIPTION
sometimes we want to launch a recording directly into debugger mode

and now we can! `?inspectorSideBar=true&tab=debugger`