### PR TITLE
fix: close quick start if clicked again

### DIFF
--- a/frontend/src/layout/navigation-3000/components/NavbarBottom.tsx
+++ b/frontend/src/layout/navigation-3000/components/NavbarBottom.tsx
@@ -23,8 +23,8 @@ export function NavbarBottom(): JSX.Element {
     const { isAccountPopoverOpen, systemStatusHealthy } = useValues(navigationLogic)
     const { closeAccountPopover, toggleAccountPopover } = useActions(navigationLogic)
     const { toggleSearchBar } = useActions(commandBarLogic)
-    const { openSidePanel } = useActions(sidePanelStateLogic)
-    const { visibleTabs } = useValues(sidePanelLogic)
+    const { openSidePanel, closeSidePanel } = useActions(sidePanelStateLogic)
+    const { visibleTabs, sidePanelOpen, selectedTab } = useValues(sidePanelLogic)
     return (
         <div className="Navbar3000__bottom">
             <ul>
@@ -34,7 +34,11 @@ export function NavbarBottom(): JSX.Element {
                         identifier="activation-button"
                         icon={<SidePanelActivationIcon />}
                         title="Quick start"
-                        onClick={() => openSidePanel(SidePanelTab.Activation)}
+                        onClick={() =>
+                            sidePanelOpen && selectedTab === SidePanelTab.Activation
+                                ? closeSidePanel()
+                                : openSidePanel(SidePanelTab.Activation)
+                        }
                     />
                 )}
                 <NavbarButton


### PR DESCRIPTION
## Problem

User's would naturally try to click this again to close it, as it is in the sidepanel

## Changes

Closes it when you click again

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Ran locally
