### PR TITLE
perf: Use UDF everywhere

### DIFF
--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel.ambr
@@ -2,52 +2,47 @@
 # name: ClickhouseTestFunnelGroups.test_funnel_aggregation_with_groups
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-         countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-         avg(step_1_average_conversion_time_inner) AS step_1_average_conversion_time,
-         median(step_1_median_conversion_time_inner) AS step_1_median_conversion_time
+  SELECT sum(step_1) AS step_1,
+         sum(step_2) AS step_2,
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT aggregation_target AS aggregation_target,
-            steps AS steps,
-            avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-            median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            breakdown AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                               step_1_conversion_time AS step_1_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  timestamp AS timestamp,
-                  step_0 AS step_0,
-                  latest_0 AS latest_0,
-                  step_1 AS step_1,
-                  latest_1 AS latest_1,
-                  if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                  if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     min(latest_1) OVER (PARTITION BY aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-              FROM
-                (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                        e.`$group_0` AS aggregation_target,
-                        if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                        if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                        if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                        if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                 FROM events AS e
-                 WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(notEquals(nullIf(nullIf(e.`$group_0`, ''), 'null'), ''), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-           WHERE ifNull(equals(step_0, 1), 0)))
-     GROUP BY aggregation_target,
-              steps
-     HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                   and isNull(max(max_steps))))
-  LIMIT 100 SETTINGS readonly=2,
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.`$group_0` AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(notEquals(nullIf(nullIf(e.`$group_0`, ''), 'null'), ''), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_2 DESC, step_1 DESC)
+  GROUP BY final_prop
+  LIMIT 100 SETTINGS join_algorithm='auto',
+                     readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
@@ -113,52 +108,47 @@
 # name: ClickhouseTestFunnelGroups.test_funnel_group_aggregation_with_groups_entity_filtering
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-         countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-         avg(step_1_average_conversion_time_inner) AS step_1_average_conversion_time,
-         median(step_1_median_conversion_time_inner) AS step_1_median_conversion_time
+  SELECT sum(step_1) AS step_1,
+         sum(step_2) AS step_2,
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT aggregation_target AS aggregation_target,
-            steps AS steps,
-            avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-            median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            breakdown AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                               step_1_conversion_time AS step_1_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  timestamp AS timestamp,
-                  step_0 AS step_0,
-                  latest_0 AS latest_0,
-                  step_1 AS step_1,
-                  latest_1 AS latest_1,
-                  if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                  if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     min(latest_1) OVER (PARTITION BY aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-              FROM
-                (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                        e.`$group_0` AS aggregation_target,
-                        if(and(equals(e.event, 'user signed up'), ifNull(equals(nullIf(nullIf(e.`$group_0`, ''), 'null'), 'org:5'), 0)), 1, 0) AS step_0,
-                        if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                        if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                        if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                 FROM events AS e
-                 WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(notEquals(nullIf(nullIf(e.`$group_0`, ''), 'null'), ''), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-           WHERE ifNull(equals(step_0, 1), 0)))
-     GROUP BY aggregation_target,
-              steps
-     HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                   and isNull(max(max_steps))))
-  LIMIT 100 SETTINGS readonly=2,
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.`$group_0` AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(and(equals(e.event, 'user signed up'), ifNull(equals(nullIf(nullIf(e.`$group_0`, ''), 'null'), 'org:5'), 0)), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(notEquals(nullIf(nullIf(e.`$group_0`, ''), 'null'), ''), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_2 DESC, step_1 DESC)
+  GROUP BY final_prop
+  LIMIT 100 SETTINGS join_algorithm='auto',
+                     readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
@@ -225,59 +215,54 @@
 # name: ClickhouseTestFunnelGroups.test_funnel_with_groups_entity_filtering
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-         countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-         avg(step_1_average_conversion_time_inner) AS step_1_average_conversion_time,
-         median(step_1_median_conversion_time_inner) AS step_1_median_conversion_time
+  SELECT sum(step_1) AS step_1,
+         sum(step_2) AS step_2,
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT aggregation_target AS aggregation_target,
-            steps AS steps,
-            avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-            median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            breakdown AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                               step_1_conversion_time AS step_1_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  timestamp AS timestamp,
-                  step_0 AS step_0,
-                  latest_0 AS latest_0,
-                  step_1 AS step_1,
-                  latest_1 AS latest_1,
-                  if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                  if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     min(latest_1) OVER (PARTITION BY aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-              FROM
-                (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                        if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                        if(and(equals(e.event, 'user signed up'), ifNull(equals(nullIf(nullIf(e.`$group_0`, ''), 'null'), 'org:5'), 0)), 1, 0) AS step_0,
-                        if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                        if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                        if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                 FROM events AS e
-                 LEFT OUTER JOIN
-                   (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                           person_distinct_id_overrides.distinct_id AS distinct_id
-                    FROM person_distinct_id_overrides
-                    WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                    GROUP BY person_distinct_id_overrides.distinct_id
-                    HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                 WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-           WHERE ifNull(equals(step_0, 1), 0)))
-     GROUP BY aggregation_target,
-              steps
-     HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                   and isNull(max(max_steps))))
-  LIMIT 100 SETTINGS readonly=2,
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(and(equals(e.event, 'user signed up'), ifNull(equals(nullIf(nullIf(e.`$group_0`, ''), 'null'), 'org:5'), 0)), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_2 DESC, step_1 DESC)
+  GROUP BY final_prop
+  LIMIT 100 SETTINGS join_algorithm='auto',
+                     readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
@@ -357,67 +342,62 @@
 # name: ClickhouseTestFunnelGroups.test_funnel_with_groups_global_filtering
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-         countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-         avg(step_1_average_conversion_time_inner) AS step_1_average_conversion_time,
-         median(step_1_median_conversion_time_inner) AS step_1_median_conversion_time
+  SELECT sum(step_1) AS step_1,
+         sum(step_2) AS step_2,
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT aggregation_target AS aggregation_target,
-            steps AS steps,
-            avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-            median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            breakdown AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                               step_1_conversion_time AS step_1_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  timestamp AS timestamp,
-                  step_0 AS step_0,
-                  latest_0 AS latest_0,
-                  step_1 AS step_1,
-                  latest_1 AS latest_1,
-                  if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                  if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     min(latest_1) OVER (PARTITION BY aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-              FROM
-                (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                        if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                        if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                        if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                        if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                        if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                 FROM events AS e
-                 LEFT OUTER JOIN
-                   (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                           person_distinct_id_overrides.distinct_id AS distinct_id
-                    FROM person_distinct_id_overrides
-                    WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                    GROUP BY person_distinct_id_overrides.distinct_id
-                    HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                 LEFT JOIN
-                   (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                           groups.group_type_index AS index,
-                           groups.group_key AS key
-                    FROM groups
-                    WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                    GROUP BY groups.group_type_index,
-                             groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                 WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'finance'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-           WHERE ifNull(equals(step_0, 1), 0)))
-     GROUP BY aggregation_target,
-              steps
-     HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                   and isNull(max(max_steps))))
-  LIMIT 100 SETTINGS readonly=2,
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           LEFT JOIN
+             (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                     groups.group_type_index AS index,
+                     groups.group_key AS key
+              FROM groups
+              WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+              GROUP BY groups.group_type_index,
+                       groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'finance'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_2 DESC, step_1 DESC)
+  GROUP BY final_prop
+  LIMIT 100 SETTINGS join_algorithm='auto',
+                     readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,

--- a/posthog/api/test/__snapshots__/test_insight.ambr
+++ b/posthog/api/test/__snapshots__/test_insight.ambr
@@ -2,95 +2,80 @@
 # name: TestInsight.test_insight_funnels_hogql_breakdown
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-         countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-         avg(step_1_average_conversion_time_inner) AS step_1_average_conversion_time,
-         median(step_1_median_conversion_time_inner) AS step_1_median_conversion_time,
-         prop AS prop
+  SELECT sum(step_1) AS step_1,
+         sum(step_2) AS step_2,
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT aggregation_target AS aggregation_target,
-            steps AS steps,
-            prop AS prop,
-            prop AS prop,
-            avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-            median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            breakdown AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               max(steps) OVER (PARTITION BY aggregation_target,
-                                             prop) AS max_steps,
-                               step_1_conversion_time AS step_1_conversion_time,
-                               prop AS prop
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', groupUniqArrayIf(prop, ifNull(notEquals(prop, []), isNotNull(prop)
+                                                                                                                       or isNotNull([]))), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                                                         and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                                                         and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                        and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                                                        and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  timestamp AS timestamp,
-                  step_0 AS step_0,
-                  latest_0 AS latest_0,
-                  step_1 AS step_1,
-                  latest_1 AS latest_1,
-                  prop AS prop,
-                  if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                  if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                      prop
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                        prop AS prop
-              FROM
-                (SELECT timestamp AS timestamp,
-                        aggregation_target AS aggregation_target,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        prop_basic AS prop_basic,
-                        prop,
-                        prop_vals AS prop_vals,
-                        if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                           if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(equals(e.event, 'user did things'), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                           ([e__person.properties___fish] AS value) AS prop_basic,
-                           prop_basic AS prop,
-                           argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
-                    FROM events AS e
-                    LEFT OUTER JOIN
-                      (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                              person_distinct_id_overrides.distinct_id AS distinct_id
-                       FROM person_distinct_id_overrides
-                       WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                       GROUP BY person_distinct_id_overrides.distinct_id
-                       HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                    LEFT JOIN
-                      (SELECT person.id AS id,
-                              replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-                       FROM person
-                       WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
-                                                                            (SELECT person.id AS id, max(person.version) AS version
-                                                                             FROM person
-                                                                             WHERE equals(person.team_id, 99999)
-                                                                             GROUP BY person.id
-                                                                             HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-                    WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
-           WHERE ifNull(equals(step_0, 1), 0)))
-     GROUP BY aggregation_target,
-              steps,
-              prop
-     HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                   and isNull(max(max_steps))))
-  GROUP BY prop
-  LIMIT 100 SETTINGS readonly=2,
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'user did things'), 1, 0) AS step_1,
+                     ([e__person.properties___fish] AS value) AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              LEFT JOIN
+                (SELECT person.id AS id,
+                        replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+                 FROM person
+                 WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                                       FROM person
+                                                                       WHERE equals(person.team_id, 99999)
+                                                                       GROUP BY person.id
+                                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_2 DESC, step_1 DESC)
+  GROUP BY final_prop
+  LIMIT 100 SETTINGS join_algorithm='auto',
+                     readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
@@ -191,69 +176,64 @@
 # name: TestInsight.test_insight_funnels_hogql_global_filters
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-         countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-         avg(step_1_average_conversion_time_inner) AS step_1_average_conversion_time,
-         median(step_1_median_conversion_time_inner) AS step_1_median_conversion_time
+  SELECT sum(step_1) AS step_1,
+         sum(step_2) AS step_2,
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT aggregation_target AS aggregation_target,
-            steps AS steps,
-            avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-            median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            breakdown AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                               step_1_conversion_time AS step_1_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  timestamp AS timestamp,
-                  step_0 AS step_0,
-                  latest_0 AS latest_0,
-                  step_1 AS step_1,
-                  latest_1 AS latest_1,
-                  if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                  if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     min(latest_1) OVER (PARTITION BY aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-              FROM
-                (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                        if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                        if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                        if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                        if(equals(e.event, 'user did things'), 1, 0) AS step_1,
-                        if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                 FROM events AS e
-                 LEFT OUTER JOIN
-                   (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                           person_distinct_id_overrides.distinct_id AS distinct_id
-                    FROM person_distinct_id_overrides
-                    WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                    GROUP BY person_distinct_id_overrides.distinct_id
-                    HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                 LEFT JOIN
-                   (SELECT person.id AS id,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-                    FROM person
-                    WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
-                                                                         (SELECT person.id AS id, max(person.version) AS version
-                                                                          FROM person
-                                                                          WHERE equals(person.team_id, 99999)
-                                                                          GROUP BY person.id
-                                                                          HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-                 WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), 1), ifNull(like(e__person.properties___fish, '%fish%'), 0))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-           WHERE ifNull(equals(step_0, 1), 0)))
-     GROUP BY aggregation_target,
-              steps
-     HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                   and isNull(max(max_steps))))
-  LIMIT 100 SETTINGS readonly=2,
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(equals(e.event, 'user did things'), 1, 0) AS step_1
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           LEFT JOIN
+             (SELECT person.id AS id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+              FROM person
+              WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                                   (SELECT person.id AS id, max(person.version) AS version
+                                                                    FROM person
+                                                                    WHERE equals(person.team_id, 99999)
+                                                                    GROUP BY person.id
+                                                                    HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), 1), ifNull(like(e__person.properties___fish, '%fish%'), 0))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_2 DESC, step_1 DESC)
+  GROUP BY final_prop
+  LIMIT 100 SETTINGS join_algorithm='auto',
+                     readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
@@ -266,69 +246,64 @@
 # name: TestInsight.test_insight_funnels_hogql_local_filters
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-         countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-         avg(step_1_average_conversion_time_inner) AS step_1_average_conversion_time,
-         median(step_1_median_conversion_time_inner) AS step_1_median_conversion_time
+  SELECT sum(step_1) AS step_1,
+         sum(step_2) AS step_2,
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT aggregation_target AS aggregation_target,
-            steps AS steps,
-            avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-            median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            breakdown AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                               step_1_conversion_time AS step_1_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  timestamp AS timestamp,
-                  step_0 AS step_0,
-                  latest_0 AS latest_0,
-                  step_1 AS step_1,
-                  latest_1 AS latest_1,
-                  if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                  if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     min(latest_1) OVER (PARTITION BY aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-              FROM
-                (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                        if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                        if(and(equals(e.event, 'user signed up'), and(and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), 1), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_0,
-                        if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                        if(and(equals(e.event, 'user did things'), and(and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), 1), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_1,
-                        if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                 FROM events AS e
-                 LEFT OUTER JOIN
-                   (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                           person_distinct_id_overrides.distinct_id AS distinct_id
-                    FROM person_distinct_id_overrides
-                    WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                    GROUP BY person_distinct_id_overrides.distinct_id
-                    HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                 LEFT JOIN
-                   (SELECT person.id AS id,
-                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-                    FROM person
-                    WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
-                                                                         (SELECT person.id AS id, max(person.version) AS version
-                                                                          FROM person
-                                                                          WHERE equals(person.team_id, 99999)
-                                                                          GROUP BY person.id
-                                                                          HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-                 WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-           WHERE ifNull(equals(step_0, 1), 0)))
-     GROUP BY aggregation_target,
-              steps
-     HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                   and isNull(max(max_steps))))
-  LIMIT 100 SETTINGS readonly=2,
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(and(equals(e.event, 'user signed up'), and(and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), 1), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_0,
+                  if(and(equals(e.event, 'user did things'), and(and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), 1), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_1
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           LEFT JOIN
+             (SELECT person.id AS id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+              FROM person
+              WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                                   (SELECT person.id AS id, max(person.version) AS version
+                                                                    FROM person
+                                                                    WHERE equals(person.team_id, 99999)
+                                                                    GROUP BY person.id
+                                                                    HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_2 DESC, step_1 DESC)
+  GROUP BY final_prop
+  LIMIT 100 SETTINGS join_algorithm='auto',
+                     readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,

--- a/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_funnels_query_runner.ambr
+++ b/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_funnels_query_runner.ambr
@@ -12,90 +12,68 @@
   '''
   SELECT sum(step_1) AS step_1,
          sum(step_2) AS step_2,
-         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
-         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
-         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
-            prop AS prop,
-            row_number() OVER (
-                               ORDER BY step_2 DESC) AS row_number
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            if(ifNull(less(row_number, 25), 0), breakdown, ['Other']) AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', groupUniqArrayIf(prop, ifNull(notEquals(prop, []), isNotNull(prop)
+                                                                                                                       or isNotNull([]))), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                                                         and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                                                         and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                        and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                                                        and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     prop AS prop
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                           prop AS prop
-                 FROM
-                   (SELECT timestamp AS timestamp,
-                           aggregation_target AS aggregation_target,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           prop_basic AS prop_basic,
-                           prop,
-                           prop_vals AS prop_vals,
-                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'purchase'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
-                              prop_basic AS prop,
-                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@posthog.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     GROUP BY prop)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                     if(equals(e.event, 'purchase'), 1, 0) AS step_1,
+                     [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@posthog.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_2 DESC, step_1 DESC)
   GROUP BY final_prop
-  LIMIT 26 SETTINGS readonly=2,
+  LIMIT 26 SETTINGS join_algorithm='auto',
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -118,90 +96,68 @@
   '''
   SELECT sum(step_1) AS step_1,
          sum(step_2) AS step_2,
-         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
-         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
-         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
-            prop AS prop,
-            row_number() OVER (
-                               ORDER BY step_2 DESC) AS row_number
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            if(ifNull(less(row_number, 25), 0), breakdown, ['Other']) AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', groupUniqArrayIf(prop, ifNull(notEquals(prop, []), isNotNull(prop)
+                                                                                                                       or isNotNull([]))), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                                                         and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                                                         and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                        and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                                                        and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     prop AS prop
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                           prop AS prop
-                 FROM
-                   (SELECT timestamp AS timestamp,
-                           aggregation_target AS aggregation_target,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           prop_basic AS prop_basic,
-                           prop,
-                           prop_vals AS prop_vals,
-                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'purchase'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
-                              prop_basic AS prop,
-                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@earlierevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     GROUP BY prop)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                     if(equals(e.event, 'purchase'), 1, 0) AS step_1,
+                     [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@earlierevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_2 DESC, step_1 DESC)
   GROUP BY final_prop
-  LIMIT 26 SETTINGS readonly=2,
+  LIMIT 26 SETTINGS join_algorithm='auto',
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -224,90 +180,68 @@
   '''
   SELECT sum(step_1) AS step_1,
          sum(step_2) AS step_2,
-         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
-         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
-         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
-            prop AS prop,
-            row_number() OVER (
-                               ORDER BY step_2 DESC) AS row_number
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            if(ifNull(less(row_number, 25), 0), breakdown, ['Other']) AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', groupUniqArrayIf(prop, ifNull(notEquals(prop, []), isNotNull(prop)
+                                                                                                                       or isNotNull([]))), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                                                         and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                                                         and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                        and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                                                        and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     prop AS prop
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                           prop AS prop
-                 FROM
-                   (SELECT timestamp AS timestamp,
-                           aggregation_target AS aggregation_target,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           prop_basic AS prop_basic,
-                           prop,
-                           prop_vals AS prop_vals,
-                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'purchase'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
-                              prop_basic AS prop,
-                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@laterevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     GROUP BY prop)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                     if(equals(e.event, 'purchase'), 1, 0) AS step_1,
+                     [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@laterevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_2 DESC, step_1 DESC)
   GROUP BY final_prop
-  LIMIT 26 SETTINGS readonly=2,
+  LIMIT 26 SETTINGS join_algorithm='auto',
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -330,100 +264,78 @@
   '''
   SELECT sum(step_1) AS step_1,
          sum(step_2) AS step_2,
-         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
-         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
-         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
-            prop AS prop,
-            row_number() OVER (
-                               ORDER BY step_2 DESC) AS row_number
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            if(ifNull(less(row_number, 25), 0), breakdown, ['Other']) AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', groupUniqArrayIf(prop, ifNull(notEquals(prop, []), isNotNull(prop)
+                                                                                                                       or isNotNull([]))), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                                                         and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                                                         and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                        and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                                                        and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     prop AS prop
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                           prop AS prop
-                 FROM
-                   (SELECT timestamp AS timestamp,
-                           aggregation_target AS aggregation_target,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           prop_basic AS prop_basic,
-                           prop,
-                           prop_vals AS prop_vals,
-                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'purchase'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
-                              prop_basic AS prop,
-                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       LEFT JOIN
-                         (SELECT person.id AS id,
-                                 replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
-                          FROM person
-                          WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
-                                                                               (SELECT person.id AS id, max(person.version) AS version
-                                                                                FROM person
-                                                                                WHERE equals(person.team_id, 99999)
-                                                                                GROUP BY person.id
-                                                                                HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(e__person.properties___email), '%@posthog.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     GROUP BY prop)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                     if(equals(e.event, 'purchase'), 1, 0) AS step_1,
+                     [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              LEFT JOIN
+                (SELECT person.id AS id,
+                        replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+                 FROM person
+                 WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                                       FROM person
+                                                                       WHERE equals(person.team_id, 99999)
+                                                                       GROUP BY person.id
+                                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(e__person.properties___email), '%@posthog.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_2 DESC, step_1 DESC)
   GROUP BY final_prop
-  LIMIT 26 SETTINGS readonly=2,
+  LIMIT 26 SETTINGS join_algorithm='auto',
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -446,100 +358,78 @@
   '''
   SELECT sum(step_1) AS step_1,
          sum(step_2) AS step_2,
-         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
-         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
-         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
-            prop AS prop,
-            row_number() OVER (
-                               ORDER BY step_2 DESC) AS row_number
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            if(ifNull(less(row_number, 25), 0), breakdown, ['Other']) AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', groupUniqArrayIf(prop, ifNull(notEquals(prop, []), isNotNull(prop)
+                                                                                                                       or isNotNull([]))), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                                                         and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                                                         and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                        and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                                                        and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     prop AS prop
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                           prop AS prop
-                 FROM
-                   (SELECT timestamp AS timestamp,
-                           aggregation_target AS aggregation_target,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           prop_basic AS prop_basic,
-                           prop,
-                           prop_vals AS prop_vals,
-                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'purchase'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
-                              prop_basic AS prop,
-                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       LEFT JOIN
-                         (SELECT person.id AS id,
-                                 replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
-                          FROM person
-                          WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
-                                                                               (SELECT person.id AS id, max(person.version) AS version
-                                                                                FROM person
-                                                                                WHERE equals(person.team_id, 99999)
-                                                                                GROUP BY person.id
-                                                                                HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(e__person.properties___email), '%@earlierevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     GROUP BY prop)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                     if(equals(e.event, 'purchase'), 1, 0) AS step_1,
+                     [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              LEFT JOIN
+                (SELECT person.id AS id,
+                        replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+                 FROM person
+                 WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                                       FROM person
+                                                                       WHERE equals(person.team_id, 99999)
+                                                                       GROUP BY person.id
+                                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(e__person.properties___email), '%@earlierevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_2 DESC, step_1 DESC)
   GROUP BY final_prop
-  LIMIT 26 SETTINGS readonly=2,
+  LIMIT 26 SETTINGS join_algorithm='auto',
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -562,100 +452,78 @@
   '''
   SELECT sum(step_1) AS step_1,
          sum(step_2) AS step_2,
-         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
-         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
-         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
-            prop AS prop,
-            row_number() OVER (
-                               ORDER BY step_2 DESC) AS row_number
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            if(ifNull(less(row_number, 25), 0), breakdown, ['Other']) AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', groupUniqArrayIf(prop, ifNull(notEquals(prop, []), isNotNull(prop)
+                                                                                                                       or isNotNull([]))), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                                                         and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                                                         and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                        and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                                                        and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     prop AS prop
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                           prop AS prop
-                 FROM
-                   (SELECT timestamp AS timestamp,
-                           aggregation_target AS aggregation_target,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           prop_basic AS prop_basic,
-                           prop,
-                           prop_vals AS prop_vals,
-                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'purchase'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
-                              prop_basic AS prop,
-                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       LEFT JOIN
-                         (SELECT person.id AS id,
-                                 replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
-                          FROM person
-                          WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
-                                                                               (SELECT person.id AS id, max(person.version) AS version
-                                                                                FROM person
-                                                                                WHERE equals(person.team_id, 99999)
-                                                                                GROUP BY person.id
-                                                                                HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(e__person.properties___email), '%@laterevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     GROUP BY prop)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                     if(equals(e.event, 'purchase'), 1, 0) AS step_1,
+                     [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              LEFT JOIN
+                (SELECT person.id AS id,
+                        replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+                 FROM person
+                 WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                                       FROM person
+                                                                       WHERE equals(person.team_id, 99999)
+                                                                       GROUP BY person.id
+                                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(e__person.properties___email), '%@laterevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_2 DESC, step_1 DESC)
   GROUP BY final_prop
-  LIMIT 26 SETTINGS readonly=2,
+  LIMIT 26 SETTINGS join_algorithm='auto',
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -678,83 +546,61 @@
   '''
   SELECT sum(step_1) AS step_1,
          sum(step_2) AS step_2,
-         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
-         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
-         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
-            prop AS prop,
-            row_number() OVER (
-                               ORDER BY step_2 DESC) AS row_number
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            if(ifNull(less(row_number, 25), 0), breakdown, ['Other']) AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', groupUniqArrayIf(prop, ifNull(notEquals(prop, []), isNotNull(prop)
+                                                                                                                       or isNotNull([]))), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                                                         and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                                                         and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                        and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                                                        and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     prop AS prop
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                           prop AS prop
-                 FROM
-                   (SELECT timestamp AS timestamp,
-                           aggregation_target AS aggregation_target,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           prop_basic AS prop_basic,
-                           prop,
-                           prop_vals AS prop_vals,
-                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.person_id AS aggregation_target,
-                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'purchase'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
-                              prop_basic AS prop,
-                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-31 00:00:00.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@posthog.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     GROUP BY prop)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.person_id AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                     if(equals(e.event, 'purchase'), 1, 0) AS step_1,
+                     [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-31 00:00:00.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@posthog.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_2 DESC, step_1 DESC)
   GROUP BY final_prop
-  LIMIT 26 SETTINGS readonly=2,
+  LIMIT 26 SETTINGS join_algorithm='auto',
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -777,83 +623,61 @@
   '''
   SELECT sum(step_1) AS step_1,
          sum(step_2) AS step_2,
-         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
-         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
-         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
-            prop AS prop,
-            row_number() OVER (
-                               ORDER BY step_2 DESC) AS row_number
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            if(ifNull(less(row_number, 25), 0), breakdown, ['Other']) AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', groupUniqArrayIf(prop, ifNull(notEquals(prop, []), isNotNull(prop)
+                                                                                                                       or isNotNull([]))), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                                                         and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                                                         and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                        and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                                                        and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     prop AS prop
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                           prop AS prop
-                 FROM
-                   (SELECT timestamp AS timestamp,
-                           aggregation_target AS aggregation_target,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           prop_basic AS prop_basic,
-                           prop,
-                           prop_vals AS prop_vals,
-                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.person_id AS aggregation_target,
-                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'purchase'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
-                              prop_basic AS prop,
-                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-31 00:00:00.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@earlierevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     GROUP BY prop)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.person_id AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                     if(equals(e.event, 'purchase'), 1, 0) AS step_1,
+                     [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-31 00:00:00.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@earlierevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_2 DESC, step_1 DESC)
   GROUP BY final_prop
-  LIMIT 26 SETTINGS readonly=2,
+  LIMIT 26 SETTINGS join_algorithm='auto',
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -876,83 +700,61 @@
   '''
   SELECT sum(step_1) AS step_1,
          sum(step_2) AS step_2,
-         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
-         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
-         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
-            prop AS prop,
-            row_number() OVER (
-                               ORDER BY step_2 DESC) AS row_number
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            if(ifNull(less(row_number, 25), 0), breakdown, ['Other']) AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', groupUniqArrayIf(prop, ifNull(notEquals(prop, []), isNotNull(prop)
+                                                                                                                       or isNotNull([]))), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                                                         and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                                                         and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                        and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                                                        and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     prop AS prop
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                           prop AS prop
-                 FROM
-                   (SELECT timestamp AS timestamp,
-                           aggregation_target AS aggregation_target,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           prop_basic AS prop_basic,
-                           prop,
-                           prop_vals AS prop_vals,
-                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.person_id AS aggregation_target,
-                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'purchase'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
-                              prop_basic AS prop,
-                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-31 00:00:00.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@laterevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     GROUP BY prop)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.person_id AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                     if(equals(e.event, 'purchase'), 1, 0) AS step_1,
+                     [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-31 00:00:00.000000', 6, 'UTC'))), in(e.event, tuple('$pageview', 'purchase')), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@laterevent.com%'), 1)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_2 DESC, step_1 DESC)
   GROUP BY final_prop
-  LIMIT 26 SETTINGS readonly=2,
+  LIMIT 26 SETTINGS join_algorithm='auto',
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,

--- a/posthog/hogql_queries/insights/funnels/funnel_correlation_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_correlation_query_runner.py
@@ -23,7 +23,6 @@ from posthog.hogql_queries.insights.funnels.funnel_query_context import FunnelQu
 from posthog.hogql_queries.insights.funnels.utils import (
     funnel_window_interval_unit_to_sql,
     get_funnel_actor_class,
-    use_udf,
 )
 from posthog.hogql_queries.query_runner import QueryRunner
 from posthog.models import Team
@@ -137,9 +136,7 @@ class FunnelCorrelationQueryRunner(QueryRunner):
         self.context.actorsQuery = self.actors_query
 
         # Used for generating the funnel persons cte
-        funnel_order_actor_class = get_funnel_actor_class(
-            self.context.funnelsFilter, use_udf(self.context.funnelsFilter, self.team)
-        )(context=self.context)
+        funnel_order_actor_class = get_funnel_actor_class(self.context.funnelsFilter, True)(context=self.context)
         assert isinstance(
             funnel_order_actor_class, FunnelActors | FunnelStrictActors | FunnelUnorderedActors | FunnelUDF
         )  # for typings

--- a/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnels_query_runner.py
@@ -19,7 +19,7 @@ from posthog.hogql_queries.insights.funnels.funnel_query_context import FunnelQu
 from posthog.hogql_queries.insights.funnels.funnel_time_to_convert import FunnelTimeToConvert
 from posthog.hogql_queries.insights.funnels.funnel_trends import FunnelTrends
 from posthog.hogql_queries.insights.funnels.funnel_trends_udf import FunnelTrendsUDF
-from posthog.hogql_queries.insights.funnels.utils import get_funnel_actor_class, get_funnel_order_class, use_udf
+from posthog.hogql_queries.insights.funnels.utils import get_funnel_actor_class, get_funnel_order_class
 from posthog.hogql_queries.query_runner import QueryRunner
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.models import Team
@@ -105,17 +105,11 @@ class FunnelsQueryRunner(QueryRunner):
         if response.timings is not None:
             timings.extend(response.timings)
 
-        return FunnelsQueryResponse(
-            isUdf=self._use_udf, results=results, timings=timings, hogql=hogql, modifiers=self.modifiers
-        )
-
-    @cached_property
-    def _use_udf(self):
-        return use_udf(self.context.funnelsFilter, self.team)
+        return FunnelsQueryResponse(isUdf=True, results=results, timings=timings, hogql=hogql, modifiers=self.modifiers)
 
     @cached_property
     def funnel_order_class(self):
-        return get_funnel_order_class(self.context.funnelsFilter, use_udf=self._use_udf)(context=self.context)
+        return get_funnel_order_class(self.context.funnelsFilter, use_udf=True)(context=self.context)
 
     @cached_property
     def funnel_class(self):
@@ -124,7 +118,7 @@ class FunnelsQueryRunner(QueryRunner):
         if funnelVizType == FunnelVizType.TRENDS:
             return (
                 FunnelTrendsUDF(context=self.context, **self.kwargs)
-                if self._use_udf and self.context.funnelsFilter.funnelOrderType != StepOrderValue.UNORDERED
+                if self.context.funnelsFilter.funnelOrderType != StepOrderValue.UNORDERED
                 else FunnelTrends(context=self.context, **self.kwargs)
             )
         elif funnelVizType == FunnelVizType.TIME_TO_CONVERT:
@@ -134,7 +128,7 @@ class FunnelsQueryRunner(QueryRunner):
 
     @cached_property
     def funnel_actor_class(self):
-        return get_funnel_actor_class(self.context.funnelsFilter, self._use_udf)(context=self.context)
+        return get_funnel_actor_class(self.context.funnelsFilter, True)(context=self.context)
 
     @cached_property
     def query_date_range(self):

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel.ambr
@@ -216,62 +216,57 @@
 # ---
 # name: TestFOSSFunnel.test_funnel_with_precalculated_cohort_step_filter.2
   '''
-  SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-         countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-         avg(step_1_average_conversion_time_inner) AS step_1_average_conversion_time,
-         median(step_1_median_conversion_time_inner) AS step_1_median_conversion_time
+  SELECT sum(step_1) AS step_1,
+         sum(step_2) AS step_2,
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT aggregation_target AS aggregation_target,
-            steps AS steps,
-            avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-            median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            breakdown AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                               step_1_conversion_time AS step_1_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  timestamp AS timestamp,
-                  step_0 AS step_0,
-                  latest_0 AS latest_0,
-                  step_1 AS step_1,
-                  latest_1 AS latest_1,
-                  if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                  if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     min(latest_1) OVER (PARTITION BY aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-              FROM
-                (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                        if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                        if(and(equals(e.event, 'user signed up'), ifNull(in(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id),
-                                                                              (SELECT cohortpeople.person_id AS person_id
-                                                                               FROM cohortpeople
-                                                                               WHERE and(equals(cohortpeople.team_id, 99999), equals(cohortpeople.cohort_id, 99999), equals(cohortpeople.version, 0)))), 0)), 1, 0) AS step_0,
-                        if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                        if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                        if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                 FROM events AS e
-                 LEFT OUTER JOIN
-                   (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                           person_distinct_id_overrides.distinct_id AS distinct_id
-                    FROM person_distinct_id_overrides
-                    WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                    GROUP BY person_distinct_id_overrides.distinct_id
-                    HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                 WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-           WHERE ifNull(equals(step_0, 1), 0)))
-     GROUP BY aggregation_target,
-              steps
-     HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                   and isNull(max(max_steps))))
-  LIMIT 100 SETTINGS readonly=2,
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(and(equals(e.event, 'user signed up'), ifNull(in(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id),
+                                                                        (SELECT cohortpeople.person_id AS person_id
+                                                                         FROM cohortpeople
+                                                                         WHERE and(equals(cohortpeople.team_id, 99999), equals(cohortpeople.cohort_id, 99999), equals(cohortpeople.version, 0)))), 0)), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_2 DESC, step_1 DESC)
+  GROUP BY final_prop
+  LIMIT 100 SETTINGS join_algorithm='auto',
+                     readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
@@ -283,103 +278,71 @@
 # ---
 # name: TestFOSSFunnel.test_funnel_with_property_groups
   '''
-  SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-         countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-         countIf(ifNull(equals(steps, 3), 0)) AS step_3,
-         avg(step_1_average_conversion_time_inner) AS step_1_average_conversion_time,
-         avg(step_2_average_conversion_time_inner) AS step_2_average_conversion_time,
-         median(step_1_median_conversion_time_inner) AS step_1_median_conversion_time,
-         median(step_2_median_conversion_time_inner) AS step_2_median_conversion_time
+  SELECT sum(step_1) AS step_1,
+         sum(step_2) AS step_2,
+         sum(step_3) AS step_3,
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_2_conversion_times)])[1] AS step_2_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_2_conversion_times)])[1] AS step_2_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT aggregation_target AS aggregation_target,
-            steps AS steps,
-            avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-            avg(step_2_conversion_time) AS step_2_average_conversion_time_inner,
-            median(step_1_conversion_time) AS step_1_median_conversion_time_inner,
-            median(step_2_conversion_time) AS step_2_median_conversion_time_inner
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            countIf(ifNull(ifNull(equals(step_reached, 2), 0), 0)) AS step_3,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            groupArrayIf(timings[2], ifNull(greater(timings[2], 0), 0)) AS step_2_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            breakdown AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                               step_1_conversion_time AS step_1_conversion_time,
-                               step_2_conversion_time AS step_2_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(3, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  timestamp AS timestamp,
-                  step_0 AS step_0,
-                  latest_0 AS latest_0,
-                  step_1 AS step_1,
-                  latest_1 AS latest_1,
-                  step_2 AS step_2,
-                  latest_2 AS latest_2,
-                  if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                  if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                  if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     step_2 AS step_2,
-                     min(latest_2) OVER (PARTITION BY aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        step_2 AS step_2,
-                        if(ifNull(less(latest_2, latest_1), 0), NULL, latest_2) AS latest_2
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              step_2 AS step_2,
-                                              min(latest_2) OVER (PARTITION BY aggregation_target
-                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(and(equals(e.event, '$pageview'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'aloha.com'), 0)), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(and(equals(e.event, '$pageview'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'aloha2.com'), 0)), 1, 0) AS step_2,
-                              if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       LEFT JOIN
-                         (SELECT person.id AS id,
-                                 replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
-                                 replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'age'), ''), 'null'), '^"|"$', '') AS properties___age
-                          FROM person
-                          WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
-                                                                               (SELECT person.id AS id, max(person.version) AS version
-                                                                                FROM person
-                                                                                WHERE equals(person.team_id, 99999)
-                                                                                GROUP BY person.id
-                                                                                HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('$pageview', 'user signed up')), or(and(ifNull(ilike(toString(e__person.properties___email), '%.com%'), 0), ifNull(equals(e__person.properties___age, '20'), 0)), or(ifNull(ilike(toString(e__person.properties___email), '%.org%'), 0), ifNull(equals(e__person.properties___age, '28'), 0)))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0)))))))
-           WHERE ifNull(equals(step_0, 1), 0)))
-     GROUP BY aggregation_target,
-              steps
-     HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                   and isNull(max(max_steps))))
-  LIMIT 100 SETTINGS readonly=2,
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(and(equals(e.event, '$pageview'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'aloha.com'), 0)), 1, 0) AS step_1,
+                  if(and(equals(e.event, '$pageview'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'aloha2.com'), 0)), 1, 0) AS step_2
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           LEFT JOIN
+             (SELECT person.id AS id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'age'), ''), 'null'), '^"|"$', '') AS properties___age
+              FROM person
+              WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                                   (SELECT person.id AS id, max(person.version) AS version
+                                                                    FROM person
+                                                                    WHERE equals(person.team_id, 99999)
+                                                                    GROUP BY person.id
+                                                                    HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('$pageview', 'user signed up')), or(and(ifNull(ilike(toString(e__person.properties___email), '%.com%'), 0), ifNull(equals(e__person.properties___age, '20'), 0)), or(ifNull(ilike(toString(e__person.properties___email), '%.org%'), 0), ifNull(equals(e__person.properties___age, '28'), 0)))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_3 DESC, step_2 DESC, step_1 DESC)
+  GROUP BY final_prop
+  LIMIT 100 SETTINGS join_algorithm='auto',
+                     readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
@@ -398,96 +361,50 @@
     (SELECT aggregation_target AS actor_id,
             actor_id AS id
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               avg(step_2_conversion_time) AS step_2_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner,
-               median(step_2_conversion_time) AS step_2_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(3, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  step_2_conversion_time AS step_2_conversion_time
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     step_2 AS step_2,
-                     latest_2 AS latest_2,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        step_2 AS step_2,
-                        min(latest_2) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           step_2 AS step_2,
-                           if(ifNull(less(latest_2, latest_1), 0), NULL, latest_2) AS latest_2
-                    FROM
-                      (SELECT aggregation_target AS aggregation_target,
-                              timestamp AS timestamp,
-                              step_0 AS step_0,
-                              latest_0 AS latest_0,
-                              step_1 AS step_1,
-                              min(latest_1) OVER (PARTITION BY aggregation_target
-                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                                 step_2 AS step_2,
-                                                 min(latest_2) OVER (PARTITION BY aggregation_target
-                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2
-                       FROM
-                         (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                                 if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                                 if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                                 if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                                 if(and(equals(e.event, '$pageview'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'aloha.com'), 0)), 1, 0) AS step_1,
-                                 if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                                 if(and(equals(e.event, '$pageview'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'aloha2.com'), 0)), 1, 0) AS step_2,
-                                 if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2
-                          FROM events AS e
-                          LEFT OUTER JOIN
-                            (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                    person_distinct_id_overrides.distinct_id AS distinct_id
-                             FROM person_distinct_id_overrides
-                             WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                             GROUP BY person_distinct_id_overrides.distinct_id
-                             HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                          LEFT JOIN
-                            (SELECT person.id AS id,
-                                    replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
-                                    replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'age'), ''), 'null'), '^"|"$', '') AS properties___age
-                             FROM person
-                             WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
-                                                                                  (SELECT person.id AS id, max(person.version) AS version
-                                                                                   FROM person
-                                                                                   WHERE equals(person.team_id, 99999)
-                                                                                   GROUP BY person.id
-                                                                                   HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-                          WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('$pageview', 'user signed up')), or(and(ifNull(ilike(toString(e__person.properties___email), '%.com%'), 0), ifNull(equals(e__person.properties___age, '20'), 0)), or(ifNull(ilike(toString(e__person.properties___email), '%.org%'), 0), ifNull(equals(e__person.properties___age, '28'), 0)))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0)))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [1, 2, 3]), 0)
-     ORDER BY aggregation_target ASC) AS source
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(and(equals(e.event, '$pageview'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'aloha.com'), 0)), 1, 0) AS step_1,
+                  if(and(equals(e.event, '$pageview'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'aloha2.com'), 0)), 1, 0) AS step_2
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           LEFT JOIN
+             (SELECT person.id AS id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'age'), ''), 'null'), '^"|"$', '') AS properties___age
+              FROM person
+              WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                                   (SELECT person.id AS id, max(person.version) AS version
+                                                                    FROM person
+                                                                    WHERE equals(person.team_id, 99999)
+                                                                    GROUP BY person.id
+                                                                    HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('$pageview', 'user signed up')), or(and(ifNull(ilike(toString(e__person.properties___email), '%.com%'), 0), ifNull(equals(e__person.properties___age, '20'), 0)), or(ifNull(ilike(toString(e__person.properties___email), '%.org%'), 0), ifNull(equals(e__person.properties___age, '28'), 0)))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
@@ -511,96 +428,50 @@
     (SELECT aggregation_target AS actor_id,
             actor_id AS id
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               avg(step_2_conversion_time) AS step_2_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner,
-               median(step_2_conversion_time) AS step_2_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(3, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  step_2_conversion_time AS step_2_conversion_time
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     step_2 AS step_2,
-                     latest_2 AS latest_2,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        step_2 AS step_2,
-                        min(latest_2) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           step_2 AS step_2,
-                           if(ifNull(less(latest_2, latest_1), 0), NULL, latest_2) AS latest_2
-                    FROM
-                      (SELECT aggregation_target AS aggregation_target,
-                              timestamp AS timestamp,
-                              step_0 AS step_0,
-                              latest_0 AS latest_0,
-                              step_1 AS step_1,
-                              min(latest_1) OVER (PARTITION BY aggregation_target
-                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                                 step_2 AS step_2,
-                                                 min(latest_2) OVER (PARTITION BY aggregation_target
-                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2
-                       FROM
-                         (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                                 if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                                 if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                                 if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                                 if(and(equals(e.event, '$pageview'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'aloha.com'), 0)), 1, 0) AS step_1,
-                                 if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                                 if(and(equals(e.event, '$pageview'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'aloha2.com'), 0)), 1, 0) AS step_2,
-                                 if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2
-                          FROM events AS e
-                          LEFT OUTER JOIN
-                            (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                    person_distinct_id_overrides.distinct_id AS distinct_id
-                             FROM person_distinct_id_overrides
-                             WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                             GROUP BY person_distinct_id_overrides.distinct_id
-                             HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                          LEFT JOIN
-                            (SELECT person.id AS id,
-                                    replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
-                                    replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'age'), ''), 'null'), '^"|"$', '') AS properties___age
-                             FROM person
-                             WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
-                                                                                  (SELECT person.id AS id, max(person.version) AS version
-                                                                                   FROM person
-                                                                                   WHERE equals(person.team_id, 99999)
-                                                                                   GROUP BY person.id
-                                                                                   HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-                          WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('$pageview', 'user signed up')), or(and(ifNull(ilike(toString(e__person.properties___email), '%.com%'), 0), ifNull(equals(e__person.properties___age, '20'), 0)), or(ifNull(ilike(toString(e__person.properties___email), '%.org%'), 0), ifNull(equals(e__person.properties___age, '28'), 0)))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0)))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [2, 3]), 0)
-     ORDER BY aggregation_target ASC) AS source
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(and(equals(e.event, '$pageview'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'aloha.com'), 0)), 1, 0) AS step_1,
+                  if(and(equals(e.event, '$pageview'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'aloha2.com'), 0)), 1, 0) AS step_2
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           LEFT JOIN
+             (SELECT person.id AS id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'age'), ''), 'null'), '^"|"$', '') AS properties___age
+              FROM person
+              WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                                   (SELECT person.id AS id, max(person.version) AS version
+                                                                    FROM person
+                                                                    WHERE equals(person.team_id, 99999)
+                                                                    GROUP BY person.id
+                                                                    HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('$pageview', 'user signed up')), or(and(ifNull(ilike(toString(e__person.properties___email), '%.com%'), 0), ifNull(equals(e__person.properties___age, '20'), 0)), or(ifNull(ilike(toString(e__person.properties___email), '%.org%'), 0), ifNull(equals(e__person.properties___age, '28'), 0)))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 1), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
@@ -624,96 +495,50 @@
     (SELECT aggregation_target AS actor_id,
             actor_id AS id
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               avg(step_2_conversion_time) AS step_2_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner,
-               median(step_2_conversion_time) AS step_2_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(3, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  step_2_conversion_time AS step_2_conversion_time
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     step_2 AS step_2,
-                     latest_2 AS latest_2,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        step_2 AS step_2,
-                        min(latest_2) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           step_2 AS step_2,
-                           if(ifNull(less(latest_2, latest_1), 0), NULL, latest_2) AS latest_2
-                    FROM
-                      (SELECT aggregation_target AS aggregation_target,
-                              timestamp AS timestamp,
-                              step_0 AS step_0,
-                              latest_0 AS latest_0,
-                              step_1 AS step_1,
-                              min(latest_1) OVER (PARTITION BY aggregation_target
-                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                                 step_2 AS step_2,
-                                                 min(latest_2) OVER (PARTITION BY aggregation_target
-                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2
-                       FROM
-                         (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                                 if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                                 if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                                 if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                                 if(and(equals(e.event, '$pageview'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'aloha.com'), 0)), 1, 0) AS step_1,
-                                 if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                                 if(and(equals(e.event, '$pageview'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'aloha2.com'), 0)), 1, 0) AS step_2,
-                                 if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2
-                          FROM events AS e
-                          LEFT OUTER JOIN
-                            (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                    person_distinct_id_overrides.distinct_id AS distinct_id
-                             FROM person_distinct_id_overrides
-                             WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                             GROUP BY person_distinct_id_overrides.distinct_id
-                             HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                          LEFT JOIN
-                            (SELECT person.id AS id,
-                                    replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
-                                    replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'age'), ''), 'null'), '^"|"$', '') AS properties___age
-                             FROM person
-                             WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
-                                                                                  (SELECT person.id AS id, max(person.version) AS version
-                                                                                   FROM person
-                                                                                   WHERE equals(person.team_id, 99999)
-                                                                                   GROUP BY person.id
-                                                                                   HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-                          WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('$pageview', 'user signed up')), or(and(ifNull(ilike(toString(e__person.properties___email), '%.com%'), 0), ifNull(equals(e__person.properties___age, '20'), 0)), or(ifNull(ilike(toString(e__person.properties___email), '%.org%'), 0), ifNull(equals(e__person.properties___age, '28'), 0)))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0)))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [3]), 0)
-     ORDER BY aggregation_target ASC) AS source
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(and(equals(e.event, '$pageview'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'aloha.com'), 0)), 1, 0) AS step_1,
+                  if(and(equals(e.event, '$pageview'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'aloha2.com'), 0)), 1, 0) AS step_2
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           LEFT JOIN
+             (SELECT person.id AS id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'age'), ''), 'null'), '^"|"$', '') AS properties___age
+              FROM person
+              WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                                   (SELECT person.id AS id, max(person.version) AS version
+                                                                    FROM person
+                                                                    WHERE equals(person.team_id, 99999)
+                                                                    GROUP BY person.id
+                                                                    HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('$pageview', 'user signed up')), or(and(ifNull(ilike(toString(e__person.properties___email), '%.com%'), 0), ifNull(equals(e__person.properties___age, '20'), 0)), or(ifNull(ilike(toString(e__person.properties___email), '%.org%'), 0), ifNull(equals(e__person.properties___age, '28'), 0)))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 2), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
@@ -739,62 +564,57 @@
 # ---
 # name: TestFOSSFunnel.test_funnel_with_static_cohort_step_filter.1
   '''
-  SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-         countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-         avg(step_1_average_conversion_time_inner) AS step_1_average_conversion_time,
-         median(step_1_median_conversion_time_inner) AS step_1_median_conversion_time
+  SELECT sum(step_1) AS step_1,
+         sum(step_2) AS step_2,
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT aggregation_target AS aggregation_target,
-            steps AS steps,
-            avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-            median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            breakdown AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                               step_1_conversion_time AS step_1_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  timestamp AS timestamp,
-                  step_0 AS step_0,
-                  latest_0 AS latest_0,
-                  step_1 AS step_1,
-                  latest_1 AS latest_1,
-                  if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                  if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     min(latest_1) OVER (PARTITION BY aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-              FROM
-                (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                        if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                        if(and(equals(e.event, 'user signed up'), ifNull(in(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id),
-                                                                              (SELECT person_static_cohort.person_id AS person_id
-                                                                               FROM person_static_cohort
-                                                                               WHERE and(equals(person_static_cohort.team_id, 99999), equals(person_static_cohort.cohort_id, 99999)))), 0)), 1, 0) AS step_0,
-                        if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                        if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                        if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                 FROM events AS e
-                 LEFT OUTER JOIN
-                   (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                           person_distinct_id_overrides.distinct_id AS distinct_id
-                    FROM person_distinct_id_overrides
-                    WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                    GROUP BY person_distinct_id_overrides.distinct_id
-                    HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                 WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-           WHERE ifNull(equals(step_0, 1), 0)))
-     GROUP BY aggregation_target,
-              steps
-     HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                   and isNull(max(max_steps))))
-  LIMIT 100 SETTINGS readonly=2,
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(and(equals(e.event, 'user signed up'), ifNull(in(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id),
+                                                                        (SELECT person_static_cohort.person_id AS person_id
+                                                                         FROM person_static_cohort
+                                                                         WHERE and(equals(person_static_cohort.team_id, 99999), equals(person_static_cohort.cohort_id, 99999)))), 0)), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_2 DESC, step_1 DESC)
+  GROUP BY final_prop
+  LIMIT 100 SETTINGS join_algorithm='auto',
+                     readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
@@ -806,59 +626,54 @@
 # ---
 # name: TestFOSSFunnel.test_timezones
   '''
-  SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-         countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-         avg(step_1_average_conversion_time_inner) AS step_1_average_conversion_time,
-         median(step_1_median_conversion_time_inner) AS step_1_median_conversion_time
+  SELECT sum(step_1) AS step_1,
+         sum(step_2) AS step_2,
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT aggregation_target AS aggregation_target,
-            steps AS steps,
-            avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-            median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            breakdown AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                               step_1_conversion_time AS step_1_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  timestamp AS timestamp,
-                  step_0 AS step_0,
-                  latest_0 AS latest_0,
-                  step_1 AS step_1,
-                  latest_1 AS latest_1,
-                  if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                  if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     min(latest_1) OVER (PARTITION BY aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-              FROM
-                (SELECT toTimeZone(e.timestamp, 'US/Pacific') AS timestamp,
-                        if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                        if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                        if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                        if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                        if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                 FROM events AS e
-                 LEFT OUTER JOIN
-                   (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                           person_distinct_id_overrides.distinct_id AS distinct_id
-                    FROM person_distinct_id_overrides
-                    WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                    GROUP BY person_distinct_id_overrides.distinct_id
-                    HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                 WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'US/Pacific'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'US/Pacific')), lessOrEquals(toTimeZone(e.timestamp, 'US/Pacific'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'US/Pacific'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-           WHERE ifNull(equals(step_0, 1), 0)))
-     GROUP BY aggregation_target,
-              steps
-     HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                   and isNull(max(max_steps))))
-  LIMIT 100 SETTINGS readonly=2,
+          (SELECT toTimeZone(e.timestamp, 'US/Pacific') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'US/Pacific'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'US/Pacific')), lessOrEquals(toTimeZone(e.timestamp, 'US/Pacific'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'US/Pacific'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_2 DESC, step_1 DESC)
+  GROUP BY final_prop
+  LIMIT 100 SETTINGS join_algorithm='auto',
+                     readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel.ambr
@@ -1,92 +1,60 @@
 # serializer version: 1
 # name: TestFOSSFunnel.test_funnel_conversion_window_seconds
   '''
-  SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-         countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-         countIf(ifNull(equals(steps, 3), 0)) AS step_3,
-         avg(step_1_average_conversion_time_inner) AS step_1_average_conversion_time,
-         avg(step_2_average_conversion_time_inner) AS step_2_average_conversion_time,
-         median(step_1_median_conversion_time_inner) AS step_1_median_conversion_time,
-         median(step_2_median_conversion_time_inner) AS step_2_median_conversion_time
+  SELECT sum(step_1) AS step_1,
+         sum(step_2) AS step_2,
+         sum(step_3) AS step_3,
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_2_conversion_times)])[1] AS step_2_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_2_conversion_times)])[1] AS step_2_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT aggregation_target AS aggregation_target,
-            steps AS steps,
-            avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-            avg(step_2_conversion_time) AS step_2_average_conversion_time_inner,
-            median(step_1_conversion_time) AS step_1_median_conversion_time_inner,
-            median(step_2_conversion_time) AS step_2_median_conversion_time_inner
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            countIf(ifNull(ifNull(equals(step_reached, 2), 0), 0)) AS step_3,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            groupArrayIf(timings[2], ifNull(greater(timings[2], 0), 0)) AS step_2_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            breakdown AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                               step_1_conversion_time AS step_1_conversion_time,
-                               step_2_conversion_time AS step_2_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(3, 15, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                        and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                        and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                       and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                       and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  timestamp AS timestamp,
-                  step_0 AS step_0,
-                  latest_0 AS latest_0,
-                  step_1 AS step_1,
-                  latest_1 AS latest_1,
-                  step_2 AS step_2,
-                  latest_2 AS latest_2,
-                  if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalSecond(15))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalSecond(15))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalSecond(15))), 0)), 2, 1)) AS steps,
-                  if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalSecond(15))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                  if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalSecond(15))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     step_2 AS step_2,
-                     min(latest_2) OVER (PARTITION BY aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        step_2 AS step_2,
-                        if(ifNull(less(latest_2, latest_1), 0), NULL, latest_2) AS latest_2
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              step_2 AS step_2,
-                                              min(latest_2) OVER (PARTITION BY aggregation_target
-                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              if(equals(e.event, 'step one'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'step two'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(equals(e.event, 'step three'), 1, 0) AS step_2,
-                              if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('step one', 'step three', 'step two'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0)))))))
-           WHERE ifNull(equals(step_0, 1), 0)))
-     GROUP BY aggregation_target,
-              steps
-     HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                   and isNull(max(max_steps))))
-  LIMIT 100 SETTINGS readonly=2,
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'step one'), 1, 0) AS step_0,
+                  if(equals(e.event, 'step two'), 1, 0) AS step_1,
+                  if(equals(e.event, 'step three'), 1, 0) AS step_2
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('step one', 'step three', 'step two'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_3 DESC, step_2 DESC, step_1 DESC)
+  GROUP BY final_prop
+  LIMIT 100 SETTINGS join_algorithm='auto',
+                     readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
@@ -105,85 +73,39 @@
     (SELECT aggregation_target AS actor_id,
             actor_id AS id
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               avg(step_2_conversion_time) AS step_2_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner,
-               median(step_2_conversion_time) AS step_2_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(3, 15, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                        and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                        and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                       and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                       and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  step_2_conversion_time AS step_2_conversion_time
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     step_2 AS step_2,
-                     latest_2 AS latest_2,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalSecond(15))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalSecond(15))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalSecond(15))), 0)), 2, 1)) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalSecond(15))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalSecond(15))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        step_2 AS step_2,
-                        min(latest_2) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           step_2 AS step_2,
-                           if(ifNull(less(latest_2, latest_1), 0), NULL, latest_2) AS latest_2
-                    FROM
-                      (SELECT aggregation_target AS aggregation_target,
-                              timestamp AS timestamp,
-                              step_0 AS step_0,
-                              latest_0 AS latest_0,
-                              step_1 AS step_1,
-                              min(latest_1) OVER (PARTITION BY aggregation_target
-                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                                 step_2 AS step_2,
-                                                 min(latest_2) OVER (PARTITION BY aggregation_target
-                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2
-                       FROM
-                         (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                                 if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                                 if(equals(e.event, 'step one'), 1, 0) AS step_0,
-                                 if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                                 if(equals(e.event, 'step two'), 1, 0) AS step_1,
-                                 if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                                 if(equals(e.event, 'step three'), 1, 0) AS step_2,
-                                 if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2
-                          FROM events AS e
-                          LEFT OUTER JOIN
-                            (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                    person_distinct_id_overrides.distinct_id AS distinct_id
-                             FROM person_distinct_id_overrides
-                             WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                             GROUP BY person_distinct_id_overrides.distinct_id
-                             HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                          WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('step one', 'step three', 'step two'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0)))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [2, 3]), 0)
-     ORDER BY aggregation_target ASC) AS source
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'step one'), 1, 0) AS step_0,
+                  if(equals(e.event, 'step two'), 1, 0) AS step_1,
+                  if(equals(e.event, 'step three'), 1, 0) AS step_2
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('step one', 'step three', 'step two'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 1), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
@@ -209,92 +131,60 @@
 # ---
 # name: TestFOSSFunnel.test_funnel_events_with_person_on_events_v2.1
   '''
-  SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-         countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-         countIf(ifNull(equals(steps, 3), 0)) AS step_3,
-         avg(step_1_average_conversion_time_inner) AS step_1_average_conversion_time,
-         avg(step_2_average_conversion_time_inner) AS step_2_average_conversion_time,
-         median(step_1_median_conversion_time_inner) AS step_1_median_conversion_time,
-         median(step_2_median_conversion_time_inner) AS step_2_median_conversion_time
+  SELECT sum(step_1) AS step_1,
+         sum(step_2) AS step_2,
+         sum(step_3) AS step_3,
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_2_conversion_times)])[1] AS step_2_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_2_conversion_times)])[1] AS step_2_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT aggregation_target AS aggregation_target,
-            steps AS steps,
-            avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-            avg(step_2_conversion_time) AS step_2_average_conversion_time_inner,
-            median(step_1_conversion_time) AS step_1_median_conversion_time_inner,
-            median(step_2_conversion_time) AS step_2_median_conversion_time_inner
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            countIf(ifNull(ifNull(equals(step_reached, 2), 0), 0)) AS step_3,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            groupArrayIf(timings[2], ifNull(greater(timings[2], 0), 0)) AS step_2_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            breakdown AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                               step_1_conversion_time AS step_1_conversion_time,
-                               step_2_conversion_time AS step_2_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(3, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  timestamp AS timestamp,
-                  step_0 AS step_0,
-                  latest_0 AS latest_0,
-                  step_1 AS step_1,
-                  latest_1 AS latest_1,
-                  step_2 AS step_2,
-                  latest_2 AS latest_2,
-                  if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                  if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                  if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     step_2 AS step_2,
-                     min(latest_2) OVER (PARTITION BY aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        step_2 AS step_2,
-                        if(ifNull(less(latest_2, latest_1), 0), NULL, latest_2) AS latest_2
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              step_2 AS step_2,
-                                              min(latest_2) OVER (PARTITION BY aggregation_target
-                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(and(equals(e.event, '$autocapture'), match(e.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Pay $10'), 0), e.elements_chain_texts)), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(and(equals(e.event, '$autocapture'), match(e.elements_chain, '(^|;)a(\\.|$|;|:)'), equals(e.elements_chain_href, '/movie')), 1, 0) AS step_2,
-                              if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('$autocapture', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0)))))))
-           WHERE ifNull(equals(step_0, 1), 0)))
-     GROUP BY aggregation_target,
-              steps
-     HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                   and isNull(max(max_steps))))
-  LIMIT 100 SETTINGS readonly=2,
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(and(equals(e.event, '$autocapture'), match(e.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Pay $10'), 0), e.elements_chain_texts)), 1, 0) AS step_1,
+                  if(and(equals(e.event, '$autocapture'), match(e.elements_chain, '(^|;)a(\\.|$|;|:)'), equals(e.elements_chain_href, '/movie')), 1, 0) AS step_2
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('$autocapture', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_3 DESC, step_2 DESC, step_1 DESC)
+  GROUP BY final_prop
+  LIMIT 100 SETTINGS join_algorithm='auto',
+                     readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
@@ -982,90 +872,68 @@
   '''
   SELECT sum(step_1) AS step_1,
          sum(step_2) AS step_2,
-         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
-         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
-         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
-            prop AS prop,
-            row_number() OVER (
-                               ORDER BY step_2 DESC) AS row_number
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            if(ifNull(less(row_number, 25), 0), breakdown, ['Other']) AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', groupUniqArrayIf(prop, ifNull(notEquals(prop, []), isNotNull(prop)
+                                                                                                                       or isNotNull([]))), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                                                         and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                                                         and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                        and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                                                        and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     prop AS prop
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                           prop AS prop
-                 FROM
-                   (SELECT timestamp AS timestamp,
-                           aggregation_target AS aggregation_target,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           prop_basic AS prop_basic,
-                           prop,
-                           prop_vals AS prop_vals,
-                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              if(equals(e.event, 'sign up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(and(equals(e.event, 'buy'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', ''), 'xyz'), 0)), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
-                              prop_basic AS prop,
-                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('buy', 'sign up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     GROUP BY prop)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'sign up'), 1, 0) AS step_0,
+                     if(and(equals(e.event, 'buy'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', ''), 'xyz'), 0)), 1, 0) AS step_1,
+                     [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('buy', 'sign up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_2 DESC, step_1 DESC)
   GROUP BY final_prop
-  LIMIT 26 SETTINGS readonly=2,
+  LIMIT 26 SETTINGS join_algorithm='auto',
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1079,97 +947,58 @@
   '''
   SELECT sum(step_1) AS step_1,
          sum(step_2) AS step_2,
-         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
-         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
-         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
-            prop AS prop,
-            row_number() OVER (
-                               ORDER BY step_2 DESC) AS row_number
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            if(ifNull(less(row_number, 25), 0), breakdown, ['Other']) AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'step_1', 'ordered', groupUniqArrayIf(prop_1, ifNull(notEquals(prop_1, []), isNotNull(prop_1)
+                                                                                                                    or isNotNull([]))), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                                                      and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                                                      and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                     and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                                                     and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  prop AS prop
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     prop AS prop
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                           prop AS prop
-                 FROM
-                   (SELECT timestamp AS timestamp,
-                           aggregation_target AS aggregation_target,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           prop_basic AS prop_basic,
-                           prop_0 AS prop_0,
-                           prop_1 AS prop_1,
-                           prop,
-                           prop_vals AS prop_vals,
-                           prop
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              if(equals(e.event, 'sign up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(and(equals(e.event, 'buy'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', ''), 'xyz'), 0)), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
-                              if(ifNull(equals(step_0, 1), 0), prop_basic, []) AS prop_0,
-                              if(ifNull(equals(step_1, 1), 0), prop_basic, []) AS prop_1,
-                              prop_1 AS prop,
-                              groupUniqArray(prop) OVER (PARTITION BY aggregation_target) AS prop_vals
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('buy', 'sign up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))) ARRAY
-                    JOIN prop_vals AS prop
-                    WHERE ifNull(notEquals(prop, []), isNotNull(prop)
-                                 or isNotNull([]))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     GROUP BY prop)
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'sign up'), 1, 0) AS step_0,
+                  if(and(equals(e.event, 'buy'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', ''), 'xyz'), 0)), 1, 0) AS step_1,
+                  [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                  if(ifNull(equals(step_0, 1), 0), prop_basic, []) AS prop_0,
+                  if(ifNull(equals(step_1, 1), 0), prop_basic, []) AS prop_1,
+                  prop_1 AS prop,
+                  groupUniqArray(prop) OVER (PARTITION BY aggregation_target) AS prop_vals
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('buy', 'sign up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_2 DESC, step_1 DESC)
   GROUP BY final_prop
-  LIMIT 26 SETTINGS readonly=2,
+  LIMIT 26 SETTINGS join_algorithm='auto',
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1183,90 +1012,68 @@
   '''
   SELECT sum(step_1) AS step_1,
          sum(step_2) AS step_2,
-         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
-         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
-         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
-            prop AS prop,
-            row_number() OVER (
-                               ORDER BY step_2 DESC) AS row_number
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            if(ifNull(less(row_number, 25), 0), breakdown, ['Other']) AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', groupUniqArrayIf(prop, ifNull(notEquals(prop, []), isNotNull(prop)
+                                                                                                                       or isNotNull([]))), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                                                         and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                                                         and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                        and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                                                        and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['', '']) AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     prop AS prop
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                           prop AS prop
-                 FROM
-                   (SELECT timestamp AS timestamp,
-                           aggregation_target AS aggregation_target,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           prop_basic AS prop_basic,
-                           prop,
-                           prop_vals AS prop_vals,
-                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['', '']) AS prop
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              if(equals(e.event, 'sign up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'buy'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), ''), ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
-                              prop_basic AS prop,
-                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('buy', 'sign up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     GROUP BY prop)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'sign up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'buy'), 1, 0) AS step_1,
+                     [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), ''), ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('buy', 'sign up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_2 DESC, step_1 DESC)
   GROUP BY final_prop
-  LIMIT 26 SETTINGS readonly=2,
+  LIMIT 26 SETTINGS join_algorithm='auto',
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1281,130 +1088,74 @@
   SELECT sum(step_1) AS step_1,
          sum(step_2) AS step_2,
          sum(step_3) AS step_3,
-         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
-         if(isNaN(avgArrayOrNull(step_2_conversion_time_array) AS inter_2_conversion), NULL, inter_2_conversion) AS step_2_average_conversion_time,
-         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
-         if(isNaN(medianArrayOrNull(step_2_conversion_time_array) AS inter_2_median), NULL, inter_2_median) AS step_2_median_conversion_time,
-         if(ifNull(less(row_number, 26), 0), prop, 'Other') AS final_prop
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_2_conversion_times)])[1] AS step_2_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_2_conversion_times)])[1] AS step_2_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-            countIf(ifNull(equals(steps, 3), 0)) AS step_3,
-            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
-            groupArray(step_2_conversion_time) AS step_2_conversion_time_array,
-            prop AS prop,
-            row_number() OVER (
-                               ORDER BY step_3 DESC) AS row_number
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            countIf(ifNull(ifNull(equals(step_reached, 2), 0), 0)) AS step_3,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            groupArrayIf(timings[2], ifNull(greater(timings[2], 0), 0)) AS step_2_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            if(ifNull(less(row_number, 25), 0), breakdown, 'Other') AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time,
-               min(step_2_conversion_time) AS step_2_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_v4(3, 1209600, 'first_touch', 'ordered', groupUniqArray(prop), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                       and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                       and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                      and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                      and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  step_2_conversion_time AS step_2_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          step_2 AS step_2,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          prop_vals AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     step_2 AS step_2,
-                     latest_2 AS latest_2,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time,
-                     prop AS prop
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        step_2 AS step_2,
-                        min(latest_2) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                           prop AS prop
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           step_2 AS step_2,
-                           if(ifNull(less(latest_2, latest_1), 0), NULL, latest_2) AS latest_2,
-                           prop AS prop
-                    FROM
-                      (SELECT aggregation_target AS aggregation_target,
-                              timestamp AS timestamp,
-                              step_0 AS step_0,
-                              latest_0 AS latest_0,
-                              step_1 AS step_1,
-                              min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                               prop
-                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                                 step_2 AS step_2,
-                                                 min(latest_2) OVER (PARTITION BY aggregation_target,
-                                                                                  prop
-                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                                                    prop AS prop
-                       FROM
-                         (SELECT timestamp AS timestamp,
-                                 aggregation_target AS aggregation_target,
-                                 step_0 AS step_0,
-                                 latest_0 AS latest_0,
-                                 step_1 AS step_1,
-                                 latest_1 AS latest_1,
-                                 step_2 AS step_2,
-                                 latest_2 AS latest_2,
-                                 prop_basic AS prop_basic,
-                                 prop,
-                                 prop_vals AS prop_vals,
-                                 prop_vals AS prop
-                          FROM
-                            (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                                    e.`$group_0` AS aggregation_target,
-                                    if(equals(e.event, 'sign up'), 1, 0) AS step_0,
-                                    if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                                    if(equals(e.event, 'play movie'), 1, 0) AS step_1,
-                                    if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                                    if(equals(e.event, 'buy'), 1, 0) AS step_2,
-                                    if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                                    ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
-                                    prop_basic AS prop,
-                                    argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
-                             FROM events AS e
-                             LEFT JOIN
-                               (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                       groups.group_type_index AS index,
-                                       groups.group_key AS key
-                                FROM groups
-                                WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                                GROUP BY groups.group_type_index,
-                                         groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                             WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-08 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('buy', 'play movie', 'sign up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0))))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     GROUP BY prop)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'sign up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'play movie'), 1, 0) AS step_1,
+                     if(equals(e.event, 'buy'), 1, 0) AS step_2,
+                     ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-08 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('buy', 'play movie', 'sign up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0)))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_3 DESC, step_2 DESC, step_1 DESC)
   GROUP BY final_prop
-  LIMIT 26 SETTINGS readonly=2,
+  LIMIT 26 SETTINGS join_algorithm='auto',
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1419,130 +1170,74 @@
   SELECT sum(step_1) AS step_1,
          sum(step_2) AS step_2,
          sum(step_3) AS step_3,
-         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
-         if(isNaN(avgArrayOrNull(step_2_conversion_time_array) AS inter_2_conversion), NULL, inter_2_conversion) AS step_2_average_conversion_time,
-         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
-         if(isNaN(medianArrayOrNull(step_2_conversion_time_array) AS inter_2_median), NULL, inter_2_median) AS step_2_median_conversion_time,
-         if(ifNull(less(row_number, 26), 0), prop, 'Other') AS final_prop
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_2_conversion_times)])[1] AS step_2_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_2_conversion_times)])[1] AS step_2_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-            countIf(ifNull(equals(steps, 3), 0)) AS step_3,
-            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
-            groupArray(step_2_conversion_time) AS step_2_conversion_time_array,
-            prop AS prop,
-            row_number() OVER (
-                               ORDER BY step_3 DESC) AS row_number
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            countIf(ifNull(ifNull(equals(step_reached, 2), 0), 0)) AS step_3,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            groupArrayIf(timings[2], ifNull(greater(timings[2], 0), 0)) AS step_2_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            if(ifNull(less(row_number, 25), 0), breakdown, 'Other') AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time,
-               min(step_2_conversion_time) AS step_2_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_v4(3, 1209600, 'first_touch', 'ordered', groupUniqArray(prop), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                       and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                       and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                      and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                      and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  step_2_conversion_time AS step_2_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          step_2 AS step_2,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          prop_vals AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     step_2 AS step_2,
-                     latest_2 AS latest_2,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time,
-                     prop AS prop
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        step_2 AS step_2,
-                        min(latest_2) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                           prop AS prop
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           step_2 AS step_2,
-                           if(ifNull(less(latest_2, latest_1), 0), NULL, latest_2) AS latest_2,
-                           prop AS prop
-                    FROM
-                      (SELECT aggregation_target AS aggregation_target,
-                              timestamp AS timestamp,
-                              step_0 AS step_0,
-                              latest_0 AS latest_0,
-                              step_1 AS step_1,
-                              min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                               prop
-                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                                 step_2 AS step_2,
-                                                 min(latest_2) OVER (PARTITION BY aggregation_target,
-                                                                                  prop
-                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                                                    prop AS prop
-                       FROM
-                         (SELECT timestamp AS timestamp,
-                                 aggregation_target AS aggregation_target,
-                                 step_0 AS step_0,
-                                 latest_0 AS latest_0,
-                                 step_1 AS step_1,
-                                 latest_1 AS latest_1,
-                                 step_2 AS step_2,
-                                 latest_2 AS latest_2,
-                                 prop_basic AS prop_basic,
-                                 prop,
-                                 prop_vals AS prop_vals,
-                                 prop_vals AS prop
-                          FROM
-                            (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                                    e.`$group_0` AS aggregation_target,
-                                    if(equals(e.event, 'sign up'), 1, 0) AS step_0,
-                                    if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                                    if(equals(e.event, 'play movie'), 1, 0) AS step_1,
-                                    if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                                    if(equals(e.event, 'buy'), 1, 0) AS step_2,
-                                    if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                                    ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
-                                    prop_basic AS prop,
-                                    argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
-                             FROM events AS e
-                             LEFT JOIN
-                               (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                       groups.group_type_index AS index,
-                                       groups.group_key AS key
-                                FROM groups
-                                WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                                GROUP BY groups.group_type_index,
-                                         groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                             WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-08 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('buy', 'play movie', 'sign up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0))))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     GROUP BY prop)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'sign up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'play movie'), 1, 0) AS step_1,
+                     if(equals(e.event, 'buy'), 1, 0) AS step_2,
+                     ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-08 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('buy', 'play movie', 'sign up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0)))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_3 DESC, step_2 DESC, step_1 DESC)
   GROUP BY final_prop
-  LIMIT 26 SETTINGS readonly=2,
+  LIMIT 26 SETTINGS join_algorithm='auto',
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1557,137 +1252,81 @@
   SELECT sum(step_1) AS step_1,
          sum(step_2) AS step_2,
          sum(step_3) AS step_3,
-         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
-         if(isNaN(avgArrayOrNull(step_2_conversion_time_array) AS inter_2_conversion), NULL, inter_2_conversion) AS step_2_average_conversion_time,
-         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
-         if(isNaN(medianArrayOrNull(step_2_conversion_time_array) AS inter_2_median), NULL, inter_2_median) AS step_2_median_conversion_time,
-         if(ifNull(less(row_number, 26), 0), prop, 'Other') AS final_prop
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_2_conversion_times)])[1] AS step_2_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_2_conversion_times)])[1] AS step_2_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-            countIf(ifNull(equals(steps, 3), 0)) AS step_3,
-            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
-            groupArray(step_2_conversion_time) AS step_2_conversion_time_array,
-            prop AS prop,
-            row_number() OVER (
-                               ORDER BY step_3 DESC) AS row_number
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            countIf(ifNull(ifNull(equals(step_reached, 2), 0), 0)) AS step_3,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            groupArrayIf(timings[2], ifNull(greater(timings[2], 0), 0)) AS step_2_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            if(ifNull(less(row_number, 25), 0), breakdown, 'Other') AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time,
-               min(step_2_conversion_time) AS step_2_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_v4(3, 1209600, 'first_touch', 'ordered', groupUniqArray(prop), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                       and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                       and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                      and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                      and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  step_2_conversion_time AS step_2_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          step_2 AS step_2,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          prop_vals AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     step_2 AS step_2,
-                     latest_2 AS latest_2,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time,
-                     prop AS prop
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        step_2 AS step_2,
-                        min(latest_2) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                           prop AS prop
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           step_2 AS step_2,
-                           if(ifNull(less(latest_2, latest_1), 0), NULL, latest_2) AS latest_2,
-                           prop AS prop
-                    FROM
-                      (SELECT aggregation_target AS aggregation_target,
-                              timestamp AS timestamp,
-                              step_0 AS step_0,
-                              latest_0 AS latest_0,
-                              step_1 AS step_1,
-                              min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                               prop
-                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                                 step_2 AS step_2,
-                                                 min(latest_2) OVER (PARTITION BY aggregation_target,
-                                                                                  prop
-                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                                                    prop AS prop
-                       FROM
-                         (SELECT timestamp AS timestamp,
-                                 aggregation_target AS aggregation_target,
-                                 step_0 AS step_0,
-                                 latest_0 AS latest_0,
-                                 step_1 AS step_1,
-                                 latest_1 AS latest_1,
-                                 step_2 AS step_2,
-                                 latest_2 AS latest_2,
-                                 prop_basic AS prop_basic,
-                                 prop,
-                                 prop_vals AS prop_vals,
-                                 prop_vals AS prop
-                          FROM
-                            (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                                    if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                                    if(equals(e.event, 'sign up'), 1, 0) AS step_0,
-                                    if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                                    if(equals(e.event, 'play movie'), 1, 0) AS step_1,
-                                    if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                                    if(equals(e.event, 'buy'), 1, 0) AS step_2,
-                                    if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                                    ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
-                                    prop_basic AS prop,
-                                    argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
-                             FROM events AS e
-                             LEFT OUTER JOIN
-                               (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                       person_distinct_id_overrides.distinct_id AS distinct_id
-                                FROM person_distinct_id_overrides
-                                WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                                GROUP BY person_distinct_id_overrides.distinct_id
-                                HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                             LEFT JOIN
-                               (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                       groups.group_type_index AS index,
-                                       groups.group_key AS key
-                                FROM groups
-                                WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                                GROUP BY groups.group_type_index,
-                                         groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                             WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('buy', 'play movie', 'sign up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0))))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     GROUP BY prop)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'sign up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'play movie'), 1, 0) AS step_1,
+                     if(equals(e.event, 'buy'), 1, 0) AS step_2,
+                     ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('buy', 'play movie', 'sign up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0)))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_3 DESC, step_2 DESC, step_1 DESC)
   GROUP BY final_prop
-  LIMIT 26 SETTINGS readonly=2,
+  LIMIT 26 SETTINGS join_algorithm='auto',
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -1705,122 +1344,64 @@
     (SELECT aggregation_target AS actor_id,
             actor_id AS id
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time,
-               min(step_2_conversion_time) AS step_2_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_v4(3, 1209600, 'first_touch', 'ordered', groupUniqArray(prop), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                       and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                       and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                      and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                      and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  step_2_conversion_time AS step_2_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          step_2 AS step_2,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          prop_vals AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     step_2 AS step_2,
-                     latest_2 AS latest_2,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time,
-                     prop AS prop
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        step_2 AS step_2,
-                        min(latest_2) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                           prop AS prop
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           step_2 AS step_2,
-                           if(ifNull(less(latest_2, latest_1), 0), NULL, latest_2) AS latest_2,
-                           prop AS prop
-                    FROM
-                      (SELECT aggregation_target AS aggregation_target,
-                              timestamp AS timestamp,
-                              step_0 AS step_0,
-                              latest_0 AS latest_0,
-                              step_1 AS step_1,
-                              min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                               prop
-                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                                 step_2 AS step_2,
-                                                 min(latest_2) OVER (PARTITION BY aggregation_target,
-                                                                                  prop
-                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                                                    prop AS prop
-                       FROM
-                         (SELECT timestamp AS timestamp,
-                                 aggregation_target AS aggregation_target,
-                                 step_0 AS step_0,
-                                 latest_0 AS latest_0,
-                                 step_1 AS step_1,
-                                 latest_1 AS latest_1,
-                                 step_2 AS step_2,
-                                 latest_2 AS latest_2,
-                                 prop_basic AS prop_basic,
-                                 prop,
-                                 prop_vals AS prop_vals,
-                                 prop_vals AS prop
-                          FROM
-                            (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                                    if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                                    if(equals(e.event, 'sign up'), 1, 0) AS step_0,
-                                    if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                                    if(equals(e.event, 'play movie'), 1, 0) AS step_1,
-                                    if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                                    if(equals(e.event, 'buy'), 1, 0) AS step_2,
-                                    if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                                    ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
-                                    prop_basic AS prop,
-                                    argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
-                             FROM events AS e
-                             LEFT OUTER JOIN
-                               (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                       person_distinct_id_overrides.distinct_id AS distinct_id
-                                FROM person_distinct_id_overrides
-                                WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                                GROUP BY person_distinct_id_overrides.distinct_id
-                                HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                             LEFT JOIN
-                               (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                       groups.group_type_index AS index,
-                                       groups.group_key AS key
-                                FROM groups
-                                WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                                GROUP BY groups.group_type_index,
-                                         groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                             WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('buy', 'play movie', 'sign up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0))))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE and(ifNull(in(steps, [1, 2, 3]), 0), ifNull(equals(arrayFlatten(array(prop)), arrayFlatten(array('finance'))), isNull(arrayFlatten(array(prop)))
-                                                       and isNull(arrayFlatten(array('finance')))))
-     ORDER BY aggregation_target ASC) AS source
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'sign up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'play movie'), 1, 0) AS step_1,
+                     if(equals(e.event, 'buy'), 1, 0) AS step_2,
+                     ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('buy', 'play movie', 'sign up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0)))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE and(ifNull(greaterOrEquals(step_reached, 0), 0), ifNull(equals(arrayFlatten(array(breakdown)), arrayFlatten(array('finance'))), isNull(arrayFlatten(array(breakdown)))
+                                                                   and isNull(arrayFlatten(array('finance')))))
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
@@ -1843,122 +1424,64 @@
     (SELECT aggregation_target AS actor_id,
             actor_id AS id
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time,
-               min(step_2_conversion_time) AS step_2_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_v4(3, 1209600, 'first_touch', 'ordered', groupUniqArray(prop), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                       and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                       and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                      and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                      and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  step_2_conversion_time AS step_2_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          step_2 AS step_2,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          prop_vals AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     step_2 AS step_2,
-                     latest_2 AS latest_2,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time,
-                     prop AS prop
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        step_2 AS step_2,
-                        min(latest_2) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                           prop AS prop
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           step_2 AS step_2,
-                           if(ifNull(less(latest_2, latest_1), 0), NULL, latest_2) AS latest_2,
-                           prop AS prop
-                    FROM
-                      (SELECT aggregation_target AS aggregation_target,
-                              timestamp AS timestamp,
-                              step_0 AS step_0,
-                              latest_0 AS latest_0,
-                              step_1 AS step_1,
-                              min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                               prop
-                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                                 step_2 AS step_2,
-                                                 min(latest_2) OVER (PARTITION BY aggregation_target,
-                                                                                  prop
-                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                                                    prop AS prop
-                       FROM
-                         (SELECT timestamp AS timestamp,
-                                 aggregation_target AS aggregation_target,
-                                 step_0 AS step_0,
-                                 latest_0 AS latest_0,
-                                 step_1 AS step_1,
-                                 latest_1 AS latest_1,
-                                 step_2 AS step_2,
-                                 latest_2 AS latest_2,
-                                 prop_basic AS prop_basic,
-                                 prop,
-                                 prop_vals AS prop_vals,
-                                 prop_vals AS prop
-                          FROM
-                            (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                                    if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                                    if(equals(e.event, 'sign up'), 1, 0) AS step_0,
-                                    if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                                    if(equals(e.event, 'play movie'), 1, 0) AS step_1,
-                                    if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                                    if(equals(e.event, 'buy'), 1, 0) AS step_2,
-                                    if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                                    ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
-                                    prop_basic AS prop,
-                                    argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
-                             FROM events AS e
-                             LEFT OUTER JOIN
-                               (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                       person_distinct_id_overrides.distinct_id AS distinct_id
-                                FROM person_distinct_id_overrides
-                                WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                                GROUP BY person_distinct_id_overrides.distinct_id
-                                HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                             LEFT JOIN
-                               (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                       groups.group_type_index AS index,
-                                       groups.group_key AS key
-                                FROM groups
-                                WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                                GROUP BY groups.group_type_index,
-                                         groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                             WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('buy', 'play movie', 'sign up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0))))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE and(ifNull(in(steps, [2, 3]), 0), ifNull(equals(arrayFlatten(array(prop)), arrayFlatten(array('finance'))), isNull(arrayFlatten(array(prop)))
-                                                    and isNull(arrayFlatten(array('finance')))))
-     ORDER BY aggregation_target ASC) AS source
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'sign up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'play movie'), 1, 0) AS step_1,
+                     if(equals(e.event, 'buy'), 1, 0) AS step_2,
+                     ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('buy', 'play movie', 'sign up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0)))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE and(ifNull(greaterOrEquals(step_reached, 1), 0), ifNull(equals(arrayFlatten(array(breakdown)), arrayFlatten(array('finance'))), isNull(arrayFlatten(array(breakdown)))
+                                                                   and isNull(arrayFlatten(array('finance')))))
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
@@ -1981,122 +1504,64 @@
     (SELECT aggregation_target AS actor_id,
             actor_id AS id
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time,
-               min(step_2_conversion_time) AS step_2_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_v4(3, 1209600, 'first_touch', 'ordered', groupUniqArray(prop), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                       and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                       and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                      and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                      and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  step_2_conversion_time AS step_2_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          step_2 AS step_2,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          prop_vals AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     step_2 AS step_2,
-                     latest_2 AS latest_2,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time,
-                     prop AS prop
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        step_2 AS step_2,
-                        min(latest_2) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                           prop AS prop
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           step_2 AS step_2,
-                           if(ifNull(less(latest_2, latest_1), 0), NULL, latest_2) AS latest_2,
-                           prop AS prop
-                    FROM
-                      (SELECT aggregation_target AS aggregation_target,
-                              timestamp AS timestamp,
-                              step_0 AS step_0,
-                              latest_0 AS latest_0,
-                              step_1 AS step_1,
-                              min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                               prop
-                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                                 step_2 AS step_2,
-                                                 min(latest_2) OVER (PARTITION BY aggregation_target,
-                                                                                  prop
-                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                                                    prop AS prop
-                       FROM
-                         (SELECT timestamp AS timestamp,
-                                 aggregation_target AS aggregation_target,
-                                 step_0 AS step_0,
-                                 latest_0 AS latest_0,
-                                 step_1 AS step_1,
-                                 latest_1 AS latest_1,
-                                 step_2 AS step_2,
-                                 latest_2 AS latest_2,
-                                 prop_basic AS prop_basic,
-                                 prop,
-                                 prop_vals AS prop_vals,
-                                 prop_vals AS prop
-                          FROM
-                            (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                                    if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                                    if(equals(e.event, 'sign up'), 1, 0) AS step_0,
-                                    if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                                    if(equals(e.event, 'play movie'), 1, 0) AS step_1,
-                                    if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                                    if(equals(e.event, 'buy'), 1, 0) AS step_2,
-                                    if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                                    ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
-                                    prop_basic AS prop,
-                                    argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
-                             FROM events AS e
-                             LEFT OUTER JOIN
-                               (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                       person_distinct_id_overrides.distinct_id AS distinct_id
-                                FROM person_distinct_id_overrides
-                                WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                                GROUP BY person_distinct_id_overrides.distinct_id
-                                HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                             LEFT JOIN
-                               (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                       groups.group_type_index AS index,
-                                       groups.group_key AS key
-                                FROM groups
-                                WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                                GROUP BY groups.group_type_index,
-                                         groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                             WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('buy', 'play movie', 'sign up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0))))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE and(ifNull(in(steps, [1, 2, 3]), 0), ifNull(equals(arrayFlatten(array(prop)), arrayFlatten(array('technology'))), isNull(arrayFlatten(array(prop)))
-                                                       and isNull(arrayFlatten(array('technology')))))
-     ORDER BY aggregation_target ASC) AS source
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'sign up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'play movie'), 1, 0) AS step_1,
+                     if(equals(e.event, 'buy'), 1, 0) AS step_2,
+                     ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('buy', 'play movie', 'sign up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0)))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE and(ifNull(greaterOrEquals(step_reached, 0), 0), ifNull(equals(arrayFlatten(array(breakdown)), arrayFlatten(array('technology'))), isNull(arrayFlatten(array(breakdown)))
+                                                                   and isNull(arrayFlatten(array('technology')))))
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
@@ -2119,122 +1584,64 @@
     (SELECT aggregation_target AS actor_id,
             actor_id AS id
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time,
-               min(step_2_conversion_time) AS step_2_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_v4(3, 1209600, 'first_touch', 'ordered', groupUniqArray(prop), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                       and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                       and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                      and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                      and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  step_2_conversion_time AS step_2_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          step_2 AS step_2,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          prop_vals AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     step_2 AS step_2,
-                     latest_2 AS latest_2,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time,
-                     prop AS prop
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        step_2 AS step_2,
-                        min(latest_2) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                           prop AS prop
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           step_2 AS step_2,
-                           if(ifNull(less(latest_2, latest_1), 0), NULL, latest_2) AS latest_2,
-                           prop AS prop
-                    FROM
-                      (SELECT aggregation_target AS aggregation_target,
-                              timestamp AS timestamp,
-                              step_0 AS step_0,
-                              latest_0 AS latest_0,
-                              step_1 AS step_1,
-                              min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                               prop
-                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                                 step_2 AS step_2,
-                                                 min(latest_2) OVER (PARTITION BY aggregation_target,
-                                                                                  prop
-                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                                                    prop AS prop
-                       FROM
-                         (SELECT timestamp AS timestamp,
-                                 aggregation_target AS aggregation_target,
-                                 step_0 AS step_0,
-                                 latest_0 AS latest_0,
-                                 step_1 AS step_1,
-                                 latest_1 AS latest_1,
-                                 step_2 AS step_2,
-                                 latest_2 AS latest_2,
-                                 prop_basic AS prop_basic,
-                                 prop,
-                                 prop_vals AS prop_vals,
-                                 prop_vals AS prop
-                          FROM
-                            (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                                    if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                                    if(equals(e.event, 'sign up'), 1, 0) AS step_0,
-                                    if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                                    if(equals(e.event, 'play movie'), 1, 0) AS step_1,
-                                    if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                                    if(equals(e.event, 'buy'), 1, 0) AS step_2,
-                                    if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                                    ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
-                                    prop_basic AS prop,
-                                    argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
-                             FROM events AS e
-                             LEFT OUTER JOIN
-                               (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                       person_distinct_id_overrides.distinct_id AS distinct_id
-                                FROM person_distinct_id_overrides
-                                WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                                GROUP BY person_distinct_id_overrides.distinct_id
-                                HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                             LEFT JOIN
-                               (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                       groups.group_type_index AS index,
-                                       groups.group_key AS key
-                                FROM groups
-                                WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                                GROUP BY groups.group_type_index,
-                                         groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                             WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('buy', 'play movie', 'sign up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0))))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE and(ifNull(in(steps, [2, 3]), 0), ifNull(equals(arrayFlatten(array(prop)), arrayFlatten(array('technology'))), isNull(arrayFlatten(array(prop)))
-                                                    and isNull(arrayFlatten(array('technology')))))
-     ORDER BY aggregation_target ASC) AS source
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'sign up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'play movie'), 1, 0) AS step_1,
+                     if(equals(e.event, 'buy'), 1, 0) AS step_2,
+                     ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('buy', 'play movie', 'sign up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0)))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE and(ifNull(greaterOrEquals(step_reached, 1), 0), ifNull(equals(arrayFlatten(array(breakdown)), arrayFlatten(array('technology'))), isNull(arrayFlatten(array(breakdown)))
+                                                                   and isNull(arrayFlatten(array('technology')))))
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_breakdowns_by_current_url.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_breakdowns_by_current_url.ambr
@@ -3,90 +3,68 @@
   '''
   SELECT sum(step_1) AS step_1,
          sum(step_2) AS step_2,
-         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
-         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
-         if(ifNull(less(row_number, 101), 0), prop, ['Other']) AS final_prop
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
-            prop AS prop,
-            row_number() OVER (
-                               ORDER BY step_2 DESC) AS row_number
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            if(ifNull(less(row_number, 100), 0), breakdown, ['Other']) AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', groupUniqArrayIf(prop, ifNull(notEquals(prop, []), isNotNull(prop)
+                                                                                                                       or isNotNull([]))), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                                                         and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                                                         and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                        and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                                                        and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     prop AS prop
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                           prop AS prop
-                 FROM
-                   (SELECT timestamp AS timestamp,
-                           aggregation_target AS aggregation_target,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           prop_basic AS prop_basic,
-                           prop,
-                           prop_vals AS prop_vals,
-                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              if(equals(e.event, 'watched movie'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'terminate funnel'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              [if(empty(replaceRegexpOne(ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', '')), ''), '[\\/?#]*$', '')), '/', replaceRegexpOne(ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', '')), ''), '[\\/?#]*$', ''))] AS prop_basic,
-                              prop_basic AS prop,
-                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('terminate funnel', 'watched movie'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     GROUP BY prop)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'watched movie'), 1, 0) AS step_0,
+                     if(equals(e.event, 'terminate funnel'), 1, 0) AS step_1,
+                     [if(empty(replaceRegexpOne(ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', '')), ''), '[\\/?#]*$', '')), '/', replaceRegexpOne(ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', '')), ''), '[\\/?#]*$', ''))] AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('terminate funnel', 'watched movie'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_2 DESC, step_1 DESC)
   GROUP BY final_prop
-  LIMIT 101 SETTINGS readonly=2,
+  LIMIT 101 SETTINGS join_algorithm='auto',
+                     readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,
@@ -100,90 +78,68 @@
   '''
   SELECT sum(step_1) AS step_1,
          sum(step_2) AS step_2,
-         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
-         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
-         if(ifNull(less(row_number, 101), 0), prop, ['Other']) AS final_prop
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
-            prop AS prop,
-            row_number() OVER (
-                               ORDER BY step_2 DESC) AS row_number
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            if(ifNull(less(row_number, 100), 0), breakdown, ['Other']) AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', groupUniqArrayIf(prop, ifNull(notEquals(prop, []), isNotNull(prop)
+                                                                                                                       or isNotNull([]))), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                                                         and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                                                         and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                        and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                                                        and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     prop AS prop
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                           prop AS prop
-                 FROM
-                   (SELECT timestamp AS timestamp,
-                           aggregation_target AS aggregation_target,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           prop_basic AS prop_basic,
-                           prop,
-                           prop_vals AS prop_vals,
-                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              if(equals(e.event, 'watched movie'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'terminate funnel'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              [if(empty(replaceRegexpOne(ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$pathname'), ''), 'null'), '^"|"$', '')), ''), '[\\/?#]*$', '')), '/', replaceRegexpOne(ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$pathname'), ''), 'null'), '^"|"$', '')), ''), '[\\/?#]*$', ''))] AS prop_basic,
-                              prop_basic AS prop,
-                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('terminate funnel', 'watched movie'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     GROUP BY prop)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'watched movie'), 1, 0) AS step_0,
+                     if(equals(e.event, 'terminate funnel'), 1, 0) AS step_1,
+                     [if(empty(replaceRegexpOne(ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$pathname'), ''), 'null'), '^"|"$', '')), ''), '[\\/?#]*$', '')), '/', replaceRegexpOne(ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$pathname'), ''), 'null'), '^"|"$', '')), ''), '[\\/?#]*$', ''))] AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('terminate funnel', 'watched movie'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_2 DESC, step_1 DESC)
   GROUP BY final_prop
-  LIMIT 101 SETTINGS readonly=2,
+  LIMIT 101 SETTINGS join_algorithm='auto',
+                     readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -14,66 +14,49 @@
      HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS event__override ON equals(event.distinct_id, event__override.distinct_id)
   JOIN
     (SELECT aggregation_target AS actor_id,
-            timestamp AS timestamp,
+            (matched_events_array[1][1]).1 AS timestamp,
+            nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+            (matched_events_array[1][1]).1 AS first_timestamp,
             steps AS steps,
-            final_timestamp AS final_timestamp,
-            first_timestamp AS first_timestamp
+            final_timestamp,
+            first_timestamp
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               argMax(latest_0, steps) AS timestamp,
-               argMax(latest_1, steps) AS final_timestamp,
-               argMax(latest_0, steps) AS first_timestamp,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  latest_0 AS latest_0,
-                                  latest_1 AS latest_1,
-                                  latest_0 AS latest_0
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                           if(and(equals(e.event, 'user signed up'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'key'), ''), 'null'), '^"|"$', ''), 'val'), 0)), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(and(equals(e.event, 'paid'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'key'), ''), 'null'), '^"|"$', ''), 'val'), 0)), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                    FROM events AS e
-                    LEFT OUTER JOIN
-                      (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                              person_distinct_id_overrides.distinct_id AS distinct_id
-                       FROM person_distinct_id_overrides
-                       WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                       GROUP BY person_distinct_id_overrides.distinct_id
-                       HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                    WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [1, 2]), 0)
-     ORDER BY aggregation_target ASC) AS funnel_actors ON equals(if(not(empty(event__override.distinct_id)), event__override.person_id, event.person_id), funnel_actors.actor_id)
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(and(equals(e.event, 'user signed up'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'key'), ''), 'null'), '^"|"$', ''), 'val'), 0)), 1, 0) AS step_0,
+                  if(and(equals(e.event, 'paid'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'key'), ''), 'null'), '^"|"$', ''), 'val'), 0)), 1, 0) AS step_1
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors ON equals(if(not(empty(event__override.distinct_id)), event__override.person_id, event.person_id), funnel_actors.actor_id)
   WHERE and(equals(event.team_id, 99999), greaterOrEquals(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-01 00:00:00', 6, 'UTC'))), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC'))), equals(event.team_id, 99999), greater(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), funnel_actors.first_timestamp), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), coalesce(funnel_actors.final_timestamp, plus(toTimeZone(funnel_actors.first_timestamp, 'UTC'), toIntervalDay(14)), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC')))), notIn(event.event, ['paid', 'user signed up']), notIn(event.event, []))
   GROUP BY name
   LIMIT 100
@@ -83,66 +66,49 @@
          countDistinctIf(funnel_actors.actor_id, ifNull(notEquals(funnel_actors.steps, 2), 1)) AS failure_count
   FROM
     (SELECT aggregation_target AS actor_id,
-            timestamp AS timestamp,
+            (matched_events_array[1][1]).1 AS timestamp,
+            nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+            (matched_events_array[1][1]).1 AS first_timestamp,
             steps AS steps,
-            final_timestamp AS final_timestamp,
-            first_timestamp AS first_timestamp
+            final_timestamp,
+            first_timestamp
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               argMax(latest_0, steps) AS timestamp,
-               argMax(latest_1, steps) AS final_timestamp,
-               argMax(latest_0, steps) AS first_timestamp,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  latest_0 AS latest_0,
-                                  latest_1 AS latest_1,
-                                  latest_0 AS latest_0
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                           if(and(equals(e.event, 'user signed up'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'key'), ''), 'null'), '^"|"$', ''), 'val'), 0)), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(and(equals(e.event, 'paid'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'key'), ''), 'null'), '^"|"$', ''), 'val'), 0)), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                    FROM events AS e
-                    LEFT OUTER JOIN
-                      (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                              person_distinct_id_overrides.distinct_id AS distinct_id
-                       FROM person_distinct_id_overrides
-                       WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                       GROUP BY person_distinct_id_overrides.distinct_id
-                       HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                    WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [1, 2]), 0)
-     ORDER BY aggregation_target ASC) AS funnel_actors
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(and(equals(e.event, 'user signed up'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'key'), ''), 'null'), '^"|"$', ''), 'val'), 0)), 1, 0) AS step_0,
+                  if(and(equals(e.event, 'paid'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'key'), ''), 'null'), '^"|"$', ''), 'val'), 0)), 1, 0) AS step_1
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -163,66 +129,49 @@
             arrayJoin(arrayZip(['$browser'], [JSONExtractString(persons.person_props, '$browser')])) AS prop
      FROM
        (SELECT aggregation_target AS actor_id,
-               timestamp AS timestamp,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      JOIN
        (SELECT persons.id AS id,
                persons.properties AS person_props
@@ -245,66 +194,49 @@
          countDistinctIf(funnel_actors.actor_id, ifNull(notEquals(funnel_actors.steps, 2), 1)) AS failure_count
   FROM
     (SELECT aggregation_target AS actor_id,
-            timestamp AS timestamp,
+            (matched_events_array[1][1]).1 AS timestamp,
+            nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+            (matched_events_array[1][1]).1 AS first_timestamp,
             steps AS steps,
-            final_timestamp AS final_timestamp,
-            first_timestamp AS first_timestamp
+            final_timestamp,
+            first_timestamp
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               argMax(latest_0, steps) AS timestamp,
-               argMax(latest_1, steps) AS final_timestamp,
-               argMax(latest_0, steps) AS first_timestamp,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  latest_0 AS latest_0,
-                                  latest_1 AS latest_1,
-                                  latest_0 AS latest_0
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                           if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                    FROM events AS e
-                    LEFT OUTER JOIN
-                      (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                              person_distinct_id_overrides.distinct_id AS distinct_id
-                       FROM person_distinct_id_overrides
-                       WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                       GROUP BY person_distinct_id_overrides.distinct_id
-                       HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                    WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [1, 2]), 0)
-     ORDER BY aggregation_target ASC) AS funnel_actors
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -325,108 +257,60 @@
             actor_id AS id
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       LEFT JOIN
-                         (SELECT person.id AS id,
-                                 replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$browser'), ''), 'null'), '^"|"$', '') AS `properties___$browser`
-                          FROM person
-                          WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
-                                                                               (SELECT person.id AS id, max(person.version) AS version
-                                                                                FROM person
-                                                                                WHERE equals(person.team_id, 99999)
-                                                                                GROUP BY person.id
-                                                                                HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__person.`properties___$browser`, 'Positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              LEFT JOIN
+                (SELECT person.id AS id,
+                        replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$browser'), ''), 'null'), '^"|"$', '') AS `properties___$browser`
+                 FROM person
+                 WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                                       FROM person
+                                                                       WHERE equals(person.team_id, 99999)
+                                                                       GROUP BY person.id
+                                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__person.`properties___$browser`, 'Positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(equals(funnel_actors.steps, 2), 0)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -468,108 +352,60 @@
             actor_id AS id
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       LEFT JOIN
-                         (SELECT person.id AS id,
-                                 replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$browser'), ''), 'null'), '^"|"$', '') AS `properties___$browser`
-                          FROM person
-                          WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
-                                                                               (SELECT person.id AS id, max(person.version) AS version
-                                                                                FROM person
-                                                                                WHERE equals(person.team_id, 99999)
-                                                                                GROUP BY person.id
-                                                                                HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__person.`properties___$browser`, 'Positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              LEFT JOIN
+                (SELECT person.id AS id,
+                        replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$browser'), ''), 'null'), '^"|"$', '') AS `properties___$browser`
+                 FROM person
+                 WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                                       FROM person
+                                                                       WHERE equals(person.team_id, 99999)
+                                                                       GROUP BY person.id
+                                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__person.`properties___$browser`, 'Positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(notEquals(funnel_actors.steps, 2), 1)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -611,108 +447,60 @@
             actor_id AS id
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       LEFT JOIN
-                         (SELECT person.id AS id,
-                                 replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$browser'), ''), 'null'), '^"|"$', '') AS `properties___$browser`
-                          FROM person
-                          WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
-                                                                               (SELECT person.id AS id, max(person.version) AS version
-                                                                                FROM person
-                                                                                WHERE equals(person.team_id, 99999)
-                                                                                GROUP BY person.id
-                                                                                HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__person.`properties___$browser`, 'Negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              LEFT JOIN
+                (SELECT person.id AS id,
+                        replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$browser'), ''), 'null'), '^"|"$', '') AS `properties___$browser`
+                 FROM person
+                 WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                                       FROM person
+                                                                       WHERE equals(person.team_id, 99999)
+                                                                       GROUP BY person.id
+                                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__person.`properties___$browser`, 'Negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(equals(funnel_actors.steps, 2), 0)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -754,108 +542,60 @@
             actor_id AS id
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       LEFT JOIN
-                         (SELECT person.id AS id,
-                                 replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$browser'), ''), 'null'), '^"|"$', '') AS `properties___$browser`
-                          FROM person
-                          WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
-                                                                               (SELECT person.id AS id, max(person.version) AS version
-                                                                                FROM person
-                                                                                WHERE equals(person.team_id, 99999)
-                                                                                GROUP BY person.id
-                                                                                HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__person.`properties___$browser`, 'Negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              LEFT JOIN
+                (SELECT person.id AS id,
+                        replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, '$browser'), ''), 'null'), '^"|"$', '') AS `properties___$browser`
+                 FROM person
+                 WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                                       FROM person
+                                                                       WHERE equals(person.team_id, 99999)
+                                                                       GROUP BY person.id
+                                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__person.`properties___$browser`, 'Negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(notEquals(funnel_actors.steps, 2), 1)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -897,66 +637,49 @@
             arrayJoin(arrayZip(['$browser'], [JSONExtractString(persons.person_props, '$browser')])) AS prop
      FROM
        (SELECT aggregation_target AS actor_id,
-               timestamp AS timestamp,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      JOIN
        (SELECT persons.id AS id,
                persons.properties AS person_props
@@ -979,66 +702,49 @@
          countDistinctIf(funnel_actors.actor_id, ifNull(notEquals(funnel_actors.steps, 2), 1)) AS failure_count
   FROM
     (SELECT aggregation_target AS actor_id,
-            timestamp AS timestamp,
+            (matched_events_array[1][1]).1 AS timestamp,
+            nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+            (matched_events_array[1][1]).1 AS first_timestamp,
             steps AS steps,
-            final_timestamp AS final_timestamp,
-            first_timestamp AS first_timestamp
+            final_timestamp,
+            first_timestamp
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               argMax(latest_0, steps) AS timestamp,
-               argMax(latest_1, steps) AS final_timestamp,
-               argMax(latest_0, steps) AS first_timestamp,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  latest_0 AS latest_0,
-                                  latest_1 AS latest_1,
-                                  latest_0 AS latest_0
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                           if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                    FROM events AS e
-                    LEFT OUTER JOIN
-                      (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                              person_distinct_id_overrides.distinct_id AS distinct_id
-                       FROM person_distinct_id_overrides
-                       WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                       GROUP BY person_distinct_id_overrides.distinct_id
-                       HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                    WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [1, 2]), 0)
-     ORDER BY aggregation_target ASC) AS funnel_actors
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -1059,108 +765,60 @@
             actor_id AS id
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       LEFT JOIN
-                         (SELECT person.id AS id,
-                                 nullIf(nullIf(person.`pmat_$browser`, ''), 'null') AS `properties___$browser`
-                          FROM person
-                          WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
-                                                                               (SELECT person.id AS id, max(person.version) AS version
-                                                                                FROM person
-                                                                                WHERE equals(person.team_id, 99999)
-                                                                                GROUP BY person.id
-                                                                                HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__person.`properties___$browser`, 'Positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              LEFT JOIN
+                (SELECT person.id AS id,
+                        nullIf(nullIf(person.`pmat_$browser`, ''), 'null') AS `properties___$browser`
+                 FROM person
+                 WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                                       FROM person
+                                                                       WHERE equals(person.team_id, 99999)
+                                                                       GROUP BY person.id
+                                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__person.`properties___$browser`, 'Positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(equals(funnel_actors.steps, 2), 0)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -1202,108 +860,60 @@
             actor_id AS id
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       LEFT JOIN
-                         (SELECT person.id AS id,
-                                 nullIf(nullIf(person.`pmat_$browser`, ''), 'null') AS `properties___$browser`
-                          FROM person
-                          WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
-                                                                               (SELECT person.id AS id, max(person.version) AS version
-                                                                                FROM person
-                                                                                WHERE equals(person.team_id, 99999)
-                                                                                GROUP BY person.id
-                                                                                HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__person.`properties___$browser`, 'Positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              LEFT JOIN
+                (SELECT person.id AS id,
+                        nullIf(nullIf(person.`pmat_$browser`, ''), 'null') AS `properties___$browser`
+                 FROM person
+                 WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                                       FROM person
+                                                                       WHERE equals(person.team_id, 99999)
+                                                                       GROUP BY person.id
+                                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__person.`properties___$browser`, 'Positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(notEquals(funnel_actors.steps, 2), 1)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -1345,108 +955,60 @@
             actor_id AS id
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       LEFT JOIN
-                         (SELECT person.id AS id,
-                                 nullIf(nullIf(person.`pmat_$browser`, ''), 'null') AS `properties___$browser`
-                          FROM person
-                          WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
-                                                                               (SELECT person.id AS id, max(person.version) AS version
-                                                                                FROM person
-                                                                                WHERE equals(person.team_id, 99999)
-                                                                                GROUP BY person.id
-                                                                                HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__person.`properties___$browser`, 'Negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              LEFT JOIN
+                (SELECT person.id AS id,
+                        nullIf(nullIf(person.`pmat_$browser`, ''), 'null') AS `properties___$browser`
+                 FROM person
+                 WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                                       FROM person
+                                                                       WHERE equals(person.team_id, 99999)
+                                                                       GROUP BY person.id
+                                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__person.`properties___$browser`, 'Negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(equals(funnel_actors.steps, 2), 0)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -1488,108 +1050,60 @@
             actor_id AS id
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       LEFT JOIN
-                         (SELECT person.id AS id,
-                                 nullIf(nullIf(person.`pmat_$browser`, ''), 'null') AS `properties___$browser`
-                          FROM person
-                          WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
-                                                                               (SELECT person.id AS id, max(person.version) AS version
-                                                                                FROM person
-                                                                                WHERE equals(person.team_id, 99999)
-                                                                                GROUP BY person.id
-                                                                                HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__person.`properties___$browser`, 'Negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              LEFT JOIN
+                (SELECT person.id AS id,
+                        nullIf(nullIf(person.`pmat_$browser`, ''), 'null') AS `properties___$browser`
+                 FROM person
+                 WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                                       FROM person
+                                                                       WHERE equals(person.team_id, 99999)
+                                                                       GROUP BY person.id
+                                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__person.`properties___$browser`, 'Negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(notEquals(funnel_actors.steps, 2), 1)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -1633,59 +1147,42 @@
      FROM events AS event
      JOIN
        (SELECT aggregation_target AS actor_id,
-               timestamp AS timestamp,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_1` AS aggregation_target,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_1`)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_1` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_1`)
      WHERE and(equals(event.team_id, 99999), greaterOrEquals(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-01 00:00:00', 6, 'UTC'))), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC'))), equals(event.team_id, 99999), greater(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), funnel_actors.first_timestamp), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), coalesce(funnel_actors.final_timestamp, plus(toTimeZone(funnel_actors.first_timestamp, 'UTC'), toIntervalDay(14)), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC')))), notIn(event.event, ['paid', 'user signed up']), in(event.event, ['positively_related', 'negatively_related'])))
   GROUP BY name,
            prop
@@ -1697,59 +1194,42 @@
          countDistinctIf(funnel_actors.actor_id, ifNull(notEquals(funnel_actors.steps, 2), 1)) AS failure_count
   FROM
     (SELECT aggregation_target AS actor_id,
-            timestamp AS timestamp,
+            (matched_events_array[1][1]).1 AS timestamp,
+            nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+            (matched_events_array[1][1]).1 AS first_timestamp,
             steps AS steps,
-            final_timestamp AS final_timestamp,
-            first_timestamp AS first_timestamp
+            final_timestamp,
+            first_timestamp
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               argMax(latest_0, steps) AS timestamp,
-               argMax(latest_1, steps) AS final_timestamp,
-               argMax(latest_0, steps) AS first_timestamp,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  latest_0 AS latest_0,
-                                  latest_1 AS latest_1,
-                                  latest_0 AS latest_0
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           e.`$group_1` AS aggregation_target,
-                           if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                    FROM events AS e
-                    WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [1, 2]), 0)
-     ORDER BY aggregation_target ASC) AS funnel_actors
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.`$group_1` AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -1772,59 +1252,42 @@
      FROM events AS event
      JOIN
        (SELECT aggregation_target AS actor_id,
-               timestamp AS timestamp,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_1` AS aggregation_target,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_1`)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_1` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_1`)
      WHERE and(equals(event.team_id, 99999), greaterOrEquals(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-01 00:00:00', 6, 'UTC'))), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC'))), equals(event.team_id, 99999), greater(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), funnel_actors.first_timestamp), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), coalesce(funnel_actors.final_timestamp, plus(toTimeZone(funnel_actors.first_timestamp, 'UTC'), toIntervalDay(14)), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC')))), notIn(event.event, ['paid', 'user signed up']), in(event.event, ['positively_related', 'negatively_related'])))
   GROUP BY name,
            prop
@@ -1836,59 +1299,42 @@
          countDistinctIf(funnel_actors.actor_id, ifNull(notEquals(funnel_actors.steps, 2), 1)) AS failure_count
   FROM
     (SELECT aggregation_target AS actor_id,
-            timestamp AS timestamp,
+            (matched_events_array[1][1]).1 AS timestamp,
+            nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+            (matched_events_array[1][1]).1 AS first_timestamp,
             steps AS steps,
-            final_timestamp AS final_timestamp,
-            first_timestamp AS first_timestamp
+            final_timestamp,
+            first_timestamp
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               argMax(latest_0, steps) AS timestamp,
-               argMax(latest_1, steps) AS final_timestamp,
-               argMax(latest_0, steps) AS first_timestamp,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  latest_0 AS latest_0,
-                                  latest_1 AS latest_1,
-                                  latest_0 AS latest_0
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           e.`$group_1` AS aggregation_target,
-                           if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                    FROM events AS e
-                    WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [1, 2]), 0)
-     ORDER BY aggregation_target ASC) AS funnel_actors
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.`$group_1` AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -1906,59 +1352,42 @@
   FROM events AS event
   JOIN
     (SELECT aggregation_target AS actor_id,
-            timestamp AS timestamp,
+            (matched_events_array[1][1]).1 AS timestamp,
+            nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+            (matched_events_array[1][1]).1 AS first_timestamp,
             steps AS steps,
-            final_timestamp AS final_timestamp,
-            first_timestamp AS first_timestamp
+            final_timestamp,
+            first_timestamp
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               argMax(latest_0, steps) AS timestamp,
-               argMax(latest_1, steps) AS final_timestamp,
-               argMax(latest_0, steps) AS first_timestamp,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  latest_0 AS latest_0,
-                                  latest_1 AS latest_1,
-                                  latest_0 AS latest_0
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           e.`$group_0` AS aggregation_target,
-                           if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                    FROM events AS e
-                    WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [1, 2]), 0)
-     ORDER BY aggregation_target ASC) AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.`$group_0` AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
   WHERE and(equals(event.team_id, 99999), greaterOrEquals(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-01 00:00:00', 6, 'UTC'))), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC'))), equals(event.team_id, 99999), greater(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), funnel_actors.first_timestamp), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), coalesce(funnel_actors.final_timestamp, plus(toTimeZone(funnel_actors.first_timestamp, 'UTC'), toIntervalDay(14)), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC')))), notIn(event.event, ['paid', 'user signed up']), notIn(event.event, []))
   GROUP BY name
   LIMIT 100
@@ -1968,59 +1397,42 @@
          countDistinctIf(funnel_actors.actor_id, ifNull(notEquals(funnel_actors.steps, 2), 1)) AS failure_count
   FROM
     (SELECT aggregation_target AS actor_id,
-            timestamp AS timestamp,
+            (matched_events_array[1][1]).1 AS timestamp,
+            nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+            (matched_events_array[1][1]).1 AS first_timestamp,
             steps AS steps,
-            final_timestamp AS final_timestamp,
-            first_timestamp AS first_timestamp
+            final_timestamp,
+            first_timestamp
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               argMax(latest_0, steps) AS timestamp,
-               argMax(latest_1, steps) AS final_timestamp,
-               argMax(latest_0, steps) AS first_timestamp,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  latest_0 AS latest_0,
-                                  latest_1 AS latest_1,
-                                  latest_0 AS latest_0
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           e.`$group_0` AS aggregation_target,
-                           if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                    FROM events AS e
-                    WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [1, 2]), 0)
-     ORDER BY aggregation_target ASC) AS funnel_actors
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.`$group_0` AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -2040,91 +1452,43 @@
      FROM events AS event
      JOIN
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
      WHERE and(equals(event.team_id, 99999), greaterOrEquals(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-01 00:00:00', 6, 'UTC'))), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC'))), equals(event.team_id, 99999), greater(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), funnel_actors.first_timestamp), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), coalesce(funnel_actors.final_timestamp, plus(toTimeZone(funnel_actors.first_timestamp, 'UTC'), toIntervalDay(14)), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC')))), notIn(event.event, ['paid', 'user signed up']), equals(event.event, 'positively_related'), ifNull(equals(funnel_actors.steps, 2), 0))
      GROUP BY actor_id
      ORDER BY actor_id ASC) AS source
@@ -2151,91 +1515,43 @@
      FROM events AS event
      JOIN
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
      WHERE and(equals(event.team_id, 99999), greaterOrEquals(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-01 00:00:00', 6, 'UTC'))), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC'))), equals(event.team_id, 99999), greater(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), funnel_actors.first_timestamp), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), coalesce(funnel_actors.final_timestamp, plus(toTimeZone(funnel_actors.first_timestamp, 'UTC'), toIntervalDay(14)), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC')))), notIn(event.event, ['paid', 'user signed up']), equals(event.event, 'positively_related'), ifNull(notEquals(funnel_actors.steps, 2), 1))
      GROUP BY actor_id
      ORDER BY actor_id ASC) AS source
@@ -2262,91 +1578,43 @@
      FROM events AS event
      JOIN
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
      WHERE and(equals(event.team_id, 99999), greaterOrEquals(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-01 00:00:00', 6, 'UTC'))), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC'))), equals(event.team_id, 99999), greater(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), funnel_actors.first_timestamp), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), coalesce(funnel_actors.final_timestamp, plus(toTimeZone(funnel_actors.first_timestamp, 'UTC'), toIntervalDay(14)), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC')))), notIn(event.event, ['paid', 'user signed up']), equals(event.event, 'negatively_related'), ifNull(equals(funnel_actors.steps, 2), 0))
      GROUP BY actor_id
      ORDER BY actor_id ASC) AS source
@@ -2373,91 +1641,43 @@
      FROM events AS event
      JOIN
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
      WHERE and(equals(event.team_id, 99999), greaterOrEquals(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-01 00:00:00', 6, 'UTC'))), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC'))), equals(event.team_id, 99999), greater(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), funnel_actors.first_timestamp), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), coalesce(funnel_actors.final_timestamp, plus(toTimeZone(funnel_actors.first_timestamp, 'UTC'), toIntervalDay(14)), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC')))), notIn(event.event, ['paid', 'user signed up']), equals(event.event, 'negatively_related'), ifNull(notEquals(funnel_actors.steps, 2), 1))
      GROUP BY actor_id
      ORDER BY actor_id ASC) AS source
@@ -2482,67 +1702,50 @@
   FROM events AS event
   JOIN
     (SELECT aggregation_target AS actor_id,
-            timestamp AS timestamp,
+            (matched_events_array[1][1]).1 AS timestamp,
+            nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+            (matched_events_array[1][1]).1 AS first_timestamp,
             steps AS steps,
-            final_timestamp AS final_timestamp,
-            first_timestamp AS first_timestamp
+            final_timestamp,
+            first_timestamp
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               argMax(latest_0, steps) AS timestamp,
-               argMax(latest_1, steps) AS final_timestamp,
-               argMax(latest_0, steps) AS first_timestamp,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  latest_0 AS latest_0,
-                                  latest_1 AS latest_1,
-                                  latest_0 AS latest_0
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           e.`$group_0` AS aggregation_target,
-                           if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                    FROM events AS e
-                    LEFT JOIN
-                      (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                              groups.group_type_index AS index,
-                              groups.group_key AS key
-                       FROM groups
-                       WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                       GROUP BY groups.group_type_index,
-                                groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                    WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'finance'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [1, 2]), 0)
-     ORDER BY aggregation_target ASC) AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.`$group_0` AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           LEFT JOIN
+             (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                     groups.group_type_index AS index,
+                     groups.group_key AS key
+              FROM groups
+              WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+              GROUP BY groups.group_type_index,
+                       groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'finance'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
   WHERE and(equals(event.team_id, 99999), greaterOrEquals(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-01 00:00:00', 6, 'UTC'))), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC'))), equals(event.team_id, 99999), greater(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), funnel_actors.first_timestamp), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), coalesce(funnel_actors.final_timestamp, plus(toTimeZone(funnel_actors.first_timestamp, 'UTC'), toIntervalDay(14)), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC')))), notIn(event.event, ['paid', 'user signed up']), notIn(event.event, []))
   GROUP BY name
   LIMIT 100
@@ -2552,67 +1755,50 @@
          countDistinctIf(funnel_actors.actor_id, ifNull(notEquals(funnel_actors.steps, 2), 1)) AS failure_count
   FROM
     (SELECT aggregation_target AS actor_id,
-            timestamp AS timestamp,
+            (matched_events_array[1][1]).1 AS timestamp,
+            nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+            (matched_events_array[1][1]).1 AS first_timestamp,
             steps AS steps,
-            final_timestamp AS final_timestamp,
-            first_timestamp AS first_timestamp
+            final_timestamp,
+            first_timestamp
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               argMax(latest_0, steps) AS timestamp,
-               argMax(latest_1, steps) AS final_timestamp,
-               argMax(latest_0, steps) AS first_timestamp,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  latest_0 AS latest_0,
-                                  latest_1 AS latest_1,
-                                  latest_0 AS latest_0
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           e.`$group_0` AS aggregation_target,
-                           if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                    FROM events AS e
-                    LEFT JOIN
-                      (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                              groups.group_type_index AS index,
-                              groups.group_key AS key
-                       FROM groups
-                       WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                       GROUP BY groups.group_type_index,
-                                groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                    WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'finance'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [1, 2]), 0)
-     ORDER BY aggregation_target ASC) AS funnel_actors
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.`$group_0` AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           LEFT JOIN
+             (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                     groups.group_type_index AS index,
+                     groups.group_key AS key
+              FROM groups
+              WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+              GROUP BY groups.group_type_index,
+                       groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'finance'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -2632,91 +1818,43 @@
      FROM events AS event
      JOIN
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
      WHERE and(equals(event.team_id, 99999), greaterOrEquals(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-01 00:00:00', 6, 'UTC'))), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC'))), equals(event.team_id, 99999), greater(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), funnel_actors.first_timestamp), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), coalesce(funnel_actors.final_timestamp, plus(toTimeZone(funnel_actors.first_timestamp, 'UTC'), toIntervalDay(14)), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC')))), notIn(event.event, ['paid', 'user signed up']), equals(event.event, 'negatively_related'), ifNull(equals(funnel_actors.steps, 2), 0))
      GROUP BY actor_id
      ORDER BY actor_id ASC) AS source
@@ -2743,91 +1881,43 @@
      FROM events AS event
      JOIN
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
      WHERE and(equals(event.team_id, 99999), greaterOrEquals(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-01 00:00:00', 6, 'UTC'))), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC'))), equals(event.team_id, 99999), greater(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), funnel_actors.first_timestamp), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), coalesce(funnel_actors.final_timestamp, plus(toTimeZone(funnel_actors.first_timestamp, 'UTC'), toIntervalDay(14)), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC')))), notIn(event.event, ['paid', 'user signed up']), equals(event.event, 'negatively_related'), ifNull(notEquals(funnel_actors.steps, 2), 1))
      GROUP BY actor_id
      ORDER BY actor_id ASC) AS source
@@ -2852,59 +1942,42 @@
   FROM events AS event
   JOIN
     (SELECT aggregation_target AS actor_id,
-            timestamp AS timestamp,
+            (matched_events_array[1][1]).1 AS timestamp,
+            nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+            (matched_events_array[1][1]).1 AS first_timestamp,
             steps AS steps,
-            final_timestamp AS final_timestamp,
-            first_timestamp AS first_timestamp
+            final_timestamp,
+            first_timestamp
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               argMax(latest_0, steps) AS timestamp,
-               argMax(latest_1, steps) AS final_timestamp,
-               argMax(latest_0, steps) AS first_timestamp,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  latest_0 AS latest_0,
-                                  latest_1 AS latest_1,
-                                  latest_0 AS latest_0
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           e.`$group_0` AS aggregation_target,
-                           if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                    FROM events AS e
-                    WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [1, 2]), 0)
-     ORDER BY aggregation_target ASC) AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.`$group_0` AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
   WHERE and(equals(event.team_id, 99999), greaterOrEquals(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-01 00:00:00', 6, 'UTC'))), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC'))), equals(event.team_id, 99999), greater(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), funnel_actors.first_timestamp), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), coalesce(funnel_actors.final_timestamp, plus(toTimeZone(funnel_actors.first_timestamp, 'UTC'), toIntervalDay(14)), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC')))), notIn(event.event, ['paid', 'user signed up']), notIn(event.event, []))
   GROUP BY name
   LIMIT 100
@@ -2914,59 +1987,42 @@
          countDistinctIf(funnel_actors.actor_id, ifNull(notEquals(funnel_actors.steps, 2), 1)) AS failure_count
   FROM
     (SELECT aggregation_target AS actor_id,
-            timestamp AS timestamp,
+            (matched_events_array[1][1]).1 AS timestamp,
+            nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+            (matched_events_array[1][1]).1 AS first_timestamp,
             steps AS steps,
-            final_timestamp AS final_timestamp,
-            first_timestamp AS first_timestamp
+            final_timestamp,
+            first_timestamp
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               argMax(latest_0, steps) AS timestamp,
-               argMax(latest_1, steps) AS final_timestamp,
-               argMax(latest_0, steps) AS first_timestamp,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  latest_0 AS latest_0,
-                                  latest_1 AS latest_1,
-                                  latest_0 AS latest_0
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           e.`$group_0` AS aggregation_target,
-                           if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                    FROM events AS e
-                    WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [1, 2]), 0)
-     ORDER BY aggregation_target ASC) AS funnel_actors
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.`$group_0` AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -2986,91 +2042,43 @@
      FROM events AS event
      JOIN
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
      WHERE and(equals(event.team_id, 99999), greaterOrEquals(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-01 00:00:00', 6, 'UTC'))), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC'))), equals(event.team_id, 99999), greater(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), funnel_actors.first_timestamp), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), coalesce(funnel_actors.final_timestamp, plus(toTimeZone(funnel_actors.first_timestamp, 'UTC'), toIntervalDay(14)), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC')))), notIn(event.event, ['paid', 'user signed up']), equals(event.event, 'positively_related'), ifNull(equals(funnel_actors.steps, 2), 0))
      GROUP BY actor_id
      ORDER BY actor_id ASC) AS source
@@ -3097,91 +2105,43 @@
      FROM events AS event
      JOIN
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
      WHERE and(equals(event.team_id, 99999), greaterOrEquals(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-01 00:00:00', 6, 'UTC'))), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC'))), equals(event.team_id, 99999), greater(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), funnel_actors.first_timestamp), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), coalesce(funnel_actors.final_timestamp, plus(toTimeZone(funnel_actors.first_timestamp, 'UTC'), toIntervalDay(14)), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC')))), notIn(event.event, ['paid', 'user signed up']), equals(event.event, 'positively_related'), ifNull(notEquals(funnel_actors.steps, 2), 1))
      GROUP BY actor_id
      ORDER BY actor_id ASC) AS source
@@ -3208,91 +2168,43 @@
      FROM events AS event
      JOIN
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
      WHERE and(equals(event.team_id, 99999), greaterOrEquals(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-01 00:00:00', 6, 'UTC'))), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC'))), equals(event.team_id, 99999), greater(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), funnel_actors.first_timestamp), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), coalesce(funnel_actors.final_timestamp, plus(toTimeZone(funnel_actors.first_timestamp, 'UTC'), toIntervalDay(14)), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC')))), notIn(event.event, ['paid', 'user signed up']), equals(event.event, 'negatively_related'), ifNull(equals(funnel_actors.steps, 2), 0))
      GROUP BY actor_id
      ORDER BY actor_id ASC) AS source
@@ -3319,91 +2231,43 @@
      FROM events AS event
      JOIN
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
      WHERE and(equals(event.team_id, 99999), greaterOrEquals(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-01 00:00:00', 6, 'UTC'))), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC'))), equals(event.team_id, 99999), greater(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), funnel_actors.first_timestamp), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), coalesce(funnel_actors.final_timestamp, plus(toTimeZone(funnel_actors.first_timestamp, 'UTC'), toIntervalDay(14)), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC')))), notIn(event.event, ['paid', 'user signed up']), equals(event.event, 'negatively_related'), ifNull(notEquals(funnel_actors.steps, 2), 1))
      GROUP BY actor_id
      ORDER BY actor_id ASC) AS source
@@ -3428,67 +2292,50 @@
   FROM events AS event
   JOIN
     (SELECT aggregation_target AS actor_id,
-            timestamp AS timestamp,
+            (matched_events_array[1][1]).1 AS timestamp,
+            nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+            (matched_events_array[1][1]).1 AS first_timestamp,
             steps AS steps,
-            final_timestamp AS final_timestamp,
-            first_timestamp AS first_timestamp
+            final_timestamp,
+            first_timestamp
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               argMax(latest_0, steps) AS timestamp,
-               argMax(latest_1, steps) AS final_timestamp,
-               argMax(latest_0, steps) AS first_timestamp,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  latest_0 AS latest_0,
-                                  latest_1 AS latest_1,
-                                  latest_0 AS latest_0
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           e.`$group_0` AS aggregation_target,
-                           if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                    FROM events AS e
-                    LEFT JOIN
-                      (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                              groups.group_type_index AS index,
-                              groups.group_key AS key
-                       FROM groups
-                       WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                       GROUP BY groups.group_type_index,
-                                groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                    WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'finance'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [1, 2]), 0)
-     ORDER BY aggregation_target ASC) AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.`$group_0` AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           LEFT JOIN
+             (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                     groups.group_type_index AS index,
+                     groups.group_key AS key
+              FROM groups
+              WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+              GROUP BY groups.group_type_index,
+                       groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'finance'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
   WHERE and(equals(event.team_id, 99999), greaterOrEquals(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-01 00:00:00', 6, 'UTC'))), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC'))), equals(event.team_id, 99999), greater(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), funnel_actors.first_timestamp), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), coalesce(funnel_actors.final_timestamp, plus(toTimeZone(funnel_actors.first_timestamp, 'UTC'), toIntervalDay(14)), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC')))), notIn(event.event, ['paid', 'user signed up']), notIn(event.event, []))
   GROUP BY name
   LIMIT 100
@@ -3498,67 +2345,50 @@
          countDistinctIf(funnel_actors.actor_id, ifNull(notEquals(funnel_actors.steps, 2), 1)) AS failure_count
   FROM
     (SELECT aggregation_target AS actor_id,
-            timestamp AS timestamp,
+            (matched_events_array[1][1]).1 AS timestamp,
+            nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+            (matched_events_array[1][1]).1 AS first_timestamp,
             steps AS steps,
-            final_timestamp AS final_timestamp,
-            first_timestamp AS first_timestamp
+            final_timestamp,
+            first_timestamp
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               argMax(latest_0, steps) AS timestamp,
-               argMax(latest_1, steps) AS final_timestamp,
-               argMax(latest_0, steps) AS first_timestamp,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  latest_0 AS latest_0,
-                                  latest_1 AS latest_1,
-                                  latest_0 AS latest_0
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           e.`$group_0` AS aggregation_target,
-                           if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                    FROM events AS e
-                    LEFT JOIN
-                      (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                              groups.group_type_index AS index,
-                              groups.group_key AS key
-                       FROM groups
-                       WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                       GROUP BY groups.group_type_index,
-                                groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                    WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'finance'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [1, 2]), 0)
-     ORDER BY aggregation_target ASC) AS funnel_actors
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.`$group_0` AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           LEFT JOIN
+             (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                     groups.group_type_index AS index,
+                     groups.group_key AS key
+              FROM groups
+              WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+              GROUP BY groups.group_type_index,
+                       groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'finance'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -3578,91 +2408,43 @@
      FROM events AS event
      JOIN
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
      WHERE and(equals(event.team_id, 99999), greaterOrEquals(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-01 00:00:00', 6, 'UTC'))), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC'))), equals(event.team_id, 99999), greater(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), funnel_actors.first_timestamp), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), coalesce(funnel_actors.final_timestamp, plus(toTimeZone(funnel_actors.first_timestamp, 'UTC'), toIntervalDay(14)), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC')))), notIn(event.event, ['paid', 'user signed up']), equals(event.event, 'negatively_related'), ifNull(equals(funnel_actors.steps, 2), 0))
      GROUP BY actor_id
      ORDER BY actor_id ASC) AS source
@@ -3689,91 +2471,43 @@
      FROM events AS event
      JOIN
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors ON equals(funnel_actors.actor_id, event.`$group_0`)
      WHERE and(equals(event.team_id, 99999), greaterOrEquals(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-01 00:00:00', 6, 'UTC'))), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC'))), equals(event.team_id, 99999), greater(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), funnel_actors.first_timestamp), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), coalesce(funnel_actors.final_timestamp, plus(toTimeZone(funnel_actors.first_timestamp, 'UTC'), toIntervalDay(14)), assumeNotNull(toDateTime64('2020-01-14 23:59:59', 6, 'UTC')))), notIn(event.event, ['paid', 'user signed up']), equals(event.event, 'negatively_related'), ifNull(notEquals(funnel_actors.steps, 2), 1))
      GROUP BY actor_id
      ORDER BY actor_id ASC) AS source
@@ -3801,59 +2535,42 @@
             arrayJoin(arrayZip(['industry'], [JSONExtractString(groups_0.properties, 'industry')])) AS prop
      FROM
        (SELECT aggregation_target AS actor_id,
-               timestamp AS timestamp,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      LEFT JOIN
        (SELECT groups.key AS key,
                groups.properties AS properties
@@ -3875,59 +2592,42 @@
          countDistinctIf(funnel_actors.actor_id, ifNull(notEquals(funnel_actors.steps, 2), 1)) AS failure_count
   FROM
     (SELECT aggregation_target AS actor_id,
-            timestamp AS timestamp,
+            (matched_events_array[1][1]).1 AS timestamp,
+            nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+            (matched_events_array[1][1]).1 AS first_timestamp,
             steps AS steps,
-            final_timestamp AS final_timestamp,
-            first_timestamp AS first_timestamp
+            final_timestamp,
+            first_timestamp
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               argMax(latest_0, steps) AS timestamp,
-               argMax(latest_1, steps) AS final_timestamp,
-               argMax(latest_0, steps) AS first_timestamp,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  latest_0 AS latest_0,
-                                  latest_1 AS latest_1,
-                                  latest_0 AS latest_0
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           e.`$group_0` AS aggregation_target,
-                           if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                    FROM events AS e
-                    WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [1, 2]), 0)
-     ORDER BY aggregation_target ASC) AS funnel_actors
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.`$group_0` AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -3946,99 +2646,51 @@
             actor_id AS key
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT JOIN
-                         (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                 groups.group_type_index AS index,
-                                 groups.group_key AS key
-                          FROM groups
-                          WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                          GROUP BY groups.group_type_index,
-                                   groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(equals(funnel_actors.steps, 2), 0)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -4064,99 +2716,51 @@
             actor_id AS key
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT JOIN
-                         (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                 groups.group_type_index AS index,
-                                 groups.group_key AS key
-                          FROM groups
-                          WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                          GROUP BY groups.group_type_index,
-                                   groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(notEquals(funnel_actors.steps, 2), 1)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -4182,99 +2786,51 @@
             actor_id AS key
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT JOIN
-                         (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                 groups.group_type_index AS index,
-                                 groups.group_key AS key
-                          FROM groups
-                          WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                          GROUP BY groups.group_type_index,
-                                   groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(equals(funnel_actors.steps, 2), 0)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -4300,99 +2856,51 @@
             actor_id AS key
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT JOIN
-                         (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                 groups.group_type_index AS index,
-                                 groups.group_key AS key
-                          FROM groups
-                          WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                          GROUP BY groups.group_type_index,
-                                   groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(notEquals(funnel_actors.steps, 2), 1)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -4420,59 +2928,42 @@
             arrayJoin(JSONExtractKeysAndValues(groups_0.properties, 'String')) AS prop
      FROM
        (SELECT aggregation_target AS actor_id,
-               timestamp AS timestamp,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      LEFT JOIN
        (SELECT groups.key AS key,
                groups.properties AS properties
@@ -4494,59 +2985,42 @@
          countDistinctIf(funnel_actors.actor_id, ifNull(notEquals(funnel_actors.steps, 2), 1)) AS failure_count
   FROM
     (SELECT aggregation_target AS actor_id,
-            timestamp AS timestamp,
+            (matched_events_array[1][1]).1 AS timestamp,
+            nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+            (matched_events_array[1][1]).1 AS first_timestamp,
             steps AS steps,
-            final_timestamp AS final_timestamp,
-            first_timestamp AS first_timestamp
+            final_timestamp,
+            first_timestamp
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               argMax(latest_0, steps) AS timestamp,
-               argMax(latest_1, steps) AS final_timestamp,
-               argMax(latest_0, steps) AS first_timestamp,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  latest_0 AS latest_0,
-                                  latest_1 AS latest_1,
-                                  latest_0 AS latest_0
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           e.`$group_0` AS aggregation_target,
-                           if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                    FROM events AS e
-                    WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [1, 2]), 0)
-     ORDER BY aggregation_target ASC) AS funnel_actors
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.`$group_0` AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -4567,59 +3041,42 @@
             arrayJoin(arrayZip(['industry'], [JSONExtractString(groups_0.properties, 'industry')])) AS prop
      FROM
        (SELECT aggregation_target AS actor_id,
-               timestamp AS timestamp,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      LEFT JOIN
        (SELECT groups.key AS key,
                groups.properties AS properties
@@ -4641,59 +3098,42 @@
          countDistinctIf(funnel_actors.actor_id, ifNull(notEquals(funnel_actors.steps, 2), 1)) AS failure_count
   FROM
     (SELECT aggregation_target AS actor_id,
-            timestamp AS timestamp,
+            (matched_events_array[1][1]).1 AS timestamp,
+            nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+            (matched_events_array[1][1]).1 AS first_timestamp,
             steps AS steps,
-            final_timestamp AS final_timestamp,
-            first_timestamp AS first_timestamp
+            final_timestamp,
+            first_timestamp
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               argMax(latest_0, steps) AS timestamp,
-               argMax(latest_1, steps) AS final_timestamp,
-               argMax(latest_0, steps) AS first_timestamp,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  latest_0 AS latest_0,
-                                  latest_1 AS latest_1,
-                                  latest_0 AS latest_0
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           e.`$group_0` AS aggregation_target,
-                           if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                    FROM events AS e
-                    WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [1, 2]), 0)
-     ORDER BY aggregation_target ASC) AS funnel_actors
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.`$group_0` AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -4712,99 +3152,51 @@
             actor_id AS key
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT JOIN
-                         (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                 groups.group_type_index AS index,
-                                 groups.group_key AS key
-                          FROM groups
-                          WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                          GROUP BY groups.group_type_index,
-                                   groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(equals(funnel_actors.steps, 2), 0)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -4830,99 +3222,51 @@
             actor_id AS key
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT JOIN
-                         (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                 groups.group_type_index AS index,
-                                 groups.group_key AS key
-                          FROM groups
-                          WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                          GROUP BY groups.group_type_index,
-                                   groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(notEquals(funnel_actors.steps, 2), 1)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -4948,99 +3292,51 @@
             actor_id AS key
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT JOIN
-                         (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                 groups.group_type_index AS index,
-                                 groups.group_key AS key
-                          FROM groups
-                          WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                          GROUP BY groups.group_type_index,
-                                   groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(equals(funnel_actors.steps, 2), 0)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -5066,99 +3362,51 @@
             actor_id AS key
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT JOIN
-                         (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                 groups.group_type_index AS index,
-                                 groups.group_key AS key
-                          FROM groups
-                          WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                          GROUP BY groups.group_type_index,
-                                   groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(notEquals(funnel_actors.steps, 2), 1)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -5186,59 +3434,42 @@
             arrayJoin(JSONExtractKeysAndValues(groups_0.properties, 'String')) AS prop
      FROM
        (SELECT aggregation_target AS actor_id,
-               timestamp AS timestamp,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      LEFT JOIN
        (SELECT groups.key AS key,
                groups.properties AS properties
@@ -5260,59 +3491,42 @@
          countDistinctIf(funnel_actors.actor_id, ifNull(notEquals(funnel_actors.steps, 2), 1)) AS failure_count
   FROM
     (SELECT aggregation_target AS actor_id,
-            timestamp AS timestamp,
+            (matched_events_array[1][1]).1 AS timestamp,
+            nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+            (matched_events_array[1][1]).1 AS first_timestamp,
             steps AS steps,
-            final_timestamp AS final_timestamp,
-            first_timestamp AS first_timestamp
+            final_timestamp,
+            first_timestamp
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               argMax(latest_0, steps) AS timestamp,
-               argMax(latest_1, steps) AS final_timestamp,
-               argMax(latest_0, steps) AS first_timestamp,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  latest_0 AS latest_0,
-                                  latest_1 AS latest_1,
-                                  latest_0 AS latest_0
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           e.`$group_0` AS aggregation_target,
-                           if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                    FROM events AS e
-                    WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [1, 2]), 0)
-     ORDER BY aggregation_target ASC) AS funnel_actors
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.`$group_0` AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -5333,59 +3547,42 @@
             arrayJoin(arrayZip(['industry'], [JSONExtractString(groups_0.properties, 'industry')])) AS prop
      FROM
        (SELECT aggregation_target AS actor_id,
-               timestamp AS timestamp,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      LEFT JOIN
        (SELECT groups.key AS key,
                groups.properties AS properties
@@ -5407,59 +3604,42 @@
          countDistinctIf(funnel_actors.actor_id, ifNull(notEquals(funnel_actors.steps, 2), 1)) AS failure_count
   FROM
     (SELECT aggregation_target AS actor_id,
-            timestamp AS timestamp,
+            (matched_events_array[1][1]).1 AS timestamp,
+            nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+            (matched_events_array[1][1]).1 AS first_timestamp,
             steps AS steps,
-            final_timestamp AS final_timestamp,
-            first_timestamp AS first_timestamp
+            final_timestamp,
+            first_timestamp
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               argMax(latest_0, steps) AS timestamp,
-               argMax(latest_1, steps) AS final_timestamp,
-               argMax(latest_0, steps) AS first_timestamp,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  latest_0 AS latest_0,
-                                  latest_1 AS latest_1,
-                                  latest_0 AS latest_0
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           e.`$group_0` AS aggregation_target,
-                           if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                    FROM events AS e
-                    WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [1, 2]), 0)
-     ORDER BY aggregation_target ASC) AS funnel_actors
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.`$group_0` AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -5478,99 +3658,51 @@
             actor_id AS key
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT JOIN
-                         (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                 groups.group_type_index AS index,
-                                 groups.group_key AS key
-                          FROM groups
-                          WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                          GROUP BY groups.group_type_index,
-                                   groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(equals(funnel_actors.steps, 2), 0)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -5596,99 +3728,51 @@
             actor_id AS key
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT JOIN
-                         (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                 groups.group_type_index AS index,
-                                 groups.group_key AS key
-                          FROM groups
-                          WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                          GROUP BY groups.group_type_index,
-                                   groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(notEquals(funnel_actors.steps, 2), 1)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -5714,99 +3798,51 @@
             actor_id AS key
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT JOIN
-                         (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                 groups.group_type_index AS index,
-                                 groups.group_key AS key
-                          FROM groups
-                          WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                          GROUP BY groups.group_type_index,
-                                   groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(equals(funnel_actors.steps, 2), 0)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -5832,99 +3868,51 @@
             actor_id AS key
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT JOIN
-                         (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                 groups.group_type_index AS index,
-                                 groups.group_key AS key
-                          FROM groups
-                          WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                          GROUP BY groups.group_type_index,
-                                   groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(notEquals(funnel_actors.steps, 2), 1)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -5952,59 +3940,42 @@
             arrayJoin(JSONExtractKeysAndValues(groups_0.properties, 'String')) AS prop
      FROM
        (SELECT aggregation_target AS actor_id,
-               timestamp AS timestamp,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      LEFT JOIN
        (SELECT groups.key AS key,
                groups.properties AS properties
@@ -6026,59 +3997,42 @@
          countDistinctIf(funnel_actors.actor_id, ifNull(notEquals(funnel_actors.steps, 2), 1)) AS failure_count
   FROM
     (SELECT aggregation_target AS actor_id,
-            timestamp AS timestamp,
+            (matched_events_array[1][1]).1 AS timestamp,
+            nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+            (matched_events_array[1][1]).1 AS first_timestamp,
             steps AS steps,
-            final_timestamp AS final_timestamp,
-            first_timestamp AS first_timestamp
+            final_timestamp,
+            first_timestamp
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               argMax(latest_0, steps) AS timestamp,
-               argMax(latest_1, steps) AS final_timestamp,
-               argMax(latest_0, steps) AS first_timestamp,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  latest_0 AS latest_0,
-                                  latest_1 AS latest_1,
-                                  latest_0 AS latest_0
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           e.`$group_0` AS aggregation_target,
-                           if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                    FROM events AS e
-                    WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [1, 2]), 0)
-     ORDER BY aggregation_target ASC) AS funnel_actors
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.`$group_0` AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -6099,59 +4053,42 @@
             arrayJoin(arrayZip(['industry'], [JSONExtractString(groups_0.properties, 'industry')])) AS prop
      FROM
        (SELECT aggregation_target AS actor_id,
-               timestamp AS timestamp,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      LEFT JOIN
        (SELECT groups.key AS key,
                groups.properties AS properties
@@ -6173,59 +4110,42 @@
          countDistinctIf(funnel_actors.actor_id, ifNull(notEquals(funnel_actors.steps, 2), 1)) AS failure_count
   FROM
     (SELECT aggregation_target AS actor_id,
-            timestamp AS timestamp,
+            (matched_events_array[1][1]).1 AS timestamp,
+            nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+            (matched_events_array[1][1]).1 AS first_timestamp,
             steps AS steps,
-            final_timestamp AS final_timestamp,
-            first_timestamp AS first_timestamp
+            final_timestamp,
+            first_timestamp
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               argMax(latest_0, steps) AS timestamp,
-               argMax(latest_1, steps) AS final_timestamp,
-               argMax(latest_0, steps) AS first_timestamp,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  latest_0 AS latest_0,
-                                  latest_1 AS latest_1,
-                                  latest_0 AS latest_0
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           e.`$group_0` AS aggregation_target,
-                           if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                    FROM events AS e
-                    WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [1, 2]), 0)
-     ORDER BY aggregation_target ASC) AS funnel_actors
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.`$group_0` AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -6244,99 +4164,51 @@
             actor_id AS key
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT JOIN
-                         (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                 groups.group_type_index AS index,
-                                 groups.group_key AS key
-                          FROM groups
-                          WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                          GROUP BY groups.group_type_index,
-                                   groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(equals(funnel_actors.steps, 2), 0)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -6362,99 +4234,51 @@
             actor_id AS key
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT JOIN
-                         (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                 groups.group_type_index AS index,
-                                 groups.group_key AS key
-                          FROM groups
-                          WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                          GROUP BY groups.group_type_index,
-                                   groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(notEquals(funnel_actors.steps, 2), 1)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -6480,99 +4304,51 @@
             actor_id AS key
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT JOIN
-                         (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                 groups.group_type_index AS index,
-                                 groups.group_key AS key
-                          FROM groups
-                          WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                          GROUP BY groups.group_type_index,
-                                   groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(equals(funnel_actors.steps, 2), 0)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -6598,99 +4374,51 @@
             actor_id AS key
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT JOIN
-                         (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                 groups.group_type_index AS index,
-                                 groups.group_key AS key
-                          FROM groups
-                          WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                          GROUP BY groups.group_type_index,
-                                   groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(notEquals(funnel_actors.steps, 2), 1)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -6718,59 +4446,42 @@
             arrayJoin(JSONExtractKeysAndValues(groups_0.properties, 'String')) AS prop
      FROM
        (SELECT aggregation_target AS actor_id,
-               timestamp AS timestamp,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      LEFT JOIN
        (SELECT groups.key AS key,
                groups.properties AS properties
@@ -6792,59 +4503,42 @@
          countDistinctIf(funnel_actors.actor_id, ifNull(notEquals(funnel_actors.steps, 2), 1)) AS failure_count
   FROM
     (SELECT aggregation_target AS actor_id,
-            timestamp AS timestamp,
+            (matched_events_array[1][1]).1 AS timestamp,
+            nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+            (matched_events_array[1][1]).1 AS first_timestamp,
             steps AS steps,
-            final_timestamp AS final_timestamp,
-            first_timestamp AS first_timestamp
+            final_timestamp,
+            first_timestamp
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               argMax(latest_0, steps) AS timestamp,
-               argMax(latest_1, steps) AS final_timestamp,
-               argMax(latest_0, steps) AS first_timestamp,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  latest_0 AS latest_0,
-                                  latest_1 AS latest_1,
-                                  latest_0 AS latest_0
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           e.`$group_0` AS aggregation_target,
-                           if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                    FROM events AS e
-                    WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [1, 2]), 0)
-     ORDER BY aggregation_target ASC) AS funnel_actors
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.`$group_0` AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -6865,59 +4559,42 @@
             arrayJoin(arrayZip(['industry'], [JSONExtractString(groups_0.properties, 'industry')])) AS prop
      FROM
        (SELECT aggregation_target AS actor_id,
-               timestamp AS timestamp,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      LEFT JOIN
        (SELECT groups.key AS key,
                groups.properties AS properties
@@ -6939,59 +4616,42 @@
          countDistinctIf(funnel_actors.actor_id, ifNull(notEquals(funnel_actors.steps, 2), 1)) AS failure_count
   FROM
     (SELECT aggregation_target AS actor_id,
-            timestamp AS timestamp,
+            (matched_events_array[1][1]).1 AS timestamp,
+            nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+            (matched_events_array[1][1]).1 AS first_timestamp,
             steps AS steps,
-            final_timestamp AS final_timestamp,
-            first_timestamp AS first_timestamp
+            final_timestamp,
+            first_timestamp
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               argMax(latest_0, steps) AS timestamp,
-               argMax(latest_1, steps) AS final_timestamp,
-               argMax(latest_0, steps) AS first_timestamp,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  latest_0 AS latest_0,
-                                  latest_1 AS latest_1,
-                                  latest_0 AS latest_0
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           e.`$group_0` AS aggregation_target,
-                           if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                    FROM events AS e
-                    WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [1, 2]), 0)
-     ORDER BY aggregation_target ASC) AS funnel_actors
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.`$group_0` AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -7010,99 +4670,51 @@
             actor_id AS key
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT JOIN
-                         (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                 groups.group_type_index AS index,
-                                 groups.group_key AS key
-                          FROM groups
-                          WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                          GROUP BY groups.group_type_index,
-                                   groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(equals(funnel_actors.steps, 2), 0)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -7128,99 +4740,51 @@
             actor_id AS key
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT JOIN
-                         (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                 groups.group_type_index AS index,
-                                 groups.group_key AS key
-                          FROM groups
-                          WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                          GROUP BY groups.group_type_index,
-                                   groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(notEquals(funnel_actors.steps, 2), 1)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -7246,99 +4810,51 @@
             actor_id AS key
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT JOIN
-                         (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                 groups.group_type_index AS index,
-                                 groups.group_key AS key
-                          FROM groups
-                          WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                          GROUP BY groups.group_type_index,
-                                   groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(equals(funnel_actors.steps, 2), 0)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -7364,99 +4880,51 @@
             actor_id AS key
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT JOIN
-                         (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                 groups.group_type_index AS index,
-                                 groups.group_key AS key
-                          FROM groups
-                          WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                          GROUP BY groups.group_type_index,
-                                   groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__group_0.properties___industry, 'negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(notEquals(funnel_actors.steps, 2), 1)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source
@@ -7484,59 +4952,42 @@
             arrayJoin(JSONExtractKeysAndValues(groups_0.properties, 'String')) AS prop
      FROM
        (SELECT aggregation_target AS actor_id,
-               timestamp AS timestamp,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                       FROM events AS e
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'paid'), 1, 0) AS step_1
+              FROM events AS e
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      LEFT JOIN
        (SELECT groups.key AS key,
                groups.properties AS properties
@@ -7558,59 +5009,42 @@
          countDistinctIf(funnel_actors.actor_id, ifNull(notEquals(funnel_actors.steps, 2), 1)) AS failure_count
   FROM
     (SELECT aggregation_target AS actor_id,
-            timestamp AS timestamp,
+            (matched_events_array[1][1]).1 AS timestamp,
+            nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+            (matched_events_array[1][1]).1 AS first_timestamp,
             steps AS steps,
-            final_timestamp AS final_timestamp,
-            first_timestamp AS first_timestamp
+            final_timestamp,
+            first_timestamp
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               argMax(latest_0, steps) AS timestamp,
-               argMax(latest_1, steps) AS final_timestamp,
-               argMax(latest_0, steps) AS first_timestamp,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  latest_0 AS latest_0,
-                                  latest_1 AS latest_1,
-                                  latest_0 AS latest_0
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           e.`$group_0` AS aggregation_target,
-                           if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(equals(e.event, 'paid'), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                    FROM events AS e
-                    WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [1, 2]), 0)
-     ORDER BY aggregation_target ASC) AS funnel_actors
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  e.`$group_0` AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                  if(equals(e.event, 'paid'), 1, 0) AS step_1
+           FROM events AS e
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlation_actors.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlation_actors.ambr
@@ -18,98 +18,50 @@
         HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS event__override ON equals(event.distinct_id, event__override.distinct_id)
      JOIN
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'insight analyzed'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('$pageview', 'insight analyzed'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors ON equals(if(not(empty(event__override.distinct_id)), event__override.person_id, event.person_id), funnel_actors.actor_id)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                     if(equals(e.event, 'insight analyzed'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('$pageview', 'insight analyzed'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors ON equals(if(not(empty(event__override.distinct_id)), event__override.person_id, event.person_id), funnel_actors.actor_id)
      WHERE and(equals(event.team_id, 99999), greaterOrEquals(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2021-01-01 00:00:00', 6, 'UTC'))), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2021-01-08 23:59:59', 6, 'UTC'))), equals(event.team_id, 99999), greater(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), funnel_actors.first_timestamp), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), coalesce(funnel_actors.final_timestamp, plus(toTimeZone(funnel_actors.first_timestamp, 'UTC'), toIntervalDay(14)), assumeNotNull(toDateTime64('2021-01-08 23:59:59', 6, 'UTC')))), notIn(event.event, ['$pageview', 'insight analyzed']), equals(event.event, 'insight loaded'), ifNull(equals(funnel_actors.steps, 2), 0))
      GROUP BY actor_id
      ORDER BY actor_id ASC) AS source
@@ -159,164 +111,51 @@
         HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS event__override ON equals(event.distinct_id, event__override.distinct_id)
      JOIN
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[3][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(step_2_matching_event) AS step_2_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_2, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  avg(step_2_conversion_time) AS step_2_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner,
-                  median(step_2_conversion_time) AS step_2_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(3, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     tuple(latest_2, uuid_2, `$session_id_2`, `$window_id_2`) AS step_2_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     step_2_conversion_time AS step_2_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_2 AS latest_2,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        step_2 AS step_2,
-                        latest_2 AS latest_2,
-                        uuid_2 AS uuid_2,
-                        `$session_id_2` AS `$session_id_2`,
-                        `$window_id_2` AS `$window_id_2`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        tuple(latest_2, uuid_2, `$session_id_2`, `$window_id_2`) AS step_2_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           uuid_1 AS uuid_1,
-                           `$session_id_1` AS `$session_id_1`,
-                           `$window_id_1` AS `$window_id_1`,
-                           step_2 AS step_2,
-                           min(latest_2) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                              last_value(uuid_2) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_2,
-                                                                      last_value(`$session_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_2`,
-                                                                                                       last_value(`$window_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_2`
-                    FROM
-                      (SELECT aggregation_target AS aggregation_target,
-                              timestamp AS timestamp,
-                              step_0 AS step_0,
-                              latest_0 AS latest_0,
-                              uuid_0 AS uuid_0,
-                              `$session_id_0` AS `$session_id_0`,
-                              `$window_id_0` AS `$window_id_0`,
-                              step_1 AS step_1,
-                              latest_1 AS latest_1,
-                              uuid_1 AS uuid_1,
-                              `$session_id_1` AS `$session_id_1`,
-                              `$window_id_1` AS `$window_id_1`,
-                              step_2 AS step_2,
-                              if(ifNull(less(latest_2, latest_1), 0), NULL, latest_2) AS latest_2,
-                              if(ifNull(less(latest_2, latest_1), 0), NULL, uuid_2) AS uuid_2,
-                              if(ifNull(less(latest_2, latest_1), 0), NULL, `$session_id_2`) AS `$session_id_2`,
-                              if(ifNull(less(latest_2, latest_1), 0), NULL, `$window_id_2`) AS `$window_id_2`
-                       FROM
-                         (SELECT aggregation_target AS aggregation_target,
-                                 timestamp AS timestamp,
-                                 step_0 AS step_0,
-                                 latest_0 AS latest_0,
-                                 uuid_0 AS uuid_0,
-                                 `$session_id_0` AS `$session_id_0`,
-                                 `$window_id_0` AS `$window_id_0`,
-                                 step_1 AS step_1,
-                                 min(latest_1) OVER (PARTITION BY aggregation_target
-                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                                    last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                             ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                            last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                             last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`,
-                                                                                                                                             step_2 AS step_2,
-                                                                                                                                             min(latest_2) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                                                                                                                                                last_value(uuid_2) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_2,
-                                                                                                                                                                                        last_value(`$session_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                                                                          ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_2`,
-                                                                                                                                                                                                                         last_value(`$window_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                                                                                                          ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_2`
-                          FROM
-                            (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                                    if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                                    e.uuid AS uuid,
-                                    if(equals(e.event, '$pageview'), 1, 0) AS step_0,
-                                    if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                                    if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                                    if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                                    if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                                    if(equals(e.event, 'insight analyzed'), 1, 0) AS step_1,
-                                    if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                                    if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                                    if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                                    if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`,
-                                    if(equals(e.event, 'insight updated'), 1, 0) AS step_2,
-                                    if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                                    if(ifNull(equals(step_2, 1), 0), uuid, NULL) AS uuid_2,
-                                    if(ifNull(equals(step_2, 1), 0), e.`$session_id`, NULL) AS `$session_id_2`,
-                                    if(ifNull(equals(step_2, 1), 0), e.`$window_id`, NULL) AS `$window_id_2`
-                             FROM events AS e
-                             LEFT OUTER JOIN
-                               (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                       person_distinct_id_overrides.distinct_id AS distinct_id
-                                FROM person_distinct_id_overrides
-                                WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                                GROUP BY person_distinct_id_overrides.distinct_id
-                                HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                             WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('$pageview', 'insight analyzed', 'insight updated'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0)))))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2, 3]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors ON equals(if(not(empty(event__override.distinct_id)), event__override.person_id, event.person_id), funnel_actors.actor_id)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                     if(equals(e.event, 'insight analyzed'), 1, 0) AS step_1,
+                     if(equals(e.event, 'insight updated'), 1, 0) AS step_2
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('$pageview', 'insight analyzed', 'insight updated'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors ON equals(if(not(empty(event__override.distinct_id)), event__override.person_id, event.person_id), funnel_actors.actor_id)
      WHERE and(equals(event.team_id, 99999), greaterOrEquals(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2021-01-01 00:00:00', 6, 'UTC'))), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), assumeNotNull(toDateTime64('2021-01-08 23:59:59', 6, 'UTC'))), equals(event.team_id, 99999), greater(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), funnel_actors.first_timestamp), less(toTimeZone(toDateTime(toTimeZone(event.timestamp, 'UTC'), 'UTC'), 'UTC'), coalesce(funnel_actors.final_timestamp, plus(toTimeZone(funnel_actors.first_timestamp, 'UTC'), toIntervalDay(14)), assumeNotNull(toDateTime64('2021-01-08 23:59:59', 6, 'UTC')))), notIn(event.event, ['$pageview', 'insight analyzed', 'insight updated']), equals(event.event, 'insight loaded'), ifNull(notEquals(funnel_actors.steps, 3), 1))
      GROUP BY actor_id
      ORDER BY actor_id ASC) AS source
@@ -358,108 +197,60 @@
             actor_id AS id
      FROM
        (SELECT aggregation_target AS actor_id,
-               final_matching_events AS matching_events,
-               timestamp AS timestamp,
+               matched_events_array[plus(step_reached, 1)] AS matching_events,
+               (matched_events_array[1][1]).1 AS timestamp,
+               nullIf((matched_events_array[2][1]).1, 0) AS final_timestamp,
+               (matched_events_array[1][1]).1 AS first_timestamp,
                steps AS steps,
-               final_timestamp AS final_timestamp,
-               first_timestamp AS first_timestamp
+               final_timestamp,
+               first_timestamp
         FROM
-          (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-                  groupArray(10)(final_matching_event) AS final_matching_events,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  argMax(latest_0, steps) AS timestamp,
-                  argMax(latest_1, steps) AS final_timestamp,
-                  argMax(latest_0, steps) AS first_timestamp,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  af_tuple.4 AS matched_event_uuids_array_array,
+                  groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+                  mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+                  arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
-                     aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time,
-                                     latest_0 AS latest_0,
-                                     latest_1 AS latest_1,
-                                     latest_0 AS latest_0
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'insight analyzed'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       LEFT JOIN
-                         (SELECT person.id AS id,
-                                 replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'foo'), ''), 'null'), '^"|"$', '') AS properties___foo
-                          FROM person
-                          WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
-                                                                               (SELECT person.id AS id, max(person.version) AS version
-                                                                                FROM person
-                                                                                WHERE equals(person.team_id, 99999)
-                                                                                GROUP BY person.id
-                                                                                HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('$pageview', 'insight analyzed')), ifNull(equals(e__person.properties___foo, 'bar'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [1, 2]), 0)
-        ORDER BY aggregation_target ASC) AS funnel_actors
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                     if(equals(e.event, 'insight analyzed'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              LEFT JOIN
+                (SELECT person.id AS id,
+                        replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'foo'), ''), 'null'), '^"|"$', '') AS properties___foo
+                 FROM person
+                 WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                                       FROM person
+                                                                       WHERE equals(person.team_id, 99999)
+                                                                       GROUP BY person.id
+                                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('$pageview', 'insight analyzed')), ifNull(equals(e__person.properties___foo, 'bar'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS funnel_actors
      WHERE ifNull(equals(funnel_actors.steps, 2), 0)
      GROUP BY funnel_actors.actor_id
      ORDER BY funnel_actors.actor_id ASC) AS source

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_persons.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_persons.ambr
@@ -6,155 +6,46 @@
          source.matching_events AS matching_events
   FROM
     (SELECT aggregation_target AS actor_id,
-            step_0_matching_events AS matching_events,
+            matched_events_array[1] AS matching_events,
             actor_id AS id
      FROM
-       (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-               groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-               groupArray(10)(step_2_matching_event) AS step_2_matching_events,
-               groupArray(10)(final_matching_event) AS final_matching_events,
-               aggregation_target AS aggregation_target,
-               steps AS steps,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               avg(step_2_conversion_time) AS step_2_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner,
-               median(step_2_conversion_time) AS step_2_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(3, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                  tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                  tuple(latest_2, uuid_2, `$session_id_2`, `$window_id_2`) AS step_2_matching_event,
-                  if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) AS final_matching_event,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  step_2_conversion_time AS step_2_conversion_time
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     uuid_0 AS uuid_0,
-                     `$session_id_0` AS `$session_id_0`,
-                     `$window_id_0` AS `$window_id_0`,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     uuid_1 AS uuid_1,
-                     `$session_id_1` AS `$session_id_1`,
-                     `$window_id_1` AS `$window_id_1`,
-                     step_2 AS step_2,
-                     latest_2 AS latest_2,
-                     uuid_2 AS uuid_2,
-                     `$session_id_2` AS `$session_id_2`,
-                     `$window_id_2` AS `$window_id_2`,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time,
-                     tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     tuple(latest_2, uuid_2, `$session_id_2`, `$window_id_2`) AS step_2_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) AS final_matching_event
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        step_2 AS step_2,
-                        min(latest_2) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                           last_value(uuid_2) OVER (PARTITION BY aggregation_target
-                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_2,
-                                                                   last_value(`$session_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_2`,
-                                                                                                    last_value(`$window_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_2`
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           uuid_1 AS uuid_1,
-                           `$session_id_1` AS `$session_id_1`,
-                           `$window_id_1` AS `$window_id_1`,
-                           step_2 AS step_2,
-                           if(ifNull(less(latest_2, latest_1), 0), NULL, latest_2) AS latest_2,
-                           if(ifNull(less(latest_2, latest_1), 0), NULL, uuid_2) AS uuid_2,
-                           if(ifNull(less(latest_2, latest_1), 0), NULL, `$session_id_2`) AS `$session_id_2`,
-                           if(ifNull(less(latest_2, latest_1), 0), NULL, `$window_id_2`) AS `$window_id_2`
-                    FROM
-                      (SELECT aggregation_target AS aggregation_target,
-                              timestamp AS timestamp,
-                              step_0 AS step_0,
-                              latest_0 AS latest_0,
-                              uuid_0 AS uuid_0,
-                              `$session_id_0` AS `$session_id_0`,
-                              `$window_id_0` AS `$window_id_0`,
-                              step_1 AS step_1,
-                              min(latest_1) OVER (PARTITION BY aggregation_target
-                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                                 last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                          ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                         last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                          last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`,
-                                                                                                                                          step_2 AS step_2,
-                                                                                                                                          min(latest_2) OVER (PARTITION BY aggregation_target
-                                                                                                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                                                                                                                                             last_value(uuid_2) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_2,
-                                                                                                                                                                                     last_value(`$session_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_2`,
-                                                                                                                                                                                                                      last_value(`$window_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_2`
-                       FROM
-                         (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                                 if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                                 e.uuid AS uuid,
-                                 if(equals(e.event, 'step one'), 1, 0) AS step_0,
-                                 if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                                 if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                                 if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                                 if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                                 if(equals(e.event, 'step two'), 1, 0) AS step_1,
-                                 if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                                 if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                                 if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                                 if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`,
-                                 if(equals(e.event, 'step three'), 1, 0) AS step_2,
-                                 if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                                 if(ifNull(equals(step_2, 1), 0), uuid, NULL) AS uuid_2,
-                                 if(ifNull(equals(step_2, 1), 0), e.`$session_id`, NULL) AS `$session_id_2`,
-                                 if(ifNull(equals(step_2, 1), 0), e.`$window_id`, NULL) AS `$window_id_2`
-                          FROM events AS e
-                          LEFT OUTER JOIN
-                            (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                    person_distinct_id_overrides.distinct_id AS distinct_id
-                             FROM person_distinct_id_overrides
-                             WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                             GROUP BY person_distinct_id_overrides.distinct_id
-                             HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                          WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('step one', 'step three', 'step two'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0)))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [1, 2, 3]), 0)
-     ORDER BY aggregation_target ASC) AS source
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'step one'), 1, 0) AS step_0,
+                  if(equals(e.event, 'step two'), 1, 0) AS step_1,
+                  if(equals(e.event, 'step three'), 1, 0) AS step_2
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('step one', 'step three', 'step two'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
@@ -190,155 +81,46 @@
          source.matching_events AS matching_events
   FROM
     (SELECT aggregation_target AS actor_id,
-            step_1_matching_events AS matching_events,
+            matched_events_array[2] AS matching_events,
             actor_id AS id
      FROM
-       (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-               groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-               groupArray(10)(step_2_matching_event) AS step_2_matching_events,
-               groupArray(10)(final_matching_event) AS final_matching_events,
-               aggregation_target AS aggregation_target,
-               steps AS steps,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               avg(step_2_conversion_time) AS step_2_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner,
-               median(step_2_conversion_time) AS step_2_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(3, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                  tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                  tuple(latest_2, uuid_2, `$session_id_2`, `$window_id_2`) AS step_2_matching_event,
-                  if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) AS final_matching_event,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  step_2_conversion_time AS step_2_conversion_time
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     uuid_0 AS uuid_0,
-                     `$session_id_0` AS `$session_id_0`,
-                     `$window_id_0` AS `$window_id_0`,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     uuid_1 AS uuid_1,
-                     `$session_id_1` AS `$session_id_1`,
-                     `$window_id_1` AS `$window_id_1`,
-                     step_2 AS step_2,
-                     latest_2 AS latest_2,
-                     uuid_2 AS uuid_2,
-                     `$session_id_2` AS `$session_id_2`,
-                     `$window_id_2` AS `$window_id_2`,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time,
-                     tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     tuple(latest_2, uuid_2, `$session_id_2`, `$window_id_2`) AS step_2_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) AS final_matching_event
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        step_2 AS step_2,
-                        min(latest_2) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                           last_value(uuid_2) OVER (PARTITION BY aggregation_target
-                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_2,
-                                                                   last_value(`$session_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_2`,
-                                                                                                    last_value(`$window_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_2`
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           uuid_1 AS uuid_1,
-                           `$session_id_1` AS `$session_id_1`,
-                           `$window_id_1` AS `$window_id_1`,
-                           step_2 AS step_2,
-                           if(ifNull(less(latest_2, latest_1), 0), NULL, latest_2) AS latest_2,
-                           if(ifNull(less(latest_2, latest_1), 0), NULL, uuid_2) AS uuid_2,
-                           if(ifNull(less(latest_2, latest_1), 0), NULL, `$session_id_2`) AS `$session_id_2`,
-                           if(ifNull(less(latest_2, latest_1), 0), NULL, `$window_id_2`) AS `$window_id_2`
-                    FROM
-                      (SELECT aggregation_target AS aggregation_target,
-                              timestamp AS timestamp,
-                              step_0 AS step_0,
-                              latest_0 AS latest_0,
-                              uuid_0 AS uuid_0,
-                              `$session_id_0` AS `$session_id_0`,
-                              `$window_id_0` AS `$window_id_0`,
-                              step_1 AS step_1,
-                              min(latest_1) OVER (PARTITION BY aggregation_target
-                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                                 last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                          ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                         last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                          last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`,
-                                                                                                                                          step_2 AS step_2,
-                                                                                                                                          min(latest_2) OVER (PARTITION BY aggregation_target
-                                                                                                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                                                                                                                                             last_value(uuid_2) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_2,
-                                                                                                                                                                                     last_value(`$session_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_2`,
-                                                                                                                                                                                                                      last_value(`$window_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_2`
-                       FROM
-                         (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                                 if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                                 e.uuid AS uuid,
-                                 if(equals(e.event, 'step one'), 1, 0) AS step_0,
-                                 if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                                 if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                                 if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                                 if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                                 if(equals(e.event, 'step two'), 1, 0) AS step_1,
-                                 if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                                 if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                                 if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                                 if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`,
-                                 if(equals(e.event, 'step three'), 1, 0) AS step_2,
-                                 if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                                 if(ifNull(equals(step_2, 1), 0), uuid, NULL) AS uuid_2,
-                                 if(ifNull(equals(step_2, 1), 0), e.`$session_id`, NULL) AS `$session_id_2`,
-                                 if(ifNull(equals(step_2, 1), 0), e.`$window_id`, NULL) AS `$window_id_2`
-                          FROM events AS e
-                          LEFT OUTER JOIN
-                            (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                    person_distinct_id_overrides.distinct_id AS distinct_id
-                             FROM person_distinct_id_overrides
-                             WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                             GROUP BY person_distinct_id_overrides.distinct_id
-                             HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                          WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('step one', 'step three', 'step two'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0)))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [2, 3]), 0)
-     ORDER BY aggregation_target ASC) AS source
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'step one'), 1, 0) AS step_0,
+                  if(equals(e.event, 'step two'), 1, 0) AS step_1,
+                  if(equals(e.event, 'step three'), 1, 0) AS step_2
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('step one', 'step three', 'step two'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 1), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
@@ -374,155 +156,46 @@
          source.matching_events AS matching_events
   FROM
     (SELECT aggregation_target AS actor_id,
-            step_1_matching_events AS matching_events,
+            matched_events_array[2] AS matching_events,
             actor_id AS id
      FROM
-       (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-               groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-               groupArray(10)(step_2_matching_event) AS step_2_matching_events,
-               groupArray(10)(final_matching_event) AS final_matching_events,
-               aggregation_target AS aggregation_target,
-               steps AS steps,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               avg(step_2_conversion_time) AS step_2_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner,
-               median(step_2_conversion_time) AS step_2_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(3, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                             and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                             and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                            and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                            and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                  tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                  tuple(latest_2, uuid_2, `$session_id_2`, `$window_id_2`) AS step_2_matching_event,
-                  if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) AS final_matching_event,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  step_2_conversion_time AS step_2_conversion_time
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     uuid_0 AS uuid_0,
-                     `$session_id_0` AS `$session_id_0`,
-                     `$window_id_0` AS `$window_id_0`,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     uuid_1 AS uuid_1,
-                     `$session_id_1` AS `$session_id_1`,
-                     `$window_id_1` AS `$window_id_1`,
-                     step_2 AS step_2,
-                     latest_2 AS latest_2,
-                     uuid_2 AS uuid_2,
-                     `$session_id_2` AS `$session_id_2`,
-                     `$window_id_2` AS `$window_id_2`,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time,
-                     tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     tuple(latest_2, uuid_2, `$session_id_2`, `$window_id_2`) AS step_2_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) AS final_matching_event
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        step_2 AS step_2,
-                        min(latest_2) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                           last_value(uuid_2) OVER (PARTITION BY aggregation_target
-                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_2,
-                                                                   last_value(`$session_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_2`,
-                                                                                                    last_value(`$window_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_2`
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           uuid_1 AS uuid_1,
-                           `$session_id_1` AS `$session_id_1`,
-                           `$window_id_1` AS `$window_id_1`,
-                           step_2 AS step_2,
-                           if(ifNull(less(latest_2, latest_1), 0), NULL, latest_2) AS latest_2,
-                           if(ifNull(less(latest_2, latest_1), 0), NULL, uuid_2) AS uuid_2,
-                           if(ifNull(less(latest_2, latest_1), 0), NULL, `$session_id_2`) AS `$session_id_2`,
-                           if(ifNull(less(latest_2, latest_1), 0), NULL, `$window_id_2`) AS `$window_id_2`
-                    FROM
-                      (SELECT aggregation_target AS aggregation_target,
-                              timestamp AS timestamp,
-                              step_0 AS step_0,
-                              latest_0 AS latest_0,
-                              uuid_0 AS uuid_0,
-                              `$session_id_0` AS `$session_id_0`,
-                              `$window_id_0` AS `$window_id_0`,
-                              step_1 AS step_1,
-                              min(latest_1) OVER (PARTITION BY aggregation_target
-                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                                 last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                          ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                         last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                          last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`,
-                                                                                                                                          step_2 AS step_2,
-                                                                                                                                          min(latest_2) OVER (PARTITION BY aggregation_target
-                                                                                                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                                                                                                                                             last_value(uuid_2) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_2,
-                                                                                                                                                                                     last_value(`$session_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_2`,
-                                                                                                                                                                                                                      last_value(`$window_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_2`
-                       FROM
-                         (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                                 if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                                 e.uuid AS uuid,
-                                 if(equals(e.event, 'step one'), 1, 0) AS step_0,
-                                 if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                                 if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                                 if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                                 if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                                 if(equals(e.event, 'step two'), 1, 0) AS step_1,
-                                 if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                                 if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                                 if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                                 if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`,
-                                 if(equals(e.event, 'step three'), 1, 0) AS step_2,
-                                 if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                                 if(ifNull(equals(step_2, 1), 0), uuid, NULL) AS uuid_2,
-                                 if(ifNull(equals(step_2, 1), 0), e.`$session_id`, NULL) AS `$session_id_2`,
-                                 if(ifNull(equals(step_2, 1), 0), e.`$window_id`, NULL) AS `$window_id_2`
-                          FROM events AS e
-                          LEFT OUTER JOIN
-                            (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                    person_distinct_id_overrides.distinct_id AS distinct_id
-                             FROM person_distinct_id_overrides
-                             WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                             GROUP BY person_distinct_id_overrides.distinct_id
-                             HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                          WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('step one', 'step three', 'step two'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0)))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(equals(steps, 2), 0)
-     ORDER BY aggregation_target ASC) AS source
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'step one'), 1, 0) AS step_0,
+                  if(equals(e.event, 'step two'), 1, 0) AS step_1,
+                  if(equals(e.event, 'step three'), 1, 0) AS step_2
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('step one', 'step three', 'step two'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(equals(step_reached, 1), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict.ambr
@@ -3,89 +3,68 @@
   '''
   SELECT sum(step_1) AS step_1,
          sum(step_2) AS step_2,
-         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
-         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
-         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
-            prop AS prop,
-            row_number() OVER (
-                               ORDER BY step_2 DESC) AS row_number
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            if(ifNull(less(row_number, 25), 0), breakdown, ['Other']) AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'strict', groupUniqArrayIf(prop, ifNull(notEquals(prop, []), isNotNull(prop)
+                                                                                                                      or isNotNull([]))), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                                                        and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                                                        and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                       and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                                                       and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS latest_1,
-                                           prop AS prop
-                 FROM
-                   (SELECT timestamp AS timestamp,
-                           aggregation_target AS aggregation_target,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           prop_basic AS prop_basic,
-                           prop,
-                           prop_vals AS prop_vals,
-                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) AS prop
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              if(equals(e.event, 'sign up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(and(equals(e.event, 'buy'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', ''), 'xyz'), 0)), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
-                              prop_basic AS prop,
-                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       WHERE and(equals(e.team_id, 99999), and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC')))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     GROUP BY prop)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'sign up'), 1, 0) AS step_0,
+                     if(and(equals(e.event, 'buy'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', ''), 'xyz'), 0)), 1, 0) AS step_1,
+                     [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              WHERE and(equals(e.team_id, 99999), and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_2 DESC, step_1 DESC)
   GROUP BY final_prop
-  LIMIT 26 SETTINGS readonly=2,
+  LIMIT 26 SETTINGS join_algorithm='auto',
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -99,96 +78,58 @@
   '''
   SELECT sum(step_1) AS step_1,
          sum(step_2) AS step_2,
-         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
-         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
-         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
-            prop AS prop,
-            row_number() OVER (
-                               ORDER BY step_2 DESC) AS row_number
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            if(ifNull(less(row_number, 25), 0), breakdown, ['Other']) AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'step_1', 'strict', groupUniqArrayIf(prop_1, ifNull(notEquals(prop_1, []), isNotNull(prop_1)
+                                                                                                                   or isNotNull([]))), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                                                     and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                                                     and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                    and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                                                    and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  prop AS prop
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS latest_1,
-                                           prop AS prop
-                 FROM
-                   (SELECT timestamp AS timestamp,
-                           aggregation_target AS aggregation_target,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           prop_basic AS prop_basic,
-                           prop_0 AS prop_0,
-                           prop_1 AS prop_1,
-                           prop,
-                           prop_vals AS prop_vals,
-                           prop
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              if(equals(e.event, 'sign up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(and(equals(e.event, 'buy'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', ''), 'xyz'), 0)), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
-                              if(ifNull(equals(step_0, 1), 0), prop_basic, []) AS prop_0,
-                              if(ifNull(equals(step_1, 1), 0), prop_basic, []) AS prop_1,
-                              prop_1 AS prop,
-                              groupUniqArray(prop) OVER (PARTITION BY aggregation_target) AS prop_vals
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       WHERE and(equals(e.team_id, 99999), and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))))) ARRAY
-                    JOIN prop_vals AS prop
-                    WHERE ifNull(notEquals(prop, []), isNotNull(prop)
-                                 or isNotNull([]))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     GROUP BY prop)
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'sign up'), 1, 0) AS step_0,
+                  if(and(equals(e.event, 'buy'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', ''), 'xyz'), 0)), 1, 0) AS step_1,
+                  [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                  if(ifNull(equals(step_0, 1), 0), prop_basic, []) AS prop_0,
+                  if(ifNull(equals(step_1, 1), 0), prop_basic, []) AS prop_1,
+                  prop_1 AS prop,
+                  groupUniqArray(prop) OVER (PARTITION BY aggregation_target) AS prop_vals
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC')))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_2 DESC, step_1 DESC)
   GROUP BY final_prop
-  LIMIT 26 SETTINGS readonly=2,
+  LIMIT 26 SETTINGS join_algorithm='auto',
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -202,89 +143,68 @@
   '''
   SELECT sum(step_1) AS step_1,
          sum(step_2) AS step_2,
-         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
-         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
-         if(ifNull(less(row_number, 26), 0), prop, ['Other']) AS final_prop
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
-            prop AS prop,
-            row_number() OVER (
-                               ORDER BY step_2 DESC) AS row_number
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            if(ifNull(less(row_number, 25), 0), breakdown, ['Other']) AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'strict', groupUniqArrayIf(prop, ifNull(notEquals(prop, []), isNotNull(prop)
+                                                                                                                      or isNotNull([]))), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                                                        and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                                                        and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                       and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                                                       and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['', '']) AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS latest_1,
-                                           prop AS prop
-                 FROM
-                   (SELECT timestamp AS timestamp,
-                           aggregation_target AS aggregation_target,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           prop_basic AS prop_basic,
-                           prop,
-                           prop_vals AS prop_vals,
-                           if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['', '']) AS prop
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              if(equals(e.event, 'sign up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'buy'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), ''), ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
-                              prop_basic AS prop,
-                              argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       WHERE and(equals(e.team_id, 99999), and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC')))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     GROUP BY prop)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'sign up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'buy'), 1, 0) AS step_1,
+                     [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), ''), ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              WHERE and(equals(e.team_id, 99999), and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_2 DESC, step_1 DESC)
   GROUP BY final_prop
-  LIMIT 26 SETTINGS readonly=2,
+  LIMIT 26 SETTINGS join_algorithm='auto',
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -299,107 +219,74 @@
   SELECT sum(step_1) AS step_1,
          sum(step_2) AS step_2,
          sum(step_3) AS step_3,
-         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
-         if(isNaN(avgArrayOrNull(step_2_conversion_time_array) AS inter_2_conversion), NULL, inter_2_conversion) AS step_2_average_conversion_time,
-         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
-         if(isNaN(medianArrayOrNull(step_2_conversion_time_array) AS inter_2_median), NULL, inter_2_median) AS step_2_median_conversion_time,
-         if(ifNull(less(row_number, 26), 0), prop, 'Other') AS final_prop
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_2_conversion_times)])[1] AS step_2_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_2_conversion_times)])[1] AS step_2_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-            countIf(ifNull(equals(steps, 3), 0)) AS step_3,
-            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
-            groupArray(step_2_conversion_time) AS step_2_conversion_time_array,
-            prop AS prop,
-            row_number() OVER (
-                               ORDER BY step_3 DESC) AS row_number
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            countIf(ifNull(ifNull(equals(step_reached, 2), 0), 0)) AS step_3,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            groupArrayIf(timings[2], ifNull(greater(timings[2], 0), 0)) AS step_2_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            if(ifNull(less(row_number, 25), 0), breakdown, 'Other') AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time,
-               min(step_2_conversion_time) AS step_2_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_v4(3, 1209600, 'first_touch', 'strict', groupUniqArray(prop), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                      and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                      and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                     and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                     and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  step_2_conversion_time AS step_2_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          step_2 AS step_2,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          prop_vals AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     step_2 AS step_2,
-                     latest_2 AS latest_2,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS latest_1,
-                                           step_2 AS step_2,
-                                           min(latest_2) OVER (PARTITION BY aggregation_target,
-                                                                            prop
-                                                               ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) AS latest_2,
-                                                              prop AS prop
-                 FROM
-                   (SELECT timestamp AS timestamp,
-                           aggregation_target AS aggregation_target,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           step_2 AS step_2,
-                           latest_2 AS latest_2,
-                           prop_basic AS prop_basic,
-                           prop,
-                           prop_vals AS prop_vals,
-                           prop_vals AS prop
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              if(equals(e.event, 'sign up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'play movie'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(equals(e.event, 'buy'), 1, 0) AS step_2,
-                              if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                              ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
-                              prop_basic AS prop,
-                              argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
-                       FROM events AS e
-                       LEFT JOIN
-                         (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                 groups.group_type_index AS index,
-                                 groups.group_key AS key
-                          FROM groups
-                          WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                          GROUP BY groups.group_type_index,
-                                   groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                       WHERE and(equals(e.team_id, 99999), and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-08 23:59:59.999999', 6, 'UTC')))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     GROUP BY prop)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'sign up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'play movie'), 1, 0) AS step_1,
+                     if(equals(e.event, 'buy'), 1, 0) AS step_2,
+                     ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-08 23:59:59.999999', 6, 'UTC'))))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_3 DESC, step_2 DESC, step_1 DESC)
   GROUP BY final_prop
-  LIMIT 26 SETTINGS readonly=2,
+  LIMIT 26 SETTINGS join_algorithm='auto',
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -414,107 +301,74 @@
   SELECT sum(step_1) AS step_1,
          sum(step_2) AS step_2,
          sum(step_3) AS step_3,
-         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
-         if(isNaN(avgArrayOrNull(step_2_conversion_time_array) AS inter_2_conversion), NULL, inter_2_conversion) AS step_2_average_conversion_time,
-         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
-         if(isNaN(medianArrayOrNull(step_2_conversion_time_array) AS inter_2_median), NULL, inter_2_median) AS step_2_median_conversion_time,
-         if(ifNull(less(row_number, 26), 0), prop, 'Other') AS final_prop
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_2_conversion_times)])[1] AS step_2_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_2_conversion_times)])[1] AS step_2_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-            countIf(ifNull(equals(steps, 3), 0)) AS step_3,
-            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
-            groupArray(step_2_conversion_time) AS step_2_conversion_time_array,
-            prop AS prop,
-            row_number() OVER (
-                               ORDER BY step_3 DESC) AS row_number
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            countIf(ifNull(ifNull(equals(step_reached, 2), 0), 0)) AS step_3,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            groupArrayIf(timings[2], ifNull(greater(timings[2], 0), 0)) AS step_2_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            if(ifNull(less(row_number, 25), 0), breakdown, 'Other') AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time,
-               min(step_2_conversion_time) AS step_2_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_v4(3, 1209600, 'first_touch', 'strict', groupUniqArray(prop), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                      and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                      and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                     and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                     and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  step_2_conversion_time AS step_2_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          step_2 AS step_2,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          prop_vals AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     step_2 AS step_2,
-                     latest_2 AS latest_2,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS latest_1,
-                                           step_2 AS step_2,
-                                           min(latest_2) OVER (PARTITION BY aggregation_target,
-                                                                            prop
-                                                               ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) AS latest_2,
-                                                              prop AS prop
-                 FROM
-                   (SELECT timestamp AS timestamp,
-                           aggregation_target AS aggregation_target,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           step_2 AS step_2,
-                           latest_2 AS latest_2,
-                           prop_basic AS prop_basic,
-                           prop,
-                           prop_vals AS prop_vals,
-                           prop_vals AS prop
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              e.`$group_0` AS aggregation_target,
-                              if(equals(e.event, 'sign up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'play movie'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(equals(e.event, 'buy'), 1, 0) AS step_2,
-                              if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                              ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
-                              prop_basic AS prop,
-                              argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
-                       FROM events AS e
-                       LEFT JOIN
-                         (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                 groups.group_type_index AS index,
-                                 groups.group_key AS key
-                          FROM groups
-                          WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                          GROUP BY groups.group_type_index,
-                                   groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                       WHERE and(equals(e.team_id, 99999), and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-08 23:59:59.999999', 6, 'UTC')))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     GROUP BY prop)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     e.`$group_0` AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'sign up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'play movie'), 1, 0) AS step_1,
+                     if(equals(e.event, 'buy'), 1, 0) AS step_2,
+                     ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-08 23:59:59.999999', 6, 'UTC'))))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_3 DESC, step_2 DESC, step_1 DESC)
   GROUP BY final_prop
-  LIMIT 26 SETTINGS readonly=2,
+  LIMIT 26 SETTINGS join_algorithm='auto',
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -529,114 +383,81 @@
   SELECT sum(step_1) AS step_1,
          sum(step_2) AS step_2,
          sum(step_3) AS step_3,
-         if(isNaN(avgArrayOrNull(step_1_conversion_time_array) AS inter_1_conversion), NULL, inter_1_conversion) AS step_1_average_conversion_time,
-         if(isNaN(avgArrayOrNull(step_2_conversion_time_array) AS inter_2_conversion), NULL, inter_2_conversion) AS step_2_average_conversion_time,
-         if(isNaN(medianArrayOrNull(step_1_conversion_time_array) AS inter_1_median), NULL, inter_1_median) AS step_1_median_conversion_time,
-         if(isNaN(medianArrayOrNull(step_2_conversion_time_array) AS inter_2_median), NULL, inter_2_median) AS step_2_median_conversion_time,
-         if(ifNull(less(row_number, 26), 0), prop, 'Other') AS final_prop
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_1_conversion_times)])[1] AS step_1_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [avgArrayOrNull(step_2_conversion_times)])[1] AS step_2_average_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_1_conversion_times)])[1] AS step_1_median_conversion_time,
+         arrayMap(x -> if(isNaN(x), NULL, x), [medianArrayOrNull(step_2_conversion_times)])[1] AS step_2_median_conversion_time,
+         groupArray(row_number) AS row_number,
+         final_prop AS final_prop
   FROM
-    (SELECT countIf(ifNull(equals(steps, 1), 0)) AS step_1,
-            countIf(ifNull(equals(steps, 2), 0)) AS step_2,
-            countIf(ifNull(equals(steps, 3), 0)) AS step_3,
-            groupArray(step_1_conversion_time) AS step_1_conversion_time_array,
-            groupArray(step_2_conversion_time) AS step_2_conversion_time_array,
-            prop AS prop,
-            row_number() OVER (
-                               ORDER BY step_3 DESC) AS row_number
+    (SELECT countIf(ifNull(ifNull(equals(step_reached, 0), 0), 0)) AS step_1,
+            countIf(ifNull(ifNull(equals(step_reached, 1), 0), 0)) AS step_2,
+            countIf(ifNull(ifNull(equals(step_reached, 2), 0), 0)) AS step_3,
+            groupArrayIf(timings[1], ifNull(greater(timings[1], 0), 0)) AS step_1_conversion_times,
+            groupArrayIf(timings[2], ifNull(greater(timings[2], 0), 0)) AS step_2_conversion_times,
+            rowNumberInAllBlocks() AS row_number,
+            if(ifNull(less(row_number, 25), 0), breakdown, 'Other') AS final_prop
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time,
-               min(step_2_conversion_time) AS step_2_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_v4(3, 1209600, 'first_touch', 'strict', groupUniqArray(prop), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                      and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                      and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                     and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                     and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  step_2_conversion_time AS step_2_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          step_2 AS step_2,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          prop_vals AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     step_2 AS step_2,
-                     latest_2 AS latest_2,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS latest_1,
-                                           step_2 AS step_2,
-                                           min(latest_2) OVER (PARTITION BY aggregation_target,
-                                                                            prop
-                                                               ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) AS latest_2,
-                                                              prop AS prop
-                 FROM
-                   (SELECT timestamp AS timestamp,
-                           aggregation_target AS aggregation_target,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           step_2 AS step_2,
-                           latest_2 AS latest_2,
-                           prop_basic AS prop_basic,
-                           prop,
-                           prop_vals AS prop_vals,
-                           prop_vals AS prop
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              if(equals(e.event, 'sign up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'play movie'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(equals(e.event, 'buy'), 1, 0) AS step_2,
-                              if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                              ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
-                              prop_basic AS prop,
-                              argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       LEFT JOIN
-                         (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                 groups.group_type_index AS index,
-                                 groups.group_key AS key
-                          FROM groups
-                          WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                          GROUP BY groups.group_type_index,
-                                   groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                       WHERE and(equals(e.team_id, 99999), and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC')))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     GROUP BY prop)
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'sign up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'play movie'), 1, 0) AS step_1,
+                     if(equals(e.event, 'buy'), 1, 0) AS step_2,
+                     ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     GROUP BY breakdown
+     ORDER BY step_3 DESC, step_2 DESC, step_1 DESC)
   GROUP BY final_prop
-  LIMIT 26 SETTINGS readonly=2,
+  LIMIT 26 SETTINGS join_algorithm='auto',
+                    readonly=2,
                     max_execution_time=60,
                     allow_experimental_object_type=1,
                     format_csv_allow_double_quotes=0,
@@ -654,99 +475,64 @@
     (SELECT aggregation_target AS actor_id,
             actor_id AS id
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time,
-               min(step_2_conversion_time) AS step_2_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_v4(3, 1209600, 'first_touch', 'strict', groupUniqArray(prop), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                      and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                      and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                     and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                     and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  step_2_conversion_time AS step_2_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          step_2 AS step_2,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          prop_vals AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     step_2 AS step_2,
-                     latest_2 AS latest_2,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS latest_1,
-                                           step_2 AS step_2,
-                                           min(latest_2) OVER (PARTITION BY aggregation_target,
-                                                                            prop
-                                                               ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) AS latest_2,
-                                                              prop AS prop
-                 FROM
-                   (SELECT timestamp AS timestamp,
-                           aggregation_target AS aggregation_target,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           step_2 AS step_2,
-                           latest_2 AS latest_2,
-                           prop_basic AS prop_basic,
-                           prop,
-                           prop_vals AS prop_vals,
-                           prop_vals AS prop
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              if(equals(e.event, 'sign up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'play movie'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(equals(e.event, 'buy'), 1, 0) AS step_2,
-                              if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                              ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
-                              prop_basic AS prop,
-                              argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       LEFT JOIN
-                         (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                 groups.group_type_index AS index,
-                                 groups.group_key AS key
-                          FROM groups
-                          WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                          GROUP BY groups.group_type_index,
-                                   groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                       WHERE and(equals(e.team_id, 99999), and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC')))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE and(ifNull(in(steps, [1, 2, 3]), 0), ifNull(equals(arrayFlatten(array(prop)), arrayFlatten(array('finance'))), isNull(arrayFlatten(array(prop)))
-                                                       and isNull(arrayFlatten(array('finance')))))
-     ORDER BY aggregation_target ASC) AS source
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'sign up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'play movie'), 1, 0) AS step_1,
+                     if(equals(e.event, 'buy'), 1, 0) AS step_2,
+                     ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE and(ifNull(greaterOrEquals(step_reached, 0), 0), ifNull(equals(arrayFlatten(array(breakdown)), arrayFlatten(array('finance'))), isNull(arrayFlatten(array(breakdown)))
+                                                                   and isNull(arrayFlatten(array('finance')))))
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
@@ -769,99 +555,64 @@
     (SELECT aggregation_target AS actor_id,
             actor_id AS id
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time,
-               min(step_2_conversion_time) AS step_2_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_v4(3, 1209600, 'first_touch', 'strict', groupUniqArray(prop), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                      and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                      and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                     and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                     and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  step_2_conversion_time AS step_2_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          step_2 AS step_2,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          prop_vals AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     step_2 AS step_2,
-                     latest_2 AS latest_2,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS latest_1,
-                                           step_2 AS step_2,
-                                           min(latest_2) OVER (PARTITION BY aggregation_target,
-                                                                            prop
-                                                               ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) AS latest_2,
-                                                              prop AS prop
-                 FROM
-                   (SELECT timestamp AS timestamp,
-                           aggregation_target AS aggregation_target,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           step_2 AS step_2,
-                           latest_2 AS latest_2,
-                           prop_basic AS prop_basic,
-                           prop,
-                           prop_vals AS prop_vals,
-                           prop_vals AS prop
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              if(equals(e.event, 'sign up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'play movie'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(equals(e.event, 'buy'), 1, 0) AS step_2,
-                              if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                              ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
-                              prop_basic AS prop,
-                              argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       LEFT JOIN
-                         (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                 groups.group_type_index AS index,
-                                 groups.group_key AS key
-                          FROM groups
-                          WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                          GROUP BY groups.group_type_index,
-                                   groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                       WHERE and(equals(e.team_id, 99999), and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC')))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE and(ifNull(in(steps, [2, 3]), 0), ifNull(equals(arrayFlatten(array(prop)), arrayFlatten(array('finance'))), isNull(arrayFlatten(array(prop)))
-                                                    and isNull(arrayFlatten(array('finance')))))
-     ORDER BY aggregation_target ASC) AS source
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'sign up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'play movie'), 1, 0) AS step_1,
+                     if(equals(e.event, 'buy'), 1, 0) AS step_2,
+                     ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE and(ifNull(greaterOrEquals(step_reached, 1), 0), ifNull(equals(arrayFlatten(array(breakdown)), arrayFlatten(array('finance'))), isNull(arrayFlatten(array(breakdown)))
+                                                                   and isNull(arrayFlatten(array('finance')))))
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
@@ -884,99 +635,64 @@
     (SELECT aggregation_target AS actor_id,
             actor_id AS id
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time,
-               min(step_2_conversion_time) AS step_2_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_v4(3, 1209600, 'first_touch', 'strict', groupUniqArray(prop), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                      and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                      and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                     and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                     and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  step_2_conversion_time AS step_2_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          step_2 AS step_2,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          prop_vals AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     step_2 AS step_2,
-                     latest_2 AS latest_2,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS latest_1,
-                                           step_2 AS step_2,
-                                           min(latest_2) OVER (PARTITION BY aggregation_target,
-                                                                            prop
-                                                               ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) AS latest_2,
-                                                              prop AS prop
-                 FROM
-                   (SELECT timestamp AS timestamp,
-                           aggregation_target AS aggregation_target,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           step_2 AS step_2,
-                           latest_2 AS latest_2,
-                           prop_basic AS prop_basic,
-                           prop,
-                           prop_vals AS prop_vals,
-                           prop_vals AS prop
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              if(equals(e.event, 'sign up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'play movie'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(equals(e.event, 'buy'), 1, 0) AS step_2,
-                              if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                              ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
-                              prop_basic AS prop,
-                              argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       LEFT JOIN
-                         (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                 groups.group_type_index AS index,
-                                 groups.group_key AS key
-                          FROM groups
-                          WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                          GROUP BY groups.group_type_index,
-                                   groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                       WHERE and(equals(e.team_id, 99999), and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC')))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE and(ifNull(in(steps, [1, 2, 3]), 0), ifNull(equals(arrayFlatten(array(prop)), arrayFlatten(array('technology'))), isNull(arrayFlatten(array(prop)))
-                                                       and isNull(arrayFlatten(array('technology')))))
-     ORDER BY aggregation_target ASC) AS source
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'sign up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'play movie'), 1, 0) AS step_1,
+                     if(equals(e.event, 'buy'), 1, 0) AS step_2,
+                     ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE and(ifNull(greaterOrEquals(step_reached, 0), 0), ifNull(equals(arrayFlatten(array(breakdown)), arrayFlatten(array('technology'))), isNull(arrayFlatten(array(breakdown)))
+                                                                   and isNull(arrayFlatten(array('technology')))))
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
@@ -999,99 +715,64 @@
     (SELECT aggregation_target AS actor_id,
             actor_id AS id
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               prop AS prop,
-               prop AS prop,
-               min(step_1_conversion_time) AS step_1_conversion_time,
-               min(step_2_conversion_time) AS step_2_conversion_time
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, prop, arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_v4(3, 1209600, 'first_touch', 'strict', groupUniqArray(prop), arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                      and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                      and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                                     and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                                     and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  prop AS prop,
-                  max(steps) OVER (PARTITION BY aggregation_target,
-                                                prop) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  step_2_conversion_time AS step_2_conversion_time,
-                                  prop AS prop
+          (SELECT timestamp AS timestamp,
+                  aggregation_target AS aggregation_target,
+                  uuid AS uuid,
+                          `$session_id` AS `$session_id`,
+                          `$window_id` AS `$window_id`,
+                          step_0 AS step_0,
+                          step_1 AS step_1,
+                          step_2 AS step_2,
+                          prop_basic AS prop_basic,
+                          prop,
+                          prop_vals AS prop_vals,
+                          prop_vals AS prop
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     step_2 AS step_2,
-                     latest_2 AS latest_2,
-                     prop AS prop,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target,
-                                                         prop
-                                            ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS latest_1,
-                                           step_2 AS step_2,
-                                           min(latest_2) OVER (PARTITION BY aggregation_target,
-                                                                            prop
-                                                               ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) AS latest_2,
-                                                              prop AS prop
-                 FROM
-                   (SELECT timestamp AS timestamp,
-                           aggregation_target AS aggregation_target,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           step_2 AS step_2,
-                           latest_2 AS latest_2,
-                           prop_basic AS prop_basic,
-                           prop,
-                           prop_vals AS prop_vals,
-                           prop_vals AS prop
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              if(equals(e.event, 'sign up'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, 'play movie'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(equals(e.event, 'buy'), 1, 0) AS step_2,
-                              if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                              ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
-                              prop_basic AS prop,
-                              argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       LEFT JOIN
-                         (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
-                                 groups.group_type_index AS index,
-                                 groups.group_key AS key
-                          FROM groups
-                          WHERE and(equals(groups.team_id, 99999), equals(index, 0))
-                          GROUP BY groups.group_type_index,
-                                   groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                       WHERE and(equals(e.team_id, 99999), and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC')))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps,
-                 prop
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE and(ifNull(in(steps, [2, 3]), 0), ifNull(equals(arrayFlatten(array(prop)), arrayFlatten(array('technology'))), isNull(arrayFlatten(array(prop)))
-                                                    and isNull(arrayFlatten(array('technology')))))
-     ORDER BY aggregation_target ASC) AS source
+             (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, 'sign up'), 1, 0) AS step_0,
+                     if(equals(e.event, 'play movie'), 1, 0) AS step_1,
+                     if(equals(e.event, 'buy'), 1, 0) AS step_2,
+                     ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
+                     prop_basic AS prop,
+                     argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              LEFT JOIN
+                (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'industry'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___industry,
+                        groups.group_type_index AS index,
+                        groups.group_key AS key
+                 FROM groups
+                 WHERE and(equals(groups.team_id, 99999), equals(index, 0))
+                 GROUP BY groups.group_type_index,
+                          groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
+              WHERE and(equals(e.team_id, 99999), and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE and(ifNull(greaterOrEquals(step_reached, 1), 0), ifNull(equals(arrayFlatten(array(breakdown)), arrayFlatten(array('technology'))), isNull(arrayFlatten(array(breakdown)))
+                                                                   and isNull(arrayFlatten(array('technology')))))
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict_persons.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict_persons.ambr
@@ -6,115 +6,46 @@
          source.matching_events AS matching_events
   FROM
     (SELECT aggregation_target AS actor_id,
-            step_0_matching_events AS matching_events,
+            matched_events_array[1] AS matching_events,
             actor_id AS id
      FROM
-       (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-               groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-               groupArray(10)(step_2_matching_event) AS step_2_matching_events,
-               groupArray(10)(final_matching_event) AS final_matching_events,
-               aggregation_target AS aggregation_target,
-               steps AS steps,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               avg(step_2_conversion_time) AS step_2_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner,
-               median(step_2_conversion_time) AS step_2_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(3, 1209600, 'first_touch', 'strict', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                            and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                            and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                           and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                           and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                  tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                  tuple(latest_2, uuid_2, `$session_id_2`, `$window_id_2`) AS step_2_matching_event,
-                  if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) AS final_matching_event,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  step_2_conversion_time AS step_2_conversion_time
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     uuid_0 AS uuid_0,
-                     `$session_id_0` AS `$session_id_0`,
-                     `$window_id_0` AS `$window_id_0`,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     uuid_1 AS uuid_1,
-                     `$session_id_1` AS `$session_id_1`,
-                     `$window_id_1` AS `$window_id_1`,
-                     step_2 AS step_2,
-                     latest_2 AS latest_2,
-                     uuid_2 AS uuid_2,
-                     `$session_id_2` AS `$session_id_2`,
-                     `$window_id_2` AS `$window_id_2`,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time,
-                     tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     tuple(latest_2, uuid_2, `$session_id_2`, `$window_id_2`) AS step_2_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) AS final_matching_event
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS latest_1,
-                                           min(uuid_1) OVER (PARTITION BY aggregation_target
-                                                             ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS uuid_1,
-                                                            min(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                       ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS `$session_id_1`,
-                                                                                      min(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS `$window_id_1`,
-                                                                                                               step_2 AS step_2,
-                                                                                                               min(latest_2) OVER (PARTITION BY aggregation_target
-                                                                                                                                   ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) AS latest_2,
-                                                                                                                                  min(uuid_2) OVER (PARTITION BY aggregation_target
-                                                                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) AS uuid_2,
-                                                                                                                                                   min(`$session_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                              ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) AS `$session_id_2`,
-                                                                                                                                                                             min(`$window_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) AS `$window_id_2`
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                           e.uuid AS uuid,
-                           if(equals(e.event, 'step one'), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                           if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                           if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                           if(equals(e.event, 'step two'), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                           if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                           if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                           if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`,
-                           if(equals(e.event, 'step three'), 1, 0) AS step_2,
-                           if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                           if(ifNull(equals(step_2, 1), 0), uuid, NULL) AS uuid_2,
-                           if(ifNull(equals(step_2, 1), 0), e.`$session_id`, NULL) AS `$session_id_2`,
-                           if(ifNull(equals(step_2, 1), 0), e.`$window_id`, NULL) AS `$window_id_2`
-                    FROM events AS e
-                    LEFT OUTER JOIN
-                      (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                              person_distinct_id_overrides.distinct_id AS distinct_id
-                       FROM person_distinct_id_overrides
-                       WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                       GROUP BY person_distinct_id_overrides.distinct_id
-                       HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                    WHERE and(equals(e.team_id, 99999), and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [1, 2, 3]), 0)
-     ORDER BY aggregation_target ASC) AS source
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'step one'), 1, 0) AS step_0,
+                  if(equals(e.event, 'step two'), 1, 0) AS step_1,
+                  if(equals(e.event, 'step three'), 1, 0) AS step_2
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC')))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 0), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
@@ -150,115 +81,46 @@
          source.matching_events AS matching_events
   FROM
     (SELECT aggregation_target AS actor_id,
-            step_1_matching_events AS matching_events,
+            matched_events_array[2] AS matching_events,
             actor_id AS id
      FROM
-       (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-               groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-               groupArray(10)(step_2_matching_event) AS step_2_matching_events,
-               groupArray(10)(final_matching_event) AS final_matching_events,
-               aggregation_target AS aggregation_target,
-               steps AS steps,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               avg(step_2_conversion_time) AS step_2_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner,
-               median(step_2_conversion_time) AS step_2_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(3, 1209600, 'first_touch', 'strict', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                            and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                            and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                           and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                           and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                  tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                  tuple(latest_2, uuid_2, `$session_id_2`, `$window_id_2`) AS step_2_matching_event,
-                  if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) AS final_matching_event,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  step_2_conversion_time AS step_2_conversion_time
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     uuid_0 AS uuid_0,
-                     `$session_id_0` AS `$session_id_0`,
-                     `$window_id_0` AS `$window_id_0`,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     uuid_1 AS uuid_1,
-                     `$session_id_1` AS `$session_id_1`,
-                     `$window_id_1` AS `$window_id_1`,
-                     step_2 AS step_2,
-                     latest_2 AS latest_2,
-                     uuid_2 AS uuid_2,
-                     `$session_id_2` AS `$session_id_2`,
-                     `$window_id_2` AS `$window_id_2`,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time,
-                     tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     tuple(latest_2, uuid_2, `$session_id_2`, `$window_id_2`) AS step_2_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) AS final_matching_event
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS latest_1,
-                                           min(uuid_1) OVER (PARTITION BY aggregation_target
-                                                             ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS uuid_1,
-                                                            min(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                       ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS `$session_id_1`,
-                                                                                      min(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS `$window_id_1`,
-                                                                                                               step_2 AS step_2,
-                                                                                                               min(latest_2) OVER (PARTITION BY aggregation_target
-                                                                                                                                   ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) AS latest_2,
-                                                                                                                                  min(uuid_2) OVER (PARTITION BY aggregation_target
-                                                                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) AS uuid_2,
-                                                                                                                                                   min(`$session_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                              ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) AS `$session_id_2`,
-                                                                                                                                                                             min(`$window_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) AS `$window_id_2`
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                           e.uuid AS uuid,
-                           if(equals(e.event, 'step one'), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                           if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                           if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                           if(equals(e.event, 'step two'), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                           if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                           if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                           if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`,
-                           if(equals(e.event, 'step three'), 1, 0) AS step_2,
-                           if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                           if(ifNull(equals(step_2, 1), 0), uuid, NULL) AS uuid_2,
-                           if(ifNull(equals(step_2, 1), 0), e.`$session_id`, NULL) AS `$session_id_2`,
-                           if(ifNull(equals(step_2, 1), 0), e.`$window_id`, NULL) AS `$window_id_2`
-                    FROM events AS e
-                    LEFT OUTER JOIN
-                      (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                              person_distinct_id_overrides.distinct_id AS distinct_id
-                       FROM person_distinct_id_overrides
-                       WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                       GROUP BY person_distinct_id_overrides.distinct_id
-                       HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                    WHERE and(equals(e.team_id, 99999), and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(in(steps, [2, 3]), 0)
-     ORDER BY aggregation_target ASC) AS source
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'step one'), 1, 0) AS step_0,
+                  if(equals(e.event, 'step two'), 1, 0) AS step_1,
+                  if(equals(e.event, 'step three'), 1, 0) AS step_2
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC')))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(greaterOrEquals(step_reached, 1), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
@@ -294,115 +156,46 @@
          source.matching_events AS matching_events
   FROM
     (SELECT aggregation_target AS actor_id,
-            step_1_matching_events AS matching_events,
+            matched_events_array[2] AS matching_events,
             actor_id AS id
      FROM
-       (SELECT groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-               groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-               groupArray(10)(step_2_matching_event) AS step_2_matching_events,
-               groupArray(10)(final_matching_event) AS final_matching_events,
-               aggregation_target AS aggregation_target,
-               steps AS steps,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               avg(step_2_conversion_time) AS step_2_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner,
-               median(step_2_conversion_time) AS step_2_median_conversion_time_inner
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_v4(3, 1209600, 'first_touch', 'strict', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                            and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                            and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                           and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                           and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               af_tuple.1 AS step_reached,
+               plus(af_tuple.1, 1) AS steps,
+               af_tuple.2 AS breakdown,
+               af_tuple.3 AS timings,
+               af_tuple.4 AS matched_event_uuids_array_array,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               arrayMap(matched_event_uuids_array -> arrayMap(event_uuid -> user_events_map[event_uuid], arrayDistinct(matched_event_uuids_array)), matched_event_uuids_array_array) AS matched_events_array,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                  tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                  tuple(latest_2, uuid_2, `$session_id_2`, `$window_id_2`) AS step_2_matching_event,
-                  if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) AS final_matching_event,
-                  aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  step_2_conversion_time AS step_2_conversion_time
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     uuid_0 AS uuid_0,
-                     `$session_id_0` AS `$session_id_0`,
-                     `$window_id_0` AS `$window_id_0`,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     uuid_1 AS uuid_1,
-                     `$session_id_1` AS `$session_id_1`,
-                     `$window_id_1` AS `$window_id_1`,
-                     step_2 AS step_2,
-                     latest_2 AS latest_2,
-                     uuid_2 AS uuid_2,
-                     `$session_id_2` AS `$session_id_2`,
-                     `$window_id_2` AS `$window_id_2`,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time,
-                     tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     tuple(latest_2, uuid_2, `$session_id_2`, `$window_id_2`) AS step_2_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) AS final_matching_event
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        min(latest_1) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS latest_1,
-                                           min(uuid_1) OVER (PARTITION BY aggregation_target
-                                                             ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS uuid_1,
-                                                            min(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                       ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS `$session_id_1`,
-                                                                                      min(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) AS `$window_id_1`,
-                                                                                                               step_2 AS step_2,
-                                                                                                               min(latest_2) OVER (PARTITION BY aggregation_target
-                                                                                                                                   ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) AS latest_2,
-                                                                                                                                  min(uuid_2) OVER (PARTITION BY aggregation_target
-                                                                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) AS uuid_2,
-                                                                                                                                                   min(`$session_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                              ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) AS `$session_id_2`,
-                                                                                                                                                                             min(`$window_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) AS `$window_id_2`
-                 FROM
-                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                           if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                           e.uuid AS uuid,
-                           if(equals(e.event, 'step one'), 1, 0) AS step_0,
-                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                           if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                           if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                           if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                           if(equals(e.event, 'step two'), 1, 0) AS step_1,
-                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                           if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                           if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                           if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`,
-                           if(equals(e.event, 'step three'), 1, 0) AS step_2,
-                           if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                           if(ifNull(equals(step_2, 1), 0), uuid, NULL) AS uuid_2,
-                           if(ifNull(equals(step_2, 1), 0), e.`$session_id`, NULL) AS `$session_id_2`,
-                           if(ifNull(equals(step_2, 1), 0), e.`$window_id`, NULL) AS `$window_id_2`
-                    FROM events AS e
-                    LEFT OUTER JOIN
-                      (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                              person_distinct_id_overrides.distinct_id AS distinct_id
-                       FROM person_distinct_id_overrides
-                       WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                       GROUP BY person_distinct_id_overrides.distinct_id
-                       HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                    WHERE and(equals(e.team_id, 99999), and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                      and isNull(max(max_steps))))
-     WHERE ifNull(equals(steps, 2), 0)
-     ORDER BY aggregation_target ASC) AS source
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'step one'), 1, 0) AS step_0,
+                  if(equals(e.event, 'step two'), 1, 0) AS step_1,
+                  if(equals(e.event, 'step three'), 1, 0) AS step_2
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC')))))
+        GROUP BY aggregation_target
+        HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+     WHERE ifNull(equals(step_reached, 1), 0)
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_actors.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_actors.ambr
@@ -6,141 +6,44 @@
          source.matching_events AS matching_events
   FROM
     (SELECT aggregation_target AS actor_id,
-            step_1_matching_events AS matching_events,
+            matching_events AS matching_events,
             actor_id AS id
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               toStartOfDay(timestamp) AS entrance_period_start,
-               max(steps) AS steps_completed,
-               groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-               groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-               groupArray(10)(step_2_matching_event) AS step_2_matching_events,
-               groupArray(10)(final_matching_event) AS final_matching_events
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), toUInt64(toDateTime(toStartOfDay(timestamp), 'UTC')), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_trends_v4(0, 2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.5), 1), 0), ifNull(equals(x.5, x_before.5), isNull(x.5)
+                                                                                                                                                                                                       and isNull(x_before.5)), ifNull(equals(x.5, x_after.5), isNull(x.5)
+                                                                                                                                                                                                                                       and isNull(x_after.5)), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                                                                                      and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                                                                                      and isNull(x_after.4)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               toTimeZone(toDateTime(toUInt64(af_tuple.1), 'UTC'), 'UTC') AS entrance_period_start,
+               af_tuple.2 AS success_bool,
+               af_tuple.3 AS breakdown,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               [user_events_map[af_tuple.4]] AS matching_events,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  timestamp AS timestamp,
-                  step_0 AS step_0,
-                  latest_0 AS latest_0,
-                  uuid_0 AS uuid_0,
-                  `$session_id_0` AS `$session_id_0`,
-                  `$window_id_0` AS `$window_id_0`,
-                  step_1 AS step_1,
-                  latest_1 AS latest_1,
-                  uuid_1 AS uuid_1,
-                  `$session_id_1` AS `$session_id_1`,
-                  `$window_id_1` AS `$window_id_1`,
-                  step_2 AS step_2,
-                  latest_2 AS latest_2,
-                  uuid_2 AS uuid_2,
-                  `$session_id_2` AS `$session_id_2`,
-                  `$window_id_2` AS `$window_id_2`,
-                  if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                  if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                  if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time,
-                  tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                  tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                  tuple(latest_2, uuid_2, `$session_id_2`, `$window_id_2`) AS step_2_matching_event,
-                  if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) AS final_matching_event
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     uuid_0 AS uuid_0,
-                     `$session_id_0` AS `$session_id_0`,
-                     `$window_id_0` AS `$window_id_0`,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     uuid_1 AS uuid_1,
-                     `$session_id_1` AS `$session_id_1`,
-                     `$window_id_1` AS `$window_id_1`,
-                     step_2 AS step_2,
-                     min(latest_2) OVER (PARTITION BY aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                        last_value(uuid_2) OVER (PARTITION BY aggregation_target
-                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_2,
-                                                                last_value(`$session_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_2`,
-                                                                                                 last_value(`$window_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_2`
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        step_2 AS step_2,
-                        if(ifNull(less(latest_2, latest_1), 0), NULL, latest_2) AS latest_2,
-                        if(ifNull(less(latest_2, latest_1), 0), NULL, uuid_2) AS uuid_2,
-                        if(ifNull(less(latest_2, latest_1), 0), NULL, `$session_id_2`) AS `$session_id_2`,
-                        if(ifNull(less(latest_2, latest_1), 0), NULL, `$window_id_2`) AS `$window_id_2`
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`,
-                                                                                                                                       step_2 AS step_2,
-                                                                                                                                       min(latest_2) OVER (PARTITION BY aggregation_target
-                                                                                                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                                                                                                                                          last_value(uuid_2) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                                   ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_2,
-                                                                                                                                                                                  last_value(`$session_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_2`,
-                                                                                                                                                                                                                   last_value(`$window_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_2`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'step one'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'step two'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`,
-                              if(equals(e.event, 'step three'), 1, 0) AS step_2,
-                              if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                              if(ifNull(equals(step_2, 1), 0), uuid, NULL) AS uuid_2,
-                              if(ifNull(equals(step_2, 1), 0), e.`$session_id`, NULL) AS `$session_id_2`,
-                              if(ifNull(equals(step_2, 1), 0), e.`$window_id`, NULL) AS `$window_id_2`
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('step one', 'step three', 'step two'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0)))))))
-           WHERE ifNull(equals(step_0, 1), 0))
-        WHERE ifNull(equals(entrance_period_start, toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), 0)
-        GROUP BY aggregation_target,
-                 entrance_period_start)
-     WHERE ifNull(greaterOrEquals(steps_completed, 2), 0)
-     ORDER BY aggregation_target ASC) AS source
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'step one'), 1, 0) AS step_0,
+                  if(equals(e.event, 'step two'), 1, 0) AS step_1,
+                  if(equals(e.event, 'step three'), 1, 0) AS step_2
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('step one', 'step three', 'step two'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0))))
+        GROUP BY aggregation_target SETTINGS date_time_output_format='iso',
+                                             date_time_input_format='best_effort')
+     WHERE and(ifNull(equals(success_bool, 1), 0), ifNull(equals(entrance_period_start, toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), 0))
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
@@ -176,141 +79,44 @@
          source.matching_events AS matching_events
   FROM
     (SELECT aggregation_target AS actor_id,
-            final_matching_events AS matching_events,
+            matching_events AS matching_events,
             actor_id AS id
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               toStartOfDay(timestamp) AS entrance_period_start,
-               max(steps) AS steps_completed,
-               groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-               groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-               groupArray(10)(step_2_matching_event) AS step_2_matching_events,
-               groupArray(10)(final_matching_event) AS final_matching_events
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), toUInt64(toDateTime(toStartOfDay(timestamp), 'UTC')), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_trends_v4(0, 3, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.5), 1), 0), ifNull(equals(x.5, x_before.5), isNull(x.5)
+                                                                                                                                                                                                       and isNull(x_before.5)), ifNull(equals(x.5, x_after.5), isNull(x.5)
+                                                                                                                                                                                                                                       and isNull(x_after.5)), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                                                                                      and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                                                                                      and isNull(x_after.4)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               toTimeZone(toDateTime(toUInt64(af_tuple.1), 'UTC'), 'UTC') AS entrance_period_start,
+               af_tuple.2 AS success_bool,
+               af_tuple.3 AS breakdown,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               [user_events_map[af_tuple.4]] AS matching_events,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  timestamp AS timestamp,
-                  step_0 AS step_0,
-                  latest_0 AS latest_0,
-                  uuid_0 AS uuid_0,
-                  `$session_id_0` AS `$session_id_0`,
-                  `$window_id_0` AS `$window_id_0`,
-                  step_1 AS step_1,
-                  latest_1 AS latest_1,
-                  uuid_1 AS uuid_1,
-                  `$session_id_1` AS `$session_id_1`,
-                  `$window_id_1` AS `$window_id_1`,
-                  step_2 AS step_2,
-                  latest_2 AS latest_2,
-                  uuid_2 AS uuid_2,
-                  `$session_id_2` AS `$session_id_2`,
-                  `$window_id_2` AS `$window_id_2`,
-                  if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                  if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                  if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time,
-                  tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                  tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                  tuple(latest_2, uuid_2, `$session_id_2`, `$window_id_2`) AS step_2_matching_event,
-                  if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) AS final_matching_event
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     uuid_0 AS uuid_0,
-                     `$session_id_0` AS `$session_id_0`,
-                     `$window_id_0` AS `$window_id_0`,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     uuid_1 AS uuid_1,
-                     `$session_id_1` AS `$session_id_1`,
-                     `$window_id_1` AS `$window_id_1`,
-                     step_2 AS step_2,
-                     min(latest_2) OVER (PARTITION BY aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                        last_value(uuid_2) OVER (PARTITION BY aggregation_target
-                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_2,
-                                                                last_value(`$session_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_2`,
-                                                                                                 last_value(`$window_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_2`
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        step_2 AS step_2,
-                        if(ifNull(less(latest_2, latest_1), 0), NULL, latest_2) AS latest_2,
-                        if(ifNull(less(latest_2, latest_1), 0), NULL, uuid_2) AS uuid_2,
-                        if(ifNull(less(latest_2, latest_1), 0), NULL, `$session_id_2`) AS `$session_id_2`,
-                        if(ifNull(less(latest_2, latest_1), 0), NULL, `$window_id_2`) AS `$window_id_2`
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`,
-                                                                                                                                       step_2 AS step_2,
-                                                                                                                                       min(latest_2) OVER (PARTITION BY aggregation_target
-                                                                                                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                                                                                                                                          last_value(uuid_2) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                                   ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_2,
-                                                                                                                                                                                  last_value(`$session_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_2`,
-                                                                                                                                                                                                                   last_value(`$window_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_2`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'step one'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'step two'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`,
-                              if(equals(e.event, 'step three'), 1, 0) AS step_2,
-                              if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                              if(ifNull(equals(step_2, 1), 0), uuid, NULL) AS uuid_2,
-                              if(ifNull(equals(step_2, 1), 0), e.`$session_id`, NULL) AS `$session_id_2`,
-                              if(ifNull(equals(step_2, 1), 0), e.`$window_id`, NULL) AS `$window_id_2`
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('step one', 'step three', 'step two'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0)))))))
-           WHERE ifNull(equals(step_0, 1), 0))
-        WHERE ifNull(equals(entrance_period_start, toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), 0)
-        GROUP BY aggregation_target,
-                 entrance_period_start)
-     WHERE and(ifNull(greaterOrEquals(steps_completed, 1), 0), ifNull(less(steps_completed, 3), 0))
-     ORDER BY aggregation_target ASC) AS source
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'step one'), 1, 0) AS step_0,
+                  if(equals(e.event, 'step two'), 1, 0) AS step_1,
+                  if(equals(e.event, 'step three'), 1, 0) AS step_2
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('step one', 'step three', 'step two'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0))))
+        GROUP BY aggregation_target SETTINGS date_time_output_format='iso',
+                                             date_time_input_format='best_effort')
+     WHERE and(ifNull(notEquals(success_bool, 1), 1), ifNull(equals(entrance_period_start, toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), 0))
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,
@@ -346,141 +152,44 @@
          source.matching_events AS matching_events
   FROM
     (SELECT aggregation_target AS actor_id,
-            final_matching_events AS matching_events,
+            matching_events AS matching_events,
             actor_id AS id
      FROM
-       (SELECT aggregation_target AS aggregation_target,
-               toStartOfDay(timestamp) AS entrance_period_start,
-               max(steps) AS steps_completed,
-               groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-               groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-               groupArray(10)(step_2_matching_event) AS step_2_matching_events,
-               groupArray(10)(final_matching_event) AS final_matching_events
+       (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), toUInt64(toDateTime(toStartOfDay(timestamp), 'UTC')), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
+               arrayJoin(aggregate_funnel_array_trends_v4(0, 3, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.5), 1), 0), ifNull(equals(x.5, x_before.5), isNull(x.5)
+                                                                                                                                                                                                       and isNull(x_before.5)), ifNull(equals(x.5, x_after.5), isNull(x.5)
+                                                                                                                                                                                                                                       and isNull(x_after.5)), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                                                                                      and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                                                                                      and isNull(x_after.4)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               toTimeZone(toDateTime(toUInt64(af_tuple.1), 'UTC'), 'UTC') AS entrance_period_start,
+               af_tuple.2 AS success_bool,
+               af_tuple.3 AS breakdown,
+               groupArray(tuple(timestamp, uuid, `$session_id`, `$window_id`)) AS user_events,
+               mapFromArrays(arrayMap(x -> x.2, user_events), user_events) AS user_events_map,
+               [user_events_map[af_tuple.4]] AS matching_events,
+               aggregation_target AS aggregation_target
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  timestamp AS timestamp,
-                  step_0 AS step_0,
-                  latest_0 AS latest_0,
-                  uuid_0 AS uuid_0,
-                  `$session_id_0` AS `$session_id_0`,
-                  `$window_id_0` AS `$window_id_0`,
-                  step_1 AS step_1,
-                  latest_1 AS latest_1,
-                  uuid_1 AS uuid_1,
-                  `$session_id_1` AS `$session_id_1`,
-                  `$window_id_1` AS `$window_id_1`,
-                  step_2 AS step_2,
-                  latest_2 AS latest_2,
-                  uuid_2 AS uuid_2,
-                  `$session_id_2` AS `$session_id_2`,
-                  `$window_id_2` AS `$window_id_2`,
-                  if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                  if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                  if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time,
-                  tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                  tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                  tuple(latest_2, uuid_2, `$session_id_2`, `$window_id_2`) AS step_2_matching_event,
-                  if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) AS final_matching_event
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     uuid_0 AS uuid_0,
-                     `$session_id_0` AS `$session_id_0`,
-                     `$window_id_0` AS `$window_id_0`,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     uuid_1 AS uuid_1,
-                     `$session_id_1` AS `$session_id_1`,
-                     `$window_id_1` AS `$window_id_1`,
-                     step_2 AS step_2,
-                     min(latest_2) OVER (PARTITION BY aggregation_target
-                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                        last_value(uuid_2) OVER (PARTITION BY aggregation_target
-                                                                 ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_2,
-                                                                last_value(`$session_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_2`,
-                                                                                                 last_value(`$window_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_2`
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        step_2 AS step_2,
-                        if(ifNull(less(latest_2, latest_1), 0), NULL, latest_2) AS latest_2,
-                        if(ifNull(less(latest_2, latest_1), 0), NULL, uuid_2) AS uuid_2,
-                        if(ifNull(less(latest_2, latest_1), 0), NULL, `$session_id_2`) AS `$session_id_2`,
-                        if(ifNull(less(latest_2, latest_1), 0), NULL, `$window_id_2`) AS `$window_id_2`
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`,
-                                                                                                                                       step_2 AS step_2,
-                                                                                                                                       min(latest_2) OVER (PARTITION BY aggregation_target
-                                                                                                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                                                                                                                                          last_value(uuid_2) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                                   ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_2,
-                                                                                                                                                                                  last_value(`$session_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_2`,
-                                                                                                                                                                                                                   last_value(`$window_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                                                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_2`
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              e.uuid AS uuid,
-                              if(equals(e.event, 'step one'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                              if(equals(e.event, 'step two'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`,
-                              if(equals(e.event, 'step three'), 1, 0) AS step_2,
-                              if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                              if(ifNull(equals(step_2, 1), 0), uuid, NULL) AS uuid_2,
-                              if(ifNull(equals(step_2, 1), 0), e.`$session_id`, NULL) AS `$session_id_2`,
-                              if(ifNull(equals(step_2, 1), 0), e.`$window_id`, NULL) AS `$window_id_2`
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('step one', 'step three', 'step two'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0)))))))
-           WHERE ifNull(equals(step_0, 1), 0))
-        WHERE ifNull(equals(entrance_period_start, toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), 0)
-        GROUP BY aggregation_target,
-                 entrance_period_start)
-     WHERE ifNull(greaterOrEquals(steps_completed, 3), 0)
-     ORDER BY aggregation_target ASC) AS source
+          (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                  if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                  e.uuid AS uuid,
+                  e.`$session_id` AS `$session_id`,
+                  e.`$window_id` AS `$window_id`,
+                  if(equals(e.event, 'step one'), 1, 0) AS step_0,
+                  if(equals(e.event, 'step two'), 1, 0) AS step_1,
+                  if(equals(e.event, 'step three'), 1, 0) AS step_2
+           FROM events AS e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.999999', 6, 'UTC'))), in(e.event, tuple('step one', 'step three', 'step two'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0))))
+        GROUP BY aggregation_target SETTINGS date_time_output_format='iso',
+                                             date_time_input_format='best_effort')
+     WHERE and(ifNull(equals(success_bool, 1), 0), ifNull(equals(entrance_period_start, toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), 0))
+     ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
   ORDER BY source.id ASC
   LIMIT 101
   OFFSET 0 SETTINGS optimize_aggregation_in_order=1,

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py
@@ -12,7 +12,7 @@ from posthog.hogql_queries.legacy_compatibility.filter_to_query import filter_to
 from posthog.models.cohort.cohort import Cohort
 from posthog.models.filters import Filter
 from posthog.queries.funnels.funnel_trends_persons import ClickhouseFunnelTrendsActors
-from posthog.schema import FunnelsQuery, FunnelsQueryResponse
+from posthog.schema import FunnelsQuery
 from posthog.test.base import (
     APIBaseTest,
     ClickhouseTestMixin,
@@ -2540,27 +2540,3 @@ class BaseTestFunnelTrends(ClickhouseTestMixin, APIBaseTest):
             assert [0, 1] == [x["reached_to_step_count"] for x in results if x["breakdown_value"] == ["Chrome"]]
             assert [1, 1] == [x["reached_from_step_count"] for x in results if x["breakdown_value"] == ["Safari"]]
             assert [1, 0] == [x["reached_to_step_count"] for x in results if x["breakdown_value"] == ["Safari"]]
-
-
-class TestFunnelTrends(BaseTestFunnelTrends):
-    __test__ = True
-
-    def test_assert_udf_flag_is_working(self):
-        filters = {
-            "insight": INSIGHT_FUNNELS,
-            "funnel_viz_type": "trends",
-            "display": TRENDS_LINEAR,
-            "interval": "hour",
-            "date_from": "2021-05-01 00:00:00",
-            "funnel_window_interval": 7,
-            "events": [
-                {"id": "step one", "order": 0},
-                {"id": "step two", "order": 1},
-                {"id": "step three", "order": 2},
-            ],
-        }
-
-        query = cast(FunnelsQuery, filter_to_query(filters))
-        results = cast(FunnelsQueryResponse, FunnelsQueryRunner(query=query, team=self.team).calculate())
-
-        self.assertFalse(results.isUdf)

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_trends_udf.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_trends_udf.py
@@ -3,7 +3,7 @@ from typing import cast
 from unittest.mock import patch, Mock
 
 from hogql_parser import parse_expr
-from posthog.constants import INSIGHT_FUNNELS, TRENDS_LINEAR, FunnelOrderType
+from posthog.constants import INSIGHT_FUNNELS, FunnelOrderType
 from posthog.hogql.constants import HogQLGlobalSettings, MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY
 from posthog.hogql.query import execute_hogql_query
 from posthog.hogql_queries.insights.funnels.funnels_query_runner import FunnelsQueryRunner
@@ -11,7 +11,6 @@ from posthog.hogql_queries.insights.funnels.test.test_funnel_trends import BaseT
 from posthog.hogql_queries.legacy_compatibility.filter_to_query import filter_to_query
 from posthog.schema import (
     FunnelsQuery,
-    FunnelsQueryResponse,
     EventsNode,
     BreakdownFilter,
     FunnelsFilter,
@@ -76,45 +75,6 @@ class TestFunnelTrendsUDF(BaseTestFunnelTrends):
         )
         # Make sure the events have been condensed down to two
         self.assertEqual(2, len(response.results[0][-1]))
-
-    def test_assert_udf_flag_is_working(self):
-        filters = {
-            "insight": INSIGHT_FUNNELS,
-            "funnel_viz_type": "trends",
-            "display": TRENDS_LINEAR,
-            "interval": "hour",
-            "date_from": "2021-05-01 00:00:00",
-            "funnel_window_interval": 7,
-            "events": [
-                {"id": "step one", "order": 0},
-                {"id": "step two", "order": 1},
-                {"id": "step three", "order": 2},
-            ],
-        }
-
-        query = cast(FunnelsQuery, filter_to_query(filters))
-        results = cast(FunnelsQueryResponse, FunnelsQueryRunner(query=query, team=self.team).calculate())
-
-        self.assertTrue(results.isUdf)
-
-    def test_assert_steps_flag_is_off(self):
-        filters = {
-            "insight": INSIGHT_FUNNELS,
-            "funnel_viz_type": "steps",
-            "interval": "hour",
-            "date_from": "2021-05-01 00:00:00",
-            "funnel_window_interval": 7,
-            "events": [
-                {"id": "step one", "order": 0},
-                {"id": "step two", "order": 1},
-                {"id": "step three", "order": 2},
-            ],
-        }
-
-        query = cast(FunnelsQuery, filter_to_query(filters))
-        results = cast(FunnelsQueryResponse, FunnelsQueryRunner(query=query, team=self.team).calculate())
-
-        self.assertFalse(results.isUdf)
 
     def test_different_prop_val_in_strict_filter(self):
         funnels_query = FunnelsQuery(

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_udf.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_udf.py
@@ -83,25 +83,6 @@ class TestFOSSFunnelUDF(funnel_test_factory(Funnel, _create_event, _create_perso
 
         self.assertTrue(results.isUdf)
 
-    def test_assert_trends_flag_is_off(self):
-        filters = {
-            "insight": INSIGHT_FUNNELS,
-            "funnel_viz_type": "trends",
-            "interval": "hour",
-            "date_from": "2021-05-01 00:00:00",
-            "funnel_window_interval": 7,
-            "events": [
-                {"id": "step one", "order": 0},
-                {"id": "step two", "order": 1},
-                {"id": "step three", "order": 2},
-            ],
-        }
-
-        query = cast(FunnelsQuery, filter_to_query(filters))
-        results = cast(FunnelsQueryResponse, FunnelsQueryRunner(query=query, team=self.team).calculate())
-
-        self.assertFalse(results.isUdf)
-
     # Old style funnels fails on this (not sure why)
     def test_events_same_timestamp_no_exclusions(self):
         _create_person(distinct_ids=["test"], team_id=self.team.pk)

--- a/posthog/hogql_queries/insights/funnels/utils.py
+++ b/posthog/hogql_queries/insights/funnels/utils.py
@@ -1,24 +1,8 @@
 from posthog.constants import FUNNEL_WINDOW_INTERVAL_TYPES
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_expr
-from posthog.hogql_queries.legacy_compatibility.feature_flag import (
-    insight_funnels_use_udf_trends,
-    insight_funnels_use_udf,
-)
-from posthog.models import Team
 from posthog.schema import FunnelConversionWindowTimeUnit, FunnelVizType, FunnelsFilter, StepOrderValue
 from rest_framework.exceptions import ValidationError
-
-
-def use_udf(funnelsFilter: FunnelsFilter, team: Team):
-    if funnelsFilter.useUdf:
-        return True
-    funnelVizType = funnelsFilter.funnelVizType
-    if funnelVizType == FunnelVizType.TRENDS and insight_funnels_use_udf_trends(team):
-        return True
-    if funnelVizType == FunnelVizType.STEPS and insight_funnels_use_udf(team):
-        return True
-    return False
 
 
 def get_funnel_order_class(funnelsFilter: FunnelsFilter, use_udf=False):

--- a/posthog/hogql_queries/insights/test/__snapshots__/test_insight_actors_query_runner.ambr
+++ b/posthog/hogql_queries/insights/test/__snapshots__/test_insight_actors_query_runner.ambr
@@ -7,55 +7,38 @@
      FROM
        (SELECT aggregation_target AS actor_id
         FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner
+          (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1)])))) AS events_array,
+                  arrayJoin(aggregate_funnel_array_v4(2, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.4), 1), 0), ifNull(equals(x.4, x_before.4), isNull(x.4)
+                                                                                                                                                                                                and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
+                                                                                                                                                                                                                                and isNull(x_after.4)), ifNull(equals(x.3, x_before.3), isNull(x.3)
+                                                                                                                                                                                                                                                               and isNull(x_before.3)), ifNull(equals(x.3, x_after.3), isNull(x.3)
+                                                                                                                                                                                                                                                                                               and isNull(x_after.3)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+                  af_tuple.1 AS step_reached,
+                  plus(af_tuple.1, 1) AS steps,
+                  af_tuple.2 AS breakdown,
+                  af_tuple.3 AS timings,
+                  aggregation_target AS aggregation_target
            FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     steps AS steps,
-                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                     step_1_conversion_time AS step_1_conversion_time
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        if(and(ifNull(less(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
-                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           step_1 AS step_1,
-                           min(latest_1) OVER (PARTITION BY aggregation_target
-                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS latest_1
-                    FROM
-                      (SELECT toTimeZone(e.timestamp, 'US/Pacific') AS timestamp,
-                              if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
-                              if(equals(e.event, '$pageview'), 1, 0) AS step_0,
-                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                              if(equals(e.event, '$pageview'), 1, 0) AS step_1,
-                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
-                       FROM events AS e
-                       LEFT OUTER JOIN
-                         (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                                 person_distinct_id_overrides.distinct_id AS distinct_id
-                          FROM person_distinct_id_overrides
-                          WHERE equals(person_distinct_id_overrides.team_id, 99999)
-                          GROUP BY person_distinct_id_overrides.distinct_id
-                          HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-                       WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'US/Pacific'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'US/Pacific')), lessOrEquals(toTimeZone(e.timestamp, 'US/Pacific'), toDateTime64('2020-01-19 23:59:59.999999', 6, 'US/Pacific'))), in(e.event, tuple('$pageview'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
-                 WHERE ifNull(equals(step_0, 1), 0)))
-           GROUP BY aggregation_target,
-                    steps
-           HAVING ifNull(equals(steps, max(max_steps)), isNull(steps)
-                         and isNull(max(max_steps))))
-        WHERE ifNull(in(steps, [2]), 0)
-        ORDER BY aggregation_target ASC) AS source
+             (SELECT toTimeZone(e.timestamp, 'US/Pacific') AS timestamp,
+                     if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id) AS aggregation_target,
+                     e.uuid AS uuid,
+                     e.`$session_id` AS `$session_id`,
+                     e.`$window_id` AS `$window_id`,
+                     if(equals(e.event, '$pageview'), 1, 0) AS step_0,
+                     if(equals(e.event, '$pageview'), 1, 0) AS step_1
+              FROM events AS e
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'US/Pacific'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'US/Pacific')), lessOrEquals(toTimeZone(e.timestamp, 'US/Pacific'), toDateTime64('2020-01-19 23:59:59.999999', 6, 'US/Pacific'))), in(e.event, tuple('$pageview'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0))))
+           GROUP BY aggregation_target
+           HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
+        WHERE ifNull(greaterOrEquals(step_reached, 1), 0)
+        ORDER BY aggregation_target ASC SETTINGS join_algorithm='auto') AS source
      INNER JOIN
        (SELECT person.id AS id,
                replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'name'), ''), 'null'), '^"|"$', '') AS properties___name


### PR DESCRIPTION
## Problem

clicking on a funnel step to get persons is slow, mostly because we take a _long_ time to parse hogql

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Use UDF instead

<img width="916" alt="image" src="https://github.com/user-attachments/assets/0b7bd69c-d0d2-4a10-8e46-bac3c0180887" />


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
