### PR TITLE
fix(batch-exports): Attempt Snowflake write/merge on consumer failure

### DIFF
--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -781,6 +781,8 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
                             multiple_files=True,
                         )
 
+                    # ensure we always write data to final table, even if we fail halfway through, as if we resume from
+                    # a heartbeat, we can continue without losing data
                     finally:
                         if can_perform_merge:
                             await bq_client.amerge_tables(

--- a/posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py
@@ -47,7 +47,7 @@ from posthog.temporal.batch_exports.spmc import (
 )
 from posthog.temporal.common.clickhouse import ClickHouseClient
 from posthog.temporal.tests.batch_exports.utils import (
-    get_flaky_clickhouse_client,
+    FlakyClickHouseClient,
     get_record_batch_from_queue,
     mocked_start_batch_export_run,
 )
@@ -1265,7 +1265,7 @@ async def test_insert_into_bigquery_activity_completes_range_when_there_is_a_fai
 
     with unittest.mock.patch(
         "posthog.temporal.common.clickhouse.ClickHouseClient",
-        lambda *args, **kwargs: get_flaky_clickhouse_client(*args, **kwargs, fail_after_records=fail_after_records),
+        lambda *args, **kwargs: FlakyClickHouseClient(*args, **kwargs, fail_after_records=fail_after_records),
     ):
         # we expect this to raise an exception
         with pytest.raises(RecordBatchTaskError):

--- a/posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py
@@ -45,9 +45,9 @@ from posthog.temporal.batch_exports.spmc import (
     RecordBatchTaskError,
     SessionsRecordBatchModel,
 )
-from posthog.temporal.common.asyncpa import InvalidMessageFormat
 from posthog.temporal.common.clickhouse import ClickHouseClient
 from posthog.temporal.tests.batch_exports.utils import (
+    get_flaky_clickhouse_client,
     get_record_batch_from_queue,
     mocked_start_batch_export_run,
 )
@@ -1240,23 +1240,7 @@ async def test_insert_into_bigquery_activity_completes_range_when_there_is_a_fai
 
     batch_export_model = BatchExportModel(name="events", schema=None)
     now = dt.datetime.now(tz=dt.UTC)
-
-    fail_after_batches = 2
-    clickhouse_max_block_size = 100
-
-    class FakeClickHouseClient(ClickHouseClient):
-        """Fake ClickHouseClient that simulates a failure after reading `fail_after_batches` batches.
-
-        Raises a `InvalidMessageFormat` exception after reading `fail_after_batches` batches. This is an error we've seen in production.
-        """
-
-        async def astream_query_as_arrow(self, *args, **kwargs):
-            count = 0
-            async for batch in super().astream_query_as_arrow(*args, **kwargs):
-                count += 1
-                if count > fail_after_batches:
-                    raise InvalidMessageFormat("Simulated failure")
-                yield batch
+    fail_after_records = 200
 
     heartbeat_details: list[BigQueryHeartbeatDetails] = []
 
@@ -1279,22 +1263,18 @@ async def test_insert_into_bigquery_activity_completes_range_when_there_is_a_fai
         **bigquery_config,
     )
 
-    with (
-        override_settings(
-            BATCH_EXPORT_BIGQUERY_UPLOAD_CHUNK_SIZE_BYTES=100,
-            CLICKHOUSE_MAX_BLOCK_SIZE_DEFAULT=clickhouse_max_block_size,
-        ),
-        unittest.mock.patch("posthog.temporal.common.clickhouse.ClickHouseClient", FakeClickHouseClient),
+    with unittest.mock.patch(
+        "posthog.temporal.common.clickhouse.ClickHouseClient",
+        lambda *args, **kwargs: get_flaky_clickhouse_client(*args, **kwargs, fail_after_records=fail_after_records),
     ):
         # we expect this to raise an exception
-
         with pytest.raises(RecordBatchTaskError):
             await activity_environment.run(insert_into_bigquery_activity, insert_inputs)
 
     assert len(heartbeat_details) > 0
     detail = heartbeat_details[-1]
     assert len(detail.done_ranges) > 0
-    assert detail.records_completed == fail_after_batches * clickhouse_max_block_size
+    assert detail.records_completed == fail_after_records
 
     # now we resume from the heartbeat
     previous_info = dataclasses.asdict(activity_environment.info)

--- a/posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py
@@ -54,7 +54,7 @@ from posthog.temporal.batch_exports.spmc import (
 )
 from posthog.temporal.common.clickhouse import ClickHouseClient
 from posthog.temporal.tests.batch_exports.utils import (
-    get_flaky_clickhouse_client,
+    FlakyClickHouseClient,
     get_record_batch_from_queue,
     mocked_start_batch_export_run,
 )
@@ -1981,6 +1981,7 @@ def test_load_private_key_raises_error_if_key_is_invalid():
         load_private_key("invalid_key", None)
 
 
+@SKIP_IF_MISSING_REQUIRED_ENV_VARS
 @pytest.mark.parametrize(
     "model", [BatchExportModel(name="events", schema=None), BatchExportModel(name="persons", schema=None)]
 )
@@ -2024,7 +2025,7 @@ async def test_insert_into_snowflake_activity_completes_range_when_there_is_a_fa
 
     with unittest.mock.patch(
         "posthog.temporal.common.clickhouse.ClickHouseClient",
-        lambda *args, **kwargs: get_flaky_clickhouse_client(*args, **kwargs, fail_after_records=fail_after_records),
+        lambda *args, **kwargs: FlakyClickHouseClient(*args, **kwargs, fail_after_records=fail_after_records),
     ):
         # We expect this to raise an exception
         with pytest.raises(RecordBatchTaskError):

--- a/posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py
@@ -1,4 +1,5 @@
 import asyncio
+import dataclasses
 import datetime as dt
 import gzip
 import json
@@ -6,6 +7,7 @@ import operator
 import os
 import re
 import tempfile
+import typing as t
 import unittest.mock
 import uuid
 from collections import deque
@@ -47,10 +49,12 @@ from posthog.temporal.batch_exports.snowflake_batch_export import (
 from posthog.temporal.batch_exports.spmc import (
     Producer,
     RecordBatchQueue,
+    RecordBatchTaskError,
     SessionsRecordBatchModel,
 )
 from posthog.temporal.common.clickhouse import ClickHouseClient
 from posthog.temporal.tests.batch_exports.utils import (
+    get_flaky_clickhouse_client,
     get_record_batch_from_queue,
     mocked_start_batch_export_run,
 )
@@ -878,6 +882,8 @@ async def assert_clickhouse_records_in_snowflake(
     backfill_details: BackfillDetails | None = None,
     sort_key: str = "event",
     expected_fields: list[str] | None = None,
+    expect_duplicates: bool = False,
+    primary_key: list[str] | None = None,
 ):
     """Assert ClickHouse records are written to Snowflake table.
 
@@ -892,6 +898,7 @@ async def assert_clickhouse_records_in_snowflake(
         include_events: Event names to be included in the export.
         batch_export_schema: Custom schema used in the batch export.
         expected_fields: List of fields expected to be in the destination table.
+        expect_duplicates: Whether duplicates are expected (e.g. when testing retrying logic).
     """
     snowflake_cursor.execute(f'SELECT * FROM "{table_name}"')
 
@@ -984,6 +991,23 @@ async def assert_clickhouse_records_in_snowflake(
                     expected_record[k] = v
 
             expected_records.append(expected_record)
+
+    if expect_duplicates:
+        primary_key = primary_key or ["uuid"]
+        seen = set()
+
+        def is_record_seen(record: dict[str, t.Any]) -> bool:
+            nonlocal seen
+
+            pk = tuple(record[key] for key in primary_key)
+
+            if pk in seen:
+                return True
+
+            seen.add(pk)
+            return False
+
+        inserted_records = [record for record in inserted_records if not is_record_seen(record)]
 
     inserted_column_names = list(inserted_records[0].keys())
     expected_column_names = list(expected_records[0].keys())
@@ -1955,3 +1979,90 @@ async def test_insert_into_snowflake_activity_handles_person_schema_changes(
 def test_load_private_key_raises_error_if_key_is_invalid():
     with pytest.raises(InvalidPrivateKeyError):
         load_private_key("invalid_key", None)
+
+
+@pytest.mark.parametrize(
+    "model", [BatchExportModel(name="events", schema=None), BatchExportModel(name="persons", schema=None)]
+)
+async def test_insert_into_snowflake_activity_completes_range_when_there_is_a_failure(
+    clickhouse_client,
+    activity_environment,
+    snowflake_cursor,
+    snowflake_config,
+    generate_test_data,
+    data_interval_start,
+    data_interval_end,
+    ateam,
+    model,
+):
+    """Test that the insert_into_snowflake_activity can resume from a failure using heartbeat details."""
+    table_name = f"test_insert_activity_table_{ateam.pk}"
+
+    events_to_create, persons_to_create = generate_test_data
+    total_records = len(persons_to_create) if model.name == "persons" else len(events_to_create)
+    # fail halfway through
+    fail_after_records = total_records // 2
+
+    heartbeat_details: list[SnowflakeHeartbeatDetails] = []
+
+    def track_hearbeat_details(*details):
+        """Record heartbeat details received."""
+        nonlocal heartbeat_details
+        snowflake_details = SnowflakeHeartbeatDetails.from_activity_details(details)
+        heartbeat_details.append(snowflake_details)
+
+    activity_environment.on_heartbeat = track_hearbeat_details
+
+    insert_inputs = SnowflakeInsertInputs(
+        team_id=ateam.pk,
+        table_name=table_name,
+        data_interval_start=data_interval_start.isoformat(),
+        data_interval_end=data_interval_end.isoformat(),
+        batch_export_model=model,
+        **snowflake_config,
+    )
+
+    with unittest.mock.patch(
+        "posthog.temporal.common.clickhouse.ClickHouseClient",
+        lambda *args, **kwargs: get_flaky_clickhouse_client(*args, **kwargs, fail_after_records=fail_after_records),
+    ):
+        # We expect this to raise an exception
+        with pytest.raises(RecordBatchTaskError):
+            await activity_environment.run(insert_into_snowflake_activity, insert_inputs)
+
+    assert len(heartbeat_details) > 0
+    detail = heartbeat_details[-1]
+    assert len(detail.done_ranges) > 0
+    assert detail.records_completed == fail_after_records
+
+    # Now we resume from the heartbeat
+    previous_info = dataclasses.asdict(activity_environment.info)
+    previous_info["heartbeat_details"] = detail.serialize_details()
+    new_info = activity.Info(
+        **previous_info,
+    )
+
+    activity_environment.info = new_info
+
+    await activity_environment.run(insert_into_snowflake_activity, insert_inputs)
+
+    assert len(heartbeat_details) > 0
+    detail = heartbeat_details[-1]
+    assert len(detail.done_ranges) == 1
+    assert detail.done_ranges[0] == (data_interval_start, data_interval_end)
+
+    sort_key = "event" if model.name == "events" else "person_id"
+
+    # Verify all the data for the whole range was exported correctly
+    await assert_clickhouse_records_in_snowflake(
+        snowflake_cursor=snowflake_cursor,
+        clickhouse_client=clickhouse_client,
+        table_name=table_name,
+        team_id=ateam.pk,
+        data_interval_start=data_interval_start,
+        data_interval_end=data_interval_end,
+        sort_key=sort_key,
+        batch_export_model=model,
+        expect_duplicates=True,
+        primary_key=["uuid"] if model.name == "events" else ["distinct_id", "person_id"],
+    )

--- a/posthog/temporal/tests/batch_exports/utils.py
+++ b/posthog/temporal/tests/batch_exports/utils.py
@@ -40,10 +40,6 @@ async def get_record_batch_from_queue(queue, produce_task):
     return None
 
 
-def get_flaky_clickhouse_client(*args, fail_after_records: int, **kwargs):
-    return FlakyClickHouseClient(*args, fail_after_records=fail_after_records, **kwargs)
-
-
 class FlakyClickHouseClient(ClickHouseClient):
     """Fake ClickHouseClient that simulates a failure after reading a certain number of records.
 


### PR DESCRIPTION
## Problem

Similarly to #29234 we could be leaving data unwritten or unmerged in the destination if the consumer fails.

## Changes

Always attempt to load files into Snowflake.

## How did you test this code?

Added new test
