### PR TITLE
feat: Add Web Analytics to Onboarding + Quick Start

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activation/activationLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activation/activationLogic.tsx
@@ -3,6 +3,7 @@ import {
     IconFeatures,
     IconGraph,
     IconMessage,
+    IconPieChart,
     IconRewindPlay,
     IconTestTube,
     IconToggle,
@@ -238,18 +239,31 @@ export const activationLogic = kea<activationLogicType>([
             }
 
             switch (id) {
+                // Quick Start
                 case ActivationTask.IngestFirstEvent:
                     router.actions.push(urls.onboarding(ProductKey.PRODUCT_ANALYTICS))
                     break
                 case ActivationTask.InviteTeamMember:
                     actions.showInviteModal()
                     break
+
+                // Product Analytics
                 case ActivationTask.CreateFirstInsight:
                     router.actions.push(urls.insightNew())
                     break
                 case ActivationTask.CreateFirstDashboard:
                     router.actions.push(urls.dashboards())
                     break
+
+                // Web Analytics
+                case ActivationTask.AddAuthorizedDomain:
+                    router.actions.push(urls.settings('environment-details', 'authorized-urls'))
+                    break
+                case ActivationTask.SetUpWebVitals:
+                    router.actions.push(urls.settings('environment-autocapture', 'web-vitals-autocapture'))
+                    break
+
+                // Session Replay
                 case ActivationTask.SetupSessionRecordings:
                     actions.openSettingsPanel({ sectionId: 'project-replay' })
                     router.actions.push(urls.replay(ReplayTabs.Home))
@@ -260,18 +274,26 @@ export const activationLogic = kea<activationLogicType>([
                 case ActivationTask.TrackCustomEvents:
                     router.actions.push(urls.eventDefinitions())
                     break
+
+                // Feature Flags
                 case ActivationTask.CreateFeatureFlag:
                     router.actions.push(urls.featureFlags())
                     break
                 case ActivationTask.UpdateFeatureFlagReleaseConditions:
                     router.actions.push(urls.featureFlags())
                     break
+
+                // Experiments
                 case ActivationTask.LaunchExperiment:
                     router.actions.push(urls.experiments())
                     break
+
+                // Data Warehouse
                 case ActivationTask.ConnectSource:
                     router.actions.push(urls.pipelineNodeNew(PipelineStage.Source))
                     break
+
+                // Surveys
                 case ActivationTask.LaunchSurvey:
                     router.actions.push(urls.surveyTemplates())
                     break
@@ -383,12 +405,19 @@ export const activationLogic = kea<activationLogicType>([
 ])
 
 export enum ActivationTask {
+    // Quick Start
     IngestFirstEvent = 'ingest_first_event',
     InviteTeamMember = 'invite_team_member',
+    SetUpReverseProxy = 'set_up_reverse_proxy',
+
+    // Product Analytics
     CreateFirstInsight = 'create_first_insight',
     CreateFirstDashboard = 'create_first_dashboard',
     TrackCustomEvents = 'track_custom_events',
-    SetUpReverseProxy = 'set_up_reverse_proxy',
+
+    // Web Analytics
+    AddAuthorizedDomain = 'add_authorized_domain',
+    SetUpWebVitals = 'set_up_web_vitals',
 
     // Session Replay
     SetupSessionRecordings = 'setup_session_recordings',
@@ -397,6 +426,7 @@ export enum ActivationTask {
     // Feature Flags
     CreateFeatureFlag = 'create_feature_flag',
     UpdateFeatureFlagReleaseConditions = 'update_feature_flag_release_conditions',
+
     // Experiments
     LaunchExperiment = 'launch_experiment',
 
@@ -411,6 +441,7 @@ export enum ActivationTask {
 export enum ActivationSection {
     QuickStart = 'quick_start',
     ProductAnalytics = 'product_analytics',
+    WebAnalytics = 'web_analytics',
     SessionReplay = 'session_replay',
     FeatureFlags = 'feature_flags',
     Experiments = 'experiments',
@@ -426,6 +457,10 @@ export const ACTIVATION_SECTIONS: Record<ActivationSection, { title: string; ico
     [ActivationSection.ProductAnalytics]: {
         title: 'Product analytics',
         icon: <IconGraph className="h-5 w-5" color={availableOnboardingProducts.product_analytics.iconColor} />,
+    },
+    [ActivationSection.WebAnalytics]: {
+        title: 'Web analytics',
+        icon: <IconPieChart className="h-5 w-5" color={availableOnboardingProducts.web_analytics.iconColor} />,
     },
     [ActivationSection.SessionReplay]: {
         title: 'Session replay',
@@ -461,6 +496,7 @@ export const ACTIVATION_SECTIONS: Record<ActivationSection, { title: string; ico
 }
 
 export const ACTIVATION_TASKS: ActivationTaskDefinition[] = [
+    // Quick Start
     {
         id: ActivationTask.IngestFirstEvent,
         title: 'Ingest your first event',
@@ -474,6 +510,15 @@ export const ACTIVATION_TASKS: ActivationTaskDefinition[] = [
         section: ActivationSection.QuickStart,
     },
     {
+        id: ActivationTask.SetUpReverseProxy,
+        title: 'Set up a reverse proxy',
+        canSkip: true,
+        section: ActivationSection.QuickStart,
+        url: 'https://posthog.com/docs/advanced/proxy',
+    },
+
+    // Product Analytics
+    {
         id: ActivationTask.CreateFirstInsight,
         title: 'Create your first insight',
         canSkip: false,
@@ -485,7 +530,6 @@ export const ACTIVATION_TASKS: ActivationTaskDefinition[] = [
         canSkip: false,
         section: ActivationSection.ProductAnalytics,
     },
-
     {
         id: ActivationTask.TrackCustomEvents,
         title: 'Track custom events',
@@ -493,13 +537,21 @@ export const ACTIVATION_TASKS: ActivationTaskDefinition[] = [
         section: ActivationSection.ProductAnalytics,
         url: 'https://posthog.com/tutorials/event-tracking-guide#setting-up-custom-events',
     },
+
+    // Web Analytics
     {
-        id: ActivationTask.SetUpReverseProxy,
-        title: 'Set up a reverse proxy',
-        canSkip: true,
-        section: ActivationSection.QuickStart,
-        url: 'https://posthog.com/docs/advanced/proxy',
+        id: ActivationTask.AddAuthorizedDomain,
+        title: 'Add an authorized domain',
+        canSkip: false,
+        section: ActivationSection.WebAnalytics,
     },
+    {
+        id: ActivationTask.SetUpWebVitals,
+        title: 'Set up web vitals',
+        canSkip: true,
+        section: ActivationSection.WebAnalytics,
+    },
+
     // Sesion Replay
     {
         id: ActivationTask.SetupSessionRecordings,
@@ -519,6 +571,7 @@ export const ACTIVATION_TASKS: ActivationTaskDefinition[] = [
             },
         ],
     },
+
     // Feature Flags
     {
         id: ActivationTask.CreateFeatureFlag,
@@ -538,6 +591,7 @@ export const ACTIVATION_TASKS: ActivationTaskDefinition[] = [
             },
         ],
     },
+
     // Experiments
     {
         id: ActivationTask.LaunchExperiment,
@@ -545,6 +599,7 @@ export const ACTIVATION_TASKS: ActivationTaskDefinition[] = [
         title: 'Launch an experiment',
         canSkip: false,
     },
+
     // Data Warehouse
     {
         id: ActivationTask.ConnectSource,
@@ -552,6 +607,7 @@ export const ACTIVATION_TASKS: ActivationTaskDefinition[] = [
         canSkip: false,
         section: ActivationSection.DataWarehouse,
     },
+
     // Surveys
     {
         id: ActivationTask.LaunchSurvey,

--- a/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
+++ b/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
@@ -14,11 +14,12 @@ import { authorizedUrlListLogic, AuthorizedUrlListType } from './authorizedUrlLi
 import { EmptyState } from './EmptyState'
 
 export interface AuthorizedUrlListProps {
+    type: AuthorizedUrlListType
     actionId?: number
     experimentId?: ExperimentIdType
     query?: string | null
-    type: AuthorizedUrlListType
     allowWildCards?: boolean
+    displaySuggestions?: boolean
 }
 
 export function AuthorizedUrlList({
@@ -28,6 +29,7 @@ export function AuthorizedUrlList({
     type,
     addText = 'Add new authorized URL',
     allowWildCards,
+    displaySuggestions = true,
 }: AuthorizedUrlListProps & { addText?: string }): JSX.Element {
     const logic = authorizedUrlListLogic({
         experimentId: experimentId ?? null,
@@ -45,7 +47,12 @@ export function AuthorizedUrlList({
 
     return (
         <div className="flex flex-col gap-2">
-            <EmptyState experimentId={experimentId} actionId={actionId} type={type} />
+            <EmptyState
+                experimentId={experimentId}
+                actionId={actionId}
+                type={type}
+                displaySuggestions={displaySuggestions}
+            />
 
             {isAddUrlFormVisible ? (
                 <div className="border rounded p-2 bg-surface-primary">
@@ -72,6 +79,10 @@ export function AuthorizedUrlList({
                 // If there are no authorized urls, highlight the first suggestion
                 const isFirstSuggestion = keyedURL.originalIndex === 0 && keyedURL.type === 'suggestion'
                 const isHighlighted = noAuthorizedUrls && isFirstSuggestion
+
+                if (!displaySuggestions && keyedURL.type === 'suggestion') {
+                    return null
+                }
 
                 return editUrlIndex === index ? (
                     <div className="border rounded p-2 bg-surface-primary">

--- a/frontend/src/lib/components/AuthorizedUrlList/EmptyState.tsx
+++ b/frontend/src/lib/components/AuthorizedUrlList/EmptyState.tsx
@@ -9,12 +9,18 @@ import { ExperimentIdType } from '~/types'
 import { authorizedUrlListLogic, AuthorizedUrlListType, KeyedAppUrl } from './authorizedUrlListLogic'
 
 type EmptyStateProps = {
+    type: AuthorizedUrlListType
     experimentId?: ExperimentIdType | null
     actionId?: number | null
-    type: AuthorizedUrlListType
+    displaySuggestions?: boolean
 }
 
-export function EmptyState({ experimentId, actionId, type }: EmptyStateProps): JSX.Element | null {
+export function EmptyState({
+    experimentId,
+    actionId,
+    type,
+    displaySuggestions = true,
+}: EmptyStateProps): JSX.Element | null {
     const logic = authorizedUrlListLogic({ experimentId: experimentId ?? null, actionId: actionId ?? null, type })
     const { urlsKeyed, suggestionsLoading, isAddUrlFormVisible } = useValues(logic)
     const { loadSuggestions } = useActions(logic)
@@ -45,7 +51,7 @@ export function EmptyState({ experimentId, actionId, type }: EmptyStateProps): J
             return null
         }
 
-        if (suggestionURLs.length > 0) {
+        if (suggestionURLs.length > 0 && displaySuggestions) {
             return (
                 <p className="mb-0">
                     There are no authorized {domainOrUrl}s. <br />
@@ -84,18 +90,21 @@ export function EmptyState({ experimentId, actionId, type }: EmptyStateProps): J
                             'When no domains are specified, recordings will be authorized on all domains.'}
                     </span>
                 </p>
-                <div className="flex flex-col items-end gap-2">
-                    <LemonButton
-                        onClick={loadSuggestions}
-                        disabled={suggestionsLoading}
-                        type="secondary"
-                        icon={<IconRefresh />}
-                        data-attr="authorized-url-list-fetch-suggestions"
-                    >
-                        {suggestionsLoading ? 'Fetching...' : 'Fetch suggestions'}
-                    </LemonButton>
-                    <span className="text-small text-secondary">Sent an event? Refetch suggestions.</span>
-                </div>
+
+                {displaySuggestions && (
+                    <div className="flex flex-col items-end gap-2">
+                        <LemonButton
+                            onClick={loadSuggestions}
+                            disabled={suggestionsLoading}
+                            type="secondary"
+                            icon={<IconRefresh />}
+                            data-attr="authorized-url-list-fetch-suggestions"
+                        >
+                            {suggestionsLoading ? 'Fetching...' : 'Fetch suggestions'}
+                        </LemonButton>
+                        <span className="text-small text-secondary">Sent an event? Refetch suggestions.</span>
+                    </div>
+                )}
             </div>
         )
     }, [
@@ -106,6 +115,7 @@ export function EmptyState({ experimentId, actionId, type }: EmptyStateProps): J
         type,
         domainOrUrl,
         loadSuggestions,
+        displaySuggestions,
     ])
 
     return children ? <div className="border rounded p-4 text-secondary">{children}</div> : null

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -252,6 +252,7 @@ export const FEATURE_FLAGS = {
     PROJECTED_TOTAL_AMOUNT: 'projected-total-amount', // owner: @zach
     SESSION_RECORDINGS_PLAYLIST_COUNT_COLUMN: 'session-recordings-playlist-count-column', // owner: @pauldambra #team-replay
     WEB_ANALYTICS_DOMAIN_DROPDOWN: 'web-analytics-domain-dropdown', // owner: @rafaeelaudibert #team-web-analytics
+    ONBOARDING_AUTHORIZED_DOMAINS: 'onboarding-authorized-domains', // owner: @rafaeelaudibert #team-web-analytics
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/scenes/onboarding/Onboarding.tsx
+++ b/frontend/src/scenes/onboarding/Onboarding.tsx
@@ -32,6 +32,7 @@ import { SDKs } from './sdks/SDKs'
 import { sdksLogic } from './sdks/sdksLogic'
 import { SessionReplaySDKInstructions } from './sdks/session-replay/SessionReplaySDKInstructions'
 import { SurveysSDKInstructions } from './sdks/surveys/SurveysSDKInstructions'
+import { OnboardingWebAnalyticsAuthorizedDomainsStep } from './web-analytics/OnboardingWebAnalyticsAuthorizedDomainsStep'
 
 export const scene: SceneExport = {
     component: Onboarding,
@@ -58,28 +59,12 @@ const OnboardingWrapper = ({ children }: { children: React.ReactNode }): JSX.Ele
     const showNewPlansStep = useFeatureFlag('ONBOARDING_NEW_PLANS_STEP', 'test')
 
     useEffect(() => {
-        createAllSteps()
-    }, [children, billingLoading])
-
-    useEffect(() => {
-        if (!allSteps.length || (billingLoading && waitForBilling)) {
-            return
-        }
-        setAllOnboardingSteps(allSteps)
-    }, [allSteps])
-
-    if (!product || !children) {
-        return <></>
-    }
-
-    const createAllSteps = (): void => {
         let steps = []
         if (Array.isArray(children)) {
             steps = [...children]
         } else {
             steps = [children as JSX.Element]
         }
-        const billingProduct = billing?.products.find((p) => p.type === productKey)
 
         if (shouldShowDataWarehouseStep) {
             const DataWarehouseStep = (
@@ -95,6 +80,8 @@ const OnboardingWrapper = ({ children }: { children: React.ReactNode }): JSX.Ele
             const ReverseProxyStep = <OnboardingReverseProxy stepKey={OnboardingStepKey.REVERSE_PROXY} />
             steps = [...steps, ReverseProxyStep]
         }
+
+        const billingProduct = billing?.products.find((p) => p.type === productKey)
         if (shouldShowBillingStep && billingProduct) {
             const BillingStep = showNewPlansStep ? (
                 <OnboardingUpgradeStep product={billingProduct} stepKey={OnboardingStepKey.PLANS} />
@@ -103,9 +90,23 @@ const OnboardingWrapper = ({ children }: { children: React.ReactNode }): JSX.Ele
             )
             steps = [...steps, BillingStep]
         }
+
         const inviteTeammatesStep = <OnboardingInviteTeammates stepKey={OnboardingStepKey.INVITE_TEAMMATES} />
         steps = [...steps, inviteTeammatesStep].filter(Boolean)
+
         setAllSteps(steps)
+    }, [children, billingLoading])
+
+    useEffect(() => {
+        if (!allSteps.length || (billingLoading && waitForBilling)) {
+            return
+        }
+
+        setAllOnboardingSteps(allSteps)
+    }, [allSteps])
+
+    if (!product || !children) {
+        return <></>
     }
 
     if (!currentOnboardingStep) {
@@ -116,7 +117,7 @@ const OnboardingWrapper = ({ children }: { children: React.ReactNode }): JSX.Ele
         )
     }
 
-    return currentOnboardingStep || <></>
+    return currentOnboardingStep
 }
 
 const ProductAnalyticsOnboarding = (): JSX.Element => {
@@ -229,6 +230,7 @@ const ProductAnalyticsOnboarding = (): JSX.Element => {
 
 const WebAnalyticsOnboarding = (): JSX.Element => {
     const { currentTeam } = useValues(teamLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     const options: ProductConfigOption[] = [
         {
@@ -285,6 +287,11 @@ const WebAnalyticsOnboarding = (): JSX.Element => {
                 sdkInstructionMap={WebAnalyticsSDKInstructions}
                 stepKey={OnboardingStepKey.INSTALL}
             />
+
+            {featureFlags[FEATURE_FLAGS.ONBOARDING_AUTHORIZED_DOMAINS] && (
+                <OnboardingWebAnalyticsAuthorizedDomainsStep stepKey={OnboardingStepKey.AUTHORIZED_DOMAINS} />
+            )}
+
             <OnboardingProductConfiguration stepKey={OnboardingStepKey.PRODUCT_CONFIGURATION} options={options} />
         </OnboardingWrapper>
     )

--- a/frontend/src/scenes/onboarding/OnboardingInviteTeammates.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingInviteTeammates.tsx
@@ -48,7 +48,7 @@ export const OnboardingInviteTeammates = ({ stepKey }: { stepKey: OnboardingStep
         <OnboardingStep
             title="Invite teammates"
             stepKey={stepKey}
-            continueAction={() =>
+            onContinue={() =>
                 preflight?.email_service_available &&
                 invitesToSend[0]?.target_email &&
                 canSubmitInvites &&

--- a/frontend/src/scenes/onboarding/OnboardingProductConfiguration.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingProductConfiguration.tsx
@@ -92,7 +92,7 @@ export const OnboardingProductConfiguration = ({
     ]
 
     return combinedList.length > 0 ? (
-        <OnboardingStep title="Set up your configuration" stepKey={stepKey} continueAction={saveConfiguration}>
+        <OnboardingStep title="Set up your configuration" stepKey={stepKey} onContinue={saveConfiguration}>
             <div className="mt-6">
                 <h2 className="pt-2">Options</h2>
                 {combinedList.map((item, idx) => (

--- a/frontend/src/scenes/onboarding/OnboardingStep.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingStep.tsx
@@ -17,9 +17,10 @@ export const OnboardingStep = ({
     showSkip = false,
     showHelpButton = false,
     onSkip,
-    continueAction,
+    onContinue,
     continueText,
     continueOverride,
+    continueDisabledReason,
     hideHeader,
     breadcrumbHighlightName,
     fullWidth = false,
@@ -31,9 +32,10 @@ export const OnboardingStep = ({
     showSkip?: boolean
     showHelpButton?: boolean
     onSkip?: () => void
-    continueAction?: () => void
+    onContinue?: () => void
     continueText?: string
     continueOverride?: JSX.Element
+    continueDisabledReason?: string
     hideHeader?: boolean
     breadcrumbHighlightName?: OnboardingStepKey
     fullWidth?: boolean
@@ -132,7 +134,7 @@ export const OnboardingStep = ({
                             status="alt"
                             data-attr="onboarding-continue"
                             onClick={() => {
-                                continueAction && continueAction()
+                                onContinue?.()
                                 !hasNextStep
                                     ? completeOnboarding(
                                           undefined,
@@ -143,6 +145,7 @@ export const OnboardingStep = ({
                                     : goToNextStep()
                             }}
                             sideIcon={hasNextStep ? <IconArrowRight /> : null}
+                            disabledReason={continueDisabledReason}
                         >
                             {continueText ? continueText : !hasNextStep ? 'Finish' : 'Next'}
                         </LemonButton>

--- a/frontend/src/scenes/onboarding/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/onboardingLogic.tsx
@@ -34,6 +34,7 @@ export enum OnboardingStepKey {
     DASHBOARD_TEMPLATE = 'dashboard_template',
     DASHBOARD_TEMPLATE_CONFIGURE = 'dashboard_template_configure',
     SESSION_REPLAY = 'session_replay',
+    AUTHORIZED_DOMAINS = 'authorized_domains',
 }
 
 export const breadcrumbExcludeSteps = [OnboardingStepKey.DASHBOARD_TEMPLATE_CONFIGURE]
@@ -56,6 +57,8 @@ export const getProductUri = (productKey: ProductKey, replayLandingPage: ReplayT
     switch (productKey) {
         case ProductKey.PRODUCT_ANALYTICS:
             return urls.insightNew()
+        case ProductKey.WEB_ANALYTICS:
+            return urls.webAnalytics()
         case ProductKey.SESSION_REPLAY:
             return urls.replay(replayLandingPage)
         case ProductKey.FEATURE_FLAGS:

--- a/frontend/src/scenes/onboarding/web-analytics/OnboardingWebAnalyticsAuthorizedDomainsStep.tsx
+++ b/frontend/src/scenes/onboarding/web-analytics/OnboardingWebAnalyticsAuthorizedDomainsStep.tsx
@@ -1,0 +1,47 @@
+import { useValues } from 'kea'
+import { AuthorizedUrlList } from 'lib/components/AuthorizedUrlList/AuthorizedUrlList'
+import { authorizedUrlListLogic, AuthorizedUrlListType } from 'lib/components/AuthorizedUrlList/authorizedUrlListLogic'
+
+import { OnboardingStepKey } from '../onboardingLogic'
+import { OnboardingStep } from '../OnboardingStep'
+
+export function OnboardingWebAnalyticsAuthorizedDomainsStep({
+    stepKey = OnboardingStepKey.AUTHORIZED_DOMAINS,
+}: {
+    usersAction?: string
+    subtitle?: string
+    stepKey?: OnboardingStepKey
+}): JSX.Element {
+    const { authorizedUrls } = useValues(
+        authorizedUrlListLogic({
+            actionId: null,
+            experimentId: null,
+            type: AuthorizedUrlListType.WEB_ANALYTICS,
+            allowWildCards: false,
+        })
+    )
+
+    return (
+        <OnboardingStep
+            title="Authorized Domains"
+            stepKey={stepKey}
+            showSkip
+            continueDisabledReason={authorizedUrls.length === 0 ? 'Add at least one authorized domain' : undefined}
+        >
+            <p>
+                These are the domains we'll use as breakdown when looking at <b>Web Analytics</b>. Make sure you add all
+                the domains you'll install PostHog at. These are also the URLs where our toolbar will be enabled.
+            </p>
+            <p>
+                <b>Wildcards are not allowed</b> (example: <code>https://*.posthog.com</code>). The domain needs to be
+                something concrete that can be launched (example: <code>https://app.posthog.com</code>).
+            </p>
+
+            <AuthorizedUrlList
+                type={AuthorizedUrlListType.WEB_ANALYTICS}
+                allowWildCards={false}
+                displaySuggestions={false}
+            />
+        </OnboardingStep>
+    )
+}

--- a/frontend/src/scenes/settings/environment/AutocaptureSettings.tsx
+++ b/frontend/src/scenes/settings/environment/AutocaptureSettings.tsx
@@ -158,11 +158,7 @@ export function WebVitalsAutocaptureSettings(): JSX.Element {
                 }}
                 checked={!!currentTeam?.autocapture_web_vitals_opt_in}
                 disabled={userLoading}
-                label={
-                    <>
-                        Enable web vitals autocapture <LemonTag>NEW</LemonTag>
-                    </>
-                }
+                label="Enable web vitals autocapture"
                 bordered
             />
             <LemonDivider />

--- a/frontend/src/scenes/teamLogic.tsx
+++ b/frontend/src/scenes/teamLogic.tsx
@@ -15,7 +15,7 @@ import {
     type ProductIntentProperties,
 } from 'lib/utils/product-intents'
 
-import { activationLogic } from '~/layout/navigation-3000/sidepanel/panels/activation/activationLogic'
+import { activationLogic, ActivationTask } from '~/layout/navigation-3000/sidepanel/panels/activation/activationLogic'
 import { CorrelationConfigType, ProductKey, ProjectType, TeamPublicType, TeamType } from '~/types'
 
 import { organizationLogic } from './organizationLogic'
@@ -246,6 +246,14 @@ export const teamLogic = kea<teamLogicType>([
         updateCurrentTeamSuccess: ({ currentTeam, payload }) => {
             if (currentTeam && !payload?.onboarding_tasks) {
                 activationLogic.findMounted()?.actions?.onTeamLoad(currentTeam)
+            }
+
+            if (payload?.autocapture_web_vitals_opt_in) {
+                activationLogic.findMounted()?.actions?.markTaskAsCompleted(ActivationTask.SetUpWebVitals)
+            }
+
+            if (payload?.app_urls && payload?.app_urls.length > 0) {
+                activationLogic.findMounted()?.actions?.markTaskAsCompleted(ActivationTask.AddAuthorizedDomain)
             }
         },
         createTeamSuccess: ({ currentTeam }) => {


### PR DESCRIPTION
## Problem

Web Analytics now requires `app_urls` to be properly set-up if we want our customers to make the most out of it.

## Changes

Changes are 2-fold:

On the `/products` onboarding, display the `app_urls` UI inline
![image](https://github.com/user-attachments/assets/ed88d4e6-ec34-489d-8b27-5e78331eabd7)

On the Quick Start guide on the sidebar
![image](https://github.com/user-attachments/assets/49ec1dbe-67c9-45b3-94df-d8bc5c30f09b)

## Does this work well for both Cloud and self-hosted?

Yep

## How did you test this code?

Manually
