### PR TITLE
feat: Deprecate `host_definition`

### DIFF
--- a/posthog/models/alert.py
+++ b/posthog/models/alert.py
@@ -29,11 +29,9 @@ def are_alerts_supported_for_insight(insight: Insight) -> bool:
     return True
 
 
+# TODO: Enable `@deprecated` once we move to Python 3.13
+# @deprecated("AlertConfiguration should be used instead.")
 class Alert(models.Model):
-    """
-    @deprecated("AlertConfiguration should be used instead.")
-    """
-
     team = models.ForeignKey("Team", on_delete=models.CASCADE)
     insight = models.ForeignKey("posthog.Insight", on_delete=models.CASCADE)
 

--- a/posthog/models/host_definition.py
+++ b/posthog/models/host_definition.py
@@ -1,20 +1,23 @@
 from django.db import models
 from django.utils import timezone
 
-from posthog.models.team import Team
-from posthog.models.project import Project
 from posthog.models.utils import UUIDModel, UniqueConstraintByExpression
 
 
+# NOTE: This model is deprecated. It was created as an attempt to track all of the domains that are using PostHog.
+# This wasn't very performant inside propdefs, and for that reason it was sunsetted.
+#
+# # TODO: Enable `@deprecated` once we move to Python 3.13
+# @deprecated("This model is no longer used due to performance issues with propdefs")
 class HostDefinition(UUIDModel):
     team = models.ForeignKey(
-        Team,
+        "Team",
         on_delete=models.CASCADE,
         related_name="host_definitions",
         related_query_name="host_definition",
     )
     project = models.ForeignKey(
-        Project,
+        "Project",
         null=True,
         on_delete=models.CASCADE,
         related_name="host_definitions",


### PR DESCRIPTION
This was an attempt to collect all domains so that we could use it on Web Analytics' UI. We've decided to go a different route because of the problems we'd have with having this inside `propdefs`. We don't usually drop any tables from our DB, so let's simply tag it as deprecated.

We've also implemented a new `@deprecated` decorator for python for this usecase, we're using it for a different already-deprecated class as well
