### PR TITLE
fix: Salesforce source errors round 2

### DIFF
--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -1,5 +1,3 @@
-from django.conf import settings
-from django.db.models import F
 from datetime import datetime, timedelta
 from enum import Enum
 from typing import Any, Optional, cast
@@ -7,17 +5,19 @@ from typing import Any, Optional, cast
 import jwt
 import requests
 import structlog
+from django.conf import settings
+from django.db.models import F
 from django.utils import timezone
-from sentry_sdk import capture_message
-from requests import JSONDecodeError  # type: ignore[attr-defined]
+from requests import JSONDecodeError
 from rest_framework.exceptions import NotAuthenticated
-from posthog.exceptions_capture import capture_exception
+from sentry_sdk import capture_message
 
 from ee.billing.billing_types import BillingStatus
 from ee.billing.quota_limiting import set_org_usage_summary, update_org_billing_quotas
 from ee.models import License
 from ee.settings import BILLING_SERVICE_URL
 from posthog.cloud_utils import get_cached_instance_license
+from posthog.exceptions_capture import capture_exception
 from posthog.models import Organization
 from posthog.models.organization import OrganizationMembership, OrganizationUsageInfo
 from posthog.models.user import User

--- a/posthog/api/test/test_exports.py
+++ b/posthog/api/test/test_exports.py
@@ -1,6 +1,7 @@
+from datetime import datetime, timedelta
 from typing import Optional
 from unittest.mock import patch
-from datetime import datetime, timedelta
+
 import celery
 import requests.exceptions
 from boto3 import resource
@@ -397,7 +398,7 @@ class TestExports(APIBaseTest):
 
                 def raise_for_status():
                     if 400 <= response.status_code < 600:
-                        raise requests.exceptions.HTTPError(response=response)
+                        raise requests.exceptions.HTTPError(response=response)  # type: ignore[arg-type]
 
                 response.raise_for_status = raise_for_status  # type: ignore[attr-defined]
                 return response
@@ -501,7 +502,7 @@ class TestExportMixin(APIBaseTest):
 
                     def raise_for_status():
                         if 400 <= response.status_code < 600:
-                            raise requests.exceptions.HTTPError(response=response)
+                            raise requests.exceptions.HTTPError(response=response)  # type: ignore[arg-type]
 
                     response.raise_for_status = raise_for_status  # type: ignore[attr-defined]
                     return response

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -1,30 +1,28 @@
 import json
-from django.http import HttpRequest
-from rest_framework.decorators import action as drf_action
-from functools import wraps
-from posthog.api.documentation import extend_schema
 import re
 import socket
 import urllib.parse
 from enum import Enum, auto
+from functools import wraps
 from ipaddress import ip_address
+from typing import Any, Literal, Optional, Union
 from urllib.parse import urlparse
-
-from requests.adapters import HTTPAdapter
-from typing import Literal, Optional, Union, Any
-
-from rest_framework.fields import Field
-from urllib3 import HTTPSConnectionPool, HTTPConnectionPool, PoolManager
 from uuid import UUID
 
 import structlog
 from django.core.exceptions import RequestDataTooBig
 from django.db.models import QuerySet
+from django.http import HttpRequest
 from prometheus_client import Counter
-from rest_framework import request, status, serializers
+from requests.adapters import HTTPAdapter
+from rest_framework import request, serializers, status
+from rest_framework.decorators import action as drf_action
 from rest_framework.exceptions import ValidationError
+from rest_framework.fields import Field
 from statshog.defaults.django import statsd
+from urllib3 import HTTPConnectionPool, HTTPSConnectionPool, PoolManager
 
+from posthog.api.documentation import extend_schema
 from posthog.constants import EventDefinitionType
 from posthog.exceptions import (
     RequestParsingError,
@@ -365,13 +363,13 @@ def raise_if_connected_to_private_ip(conn):
 class PublicIPOnlyHTTPConnectionPool(HTTPConnectionPool):
     def _validate_conn(self, conn):
         raise_if_connected_to_private_ip(conn)
-        super()._validate_conn(conn)
+        super()._validate_conn(conn)  # type: ignore[misc]
 
 
 class PublicIPOnlyHTTPSConnectionPool(HTTPSConnectionPool):
     def _validate_conn(self, conn):
         raise_if_connected_to_private_ip(conn)
-        super()._validate_conn(conn)
+        super()._validate_conn(conn)  # type: ignore[misc]
 
 
 class PublicIPOnlyHttpAdapter(HTTPAdapter):
@@ -390,7 +388,7 @@ class PublicIPOnlyHttpAdapter(HTTPAdapter):
             block=block,
             **pool_kwargs,
         )
-        self.poolmanager.pool_classes_by_scheme = {
+        self.poolmanager.pool_classes_by_scheme = {  # type: ignore[attr-defined]
             "http": PublicIPOnlyHTTPConnectionPool,
             "https": PublicIPOnlyHTTPSConnectionPool,
         }

--- a/posthog/temporal/data_imports/external_data_job.py
+++ b/posthog/temporal/data_imports/external_data_job.py
@@ -3,32 +3,33 @@ import datetime as dt
 import json
 import re
 
-from django.db import close_old_connections
 import posthoganalytics
+from django.db import close_old_connections
 from temporalio import activity, exceptions, workflow
 from temporalio.common import RetryPolicy
 
-
 # TODO: remove dependency
 from posthog.temporal.common.base import PostHogWorkflow
+from posthog.temporal.common.logger import bind_temporal_worker_logger_sync
 from posthog.temporal.data_imports.workflow_activities.check_billing_limits import (
     CheckBillingLimitsActivityInputs,
     check_billing_limits_activity,
 )
-from posthog.temporal.data_imports.workflow_activities.import_data_sync import import_data_activity_sync
+from posthog.temporal.data_imports.workflow_activities.create_job_model import (
+    CreateExternalDataJobModelActivityInputs,
+    create_external_data_job_model_activity,
+)
+from posthog.temporal.data_imports.workflow_activities.import_data_sync import (
+    ImportDataActivityInputs,
+    import_data_activity_sync,
+)
 from posthog.temporal.data_imports.workflow_activities.sync_new_schemas import (
     SyncNewSchemasActivityInputs,
     sync_new_schemas_activity,
 )
 from posthog.temporal.utils import ExternalDataWorkflowInputs
-from posthog.temporal.data_imports.workflow_activities.create_job_model import (
-    CreateExternalDataJobModelActivityInputs,
-    create_external_data_job_model_activity,
-)
-from posthog.temporal.data_imports.workflow_activities.import_data_sync import ImportDataActivityInputs
 from posthog.utils import get_machine_id
 from posthog.warehouse.data_load.source_templates import create_warehouse_templates_for_source
-
 from posthog.warehouse.external_data_source.jobs import (
     update_external_job_status,
 )
@@ -36,7 +37,6 @@ from posthog.warehouse.models import (
     ExternalDataJob,
     ExternalDataSource,
 )
-from posthog.temporal.common.logger import bind_temporal_worker_logger_sync
 from posthog.warehouse.models.external_data_schema import update_should_sync
 
 Any_Source_Errors: list[str] = ["Could not establish session to SSH gateway"]
@@ -67,6 +67,10 @@ Non_Retryable_Schema_Errors: dict[ExternalDataSource.Type, list[str]] = {
         "Can't connect to MySQL server on",
         "No primary key defined for table",
         "Access denied for user",
+    ],
+    ExternalDataSource.Type.SALESFORCE: [
+        "400 Client Error: Bad Request for url",
+        "403 Client Error: Forbidden for url",
     ],
     ExternalDataSource.Type.SNOWFLAKE: [
         "This account has been marked for decommission",

--- a/posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
@@ -1,9 +1,12 @@
-from ipaddress import IPv4Address, IPv6Address
-from dateutil import parser
 import decimal
 import uuid
+from ipaddress import IPv4Address, IPv6Address
+
 import pyarrow as pa
-from posthog.temporal.data_imports.pipelines.pipeline.utils import table_from_py_list
+import pytest
+from dateutil import parser
+
+from posthog.temporal.data_imports.pipelines.pipeline.utils import _get_max_decimal_type, table_from_py_list
 
 
 def test_table_from_py_list_uuid():
@@ -220,6 +223,26 @@ def test_table_from_py_list_with_schema_and_too_small_decimal_type():
         )
     )
     assert table.schema.equals(expected_schema)
+
+
+@pytest.mark.parametrize(
+    "decimals,expected",
+    [
+        ([decimal.Decimal("1")], pa.decimal128(2, 1)),
+        ([decimal.Decimal("1.001112")], pa.decimal128(7, 6)),
+        ([decimal.Decimal("0.001112")], pa.decimal128(6, 6)),
+        ([decimal.Decimal("1.0100000")], pa.decimal128(8, 7)),
+        # That is 1 followed by 37 zeroes to go over the pa.Decimal128 precision limit of 38.
+        ([decimal.Decimal("10000000000000000000000000000000000000.1")], pa.decimal256(39, 1)),
+    ],
+)
+def test_get_max_decimal_type_returns_correct_decimal_type(
+    decimals: list[decimal.Decimal],
+    expected: pa.Decimal128Type | pa.Decimal256Type,
+):
+    """Test whether expected PyArrow decimal type variant is returned."""
+    result = _get_max_decimal_type(decimals)
+    assert result == expected
 
 
 def test_table_from_py_list_with_ipv4_address():

--- a/posthog/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/utils.py
@@ -1,25 +1,25 @@
 import decimal
 from ipaddress import IPv4Address, IPv6Address
 import json
-from collections.abc import Sequence
 import math
-from typing import Any, Optional
-from collections.abc import Hashable
-from collections.abc import Iterator
-from dateutil import parser
 import uuid
-import orjson
+from collections.abc import Hashable, Iterator, Sequence
+from typing import Any, Optional
+
+import deltalake as deltalake
 import numpy as np
+import orjson
 import pandas as pd
 import pyarrow as pa
 import pyarrow.compute as pc
-from dlt.common.libs.deltalake import ensure_delta_compatible_arrow_schema
-from dlt.sources import DltResource
-import deltalake as deltalake
+from dateutil import parser
 from django.db.models import F
-from posthog.temporal.common.logger import FilteringBoundLogger
 from dlt.common.data_types.typing import TDataType
+from dlt.common.libs.deltalake import ensure_delta_compatible_arrow_schema
 from dlt.common.normalizers.naming.snake_case import NamingConvention
+from dlt.sources import DltResource
+
+from posthog.temporal.common.logger import FilteringBoundLogger
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from posthog.warehouse.models import ExternalDataJob, ExternalDataSchema
 
@@ -329,15 +329,29 @@ def build_pyarrow_decimal_type(precision: int, scale: int) -> pa.Decimal128Type 
 
 
 def _get_max_decimal_type(values: list[decimal.Decimal]) -> pa.Decimal128Type | pa.Decimal256Type:
+    """Determine maximum precision and scale from all `decimal.Decimal` values.
+
+    Returns:
+        A `pa.Decimal128Type` or `pa.Decimal256Type` with enough precision and
+        scale to hold all `values`.
+    """
     max_precision = 1
     max_scale = 0
 
     for value in values:
-        sign, digits, exponent = value.as_tuple()
+        _, digits, exponent = value.as_tuple()
         if not isinstance(exponent, int):
             continue
-        precision = len(digits)
-        scale = -exponent if exponent < 0 else 0
+
+        # This implementation accounts for leading zeroes being excluded from digits
+        # It is based on Arrow, see:
+        # https://github.com/apache/arrow/blob/main/python/pyarrow/src/arrow/python/decimal.cc#L75
+        if exponent < 0:
+            precision = max(len(digits), -exponent)
+            scale = -exponent
+        else:
+            precision = len(digits) + exponent
+            scale = 0
 
         max_precision = max(precision, max_precision)
         max_scale = max(scale, max_scale)

--- a/posthog/temporal/data_imports/pipelines/salesforce/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/salesforce/__init__.py
@@ -1,13 +1,16 @@
+import re
 from datetime import datetime
 from typing import Any, Optional
-import dlt
 from urllib.parse import urlencode
+
+import dlt
+from dlt.sources.helpers.requests import Request, Response
 from dlt.sources.helpers.rest_client.paginators import BasePaginator
-from dlt.sources.helpers.requests import Response, Request
+
+from posthog.temporal.common.logger import get_internal_logger
 from posthog.temporal.data_imports.pipelines.rest_source import RESTAPIConfig, rest_api_resources
 from posthog.temporal.data_imports.pipelines.rest_source.typing import EndpointResource
 from posthog.temporal.data_imports.pipelines.salesforce.auth import SalseforceAuth
-import re
 
 
 # Note: When pulling all fields, salesforce requires a 200 limit. We circumvent the pagination by using Id ordering.
@@ -310,18 +313,35 @@ class SalesforceEndpointPaginator(BasePaginator):
         super().__init__()
         self.instance_url = instance_url
         self.is_incremental = is_incremental
+        self.logger = get_internal_logger()
+
+    def __repr__(self):
+        pairs = (
+            f"{attr}={repr(getattr(self, attr))}"
+            for attr in ("is_incremental", "_has_next_page", "_model_name", "_last_record_id")
+        )
+        return f"<SalesforceEndpointPaginator at {hex(id(self))}: {', '.join(pairs)}>"
 
     def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
         res = response.json()
 
-        self._next_page = None
-
         if not res or not res["records"]:
             self._has_next_page = False
+            self.logger.debug(
+                "No more Salesforce pages", instance_url=self.instance_url, is_incremental=self.is_incremental
+            )
             return
 
         last_record = res["records"][-1]
         model_name = res["records"][0]["attributes"]["type"]
+
+        self.logger.debug(
+            "More Salesforce pages required",
+            instance_url=self.instance_url,
+            is_incremental=self.is_incremental,
+            model_name=model_name,
+            last_record_id=last_record["Id"],
+        )
 
         self._has_next_page = True
         self._last_record_id = last_record["Id"]
@@ -332,12 +352,29 @@ class SalesforceEndpointPaginator(BasePaginator):
             # Cludge: Need to get initial value for date filter
             query = request.params.get("q", "")
             date_match = re.search(r"SystemModstamp >= (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.+?)\s", query)
+
+            self.logger.debug(
+                "Constructing incremental query",
+                instance_url=self.instance_url,
+                is_incremental=self.is_incremental,
+                model_name=self._model_name,
+                last_record_id=self._last_record_id,
+            )
+
             if date_match:
                 date_filter = date_match.group(1)
                 query = f"SELECT FIELDS(ALL) FROM {self._model_name} WHERE Id > '{self._last_record_id}' AND SystemModstamp >= {date_filter} ORDER BY Id ASC LIMIT 200"
             else:
                 raise ValueError("No date filter found in initial query. Incremental loading requires a date filter.")
         else:
+            self.logger.debug(
+                "Constructing non-incremental query",
+                instance_url=self.instance_url,
+                is_incremental=self.is_incremental,
+                model_name=self._model_name,
+                last_record_id=self._last_record_id,
+            )
+
             query = f"SELECT FIELDS(ALL) FROM {self._model_name} WHERE Id > '{self._last_record_id}' ORDER BY Id ASC LIMIT 200"
 
         _next_page = f"/services/data/v61.0/query" + "?" + urlencode({"q": query})

--- a/posthog/temporal/data_imports/pipelines/salesforce/test/test_auth.py
+++ b/posthog/temporal/data_imports/pipelines/salesforce/test/test_auth.py
@@ -1,0 +1,94 @@
+import unittest.mock
+import requests
+import pytest
+import json
+
+from posthog.temporal.data_imports.pipelines.salesforce import auth
+
+
+def test_salesforce_refresh_access_token_raises_on_client_failure():
+    """Test whether an exception is raised when failing with a client error."""
+    status_code = 400
+    error_description = "Bad client!"
+
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = json.dumps({"error_description": error_description}).encode("utf-8")
+
+    with (
+        unittest.mock.patch(
+            "posthog.temporal.data_imports.pipelines.salesforce.auth.requests.post", return_value=response
+        ),
+        pytest.raises(auth.SalesforceAuthRequestError) as exc,
+    ):
+        _ = auth.salesforce_refresh_access_token("something")
+
+    assert exc.value.response == response
+    assert "Client Error" in str(exc.value)
+    assert error_description in str(exc.value)
+
+
+def test_salesforce_refresh_access_token_raises_on_server_failure():
+    """Test whether an exception is raised when failing with a server error."""
+    status_code = 500
+    response_body = "something went terribly wrong"
+
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = response_body.encode("utf-8")
+
+    with (
+        unittest.mock.patch(
+            "posthog.temporal.data_imports.pipelines.salesforce.auth.requests.post", return_value=response
+        ),
+        pytest.raises(auth.SalesforceAuthRequestError) as exc,
+    ):
+        _ = auth.salesforce_refresh_access_token("something")
+
+    assert exc.value.response == response
+    assert "Server Error" in str(exc.value)
+    assert response_body in str(exc.value)
+
+
+def test_get_salesforce_access_token_from_code_raises_on_client_failure():
+    """Test whether an exception is raised when failing with a client error."""
+    status_code = 400
+    error_description = "Bad client!"
+
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = json.dumps({"error_description": error_description}).encode("utf-8")
+
+    with (
+        unittest.mock.patch(
+            "posthog.temporal.data_imports.pipelines.salesforce.auth.requests.post", return_value=response
+        ),
+        pytest.raises(auth.SalesforceAuthRequestError) as exc,
+    ):
+        _ = auth.get_salesforce_access_token_from_code("something", "something")
+
+    assert exc.value.response == response
+    assert "Client Error" in str(exc.value)
+    assert error_description in str(exc.value)
+
+
+def test_get_salesforce_access_token_from_code_raises_on_server_failure():
+    """Test whether an exception is raised when failing with a server error."""
+    status_code = 500
+    response_body = "something went terribly wrong"
+
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = response_body.encode("utf-8")
+
+    with (
+        unittest.mock.patch(
+            "posthog.temporal.data_imports.pipelines.salesforce.auth.requests.post", return_value=response
+        ),
+        pytest.raises(auth.SalesforceAuthRequestError) as exc,
+    ):
+        _ = auth.get_salesforce_access_token_from_code("something", "something")
+
+    assert exc.value.response == response
+    assert "Server Error" in str(exc.value)
+    assert response_body in str(exc.value)

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -37,7 +37,7 @@ types-python-dateutil>=2.8.3
 types-pytz==2023.3
 types-redis==4.3.20
 types-retry==0.9.9.4
-types-requests==2.26.1
+types-requests==2.31.0.6 # >= 2.31.0.7 versions require urllib>=2, which is incompatible with our dependencies
 types-tzlocal~=5.1.0.1
 parameterized==0.9.0
 pyarrow==18.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -177,6 +177,10 @@ googleapis-common-protos==1.60.0
     # via
     #   -c requirements.txt
     #   opentelemetry-exporter-otlp-proto-grpc
+greenlet==3.1.1
+    # via
+    #   -c requirements.txt
+    #   sqlalchemy
 grpcio==1.63.2
     # via
     #   -c requirements.txt
@@ -686,7 +690,7 @@ types-pyyaml==6.0.1
     #   responses
 types-redis==4.3.20
     # via -r requirements-dev.in
-types-requests==2.26.1
+types-requests==2.31.0.6
     # via
     #   -r requirements-dev.in
     #   djangorestframework-stubs
@@ -698,6 +702,8 @@ types-toml==0.10.8.20240310
     # via inline-snapshot
 types-tzlocal==5.1.0.1
     # via -r requirements-dev.in
+types-urllib3==1.26.25.14
+    # via types-requests
 typing-extensions==4.12.2
     # via
     #   -c requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -101,7 +101,7 @@ sqlalchemy==2.0.38
 sqlalchemy-bigquery[bqstorage]==1.12.1
 sshtunnel==0.4.0
 statshog==1.0.6
-structlog==25.1.0
+structlog==23.2.0
 sqlparse==0.4.4
 temporalio==1.7.1
 token-bucket==0.3.0

--- a/requirements.in
+++ b/requirements.in
@@ -101,7 +101,7 @@ sqlalchemy==2.0.38
 sqlalchemy-bigquery[bqstorage]==1.12.1
 sshtunnel==0.4.0
 statshog==1.0.6
-structlog==23.2.0
+structlog==25.1.0
 sqlparse==0.4.4
 temporalio==1.7.1
 token-bucket==0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -843,7 +843,7 @@ statshog==1.0.6
     # via -r requirements.in
 stripe==10.3.0
     # via -r requirements.in
-structlog==25.1.0
+structlog==23.2.0
     # via
     #   -r requirements.in
     #   dagster

--- a/requirements.txt
+++ b/requirements.txt
@@ -843,7 +843,7 @@ statshog==1.0.6
     # via -r requirements.in
 stripe==10.3.0
     # via -r requirements.in
-structlog==23.2.0
+structlog==25.1.0
     # via
     #   -r requirements.in
     #   dagster

--- a/requirements.txt
+++ b/requirements.txt
@@ -332,6 +332,8 @@ graphql-core==3.2.5
     #   graphql-relay
 graphql-relay==3.2.0
     # via graphene
+greenlet==3.1.1
+    # via sqlalchemy
 grpcio==1.63.2
     # via
     #   -r requirements.in


### PR DESCRIPTION
## Problem

PR #29051  addressed multiple salesforce errors but was reverted due to a pickle error. This error is caused by dlt using `copy.deepcopy` to copy the Salesforce paginator class, which contains a logger instance that is not pickle-able. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Re-add all the fixes.
Separate logger from paginator so that paginator is now pickle-able once again.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Manually locally.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
