### PR TITLE
fix: EU looks like it needs the password field for dict creation on deletes

### DIFF
--- a/dags/deletes.py
+++ b/dags/deletes.py
@@ -192,13 +192,14 @@ class PendingDeletesDictionary:
                 created_at DateTime,
             )
             PRIMARY KEY team_id, key
-            SOURCE(CLICKHOUSE(DB %(database)s PASSWORD %(password)s QUERY %(query)s))
+            SOURCE(CLICKHOUSE(DB %(database)s USER %(user)s PASSWORD %(password)s QUERY %(query)s))
             LAYOUT(COMPLEX_KEY_HASHED(SHARDS {shards}))
             LIFETIME(0)
             SETTINGS(max_execution_time={max_execution_time}, max_memory_usage={max_memory_usage})
             """,
             {
                 "database": settings.CLICKHOUSE_DATABASE,
+                "user": settings.CLICKHOUSE_USER,
                 "password": settings.CLICKHOUSE_PASSWORD,
                 "query": self.query,
             },


### PR DESCRIPTION
## Problem

debugging https://dagster.prod-eu.posthog.dev/runs/e9f48dab-dcb1-4db0-9dbb-e8492fcad669?logFileKey=pmsvzrsq&selection=%2A and it looks like we still need to pass password for dict creation

## Changes

Pass the password!

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
