### PR TITLE
chore: usage report rate limits / timeouts

### DIFF
--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -1860,6 +1860,7 @@ class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
             f"{BILLING_SERVICE_URL}/api/usage",
             json=full_report_as_dict,
             headers={"Authorization": f"Bearer {token}"},
+            timeout=15,
         )
 
         mock_posthog.capture.assert_any_call(
@@ -1899,6 +1900,7 @@ class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
                 f"{BILLING_SERVICE_URL}/api/usage",
                 json=full_report_as_dict,
                 headers={"Authorization": f"Bearer {token}"},
+                timeout=15,
             )
 
             mock_posthog.capture.assert_any_call(

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -310,7 +310,7 @@ def send_report_to_billing_service(org_id: str, report: dict[str, Any]) -> None:
         if token:
             headers["Authorization"] = f"Bearer {token}"
 
-        response = requests.post(f"{BILLING_SERVICE_URL}/api/usage", json=report, headers=headers)
+        response = requests.post(f"{BILLING_SERVICE_URL}/api/usage", json=report, headers=headers, timeout=15)
         if response.status_code != 200:
             raise Exception(
                 f"Failed to send usage report to billing service code:{response.status_code} response:{response.text}"

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -287,7 +287,7 @@ def get_org_user_count(organization_id: str) -> int:
     return OrganizationMembership.objects.filter(organization_id=organization_id).count()
 
 
-@shared_task(**USAGE_REPORT_TASK_KWARGS, max_retries=3, rate_limit="10/s")
+@shared_task(**USAGE_REPORT_TASK_KWARGS, max_retries=3, rate_limit="5/s")
 def send_report_to_billing_service(org_id: str, report: dict[str, Any]) -> None:
     if not settings.EE_AVAILABLE:
         return


### PR DESCRIPTION
## Changes

Seeing some consistent failures so trying to take the load off billing a bit more

See sentry: https://posthog.sentry.io/issues/3950652020/?project=1899813&query=is%3Aunresolved%20usage_report&referrer=issue-stream&statsPeriod=14d&stream_index=0

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

It doesn't have an impact.