### PR TITLE
chore: Require Web Analytics review on web analytics code

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,6 @@
+# If a file is set here, then PRs will require that team's approval to get that code merged.
+
+# Surveys team owns all survey-related code
 frontend/src/scenes/settings/environment/SurveySettings.tsx @PostHog/team-surveys
 frontend/src/scenes/surveys/ @PostHog/team-surveys
 frontend/src/scenes/onboarding/sdks/surveys @PostHog/team-surveys
@@ -10,8 +13,20 @@ posthog/tasks/stop_surveys_reached_target.py @PostHog/team-surveys
 posthog/tasks/update_survey_adaptive_sampling @PostHog/team-surveys
 posthog/tasks/update_survey_iteration @PostHog/team-surveys
 posthog/tasks/test/test_stop_surveys_reached_target.py @PostHog/team-surveys
-plugin-server/src/ @PostHog/team-cdp
+
+# CDP team owns plugin server code
+plugin-server/src/ @PostHog/team-cdp
+
+# ClickHouse team owns Clickhouse migrations
 posthog/clickhouse/migrations/** @PostHog/clickhouse
-posthog/clickhouse/migrations2/** @PostHog/clickhouse
+
+# Web Analytics team owns web analytics code
+frontend/src/scenes/web-analytics/** @PostHog/web-analytics
+posthog/hogql_queries/web_analytics/** @PostHog/web-analytics
+frontend/src/toolbar/web-vitals/** @PostHog/web-analytics
+posthog/hogql/database/schema/sessions_v1.py @PostHog/web-analytics
+posthog/hogql/database/schema/sessions_v2.py @PostHog/web-analytics
+
+# Paul owns testing infrastructure
 cypress/** @pauldambra
 playwright/** @pauldambra


### PR DESCRIPTION
Just making sure we get a review if some other team attempts to change our code, there's some tricky stuff we'd like to protect with sessions, for example