### PR TITLE
chore(dev): Restore auto pnpm install

### DIFF
--- a/bin/plugin-server
+++ b/bin/plugin-server
@@ -38,7 +38,7 @@ cd plugin-server
 
 if [[ -n $DEBUG ]]; then
   echo "🧐 Verifying installed packages..."
-  pnpm --filter=@posthog/plugin-server install --frozen-lockfile
+  pnpm --filter=@posthog/plugin-server install
 fi
 
 if [ $? -ne 0 ]; then

--- a/bin/start-frontend
+++ b/bin/start-frontend
@@ -8,5 +8,5 @@ set -e
 # In particular, DEBUG=1 enables a lot of Tailwind logging we don't need, so let's set 0 instead
 export DEBUG=0
 
-pnpm --filter=@posthog/frontend... install --frozen-lockfile
+pnpm --filter=@posthog/frontend... install
 bin/turbo --filter=@posthog/frontend start


### PR DESCRIPTION
## Problem

Dev start scripts used to do the handy thing of `pnpm i` so that it wasn't necessary to `pnpm i` manually – especially on branch changes. But recent monorepo changes added `--frozen-lockfile` to a lot of places, both prod and dev.

## Changes

Removing `--frozen-lockfile` from dev, for that convenient previous behavior – no prod touched here.