### PR TITLE
fix: Handle consumer errors in batch exports

### DIFF
--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -722,31 +722,32 @@ async def insert_into_postgres_activity(inputs: PostgresInsertInputs) -> Records
                     postgresql_table_schema=inputs.schema,
                     postgresql_table_fields=schema_columns,
                 )
-                _ = await run_consumer(
-                    consumer=consumer,
-                    queue=queue,
-                    producer_task=producer_task,
-                    schema=record_batch_schema,
-                    max_bytes=settings.BATCH_EXPORT_POSTGRES_UPLOAD_CHUNK_SIZE_BYTES,
-                    json_columns=(),
-                    writer_file_kwargs={
-                        "delimiter": "\t",
-                        "quoting": csv.QUOTE_MINIMAL,
-                        "escape_char": None,
-                        "field_names": schema_columns,
-                    },
-                    multiple_files=True,
-                )
-
-                if requires_merge:
-                    await pg_client.amerge_mutable_tables(
-                        final_table_name=pg_table,
-                        stage_table_name=pg_stage_table,
-                        schema=inputs.schema,
-                        update_when_matched=table_fields,
-                        merge_key=merge_key,
-                        update_key=update_key,
+                try:
+                    _ = await run_consumer(
+                        consumer=consumer,
+                        queue=queue,
+                        producer_task=producer_task,
+                        schema=record_batch_schema,
+                        max_bytes=settings.BATCH_EXPORT_POSTGRES_UPLOAD_CHUNK_SIZE_BYTES,
+                        json_columns=(),
+                        writer_file_kwargs={
+                            "delimiter": "\t",
+                            "quoting": csv.QUOTE_MINIMAL,
+                            "escape_char": None,
+                            "field_names": schema_columns,
+                        },
+                        multiple_files=True,
                     )
+                finally:
+                    if requires_merge:
+                        await pg_client.amerge_mutable_tables(
+                            final_table_name=pg_table,
+                            stage_table_name=pg_stage_table,
+                            schema=inputs.schema,
+                            update_when_matched=table_fields,
+                            merge_key=merge_key,
+                            update_key=update_key,
+                        )
 
                 return details.records_completed
 

--- a/posthog/temporal/tests/batch_exports/test_postgres_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_postgres_batch_export_workflow.py
@@ -1268,7 +1268,7 @@ async def test_insert_into_postgres_activity_completes_range_when_there_is_a_fai
     postgres_config,
     model,
 ):
-    """Test that the insert_into_snowflake_activity can resume from a failure using heartbeat details."""
+    """Test that the insert_into_postgres_activity can resume from a failure using heartbeat details."""
     table_name = f"test_insert_activity_table_{ateam.pk}"
 
     events_to_create, persons_to_create = generate_test_data
@@ -1278,13 +1278,13 @@ async def test_insert_into_postgres_activity_completes_range_when_there_is_a_fai
 
     heartbeat_details: list[PostgreSQLHeartbeatDetails] = []
 
-    def track_hearbeat_details(*details):
+    def track_heartbeat_details(*details):
         """Record heartbeat details received."""
         nonlocal heartbeat_details
-        snowflake_details = PostgreSQLHeartbeatDetails.from_activity_details(details)
-        heartbeat_details.append(snowflake_details)
+        postgres_details = PostgreSQLHeartbeatDetails.from_activity_details(details)
+        heartbeat_details.append(postgres_details)
 
-    activity_environment.on_heartbeat = track_hearbeat_details
+    activity_environment.on_heartbeat = track_heartbeat_details
 
     insert_inputs = PostgresInsertInputs(
         team_id=ateam.pk,

--- a/posthog/temporal/tests/batch_exports/test_postgres_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_postgres_batch_export_workflow.py
@@ -1,7 +1,10 @@
 import asyncio
+import collections.abc
+import dataclasses
 import datetime as dt
 import json
 import operator
+import unittest.mock
 import uuid
 
 import psycopg
@@ -31,18 +34,22 @@ from posthog.temporal.batch_exports.postgres_batch_export import (
     PostgresBatchExportInputs,
     PostgresBatchExportWorkflow,
     PostgresInsertInputs,
+    PostgreSQLHeartbeatDetails,
     insert_into_postgres_activity,
     postgres_default_fields,
 )
 from posthog.temporal.batch_exports.spmc import (
     Producer,
     RecordBatchQueue,
+    RecordBatchTaskError,
     SessionsRecordBatchModel,
 )
 from posthog.temporal.common.clickhouse import ClickHouseClient
 from posthog.temporal.tests.batch_exports.utils import (
+    FlakyClickHouseClient,
     get_record_batch_from_queue,
     mocked_start_batch_export_run,
+    remove_duplicates_from_records,
 )
 from posthog.temporal.tests.utils.events import generate_test_events_in_clickhouse
 from posthog.temporal.tests.utils.models import (
@@ -87,6 +94,8 @@ async def assert_clickhouse_records_in_postgres(
     sort_key: str = "event",
     backfill_details: BackfillDetails | None = None,
     expected_fields: list[str] | None = None,
+    expect_duplicates: bool = False,
+    primary_key: collections.abc.Sequence[str] | None = None,
 ):
     """Assert expected records are written to a given PostgreSQL table.
 
@@ -190,6 +199,9 @@ async def assert_clickhouse_records_in_postgres(
                     expected_record[k] = v
 
             expected_records.append(expected_record)
+
+    if expect_duplicates:
+        inserted_records = remove_duplicates_from_records(inserted_records, primary_key)
 
     inserted_column_names = list(inserted_records[0].keys())
     expected_column_names = list(expected_records[0].keys())
@@ -1238,4 +1250,95 @@ async def test_postgres_export_workflow_with_many_files(
         exclude_events=exclude_events,
         batch_export_model=model,
         sort_key="event",
+    )
+
+
+@pytest.mark.parametrize("model", [BatchExportModel(name="persons", schema=None)])
+async def test_insert_into_postgres_activity_completes_range_when_there_is_a_failure(
+    clickhouse_client,
+    activity_environment,
+    postgres_connection,
+    interval,
+    postgres_batch_export,
+    ateam,
+    exclude_events,
+    generate_test_data,
+    data_interval_start,
+    data_interval_end,
+    postgres_config,
+    model,
+):
+    """Test that the insert_into_snowflake_activity can resume from a failure using heartbeat details."""
+    table_name = f"test_insert_activity_table_{ateam.pk}"
+
+    events_to_create, persons_to_create = generate_test_data
+    total_records = len(persons_to_create) if model.name == "persons" else len(events_to_create)
+    # fail halfway through
+    fail_after_records = total_records // 2
+
+    heartbeat_details: list[PostgreSQLHeartbeatDetails] = []
+
+    def track_hearbeat_details(*details):
+        """Record heartbeat details received."""
+        nonlocal heartbeat_details
+        snowflake_details = PostgreSQLHeartbeatDetails.from_activity_details(details)
+        heartbeat_details.append(snowflake_details)
+
+    activity_environment.on_heartbeat = track_hearbeat_details
+
+    insert_inputs = PostgresInsertInputs(
+        team_id=ateam.pk,
+        table_name=table_name,
+        data_interval_start=data_interval_start.isoformat(),
+        data_interval_end=data_interval_end.isoformat(),
+        exclude_events=exclude_events,
+        batch_export_model=model,
+        **postgres_config,
+    )
+
+    with unittest.mock.patch(
+        "posthog.temporal.common.clickhouse.ClickHouseClient",
+        lambda *args, **kwargs: FlakyClickHouseClient(*args, **kwargs, fail_after_records=fail_after_records),
+    ):
+        # We expect this to raise an exception
+        with pytest.raises(RecordBatchTaskError):
+            await activity_environment.run(insert_into_postgres_activity, insert_inputs)
+
+    assert len(heartbeat_details) > 0
+    detail = heartbeat_details[-1]
+    assert len(detail.done_ranges) > 0
+    assert detail.records_completed == fail_after_records
+
+    # Now we resume from the heartbeat
+    previous_info = dataclasses.asdict(activity_environment.info)
+    previous_info["heartbeat_details"] = detail.serialize_details()
+    new_info = activity.Info(
+        **previous_info,
+    )
+
+    activity_environment.info = new_info
+
+    await activity_environment.run(insert_into_postgres_activity, insert_inputs)
+
+    assert len(heartbeat_details) > 0
+    detail = heartbeat_details[-1]
+    assert len(detail.done_ranges) == 1
+    assert detail.done_ranges[0] == (data_interval_start, data_interval_end)
+
+    sort_key = "event" if model.name == "events" else "person_id"
+
+    # Verify all the data for the whole range was exported correctly
+    await assert_clickhouse_records_in_postgres(
+        postgres_connection=postgres_connection,
+        clickhouse_client=clickhouse_client,
+        schema_name=postgres_config["schema"],
+        table_name=table_name,
+        team_id=ateam.pk,
+        data_interval_start=data_interval_start,
+        data_interval_end=data_interval_end,
+        batch_export_model=model,
+        exclude_events=exclude_events,
+        sort_key=sort_key,
+        expect_duplicates=True,
+        primary_key=["uuid"] if model.name == "events" else ["distinct_id", "person_id"],
     )

--- a/posthog/temporal/tests/batch_exports/test_redshift_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_redshift_batch_export_workflow.py
@@ -1237,7 +1237,7 @@ async def test_insert_into_redshift_activity_completes_range_when_there_is_a_fai
     ateam,
     model,
 ):
-    """Test that the insert_into_snowflake_activity can resume from a failure using heartbeat details."""
+    """Test that the insert_into_redshift_activity can resume from a failure using heartbeat details."""
     if MISSING_REQUIRED_ENV_VARS and model.name == "persons":
         pytest.skip("Persons batch export cannot be tested in PostgreSQL")
 
@@ -1250,13 +1250,13 @@ async def test_insert_into_redshift_activity_completes_range_when_there_is_a_fai
 
     heartbeat_details: list[RedshiftHeartbeatDetails] = []
 
-    def track_hearbeat_details(*details):
+    def track_heartbeat_details(*details):
         """Record heartbeat details received."""
         nonlocal heartbeat_details
-        snowflake_details = RedshiftHeartbeatDetails.from_activity_details(details)
-        heartbeat_details.append(snowflake_details)
+        redshift_details = RedshiftHeartbeatDetails.from_activity_details(details)
+        heartbeat_details.append(redshift_details)
 
-    activity_environment.on_heartbeat = track_hearbeat_details
+    activity_environment.on_heartbeat = track_heartbeat_details
 
     insert_inputs = RedshiftInsertInputs(
         team_id=ateam.pk,

--- a/posthog/temporal/tests/batch_exports/test_redshift_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_redshift_batch_export_workflow.py
@@ -1,8 +1,11 @@
 import ast
+import collections.abc
+import dataclasses
 import datetime as dt
 import json
 import operator
 import os
+import unittest.mock
 import uuid
 import warnings
 
@@ -31,6 +34,7 @@ from posthog.temporal.batch_exports.batch_exports import (
 from posthog.temporal.batch_exports.redshift_batch_export import (
     RedshiftBatchExportInputs,
     RedshiftBatchExportWorkflow,
+    RedshiftHeartbeatDetails,
     RedshiftInsertInputs,
     insert_into_redshift_activity,
     redshift_default_fields,
@@ -38,6 +42,7 @@ from posthog.temporal.batch_exports.redshift_batch_export import (
 from posthog.temporal.batch_exports.spmc import (
     Producer,
     RecordBatchQueue,
+    RecordBatchTaskError,
     SessionsRecordBatchModel,
 )
 from posthog.temporal.batch_exports.temporary_file import (
@@ -45,8 +50,10 @@ from posthog.temporal.batch_exports.temporary_file import (
 )
 from posthog.temporal.common.clickhouse import ClickHouseClient
 from posthog.temporal.tests.batch_exports.utils import (
+    FlakyClickHouseClient,
     get_record_batch_from_queue,
     mocked_start_batch_export_run,
+    remove_duplicates_from_records,
 )
 from posthog.temporal.tests.utils.events import generate_test_events_in_clickhouse
 from posthog.temporal.tests.utils.models import (
@@ -82,7 +89,7 @@ EXPECTED_PERSONS_BATCH_EXPORT_FIELDS = [
 ]
 
 
-async def assert_clickhouse_records_in_redshfit(
+async def assert_clickhouse_records_in_redshift(
     redshift_connection,
     clickhouse_client: ClickHouseClient,
     schema_name: str,
@@ -97,6 +104,7 @@ async def assert_clickhouse_records_in_redshfit(
     backfill_details: BackfillDetails | None = None,
     expected_duplicates_threshold: float = 0.0,
     expected_fields: list[str] | None = None,
+    primary_key: collections.abc.Sequence[str] | None = None,
 ):
     """Assert expected records are written to a given Redshift table.
 
@@ -226,17 +234,7 @@ async def assert_clickhouse_records_in_redshfit(
                 expected_records.append(expected_record)
 
     if expected_duplicates_threshold > 0.0:
-        seen = set()
-
-        def is_record_seen(record) -> bool:
-            nonlocal seen
-            if record["uuid"] in seen:
-                return True
-
-            seen.add(record["uuid"])
-            return False
-
-        inserted_records = [record for record in inserted_records if not is_record_seen(record)]
+        inserted_records = remove_duplicates_from_records(inserted_records, primary_key)
         unduplicated_len = len(inserted_records)
         assert (unduplicated_len - len(inserted_records)) / len(inserted_records) < expected_duplicates_threshold
 
@@ -441,7 +439,7 @@ async def test_insert_into_redshift_activity_inserts_data_into_redshift_table(
         elif batch_export_model.name == "sessions":
             sort_key = "session_id"
 
-    await assert_clickhouse_records_in_redshfit(
+    await assert_clickhouse_records_in_redshift(
         redshift_connection=psycopg_connection,
         clickhouse_client=clickhouse_client,
         schema_name=redshift_config["schema"],
@@ -556,7 +554,7 @@ async def test_insert_into_bigquery_activity_resumes_from_heartbeat(
     activity_environment.info = fake_info
     await activity_environment.run(insert_into_redshift_activity, insert_inputs)
 
-    await assert_clickhouse_records_in_redshfit(
+    await assert_clickhouse_records_in_redshift(
         redshift_connection=psycopg_connection,
         clickhouse_client=clickhouse_client,
         schema_name=redshift_config["schema"],
@@ -661,7 +659,7 @@ async def test_insert_into_redshift_activity_completes_range(
 
     await activity_environment.run(insert_into_redshift_activity, insert_inputs)
 
-    await assert_clickhouse_records_in_redshfit(
+    await assert_clickhouse_records_in_redshift(
         redshift_connection=psycopg_connection,
         clickhouse_client=clickhouse_client,
         schema_name=redshift_config["schema"],
@@ -801,7 +799,7 @@ async def test_redshift_export_workflow(
         elif batch_export_model.name == "sessions":
             sort_key = "session_id"
 
-    await assert_clickhouse_records_in_redshfit(
+    await assert_clickhouse_records_in_redshift(
         redshift_connection=psycopg_connection,
         clickhouse_client=clickhouse_client,
         schema_name=redshift_config["schema"],
@@ -968,7 +966,7 @@ async def test_insert_into_redshift_activity_merges_persons_data_in_follow_up_ru
 
     await activity_environment.run(insert_into_redshift_activity, insert_inputs)
 
-    await assert_clickhouse_records_in_redshfit(
+    await assert_clickhouse_records_in_redshift(
         redshift_connection=psycopg_connection,
         clickhouse_client=clickhouse_client,
         schema_name=redshift_config["schema"],
@@ -1005,7 +1003,7 @@ async def test_insert_into_redshift_activity_merges_persons_data_in_follow_up_ru
 
     await activity_environment.run(insert_into_redshift_activity, insert_inputs)
 
-    await assert_clickhouse_records_in_redshfit(
+    await assert_clickhouse_records_in_redshift(
         redshift_connection=psycopg_connection,
         clickhouse_client=clickhouse_client,
         schema_name=redshift_config["schema"],
@@ -1052,7 +1050,7 @@ async def test_insert_into_redshift_activity_merges_sessions_data_in_follow_up_r
 
     await activity_environment.run(insert_into_redshift_activity, insert_inputs)
 
-    await assert_clickhouse_records_in_redshfit(
+    await assert_clickhouse_records_in_redshift(
         redshift_connection=psycopg_connection,
         clickhouse_client=clickhouse_client,
         schema_name=redshift_config["schema"],
@@ -1092,7 +1090,7 @@ async def test_insert_into_redshift_activity_merges_sessions_data_in_follow_up_r
 
     await activity_environment.run(insert_into_redshift_activity, insert_inputs)
 
-    await assert_clickhouse_records_in_redshfit(
+    await assert_clickhouse_records_in_redshift(
         redshift_connection=psycopg_connection,
         clickhouse_client=clickhouse_client,
         schema_name=redshift_config["schema"],
@@ -1163,7 +1161,7 @@ async def test_insert_into_redshift_activity_handles_person_schema_changes(
 
     await activity_environment.run(insert_into_redshift_activity, insert_inputs)
 
-    await assert_clickhouse_records_in_redshfit(
+    await assert_clickhouse_records_in_redshift(
         redshift_connection=psycopg_connection,
         clickhouse_client=clickhouse_client,
         schema_name=redshift_config["schema"],
@@ -1212,7 +1210,7 @@ async def test_insert_into_redshift_activity_handles_person_schema_changes(
     # This time we don't expect there to be a created_at column
     expected_fields = [f for f in EXPECTED_PERSONS_BATCH_EXPORT_FIELDS if f != "created_at"]
 
-    await assert_clickhouse_records_in_redshfit(
+    await assert_clickhouse_records_in_redshift(
         redshift_connection=psycopg_connection,
         clickhouse_client=clickhouse_client,
         schema_name=redshift_config["schema"],
@@ -1223,4 +1221,96 @@ async def test_insert_into_redshift_activity_handles_person_schema_changes(
         properties_data_type=properties_data_type,
         sort_key="person_id",
         expected_fields=expected_fields,
+    )
+
+
+@pytest.mark.parametrize("model", [BatchExportModel(name="persons", schema=None)])
+async def test_insert_into_redshift_activity_completes_range_when_there_is_a_failure(
+    clickhouse_client,
+    activity_environment,
+    psycopg_connection,
+    redshift_config,
+    generate_test_data,
+    data_interval_start,
+    data_interval_end,
+    exclude_events,
+    ateam,
+    model,
+):
+    """Test that the insert_into_snowflake_activity can resume from a failure using heartbeat details."""
+    if MISSING_REQUIRED_ENV_VARS and model.name == "persons":
+        pytest.skip("Persons batch export cannot be tested in PostgreSQL")
+
+    table_name = f"test_insert_activity_table_{ateam.pk}"
+
+    events_to_create, persons_to_create = generate_test_data
+    total_records = len(persons_to_create) if model.name == "persons" else len(events_to_create)
+    # fail halfway through
+    fail_after_records = total_records // 2
+
+    heartbeat_details: list[RedshiftHeartbeatDetails] = []
+
+    def track_hearbeat_details(*details):
+        """Record heartbeat details received."""
+        nonlocal heartbeat_details
+        snowflake_details = RedshiftHeartbeatDetails.from_activity_details(details)
+        heartbeat_details.append(snowflake_details)
+
+    activity_environment.on_heartbeat = track_hearbeat_details
+
+    insert_inputs = RedshiftInsertInputs(
+        team_id=ateam.pk,
+        table_name=table_name,
+        data_interval_start=data_interval_start.isoformat(),
+        data_interval_end=data_interval_end.isoformat(),
+        exclude_events=exclude_events,
+        batch_export_model=model,
+        **redshift_config,
+    )
+
+    with unittest.mock.patch(
+        "posthog.temporal.common.clickhouse.ClickHouseClient",
+        lambda *args, **kwargs: FlakyClickHouseClient(*args, **kwargs, fail_after_records=fail_after_records),
+    ):
+        # We expect this to raise an exception
+        with pytest.raises(RecordBatchTaskError):
+            await activity_environment.run(insert_into_redshift_activity, insert_inputs)
+
+    assert len(heartbeat_details) > 0
+    detail = heartbeat_details[-1]
+    assert len(detail.done_ranges) > 0
+    assert detail.records_completed == fail_after_records
+
+    # Now we resume from the heartbeat
+    previous_info = dataclasses.asdict(activity_environment.info)
+    previous_info["heartbeat_details"] = detail.serialize_details()
+    new_info = activity.Info(
+        **previous_info,
+    )
+
+    activity_environment.info = new_info
+
+    await activity_environment.run(insert_into_redshift_activity, insert_inputs)
+
+    assert len(heartbeat_details) > 0
+    detail = heartbeat_details[-1]
+    assert len(detail.done_ranges) == 1
+    assert detail.done_ranges[0] == (data_interval_start, data_interval_end)
+
+    sort_key = "event" if model.name == "events" else "person_id"
+
+    # Verify all the data for the whole range was exported correctly
+    await assert_clickhouse_records_in_redshift(
+        redshift_connection=psycopg_connection,
+        clickhouse_client=clickhouse_client,
+        schema_name=redshift_config["schema"],
+        table_name=table_name,
+        team_id=ateam.pk,
+        date_ranges=[(data_interval_start, data_interval_end)],
+        batch_export_model=model,
+        exclude_events=exclude_events,
+        properties_data_type="SUPER",
+        sort_key=sort_key,
+        expected_duplicates_threshold=1.0,
+        primary_key=["uuid"] if model.name == "events" else ["distinct_id", "person_id"],
     )

--- a/posthog/temporal/tests/batch_exports/utils.py
+++ b/posthog/temporal/tests/batch_exports/utils.py
@@ -75,7 +75,7 @@ def remove_duplicates_from_records(
     comparisons won't fail.
     """
     if not key:
-        dedup_key = ("uuid",)
+        dedup_key: tuple[str, ...] = ("uuid",)
     else:
         dedup_key = tuple(key)
 

--- a/posthog/temporal/tests/batch_exports/utils.py
+++ b/posthog/temporal/tests/batch_exports/utils.py
@@ -75,16 +75,16 @@ def remove_duplicates_from_records(
     comparisons won't fail.
     """
     if not key:
-        dedup_key = ["uuid"]
+        dedup_key = ("uuid",)
     else:
-        dedup_key = key
+        dedup_key = tuple(key)
 
     seen = set()
 
     def is_record_seen(record: dict[str, typing.Any]) -> bool:
         nonlocal seen
 
-        pk = tuple(record[key] for key in dedup_key)
+        pk = tuple(record[k] for k in dedup_key)
 
         if pk in seen:
             return True

--- a/posthog/temporal/tests/batch_exports/utils.py
+++ b/posthog/temporal/tests/batch_exports/utils.py
@@ -1,4 +1,6 @@
 import asyncio
+import collections.abc
+import typing
 import uuid
 
 from asgiref.sync import sync_to_async
@@ -60,3 +62,36 @@ class FlakyClickHouseClient(ClickHouseClient):
                 if count > self.fail_after_records:
                     raise InvalidMessageFormat("Simulated failure")
                 yield sliced_batch
+
+
+def remove_duplicates_from_records(
+    records: list[dict[str, typing.Any]], key: collections.abc.Sequence[str] | None = None
+) -> list[dict[str, typing.Any]]:
+    """Remove duplicates from a list of records.
+
+    Used in batch exports testing when we expect a number of duplicates not known
+    beforehand to be present in the results. Since we can't know how many duplicates
+    there are, and which exact records will be duplicated, we remove them so that
+    comparisons won't fail.
+    """
+    if not key:
+        dedup_key = ["uuid"]
+    else:
+        dedup_key = key
+
+    seen = set()
+
+    def is_record_seen(record: dict[str, typing.Any]) -> bool:
+        nonlocal seen
+
+        pk = tuple(record[key] for key in dedup_key)
+
+        if pk in seen:
+            return True
+
+        seen.add(pk)
+        return False
+
+    inserted_records = [record for record in records if not is_record_seen(record)]
+
+    return inserted_records


### PR DESCRIPTION
## Problem

We were not merging partial data in the event of a crash, we should. Similar to #29234.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Catch any errors in consumer and attempt to merge any partial data.
Also, this PR corrects a disgracing typo where we had `redshfit` instead of `redshift`.
Added a new utility to remove duplicates while testing.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Ran all tests. Added new ones.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
