### PR TITLE
chore: add --staff to generate_demo_data script

### DIFF
--- a/posthog/management/commands/generate_demo_data.py
+++ b/posthog/management/commands/generate_demo_data.py
@@ -71,9 +71,8 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--staff",
-            type=bool,
-            default=False,
             help="Created a staff user",
+            action="store_true",
         )
 
     def handle(self, *args, **options):

--- a/posthog/management/commands/generate_demo_data.py
+++ b/posthog/management/commands/generate_demo_data.py
@@ -71,8 +71,9 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--staff",
-            help="Created a staff user",
             action="store_true",
+            default=False,
+            help="Create a staff user",
         )
 
     def handle(self, *args, **options):

--- a/posthog/management/commands/generate_demo_data.py
+++ b/posthog/management/commands/generate_demo_data.py
@@ -69,6 +69,12 @@ class Command(BaseCommand):
             default="hedgebox",
             help="Product to simulate (default: hedgebox, alternatives: spikegpt)",
         )
+        parser.add_argument(
+            "--staff",
+            type=bool,
+            default=False,
+            help="Created a staff user",
+        )
 
     def handle(self, *args, **options):
         timer = monotonic()
@@ -123,6 +129,7 @@ class Command(BaseCommand):
                         email,
                         "Employee 427",
                         "Hedgebox Inc.",
+                        is_staff=options.get("staff"),
                         password=password,
                         disallow_collision=True,
                     )

--- a/posthog/management/commands/generate_demo_data.py
+++ b/posthog/management/commands/generate_demo_data.py
@@ -71,6 +71,7 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--staff",
+            type=bool,
             action="store_true",
             default=False,
             help="Create a staff user",
@@ -129,7 +130,7 @@ class Command(BaseCommand):
                         email,
                         "Employee 427",
                         "Hedgebox Inc.",
-                        is_staff=options.get("staff"),
+                        is_staff=bool(options.get("staff")),
                         password=password,
                         disallow_collision=True,
                     )


### PR DESCRIPTION
## Problem

User for artificial data is not admin, cannot open admin panel

## Changes

add `--staff ` option to script

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Run: `DEBUG=1 ./manage.py generate_demo_data --staff` :)