### PR TITLE
chore(data-warehouse): Dont allow deleting of tables with a source

### DIFF
--- a/posthog/warehouse/api/table.py
+++ b/posthog/warehouse/api/table.py
@@ -185,6 +185,12 @@ class TableViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
     def destroy(self, request: request.Request, *args: Any, **kwargs: Any) -> response.Response:
         instance: DataWarehouseTable = self.get_object()
+
+        if instance.external_data_source is not None:
+            return response.Response(
+                status=status.HTTP_400_BAD_REQUEST, data={"message": "Can't delete a sourced table"}
+            )
+
         instance.soft_delete()
 
         return response.Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## Problem
- This isn't possible from the frontend right now, but it is possible via our frontend API and so I just wanna make a guard on the backend to make sure sourced tables dont get deleted

## Changes
- Dont allow deletions of `Table` objects if attempted via the API

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Added tests