### PR TITLE
fix: Error in staff arg in `generate_demo_data`

### DIFF
--- a/posthog/management/commands/generate_demo_data.py
+++ b/posthog/management/commands/generate_demo_data.py
@@ -71,7 +71,6 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--staff",
-            type=bool,
             action="store_true",
             default=False,
             help="Create a staff user",


### PR DESCRIPTION
## Problem

PR #29178 introduced a new `--staff` argument to the `generate_demo_data` command but seems to have introduced a bug:

```
  File "/Users/ross/dev/posthog/posthog/management/commands/generate_demo_data.py", line 72, in add_arguments
    parser.add_argument(
  File "/nix/store/327bf08j5b7l9cnzink3g4vp32y5352j-python3-3.11.9/lib/python3.11/argparse.py", line 1455, in add_argument
    action = action_class(**kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^
TypeError: _StoreTrueAction.__init__() got an unexpected keyword argument 'type'
```

## Changes

Removes the `type=bool` argument which isn't needed in this case

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Ran locally
