### PR TITLE
fix: Always show person-on-events for hog functions

### DIFF
--- a/frontend/src/scenes/pipeline/hogfunctions/filters/HogFunctionFilters.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/filters/HogFunctionFilters.tsx
@@ -46,7 +46,7 @@ function sanitizeActionFilters(filters?: FilterType): Partial<HogFunctionFilters
 
 export function HogFunctionFilters(): JSX.Element {
     const { groupsTaxonomicTypes } = useValues(groupsModel)
-    const { configuration, type, useMapping } = useValues(hogFunctionConfigurationLogic)
+    const { configuration, type, useMapping, filtersContainPersonProperties } = useValues(hogFunctionConfigurationLogic)
 
     if (type === 'broadcast') {
         return (
@@ -200,6 +200,14 @@ export function HogFunctionFilters(): JSX.Element {
                     )
                 }}
             </LemonField>
+
+            {filtersContainPersonProperties ? (
+                <LemonBanner type="warning">
+                    You are filtering on Person properties. Be aware that this filtering applies at the time the event
+                    is processed so if Person Profiles are not enabled or the person property has not been set by then
+                    then the filters may not work as expected.
+                </LemonBanner>
+            ) : null}
             {showMasking ? (
                 <LemonField name="masking" label="Trigger options">
                     {({ value, onChange }) => (

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
@@ -763,6 +763,28 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
             { resultEqualityCheck: equal },
         ],
 
+        filtersContainPersonProperties: [
+            (s) => [s.configuration],
+            (configuration) => {
+                const filters = configuration.filters
+                let containsPersonProperties = false
+                if (filters?.properties && !containsPersonProperties) {
+                    containsPersonProperties = filters.properties.some((p) => p.type === 'person')
+                }
+                if (filters?.actions && !containsPersonProperties) {
+                    containsPersonProperties = filters.actions.some((a) =>
+                        a.properties?.some((p) => p.type === 'person')
+                    )
+                }
+                if (filters?.events && !containsPersonProperties) {
+                    containsPersonProperties = filters.events.some((e) =>
+                        e.properties?.some((p) => p.type === 'person')
+                    )
+                }
+                return containsPersonProperties
+            },
+        ],
+
         sparklineQuery: [
             (s) => [s.configuration, s.matchingFilters, s.type],
             (configuration, matchingFilters, type): TrendsQuery | null => {

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
@@ -840,6 +840,10 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                     select: ['*', 'person'],
                     after: '-7d',
                     orderBy: ['timestamp DESC'],
+                    modifiers: {
+                        // NOTE: We always want to show events with the person properties at the time the event was created as that is what the function will see
+                        personsOnEventsMode: 'person_id_no_override_properties_on_events',
+                    },
                 }
                 groupTypes.forEach((groupType) => {
                     const name = escapePropertyAsHogQlIdentifier(groupType.group_type)

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4740,7 +4740,7 @@ export type HogFunctionFilterPropertyFilter = (
 export interface HogFunctionFiltersType {
     events?: HogFunctionFilterEvents[]
     actions?: HogFunctionFilterActions[]
-    properties?: HogFunctionFilterPropertyFilter[]
+    properties?: HogFunctionFilterPropertyFilter
     filter_test_accounts?: boolean
     bytecode?: any[]
     bytecode_error?: string

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4728,19 +4728,18 @@ export interface HogFunctionFilterActions extends HogFunctionFilterBase {
     type: 'actions'
 }
 
-export type HogFunctionFilterPropertyFilter = (
+export type HogFunctionFilterPropertyFilter =
     | EventPropertyFilter
     | PersonPropertyFilter
     | ElementPropertyFilter
     | GroupPropertyFilter
     | FeaturePropertyFilter
     | HogQLPropertyFilter
-)[]
 
 export interface HogFunctionFiltersType {
     events?: HogFunctionFilterEvents[]
     actions?: HogFunctionFilterActions[]
-    properties?: HogFunctionFilterPropertyFilter
+    properties?: HogFunctionFilterPropertyFilter[]
     filter_test_accounts?: boolean
     bytecode?: any[]
     bytecode_error?: string


### PR DESCRIPTION
## Problem

The historic query by default uses the joining Person which doesn't make sense for hog functions given the person info is always at the time of the event, making it look like triggers should have happened that wouldn't have.


## Changes

<img width="599" alt="Screenshot 2025-02-25 at 14 07 20" src="https://github.com/user-attachments/assets/02db95e9-04a5-4605-b1ec-4fc3a1f0ca02" />

* Adds the modified (thanks @mariusandra )
* Also adds a warning if filtering on person properties

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
