### PR TITLE
feat(flags): Allow release condition sets to be re-ordered

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -12,7 +12,7 @@ import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { INSTANTLY_AVAILABLE_PROPERTIES } from 'lib/constants'
 import { groupsAccessLogic, GroupsAccessStatus } from 'lib/introductions/groupsAccessLogic'
 import { GroupsIntroductionOption } from 'lib/introductions/GroupsIntroductionOption'
-import { IconErrorOutline, IconOpenInNew, IconSubArrowRight } from 'lib/lemon-ui/icons'
+import { IconArrowDown, IconArrowUp, IconErrorOutline, IconOpenInNew, IconSubArrowRight } from 'lib/lemon-ui/icons'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
@@ -121,6 +121,8 @@ export function FeatureFlagReleaseConditions({
         duplicateConditionSet,
         removeConditionSet,
         addConditionSet,
+        moveConditionSetUp,
+        moveConditionSetDown,
     } = useActions(releaseConditionsLogic)
 
     const { showGroupsOptions, groupTypes, aggregationLabel } = useValues(groupsModel)
@@ -182,9 +184,33 @@ export function FeatureFlagReleaseConditions({
                         </div>
                         {!readOnly && (
                             <div className="flex">
+                                {filterGroups.length > 1 && (
+                                    <div className="flex mr-2">
+                                        <LemonButton
+                                            icon={<IconArrowDown />}
+                                            noPadding
+                                            tooltip="Move condition set down in precendence"
+                                            disabledReason={
+                                                index === filterGroups.length - 1
+                                                    ? 'Cannot move last condition set down'
+                                                    : null
+                                            }
+                                            onClick={() => moveConditionSetDown(index)}
+                                        />
+
+                                        <LemonButton
+                                            icon={<IconArrowUp />}
+                                            noPadding
+                                            tooltip="Move condition set up in precendence"
+                                            disabledReason={index === 0 ? 'Cannot move first condition set up' : null}
+                                            onClick={() => moveConditionSetUp(index)}
+                                        />
+                                    </div>
+                                )}
                                 <LemonButton
                                     icon={<IconCopy />}
                                     noPadding
+                                    tooltip="Duplicate condition set"
                                     onClick={() => duplicateConditionSet(index)}
                                 />
                                 {!isEarlyAccessFeatureCondition(group) &&
@@ -192,6 +218,7 @@ export function FeatureFlagReleaseConditions({
                                         <LemonButton
                                             icon={<IconTrash />}
                                             noPadding
+                                            tooltip="Remove condition set"
                                             onClick={() => {
                                                 removeConditionSet(index)
                                                 if (filterGroups.length === 1) {

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -189,7 +189,7 @@ export function FeatureFlagReleaseConditions({
                                         <LemonButton
                                             icon={<IconArrowDown />}
                                             noPadding
-                                            tooltip="Move condition set down in precendence"
+                                            tooltip="Move condition set down in precedence"
                                             disabledReason={
                                                 index === filterGroups.length - 1
                                                     ? 'Cannot move last condition set down'

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -201,7 +201,7 @@ export function FeatureFlagReleaseConditions({
                                         <LemonButton
                                             icon={<IconArrowUp />}
                                             noPadding
-                                            tooltip="Move condition set up in precendence"
+                                            tooltip="Move condition set up in precedence"
                                             disabledReason={index === 0 ? 'Cannot move first condition set up' : null}
                                             onClick={() => moveConditionSetUp(index)}
                                         />

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsLogic.ts
@@ -126,10 +126,11 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                     if (!state || index === state.groups.length - 1) {
                         return state
                     }
+
                     const groups = [...state.groups]
-                    const temp = groups[index]
-                    groups[index] = groups[index + 1]
-                    groups[index + 1] = temp
+                    const condition = groups[index]
+                    groups.splice(index, 1)
+                    groups.splice(index + 1, 0, condition)
                     return { ...state, groups }
                 },
                 moveConditionSetUp: (state, { index }) => {
@@ -137,9 +138,9 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                         return state
                     }
                     const groups = [...state.groups]
-                    const temp = groups[index]
-                    groups[index] = groups[index - 1]
-                    groups[index - 1] = temp
+                    const condition = groups[index]
+                    groups.splice(index, 1)
+                    groups.splice(index - 1, 0, condition)
                     return { ...state, groups }
                 },
             },

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsLogic.ts
@@ -41,6 +41,8 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
         addConditionSet: true,
         removeConditionSet: (index: number) => ({ index }),
         duplicateConditionSet: (index: number) => ({ index }),
+        moveConditionSetUp: (index: number) => ({ index }),
+        moveConditionSetDown: (index: number) => ({ index }),
         updateConditionSet: (
             index: number,
             newRolloutPercentage?: number,
@@ -118,6 +120,26 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                         return state
                     }
                     const groups = state.groups.concat([state.groups[index]])
+                    return { ...state, groups }
+                },
+                moveConditionSetDown: (state, { index }) => {
+                    if (!state || index === state.groups.length - 1) {
+                        return state
+                    }
+                    const groups = [...state.groups]
+                    const temp = groups[index]
+                    groups[index] = groups[index + 1]
+                    groups[index + 1] = temp
+                    return { ...state, groups }
+                },
+                moveConditionSetUp: (state, { index }) => {
+                    if (!state || index === 0) {
+                        return state
+                    }
+                    const groups = [...state.groups]
+                    const temp = groups[index]
+                    groups[index] = groups[index - 1]
+                    groups[index - 1] = temp
                     return { ...state, groups }
                 },
             },


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/28452

Demo: 

https://github.com/user-attachments/assets/b603c919-a77d-44db-9fdb-11b75c5b33e6



## Changes

- New UX allowing release conditions to be bumped up or down
- Tooltips on all condition set actions

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

See video above
