### PR TITLE
chore: added content ref for project tree, added skip to content link

### DIFF
--- a/frontend/src/layout/navigation-3000/Navigation.tsx
+++ b/frontend/src/layout/navigation-3000/Navigation.tsx
@@ -6,7 +6,7 @@ import { BillingAlertsV2 } from 'lib/components/BillingAlertsV2'
 import { CommandBar } from 'lib/components/CommandBar/CommandBar'
 import { FlaggedFeature } from 'lib/components/FlaggedFeature'
 import { FEATURE_FLAGS } from 'lib/constants'
-import { ReactNode } from 'react'
+import { ReactNode, useRef } from 'react'
 import { SceneConfig } from 'scenes/sceneTypes'
 
 import { navigationLogic } from '../navigation/navigationLogic'
@@ -30,6 +30,7 @@ export function Navigation({
     const { theme } = useValues(themeLogic)
     const { mobileLayout } = useValues(navigationLogic)
     const { activeNavbarItem, mode } = useValues(navigation3000Logic)
+    const mainRef = useRef<HTMLElement>(null)
 
     if (mode !== 'full') {
         return (
@@ -44,13 +45,23 @@ export function Navigation({
     return (
         // eslint-disable-next-line react/forbid-dom-props
         <div className={clsx('Navigation3000', mobileLayout && 'Navigation3000--mobile')} style={theme?.mainStyle}>
+            {/* eslint-disable-next-line react/forbid-elements */}
+            <a
+                href="#main-content"
+                className="sr-only focus:not-sr-only focus:fixed focus:z-[9999999] focus:top-4 focus:left-4 focus:p-4 focus:bg-white focus:dark:bg-gray-800 focus:rounded focus:shadow-lg"
+                tabIndex={0}
+            >
+                Skip to content
+            </a>
+
             <FlaggedFeature flag={FEATURE_FLAGS.TREE_VIEW} fallback={<Navbar />}>
-                <ProjectTree />
+                <ProjectTree contentRef={mainRef} />
             </FlaggedFeature>
             <FlaggedFeature flag={FEATURE_FLAGS.POSTHOG_3000_NAV}>
                 {activeNavbarItem && <Sidebar key={activeNavbarItem.identifier} navbarItem={activeNavbarItem} />}
             </FlaggedFeature>
-            <main>
+
+            <main ref={mainRef} role="main" tabIndex={0} id="main-content">
                 {(sceneConfig?.layout !== 'app-raw-no-header' || mobileLayout) && <TopBar />}
                 <div
                     className={clsx(

--- a/frontend/src/layout/navigation-3000/components/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/navigation-3000/components/ProjectTree/ProjectTree.tsx
@@ -41,7 +41,7 @@ export function Droppable(props: { id: string; children: ReactNode }): JSX.Eleme
     return <div ref={setNodeRef}>{props.children}</div>
 }
 
-export function ProjectTree(): JSX.Element {
+export function ProjectTree({ contentRef }: { contentRef: React.RefObject<HTMLElement> }): JSX.Element {
     const { theme } = useValues(themeLogic)
     const { isNavShown, mobileLayout } = useValues(navigation3000Logic)
     const { toggleNavCollapsed, hideNavOnMobile } = useActions(navigation3000Logic)
@@ -92,6 +92,7 @@ export function ProjectTree(): JSX.Element {
                     >
                         <ScrollableShadows innerClassName="Navbar3000__top" direction="vertical">
                             <LemonTree
+                                contentRef={contentRef}
                                 className="px-0 py-1"
                                 data={treeData}
                                 renderItem={(item, children): JSX.Element => {

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -187,7 +187,7 @@ export type LemonTreeProps = HTMLAttributes<HTMLDivElement> & {
     right?: (item: TreeDataItem) => React.ReactNode
 
     /** The ref of the content to focus when the tree is clicked. TODO: make non-optional. */
-    contentRef?: React.RefObject<HTMLDivElement>
+    contentRef?: React.RefObject<HTMLElement>
 }
 
 const LemonTree = forwardRef<HTMLDivElement, LemonTreeProps>(
@@ -297,7 +297,7 @@ const LemonTree = forwardRef<HTMLDivElement, LemonTreeProps>(
         }, [contentRef])
 
         // Add helper function to find path to an item
-        const findPathToItem = (items: TreeDataItem[], targetId: string, path: string[] = []): string[] => {
+        const findPathToItem = useCallback((items: TreeDataItem[], targetId: string, path: string[] = []): string[] => {
             for (const item of items) {
                 if (item.id === targetId) {
                     return path
@@ -310,7 +310,7 @@ const LemonTree = forwardRef<HTMLDivElement, LemonTreeProps>(
                 }
             }
             return []
-        }
+        }, [])
 
         // Add function to handle type-ahead search
         const handleTypeAhead = useCallback(
@@ -551,17 +551,7 @@ const LemonTree = forwardRef<HTMLDivElement, LemonTreeProps>(
                     }
                 }
             },
-            [
-                focusedId,
-                expandedItemIds,
-                getVisibleItems,
-                handleTypeAhead,
-                data,
-                focusContent,
-                handleClick,
-                onNodeClick,
-                onFolderClick,
-            ]
+            [focusedId, expandedItemIds, getVisibleItems, handleTypeAhead, data, focusContent, handleClick, onNodeClick]
         )
 
         return (


### PR DESCRIPTION
## Problem
Lemon tree was missing a a11y feature which was passing the main content ref so it can focus on it when using keyboard ENTER. 

Also, once loading the app, it was cumbersome to tab all the way to the content, so added in "Skip to content" link.

Note: <main> doesn't show the outline for normal mouse clicking, only when using tabbing.

## Changes
* Added tabindex=0 to `<main>`
* Passed down contentRef (`<main>`) to Lemon Tree
* Added "skip to content" link which once clicked, would focus `<main>` so users can scroll and tab from there.
    * yes, this adds a `http://localhost:8010/project/1/dashboard#main-content` hash to URL (which goes away on next click away) but this is normal behaviour.


![2025-02-26 11 52 02](https://github.com/user-attachments/assets/3d4a3f68-5992-4b01-98f7-44660d24c224)


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
It should

## How did you test this code?
Locally