### PR TITLE
chore(insights): forbid creating new insights with filters

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -374,6 +374,10 @@ class InsightSerializer(InsightBasicSerializer):
 
     @monitor(feature=Feature.INSIGHT, endpoint="insight", method="POST")
     def create(self, validated_data: dict, *args: Any, **kwargs: Any) -> Insight:
+        if "filters" in validated_data:
+            raise ValidationError(
+                {"filters": "This field is deprecated and no longer allowed. Please use `query` instead."},
+            )
         request = self.context["request"]
         tags = validated_data.pop("tags", None)  # tags are created separately as global tag relationships
         team_id = self.context["team_id"]

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -639,6 +639,22 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             ],
         )
 
+    def test_create_insight_with_filters_fails(self) -> None:
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/insights",
+            data={
+                "name": "an insight with legacy filters",
+                "filters": {
+                    "events": [{"id": "$pageview"}],
+                    "date_from": "-90d",
+                },
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        response_data = response.json()
+        self.assertEqual(response_data["type"], "validation_error")
+        self.assertEqual(response_data["attr"], "filters")
+
     @freeze_time("2012-01-14T03:21:34.000Z")
     def test_create_insight_with_no_names_logs_no_activity(self) -> None:
         response = self.client.post(


### PR DESCRIPTION
## Problem

We're contacting users to deprecate creating new insights with filters - they should use queries instead. After a reasonable time we should enforce this programatically.

Dashboard on legacy usage: https://us.posthog.com/project/2/dashboard/289911

## Changes

Forbids filters in the request payload. I also want to see which tests fail based on that.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
