### PR TITLE
feat: rate limit number of concurrent queries executed on ClickHouse (through API)

### DIFF
--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -140,8 +140,8 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
             return Response(result, status=response_status)
         except (ExposedHogQLError, ExposedCHQueryError) as e:
             raise ValidationError(str(e), getattr(e, "code_name", None))
-        except ConcurrencyLimitExceeded:
-            raise Throttled()
+        except ConcurrencyLimitExceeded as c:
+            raise Throttled(detail=str(c))
         except Exception as e:
             self.handle_column_ch_error(e)
             capture_exception(e)

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -7,13 +7,14 @@ from django.http import JsonResponse, StreamingHttpResponse
 from drf_spectacular.utils import OpenApiResponse
 from pydantic import BaseModel
 from rest_framework import status, viewsets
-from rest_framework.exceptions import NotAuthenticated, ValidationError
+from rest_framework.exceptions import NotAuthenticated, ValidationError, Throttled
 from rest_framework.request import Request
 from rest_framework.response import Response
 from sentry_sdk import set_tag
 from asgiref.sync import sync_to_async
 from concurrent.futures import ThreadPoolExecutor
 
+from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded
 from posthog.exceptions_capture import capture_exception
 from posthog.api.documentation import extend_schema
 from posthog.api.mixins import PydanticModelMixin
@@ -139,6 +140,8 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
             return Response(result, status=response_status)
         except (ExposedHogQLError, ExposedCHQueryError) as e:
             raise ValidationError(str(e), getattr(e, "code_name", None))
+        except ConcurrencyLimitExceeded:
+            raise Throttled()
         except Exception as e:
             self.handle_column_ch_error(e)
             capture_exception(e)

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -11,7 +11,7 @@ from rest_framework.exceptions import APIException, NotFound
 
 from posthog import celery, redis
 from posthog.clickhouse.client.async_task_chain import add_task_to_on_commit
-from posthog.clickhouse.query_tagging import tag_queries
+from posthog.clickhouse.query_tagging import tag_queries, get_query_tag_value
 from posthog.errors import CHQueryErrorTooManySimultaneousQueries, ExposedCHQueryError
 from posthog.hogql.constants import LimitContext
 from posthog.hogql.errors import ExposedHogQLError
@@ -246,7 +246,8 @@ def enqueue_process_query_task(
     )
     manager.store_query_status(query_status)
 
-    task_signature = process_query_task.si(team.id, user_id, query_id, query_json, LimitContext.QUERY_ASYNC)
+    is_api = get_query_tag_value("access_method") == "personal_api_key"
+    task_signature = process_query_task.si(team.id, user_id, query_id, query_json, is_api, LimitContext.QUERY_ASYNC)
 
     if _test_only_bypass_celery:
         task_signature()

--- a/posthog/clickhouse/client/limit.py
+++ b/posthog/clickhouse/client/limit.py
@@ -69,14 +69,13 @@ class RateLimit:
 
     @contextmanager
     def run(self, *args, **kwargs):
-        cleanup = None
-        if not self.applicable or self.applicable(*args, **kwargs):
+        applicable = not self.applicable or self.applicable(*args, **kwargs)
+        if applicable:
             running_task_key, task_id = self.use(*args, **kwargs)
-            cleanup = True
         try:
             yield
         finally:
-            if cleanup:
+            if applicable:
                 self.release(running_task_key, task_id)
 
     def use(self, *args, **kwargs):
@@ -102,7 +101,7 @@ class RateLimit:
             ).inc()
 
             raise ConcurrencyLimitExceeded(
-                f"Exceeded maximum concurrent tasks limit: {self.max_concurrent_tasks} for key: {task_name} and task: {task_id}"
+                f"Exceeded maximum concurrency limit: {self.max_concurrent_tasks} for key: {task_name} and task: {task_id}"
             )
 
         return running_tasks_key, task_id

--- a/posthog/clickhouse/client/limit.py
+++ b/posthog/clickhouse/client/limit.py
@@ -1,3 +1,4 @@
+import dataclasses
 import time
 from functools import wraps
 from typing import Optional
@@ -7,6 +8,12 @@ from celery import current_task
 from prometheus_client import Counter
 
 from posthog import redis
+
+CONCURRENT_QUERY_LIMIT_EXCEEDED_COUNTER = Counter(
+    "posthog_clickhouse_query_concurrency_limit_exceeded",
+    "Number of times a ClickHouse query exceeded the concurrency limit",
+    ["task_name", "limit", "limit_name"],
+)
 
 CONCURRENT_TASKS_LIMIT_EXCEEDED_COUNTER = Counter(
     "posthog_celery_task_concurrency_limit_exceeded",
@@ -38,6 +45,96 @@ end
 redis.call('ZADD', key, expiration_time, task_id)
 return 1
 """
+
+
+@dataclasses.dataclass
+class RateLimit:
+    """
+    Ensures that only max_concurrent_tasks of tasks_name are executed at a given time.
+    Tasks have ttl as a safeguard against not being removed.
+    """
+
+    max_concurrent_tasks: int
+    limit_name: str
+    get_task_name: Callable
+    get_task_id: Callable
+    get_task_key: Callable = None
+    get_time: Callable[[], int] = lambda: int(time.time())
+    applicable: Optional[Callable] = None
+    ttl: int = 60
+
+    @property
+    def redis_client(self):
+        return redis.get_client()
+
+    class Run:
+        def __init__(self, limit, running_task_key, task_id):
+            self.limit = limit
+            self.running_task_key = running_task_key
+            self.task_id = task_id
+
+        def __enter__(self):
+            pass
+
+        def __exit__(self, applicable, running_task_key, task_id):
+            if self.limit:
+                self.limit.release(self.running_task_key, self.task_id)
+
+    def run(self, *args, **kwargs):
+        if self.applicable and not self.applicable(*args, **kwargs):
+            return self.Run()
+        running_tasks_key, task_id = self.use(*args, **kwargs)
+        return self.Run(self, running_tasks_key, task_id)
+
+    def use(self, *args, **kwargs):
+        """
+        Acquire the resource before execution or throw exception.
+        """
+        if self.applicable and not self.applicable(*args, **kwargs):
+            return
+        task_name = self.get_task_name(*args, **kwargs)
+        running_tasks_key = self.get_task_key(*args, **kwargs) if self.get_task_key else task_name
+        task_id = self.get_task_id(*args, **kwargs)
+        current_time = self.get_time()
+
+        # Atomically check, remove expired if limit hit, and add the new task
+        if (
+            self.redis_client.eval(
+                lua_script, 1, running_tasks_key, current_time, task_id, self.max_concurrent_tasks, self.ttl
+            )
+            == 0
+        ):
+            CONCURRENT_QUERY_LIMIT_EXCEEDED_COUNTER.labels(
+                task_name=task_name, limit=self.max_concurrent_tasks, limit_name=self.limit_name
+            ).inc()
+
+            raise CeleryConcurrencyLimitExceeded(
+                f"Exceeded maximum concurrent tasks limit: {self.max_concurrent_tasks} for key: {task_name} and task: {task_id}"
+            )
+
+        return running_tasks_key, task_id
+
+    def release(self, running_task_key, task_id):
+        """
+        Release the resource, when the execution finishes.
+        """
+        self.redis_client.zrem(running_task_key, task_id)
+
+    def wrap(self, task_func):
+        @wraps(task_func)
+        def wrapper(*args, **kwargs):
+            applicable = self.applicable(*args, **kwargs)
+            if applicable:
+                running_tasks_key, task_id = self.use(*args, **kwargs)
+            try:
+                # Execute the task
+                return task_func(*args, **kwargs)
+            finally:
+                # Remove the task ID from the sorted set when the task finishes
+                if applicable:
+                    self.release(running_tasks_key, task_id)
+
+        return wrapper
 
 
 class CeleryConcurrencyLimitExceeded(Exception):

--- a/posthog/clickhouse/client/test/test_limit.py
+++ b/posthog/clickhouse/client/test/test_limit.py
@@ -1,0 +1,87 @@
+from posthog.clickhouse.client.limit import RateLimit, CeleryConcurrencyLimitExceeded
+from posthog.test.base import BaseTest
+from posthog.redis import get_client
+
+
+class TestRateLimit(BaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.redis_client = get_client()
+        self.limit = RateLimit(
+            max_concurrent_tasks=1,
+            applicable=lambda *args, **kwargs: (kwargs.get("is_api") if "is_api" in kwargs else args[0]),
+            limit_name="api_per_team",
+            get_task_name=lambda *args, **kwargs: f"rate-limit-test-task:{kwargs.get('team_id') or args[1]}",
+            get_task_key=lambda *args, **kwargs: f"limit:rate-limit-test-task:{kwargs.get('team_id') or args[1]}",
+            get_task_id=lambda *args, **kwargs: f"{kwargs.get('task_id') or args[2]}",
+            ttl=10,
+        )
+        self.cancels = []
+
+    def tearDown(self) -> None:
+        for a, b in self.cancels:
+            self.limit.release(a, b)
+
+    def test_rate_limit(self):
+        args, kwargs = (), {"is_api": True, "team_id": 7, "task_id": 17}
+
+        self.cancels.append(self.limit.use(*args, **kwargs))
+
+    def test_rate_limit_fail(self):
+        self.cancels.append(self.limit.use(is_api=True, team_id=8, task_id=17))
+        with self.assertRaises(CeleryConcurrencyLimitExceeded):
+            self.cancels.append(self.limit.use(True, 8, 18))
+
+    def test_rate_limits_no_inference(self):
+        """
+        User limits do not interfere even with same task ids.
+        """
+        self.cancels.append(self.limit.use(is_api=True, team_id=9, task_id=17))
+        self.cancels.append(self.limit.use(is_api=True, team_id=10, task_id=17))
+        self.cancels.append(self.limit.use(is_api=True, team_id=11, task_id=17))
+
+    def test_ttl(self):
+        x = 0
+
+        def get_time_plus_100():
+            nonlocal x
+            x = x + 100
+            return x
+
+        self.limit.get_time = get_time_plus_100
+        self.cancels.append(self.limit.use(is_api=True, team_id=9, task_id=17))
+        self.cancels.append(self.limit.use(is_api=True, team_id=9, task_id=18))
+        self.cancels.append(self.limit.use(is_api=True, team_id=9, task_id=19))
+
+    def test_applicable(self):
+        @self.limit.wrap
+        def some_func(is_api: bool, team_id: int, task_id: int):
+            pass
+
+        some_func(is_api=True, team_id=9, task_id=17)
+        # none of the belows
+        some_func(is_api=False, team_id=9, task_id=19)
+        some_func(is_api=False, team_id=9, task_id=19)
+        some_func(is_api=False, team_id=9, task_id=19)
+
+    def test_context(self):
+        result = 0
+        with self.limit.run(is_api=True, team_id=9, task_id=17):
+            result += 1
+
+        with self.limit.run(is_api=True, team_id=9, task_id=17):
+            result += 2
+
+        assert result == 3
+
+    def test_context_fail(self):
+        result = 0
+        with self.limit.run(is_api=True, team_id=9, task_id=17):
+            result += 1
+            with self.assertRaises(CeleryConcurrencyLimitExceeded):
+                with self.limit.run(is_api=True, team_id=9, task_id=18):
+                    result += 2
+                result += 4
+            result += 8
+
+        assert result == 9

--- a/posthog/clickhouse/client/test/test_limit.py
+++ b/posthog/clickhouse/client/test/test_limit.py
@@ -103,7 +103,6 @@ class TestRateLimit(BaseTest):
             with self.limit.run(is_api=True, team_id=9, task_id=17):
                 result += 2
                 raise Exception()
-            result += 4
 
         with self.limit.run(is_api=True, team_id=9, task_id=17):
             result += 8

--- a/posthog/clickhouse/client/test/test_limit.py
+++ b/posthog/clickhouse/client/test/test_limit.py
@@ -95,3 +95,17 @@ class TestRateLimit(BaseTest):
             result += 4
 
         assert result == 7
+
+    def test_exception(self):
+        result = 0
+        with self.assertRaises(Exception):
+            result += 1
+            with self.limit.run(is_api=True, team_id=9, task_id=17):
+                result += 2
+                raise Exception()
+            result += 4
+
+        with self.limit.run(is_api=True, team_id=9, task_id=17):
+            result += 8
+
+        assert result == 11

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -9,6 +9,7 @@ from prometheus_client import Counter
 from pydantic import BaseModel, ConfigDict
 from sentry_sdk import get_traceparent, push_scope, set_tag
 
+from posthog.clickhouse.client.limit import get_api_personal_rate_limiter
 from posthog.exceptions_capture import capture_exception
 from posthog.caching.utils import ThresholdMode, cache_target_age, is_stale, last_refresh_from_cached_result
 from posthog.clickhouse.client.execute_async import QueryNotFoundError, enqueue_process_query_task, get_query_status
@@ -712,7 +713,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             results = self.handle_cache_and_async_logic(
                 execution_mode=execution_mode, cache_manager=cache_manager, user=user
             )
-            if results is not None:
+            if results:
                 return results
 
         last_refresh = datetime.now(UTC)
@@ -724,15 +725,17 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             self.modifiers = create_default_modifiers_for_user(user, self.team, self.modifiers)
             self.modifiers.useMaterializedViews = True
 
-        fresh_response_dict = {
-            **self.calculate().model_dump(),
-            "is_cached": False,
-            "last_refresh": last_refresh,
-            "next_allowed_client_refresh": last_refresh + self._refresh_frequency(),
-            "cache_key": cache_key,
-            "timezone": self.team.timezone,
-            "cache_target_age": target_age,
-        }
+        is_api = get_query_tag_value("access_method") == "personal_api_key"
+        with get_api_personal_rate_limiter().run(is_api=is_api, team_id=self.team.pk, task_id=self.query_id):
+            fresh_response_dict = {
+                **self.calculate().model_dump(),
+                "is_cached": False,
+                "last_refresh": last_refresh,
+                "next_allowed_client_refresh": last_refresh + self._refresh_frequency(),
+                "cache_key": cache_key,
+                "timezone": self.team.timezone,
+                "cache_target_age": target_age,
+            }
         if get_query_tag_value("trigger"):
             fresh_response_dict["calculation_trigger"] = get_query_tag_value("trigger")
         fresh_response = CachedResponse(**fresh_response_dict)

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -13,7 +13,7 @@ from prometheus_client import Gauge
 from redis import Redis
 from structlog import get_logger
 
-from posthog.clickhouse.client.limit import CeleryConcurrencyLimitExceeded, limit_concurrency
+from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded, limit_concurrency
 from posthog.cloud_utils import is_cloud
 from posthog.errors import CHQueryErrorTooManySimultaneousQueries
 from posthog.hogql.constants import LimitContext
@@ -45,7 +45,7 @@ def redis_heartbeat() -> None:
     autoretry_for=(
         # Important: Only retry for things that might be okay on the next try
         CHQueryErrorTooManySimultaneousQueries,
-        CeleryConcurrencyLimitExceeded,
+        ConcurrencyLimitExceeded,
     ),
     retry_backoff=1,
     retry_backoff_max=10,

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -67,11 +67,11 @@ def process_query_task(
     is_api: bool,
     limit_context: Optional[LimitContext] = None,
 ) -> None:
+    """
+    Kick off query
+    Once complete save results to redis
+    """
     with get_api_personal_rate_limiter().run(is_api=is_api, team_id=team_id, task_id=query_id):
-        """
-        Kick off query
-        Once complete save results to redis
-        """
         from posthog.clickhouse.client import execute_process_query
 
         execute_process_query(

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -13,7 +13,7 @@ from prometheus_client import Gauge
 from redis import Redis
 from structlog import get_logger
 
-from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded, limit_concurrency
+from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded, limit_concurrency, get_api_personal_rate_limiter
 from posthog.cloud_utils import is_cloud
 from posthog.errors import CHQueryErrorTooManySimultaneousQueries
 from posthog.hogql.constants import LimitContext
@@ -64,21 +64,23 @@ def process_query_task(
     user_id: Optional[int],
     query_id: str,
     query_json: dict,
+    is_api: bool,
     limit_context: Optional[LimitContext] = None,
 ) -> None:
-    """
-    Kick off query
-    Once complete save results to redis
-    """
-    from posthog.clickhouse.client import execute_process_query
+    with get_api_personal_rate_limiter().run(is_api=is_api, team_id=team_id, task_id=query_id):
+        """
+        Kick off query
+        Once complete save results to redis
+        """
+        from posthog.clickhouse.client import execute_process_query
 
-    execute_process_query(
-        team_id=team_id,
-        user_id=user_id,
-        query_id=query_id,
-        query_json=query_json,
-        limit_context=limit_context,
-    )
+        execute_process_query(
+            team_id=team_id,
+            user_id=user_id,
+            query_id=query_id,
+            query_json=query_json,
+            limit_context=limit_context,
+        )
 
 
 @shared_task(ignore_result=True)


### PR DESCRIPTION
## Problem

Want to limit number of concurrent ops running.

## Changes

* Add rate limiter class for it.
* Introduce rate limiter when a /query request is made by using personal_api_token

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Class is tested, integration in further PRs.