### PR TITLE
chore: Delete persons workflow retries forever

### DIFF
--- a/posthog/temporal/delete_persons/delete_persons_workflow.py
+++ b/posthog/temporal/delete_persons/delete_persons_workflow.py
@@ -207,11 +207,11 @@ class DeletePersonsWorkflow(PostHogWorkflow):
             mogrify_delete_queries_activity,
             mogrify_delete_queries_activity_inputs,
             heartbeat_timeout=dt.timedelta(seconds=30),
-            start_to_close_timeout=dt.timedelta(hours=2),
+            start_to_close_timeout=dt.timedelta(minutes=5),
             retry_policy=temporalio.common.RetryPolicy(
                 initial_interval=dt.timedelta(seconds=10),
                 maximum_interval=dt.timedelta(seconds=60),
-                maximum_attempts=1,
+                maximum_attempts=0,
                 non_retryable_error_types=[],
             ),
         )
@@ -235,8 +235,8 @@ class DeletePersonsWorkflow(PostHogWorkflow):
                 start_to_close_timeout=dt.timedelta(hours=2),
                 retry_policy=temporalio.common.RetryPolicy(
                     initial_interval=dt.timedelta(seconds=10),
-                    maximum_interval=dt.timedelta(seconds=60),
-                    maximum_attempts=1,
+                    maximum_interval=dt.timedelta(seconds=360),
+                    maximum_attempts=0,
                     non_retryable_error_types=[],
                 ),
             )


### PR DESCRIPTION
## Problem

Delete persons workflow runs without problems, but worker restarts can cause it to fail and have to be manually retried.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Let Temporal handle retrying by setting a RetryPolicy without retry limit. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
