### PR TITLE
fix: Fix query awaited endpoint

### DIFF
--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -158,6 +158,7 @@ async function executeQuery<N extends DataNode>(
                     onerror(err) {
                         abortController.abort()
                         reject(err)
+                        throw err // make sure fetchEventSource doesn't attempt to retry
                     },
                 }).catch(reject)
             })

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -314,7 +314,8 @@ async def query_awaited(request: Request, *args, **kwargs) -> StreamingHttpRespo
                             status = await sync_to_async(manager.get_clickhouse_progresses)()
 
                             if isinstance(status, BaseModel):
-                                yield f"data: {status.model_dump_json(by_alias=True)}\n\n".encode()
+                                status_update = {"complete": False, **status.model_dump(by_alias=True)}
+                                yield f"data: {json.dumps(status_update)}\n\n".encode()
                                 last_update_time = current_time
                     # Just ignore errors when getting progress, shouldn't impact users
                     except Exception as e:


### PR DESCRIPTION
## Problem

I messed up with the last PR, we treated the status updates as query completes. Also had some issues with infinite retries

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
