### PR TITLE
feat: Add default retry policy to ClickhouseCluster methods called in Dagster jobs

### DIFF
--- a/dags/common.py
+++ b/dags/common.py
@@ -1,6 +1,6 @@
 import dagster
+from clickhouse_driver.errors import Error, ErrorCodes
 
-from clickhouse_driver.errors import ErrorCodes, Error
 from posthog.clickhouse.cluster import (
     ClickhouseCluster,
     ExponentialBackoff,

--- a/dags/common.py
+++ b/dags/common.py
@@ -22,14 +22,15 @@ class ClickhouseClusterResource(dagster.ConfigurableResource):
     }
 
     def create_resource(self, context: dagster.InitResourceContext) -> ClickhouseCluster:
-        retry_policy = RetryPolicy(
-            max_attempts=3,
-            delay=30,
-            exceptions=lambda e: isinstance(e, Error)
-            and e.code
-            in (
-                ErrorCodes.NETWORK_ERROR,
-                ErrorCodes.TOO_MANY_SIMULTANEOUS_QUERIES,
+        return get_cluster(
+            context.log,
+            client_settings=self.client_settings,
+            retry_policy=RetryPolicy(
+                max_attempts=3,
+                delay=30,
+                exceptions=lambda e: (
+                    isinstance(e, Error)
+                    and e.code in (ErrorCodes.NETWORK_ERROR, ErrorCodes.TOO_MANY_SIMULTANEOUS_QUERIES)
+                ),
             ),
         )
-        return get_cluster(context.log, client_settings=self.client_settings, retry_policy=retry_policy)

--- a/dags/common.py
+++ b/dags/common.py
@@ -3,6 +3,7 @@ import dagster
 from clickhouse_driver.errors import ErrorCodes, Error
 from posthog.clickhouse.cluster import (
     ClickhouseCluster,
+    ExponentialBackoff,
     RetryPolicy,
     get_cluster,
 )
@@ -27,7 +28,7 @@ class ClickhouseClusterResource(dagster.ConfigurableResource):
             client_settings=self.client_settings,
             retry_policy=RetryPolicy(
                 max_attempts=3,
-                delay=30,
+                delay=ExponentialBackoff(15),
                 exceptions=lambda e: (
                     isinstance(e, Error)
                     and e.code in (ErrorCodes.NETWORK_ERROR, ErrorCodes.TOO_MANY_SIMULTANEOUS_QUERIES)

--- a/dags/common.py
+++ b/dags/common.py
@@ -27,8 +27,8 @@ class ClickhouseClusterResource(dagster.ConfigurableResource):
             context.log,
             client_settings=self.client_settings,
             retry_policy=RetryPolicy(
-                max_attempts=3,
-                delay=ExponentialBackoff(15),
+                max_attempts=4,
+                delay=ExponentialBackoff(20),
                 exceptions=lambda e: (
                     isinstance(e, Error)
                     and e.code in (ErrorCodes.NETWORK_ERROR, ErrorCodes.TOO_MANY_SIMULTANEOUS_QUERIES)

--- a/dags/common.py
+++ b/dags/common.py
@@ -1,7 +1,9 @@
 import dagster
 
+from clickhouse_driver.errors import ErrorCodes, Error
 from posthog.clickhouse.cluster import (
     ClickhouseCluster,
+    RetryPolicy,
     get_cluster,
 )
 
@@ -20,4 +22,14 @@ class ClickhouseClusterResource(dagster.ConfigurableResource):
     }
 
     def create_resource(self, context: dagster.InitResourceContext) -> ClickhouseCluster:
-        return get_cluster(context.log, client_settings=self.client_settings)
+        retry_policy = RetryPolicy(
+            max_attempts=3,
+            delay=30,
+            exceptions=lambda e: isinstance(e, Error)
+            and e.code
+            in (
+                ErrorCodes.NETWORK_ERROR,
+                ErrorCodes.TOO_MANY_SIMULTANEOUS_QUERIES,
+            ),
+        )
+        return get_cluster(context.log, client_settings=self.client_settings, retry_policy=retry_policy)

--- a/dags/definitions.py
+++ b/dags/definitions.py
@@ -70,3 +70,8 @@ defs = Definitions(
     sensors=[run_deletes_after_squash],
     resources=resources,
 )
+
+if settings.DEBUG:
+    from . import testing
+
+    defs.jobs.append(testing.error)

--- a/dags/testing.py
+++ b/dags/testing.py
@@ -1,0 +1,26 @@
+import dagster
+
+from posthog.clickhouse.cluster import ClickhouseCluster, Query
+
+
+class ErrorConfig(dagster.Config):
+    code: int
+
+
+@dagster.op
+def error_op(
+    config: ErrorConfig,
+    cluster: dagster.ResourceParam[ClickhouseCluster],
+):
+    cluster.map_all_hosts(
+        Query(
+            "SELECT throwIf(true, %(message)s, toInt32(%(code)s))",
+            {"message": "an error occurred", "code": config.code},
+            {"allow_custom_error_code_in_throwif": "true"},
+        ),
+    ).result()
+
+
+@dagster.job
+def error():
+    error_op()

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from typing import Any, Generic, Literal, NamedTuple, TypeVar
 from collections.abc import Iterable
 
+import dagster
 from clickhouse_driver import Client
 from clickhouse_pool import ChPool
 
@@ -27,7 +28,7 @@ from posthog.settings import CLICKHOUSE_PER_TEAM_SETTINGS
 from posthog.settings.data_stores import CLICKHOUSE_CLUSTER
 
 
-logger = logging.getLogger(__name__)
+logger = dagster.get_dagster_logger("clickhouse")
 
 
 def ON_CLUSTER_CLAUSE(on_cluster=True):

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -336,6 +336,14 @@ class Query:
 
 
 @dataclass
+class ExponentialBackoff:
+    delay: float
+
+    def __call__(self, attempt: int) -> float:
+        return self.delay * (attempt**2)
+
+
+@dataclass
 class RetryPolicy:
     max_attempts: int
     delay: float | Callable[[int], float]

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -379,7 +379,7 @@ class Retryable(Generic[T]):  # note: this class exists primarily to allow a rea
                 if is_retryable_exception(e) and attempt < self.policy.max_attempts:
                     delay = delay_fn(attempt)
                     logger.warning(
-                        "Failed to invoke %r (attempt #%s), retrying in %0.2fs...", self.callable, attempt, delay
+                        "Failed to execute %r (attempt #%s, retry in %0.2fs): %s", self.callable, attempt, delay, e
                     )
                     time.sleep(delay)
                 else:

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -330,9 +330,10 @@ def get_cluster(
 class Query:
     query: str
     parameters: Any | None = None
+    settings: dict[str, str] | None = None
 
     def __call__(self, client: Client):
-        return client.execute(self.query, self.parameters)
+        return client.execute(self.query, self.parameters, settings=self.settings)
 
 
 @dataclass

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -307,14 +307,22 @@ class ClickhouseCluster:
 
 
 def get_cluster(
-    logger: logging.Logger | None = None, client_settings: Mapping[str, str] | None = None, cluster: str | None = None
+    logger: logging.Logger | None = None,
+    client_settings: Mapping[str, str] | None = None,
+    cluster: str | None = None,
+    retry_policy: RetryPolicy | None = None,
 ) -> ClickhouseCluster:
     extra_hosts = []
     for host_config in map(copy, CLICKHOUSE_PER_TEAM_SETTINGS.values()):
         extra_hosts.append(ConnectionInfo(host_config.pop("host"), None))
         assert len(host_config) == 0, f"unexpected values: {host_config!r}"
     return ClickhouseCluster(
-        default_client(), extra_hosts=extra_hosts, logger=logger, client_settings=client_settings, cluster=cluster
+        default_client(),
+        extra_hosts=extra_hosts,
+        logger=logger,
+        client_settings=client_settings,
+        cluster=cluster,
+        retry_policy=retry_policy,
     )
 
 

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -366,10 +366,10 @@ class Retryable(Generic[T]):  # note: this class exists primarily to allow a rea
         else:
             is_retryable_exception = self.policy.exceptions
 
-        if callable(self.policy.delay):
-            delay_fn = self.policy.delay
-        else:
+        if not callable(self.policy.delay):
             delay_fn = lambda _: self.policy.delay
+        else:
+            delay_fn = self.policy.delay
 
         counter = itertools.count(1)
         while (attempt := next(counter)) <= self.policy.max_attempts:

--- a/posthog/clickhouse/test/test_cluster.py
+++ b/posthog/clickhouse/test/test_cluster.py
@@ -81,7 +81,7 @@ def test_retry_policy():
     assert e.value.args == (sentinel.ERROR,)
     assert angry_function.call_count == 2
 
-    # surprising function should not be retried
+    # function that throws a surprising non-retryable error should not be retried
     surprising_function = Mock(side_effect=Exception(sentinel.ERROR))
     task = RetryPolicy(max_attempts=2, delay=0, exceptions=(ValueError,))(surprising_function)
     with pytest.raises(Exception) as e:
@@ -89,6 +89,28 @@ def test_retry_policy():
 
     assert e.value.args == (sentinel.ERROR,)
     assert surprising_function.call_count == 1
+
+
+def test_retry_policy_exception_test():
+    retryable_exception = Exception(sentinel.RETRYABLE)
+    policy = RetryPolicy(max_attempts=2, delay=0, exceptions=lambda e: e == retryable_exception)
+
+    retryable_callable = Mock(side_effect=retryable_exception)
+    task = policy(retryable_callable)
+    with pytest.raises(Exception) as e:
+        task(Mock())
+
+    assert e.value == retryable_exception
+    assert retryable_callable.call_count == policy.max_attempts
+
+    non_retryable_exception = Exception(sentinel.NON_RETRYABLE)
+    non_retryable_callable = Mock(side_effect=non_retryable_exception)
+    task = policy(non_retryable_callable)
+    with pytest.raises(Exception) as e:
+        task(Mock())
+
+    assert e.value == non_retryable_exception
+    assert non_retryable_callable.call_count == 1
 
 
 def test_mutations(cluster: ClickhouseCluster) -> None:


### PR DESCRIPTION
## Problem

Sometimes these calls fail due to unreachable or overloaded hosts.

Examples:

- https://dagster.prod-us.posthog.dev/runs/96f1c97d-6fcd-4e03-9702-f91990f7b08a Code: 210. Connection refused
- https://dagster.prod-us.posthog.dev/runs/345f918c-460c-4bcc-af0e-511a20485810 Code: 202. DB::Exception: Too many simultaneous queries.

## Changes

Automates the process of "wait a while and try again" which is what we end up doing here anyway.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added unit tests for new policy functionality, use in jobs is already covered by existing integration tests, manually tested log output appears in console UI using new testing job that throws configurable errors