### PR TITLE
fix: livestream hammers the network

### DIFF
--- a/frontend/src/scenes/activity/live/liveEventsTableLogic.tsx
+++ b/frontend/src/scenes/activity/live/liveEventsTableLogic.tsx
@@ -192,6 +192,10 @@ export const liveEventsTableLogic = kea<liveEventsTableLogicType>([
                 actions.setStats(data)
             } catch (error) {
                 console.error('Failed to poll stats:', error)
+            } finally {
+                cache.statsTimer = setTimeout(() => {
+                    actions.pollStats()
+                }, 1500)
             }
         },
         addEvents: ({ events }) => {
@@ -209,16 +213,14 @@ export const liveEventsTableLogic = kea<liveEventsTableLogicType>([
     events(({ actions, cache }) => ({
         afterMount: () => {
             actions.updateEventsConnection()
-            cache.statsInterval = setInterval(() => {
-                actions.pollStats()
-            }, 1500)
+            actions.pollStats()
         },
         beforeUnmount: () => {
             if (cache.eventSourceController) {
                 cache.eventSourceController.abort()
             }
-            if (cache.statsInterval) {
-                clearInterval(cache.statsInterval)
+            if (cache.statsTimer) {
+                clearTimeout(cache.statsTimer)
             }
         },
     })),


### PR DESCRIPTION
<img width="631" alt="Screenshot 2025-02-25 at 20 46 07" src="https://github.com/user-attachments/assets/0f6a0349-28cb-4217-afd5-2c86b078e343" />

livestream polls the endpoint every 1.5 seconds no matter what happens
so in the case where it is never going to respond or will response very slowly we end up with many many many network requests queued

we can (I think) just make the next call 1.5 seconds after the previous one completes instead