### PR TITLE
fix: Make v2 ingestion the default

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -153,10 +153,7 @@
                 "KAFKA_HOSTS": "localhost:9092",
                 "WORKER_CONCURRENCY": "2",
                 "OBJECT_STORAGE_ENABLED": "True",
-                "HOG_HOOK_URL": "http://localhost:3300/hoghook",
-                "PLUGIN_SERVER_MODE": "all-v2",
-                "HOG_TRANSFORMATIONS_ENABLED": "True",
-                "HOG_TRANSFORMATIONS_COMPARISON_PERCENTAGE": "1"
+                "HOG_HOOK_URL": "http://localhost:3300/hoghook"
             },
             "presentation": {
                 "group": "main"

--- a/plugin-server/src/capabilities.ts
+++ b/plugin-server/src/capabilities.ts
@@ -7,36 +7,28 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
         : null
     const sharedCapabilities = !isTestEnv() ? { http: true } : {}
 
-    const singleProcessCapabilities: PluginServerCapabilities = {
-        mmdb: true,
-        ingestion: true,
-        ingestionOverflow: true,
-        ingestionHistorical: true,
-        eventsIngestionPipelines: true, // with null PluginServerMode we run all of them
-        pluginScheduledTasks: true,
-        processPluginJobs: true,
-        processAsyncOnEventHandlers: true,
-        processAsyncWebhooksHandlers: true,
-        sessionRecordingBlobIngestion: true,
-        sessionRecordingBlobOverflowIngestion: config.SESSION_RECORDING_OVERFLOW_ENABLED,
-        sessionRecordingBlobIngestionV2: true,
-        sessionRecordingBlobIngestionV2Overflow: config.SESSION_RECORDING_OVERFLOW_ENABLED,
-        appManagementSingleton: true,
-        preflightSchedules: true,
-        cdpProcessedEvents: true,
-        cdpInternalEvents: true,
-        cdpCyclotronWorker: true,
-        cdpCyclotronWorkerPlugins: true,
-        cdpApi: true,
-        syncInlinePlugins: true,
-        ...sharedCapabilities,
-    }
-
     switch (mode) {
         case null:
             return {
-                ...singleProcessCapabilities,
+                mmdb: true,
                 ingestionV2Combined: true,
+                pluginScheduledTasks: true,
+                processPluginJobs: true,
+                processAsyncOnEventHandlers: true,
+                processAsyncWebhooksHandlers: true,
+                sessionRecordingBlobIngestion: true,
+                sessionRecordingBlobOverflowIngestion: config.SESSION_RECORDING_OVERFLOW_ENABLED,
+                sessionRecordingBlobIngestionV2: true,
+                sessionRecordingBlobIngestionV2Overflow: config.SESSION_RECORDING_OVERFLOW_ENABLED,
+                appManagementSingleton: true,
+                preflightSchedules: true,
+                cdpProcessedEvents: true,
+                cdpInternalEvents: true,
+                cdpCyclotronWorker: true,
+                cdpCyclotronWorkerPlugins: true,
+                cdpApi: true,
+                syncInlinePlugins: true,
+                ...sharedCapabilities,
             }
 
         case PluginServerMode.ingestion_v2:

--- a/plugin-server/src/capabilities.ts
+++ b/plugin-server/src/capabilities.ts
@@ -36,10 +36,6 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
         case null:
             return {
                 ...singleProcessCapabilities,
-            }
-        case PluginServerMode.all_v2:
-            return {
-                ...singleProcessCapabilities,
                 ingestionV2Combined: true,
             }
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -73,7 +73,6 @@ export enum KafkaSaslMechanism {
 }
 
 export enum PluginServerMode {
-    all_v2 = 'all-v2',
     ingestion = 'ingestion',
     ingestion_v2 = 'ingestion-v2',
     ingestion_overflow = 'ingestion-overflow',

--- a/plugin-server/tests/server.test.ts
+++ b/plugin-server/tests/server.test.ts
@@ -89,13 +89,8 @@ describe('server', () => {
             {},
             {
                 http: true,
-                pluginScheduledTasks: true,
-                processPluginJobs: true,
-                processAsyncOnEventHandlers: true,
-                processAsyncWebhooksHandlers: true,
                 cdpProcessedEvents: true,
                 cdpCyclotronWorker: true,
-                syncInlinePlugins: true,
             }
         )
     })


### PR DESCRIPTION
## Problem

Locally the default should for sure now be the new ingestion consumers

## Changes

* Removes the special flag and makes this the default

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
