### PR TITLE
feat: query metadata to return index usage

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -6917,10 +6917,10 @@
         "ExperimentDataWarehouseMetricConfig": {
             "additionalProperties": false,
             "properties": {
-                "after_exposure_identifier_field": {
+                "data_warehouse_join_key": {
                     "type": "string"
                 },
-                "exposure_identifier_field": {
+                "events_join_key": {
                     "type": "string"
                 },
                 "kind": {
@@ -6936,6 +6936,9 @@
                 "math_property": {
                     "type": "string"
                 },
+                "name": {
+                    "type": "string"
+                },
                 "table_name": {
                     "type": "string"
                 },
@@ -6943,13 +6946,27 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "kind",
-                "table_name",
-                "timestamp_field",
-                "exposure_identifier_field",
-                "after_exposure_identifier_field"
-            ],
+            "required": ["kind", "table_name", "timestamp_field", "events_join_key", "data_warehouse_join_key"],
+            "type": "object"
+        },
+        "ExperimentEventExposureConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "event": {
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "ExperimentEventExposureConfig",
+                    "type": "string"
+                },
+                "properties": {
+                    "items": {
+                        "$ref": "#/definitions/AnyPropertyFilter"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["kind", "event", "properties"],
             "type": "object"
         },
         "ExperimentEventMetricConfig": {
@@ -6983,6 +7000,18 @@
                 }
             },
             "required": ["kind", "event"],
+            "type": "object"
+        },
+        "ExperimentExposureCriteria": {
+            "additionalProperties": false,
+            "properties": {
+                "exposure_config": {
+                    "$ref": "#/definitions/ExperimentEventExposureConfig"
+                },
+                "filterTestAccounts": {
+                    "type": "boolean"
+                }
+            },
             "type": "object"
         },
         "ExperimentExposureQuery": {
@@ -7151,9 +7180,6 @@
         "ExperimentMetric": {
             "additionalProperties": false,
             "properties": {
-                "filterTestAccounts": {
-                    "type": "boolean"
-                },
                 "inverse": {
                     "type": "boolean"
                 },
@@ -8846,6 +8872,9 @@
                 "code_name": {
                     "type": "string"
                 },
+                "isNull": {
+                    "type": "boolean"
+                },
                 "value": {},
                 "variableId": {
                     "type": "string"
@@ -9969,6 +9998,7 @@
                 "ExperimentMetric",
                 "ExperimentQuery",
                 "ExperimentExposureQuery",
+                "ExperimentEventExposureConfig",
                 "ExperimentEventMetricConfig",
                 "ExperimentActionMetricConfig",
                 "ExperimentDataWarehouseMetricConfig",

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -6917,10 +6917,10 @@
         "ExperimentDataWarehouseMetricConfig": {
             "additionalProperties": false,
             "properties": {
-                "data_warehouse_join_key": {
+                "after_exposure_identifier_field": {
                     "type": "string"
                 },
-                "events_join_key": {
+                "exposure_identifier_field": {
                     "type": "string"
                 },
                 "kind": {
@@ -6936,9 +6936,6 @@
                 "math_property": {
                     "type": "string"
                 },
-                "name": {
-                    "type": "string"
-                },
                 "table_name": {
                     "type": "string"
                 },
@@ -6946,27 +6943,13 @@
                     "type": "string"
                 }
             },
-            "required": ["kind", "table_name", "timestamp_field", "events_join_key", "data_warehouse_join_key"],
-            "type": "object"
-        },
-        "ExperimentEventExposureConfig": {
-            "additionalProperties": false,
-            "properties": {
-                "event": {
-                    "type": "string"
-                },
-                "kind": {
-                    "const": "ExperimentEventExposureConfig",
-                    "type": "string"
-                },
-                "properties": {
-                    "items": {
-                        "$ref": "#/definitions/AnyPropertyFilter"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": ["kind", "event", "properties"],
+            "required": [
+                "kind",
+                "table_name",
+                "timestamp_field",
+                "exposure_identifier_field",
+                "after_exposure_identifier_field"
+            ],
             "type": "object"
         },
         "ExperimentEventMetricConfig": {
@@ -7000,18 +6983,6 @@
                 }
             },
             "required": ["kind", "event"],
-            "type": "object"
-        },
-        "ExperimentExposureCriteria": {
-            "additionalProperties": false,
-            "properties": {
-                "exposure_config": {
-                    "$ref": "#/definitions/ExperimentEventExposureConfig"
-                },
-                "filterTestAccounts": {
-                    "type": "boolean"
-                }
-            },
             "type": "object"
         },
         "ExperimentExposureQuery": {
@@ -7180,6 +7151,9 @@
         "ExperimentMetric": {
             "additionalProperties": false,
             "properties": {
+                "filterTestAccounts": {
+                    "type": "boolean"
+                },
                 "inverse": {
                     "type": "boolean"
                 },
@@ -8607,6 +8581,9 @@
                     },
                     "type": "array"
                 },
+                "isUsingIndices": {
+                    "$ref": "#/definitions/QueryIndexUsage"
+                },
                 "isValid": {
                     "type": "boolean"
                 },
@@ -8868,9 +8845,6 @@
             "properties": {
                 "code_name": {
                     "type": "string"
-                },
-                "isNull": {
-                    "type": "boolean"
                 },
                 "value": {},
                 "variableId": {
@@ -9995,7 +9969,6 @@
                 "ExperimentMetric",
                 "ExperimentQuery",
                 "ExperimentExposureQuery",
-                "ExperimentEventExposureConfig",
                 "ExperimentEventMetricConfig",
                 "ExperimentActionMetricConfig",
                 "ExperimentDataWarehouseMetricConfig",
@@ -10508,6 +10481,10 @@
             ],
             "type": "string"
         },
+        "QueryIndexUsage": {
+            "enum": ["undecisive", "no", "partial", "yes"],
+            "type": "string"
+        },
         "QueryRequest": {
             "additionalProperties": false,
             "properties": {
@@ -10908,6 +10885,9 @@
                                 "$ref": "#/definitions/HogQLNotice"
                             },
                             "type": "array"
+                        },
+                        "isUsingIndices": {
+                            "$ref": "#/definitions/QueryIndexUsage"
                         },
                         "isValid": {
                             "type": "boolean"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -102,6 +102,7 @@ export enum NodeKind {
     ExperimentMetric = 'ExperimentMetric',
     ExperimentQuery = 'ExperimentQuery',
     ExperimentExposureQuery = 'ExperimentExposureQuery',
+    ExperimentEventExposureConfig = 'ExperimentEventExposureConfig',
     ExperimentEventMetricConfig = 'ExperimentEventMetricConfig',
     ExperimentActionMetricConfig = 'ExperimentActionMetricConfig',
     ExperimentDataWarehouseMetricConfig = 'ExperimentDataWarehouseMetricConfig',
@@ -300,6 +301,7 @@ export interface HogQLVariable {
     variableId: string
     code_name: string
     value?: any
+    isNull?: boolean
 }
 
 export interface HogQLQuery extends DataNode<HogQLQueryResponse> {
@@ -1858,6 +1860,17 @@ export interface ExperimentTrendsQuery extends DataNode<ExperimentTrendsQueryRes
     exposure_query?: TrendsQuery
 }
 
+export interface ExperimentExposureCriteria {
+    filterTestAccounts?: boolean
+    exposure_config?: ExperimentEventExposureConfig
+}
+
+export interface ExperimentEventExposureConfig {
+    kind: NodeKind.ExperimentEventExposureConfig
+    event: string
+    properties: AnyPropertyFilter[]
+}
+
 export enum ExperimentMetricType {
     COUNT = 'count',
     CONTINUOUS = 'continuous',
@@ -1870,7 +1883,6 @@ export interface ExperimentMetric {
     kind: NodeKind.ExperimentMetric
     name?: string
     metric_type: ExperimentMetricType
-    filterTestAccounts?: boolean
     inverse?: boolean
     metric_config: ExperimentEventMetricConfig | ExperimentActionMetricConfig | ExperimentDataWarehouseMetricConfig
 }
@@ -1899,10 +1911,11 @@ export interface ExperimentActionMetricConfig {
 
 export interface ExperimentDataWarehouseMetricConfig {
     kind: NodeKind.ExperimentDataWarehouseMetricConfig
+    name?: string
     table_name: string
     timestamp_field: string
-    exposure_identifier_field: string
-    after_exposure_identifier_field: string
+    events_join_key: string
+    data_warehouse_join_key: string
     math?: ExperimentMetricMath
     math_hogql?: string
     math_property?: string

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -102,7 +102,6 @@ export enum NodeKind {
     ExperimentMetric = 'ExperimentMetric',
     ExperimentQuery = 'ExperimentQuery',
     ExperimentExposureQuery = 'ExperimentExposureQuery',
-    ExperimentEventExposureConfig = 'ExperimentEventExposureConfig',
     ExperimentEventMetricConfig = 'ExperimentEventMetricConfig',
     ExperimentActionMetricConfig = 'ExperimentActionMetricConfig',
     ExperimentDataWarehouseMetricConfig = 'ExperimentDataWarehouseMetricConfig',
@@ -301,7 +300,6 @@ export interface HogQLVariable {
     variableId: string
     code_name: string
     value?: any
-    isNull?: boolean
 }
 
 export interface HogQLQuery extends DataNode<HogQLQueryResponse> {
@@ -388,10 +386,18 @@ export interface HogQLNotice {
     fix?: string
 }
 
+export enum QueryIndexUsage {
+    Undecisive = 'undecisive',
+    No = 'no',
+    Partial = 'partial',
+    Yes = 'yes',
+}
+
 export interface HogQLMetadataResponse {
     query?: string
     isValid?: boolean
     isValidView?: boolean
+    isUsingIndices?: QueryIndexUsage
     errors: HogQLNotice[]
     warnings: HogQLNotice[]
     notices: HogQLNotice[]
@@ -1852,17 +1858,6 @@ export interface ExperimentTrendsQuery extends DataNode<ExperimentTrendsQueryRes
     exposure_query?: TrendsQuery
 }
 
-export interface ExperimentExposureCriteria {
-    filterTestAccounts?: boolean
-    exposure_config?: ExperimentEventExposureConfig
-}
-
-export interface ExperimentEventExposureConfig {
-    kind: NodeKind.ExperimentEventExposureConfig
-    event: string
-    properties: AnyPropertyFilter[]
-}
-
 export enum ExperimentMetricType {
     COUNT = 'count',
     CONTINUOUS = 'continuous',
@@ -1875,6 +1870,7 @@ export interface ExperimentMetric {
     kind: NodeKind.ExperimentMetric
     name?: string
     metric_type: ExperimentMetricType
+    filterTestAccounts?: boolean
     inverse?: boolean
     metric_config: ExperimentEventMetricConfig | ExperimentActionMetricConfig | ExperimentDataWarehouseMetricConfig
 }
@@ -1903,11 +1899,10 @@ export interface ExperimentActionMetricConfig {
 
 export interface ExperimentDataWarehouseMetricConfig {
     kind: NodeKind.ExperimentDataWarehouseMetricConfig
-    name?: string
     table_name: string
     timestamp_field: string
-    events_join_key: string
-    data_warehouse_join_key: string
+    exposure_identifier_field: string
+    after_exposure_identifier_field: string
     math?: ExperimentMetricMath
     math_hogql?: string
     math_property?: string

--- a/posthog/clickhouse/explain.py
+++ b/posthog/clickhouse/explain.py
@@ -96,8 +96,11 @@ def guestimate_index_use(plan_with_indexes: dict) -> dict:
             partition = selected_less_granules(index)
         elif index_type == "PrimaryKey":
             primary_key = len(index.get("Keys", [])) > 0 and selected_less_granules(index)
-    if ((not has_min_max and not has_partition) or min_max or partition) and primary_key:
-        result["use"] = QueryIndexUsage.YES
+    if primary_key:
+        if (not has_min_max and not has_partition) or min_max or partition:
+            result["use"] = QueryIndexUsage.YES
+        else:
+            result["use"] = QueryIndexUsage.PARTIAL
 
     return result
 

--- a/posthog/clickhouse/explain.py
+++ b/posthog/clickhouse/explain.py
@@ -1,0 +1,97 @@
+import json
+
+from posthog.schema import QueryIndexUsage
+
+
+def find_all_reads(explain: dict) -> list[dict]:
+    reads = []
+    plan = explain.get("Plan", explain)
+    if "Indexes" in plan:
+        reads.append(plan)
+    for subplan in plan.get("Plans", []):
+        reads = reads + find_all_reads(subplan)
+    return reads
+
+
+def selected_less_granules(index, tiny_data_granules=100) -> bool:
+    initial_granules = index.get("Initial Granules", 0)
+    return index.get("Selected Granules", 0) < initial_granules or initial_granules < tiny_data_granules
+
+
+def guestimate_index_use(plan_with_indexes: dict) -> dict:
+    db_table = plan_with_indexes.get("Description", "")
+    result = {
+        "table": db_table,
+    }
+    if "Indexes" not in plan_with_indexes:
+        result["use"] = QueryIndexUsage.NO
+        return result
+
+    indexes = plan_with_indexes.get("Indexes", [])
+
+    if db_table.endswith(".person_distinct_id_overrides"):
+        result["use"] = QueryIndexUsage.NO
+        if len(indexes) == 1:
+            index = indexes[0]
+            if (
+                index.get("Condition", "") != "true"
+                and "team_id" in index.get("Keys", [])
+                and selected_less_granules(index)
+            ):
+                result["use"] = QueryIndexUsage.YES
+
+        return result
+    elif db_table.endswith(".sharded_events"):
+        result["use"] = QueryIndexUsage.NO
+        minMax = False
+        partition = False
+        primary_key = False
+        for index in indexes:
+            if index.get("Condition", "") == "true":
+                continue
+            index_type = index.get("Type", "")
+            if index_type == "MinMax":
+                minMax = selected_less_granules(index)
+            elif index_type == "Partition":
+                partition = selected_less_granules(index)
+            elif index_type == "PrimaryKey":
+                primary_key = len(index.get("Keys", [])) > 1 and selected_less_granules(index)
+        if (minMax or partition) and primary_key:
+            result["use"] = QueryIndexUsage.YES
+
+        return result
+
+    result["use"] = QueryIndexUsage.UNDECISIVE
+    minMax = False
+    partition = False
+    primary_key = False
+    for index in indexes:
+        if index.get("Condition", "") == "true":
+            continue
+        index_type = index.get("Type", "")
+        if index_type == "MinMax":
+            minMax = selected_less_granules(index)
+        elif index_type == "Partition":
+            partition = selected_less_granules(index)
+        elif index_type == "PrimaryKey":
+            primary_key = len(index.get("Keys", [])) > 1 and selected_less_granules(index)
+    if (minMax or partition) and primary_key:
+        result["use"] = QueryIndexUsage.YES
+
+    return result
+
+
+def extract_index_usage_from_plan(plan: str) -> QueryIndexUsage:
+    try:
+        explain = json.loads(plan)
+        all_indices_use = [guestimate_index_use(r) for r in find_all_reads(explain[0])]
+        if all(x["use"] == QueryIndexUsage.YES for x in all_indices_use):
+            return QueryIndexUsage.YES
+        elif any(x["use"] == QueryIndexUsage.YES for x in all_indices_use):
+            return QueryIndexUsage.PARTIAL
+        elif all(x["use"] == QueryIndexUsage.NO for x in all_indices_use):
+            return QueryIndexUsage.NO
+    except json.decoder.JSONDecodeError:
+        pass
+
+    return QueryIndexUsage.UNDECISIVE

--- a/posthog/clickhouse/explain.py
+++ b/posthog/clickhouse/explain.py
@@ -77,7 +77,9 @@ def guestimate_index_use(plan_with_indexes: dict) -> dict:
         return result
 
     result["use"] = QueryIndexUsage.UNDECISIVE
+    hasMinMax = False
     minMax = False
+    hasPartition = False
     partition = False
     primary_key = False
     for index in indexes:
@@ -85,12 +87,14 @@ def guestimate_index_use(plan_with_indexes: dict) -> dict:
             continue
         index_type = index.get("Type", "")
         if index_type == "MinMax":
+            hasMinMax = True
             minMax = selected_less_granules(index)
         elif index_type == "Partition":
+            hasPartition = True
             partition = selected_less_granules(index)
         elif index_type == "PrimaryKey":
             primary_key = len(index.get("Keys", [])) > 1 and selected_less_granules(index)
-    if (minMax or partition) and primary_key:
+    if ((not hasMinMax and not hasPartition) or minMax or partition) and primary_key:
         result["use"] = QueryIndexUsage.YES
 
     return result

--- a/posthog/clickhouse/test/test_explain.py
+++ b/posthog/clickhouse/test/test_explain.py
@@ -308,6 +308,132 @@ test_cases = [
 ]
 """,
     },
+    {
+        "query": "local query little granules",
+        "reads": 1,
+        "reads_use": [
+            {
+                "table": "default.sharded_events",
+                "use": QueryIndexUsage.NO,
+            }
+        ],
+        "use": QueryIndexUsage.NO,
+        "plan": """
+[
+  {
+    "Plan": {
+      "Node Type": "Expression",
+      "Description": "(Project names + Projection)",
+      "Plans": [
+        {
+          "Node Type": "Limit",
+          "Description": "preliminary LIMIT (without OFFSET)",
+          "Plans": [
+            {
+              "Node Type": "Expression",
+              "Plans": [
+                {
+                  "Node Type": "ReadFromMergeTree",
+                  "Description": "default.sharded_events",
+                  "Indexes": [
+                    {
+                      "Type": "MinMax",
+                      "Condition": "true",
+                      "Initial Parts": 12,
+                      "Selected Parts": 12,
+                      "Initial Granules": 39,
+                      "Selected Granules": 39
+                    },
+                    {
+                      "Type": "Partition",
+                      "Condition": "true",
+                      "Initial Parts": 12,
+                      "Selected Parts": 12,
+                      "Initial Granules": 39,
+                      "Selected Granules": 39
+                    },
+                    {
+                      "Type": "PrimaryKey",
+                      "Keys": ["team_id"],
+                      "Condition": "(team_id in [1, 1])",
+                      "Initial Parts": 12,
+                      "Selected Parts": 9,
+                      "Initial Granules": 39,
+                      "Selected Granules": 32
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+]
+""",
+    },
+    {
+        "query": "local query little granules, using index",
+        "reads": 1,
+        "reads_use": [{"table": "default.sharded_events", "use": QueryIndexUsage.YES}],
+        "use": QueryIndexUsage.YES,
+        "plan": """
+[
+  {
+    "Plan": {
+      "Node Type": "Expression",
+      "Description": "(Project names + Projection)",
+      "Plans": [
+        {
+          "Node Type": "Limit",
+          "Description": "preliminary LIMIT (without OFFSET)",
+          "Plans": [
+            {
+              "Node Type": "Expression",
+              "Plans": [
+                {
+                  "Node Type": "ReadFromMergeTree",
+                  "Description": "default.sharded_events",
+                  "Indexes": [
+                    {
+                      "Type": "MinMax",
+                      "Keys": ["timestamp"],
+                      "Condition": "(toTimezone(timestamp, 'UTC') in ('1735831217', +Inf))",
+                      "Initial Parts": 11,
+                      "Selected Parts": 6,
+                      "Initial Granules": 38,
+                      "Selected Granules": 32
+                    },
+                    {
+                      "Type": "Partition",
+                      "Condition": "true",
+                      "Initial Parts": 6,
+                      "Selected Parts": 6,
+                      "Initial Granules": 32,
+                      "Selected Granules": 32
+                    },
+                    {
+                      "Type": "PrimaryKey",
+                      "Keys": ["team_id"],
+                      "Condition": "(team_id in [1, 1])",
+                      "Initial Parts": 6,
+                      "Selected Parts": 5,
+                      "Initial Granules": 32,
+                      "Selected Granules": 27
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+]
+""",
+    },
 ]
 
 

--- a/posthog/clickhouse/test/test_explain.py
+++ b/posthog/clickhouse/test/test_explain.py
@@ -1,0 +1,320 @@
+import json
+
+import pytest
+
+from posthog.clickhouse.explain import find_all_reads, guestimate_index_use, extract_index_usage_from_plan
+from posthog.schema import QueryIndexUsage
+
+test_cases = [
+    {
+        "query": "a proper query with all filters on events",
+        "reads": 1,
+        "reads_use": [{"table": "posthog.sharded_events", "use": QueryIndexUsage.YES}],
+        "use": QueryIndexUsage.YES,
+        "plan": """[
+  {
+    "Plan": {
+      "Node Type": "Union",
+      "Plans": [
+        {
+          "Node Type": "Expression",
+          "Description": "(Projection + Before ORDER BY)",
+          "Plans": [
+            {
+              "Node Type": "Expression",
+              "Plans": [
+                {
+                  "Node Type": "ReadFromMergeTree",
+                  "Description": "posthog.sharded_events",
+                  "Indexes": [
+                    {
+                      "Type": "MinMax",
+                      "Keys": [
+                        "timestamp"
+                      ],
+                      "Condition": "(timestamp in ('1735828351', +Inf))",
+                      "Initial Parts": 2799,
+                      "Selected Parts": 222,
+                      "Initial Granules": 173418552,
+                      "Selected Granules": 26462626
+                    },
+                    {
+                      "Type": "Partition",
+                      "Keys": [
+                        "toYYYYMM(timestamp)"
+                      ],
+                      "Condition": "(toYYYYMM(timestamp) in [202501, +Inf))",
+                      "Initial Parts": 222,
+                      "Selected Parts": 222,
+                      "Initial Granules": 26462626,
+                      "Selected Granules": 26462626
+                    },
+                    {
+                      "Type": "PrimaryKey",
+                      "Keys": [
+                        "team_id",
+                        "toDate(timestamp)",
+                        "event"
+                      ],
+                      "Condition": "and((toDate(timestamp) in [20090, +Inf)), and((event in ['$pageview', '$pageview']), (team_id in [2, 2])))",
+                      "Initial Parts": 222,
+                      "Selected Parts": 181,
+                      "Initial Granules": 26462626,
+                      "Selected Granules": 35950
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Node Type": "ReadFromRemote",
+          "Description": "Read from remote replica"
+        }
+      ]
+    }
+  }
+]
+""",
+    },
+    {
+        "query": "missing timestamp condition",
+        "reads": 1,
+        "reads_use": [{"table": "posthog.sharded_events", "use": QueryIndexUsage.NO}],
+        "use": QueryIndexUsage.NO,
+        "plan": """
+[
+  {
+    "Plan": {
+      "Node Type": "Union",
+      "Plans": [
+        {
+          "Node Type": "Expression",
+          "Description": "(Projection + Before ORDER BY)",
+          "Plans": [
+            {
+              "Node Type": "Expression",
+              "Plans": [
+                {
+                  "Node Type": "ReadFromMergeTree",
+                  "Description": "posthog.sharded_events",
+                  "Indexes": [
+                    {
+                      "Type": "MinMax",
+                      "Condition": "true",
+                      "Initial Parts": 2972,
+                      "Selected Parts": 2972,
+                      "Initial Granules": 171921031,
+                      "Selected Granules": 171921031
+                    },
+                    {
+                      "Type": "Partition",
+                      "Condition": "true",
+                      "Initial Parts": 2972,
+                      "Selected Parts": 2972,
+                      "Initial Granules": 171921031,
+                      "Selected Granules": 171921031
+                    },
+                    {
+                      "Type": "PrimaryKey",
+                      "Keys": [
+                        "team_id",
+                        "event"
+                      ],
+                      "Condition": "and((event in ['$pageview', '$pageview']), (team_id in [2, 2]))",
+                      "Initial Parts": 2972,
+                      "Selected Parts": 1002,
+                      "Initial Granules": 171921031,
+                      "Selected Granules": 245218
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Node Type": "ReadFromRemote",
+          "Description": "Read from remote replica"
+        }
+      ]
+    }
+  }
+]
+""",
+    },
+    {
+        "query": "production query often failing cause ClickHouse not using index",
+        "reads": 2,
+        "reads_use": [
+            {"table": "posthog.sharded_events", "use": QueryIndexUsage.NO},
+            {"table": "posthog.person_distinct_id_overrides", "use": QueryIndexUsage.YES},
+        ],
+        "use": QueryIndexUsage.PARTIAL,
+        "plan": """
+[
+  {
+    "Plan": {
+      "Node Type": "Expression",
+      "Description": "Projection",
+      "Plans": [
+        {
+          "Node Type": "Limit",
+          "Description": "preliminary LIMIT (without OFFSET)",
+          "Plans": [
+            {
+              "Node Type": "Sorting",
+              "Description": "Sorting for ORDER BY",
+              "Plans": [
+                {
+                  "Node Type": "Expression",
+                  "Description": "Before ORDER BY",
+                  "Plans": [
+                    {
+                      "Node Type": "Aggregating",
+                      "Plans": [
+                        {
+                          "Node Type": "Expression",
+                          "Description": "(Before GROUP BY + (Projection + Before ORDER BY))",
+                          "Plans": [
+                            {
+                              "Node Type": "MergingAggregated",
+                              "Plans": [
+                                {
+                                  "Node Type": "Union",
+                                  "Plans": [
+                                    {
+                                      "Node Type": "Aggregating",
+                                      "Plans": [
+                                        {
+                                          "Node Type": "Expression",
+                                          "Description": "(Before GROUP BY + )",
+                                          "Plans": [
+                                            {
+                                              "Node Type": "Join",
+                                              "Description": "JOIN FillRightFirst",
+                                              "Plans": [
+                                                {
+                                                  "Node Type": "Expression",
+                                                  "Plans": [
+                                                    {
+                                                      "Node Type": "ReadFromMergeTree",
+                                                      "Description": "posthog.sharded_events",
+                                                      "Indexes": [
+                                                        {
+                                                          "Type": "MinMax",
+                                                          "Condition": "true",
+                                                          "Initial Parts": 2759,
+                                                          "Selected Parts": 2759,
+                                                          "Initial Granules": 173438060,
+                                                          "Selected Granules": 173438060
+                                                        },
+                                                        {
+                                                          "Type": "Partition",
+                                                          "Condition": "true",
+                                                          "Initial Parts": 2759,
+                                                          "Selected Parts": 2759,
+                                                          "Initial Granules": 173438060,
+                                                          "Selected Granules": 173438060
+                                                        },
+                                                        {
+                                                          "Type": "PrimaryKey",
+                                                          "Keys": [
+                                                            "team_id"
+                                                          ],
+                                                          "Condition": "(team_id in [16617, 16617])",
+                                                          "Initial Parts": 2759,
+                                                          "Selected Parts": 1699,
+                                                          "Initial Granules": 173438060,
+                                                          "Selected Granules": 1877152
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "Node Type": "Expression",
+                                                  "Description": "(Joined actions + (Rename joined columns + (Projection + Before ORDER BY)))",
+                                                  "Plans": [
+                                                    {
+                                                      "Node Type": "Filter",
+                                                      "Description": "HAVING",
+                                                      "Plans": [
+                                                        {
+                                                          "Node Type": "Aggregating",
+                                                          "Plans": [
+                                                            {
+                                                              "Node Type": "Expression",
+                                                              "Description": "Before GROUP BY",
+                                                              "Plans": [
+                                                                {
+                                                                  "Node Type": "Expression",
+                                                                  "Plans": [
+                                                                    {
+                                                                      "Node Type": "ReadFromMergeTree",
+                                                                      "Description": "posthog.person_distinct_id_overrides",
+                                                                      "Indexes": [
+                                                                        {
+                                                                          "Type": "PrimaryKey",
+                                                                          "Keys": [
+                                                                            "team_id"
+                                                                          ],
+                                                                          "Condition": "(team_id in [16617, 16617])",
+                                                                          "Initial Parts": 18,
+                                                                          "Selected Parts": 18,
+                                                                          "Initial Granules": 155239,
+                                                                          "Selected Granules": 18
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Node Type": "ReadFromRemote",
+                                      "Description": "Read from remote replica"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+]
+""",
+    },
+]
+
+
+@pytest.mark.parametrize("case", test_cases, ids=[x["query"] for x in test_cases])
+def test_full_queries(case):
+    explain = json.loads(case["plan"])
+    reads = find_all_reads(explain[0])
+    assert case["reads"] == len(reads)
+    assert case["reads_use"] == [guestimate_index_use(r) for r in reads]
+    assert case["use"] == extract_index_usage_from_plan(case["plan"])

--- a/posthog/hogql/metadata.py
+++ b/posthog/hogql/metadata.py
@@ -1,9 +1,9 @@
-import json
 from typing import Optional, cast
 
 from django.conf import settings
 
 from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.explain import extract_index_usage_from_plan
 from posthog.hogql import ast
 from posthog.hogql.compiler.bytecode import create_bytecode
 from posthog.hogql.context import HogQLContext
@@ -30,10 +30,6 @@ from posthog.schema import (
     QueryIndexUsage,
 )
 from posthog.hogql.visitor import TraversingVisitor
-
-
-def extract_index_usage_from_plan(plan: str) -> QueryIndexUsage:
-    return QueryIndexUsage.UNDECISIVE
 
 
 def get_hogql_metadata(
@@ -98,8 +94,8 @@ def get_hogql_metadata(
                     team_id=team.pk,
                     readonly=True,
                 )
-                response.isUsingIndices = extract_index_usage_from_plan(json.loads(explain_results[0][0][0]))
-            finally:
+                response.isUsingIndices = extract_index_usage_from_plan(explain_results[0][0][0])
+            except:
                 response.isUsingIndices = QueryIndexUsage.UNDECISIVE
         else:
             raise ValueError(f"Unsupported language: {query.language}")

--- a/posthog/hogql/test/test_metadata.py
+++ b/posthog/hogql/test/test_metadata.py
@@ -7,6 +7,57 @@ from posthog.models import Cohort, PropertyDefinition
 from posthog.schema import HogLanguage, HogQLMetadata, HogQLMetadataResponse, HogQLQuery
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 
+explain_plan_0 = """
+[
+  {
+    "Plan": {
+      "Node Type": "Expression",
+      "Description": "(Project names + Projection)",
+      "Plans": [
+        {
+          "Node Type": "Expression",
+          "Plans": [
+            {
+              "Node Type": "ReadFromMergeTree",
+              "Description": "default.sharded_events",
+              "Indexes": [
+                {
+                  "Type": "MinMax",
+                  "Keys": ["timestamp"],
+                  "Condition": "(timestamp in ('1735828351', +Inf))",
+                  "Initial Parts": 7,
+                  "Selected Parts": 3,
+                  "Initial Granules": 14,
+                  "Selected Granules": 9
+                },
+                {
+                  "Type": "Partition",
+                  "Keys": ["toYYYYMM(timestamp)"],
+                  "Condition": "(toYYYYMM(timestamp) in [202501, +Inf))",
+                  "Initial Parts": 3,
+                  "Selected Parts": 3,
+                  "Initial Granules": 9,
+                  "Selected Granules": 9
+                },
+                {
+                  "Type": "PrimaryKey",
+                  "Keys": ["team_id", "toDate(timestamp)"],
+                  "Condition": "and((toDate(timestamp) in [20090, +Inf)), (team_id in [1, 1]))",
+                  "Initial Parts": 3,
+                  "Selected Parts": 3,
+                  "Initial Granules": 9,
+                  "Selected Granules": 9
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+]
+"""
+
 
 class TestMetadata(ClickhouseTestMixin, APIBaseTest):
     maxDiff = None

--- a/posthog/hogql/test/test_metadata.py
+++ b/posthog/hogql/test/test_metadata.py
@@ -1,4 +1,3 @@
-import json
 from typing import Optional
 
 from django.test import override_settings
@@ -7,65 +6,6 @@ from posthog.hogql.metadata import get_hogql_metadata
 from posthog.models import Cohort, PropertyDefinition
 from posthog.schema import HogLanguage, HogQLMetadata, HogQLMetadataResponse, HogQLQuery
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
-
-explain_plan_0 = """
-[
-  {
-    "Plan": {
-      "Node Type": "Expression",
-      "Description": "(Project names + Projection)",
-      "Plans": [
-        {
-          "Node Type": "Expression",
-          "Plans": [
-            {
-              "Node Type": "ReadFromMergeTree",
-              "Description": "default.sharded_events",
-              "Indexes": [
-                {
-                  "Type": "MinMax",
-                  "Keys": ["timestamp"],
-                  "Condition": "(timestamp in ('1735828351', +Inf))",
-                  "Initial Parts": 7,
-                  "Selected Parts": 3,
-                  "Initial Granules": 14,
-                  "Selected Granules": 9
-                },
-                {
-                  "Type": "Partition",
-                  "Keys": ["toYYYYMM(timestamp)"],
-                  "Condition": "(toYYYYMM(timestamp) in [202501, +Inf))",
-                  "Initial Parts": 3,
-                  "Selected Parts": 3,
-                  "Initial Granules": 9,
-                  "Selected Granules": 9
-                },
-                {
-                  "Type": "PrimaryKey",
-                  "Keys": ["team_id", "toDate(timestamp)"],
-                  "Condition": "and((toDate(timestamp) in [20090, +Inf)), (team_id in [1, 1]))",
-                  "Initial Parts": 3,
-                  "Selected Parts": 3,
-                  "Initial Granules": 9,
-                  "Selected Granules": 9
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  }
-]
-"""
-
-
-def test_something_simple():
-    explain = json.loads(explain_plan_0)
-    for plan in explain.get(0, {}).get("Plan", {}).get("Plans", []):
-        if plan.get("Node Type", "") == "ReadFromMergeTree":
-            for index in plan.get("Indexes", []):
-                return index.get("Condition", "")
 
 
 class TestMetadata(ClickhouseTestMixin, APIBaseTest):

--- a/posthog/hogql/test/test_metadata.py
+++ b/posthog/hogql/test/test_metadata.py
@@ -1,3 +1,4 @@
+import json
 from typing import Optional
 
 from django.test import override_settings
@@ -57,6 +58,14 @@ explain_plan_0 = """
   }
 ]
 """
+
+
+def test_something_simple():
+    explain = json.loads(explain_plan_0)
+    for plan in explain.get(0, {}).get("Plan", {}).get("Plans", []):
+        if plan.get("Node Type", "") == "ReadFromMergeTree":
+            for index in plan.get("Indexes", []):
+                return index.get("Condition", "")
 
 
 class TestMetadata(ClickhouseTestMixin, APIBaseTest):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -985,7 +985,6 @@ class HogQLVariable(BaseModel):
         extra="forbid",
     )
     code_name: str
-    isNull: Optional[bool] = None
     value: Optional[Any] = None
     variableId: str
 
@@ -1135,7 +1134,6 @@ class NodeKind(StrEnum):
     EXPERIMENT_METRIC = "ExperimentMetric"
     EXPERIMENT_QUERY = "ExperimentQuery"
     EXPERIMENT_EXPOSURE_QUERY = "ExperimentExposureQuery"
-    EXPERIMENT_EVENT_EXPOSURE_CONFIG = "ExperimentEventExposureConfig"
     EXPERIMENT_EVENT_METRIC_CONFIG = "ExperimentEventMetricConfig"
     EXPERIMENT_ACTION_METRIC_CONFIG = "ExperimentActionMetricConfig"
     EXPERIMENT_DATA_WAREHOUSE_METRIC_CONFIG = "ExperimentDataWarehouseMetricConfig"
@@ -1259,6 +1257,13 @@ class PropertyOperator(StrEnum):
     IN_ = "in"
     NOT_IN = "not_in"
     IS_CLEANED_PATH_EXACT = "is_cleaned_path_exact"
+
+
+class QueryIndexUsage(StrEnum):
+    UNDECISIVE = "undecisive"
+    NO = "no"
+    PARTIAL = "partial"
+    YES = "yes"
 
 
 class QueryResponseAlternative5(BaseModel):
@@ -2268,13 +2273,12 @@ class ExperimentDataWarehouseMetricConfig(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    data_warehouse_join_key: str
-    events_join_key: str
+    after_exposure_identifier_field: str
+    exposure_identifier_field: str
     kind: Literal["ExperimentDataWarehouseMetricConfig"] = "ExperimentDataWarehouseMetricConfig"
     math: Optional[ExperimentMetricMath] = None
     math_hogql: Optional[str] = None
     math_property: Optional[str] = None
-    name: Optional[str] = None
     table_name: str
     timestamp_field: str
 
@@ -2538,6 +2542,7 @@ class QueryResponseAlternative7(BaseModel):
         extra="forbid",
     )
     errors: list[HogQLNotice]
+    isUsingIndices: Optional[QueryIndexUsage] = None
     isValid: Optional[bool] = None
     isValidView: Optional[bool] = None
     notices: list[HogQLNotice]
@@ -4620,31 +4625,6 @@ class ExperimentActionMetricConfig(BaseModel):
     ] = Field(default=None, description="Properties configurable in the interface")
 
 
-class ExperimentEventExposureConfig(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    event: str
-    kind: Literal["ExperimentEventExposureConfig"] = "ExperimentEventExposureConfig"
-    properties: list[
-        Union[
-            EventPropertyFilter,
-            PersonPropertyFilter,
-            ElementPropertyFilter,
-            SessionPropertyFilter,
-            CohortPropertyFilter,
-            RecordingPropertyFilter,
-            LogEntryPropertyFilter,
-            GroupPropertyFilter,
-            FeaturePropertyFilter,
-            HogQLPropertyFilter,
-            EmptyPropertyFilter,
-            DataWarehousePropertyFilter,
-            DataWarehousePersonPropertyFilter,
-        ]
-    ]
-
-
 class ExperimentEventMetricConfig(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -4676,14 +4656,6 @@ class ExperimentEventMetricConfig(BaseModel):
     ] = Field(default=None, description="Properties configurable in the interface")
 
 
-class ExperimentExposureCriteria(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    exposure_config: Optional[ExperimentEventExposureConfig] = None
-    filterTestAccounts: Optional[bool] = None
-
-
 class ExperimentExposureQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -4700,6 +4672,7 @@ class ExperimentMetric(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    filterTestAccounts: Optional[bool] = None
     inverse: Optional[bool] = None
     kind: Literal["ExperimentMetric"] = "ExperimentMetric"
     metric_config: Union[ExperimentEventMetricConfig, ExperimentActionMetricConfig, ExperimentDataWarehouseMetricConfig]
@@ -4956,6 +4929,7 @@ class HogQLMetadataResponse(BaseModel):
         extra="forbid",
     )
     errors: list[HogQLNotice]
+    isUsingIndices: Optional[QueryIndexUsage] = None
     isValid: Optional[bool] = None
     isValidView: Optional[bool] = None
     notices: list[HogQLNotice]

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -985,6 +985,7 @@ class HogQLVariable(BaseModel):
         extra="forbid",
     )
     code_name: str
+    isNull: Optional[bool] = None
     value: Optional[Any] = None
     variableId: str
 
@@ -1134,6 +1135,7 @@ class NodeKind(StrEnum):
     EXPERIMENT_METRIC = "ExperimentMetric"
     EXPERIMENT_QUERY = "ExperimentQuery"
     EXPERIMENT_EXPOSURE_QUERY = "ExperimentExposureQuery"
+    EXPERIMENT_EVENT_EXPOSURE_CONFIG = "ExperimentEventExposureConfig"
     EXPERIMENT_EVENT_METRIC_CONFIG = "ExperimentEventMetricConfig"
     EXPERIMENT_ACTION_METRIC_CONFIG = "ExperimentActionMetricConfig"
     EXPERIMENT_DATA_WAREHOUSE_METRIC_CONFIG = "ExperimentDataWarehouseMetricConfig"
@@ -2273,12 +2275,13 @@ class ExperimentDataWarehouseMetricConfig(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    after_exposure_identifier_field: str
-    exposure_identifier_field: str
+    data_warehouse_join_key: str
+    events_join_key: str
     kind: Literal["ExperimentDataWarehouseMetricConfig"] = "ExperimentDataWarehouseMetricConfig"
     math: Optional[ExperimentMetricMath] = None
     math_hogql: Optional[str] = None
     math_property: Optional[str] = None
+    name: Optional[str] = None
     table_name: str
     timestamp_field: str
 
@@ -4625,6 +4628,31 @@ class ExperimentActionMetricConfig(BaseModel):
     ] = Field(default=None, description="Properties configurable in the interface")
 
 
+class ExperimentEventExposureConfig(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    event: str
+    kind: Literal["ExperimentEventExposureConfig"] = "ExperimentEventExposureConfig"
+    properties: list[
+        Union[
+            EventPropertyFilter,
+            PersonPropertyFilter,
+            ElementPropertyFilter,
+            SessionPropertyFilter,
+            CohortPropertyFilter,
+            RecordingPropertyFilter,
+            LogEntryPropertyFilter,
+            GroupPropertyFilter,
+            FeaturePropertyFilter,
+            HogQLPropertyFilter,
+            EmptyPropertyFilter,
+            DataWarehousePropertyFilter,
+            DataWarehousePersonPropertyFilter,
+        ]
+    ]
+
+
 class ExperimentEventMetricConfig(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -4656,6 +4684,14 @@ class ExperimentEventMetricConfig(BaseModel):
     ] = Field(default=None, description="Properties configurable in the interface")
 
 
+class ExperimentExposureCriteria(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    exposure_config: Optional[ExperimentEventExposureConfig] = None
+    filterTestAccounts: Optional[bool] = None
+
+
 class ExperimentExposureQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -4672,7 +4708,6 @@ class ExperimentMetric(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    filterTestAccounts: Optional[bool] = None
     inverse: Optional[bool] = None
     kind: Literal["ExperimentMetric"] = "ExperimentMetric"
     metric_config: Union[ExperimentEventMetricConfig, ExperimentActionMetricConfig, ExperimentDataWarehouseMetricConfig]


### PR DESCRIPTION
## Problem

No way to understand why queries are slow

## Changes

Added isUsingIndices to HogQL Metadata Response.

Doing a full check is quite a complex task, what is done here is a verification that there are at least some conditions on primary keys.

![Screenshot 2025-02-26 at 01 32 02](https://github.com/user-attachments/assets/29b6c685-ac61-4261-b560-77267e4540e0)

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Have tests. Run locally.
