### PR TITLE
fix(experiments): fix test data generation mgmt cmd

### DIFF
--- a/posthog/management/commands/generate_experiment_data.py
+++ b/posthog/management/commands/generate_experiment_data.py
@@ -210,6 +210,7 @@ class Command(BaseCommand):
             )[0]
             variant_counts[variant] += 1
             distinct_id = str(uuid.uuid4())
+            feature_flag_property = f"$feature/{experiment_id}"
             random_timestamp = datetime.fromtimestamp(
                 random.uniform(
                     experiment_config.start_timestamp.timestamp(),
@@ -222,6 +223,7 @@ class Command(BaseCommand):
                 event="$feature_flag_called",
                 timestamp=random_timestamp,
                 properties={
+                    feature_flag_property: variant,
                     "$feature_flag_response": variant,
                     "$feature_flag": experiment_id,
                 },


### PR DESCRIPTION
## Problem
After https://github.com/PostHog/posthog/pull/29015, we require that `$feature_flag_called` events also contain the property `$feature/<key>: <variant>`. Earlier, we just required `$feature_flag: <key>` and `$feature_flag_response: <variant>`. Now we require all three. I think we should research a little deeper here, as this data is duplicated.  Any difference in the logic that sets them we should be aware of? Etc. But for now, just fix the issue so data generation works again.

## Changes
Add the property  `$feature/<feature-flag-key>: <variant>` to the data generation mgmt cmd.

## How did you test this code?
* data generation currently does not work on master, gives "no control variant found error".
* data generation works again with this change
