### PR TITLE
fix(experiments): use materialized columns in exposure queries

### DIFF
--- a/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
@@ -100,10 +100,7 @@ class ExperimentExposuresQueryRunner(QueryRunner):
                     ),
                     ast.CompareOperation(
                         op=ast.CompareOperationOp.In,
-                        left=parse_expr(
-                            "replaceAll(JSONExtractRaw(properties, {feature_flag_property}), '\"', '')",
-                            placeholders={"feature_flag_property": ast.Constant(value=feature_flag_property)},
-                        ),
+                        left=ast.Field(chain=["properties", feature_flag_property]),
                         right=ast.Constant(value=self.variants),
                     ),
                     *exposure_property_filters,
@@ -119,20 +116,17 @@ class ExperimentExposuresQueryRunner(QueryRunner):
                     ),
                     ast.CompareOperation(
                         op=ast.CompareOperationOp.Eq,
-                        left=parse_expr("replaceAll(JSONExtractRaw(properties, '$feature_flag'), '\"', '')"),
+                        left=ast.Field(chain=["properties", "$feature_flag"]),
                         right=ast.Constant(value=feature_flag_key),
                     ),
                     ast.CompareOperation(
                         op=ast.CompareOperationOp.In,
-                        left=parse_expr("replaceAll(JSONExtractRaw(properties, '$feature_flag_response'), '\"', '')"),
+                        left=ast.Field(chain=["properties", "$feature_flag_response"]),
                         right=ast.Constant(value=self.variants),
                     ),
                     ast.CompareOperation(
                         op=ast.CompareOperationOp.In,
-                        left=parse_expr(
-                            "replaceAll(JSONExtractRaw(properties, {feature_flag_property}), '\"', '')",
-                            placeholders={"feature_flag_property": ast.Constant(value=feature_flag_property)},
-                        ),
+                        left=ast.Field(chain=["properties", feature_flag_property]),
                         right=ast.Constant(value=self.variants),
                     ),
                 ]
@@ -148,11 +142,11 @@ class ExperimentExposuresQueryRunner(QueryRunner):
                 table=ast.SelectQuery(
                     select=[
                         parse_expr("toDate(toString(min(timestamp))) as day"),
-                        parse_expr(
-                            "replaceAll(JSONExtractRaw(properties, {feature_flag_property}), '\"', '') AS variant",
-                            placeholders={"feature_flag_property": ast.Constant(value=feature_flag_property)},
+                        ast.Alias(
+                            alias="variant",
+                            expr=ast.Field(chain=["properties", feature_flag_property]),
                         ),
-                        parse_expr("person_id"),
+                        ast.Field(chain=["person_id"]),
                     ],
                     select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
                     where=ast.And(
@@ -172,11 +166,8 @@ class ExperimentExposuresQueryRunner(QueryRunner):
                         ]
                     ),
                     group_by=[
-                        parse_expr("person_id"),
-                        parse_expr(
-                            "replaceAll(JSONExtractRaw(properties, {feature_flag_property}), '\"', '')",
-                            placeholders={"feature_flag_property": ast.Constant(value=feature_flag_property)},
-                        ),
+                        ast.Field(chain=["person_id"]),
+                        ast.Field(chain=["properties", feature_flag_property]),
                     ],
                 ),
                 alias="subq",

--- a/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_exposures_query_runner.ambr
+++ b/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_exposures_query_runner.ambr
@@ -6,7 +6,7 @@
          count(subq.person_id) AS exposed_count
   FROM
     (SELECT toDateOrNull(toString(min(toTimeZone(events.timestamp, 'UTC')))) AS day,
-            replaceAll(JSONExtractRaw(events.properties, '$feature/test-experiment'), '"', '') AS variant,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '') AS variant,
             if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id
      FROM events
      LEFT OUTER JOIN
@@ -16,9 +16,9 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceAll(JSONExtractRaw(events.properties, '$feature_flag'), '"', ''), 'test-experiment'), 0), ifNull(in(replaceAll(JSONExtractRaw(events.properties, '$feature_flag_response'), '"', ''), ['control', 'test']), 0), ifNull(in(replaceAll(JSONExtractRaw(events.properties, '$feature/test-experiment'), '"', ''), ['control', 'test']), 0)), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')))
+     WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0), ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']), 0), ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', ''), ['control', 'test']), 0)), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')))
      GROUP BY if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id),
-              replaceAll(JSONExtractRaw(events.properties, '$feature/test-experiment'), '"', '')) AS subq
+              replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')) AS subq
   GROUP BY subq.day,
            subq.variant
   ORDER BY subq.day ASC
@@ -38,7 +38,7 @@
          count(subq.person_id) AS exposed_count
   FROM
     (SELECT toDateOrNull(toString(min(toTimeZone(events.timestamp, 'UTC')))) AS day,
-            replaceAll(JSONExtractRaw(events.properties, '$feature/test-experiment'), '"', '') AS variant,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '') AS variant,
             if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id
      FROM events
      LEFT OUTER JOIN
@@ -58,9 +58,9 @@
                                                               WHERE equals(person.team_id, 99999)
                                                               GROUP BY person.id
                                                               HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
-     WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceAll(JSONExtractRaw(events.properties, '$feature_flag'), '"', ''), 'test-experiment'), 0), ifNull(in(replaceAll(JSONExtractRaw(events.properties, '$feature_flag_response'), '"', ''), ['control', 'test']), 0), ifNull(in(replaceAll(JSONExtractRaw(events.properties, '$feature/test-experiment'), '"', ''), ['control', 'test']), 0)), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1))
+     WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0), ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']), 0), ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', ''), ['control', 'test']), 0)), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1))
      GROUP BY if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id),
-              replaceAll(JSONExtractRaw(events.properties, '$feature/test-experiment'), '"', '')) AS subq
+              replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')) AS subq
   GROUP BY subq.day,
            subq.variant
   ORDER BY subq.day ASC
@@ -80,7 +80,7 @@
          count(subq.person_id) AS exposed_count
   FROM
     (SELECT toDateOrNull(toString(min(toTimeZone(events.timestamp, 'UTC')))) AS day,
-            replaceAll(JSONExtractRaw(events.properties, '$feature/test-experiment'), '"', '') AS variant,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '') AS variant,
             if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id
      FROM events
      LEFT OUTER JOIN
@@ -90,9 +90,9 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceAll(JSONExtractRaw(events.properties, '$feature_flag'), '"', ''), 'test-experiment'), 0), ifNull(in(replaceAll(JSONExtractRaw(events.properties, '$feature_flag_response'), '"', ''), ['control', 'test']), 0), ifNull(in(replaceAll(JSONExtractRaw(events.properties, '$feature/test-experiment'), '"', ''), ['control', 'test']), 0)), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')))
+     WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0), ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']), 0), ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', ''), ['control', 'test']), 0)), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')))
      GROUP BY if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id),
-              replaceAll(JSONExtractRaw(events.properties, '$feature/test-experiment'), '"', '')) AS subq
+              replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')) AS subq
   GROUP BY subq.day,
            subq.variant
   ORDER BY subq.day ASC
@@ -112,7 +112,7 @@
          count(subq.person_id) AS exposed_count
   FROM
     (SELECT toDateOrNull(toString(min(toTimeZone(events.timestamp, 'UTC')))) AS day,
-            replaceAll(JSONExtractRaw(events.properties, '$feature/test-experiment'), '"', '') AS variant,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '') AS variant,
             if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id
      FROM events
      LEFT OUTER JOIN
@@ -122,9 +122,9 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceAll(JSONExtractRaw(events.properties, '$feature_flag'), '"', ''), 'test-experiment'), 0), ifNull(in(replaceAll(JSONExtractRaw(events.properties, '$feature_flag_response'), '"', ''), ['control', 'test']), 0), ifNull(in(replaceAll(JSONExtractRaw(events.properties, '$feature/test-experiment'), '"', ''), ['control', 'test']), 0)), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')))
+     WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0), ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']), 0), ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', ''), ['control', 'test']), 0)), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')))
      GROUP BY if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id),
-              replaceAll(JSONExtractRaw(events.properties, '$feature/test-experiment'), '"', '')) AS subq
+              replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')) AS subq
   GROUP BY subq.day,
            subq.variant
   ORDER BY subq.day ASC
@@ -144,7 +144,7 @@
          count(subq.person_id) AS exposed_count
   FROM
     (SELECT toDateOrNull(toString(min(toTimeZone(events.timestamp, 'UTC')))) AS day,
-            replaceAll(JSONExtractRaw(events.properties, '$feature/test-experiment'), '"', '') AS variant,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '') AS variant,
             if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id
      FROM events
      LEFT OUTER JOIN
@@ -154,9 +154,9 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceAll(JSONExtractRaw(events.properties, '$feature_flag'), '"', ''), 'test-experiment'), 0), ifNull(in(replaceAll(JSONExtractRaw(events.properties, '$feature_flag_response'), '"', ''), ['control', 'test']), 0), ifNull(in(replaceAll(JSONExtractRaw(events.properties, '$feature/test-experiment'), '"', ''), ['control', 'test']), 0)), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')))
+     WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$feature_flag_called'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0), ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']), 0), ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', ''), ['control', 'test']), 0)), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')))
      GROUP BY if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id),
-              replaceAll(JSONExtractRaw(events.properties, '$feature/test-experiment'), '"', '')) AS subq
+              replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')) AS subq
   GROUP BY subq.day,
            subq.variant
   ORDER BY subq.day ASC
@@ -176,7 +176,7 @@
          count(subq.person_id) AS exposed_count
   FROM
     (SELECT toDateOrNull(toString(min(toTimeZone(events.timestamp, 'UTC')))) AS day,
-            replaceAll(JSONExtractRaw(events.properties, '$feature/test-experiment'), '"', '') AS variant,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '') AS variant,
             if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS person_id
      FROM events
      LEFT OUTER JOIN
@@ -186,9 +186,9 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$pageview'), ifNull(in(replaceAll(JSONExtractRaw(events.properties, '$feature/test-experiment'), '"', ''), ['control', 'test']), 0), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'plan'), ''), 'null'), '^"|"$', ''), 'free'), 1)), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')))
+     WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$pageview'), ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', ''), ['control', 'test']), 0), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'plan'), ''), 'null'), '^"|"$', ''), 'free'), 1)), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp.000000', 6, 'UTC')))
      GROUP BY if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id),
-              replaceAll(JSONExtractRaw(events.properties, '$feature/test-experiment'), '"', '')) AS subq
+              replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature/test-experiment'), ''), 'null'), '^"|"$', '')) AS subq
   GROUP BY subq.day,
            subq.variant
   ORDER BY subq.day ASC


### PR DESCRIPTION
See https://github.com/PostHog/posthog/pull/29287

## Problem
Exposure queries are slower than they have to be due to not using materialized columns.

## Changes
Rewrite raw `parse_expr` to hogql `ast.Field` such that they can be resolved to materialized columns.

## How did you test this code?
* tests passes
