### PR TITLE
fix(devex): increase project tree api limit

### DIFF
--- a/posthog/api/file_system.py
+++ b/posthog/api/file_system.py
@@ -50,7 +50,7 @@ class FileSystemSerializer(serializers.ModelSerializer):
 
 
 class FileSystemsLimitOffsetPagination(pagination.LimitOffsetPagination):
-    default_limit = 1000
+    default_limit = 20000
 
 
 class UnfiledFilesQuerySerializer(serializers.Serializer):


### PR DESCRIPTION
## Problem

We have 7k items in our project tree, but the query returns the first 1k.

## Changes

This is a quick fix: bump the limit to 20k.

## How did you test this code?

Didn't really