### PR TITLE
feat(web-analytics): Fix some weird interactions between host and domain filter

### DIFF
--- a/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
@@ -28,7 +28,7 @@ export const WebAnalyticsFilters = (): JSX.Element => {
     const { authorizedUrls } = useValues(
         authorizedUrlListLogic({ type: AuthorizedUrlListType.WEB_ANALYTICS, actionId: null, experimentId: null })
     )
-    const { domainFilter } = useValues(webAnalyticsLogic)
+    const { domainFilter, hasHostFilter } = useValues(webAnalyticsLogic)
     const { setDomainFilter } = useActions(webAnalyticsLogic)
 
     const { featureFlags } = useValues(featureFlagLogic)
@@ -52,7 +52,10 @@ export const WebAnalyticsFilters = (): JSX.Element => {
                                     options={[
                                         {
                                             options: [
-                                                { label: 'All domains', value: 'all' },
+                                                {
+                                                    label: hasHostFilter ? 'Filtering by host' : 'All domains',
+                                                    value: 'all',
+                                                },
                                                 ...authorizedUrls.map((url) => ({ label: url, value: url })),
                                             ],
                                             footer: (

--- a/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
@@ -45,7 +45,7 @@ export const WebAnalyticsFilters = (): JSX.Element => {
                                 <LemonSelect
                                     className="grow md:grow-0"
                                     size="small"
-                                    value={domainFilter || 'all'}
+                                    value={domainFilter ?? (hasHostFilter ? 'host' : 'all')}
                                     icon={<IconGlobe />}
                                     onChange={(value) => setDomainFilter(value)}
                                     disabled={authorizedUrls.length === 0}
@@ -53,9 +53,17 @@ export const WebAnalyticsFilters = (): JSX.Element => {
                                         {
                                             options: [
                                                 {
-                                                    label: hasHostFilter ? 'Filtering by host' : 'All domains',
+                                                    label: 'All domains',
                                                     value: 'all',
                                                 },
+                                                ...(hasHostFilter
+                                                    ? [
+                                                          {
+                                                              label: 'All domains (host filter active)',
+                                                              value: 'host',
+                                                          },
+                                                      ]
+                                                    : []),
                                                 ...authorizedUrls.map((url) => ({ label: url, value: url })),
                                             ],
                                             footer: (

--- a/frontend/src/scenes/web-analytics/WebPropertyFilters.tsx
+++ b/frontend/src/scenes/web-analytics/WebPropertyFilters.tsx
@@ -4,7 +4,6 @@ import { useActions, useValues } from 'kea'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { isEventPersonOrSessionPropertyFilter } from 'lib/components/PropertyFilters/utils'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { IconWithCount } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { useState } from 'react'
@@ -14,14 +13,8 @@ import { webAnalyticsLogic } from './webAnalyticsLogic'
 export const WebPropertyFilters = (): JSX.Element => {
     const { rawWebAnalyticsFilters } = useValues(webAnalyticsLogic)
     const { setWebAnalyticsFilters } = useActions(webAnalyticsLogic)
-    const useDomainDropdown = useFeatureFlag('WEB_ANALYTICS_DOMAIN_DROPDOWN')
 
     const [displayFilters, setDisplayFilters] = useState(false)
-
-    // Removing host because it's controlled by the domain filter and we don't want to display it here
-    const propertyFilters = useDomainDropdown
-        ? rawWebAnalyticsFilters.filter((filter) => filter.key !== '$host')
-        : rawWebAnalyticsFilters
 
     return (
         <Popover
@@ -41,7 +34,7 @@ export const WebPropertyFilters = (): JSX.Element => {
                         onChange={(filters) =>
                             setWebAnalyticsFilters(filters.filter(isEventPersonOrSessionPropertyFilter))
                         }
-                        propertyFilters={propertyFilters}
+                        propertyFilters={rawWebAnalyticsFilters}
                         pageKey="web-analytics"
                         eventNames={['$pageview']}
                     />
@@ -50,7 +43,7 @@ export const WebPropertyFilters = (): JSX.Element => {
         >
             <LemonButton
                 icon={
-                    <IconWithCount count={propertyFilters.length} showZero={false}>
+                    <IconWithCount count={rawWebAnalyticsFilters.length} showZero={false}>
                         <IconFilter />
                     </IconWithCount>
                 }

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -385,15 +385,31 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
 
                     return [...oldPropertyFilters, newFilter]
                 },
+                setDomainFilter: (state) => {
+                    // the domain and host filters don't interact well, so remove the host filter when the domain filter is set
+                    return state.filter((filter) => filter.key !== '$host')
+                },
             },
         ],
         domainFilter: [
             null as string | null,
             persistConfig,
             {
-                setDomainFilter: (_: string | null, payload: unknown) => {
-                    const { domain } = payload as { domain: string | null }
+                setDomainFilter: (_: string | null, payload: { domain: string | null }) => {
+                    const { domain } = payload
                     return domain
+                },
+                togglePropertyFilter: (state, { key }) => {
+                    // the domain and host filters don't interact well, so remove the domain filter when the host filter is set
+                    return key === '$host' ? null : state
+                },
+                setWebAnalyticsFilters: (state, { webAnalyticsFilters }) => {
+                    // the domain and host filters don't interact well, so remove the domain filter when the host filter is set
+
+                    if (webAnalyticsFilters.some((f) => f.key === '$host')) {
+                        return null
+                    }
+                    return state
                 },
             },
         ],
@@ -603,6 +619,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 return hasAvailableFeature(AvailableFeature.PATHS_ADVANCED) && isPathCleaningEnabled
             },
         ],
+        hasHostFilter: [(s) => [s.rawWebAnalyticsFilters], (filters) => filters.some((f) => f.key === '$host')],
         webAnalyticsFilters: [
             (s) => [
                 s.rawWebAnalyticsFilters,

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -405,7 +405,6 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 },
                 setWebAnalyticsFilters: (state, { webAnalyticsFilters }) => {
                     // the domain and host filters don't interact well, so remove the domain filter when the host filter is set
-
                     if (webAnalyticsFilters.some((f) => f.key === '$host')) {
                         return null
                     }


### PR DESCRIPTION
## Problem
If we're using domain filters, but the user sets a host filter, weird things can happen.



## Changes
This makes host and domains filter fully mutually exclusive, but either can work well on its own

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
Try setting a domain filter with a host filter already set, and vice versa
