### PR TITLE
fix: Be more tolerant of intra-cluster latency when running mutations on shards

### DIFF
--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -488,6 +488,8 @@ class MutationRunner:
 
         cluster.map_all_hosts_in_shards(
             {
+                # during periods of elevated replication lag, it may take some time for mutations to become available on
+                # the shards, so give them a little bit of breathing room with retries
                 shard_num: RetryPolicy(mutation.wait, max_attempts=3, delay=10.0, exceptions=(MutationNotFound,))
                 for shard_num, mutation in shard_mutations.items()
             }

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import itertools
 import logging
 import re
 import time
@@ -14,7 +15,7 @@ from concurrent.futures import (
 )
 from copy import copy
 from dataclasses import dataclass, field
-from typing import Any, Literal, NamedTuple, TypeVar
+from typing import Any, Generic, Literal, NamedTuple, TypeVar
 from collections.abc import Iterable
 
 from clickhouse_driver import Client
@@ -24,6 +25,9 @@ from posthog import settings
 from posthog.clickhouse.client.connection import NodeRole, _make_ch_pool, default_client
 from posthog.settings import CLICKHOUSE_PER_TEAM_SETTINGS
 from posthog.settings.data_stores import CLICKHOUSE_CLUSTER
+
+
+logger = logging.getLogger(__name__)
 
 
 def ON_CLUSTER_CLAUSE(on_cluster=True):
@@ -318,6 +322,30 @@ class Query:
         return client.execute(self.query, self.parameters)
 
 
+@dataclass
+class RetryPolicy(Generic[T]):
+    callable: Callable[[Client], T]
+    max_attempts: int
+    delay: float
+    exceptions: tuple[type[Exception], ...] = (Exception,)
+
+    def __call__(self, client: Client) -> T:
+        counter = itertools.count(1)
+        while (attempt := next(counter)) <= self.max_attempts:
+            try:
+                return self.callable(client)
+            except Exception as e:
+                if isinstance(e, self.exceptions) and attempt < self.max_attempts:
+                    logger.warning(
+                        "Failed to invoke %r (attempt #%s), retrying in %s...", self.callable, attempt, self.delay
+                    )
+                    time.sleep(self.delay)
+                else:
+                    raise
+
+        raise RuntimeError("unexpected fallthrough")
+
+
 class MutationNotFound(Exception):
     pass
 
@@ -459,5 +487,8 @@ class MutationRunner:
         assert len(shard_mutations) == len(shard_host_mutations)
 
         cluster.map_all_hosts_in_shards(
-            {shard_num: mutation.wait for shard_num, mutation in shard_mutations.items()}
+            {
+                shard_num: RetryPolicy(mutation.wait, max_attempts=3, delay=10.0, exceptions=(MutationNotFound,))
+                for shard_num, mutation in shard_mutations.items()
+            }
         ).result()

--- a/posthog/clickhouse/test/test_cluster.py
+++ b/posthog/clickhouse/test/test_cluster.py
@@ -2,7 +2,7 @@ import re
 import uuid
 from collections import defaultdict
 from collections.abc import Callable, Iterator
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, sentinel
 
 import pytest
 from clickhouse_driver import Client
@@ -16,6 +16,7 @@ from posthog.clickhouse.cluster import (
     MutationRunner,
     T,
     Query,
+    RetryPolicy,
     get_cluster,
 )
 from posthog.models.event.sql import EVENTS_DATA_TABLE
@@ -54,6 +55,34 @@ def test_exception_summary(snapshot, cluster: ClickhouseCluster) -> None:
         cluster.map_all_hosts(explode).result()
 
     assert replace_memory_addresses_and_ips(e.value.message) == snapshot
+
+
+def test_retry_policy():
+    # happy function, should not be retried
+    task = RetryPolicy(Mock(side_effect=[sentinel.RESULT]), max_attempts=2, delay=0)
+    assert task(Mock()) is sentinel.RESULT
+    assert task.callable.call_count == 1
+
+    # flaky function, should be retried
+    task = RetryPolicy(Mock(side_effect=[Exception(), sentinel.RESULT]), max_attempts=2, delay=0)
+    assert task(Mock()) is sentinel.RESULT
+    assert task.callable.call_count == 2
+
+    # always fails, up to max allowed
+    task = RetryPolicy(Mock(side_effect=Exception(sentinel.ERROR)), max_attempts=2, delay=0)
+    with pytest.raises(Exception) as e:
+        task(Mock())
+
+    assert e.value.args == (sentinel.ERROR,)
+    assert task.callable.call_count == 2
+
+    # unexpected error, should not be retried
+    task = RetryPolicy(Mock(side_effect=Exception(sentinel.ERROR)), max_attempts=2, delay=0, exceptions=(ValueError,))
+    with pytest.raises(Exception) as e:
+        task(Mock())
+
+    assert e.value.args == (sentinel.ERROR,)
+    assert task.callable.call_count == 1
 
 
 def test_mutations(cluster: ClickhouseCluster) -> None:


### PR DESCRIPTION
## Problem

`MutationRunner.run_on_shards` sometimes tries to check mutation status on shards before the shard is aware of the mutation. This seems especially likely when those servers are under heavy load.

## Changes

Wraps the mutation waiter in a retry policy that retries several times in the event that a mutation is not yet available before giving up.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added unit test for retry policy, change to the job is covered by existing integration test