### PR TITLE
fix: Path to geoip file

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -94,7 +94,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         REDIS_POOL_MAX_SIZE: 3,
         DISABLE_MMDB: isTestEnv(),
         MMDB_FILE_LOCATION:
-            isDevEnv() || isTestEnv() ? './share/GeoLite2-City.mmdb' : '/s3/ingestion-assets/mmdb/GeoLite2-City.mmdb',
+            isDevEnv() || isTestEnv() ? '../share/GeoLite2-City.mmdb' : '/s3/ingestion-assets/mmdb/GeoLite2-City.mmdb',
         MMDB_COMPARE_MODE: isTestEnv() || isDevEnv() ? false : true, // For now production is only testing it
         DISTINCT_ID_LRU_SIZE: 10000,
         EVENT_PROPERTY_LRU_SIZE: 10000,

--- a/plugin-server/src/utils/geoip.ts
+++ b/plugin-server/src/utils/geoip.ts
@@ -1,5 +1,4 @@
 import { City, Reader, ReaderModel } from '@maxmind/geoip2-node'
-import { join } from 'path'
 import { Counter } from 'prom-client'
 
 import { Hub, PluginsServerConfig } from '../types'
@@ -22,7 +21,7 @@ export class GeoIPService {
 
     private getMmdb() {
         if (!this._mmdbPromise) {
-            this._mmdbPromise = Reader.open(join(this.config.BASE_DIR, this.config.MMDB_FILE_LOCATION)).catch((e) => {
+            this._mmdbPromise = Reader.open(this.config.MMDB_FILE_LOCATION).catch((e) => {
                 status.warn('🌎', 'Error getting MMDB', {
                     error: e.message,
                 })


### PR DESCRIPTION
## Problem

For production we use a root path but locally a relative one.


## Changes

* Don't prefix with the base path

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
