### PR TITLE
fix(insight-variables): Fixed insight variables erroring

### DIFF
--- a/posthog/api/test/test_query.py
+++ b/posthog/api/test/test_query.py
@@ -8,6 +8,7 @@ from rest_framework import status
 from posthog.api.services.query import process_query_dict
 
 
+from posthog.models.insight_variable import InsightVariable
 from posthog.models.property_definition import PropertyDefinition, PropertyType
 from posthog.models.utils import UUIDT
 from posthog.hogql.constants import LimitContext
@@ -1009,6 +1010,44 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response_without_dashboard_filters.results, [(2,)])
         assert isinstance(response_with_dashboard_filters, CachedHogQLQueryResponse)
         self.assertEqual(response_with_dashboard_filters.results, [(1,)])
+
+    def test_dashboard_variables_overrides(self):
+        variable = InsightVariable.objects.create(
+            team=self.team, name="Test", code_name="test", default_value="some_default_value", type="String"
+        )
+        variable_id = str(variable.pk)
+        variable_override_value = "helloooooo"
+
+        api_response = self.client.post(
+            f"/api/projects/{self.team.id}/query/",
+            {
+                "query": {
+                    "kind": "HogQLQuery",
+                    "query": "select {variables.test}",
+                    "explain": True,
+                    "filters": {"dateRange": {"date_from": "-7d"}},
+                    "variables": {
+                        variable_id: {
+                            "variableId": variable_id,
+                            "code_name": variable.code_name,
+                            "value": variable_override_value,
+                        }
+                    },
+                },
+                "client_query_id": "5d92fb51-5088-45e8-91b2-843aef3d69bd",
+                "filters_override": None,
+                "variables_override": {
+                    variable_id: {
+                        "code_name": variable.code_name,
+                        "variableId": variable_id,
+                        "value": variable_override_value,
+                    }
+                },
+            },
+        ).json()
+
+        response = CachedHogQLQueryResponse.model_validate(api_response)
+        assert response.results[0][0] == variable_override_value
 
 
 class TestQueryAwaited(ClickhouseTestMixin, APIBaseTest):

--- a/posthog/hogql_queries/apply_dashboard_filters.py
+++ b/posthog/hogql_queries/apply_dashboard_filters.py
@@ -1,7 +1,7 @@
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.query_runner import get_query_runner
 from posthog.models import Team
-from posthog.schema import DashboardFilter, NodeKind
+from posthog.schema import DashboardFilter, HogQLVariable, NodeKind
 from typing import Any
 
 WRAPPER_NODE_KINDS = [NodeKind.DATA_TABLE_NODE, NodeKind.DATA_VISUALIZATION_NODE, NodeKind.INSIGHT_VIZ_NODE]
@@ -88,13 +88,14 @@ def apply_dashboard_variables(query: Any, variables_overrides: dict[str, dict], 
 
         updated_variables = query_variables.copy()
         for variable_id, overriden_hogql_variable in variables_overrides.items():
-            query_variable = updated_variables.get(variable_id)
+            query_variable: HogQLVariable = updated_variables.get(variable_id)
+
             if query_variable:
-                updated_variables[variable_id] = {
-                    "variableId": variable_id,
-                    "code_name": query_variable["code_name"],
-                    "value": overriden_hogql_variable.get("value"),
-                }
+                updated_variables[variable_id] = HogQLVariable(
+                    variableId=variable_id,
+                    code_name=query_variable.code_name,
+                    value=overriden_hogql_variable.get("value"),
+                )
 
         return query.model_copy(update={"variables": updated_variables})
 


### PR DESCRIPTION
## Problem
- Insights with dashboard variables overrides were erroring due to how we were accessing the variable - we were expecting it to be a `dict` when it was actually a `HogQLVariable`
- Introduced by some query awaited stuff and changing how we parse the variables
- [Reported in slack here](https://posthog.slack.com/archives/C019RAX2XBN/p1740650991612949)

## Changes
- Assume the variable is a `HogQLVariable` and ensure we return `HogQLVariable` types
- Added a test for this 

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Added a test