### PR TITLE
fix: ssl and cmake issue with flox

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -43,6 +43,8 @@ go = { pkg-path = "go", version = "1.22", pkg-group = "go" }
 mprocs = { pkg-path = "mprocs" }
 nodemon = { pkg-path = "nodemon" }
 xmlsec = { pkg-path = "xmlsec", version = "1.3.6" }
+openssl = { pkg-path = "openssl", version = "3.4.1", pkg-group = "openssl" }
+cmake = { pkg-path = "cmake", version = "3.31.5", pkg-group = "cmake" }
 
 # Set environment variables in the `[vars]` section. These variables may not
 # reference one another, and are added to the environment without first
@@ -52,6 +54,8 @@ xmlsec = { pkg-path = "xmlsec", version = "1.3.6" }
 DEBUG = "1"
 POSTHOG_SKIP_MIGRATION_CHECKS = "1"
 DIRENV_LOG_FORMAT = "" # Disable direnv activation logging (in case direnv is present)
+LDFLAGS="-L$FLOX_ENV/lib"
+CPPFLAGS="-I$FLOX_ENV/include"
 
 # The `hook.on-activate` script is run by the *bash* shell immediately upon
 # activating an environment, and will not be invoked if Flox detects that the


### PR DESCRIPTION
## Problem

when using flox and running `bin/start` we had problems spinning up posthog because of 

- oppenssl being unhappy 
- cmake missing 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- added openssl to manifest.toml
- added cmake to manifest.toml

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- tested locally

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
