### PR TITLE
fix: rust docker image build workflow fix

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -102,6 +102,13 @@ jobs:
               id: buildx
               uses: docker/setup-buildx-action@v2
 
+            - name: Retrieve sccache configuration
+              id: sccache
+              run: |
+                  echo "endpoint=$SCCACHE_WEBDAV_ENDPOINT" >> "$GITHUB_OUTPUT"
+                  echo "::add-mask::$SCCACHE_WEBDAV_TOKEN"
+                  echo "token=$SCCACHE_WEBDAV_TOKEN" >> "$GITHUB_OUTPUT"
+
             - name: Build and push image
               id: docker_build
               uses: depot/build-push-action@v1
@@ -114,8 +121,8 @@ jobs:
                   platforms: linux/arm64,linux/amd64
                   build-args: BIN=${{ matrix.image }}
                   secrets: |
-                      SCCACHE_WEBDAV_ENDPOINT=${{ env.SCCACHE_WEBDAV_ENDPOINT }}
-                      SCCACHE_WEBDAV_TOKEN=${{ env.SCCACHE_WEBDAV_TOKEN }}
+                      SCCACHE_WEBDAV_ENDPOINT=${{ steps.sccache.outputs.endpoint }}
+                      SCCACHE_WEBDAV_TOKEN=${{ steps.sccache.outputs.token }}
 
             - name: Container image digest
               id: digest


### PR DESCRIPTION
Taken from #29362 because we have trouble running CI for external contributions.