### PR TITLE
fix(environments): Fix level of filtering for flags and definitions

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -462,7 +462,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         name: 'Feature Flags',
                         searchPlaceholder: 'feature flags',
                         type: TaxonomicFilterGroupType.FeatureFlags,
-                        endpoint: combineUrl(`api/projects/${teamId}/feature_flags/`).url,
+                        endpoint: combineUrl(`api/projects/${projectId}/feature_flags/`).url,
                         getName: (featureFlag: FeatureFlagType) => featureFlag.key || featureFlag.name,
                         getValue: (featureFlag: FeatureFlagType) => featureFlag.id || '',
                         getPopoverHeader: () => `Feature Flags`,
@@ -492,7 +492,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         searchPlaceholder: 'notebooks',
                         type: TaxonomicFilterGroupType.Notebooks,
                         value: 'notebooks',
-                        endpoint: `api/projects/${teamId}/notebooks/`,
+                        endpoint: `api/projects/${projectId}/notebooks/`,
                         getName: (notebook: NotebookType) => notebook.title || `Notebook ${notebook.short_id}`,
                         getValue: (notebook: NotebookType) => notebook.short_id,
                         getPopoverHeader: () => 'Notebooks',
@@ -567,8 +567,8 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                 })),
         ],
         groupAnalyticsTaxonomicGroups: [
-            (s) => [s.groupTypes, s.currentProjectId, s.currentTeamId, s.aggregationLabel],
-            (groupTypes, projectId, teamId, aggregationLabel): TaxonomicFilterGroup[] =>
+            (s) => [s.groupTypes, s.currentProjectId, s.aggregationLabel],
+            (groupTypes, projectId, aggregationLabel): TaxonomicFilterGroup[] =>
                 Array.from(groupTypes.values()).map((type) => ({
                     name: `${capitalizeFirstLetter(aggregationLabel(type.group_type_index).singular)} properties`,
                     searchPlaceholder: `${aggregationLabel(type.group_type_index).singular} properties`,
@@ -578,7 +578,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         group_type_index: type.group_type_index,
                     }).url,
                     valuesEndpoint: (key) =>
-                        `api/projects/${teamId}/groups/property_values?${toParams({
+                        `api/projects/${projectId}/groups/property_values?${toParams({
                             key,
                             group_type_index: type.group_type_index,
                         })}`,

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -137,7 +137,7 @@ const constructValuesEndpoint = (
     properties?: { key: string; values: string | string[] }[]
 ): string => {
     const basePath =
-        type === PropertyDefinitionType.Session ? `api/projects/${teamId}/${type}s/values` : `api/${type}/values`
+        type === PropertyDefinitionType.Session ? `api/environments/${teamId}/${type}s/values` : `api/${type}/values`
     const path = endpoint ? endpoint : basePath + `?key=${encodeURIComponent(propertyKey)}`
 
     let eventParams = ''

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1214,7 +1214,7 @@ export const experimentLogic = kea<experimentLogicType>([
                                 ? query.count_query
                                 : query.funnels_query) as InsightQueryNode,
                         }
-                        await api.create(`api/projects/${teamLogic.values.currentTeamId}/insights`, {
+                        await api.create(`api/projects/${projectLogic.values.currentProjectId}/insights`, {
                             name: query.name || undefined,
                             query: insightQuery,
                             dashboards: [dashboard.id],


### PR DESCRIPTION
## Problem

Users highlighted a few places which weren't updated for project- vs. environment-level filtering. See ZEN-25873 and possibly ZEN-23947.

## Changes

This fixes discrepancies around flags and definitions that I identified.