### PR TITLE
fix: use empty list for no types instead of None

### DIFF
--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -250,7 +250,7 @@ class EventsQueryRunner(QueryRunner):
         return EventsQueryResponse(
             results=self.paginator.results,
             columns=self.columns(query_result.columns),
-            types=[t for _, t in query_result.types] if query_result.types else None,
+            types=[t for _, t in query_result.types] if query_result.types else [],
             timings=self.timings.to_list(),
             hogql=query_result.hogql,
             modifiers=self.modifiers,


### PR DESCRIPTION
## Problem

this should fix an error where you filter for an event type that has no results and get a type error

![image](https://github.com/user-attachments/assets/26931ac7-3e78-4c45-86f3-123104a307b4)

types needs to be a list, not None, so use emptylist instead of None

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
