### PR TITLE
chore: remove a legacy leftover s/posthog.client/posthog.clickhouse.client

### DIFF
--- a/ee/api/test/test_instance_settings.py
+++ b/ee/api/test/test_instance_settings.py
@@ -2,7 +2,7 @@
 from rest_framework import status
 
 from ee.api.test.base import APILicensedTest
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models.instance_setting import get_instance_setting
 from posthog.models.performance.sql import PERFORMANCE_EVENT_DATA_TABLE
 from posthog.settings.data_stores import CLICKHOUSE_DATABASE

--- a/ee/clickhouse/materialized_columns/analyze.py
+++ b/ee/clickhouse/materialized_columns/analyze.py
@@ -20,7 +20,7 @@ from ee.settings import (
     MATERIALIZE_COLUMNS_MINIMUM_QUERY_TIME,
 )
 from posthog.cache_utils import instance_memoize
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models.filters.mixins.utils import cached_property
 from posthog.models.person.sql import (
     GET_EVENT_PROPERTIES_COUNT,

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -14,7 +14,7 @@ from posthog.cache_utils import cache_for
 from posthog.clickhouse.cluster import ClickhouseCluster, FuturesMap, HostInfo, get_cluster
 from posthog.clickhouse.kafka_engine import trim_quotes_expr
 from posthog.clickhouse.materialized_columns import ColumnName, TablesWithMaterializedColumns
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models.event.sql import EVENTS_DATA_TABLE
 from posthog.models.person.sql import PERSONS_TABLE
 from posthog.models.property import PropertyName, TableColumn, TableWithProperties

--- a/ee/clickhouse/materialized_columns/test/test_analyze.py
+++ b/ee/clickhouse/materialized_columns/test/test_analyze.py
@@ -1,5 +1,5 @@
 from posthog.test.base import BaseTest, ClickhouseTestMixin
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from ee.clickhouse.materialized_columns.analyze import materialize_properties_task
 
 from unittest.mock import patch, call

--- a/ee/clickhouse/materialized_columns/test/test_columns.py
+++ b/ee/clickhouse/materialized_columns/test/test_columns.py
@@ -18,7 +18,7 @@ from ee.clickhouse.materialized_columns.columns import (
 )
 from ee.tasks.materialized_columns import mark_all_materialized
 from posthog.clickhouse.materialized_columns import TablesWithMaterializedColumns
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.conftest import create_clickhouse_tables
 from posthog.constants import GROUP_TYPES_LIMIT
 from posthog.models.event.sql import EVENTS_DATA_TABLE

--- a/ee/clickhouse/models/test/test_action.py
+++ b/ee/clickhouse/models/test/test_action.py
@@ -1,6 +1,6 @@
 import dataclasses
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.hogql.compiler.bytecode import create_bytecode
 from posthog.hogql.hogql import HogQLContext
 from posthog.hogql.property import action_to_expr

--- a/ee/clickhouse/models/test/test_cohort.py
+++ b/ee/clickhouse/models/test/test_cohort.py
@@ -5,7 +5,7 @@ from typing import Optional
 from django.utils import timezone
 from freezegun import freeze_time
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.hogql.constants import MAX_SELECT_COHORT_CALCULATION_LIMIT
 from posthog.hogql.hogql import HogQLContext
 from posthog.models.action import Action

--- a/ee/clickhouse/models/test/test_dead_letter_queue.py
+++ b/ee/clickhouse/models/test/test_dead_letter_queue.py
@@ -13,7 +13,7 @@ from posthog.clickhouse.dead_letter_queue import (
     INSERT_DEAD_LETTER_QUEUE_EVENT_SQL,
     KAFKA_DEAD_LETTER_QUEUE_TABLE_SQL,
 )
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.kafka_client.topics import KAFKA_DEAD_LETTER_QUEUE
 from posthog.settings import KAFKA_HOSTS
 from posthog.test.base import BaseTest, ClickhouseTestMixin

--- a/ee/clickhouse/models/test/test_filters.py
+++ b/ee/clickhouse/models/test/test_filters.py
@@ -1,7 +1,7 @@
 import json
 from typing import Optional
 
-from posthog.client import query_with_columns, sync_execute
+from posthog.clickhouse.client import query_with_columns, sync_execute
 from posthog.constants import FILTER_TEST_ACCOUNTS
 from posthog.models import Element, Organization, Person, Team
 from posthog.models.cohort import Cohort

--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -7,7 +7,7 @@ from freezegun.api import freeze_time
 from rest_framework.exceptions import ValidationError
 
 from ee.clickhouse.materialized_columns.columns import materialize
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.constants import PropertyOperatorType
 from posthog.models.cohort import Cohort
 from posthog.models.element import Element

--- a/ee/clickhouse/models/test/utils/util.py
+++ b/ee/clickhouse/models/test/utils/util.py
@@ -1,6 +1,6 @@
 from time import sleep, time
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 
 
 # this normally is unnecessary as CH is fast to consume from Kafka when testing

--- a/ee/clickhouse/queries/experiments/utils.py
+++ b/ee/clickhouse/queries/experiments/utils.py
@@ -1,6 +1,6 @@
 from typing import Union
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS
 from posthog.models.filters.filter import Filter
 from posthog.models.team.team import Team

--- a/ee/clickhouse/queries/related_actors_query.py
+++ b/ee/clickhouse/queries/related_actors_query.py
@@ -4,7 +4,7 @@ from typing import Optional, Union
 
 from django.utils.timezone import now
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models import Team
 from posthog.models.filters.utils import validate_group_type_index
 from posthog.models.group_type_mapping import GroupTypeMapping

--- a/ee/clickhouse/queries/test/test_cohort_query.py
+++ b/ee/clickhouse/queries/test/test_cohort_query.py
@@ -5,7 +5,7 @@ from freezegun import freeze_time
 
 
 from ee.clickhouse.queries.enterprise_cohort_query import check_negation_clause
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.constants import PropertyOperatorType
 from posthog.hogql_queries.hogql_cohort_query import TestWrapperCohortQuery as CohortQuery
 from posthog.models import Team

--- a/ee/clickhouse/queries/test/test_event_query.py
+++ b/ee/clickhouse/queries/test/test_event_query.py
@@ -1,7 +1,7 @@
 from freezegun import freeze_time
 
 from ee.clickhouse.materialized_columns.columns import materialize
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models import Action
 from posthog.models.cohort import Cohort
 from posthog.models.element import Element

--- a/ee/clickhouse/queries/test/test_person_query.py
+++ b/ee/clickhouse/queries/test/test_person_query.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ee.clickhouse.materialized_columns.columns import materialize
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models.filters import Filter
 from posthog.models.team import Team
 from posthog.queries.person_query import PersonQuery

--- a/ee/clickhouse/queries/test/test_util.py
+++ b/ee/clickhouse/queries/test/test_util.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 from freezegun.api import freeze_time
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.hogql.hogql import HogQLContext
 from posthog.models.action import Action
 from posthog.models.cohort import Cohort

--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -13,7 +13,7 @@ from ee.clickhouse.queries.related_actors_query import RelatedActorsQuery
 from posthog.api.documentation import extend_schema
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.clickhouse.kafka_engine import trim_quotes_expr
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models.group import Group
 from posthog.models.group_type_mapping import GroupTypeMapping
 

--- a/ee/tasks/materialized_columns.py
+++ b/ee/tasks/materialized_columns.py
@@ -4,7 +4,7 @@ from celery.utils.log import get_task_logger
 from clickhouse_driver import Client
 
 from ee.clickhouse.materialized_columns.columns import MaterializedColumn, tables as table_infos
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.settings import CLICKHOUSE_DATABASE
 from posthog.clickhouse.cluster import get_cluster
 from posthog.clickhouse.materialized_columns import ColumnName, TablesWithMaterializedColumns

--- a/ee/tasks/send_license_usage.py
+++ b/ee/tasks/send_license_usage.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 from django.utils.timezone import now
 
 from ee.models.license import License
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models import User
 from posthog.settings import SITE_URL
 

--- a/ee/tasks/test/test_calculate_cohort.py
+++ b/ee/tasks/test/test_calculate_cohort.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from freezegun import freeze_time
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models.cohort import Cohort
 from posthog.models.person import Person
 from posthog.tasks.calculate_cohort import insert_cohort_from_insight_filter

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -38,7 +38,7 @@ from posthog.api.person import get_funnel_actor_class
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.utils import get_target_entity
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.constants import (
     INSIGHT_FUNNELS,
     INSIGHT_LIFECYCLE,

--- a/posthog/api/dead_letter_queue.py
+++ b/posthog/api/dead_letter_queue.py
@@ -3,7 +3,7 @@ from typing import Any, Optional, Union
 
 from rest_framework import mixins, permissions, serializers, viewsets
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.permissions import IsStaffUser
 
 # keep in sync with posthog/frontend/src/scenes/instance/DeadLetterQueue/MetricsTab.tsx

--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -10,7 +10,7 @@ from rest_framework import exceptions, viewsets
 from rest_framework.response import Response
 from rest_framework.request import Request
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.cloud_utils import is_cloud
 from posthog.settings.base_variables import DEBUG
 from posthog.settings.data_stores import CLICKHOUSE_CLUSTER

--- a/posthog/api/element.py
+++ b/posthog/api/element.py
@@ -7,7 +7,7 @@ from statshog.defaults.django import statsd
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.auth import TemporaryTokenAuthentication
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models import Element, Filter
 from posthog.models.element.element import chain_to_elements
 from posthog.models.element.sql import GET_ELEMENTS, GET_VALUES

--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -21,7 +21,7 @@ from posthog.exceptions_capture import capture_exception
 
 from posthog.api.documentation import PropertiesSerializer, extend_schema
 from posthog.api.routing import TeamAndOrgViewSetMixin
-from posthog.client import query_with_columns
+from posthog.clickhouse.client import query_with_columns
 from posthog.hogql.constants import DEFAULT_RETURNED_ROWS, MAX_SELECT_RETURNED_ROWS
 from posthog.models import Element, Filter, Person
 from posthog.models.event.query_event_list import query_events_list

--- a/posthog/api/ingestion_warnings.py
+++ b/posthog/api/ingestion_warnings.py
@@ -7,7 +7,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 
 
 class IngestionWarningsViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):

--- a/posthog/api/instance_settings.py
+++ b/posthog/api/instance_settings.py
@@ -93,7 +93,7 @@ class InstanceSettingsSerializer(serializers.Serializer):
                 raise serializers.ValidationError("This setting cannot be updated on cloud.")
 
             # TODO: Move to top-level imports once CH is moved out of `ee`
-            from posthog.client import sync_execute
+            from posthog.clickhouse.client import sync_execute
             from posthog.session_recordings.sql.session_recording_event_sql import (
                 UPDATE_RECORDINGS_TABLE_TTL_SQL,
             )
@@ -107,7 +107,7 @@ class InstanceSettingsSerializer(serializers.Serializer):
                 raise serializers.ValidationError("This setting cannot be updated on cloud.")
 
             # TODO: Move to top-level imports once CH is moved out of `ee`
-            from posthog.client import sync_execute
+            from posthog.clickhouse.client import sync_execute
             from posthog.models.performance.sql import (
                 UPDATE_PERFORMANCE_EVENTS_TABLE_TTL_SQL,
             )

--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -28,7 +28,7 @@ from posthog.api.feature_flag import (
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.utils import action, get_token
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.cloud_utils import is_cloud
 from posthog.constants import AvailableFeature
 from posthog.event_usage import report_user_action

--- a/posthog/api/test/test_event.py
+++ b/posthog/api/test/test_event.py
@@ -544,7 +544,7 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
 
             page2 = self.client.get(response["next"]).json()
 
-            from posthog.client import sync_execute
+            from posthog.clickhouse.client import sync_execute
 
             self.assertEqual(
                 sync_execute(
@@ -594,7 +594,7 @@ class TestEvents(ClickhouseTestMixin, APIBaseTest):
 
             page2 = self.client.get(response["next"]).json()
 
-            from posthog.client import sync_execute
+            from posthog.clickhouse.client import sync_execute
 
             self.assertEqual(
                 sync_execute(

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 from freezegun.api import freeze_time
 from rest_framework import status
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models import Cohort, Organization, Person, Team
 from posthog.models.async_deletion import AsyncDeletion, DeletionType
 from posthog.models.person import PersonDistinctId

--- a/posthog/api/test/test_stickiness.py
+++ b/posthog/api/test/test_stickiness.py
@@ -9,7 +9,7 @@ from django.test.client import Client
 from django.utils import timezone
 from freezegun import freeze_time
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.constants import ENTITY_ID, ENTITY_TYPE
 from posthog.models.team import Team
 from posthog.test.base import (

--- a/posthog/async_migrations/disk_util.py
+++ b/posthog/async_migrations/disk_util.py
@@ -1,4 +1,4 @@
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.settings import CLICKHOUSE_DATABASE
 
 

--- a/posthog/async_migrations/examples/example.py
+++ b/posthog/async_migrations/examples/example.py
@@ -3,7 +3,7 @@ from posthog.async_migrations.definition import (
     AsyncMigrationOperation,
     AsyncMigrationOperationSQL,
 )
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.constants import AnalyticsDBMS
 from posthog.models.person.sql import (
     KAFKA_PERSONS_DISTINCT_ID_TABLE_SQL,

--- a/posthog/async_migrations/migrations/0002_events_sample_by.py
+++ b/posthog/async_migrations/migrations/0002_events_sample_by.py
@@ -9,7 +9,7 @@ from posthog.async_migrations.definition import (
 )
 from posthog.async_migrations.disk_util import analyze_enough_disk_space_free_for_table
 from posthog.async_migrations.utils import run_optimize_table
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.cloud_utils import is_cloud
 from posthog.constants import AnalyticsDBMS
 from posthog.models.instance_setting import set_instance_setting

--- a/posthog/async_migrations/migrations/0003_fill_person_distinct_id2.py
+++ b/posthog/async_migrations/migrations/0003_fill_person_distinct_id2.py
@@ -4,7 +4,7 @@ from posthog.async_migrations.definition import (
     AsyncMigrationDefinition,
     AsyncMigrationOperationSQL,
 )
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.constants import AnalyticsDBMS
 from posthog.settings import CLICKHOUSE_DATABASE
 

--- a/posthog/async_migrations/migrations/0004_replicated_schema.py
+++ b/posthog/async_migrations/migrations/0004_replicated_schema.py
@@ -4,7 +4,7 @@ import structlog
 from django.conf import settings
 
 from posthog.async_migrations.definition import AsyncMigrationDefinition
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 
 logger = structlog.get_logger(__name__)
 

--- a/posthog/async_migrations/migrations/0005_person_replacing_by_version.py
+++ b/posthog/async_migrations/migrations/0005_person_replacing_by_version.py
@@ -14,7 +14,7 @@ from posthog.async_migrations.definition import (
 from posthog.async_migrations.utils import execute_op_clickhouse, run_optimize_table
 from posthog.clickhouse.kafka_engine import STORAGE_POLICY
 from posthog.clickhouse.table_engines import ReplacingMergeTree
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.constants import AnalyticsDBMS
 from posthog.models.async_migration import AsyncMigration
 from posthog.models.person.person import Person

--- a/posthog/async_migrations/migrations/0007_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/migrations/0007_persons_and_groups_on_events_backfill.py
@@ -16,7 +16,7 @@ from posthog.async_migrations.utils import (
     run_optimize_table,
     sleep_until_finished,
 )
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models.event.sql import EVENTS_DATA_TABLE
 from posthog.utils import str_to_bool
 

--- a/posthog/async_migrations/migrations/0008_speed_up_kafka_timestamp_filters.py
+++ b/posthog/async_migrations/migrations/0008_speed_up_kafka_timestamp_filters.py
@@ -7,7 +7,7 @@ from posthog.async_migrations.definition import (
     AsyncMigrationDefinition,
     AsyncMigrationOperationSQL,
 )
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.constants import AnalyticsDBMS
 from posthog.version_requirement import ServiceVersionRequirement
 

--- a/posthog/async_migrations/migrations/0010_move_old_partitions.py
+++ b/posthog/async_migrations/migrations/0010_move_old_partitions.py
@@ -6,7 +6,7 @@ from posthog.async_migrations.definition import (
     AsyncMigrationDefinition,
     AsyncMigrationOperationSQL,
 )
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.constants import AnalyticsDBMS
 from posthog.version_requirement import ServiceVersionRequirement
 from datetime import datetime

--- a/posthog/async_migrations/test/test_0007_persons_and_groups_on_events_backfill.py
+++ b/posthog/async_migrations/test/test_0007_persons_and_groups_on_events_backfill.py
@@ -9,7 +9,7 @@ from posthog.async_migrations.setup import (
     setup_async_migrations,
 )
 from posthog.async_migrations.test.util import AsyncMigrationBaseTest
-from posthog.client import query_with_columns, sync_execute
+from posthog.clickhouse.client import query_with_columns, sync_execute
 from posthog.models import Person
 from posthog.models.async_migration import (
     AsyncMigration,

--- a/posthog/async_migrations/test/test_migrations_not_required.py
+++ b/posthog/async_migrations/test/test_migrations_not_required.py
@@ -2,7 +2,7 @@ import pytest
 
 from posthog.async_migrations.setup import ALL_ASYNC_MIGRATIONS
 from posthog.async_migrations.test.util import AsyncMigrationBaseTest
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models.person.sql import COMMENT_DISTINCT_ID_COLUMN_SQL
 
 pytestmark = pytest.mark.async_migrations

--- a/posthog/async_migrations/test/test_utils.py
+++ b/posthog/async_migrations/test/test_utils.py
@@ -27,7 +27,7 @@ DEFAULT_POSTGRES_OP = AsyncMigrationOperationSQL(database=AnalyticsDBMS.POSTGRES
 
 
 class TestUtils(AsyncMigrationBaseTest):
-    @patch("posthog.client.sync_execute")
+    @patch("posthog.clickhouse.client.sync_execute")
     def test_execute_op_clickhouse(self, mock_sync_execute):
         execute_op(DEFAULT_CH_OP, "some_id")
 

--- a/posthog/async_migrations/utils.py
+++ b/posthog/async_migrations/utils.py
@@ -63,7 +63,7 @@ def execute_op_clickhouse(
     # If True, query is run on each shard.
     per_shard=False,
 ):
-    from posthog import client
+    from posthog.clickhouse import client
 
     tag_queries(kind="async_migration", id=query_id)
     settings = settings if settings else {"max_execution_time": timeout_seconds}

--- a/posthog/batch_exports/models.py
+++ b/posthog/batch_exports/models.py
@@ -5,7 +5,7 @@ from math import ceil
 
 from django.db import models
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.helpers.encrypted_fields import EncryptedJSONField
 from posthog.models.utils import UUIDModel
 

--- a/posthog/caching/utils.py
+++ b/posthog/caching/utils.py
@@ -5,7 +5,7 @@ from typing import Any, Optional, Union
 import posthoganalytics
 from dateutil.parser import isoparse, parser
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.cloud_utils import is_cloud
 from posthog.models.filters.filter import Filter
 from posthog.models.filters.path_filter import PathFilter

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -9,7 +9,7 @@ from django.test import TestCase, SimpleTestCase
 from django.db import transaction
 
 from posthog.clickhouse.client import execute_async as client
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.errors import CHQueryErrorTooManySimultaneousQueries
 from posthog.models import Organization, Team
 from posthog.models.user import User
@@ -220,7 +220,7 @@ class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):
         except Exception as e:
             self.assertEqual(str(e), f"Query {query_id} not found for team {wrong_team}")
 
-    @patch("posthog.client.execute_process_query")
+    @patch("posthog.clickhouse.client.execute_process_query")
     def test_async_query_client_is_lazy(self, execute_process_query_mock):
         query = build_query("SELECT 4 + 4")
         query_id = uuid.uuid4().hex
@@ -241,7 +241,7 @@ class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):
         # Assert that we only called clickhouse once
         execute_process_query_mock.assert_called_once()
 
-    @patch("posthog.client.execute_process_query")
+    @patch("posthog.clickhouse.client.execute_process_query")
     def test_async_query_client_is_lazy_but_not_too_lazy(self, execute_process_query_mock):
         query = build_query("SELECT 8 + 8")
         query_id = uuid.uuid4().hex
@@ -262,7 +262,7 @@ class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):
         # Assert that we called clickhouse twice
         self.assertEqual(execute_process_query_mock.call_count, 2)
 
-    @patch("posthog.client.execute_process_query")
+    @patch("posthog.clickhouse.client.execute_process_query")
     def test_async_query_client_manual_query_uuid(self, execute_process_query_mock):
         # This is a unique test because technically in the test pattern `SELECT 8 + 8` is already
         # in redis. This tests to make sure it is treated as a unique run of that query
@@ -285,7 +285,7 @@ class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):
         # Assert that we called clickhouse twice
         self.assertEqual(execute_process_query_mock.call_count, 2)
 
-    @patch("posthog.client.execute_process_query")
+    @patch("posthog.clickhouse.client.execute_process_query")
     @patch("posthog.api.services.query.process_query_dict")
     def test_async_query_refreshes_if_requested(self, process_query_dict_mock, execute_process_query_mock):
         query = build_query("SELECT 8 + 8")

--- a/posthog/clickhouse/migrations/0021_session_recording_events_materialize_full_snapshot.py
+++ b/posthog/clickhouse/migrations/0021_session_recording_events_materialize_full_snapshot.py
@@ -1,6 +1,6 @@
 from infi.clickhouse_orm import migrations
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.settings import CLICKHOUSE_CLUSTER
 
 SESSION_RECORDING_EVENTS_MATERIALIZED_COLUMN_COMMENTS_SQL = (

--- a/posthog/clickhouse/migrations/0026_fix_materialized_window_and_session_ids.py
+++ b/posthog/clickhouse/migrations/0026_fix_materialized_window_and_session_ids.py
@@ -1,7 +1,7 @@
 from infi.clickhouse_orm import migrations
 
 from posthog.clickhouse.materialized_columns import get_materialized_column_for_property
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.settings import CLICKHOUSE_CLUSTER
 
 

--- a/posthog/clickhouse/migrations/0027_persons_and_groups_on_events.py
+++ b/posthog/clickhouse/migrations/0027_persons_and_groups_on_events.py
@@ -1,7 +1,7 @@
 from infi.clickhouse_orm import migrations
 
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models.event.sql import (
     EVENTS_TABLE_JSON_MV_SQL,
     KAFKA_EVENTS_TABLE_JSON_SQL,

--- a/posthog/clickhouse/migrations/0029_cohortpeople_version.py
+++ b/posthog/clickhouse/migrations/0029_cohortpeople_version.py
@@ -1,6 +1,6 @@
 from infi.clickhouse_orm import migrations
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.settings import CLICKHOUSE_CLUSTER
 
 ADD_COLUMNS_BASE_SQL = """

--- a/posthog/clickhouse/migrations/0030_created_at_persons_and_groups_on_events.py
+++ b/posthog/clickhouse/migrations/0030_created_at_persons_and_groups_on_events.py
@@ -1,7 +1,7 @@
 from infi.clickhouse_orm import migrations
 
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models.event.sql import (
     EVENTS_TABLE_JSON_MV_SQL,
     KAFKA_EVENTS_TABLE_JSON_SQL,

--- a/posthog/clickhouse/migrations/0036_session_recording_events_materialized_columns.py
+++ b/posthog/clickhouse/migrations/0036_session_recording_events_materialized_columns.py
@@ -1,6 +1,6 @@
 from infi.clickhouse_orm import migrations
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.session_recordings.sql.session_recording_event_sql import (
     MATERIALIZED_COLUMNS,
 )

--- a/posthog/clickhouse/migrations/0047_add_insertion_timestamp_to_events.py
+++ b/posthog/clickhouse/migrations/0047_add_insertion_timestamp_to_events.py
@@ -1,7 +1,7 @@
 from infi.clickhouse_orm import migrations
 
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models.event.sql import (
     EVENTS_TABLE_JSON_MV_SQL,
     KAFKA_EVENTS_TABLE_JSON_SQL,

--- a/posthog/clickhouse/migrations/0057_events_person_mode.py
+++ b/posthog/clickhouse/migrations/0057_events_person_mode.py
@@ -1,7 +1,7 @@
 from infi.clickhouse_orm import migrations
 
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models.event.sql import (
     EVENTS_TABLE_JSON_MV_SQL,
     KAFKA_EVENTS_TABLE_JSON_SQL,

--- a/posthog/clickhouse/migrations/0060_person_mode_force_upgrade.py
+++ b/posthog/clickhouse/migrations/0060_person_mode_force_upgrade.py
@@ -1,7 +1,7 @@
 from infi.clickhouse_orm import migrations
 
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models.event.sql import (
     EVENTS_TABLE_JSON_MV_SQL,
     KAFKA_EVENTS_TABLE_JSON_SQL,

--- a/posthog/clickhouse/migrations/test/test_0064.py
+++ b/posthog/clickhouse/migrations/test/test_0064.py
@@ -2,7 +2,7 @@
 import importlib
 
 from posthog.test.base import BaseTest, ClickhouseDestroyTablesMixin, _create_event
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models.utils import UUIDT
 
 module = importlib.import_module("posthog.clickhouse.migrations.0064_materialize_elements_chain")

--- a/posthog/clickhouse/system_status.py
+++ b/posthog/clickhouse/system_status.py
@@ -11,7 +11,7 @@ from posthog.api.dead_letter_queue import (
     get_dead_letter_queue_size,
 )
 from posthog.cache_utils import cache_for
-from posthog.client import query_with_columns, sync_execute
+from posthog.clickhouse.client import query_with_columns, sync_execute
 from posthog.models.event.util import (
     get_event_count,
     get_event_count_for_last_month,

--- a/posthog/client.py
+++ b/posthog/client.py
@@ -1,2 +1,0 @@
-# File kept around for legacy purposes
-from posthog.clickhouse.client import *  # noqa T401

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -2,7 +2,7 @@ import pytest
 from django.conf import settings
 from infi.clickhouse_orm import Database
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models.raw_sessions.sql import TRUNCATE_RAW_SESSIONS_TABLE_SQL
 from posthog.test.base import PostHogTestCase, run_clickhouse_statement_in_parallel
 

--- a/posthog/demo/matrix/manager.py
+++ b/posthog/demo/matrix/manager.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.core import exceptions
 from django.db import transaction, IntegrityError
 
-from posthog.client import query_with_columns, sync_execute
+from posthog.clickhouse.client import query_with_columns, sync_execute
 from posthog.demo.matrix.taxonomy_inference import infer_taxonomy_for_team
 from posthog.models import (
     Cohort,

--- a/posthog/demo/matrix/taxonomy_inference.py
+++ b/posthog/demo/matrix/taxonomy_inference.py
@@ -58,7 +58,7 @@ def infer_taxonomy_for_team(team_id: int) -> tuple[int, int, int]:
 
 
 def _get_events_last_seen_at(team_id: int) -> dict[str, timezone.datetime]:
-    from posthog.client import sync_execute
+    from posthog.clickhouse.client import sync_execute
 
     return dict(sync_execute(_GET_EVENTS_LAST_SEEN_AT, {"team_id": team_id}))
 
@@ -69,7 +69,7 @@ InferredProperties = dict[InferredPropertyKey, Optional[PropertyType]]
 
 def _get_property_types(team_id: int) -> InferredProperties:
     """Determine property types based on ClickHouse data."""
-    from posthog.client import sync_execute
+    from posthog.clickhouse.client import sync_execute
 
     property_types: InferredProperties = {
         (PropertyDefinition.Type.EVENT, property_key, None): _infer_property_type(sample_json_value)
@@ -110,7 +110,7 @@ def _infer_property_type(sample_json_value: str) -> Optional[PropertyType]:
 
 def _get_event_property_pairs(team_id: int) -> list[tuple[str, str]]:
     """Determine which properties have been since with which events based on ClickHouse data."""
-    from posthog.client import sync_execute
+    from posthog.clickhouse.client import sync_execute
 
     return [row[0] for row in sync_execute(_GET_EVENT_PROPERTIES, {"team_id": team_id})]
 

--- a/posthog/demo/test/test_matrix_manager.py
+++ b/posthog/demo/test/test_matrix_manager.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from zoneinfo import ZoneInfo
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.demo.matrix.manager import MatrixManager
 from posthog.demo.matrix.matrix import Cluster, Matrix
 from posthog.demo.matrix.models import SimPerson, SimSessionIntent

--- a/posthog/health.py
+++ b/posthog/health.py
@@ -28,7 +28,7 @@ from django.http import HttpRequest, HttpResponse, JsonResponse
 from structlog import get_logger
 
 from posthog.celery import app
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.database_healthcheck import DATABASE_FOR_FLAG_MATCHING
 from posthog.kafka_client.client import can_connect as can_connect_to_kafka
 

--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -22,7 +22,7 @@ from posthog.hogql.visitor import clone_expr
 from posthog.hogql.resolver_utils import extract_select_queries
 from posthog.models.team import Team
 from posthog.clickhouse.query_tagging import tag_queries
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.schema import (
     HogQLQueryResponse,
     HogQLFilters,

--- a/posthog/kafka_client/client.py
+++ b/posthog/kafka_client/client.py
@@ -15,7 +15,7 @@ from kafka.structs import TopicPartition
 from statshog.defaults.django import statsd
 from structlog import get_logger
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.kafka_client import helper
 from posthog.utils import SingletonDecorator
 

--- a/posthog/management/commands/backfill_persons_and_groups_on_events.py
+++ b/posthog/management/commands/backfill_persons_and_groups_on_events.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from posthog.clickhouse.query_tagging import reset_query_tags, tag_queries
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models.event.sql import EVENTS_DATA_TABLE
 from posthog.models.group.sql import GROUPS_TABLE
 from posthog.models.person.sql import PERSON_DISTINCT_ID2_TABLE, PERSONS_TABLE

--- a/posthog/management/commands/fix_person_distinct_ids_after_delete.py
+++ b/posthog/management/commands/fix_person_distinct_ids_after_delete.py
@@ -5,7 +5,7 @@ import structlog
 from django.core.management.base import BaseCommand
 from django.db import transaction
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.kafka_client.client import KafkaProducer
 from posthog.models.person import PersonDistinctId
 from posthog.models.person.util import create_person_distinct_id

--- a/posthog/management/commands/sync_persons_to_clickhouse.py
+++ b/posthog/management/commands/sync_persons_to_clickhouse.py
@@ -6,7 +6,7 @@ import structlog
 from django.core.management.base import BaseCommand
 from django.utils.timezone import now
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.kafka_client.client import KafkaProducer
 from posthog.models.group.group import Group
 from posthog.models.group.util import raw_create_group_ch

--- a/posthog/management/commands/sync_replicated_schema.py
+++ b/posthog/management/commands/sync_replicated_schema.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from posthog.clickhouse.schema import CREATE_TABLE_QUERIES, get_table_name
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.cloud_utils import is_cloud
 
 logger = structlog.get_logger(__name__)

--- a/posthog/management/commands/test/test_backfill_persons_and_groups_on_events.py
+++ b/posthog/management/commands/test/test_backfill_persons_and_groups_on_events.py
@@ -4,7 +4,7 @@ from uuid import UUID, uuid4
 import pytest
 from django.conf import settings
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.conftest import create_clickhouse_tables
 from posthog.management.commands.backfill_persons_and_groups_on_events import (
     run_backfill,

--- a/posthog/management/commands/test/test_fix_person_distinct_ids_after_delete.py
+++ b/posthog/management/commands/test/test_fix_person_distinct_ids_after_delete.py
@@ -5,7 +5,7 @@ from uuid import UUID, uuid4
 import pytest
 
 import posthog.management.commands.fix_person_distinct_ids_after_delete
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.management.commands.fix_person_distinct_ids_after_delete import run
 from posthog.models.person.person import Person, PersonDistinctId
 from posthog.models.person.sql import PERSON_DISTINCT_ID2_TABLE

--- a/posthog/management/commands/test/test_sync_persons_to_clickhouse.py
+++ b/posthog/management/commands/test/test_sync_persons_to_clickhouse.py
@@ -6,7 +6,7 @@ from uuid import UUID, uuid4
 import pytest
 
 import posthog.management.commands.sync_persons_to_clickhouse
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.management.commands.sync_persons_to_clickhouse import (
     run,
     run_distinct_id_sync,

--- a/posthog/management/commands/test/test_sync_replicated_schema.py
+++ b/posthog/management/commands/test/test_sync_replicated_schema.py
@@ -1,7 +1,7 @@
 import pytest
 from django.conf import settings
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.conftest import create_clickhouse_tables
 from posthog.management.commands.sync_replicated_schema import Command
 from posthog.test.base import BaseTest, ClickhouseTestMixin

--- a/posthog/migrations/0187_stale_events.py
+++ b/posthog/migrations/0187_stale_events.py
@@ -5,7 +5,7 @@ from django.db import migrations, models
 
 def set_created_at(apps, schema_editor):
     try:
-        from posthog.client import sync_execute
+        from posthog.clickhouse.client import sync_execute
     except ImportError:
         sync_execute = None
 

--- a/posthog/models/async_deletion/delete_cohorts.py
+++ b/posthog/models/async_deletion/delete_cohorts.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models.async_deletion import AsyncDeletion, DeletionType
 from posthog.models.async_deletion.delete import AsyncDeletionProcess, logger
 

--- a/posthog/models/async_deletion/delete_events.py
+++ b/posthog/models/async_deletion/delete_events.py
@@ -3,7 +3,7 @@ from typing import Any
 from clickhouse_driver.errors import SocketTimeoutError
 from prometheus_client import Counter
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models.async_deletion import AsyncDeletion, DeletionType
 from posthog.models.async_deletion.delete import AsyncDeletionProcess, logger
 from posthog.settings.data_stores import CLICKHOUSE_CLUSTER

--- a/posthog/models/async_deletion/test_delete_person.py
+++ b/posthog/models/async_deletion/test_delete_person.py
@@ -1,6 +1,6 @@
 import pytest
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models.async_deletion.delete_person import remove_deleted_person_data
 from posthog.models.person.util import create_person
 from posthog.test.base import BaseTest, ClickhouseTestMixin

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -12,7 +12,7 @@ from posthog.hogql.resolver_utils import extract_select_queries
 from posthog.queries.util import PersonPropertiesMode
 from posthog.clickhouse.client.connection import Workload
 from posthog.clickhouse.query_tagging import tag_queries
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.constants import PropertyOperatorType
 from posthog.hogql import ast
 from posthog.hogql.constants import LimitContext

--- a/posthog/models/event/util.py
+++ b/posthog/models/event/util.py
@@ -8,7 +8,7 @@ from dateutil.parser import isoparse
 from django.utils import timezone
 from rest_framework import serializers
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.kafka_client.client import ClickhouseProducer
 from posthog.kafka_client.topics import KAFKA_EVENTS_JSON
 from posthog.models import Group

--- a/posthog/models/feature_flag/flag_analytics.py
+++ b/posthog/models/feature_flag/flag_analytics.py
@@ -10,7 +10,7 @@ from posthog.redis import redis, get_client
 import time
 from posthog.exceptions_capture import capture_exception
 from django.conf import settings
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from datetime import datetime
 
 

--- a/posthog/models/feature_flag/user_blast_radius.py
+++ b/posthog/models/feature_flag/user_blast_radius.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from rest_framework.exceptions import ValidationError
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models.cohort import Cohort
 from posthog.models.filters import Filter
 from posthog.models.property import GroupTypeIndex

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -11,7 +11,7 @@ from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 from django.utils.timezone import now
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.kafka_client.client import ClickhouseProducer
 from posthog.kafka_client.topics import (
     KAFKA_PERSON,

--- a/posthog/models/plugin.py
+++ b/posthog/models/plugin.py
@@ -34,7 +34,7 @@ from posthog.plugins.utils import (
 from .utils import UUIDModel, sane_repr
 
 try:
-    from posthog.client import sync_execute
+    from posthog.clickhouse.client import sync_execute
 except ImportError:
     pass
 

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -444,7 +444,7 @@ class Team(UUIDClassicModel):
 
     @cached_property
     def persons_seen_so_far(self) -> int:
-        from posthog.client import sync_execute
+        from posthog.clickhouse.client import sync_execute
         from posthog.queries.person_query import PersonQuery
 
         filter = Filter(data={"full": "true"})
@@ -461,7 +461,7 @@ class Team(UUIDClassicModel):
 
     @lru_cache(maxsize=5)
     def groups_seen_so_far(self, group_type_index: GroupTypeIndex) -> int:
-        from posthog.client import sync_execute
+        from posthog.clickhouse.client import sync_execute
 
         return sync_execute(
             f"""

--- a/posthog/models/test/test_async_deletion_model.py
+++ b/posthog/models/test/test_async_deletion_model.py
@@ -1,7 +1,7 @@
 from uuid import UUID, uuid4
 import datetime as dt
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models import AsyncDeletion, DeletionType, Team, User
 from posthog.models.async_deletion.delete_cohorts import AsyncCohortDeletion
 from posthog.models.async_deletion.delete_events import AsyncEventDeletion

--- a/posthog/models/test/test_person_model.py
+++ b/posthog/models/test/test_person_model.py
@@ -1,6 +1,6 @@
 from uuid import uuid4
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models import Person, PersonDistinctId
 from posthog.models.event.util import create_event
 from posthog.models.person.util import delete_person

--- a/posthog/queries/app_metrics/app_metrics.py
+++ b/posthog/queries/app_metrics/app_metrics.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 
 from django.utils.timezone import now
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models.app_metrics.sql import (
     QUERY_APP_METRICS_DELIVERY_RATE,
     QUERY_APP_METRICS_ERROR_DETAILS,

--- a/posthog/queries/funnels/test/test_funnel.py
+++ b/posthog/queries/funnels/test/test_funnel.py
@@ -6,7 +6,7 @@ from django.test import override_settings
 from freezegun import freeze_time
 from rest_framework.exceptions import ValidationError
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.constants import FILTER_TEST_ACCOUNTS, INSIGHT_FUNNELS
 from posthog.models import Action, Element
 from posthog.models.cohort import Cohort

--- a/posthog/queries/insight.py
+++ b/posthog/queries/insight.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from rest_framework.exceptions import ValidationError
 from posthog.clickhouse.query_tagging import tag_queries
-from posthog.client import query_with_columns, sync_execute
+from posthog.clickhouse.client import query_with_columns, sync_execute
 from posthog.errors import ExposedCHQueryError
 from posthog.types import FilterType
 

--- a/posthog/queries/time_to_see_data/sessions.py
+++ b/posthog/queries/time_to_see_data/sessions.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from posthog.client import query_with_columns
+from posthog.clickhouse.client import query_with_columns
 from posthog.queries.time_to_see_data.hierarchy import construct_hierarchy
 from posthog.queries.time_to_see_data.serializers import (
     SessionEventsQuerySerializer,

--- a/posthog/rbac/test/test_user_access_control.py
+++ b/posthog/rbac/test/test_user_access_control.py
@@ -260,8 +260,10 @@ class TestUserAccessControl(BaseUserAccessControlTest):
         )
 
         # NOTE: This is different to the API queries as the TeamAndOrgViewsetMixing takes care of filtering out based on the parent org
-        filtered_teams = list(self.user_access_control.filter_queryset_by_access_level(Team.objects.all()))
-        self.assertListEqual([self.team, team3], filtered_teams)
+        filtered_teams = list(
+            self.user_access_control.filter_queryset_by_access_level(Team.objects.all()).order_by("id")
+        )
+        assert [self.team, team3] == filtered_teams
 
         other_user_filtered_teams = list(
             self.other_user_access_control.filter_queryset_by_access_level(Team.objects.all())
@@ -279,7 +281,9 @@ class TestUserAccessControl(BaseUserAccessControlTest):
         self.organization_membership.save()
 
         filtered_teams = list(
-            self.user_access_control.filter_queryset_by_access_level(Team.objects.all(), include_all_if_admin=True)
+            self.user_access_control.filter_queryset_by_access_level(
+                Team.objects.all(), include_all_if_admin=True
+            ).order_by("id")
         )
         self.assertListEqual([self.team, team2, team3], filtered_teams)
 

--- a/posthog/session_recordings/models/system_status_queries.py
+++ b/posthog/session_recordings/models/system_status_queries.py
@@ -1,6 +1,6 @@
 import dataclasses
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 
 
 @dataclasses.dataclass(frozen=True)

--- a/posthog/settings/shell_plus.py
+++ b/posthog/settings/shell_plus.py
@@ -16,7 +16,7 @@ SHELL_PLUS_POST_IMPORTS = [
     ("infi.clickhouse_orm.utils", ("import_submodules",)),
     ("posthog.models.filters", ("Filter",)),
     ("posthog.models.property", ("Property",)),
-    ("posthog.client", ("sync_execute",)),
+    ("posthog.clickhouse.client", ("sync_execute",)),
     ("posthog.hogql", ("ast")),
     ("posthog.hogql.parser", ("parse_select", "parse_expr")),
     ("posthog.hogql.query", ("execute_hogql_query")),

--- a/posthog/tasks/check_clickhouse_schema_drift.py
+++ b/posthog/tasks/check_clickhouse_schema_drift.py
@@ -6,7 +6,7 @@ from clickhouse_driver.errors import Error as ClickhouseError
 from django.conf import settings
 from statshog.defaults.django import statsd
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 
 logger = structlog.get_logger(__name__)
 

--- a/posthog/tasks/stop_surveys_reached_target.py
+++ b/posthog/tasks/stop_surveys_reached_target.py
@@ -4,7 +4,7 @@ from django.utils import timezone
 from datetime import datetime
 
 from posthog.clickhouse.client.connection import Workload
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models import Survey
 from posthog.models.utils import UUIDT
 

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -70,7 +70,7 @@ def process_query_task(
     Kick off query
     Once complete save results to redis
     """
-    from posthog.client import execute_process_query
+    from posthog.clickhouse.client import execute_process_query
 
     execute_process_query(
         team_id=team_id,
@@ -193,7 +193,7 @@ HEARTBEAT_EVENT_TO_INGESTION_LAG_METRIC = {"$heartbeat": "ingestion_api"}
 def ingestion_lag() -> None:
     from statshog.defaults.django import statsd
 
-    from posthog.client import sync_execute
+    from posthog.clickhouse.client import sync_execute
     from posthog.models.team.team import Team
 
     query = """
@@ -246,7 +246,7 @@ def replay_count_metrics() -> None:
     try:
         logger.info("[replay_count_metrics] running task")
 
-        from posthog.client import sync_execute
+        from posthog.clickhouse.client import sync_execute
 
         # ultimately I want to observe values by team id, but at the moment that would be lots of series, let's reduce the value first
         query = """
@@ -370,7 +370,7 @@ def graphile_worker_queue_size() -> None:
 def clickhouse_row_count() -> None:
     from statshog.defaults.django import statsd
 
-    from posthog.client import sync_execute
+    from posthog.clickhouse.client import sync_execute
 
     with pushed_metrics_registry("celery_clickhouse_row_count") as registry:
         row_count_gauge = Gauge(
@@ -404,7 +404,7 @@ def clickhouse_errors_count() -> None:
     225 - NO_ZOOKEEPER
     242 - TABLE_IS_READ_ONLY
     """
-    from posthog.client import sync_execute
+    from posthog.clickhouse.client import sync_execute
 
     QUERY = """
         select
@@ -437,7 +437,7 @@ def clickhouse_errors_count() -> None:
 def clickhouse_part_count() -> None:
     from statshog.defaults.django import statsd
 
-    from posthog.client import sync_execute
+    from posthog.clickhouse.client import sync_execute
 
     QUERY = """
         SELECT table, count(1) freq
@@ -468,7 +468,7 @@ def clickhouse_part_count() -> None:
 def clickhouse_mutation_count() -> None:
     from statshog.defaults.django import statsd
 
-    from posthog.client import sync_execute
+    from posthog.clickhouse.client import sync_execute
 
     QUERY = """
         SELECT

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -19,7 +19,7 @@ from posthog.exceptions_capture import capture_exception
 
 from posthog import version_requirement
 from posthog.clickhouse.client.connection import Workload
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.cloud_utils import get_cached_instance_license
 from posthog.constants import FlagRequestType
 from posthog.logging.timing import timed_log

--- a/posthog/tasks/verify_persons_data_in_sync.py
+++ b/posthog/tasks/verify_persons_data_in_sync.py
@@ -8,7 +8,7 @@ from celery import shared_task
 from django.db.models.query import Prefetch
 from django.utils.timezone import now
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models.person import Person
 
 logger = structlog.get_logger(__name__)

--- a/posthog/test/test_celery.py
+++ b/posthog/test/test_celery.py
@@ -5,7 +5,7 @@ from posthog.tasks.tasks import clickhouse_errors_count
 
 
 class TestCeleryMetrics(TestCase):
-    @patch("posthog.client.sync_execute")
+    @patch("posthog.clickhouse.client.sync_execute")
     @patch("posthog.metrics._push")
     @patch("django.conf.settings.PROM_PUSHGATEWAY_ADDRESS", value="127.0.0.1")
     def test_clickhouse_errors_count(self, _, mock_push_to_gateway, mock_sync_execute):

--- a/posthog/test/test_cohort_model.py
+++ b/posthog/test/test_cohort_model.py
@@ -1,6 +1,6 @@
 import pytest
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models import Cohort, Person, Team
 from posthog.models.cohort.sql import GET_COHORTPEOPLE_BY_COHORT_ID
 from posthog.test.base import BaseTest

--- a/posthog/test/test_journeys.py
+++ b/posthog/test/test_journeys.py
@@ -8,7 +8,7 @@ from uuid import UUID, uuid4
 
 from django.utils import timezone
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models import Group, Person, PersonDistinctId, Team
 from posthog.models.event.sql import EVENTS_DATA_TABLE
 from posthog.test.base import _create_event, flush_persons_and_events

--- a/posthog/test/test_plugin_log_entry.py
+++ b/posthog/test/test_plugin_log_entry.py
@@ -1,6 +1,6 @@
 from django.utils import timezone
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.models import Plugin, PluginConfig
 from posthog.models.plugin import (
     PluginLogEntrySource,

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -255,7 +255,7 @@ if settings.TEST:
     # Used in posthog-js e2e tests
     @csrf_exempt
     def delete_events(request):
-        from posthog.client import sync_execute
+        from posthog.clickhouse.client import sync_execute
         from posthog.models.event.sql import TRUNCATE_EVENTS_TABLE_SQL
 
         sync_execute(TRUNCATE_EVENTS_TABLE_SQL())

--- a/posthog/warehouse/api/test/test_log_entry.py
+++ b/posthog/warehouse/api/test/test_log_entry.py
@@ -4,7 +4,7 @@ import pytest
 from posthog.api.test.test_organization import create_organization
 from posthog.api.test.test_team import create_team
 from posthog.api.test.test_user import create_user
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from django.test.client import Client as TestClient
 from posthog.warehouse.models import (
     ExternalDataSchema,

--- a/posthog/warehouse/models/table.py
+++ b/posthog/warehouse/models/table.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Optional, TypeAlias
 from django.db import models
 
-from posthog.client import sync_execute
+from posthog.clickhouse.client import sync_execute
 from posthog.errors import wrap_query_error
 from posthog.hogql import ast
 from posthog.hogql.database.models import (


### PR DESCRIPTION
## Problem

posthog/client.py was a legacy leftover that was causing exception in some edge cases

## Changes

Fix import to use posthog.clickhouse.client

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

local run+tests