### PR TITLE
fix(batch-exports): Do not resume BigQuery batch exports from heartbeats

### DIFF
--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -33,7 +33,6 @@ from posthog.temporal.batch_exports.batch_exports import (
 from posthog.temporal.batch_exports.heartbeat import (
     BatchExportRangeHeartbeatDetails,
     DateRange,
-    should_resume_from_activity_heartbeat,
 )
 from posthog.temporal.batch_exports.spmc import (
     Consumer,
@@ -636,9 +635,9 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
         Heartbeater() as heartbeater,
         set_status_to_running_task(run_id=inputs.run_id, logger=logger),
     ):
-        _, details = await should_resume_from_activity_heartbeat(activity, BigQueryHeartbeatDetails)
-        if details is None:
-            details = BigQueryHeartbeatDetails()
+        # For now we don't resume from a heartbeat as this is causing events to be missed due to the way we're merging
+        # data into the destination table
+        details = BigQueryHeartbeatDetails()
 
         done_ranges: list[DateRange] = details.done_ranges
 


### PR DESCRIPTION
## Problem

Resuming from heartbeats leads to missing events in many cases for BigQuery batch exports, so disable this for now until we've found a way to address it.

## Changes

Always initialize with empty heartbeat

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Automated tests
