### PR TITLE
fix(data-warehouse): Update snowflake home directory for all deployments

### DIFF
--- a/posthog/__init__.py
+++ b/posthog/__init__.py
@@ -3,3 +3,9 @@
 from posthog.celery import app as celery_app
 
 __all__ = ("celery_app",)
+
+# snowflake-connector-python tries to access a root folder which errors out in pods.
+# This sets the snowflake home directory to a relative folder
+import os
+
+os.environ["SNOWFLAKE_HOME"] = "./.snowflake"


### PR DESCRIPTION
## Problem
- Snowflake connector in python got an update that means it tries to access `.root/.snowflake` folder in our pods which throws a permission error

## Changes
- For all deployments, set the snowflake home to a relative folder of the python app
- Not using env vars as we'd need to set this for _most_ deployments