### PR TITLE
chore(data-warehouse): Update deltalake - take three!

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ dagster-webserver==1.9.9
 dagster-postgres==0.25.9
 dagster-celery==0.25.9
 # dagster-cloud==1.9.8
-deltalake==0.23.2
+deltalake==0.25.2
 dj-database-url==0.5.0
 Django~=4.2.17
 django-axes==5.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -182,7 +182,7 @@ defusedxml==0.6.0
     # via
     #   python3-openid
     #   social-auth-core
-deltalake==0.23.2
+deltalake==0.25.2
     # via -r requirements.in
 distro==1.9.0
     # via


### PR DESCRIPTION
## Changes
- Follow on from https://github.com/PostHog/posthog/pull/29136/
- deltalake have released the fixed python wheel for aarch64 !!

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Testing the built image on `dev` first 
