### PR TITLE
fix(data-visualization): display arrays with numbers as arrays

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -178,6 +178,9 @@ export const convertTableValue = (
 }
 
 const toFriendlyClickhouseTypeName = (type: string): ColumnScalar => {
+    if (type.indexOf('Array') !== -1) {
+        return 'ARRAY'
+    }
     if (type.indexOf('Tuple') !== -1) {
         return 'TUPLE'
     }

--- a/frontend/src/queries/nodes/DataVisualization/types.ts
+++ b/frontend/src/queries/nodes/DataVisualization/types.ts
@@ -1,4 +1,13 @@
-export type ColumnScalar = 'INTEGER' | 'FLOAT' | 'DATETIME' | 'DATE' | 'BOOLEAN' | 'DECIMAL' | 'STRING' | 'TUPLE'
+export type ColumnScalar =
+    | 'INTEGER'
+    | 'FLOAT'
+    | 'DATETIME'
+    | 'DATE'
+    | 'BOOLEAN'
+    | 'DECIMAL'
+    | 'STRING'
+    | 'TUPLE'
+    | 'ARRAY'
 
 export interface FormattingTemplate {
     id: string


### PR DESCRIPTION
## Problem

Array columns with numbers are incorrectly displayed as a single number. Try e.g. `select [1,2,3]`

## Changes

Tried my best to figure out the correct change, but the table / formatting logic is quite convoluted. `ColumnScalar` indicates that this can't be an array? However tuples are in there already.

**Before**
<img width="110" alt="Screenshot 2025-02-27 at 15 23 05" src="https://github.com/user-attachments/assets/4177dfca-dcda-40c0-8990-118bf49bccf2" />

**After**
<img width="264" alt="Screenshot 2025-02-27 at 15 23 13" src="https://github.com/user-attachments/assets/79cfa3c8-60af-4bd4-915f-557b0dffd69a" />


## How did you test this code?

Tried locally