### PR TITLE
fix(batch-exports): Attempt bigquery merge on consumer failure

### DIFF
--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -768,26 +768,28 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
                         bigquery_table=bigquery_stage_table if can_perform_merge else bigquery_table,
                         table_schema=stage_schema if can_perform_merge else schema,
                     )
-                    await run_consumer(
-                        consumer=consumer,
-                        queue=queue,
-                        producer_task=producer_task,
-                        schema=record_batch_schema,
-                        max_bytes=settings.BATCH_EXPORT_BIGQUERY_UPLOAD_CHUNK_SIZE_BYTES,
-                        json_columns=() if can_perform_merge else json_columns,
-                        writer_file_kwargs={"compression": "zstd"} if can_perform_merge else {},
-                        multiple_files=True,
-                    )
-
-                    if can_perform_merge:
-                        await bq_client.amerge_tables(
-                            final_table=bigquery_table,
-                            stage_table=bigquery_stage_table,
-                            mutable=mutable,
-                            merge_key=merge_key,
-                            update_key=update_key,
-                            stage_fields_cast_to_json=json_columns,
+                    try:
+                        await run_consumer(
+                            consumer=consumer,
+                            queue=queue,
+                            producer_task=producer_task,
+                            schema=record_batch_schema,
+                            max_bytes=settings.BATCH_EXPORT_BIGQUERY_UPLOAD_CHUNK_SIZE_BYTES,
+                            json_columns=() if can_perform_merge else json_columns,
+                            writer_file_kwargs={"compression": "zstd"} if can_perform_merge else {},
+                            multiple_files=True,
                         )
+
+                    finally:
+                        if can_perform_merge:
+                            await bq_client.amerge_tables(
+                                final_table=bigquery_table,
+                                stage_table=bigquery_stage_table,
+                                mutable=mutable,
+                                merge_key=merge_key,
+                                update_key=update_key,
+                                stage_fields_cast_to_json=json_columns,
+                            )
 
         return details.records_completed
 


### PR DESCRIPTION
## Problem

We could be leaving data in stage that never gets merged if there is an error while consuming.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Always merge stage to get partial results in.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
