### PR TITLE
[Support SuperDay] - feat: Added bug report button to support panel sidebar

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
@@ -14,6 +14,7 @@ import {
     IconStack,
     IconTestTube,
     IconToggle,
+    IconBug,
 } from '@posthog/icons'
 import { LemonBanner, LemonButton, Link } from '@posthog/lemon-ui'
 import { LemonCollapse } from '@posthog/lemon-ui'
@@ -365,6 +366,19 @@ export const SidePanelSupport = (): JSX.Element => {
                                             targetBlank
                                         >
                                             Request a feature
+                                        </LemonButton>
+                                    </li>
+                                    <li>
+                                        <LemonButton
+                                            type="secondary"
+                                            status="alt"
+                                            to={`https://github.com/PostHog/posthog/issues/new?&labels=bug&template=bug_report.yml&debug-info=${encodeURIComponent(
+                                                getPublicSupportSnippet(region, currentOrganization, currentTeam)
+                                            )}`}
+                                            icon={<IconBug />}
+                                            targetBlank
+                                        >
+                                            Request a bug
                                         </LemonButton>
                                     </li>
                                 </ul>


### PR DESCRIPTION
New button added to feedback section in the support side panel to allow users to report a bug.

@abigailbramble 