### PR TITLE
feat(experiments): add pre-launch checklist

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -19,6 +19,7 @@ import { ExposureCriteria } from './ExposureCriteria'
 import { Exposures } from './Exposures'
 import { Info } from './Info'
 import { Overview } from './Overview'
+import { PreLaunchChecklist } from './PreLaunchChecklist'
 import { ReleaseConditionsModal, ReleaseConditionsTable } from './ReleaseConditionsTable'
 import { SummaryTable } from './SummaryTable'
 
@@ -105,20 +106,23 @@ export function ExperimentView(): JSX.Element {
                         <Info />
                         <div className="xl:flex">
                             {shouldUseExperimentMetrics ? (
-                                <div className="w-1/2 mt-8 xl:mt-0">
-                                    <h2 className="font-semibold text-lg mb-1">Data collection</h2>
-                                    <LemonButton
-                                        icon={<IconCalculator />}
-                                        type="secondary"
-                                        size="xsmall"
-                                        onClick={openCalculateRunningTimeModal}
-                                    >
-                                        Calculate running time
-                                    </LemonButton>
-                                    <div className="mt-4">
-                                        <ExposureCriteria />
+                                <>
+                                    <div className="w-1/2 mt-8 xl:mt-0">
+                                        <h2 className="font-semibold text-lg mb-1">Data collection</h2>
+                                        <LemonButton
+                                            icon={<IconCalculator />}
+                                            type="secondary"
+                                            size="xsmall"
+                                            onClick={openCalculateRunningTimeModal}
+                                        >
+                                            Calculate running time
+                                        </LemonButton>
+                                        <div className="mt-4">
+                                            <ExposureCriteria />
+                                        </div>
                                     </div>
-                                </div>
+                                    <PreLaunchChecklist />
+                                </>
                             ) : (
                                 <div className="w-1/2 mt-8 xl:mt-0">
                                     <DataCollection />

--- a/frontend/src/scenes/experiments/ExperimentView/Info.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Info.tsx
@@ -1,11 +1,13 @@
-import { IconRefresh, IconWarning } from '@posthog/icons'
+import { IconPencil, IconRefresh, IconWarning } from '@posthog/icons'
 import { LemonButton, Link, ProfilePicture, Tooltip } from '@posthog/lemon-ui'
+import { LemonModal } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
-import { EditableField } from 'lib/components/EditableField/EditableField'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { IconOpenInNew } from 'lib/lemon-ui/icons'
+import { LemonTextArea } from 'lib/lemon-ui/LemonTextArea/LemonTextArea'
+import { useEffect, useState } from 'react'
 import { urls } from 'scenes/urls'
 
 import { ProgressStatus } from '~/types'
@@ -16,9 +18,27 @@ import { StatusTag } from './components'
 import { ExperimentDates } from './ExperimentDates'
 
 export function Info(): JSX.Element {
-    const { experiment, featureFlags, metricResults, metricResultsLoading, secondaryMetricResultsLoading } =
-        useValues(experimentLogic)
-    const { updateExperiment, setExperimentStatsVersion, refreshExperimentResults } = useActions(experimentLogic)
+    const {
+        experiment,
+        featureFlags,
+        metricResults,
+        metricResultsLoading,
+        secondaryMetricResultsLoading,
+        isDescriptionModalOpen,
+    } = useValues(experimentLogic)
+    const {
+        updateExperiment,
+        setExperimentStatsVersion,
+        refreshExperimentResults,
+        openDescriptionModal,
+        closeDescriptionModal,
+    } = useActions(experimentLogic)
+
+    const [tempDescription, setTempDescription] = useState(experiment.description || '')
+
+    useEffect(() => {
+        setTempDescription(experiment.description || '')
+    }, [experiment.description])
 
     const { created_by } = experiment
 
@@ -147,19 +167,46 @@ export function Info(): JSX.Element {
                 </div>
             </div>
             <div className="block mt-4">
-                <div className="text-xs font-semibold uppercase tracking-wide">Description</div>
-                <EditableField
-                    className="py-2"
-                    multiline
-                    markdown
-                    name="description"
-                    value={experiment.description || ''}
-                    placeholder="Add your hypothesis for this test (optional)"
-                    onSave={(value) => updateExperiment({ description: value })}
-                    maxLength={400}
-                    data-attr="experiment-description"
-                    compactButtons
-                />
+                <div className="flex items-center gap-2">
+                    <div className="text-xs font-semibold uppercase tracking-wide">Hypothesis</div>
+                    <LemonButton type="secondary" size="xsmall" icon={<IconPencil />} onClick={openDescriptionModal} />
+                </div>
+                {experiment.description ? (
+                    <p className="py-2 m-0">{experiment.description}</p>
+                ) : (
+                    <p className="py-2 m-0 text-muted">Add your hypothesis for this test</p>
+                )}
+
+                <LemonModal
+                    isOpen={isDescriptionModalOpen}
+                    onClose={closeDescriptionModal}
+                    title="Edit hypothesis"
+                    footer={
+                        <div className="flex items-center gap-2 justify-end">
+                            <LemonButton type="secondary" onClick={closeDescriptionModal}>
+                                Cancel
+                            </LemonButton>
+                            <LemonButton
+                                type="primary"
+                                onClick={() => {
+                                    updateExperiment({ description: tempDescription })
+                                    closeDescriptionModal()
+                                }}
+                            >
+                                Save
+                            </LemonButton>
+                        </div>
+                    }
+                >
+                    <LemonTextArea
+                        className="w-full"
+                        value={tempDescription}
+                        onChange={(value) => setTempDescription(value)}
+                        placeholder="Add your hypothesis for this test (optional)"
+                        minRows={6}
+                        maxLength={400}
+                    />
+                </LemonModal>
             </div>
         </div>
     )

--- a/frontend/src/scenes/experiments/ExperimentView/PreLaunchChecklist.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/PreLaunchChecklist.tsx
@@ -1,0 +1,156 @@
+import { IconCheckCircle } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+import { useActions, useValues } from 'kea'
+
+import { experimentLogic } from '../experimentLogic'
+
+export function PreLaunchChecklist(): JSX.Element {
+    const { experiment } = useValues(experimentLogic)
+    const { openDescriptionModal, openPrimaryMetricSourceModal, openCalculateRunningTimeModal } =
+        useActions(experimentLogic)
+    return (
+        <div className="w-1/2 mt-8 xl:mt-0">
+            <div className="bg-bg-light rounded p-4 border">
+                <div className="mb-4">
+                    <div className="font-semibold text-lg">Pre-launch checklist</div>
+                </div>
+                <div>
+                    {/* Step 1 - Hypothesis */}
+                    <div className="flex gap-3 mb-6">
+                        {experiment.description ? (
+                            <IconCheckCircle className="text-success flex-none w-6 h-6" />
+                        ) : (
+                            <div className="flex-none w-5 h-5 rounded-full border-2 border-orange" />
+                        )}
+                        <div className="flex-1">
+                            <div className={`text-xs font-semibold ${experiment.description ? 'text-success' : ''}`}>
+                                Step 1
+                            </div>
+                            <div className="flex items-center justify-between">
+                                <div>
+                                    <div
+                                        className={`font-semibold ${
+                                            experiment.description ? 'text-muted line-through' : ''
+                                        }`}
+                                    >
+                                        Add hypothesis
+                                    </div>
+                                    <div
+                                        className={`text-sm ${
+                                            experiment.description ? 'text-muted line-through' : 'text-muted'
+                                        }`}
+                                    >
+                                        Document what you expect to learn from this experiment
+                                    </div>
+                                </div>
+                                {!experiment.description && (
+                                    <LemonButton
+                                        type="secondary"
+                                        size="small"
+                                        onClick={() => {
+                                            openDescriptionModal()
+                                        }}
+                                    >
+                                        Add hypothesis
+                                    </LemonButton>
+                                )}
+                            </div>
+                        </div>
+                    </div>
+
+                    {/* Step 2 - Metric */}
+                    <div className="flex gap-3 mb-6">
+                        {experiment.metrics?.length > 0 ? (
+                            <IconCheckCircle className="text-success flex-none w-6 h-6" />
+                        ) : (
+                            <div className="flex-none w-5 h-5 rounded-full border-2 border-orange" />
+                        )}
+                        <div className="flex-1">
+                            <div
+                                className={`text-xs font-semibold ${
+                                    experiment.metrics?.length > 0 ? 'text-success' : ''
+                                }`}
+                            >
+                                Step 2
+                            </div>
+                            <div className="flex items-center justify-between">
+                                <div>
+                                    <div
+                                        className={`font-semibold ${
+                                            experiment.metrics?.length > 0 ? 'text-muted line-through' : ''
+                                        }`}
+                                    >
+                                        Add first metric
+                                    </div>
+                                    <div
+                                        className={`text-sm ${
+                                            experiment.metrics?.length > 0 ? 'text-muted line-through' : 'text-muted'
+                                        }`}
+                                    >
+                                        Define your experiment's primary success metric
+                                    </div>
+                                </div>
+                                {!(experiment.metrics?.length > 0) && (
+                                    <LemonButton
+                                        type="secondary"
+                                        size="small"
+                                        onClick={() => {
+                                            openPrimaryMetricSourceModal()
+                                        }}
+                                    >
+                                        Add metric
+                                    </LemonButton>
+                                )}
+                            </div>
+                        </div>
+                    </div>
+
+                    {/* Step 3 - Running time */}
+                    <div className="flex gap-3">
+                        {experiment.parameters?.recommended_running_time ? (
+                            <IconCheckCircle className="text-success flex-none w-6 h-6" />
+                        ) : (
+                            <div className="flex-none w-5 h-5 rounded-full border-2 border-orange" />
+                        )}
+                        <div className="flex-1">
+                            <div
+                                className={`text-xs font-semibold ${
+                                    experiment.parameters?.recommended_running_time ? 'text-success' : ''
+                                }`}
+                            >
+                                Step 3
+                            </div>
+                            <div className="flex items-center justify-between">
+                                <div>
+                                    <div
+                                        className={`font-semibold ${
+                                            experiment.parameters?.recommended_running_time
+                                                ? 'text-muted line-through'
+                                                : ''
+                                        }`}
+                                    >
+                                        Calculate experiment duration
+                                    </div>
+                                    <div
+                                        className={`text-sm ${
+                                            experiment.parameters?.recommended_running_time
+                                                ? 'text-muted line-through'
+                                                : 'text-muted'
+                                        }`}
+                                    >
+                                        Determine how long your experiment needs to run
+                                    </div>
+                                </div>
+                                {!experiment.parameters?.recommended_running_time && experiment.metrics?.length > 0 && (
+                                    <LemonButton type="secondary" size="small" onClick={openCalculateRunningTimeModal}>
+                                        Calculate
+                                    </LemonButton>
+                                )}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -269,6 +269,8 @@ export const experimentLogic = kea<experimentLogicType>([
         closeDistributionModal: true,
         openReleaseConditionsModal: true,
         closeReleaseConditionsModal: true,
+        openDescriptionModal: true,
+        closeDescriptionModal: true,
         updateExperimentVariantImages: (variantPreviewMediaIds: Record<string, string[]>) => ({
             variantPreviewMediaIds,
         }),
@@ -786,6 +788,13 @@ export const experimentLogic = kea<experimentLogicType>([
             {
                 openCalculateRunningTimeModal: () => true,
                 closeCalculateRunningTimeModal: () => false,
+            },
+        ],
+        isDescriptionModalOpen: [
+            false,
+            {
+                openDescriptionModal: () => true,
+                closeDescriptionModal: () => false,
             },
         ],
     }),


### PR DESCRIPTION
## Problem
I'm currently working on the [running time calculator](https://github.com/PostHog/posthog/pull/29062). When discussing the current design with @danielbachhuber, we identified a few issues:
- The calculator should work with existing experiment metrics, so users shouldn’t have to configure a metric again just to make an estimation.
- However, this means the experiment metric must be set up before users can open the calculator.
- Ideally, the user flow should be: first set up a metric, then calculate the running time.

The current UI doesn't do a good job of guiding them through this flow.

## Changes
I'm proposing an interactive pre-launch checklist in experiment draft mode. This is only rendered for experiments with the new metrics.

![image](https://github.com/user-attachments/assets/31f82891-750c-4a47-b7b0-5736d43c0b0a)

**Notes:**
- Along with adding a metric and running time, I’ve also included a hypothesis field, since defining a hypothesis adds more rigor.
- I had to refactor the description field to allow triggering edits from another component (by opening a modal).
- In the future, we could extend this checklist, possibly adding a test/diagnostics step to check if events are being received before launching the experiment.

**Next up:**
Adjust the running time calculator so that it allows the user to choose from existing metrics defined on the experiment, rather than asking them to define one in the calculator.

## How did you test this code?
👀 