### PR TITLE
fix: weird copy when rendering dates in feature flag conditions

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -70,8 +70,7 @@ function PropertyValueComponent({ property }: { property: AnyPropertyFilter }): 
                                   false,
                                   String(val).slice(-1) === 'h' ? 'MMMM D, YYYY HH:mm:ss' : 'MMMM D, YYYY',
                                   true
-                              )}{' '}
-                                                            )`
+                              )} )`
                             : ''}
                     </span>
                 </LemonSnack>


### PR DESCRIPTION
## Problem

trivial copy change

## Changes

before:

![CleanShot 2025-02-26 at 14 19 16@2x](https://github.com/user-attachments/assets/e77dac4c-c54f-4780-b9bd-1177756fc1d6)

after:

![CleanShot 2025-02-26 at 14 19 41@2x](https://github.com/user-attachments/assets/fda473d1-644e-412c-95c4-c53c82d9199c)


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

yes

## How did you test this code?

verified locally
