### PR TITLE
fix(insight-variables): dont optimistically reset insight variable

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/variablesLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/variablesLogic.ts
@@ -205,7 +205,6 @@ export const variablesLogic = kea<variablesLogicType>([
             const queryVariableMatches = getVariablesFromQuery(query)
 
             if (!queryVariableMatches.length) {
-                actions.resetVariables()
                 return
             }
 

--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/variablesLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/variablesLogic.ts
@@ -229,15 +229,11 @@ export const variablesLogic = kea<variablesLogicType>([
                 return
             }
 
-            const queryVariableMatches = getVariablesFromQuery(query.source.query)
-
             const variables = Object.values(query.source.variables ?? {})
 
             if (variables.length) {
                 variables.forEach((variable) => {
-                    if (queryVariableMatches.includes(variable.code_name)) {
-                        actions.addVariable(variable)
-                    }
+                    actions.addVariable(variable)
                 })
             }
         },


### PR DESCRIPTION
## Problem

- insight variable is parsed every keystroke

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- don't reset

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
