### PR TITLE
fix: clarify Zapier webhook path

### DIFF
--- a/posthog/cdp/templates/zapier/template_zapier.py
+++ b/posthog/cdp/templates/zapier/template_zapier.py
@@ -26,7 +26,7 @@ if (inputs.debug) {
             "key": "hook",
             "type": "string",
             "label": "Zapier hook path",
-            "description": "The path of the Zapier webhook. You can create your own or use our native Zapier integration https://zapier.com/apps/posthog/integrations",
+            "description": "The path of the Zapier webhook. This value should be the part of the webhook URL after https://hooks.zapier.com/ (for example: hooks/catch/12345678/2gygaul/). You can create your own or use our native Zapier integration https://zapier.com/apps/posthog/integrations",
             "secret": False,
             "required": True,
             "hidden": False,


### PR DESCRIPTION
## Problem

It was unclear which part of the Zapier webhook URL should be used in the destination.

## Changes

Adds a comment specifying the format.

Cherry-picked from https://github.com/PostHog/posthog/pull/29073, to streamlined the deployment.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Only a documentation change. 