### PR TITLE
chore: run migrations on bin/start

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -1,6 +1,6 @@
 procs:
     backend:
-        shell: 'bin/check_kafka_clickhouse_up && ./bin/start-backend'
+        shell: 'bin/check_kafka_clickhouse_up && python manage.py migrate && ./bin/start-backend'
 
     celery-worker:
         shell: 'bin/check_kafka_clickhouse_up && ./bin/start-celery worker'


### PR DESCRIPTION
## Problem

So often i run `bin/start` and it crashes until i realise there are migrations i need to apply. then i need to quit it .. run the migrations and start `bin/start` again

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

apply migrations right away on `bin/start`

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- locally

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
