### PR TITLE
fix(experiments): Ensure web experiments use stats v2

### DIFF
--- a/posthog/api/test/test_web_experiment.py
+++ b/posthog/api/test/test_web_experiment.py
@@ -53,6 +53,8 @@ class TestWebExperiment(APIBaseTest):
 
         assert web_experiment.created_by == self.user
 
+        assert web_experiment.get_stats_config("version") == 2
+
         assert web_experiment.variants is not None
         assert web_experiment.type == "web"
         assert web_experiment.variants.get("control") is not None

--- a/posthog/api/web_experiment.py
+++ b/posthog/api/web_experiment.py
@@ -96,8 +96,12 @@ class WebExperimentsAPISerializer(serializers.ModelSerializer):
         feature_flag_serializer.is_valid(raise_exception=True)
         feature_flag = feature_flag_serializer.save()
 
+        stats_config = {
+            "version": 2,
+        }
+
         experiment = WebExperiment.objects.create(
-            team_id=self.context["team_id"], feature_flag=feature_flag, **create_params
+            team_id=self.context["team_id"], feature_flag=feature_flag, **create_params, stats_config=stats_config
         )
         return experiment
 


### PR DESCRIPTION
## Changes

Ensures web experiments created from the toolbar use stats v2.

## How did you test this code?

Tests should pass.

I also created a web experiment from the toolbar and verified the expected stats version displayed in the UI.