### PR TITLE
feat: add a slack interactivity callback endpoint

### DIFF
--- a/ee/api/integration.py
+++ b/ee/api/integration.py
@@ -22,6 +22,10 @@ class PublicIntegrationViewSet(viewsets.GenericViewSet):
     authentication_classes = []
     permission_classes = []
 
+    @action(methods=["POST"], detail=False, url_path="slack/interactivity-callback")
+    def slack_interactivity_callback(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        return Response({"status": "ok"})
+
     @action(methods=["POST"], detail=False, url_path="slack/events")
     def slack_events(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         try:

--- a/ee/api/integration.py
+++ b/ee/api/integration.py
@@ -24,6 +24,10 @@ class PublicIntegrationViewSet(viewsets.GenericViewSet):
 
     @action(methods=["POST"], detail=False, url_path="slack/interactivity-callback")
     def slack_interactivity_callback(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        # This is an empty endpoint for the Slack interactivity callback.
+        # We don't verify the request, as we don't do anything with the submitted data.
+        # We only use it to supress the warnings when users press buttons in Slack messages.
+        # In case we decide to do something with it, please add the verification process here.
         return Response({"status": "ok"})
 
     @action(methods=["POST"], detail=False, url_path="slack/events")


### PR DESCRIPTION
## Problem

When pressing any action buttons in messages posted by the PostHog Slackbot, a warning icon pops up next to the button. Slack requires applications to enable "Interactivity" and provide a webhook which they can call whenever a button is pressed.

## Changes

Adds a simple endpoint which always responds with 200. 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

I tested the Slack interface using a mock webhook service on dev, the warnings went away.