### PR TITLE
chore(rust): retrieve sccache server config from environment

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -102,6 +102,13 @@ jobs:
               id: buildx
               uses: docker/setup-buildx-action@v2
 
+            - name: Retrieve sccache configuration
+              id: sccache
+              run: |
+                echo "endpoint=$SCCACHE_WEBDAV_ENDPOINT" >> "$GITHUB_OUTPUT"
+                echo "::add-mask::$SCCACHE_WEBDAV_TOKEN"
+                echo "token=$SCCACHE_WEBDAV_TOKEN" >> "$GITHUB_OUTPUT"
+
             - name: Build and push image
               id: docker_build
               uses: depot/build-push-action@v1
@@ -114,8 +121,8 @@ jobs:
                   platforms: linux/arm64,linux/amd64
                   build-args: BIN=${{ matrix.image }}
                   secrets: |
-                      SCCACHE_WEBDAV_ENDPOINT=${{ env.SCCACHE_WEBDAV_ENDPOINT }}
-                      SCCACHE_WEBDAV_TOKEN=${{ env.SCCACHE_WEBDAV_TOKEN }}
+                      SCCACHE_WEBDAV_ENDPOINT=${{ steps.sccache.outputs.endpoint }}
+                      SCCACHE_WEBDAV_TOKEN=${{ steps.sccache.outputs.token }}
 
             - name: Container image digest
               id: digest


### PR DESCRIPTION
## Problem

cc @oliverb123 - the `${{ env.XYZ }}` context is only populated with env variables set by the job and not "environment variables inherited by the runner process" apparently, per the docs. Currently these env vars we are setting are the latter and so aren't visible under `env.`

## Changes

There may be a way for us to fix this on the runner side so that they are visible under `env`, however in the meantime this PR retrieves the values using a dedicated step, setting the endpoint and token as step outputs.

## Does this work well for both Cloud and self-hosted?

N/A

## How did you test this code?

N/A
