### PR TITLE
fix: open ssl path for cmake

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -54,6 +54,9 @@ cmake = { pkg-path = "cmake", version = "3.31.5", pkg-group = "cmake" }
 DEBUG = "1"
 POSTHOG_SKIP_MIGRATION_CHECKS = "1"
 DIRENV_LOG_FORMAT = "" # Disable direnv activation logging (in case direnv is present)
+OPENSSL_ROOT_DIR = "$FLOX_ENV"
+OPENSSL_LIB_DIR = "$FLOX_ENV/lib"
+OPENSSL_INCLUDE_DIR = "$FLOX_ENV/include"
 LDFLAGS="-L$FLOX_ENV/lib"
 CPPFLAGS="-I$FLOX_ENV/include"
 


### PR DESCRIPTION
I was getting errors from rust apps when running bin/start in a fresh setup 

```
  Compiling rdkafka-sys v4.8.0+2.3.0
error: failed to run custom build command for `rdkafka-sys v4.8.0+2.3.0`
```

snip...

```
Could NOT find OpenSSL, try to set the path to OpenSSL root folder in the
    system variable OPENSSL_ROOT_DIR (missing: OPENSSL_CRYPTO_LIBRARY
    OPENSSL_INCLUDE_DIR)
    ```
    
    setting this and restart my shell fixed it