### PR TITLE
fix(vscode): plugin server launch script with loose envs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -143,7 +143,7 @@
         },
         {
             "name": "Plugin Server",
-            "command": "bin/turbo --filter=@posthog/plugin-server start",
+            "command": "bin/turbo --env-mode=loose --filter=@posthog/plugin-server start",
             "request": "launch",
             "type": "node-terminal",
             "cwd": "${workspaceFolder}",


### PR DESCRIPTION
## Problem

Couldn't launch plugin server via vscode launch config as the env variables are not passed on.

## Changes

Pass though the envs.

## How did you test this code?

Ran it locally, it started