### PR TITLE
fix(bimports): commit before sleeping

### DIFF
--- a/rust/batch-import-worker/src/emit/kafka.rs
+++ b/rust/batch-import-worker/src/emit/kafka.rs
@@ -81,7 +81,7 @@ impl<'a> Transaction<'a> for KafkaEmitterTransaction<'a> {
         Ok(())
     }
 
-    async fn commit_write(self: Box<Self>) -> Result<(), Error> {
+    async fn commit_write(self: Box<Self>) -> Result<Duration, Error> {
         let unboxed = *self;
         let count = unboxed.count.load(Ordering::SeqCst);
         let min_duration = unboxed.get_min_txn_duration(count);
@@ -93,8 +93,7 @@ impl<'a> Transaction<'a> for KafkaEmitterTransaction<'a> {
         );
         unboxed.inner.commit()?;
         info!("committed transaction");
-        tokio::time::sleep(to_sleep).await;
-        Ok(())
+        Ok(to_sleep)
     }
 }
 

--- a/rust/batch-import-worker/src/emit/mod.rs
+++ b/rust/batch-import-worker/src/emit/mod.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use anyhow::Error;
 use async_trait::async_trait;
 use common_types::InternallyCapturedEvent;
@@ -15,8 +17,9 @@ pub trait Emitter: Send + Sync {
 pub trait Transaction<'a>: Send + Sync {
     async fn emit(&self, data: &[InternallyCapturedEvent]) -> Result<(), Error>;
 
-    async fn commit_write(self: Box<Self>) -> Result<(), Error> {
-        Ok(())
+    // Commits return a delay to wait before the next commit start
+    async fn commit_write(self: Box<Self>) -> Result<Duration, Error> {
+        Ok(Duration::from_secs(0))
     }
 }
 

--- a/rust/batch-import-worker/src/job/mod.rs
+++ b/rust/batch-import-worker/src/job/mod.rs
@@ -240,10 +240,12 @@ impl Job {
         self.begin_part_commit(&key, parsed.consumed).await?;
         info!("Beginning emitter part commit");
 
-        txn.commit_write().await?;
+        let to_sleep = txn.commit_write().await?;
         info!("Finishing PG part commit");
         self.complete_commit().await?;
         info!("Committed part {} consumed {} bytes", key, parsed.consumed);
+        info!("Sleeping for {:?}", to_sleep);
+        tokio::time::sleep(to_sleep).await;
         liveness_loop_flag.store(false, Ordering::Relaxed);
 
         Ok(())

--- a/rust/batch-import-worker/src/job/model.rs
+++ b/rust/batch-import-worker/src/job/model.rs
@@ -151,8 +151,9 @@ impl JobModel {
         }
 
         if extend_lease {
-            self.leased_until =
-                Some(self.leased_until.unwrap_or_else(Utc::now) + chrono::Duration::minutes(5));
+            // We only allow the lease to be set to 5 minutes from now, except in the initial claim
+            // case, where we allow it to be set to 30 minutes from now, because job init can be slow
+            self.leased_until = Some(Utc::now() + chrono::Duration::minutes(5));
         } else {
             self.leased_until = None;
         };


### PR DESCRIPTION
With the slower event rate of 1k/s, workers are sleeping for more than a minute after kafka transaction commits. This is leading to pods getting interrupted in the step between the kafka commit and PG commit, which leaves the jobs in a paused state, so they get stuck and require manual intervention. Instead, the kafka transaction commit can just return how long to job should sleep for after then /entire/ commit is done, and then we should sleep.