### PR TITLE
fix: move billing load to another logic

### DIFF
--- a/frontend/src/scenes/billing/billingLogic.tsx
+++ b/frontend/src/scenes/billing/billingLogic.tsx
@@ -227,6 +227,7 @@ export const billingLogic = kea<billingLogicType>([
                     try {
                         const response = await api.update('api/billing', { custom_limits_usd: limits })
                         lemonToast.success('Billing limits updated')
+                        actions.loadBilling()
                         return parseBillingResponse(response)
                     } catch (error: any) {
                         lemonToast.error(

--- a/frontend/src/scenes/billing/billingProductLogic.ts
+++ b/frontend/src/scenes/billing/billingProductLogic.ts
@@ -322,7 +322,6 @@ export const billingProductLogic = kea<billingProductLogicType>([
     listeners(({ actions, values, props }) => ({
         updateBillingLimitsSuccess: () => {
             actions.billingLoaded()
-            actions.loadBilling()
         },
         billingLoaded: () => {
             function calculateDefaultBillingLimit(product: BillingProductV2Type | BillingProductV2AddonType): number {


### PR DESCRIPTION
## Changes

Move the load billing call to be in the top level billing logic so it's only called once instead of for every product in the `updateBillingLimitsSuccess` callback 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

It doesn't have an impact.

## How did you test this code?

Manually
