### PR TITLE
feat: add missing os to icon mapping

### DIFF
--- a/frontend/src/lib/components/PropertyIcon.tsx
+++ b/frontend/src/lib/components/PropertyIcon.tsx
@@ -38,8 +38,8 @@ const osIcons = {
     ['windows mobile']: <IconWindows />,
     ['windows phone']: <IconWindows />,
     ['xbox']: <IconWindows />,
-    ['playstation']: <IconGearFilled />,
-    ['nintendo']: <IconGearFilled />,
+    ['playstation']: <IconHeadset />,
+    ['nintendo']: <IconHeadset />,
     ['blackberry']: <IconBlackberry />,
     ['watchos']: <IconMacOS />,
 }

--- a/frontend/src/lib/components/PropertyIcon.tsx
+++ b/frontend/src/lib/components/PropertyIcon.tsx
@@ -34,6 +34,14 @@ const osIcons = {
     ['android']: <IconAndroidOS />,
     ['ios']: <IconAppleIOS />,
     ['other']: <IconGearFilled />,
+    ['chrome os']: <IconChrome />,
+    ['windows mobile']: <IconWindows />,
+    ['windows phone']: <IconWindows />,
+    ['xbox']: <IconWindows />,
+    ['playstation']: <IconGearFilled />,
+    ['nintendo']: <IconGearFilled />,
+    ['blackberry']: <IconBlackberry />,
+    ['watchos']: <IconMacOS />,
 }
 
 export const PROPERTIES_ICON_MAP = {

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -283,6 +283,16 @@ const BreakdownValueCell: QueryContextColumnComponent = (props) => {
                 )
             }
             break
+        case WebStatsBreakdown.OS:
+            if (typeof value === 'string') {
+                return (
+                    <div className="flex items-center gap-2">
+                        <PropertyIcon property="$os" value={value} />
+                        <span>{value}</span>
+                    </div>
+                )
+            }
+            break
     }
 
     if (typeof value === 'string') {


### PR DESCRIPTION
## Problem

Added OS icons to the browser breakdown table on the web analytics page. The only missing one now is "Viewports" which I am not sure we want to have icons for or not since they are more granular than the other tabs.

## Changes

<img width="1391" alt="Screenshot 2025-02-25 at 13 29 22" src="https://github.com/user-attachments/assets/2180d60a-6b45-4736-af72-54620aa5bbd6" />

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manually using the matrix distribution.
