### PR TITLE
chore(flags): remove decide request log now that django logs showing up in Loki

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -258,16 +258,6 @@ def get_decide(request: HttpRequest):
 
     # --- 4. Process authenticated requests ---
     if team:
-        # Set up logging and context
-        is_request_sampled_for_logging = random() < settings.DECIDE_REQUEST_LOGGING_SAMPLING_RATE
-        if is_request_sampled_for_logging:
-            logger.warn(
-                "DECIDE_REQUEST_STARTED",
-                team_id=team.id,
-                distinct_id=data.get("distinct_id", None),
-                user_agent=request.headers.get("User-Agent", ""),
-            )
-
         # Check if team is allowed to use decide
         if team.id in settings.DECIDE_SHORT_CIRCUITED_TEAM_IDS:
             return cors_response(
@@ -283,9 +273,7 @@ def get_decide(request: HttpRequest):
         structlog.contextvars.bind_contextvars(team_id=team.id)
 
         # --- 5. Handle feature flags ---
-        flags_response = get_feature_flags_response(
-            request, data, team, token, api_version, is_request_sampled_for_logging
-        )
+        flags_response = get_feature_flags_response(request, data, team, token, api_version)
         response = get_base_config(token, team, request, skip_db=flags_response.get("errorsWhileComputingFlags", False))
 
         # For remote config, we need to ensure quota limiting is reflected
@@ -317,9 +305,7 @@ def get_decide(request: HttpRequest):
     return cors_response(request, JsonResponse(response))
 
 
-def get_feature_flags_response(
-    request: HttpRequest, data: dict, team: Team, token: str, api_version: int, is_request_sampled_for_logging: bool
-) -> dict:
+def get_feature_flags_response(request: HttpRequest, data: dict, team: Team, token: str, api_version: int) -> dict:
     """Determine feature flag response based on various conditions."""
 
     # Early exit if flags are disabled via request
@@ -381,7 +367,7 @@ def get_feature_flags_response(
     )
 
     # Record metrics and handle billing
-    _record_feature_flag_metrics(team, feature_flags, errors, data, is_request_sampled_for_logging, request)
+    _record_feature_flag_metrics(team, feature_flags, errors, data)
 
     # Format response based on API version
     return _format_feature_flags_response(feature_flags, feature_flag_payloads, errors, api_version)
@@ -410,8 +396,6 @@ def _record_feature_flag_metrics(
     feature_flags: dict,
     errors: bool,
     data: dict,
-    is_request_sampled_for_logging: bool,
-    request: HttpRequest,
 ):
     """Record metrics and handle billing for feature flag computations."""
     if not feature_flags:
@@ -423,16 +407,6 @@ def _record_feature_flag_metrics(
         errors_computing=errors,
         has_hash_key_override=bool(data.get("$anon_distinct_id")),
     ).inc()
-
-    if is_request_sampled_for_logging:
-        logger.warn(
-            "DECIDE_REQUEST_SUCCEEDED",
-            team_id=team.id,
-            distinct_id=data.get("distinct_id"),
-            user_agent=request.headers.get("User-Agent", ""),
-            errors_while_computing=errors or False,
-            has_hash_key_override=bool(data.get("$anon_distinct_id")),
-        )
 
     # Handle billing analytics
     if not all(flag.startswith(SURVEY_TARGETING_FLAG_PREFIX) for flag in feature_flags.keys()):

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -41,10 +41,6 @@ DECIDE_SKIP_POSTGRES_FLAGS = get_from_env("DECIDE_SKIP_POSTGRES_FLAGS", False, t
 DECIDE_BILLING_SAMPLING_RATE = get_from_env("DECIDE_BILLING_SAMPLING_RATE", 0.1, type_cast=float)
 DECIDE_BILLING_ANALYTICS_TOKEN = get_from_env("DECIDE_BILLING_ANALYTICS_TOKEN", None, type_cast=str, optional=True)
 
-# Decide request logging settings
-
-DECIDE_REQUEST_LOGGING_SAMPLING_RATE = get_from_env("DECIDE_REQUEST_LOGGING_SAMPLING_RATE", 0.05, type_cast=float)
-
 # Decide regular request analytics
 # Takes 3 possible formats, all separated by commas:
 # A number: "2"


### PR DESCRIPTION

## Problem

We no longer need this now that the new `posthog-decide-django` service is ingesting standard django `request_started` and `request_finished` logs: https://grafana.prod-us.posthog.dev/a/grafana-lokiexplore-app/explore/service/posthog-decide-django/logs?patterns=%5B%5D&from=now-15m&to=now&var-ds=P8E80F9AEF21F6940&var-filters=service_name%7C%3D%7Cposthog-decide-django&var-fields=team_id%7C%3D%7C__CV%CE%A9__%7B%22value%22:%229291%22__gfc__%22parser%22:%22mixed%22%7D,9291&var-levels=&var-metadata=&var-patterns=&var-lineFilterV2=&var-lineFilters=&urlColumns=%5B%5D&visualizationType=%22logs%22&displayedFields=%5B%5D&timezone=browser&var-all-fields=team_id%7C%3D%7C__CV%CE%A9__%7B%22value%22:%229291%22__gfc__%22parser%22:%22mixed%22%7D,9291&sortOrder=%22Descending%22&wrapLogMessage=false

## Changes

Remove sampled logs

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Made sure decide still succeeds after this change, existing tests should also cover this
