### PR TITLE
feat: Add dagster job to export query logs to s3

### DIFF
--- a/dags/README.md
+++ b/dags/README.md
@@ -1,0 +1,17 @@
+# Dagster
+
+## Running locally
+
+You'll need to set DAGSTER_HOME
+
+Easiest is to just start jobs from your cli
+```bash
+dagster job execute -m dags.export_query_logs_to_s3 --config dags/query_log_example.yaml
+```
+
+You can also run the interface
+```bash
+dagster dev
+```
+
+By default this will run on http://127.0.0.1:3000/

--- a/dags/export_query_logs_to_s3.py
+++ b/dags/export_query_logs_to_s3.py
@@ -1,0 +1,214 @@
+import datetime
+from typing import ClassVar
+
+import dagster
+import pydantic
+from clickhouse_driver import Client
+
+from posthog.clickhouse.cluster import ClickhouseCluster
+from posthog.settings.dagster import DAGSTER_S3_BUCKET
+from posthog.settings.base_variables import DEBUG
+from posthog.settings.object_storage import (
+    OBJECT_STORAGE_ENDPOINT,
+    OBJECT_STORAGE_ACCESS_KEY_ID,
+    OBJECT_STORAGE_SECRET_ACCESS_KEY,
+)
+
+from dags.common import ClickhouseClusterResource
+
+
+class DateRange(dagster.Config):
+    date_from: str  # Format: YYYY-MM-DD
+    date_to: str  # Format: YYYY-MM-DD
+
+    FORMAT: ClassVar[str] = "%Y-%m-%d"
+
+    @pydantic.field_validator("date_from", "date_to")
+    @classmethod
+    def validate_format(cls, value: str) -> str:
+        cls.parse_date(value)
+        return value
+
+    @pydantic.model_validator(mode="after")
+    def validate_bounds(self):
+        if not self.parse_date(self.date_from) <= self.parse_date(self.date_to):
+            raise ValueError("expected date_from to be less than (or equal to) date_to")
+        return self
+
+    @classmethod
+    def parse_date(cls, value: str) -> datetime.date:
+        return datetime.datetime.strptime(value, cls.FORMAT).date()
+
+
+class QueryLogsExportConfig(dagster.Config):
+    date_range: DateRange = None  # Optional, if not provided will use yesterday's date
+    s3_path: str = "query_logs"  # Subdirectory in the S3 bucket
+
+
+@dagster.op
+def export_query_logs(
+    context: dagster.OpExecutionContext,
+    config: QueryLogsExportConfig,
+    cluster: dagster.ResourceParam[ClickhouseCluster],
+):
+    """
+    Export ClickHouse query logs to S3 using ClickHouse's native S3 export functionality.
+    Exports all columns from the system.query_log table for the specified date range.
+    """
+    # If date_range is not provided, use yesterday's date
+    if config.date_range is None:
+        yesterday = datetime.date.today() - datetime.timedelta(days=1)
+        date_from = yesterday
+        date_to = yesterday
+    else:
+        date_from = DateRange.parse_date(config.date_range.date_from)
+        date_to = DateRange.parse_date(config.date_range.date_to)
+
+    # Format dates for the S3 path
+    date_from_str = date_from.strftime("%Y%m%d")
+    date_to_str = date_to.strftime("%Y%m%d")
+
+    # We'll create a function that generates the query for each host
+    # This allows us to include the hostname in the filename to avoid conflicts
+    def generate_export_query(client: Client):
+        # Get the hostname from the client
+        [[hostname]] = client.execute("SELECT hostName()")
+
+        # Create a unique filename based on the date range and hostname
+        s3_filename = f"{config.s3_path}/query_logs_{hostname}_{date_from_str}_to_{date_to_str}.parquet"
+
+        if DEBUG:
+            context.log.info(f"Using MinIO for local development on host {hostname}")
+            # For MinIO, we need to use the HTTP endpoint directly
+            # Format: http://endpoint/bucket/path
+            s3_path = f"{OBJECT_STORAGE_ENDPOINT}/{DAGSTER_S3_BUCKET}/{s3_filename}"
+
+            # Build the function call with credentials
+            s3_function_args = (
+                f"'{s3_path}', "
+                f"'{OBJECT_STORAGE_ACCESS_KEY_ID}', "
+                f"'{OBJECT_STORAGE_SECRET_ACCESS_KEY}', "
+                f"'Parquet'"
+            )
+        else:
+            # In production, use the standard S3 URL format with AWS
+            s3_path = f"https://{DAGSTER_S3_BUCKET}.s3.amazonaws.com/{s3_filename}"
+            # AWS credentials are handled by the instance profile
+            s3_function_args = f"'{s3_path}', 'Parquet'"
+
+        # Construct the export query
+        # Explicitly select all columns except transaction_id which contains a UUID that Parquet doesn't support
+        query = f"""
+        INSERT INTO FUNCTION s3({s3_function_args})
+        SELECT
+            hostname,
+            type,
+            event_date,
+            event_time,
+            event_time_microseconds,
+            query_start_time,
+            query_start_time_microseconds,
+            query_duration_ms,
+            read_rows,
+            read_bytes,
+            written_rows,
+            written_bytes,
+            result_rows,
+            result_bytes,
+            memory_usage,
+            current_database,
+            query,
+            formatted_query,
+            normalized_query_hash,
+            query_kind,
+            databases,
+            tables,
+            columns,
+            partitions,
+            projections,
+            views,
+            exception_code,
+            exception,
+            stack_trace,
+            is_initial_query,
+            user,
+            query_id,
+            address,
+            port,
+            initial_user,
+            initial_query_id,
+            initial_address,
+            initial_port,
+            initial_query_start_time,
+            initial_query_start_time_microseconds,
+            interface,
+            is_secure,
+            os_user,
+            client_hostname,
+            client_name,
+            client_revision,
+            client_version_major,
+            client_version_minor,
+            client_version_patch,
+            http_method,
+            http_user_agent,
+            http_referer,
+            forwarded_for,
+            quota_key,
+            distributed_depth,
+            revision,
+            log_comment,
+            thread_ids,
+            peak_threads_usage,
+            ProfileEvents,
+            Settings,
+            used_aggregate_functions,
+            used_aggregate_function_combinators,
+            used_database_engines,
+            used_data_type_families,
+            used_dictionaries,
+            used_formats,
+            used_functions,
+            used_storages,
+            used_table_functions,
+            used_row_policies,
+            used_privileges,
+            missing_privileges,
+            -- transaction_id is excluded because it contains a UUID which Parquet doesn't support
+            query_cache_usage,
+            asynchronous_read_counters,
+            ProfileEvents.Names,
+            ProfileEvents.Values,
+            Settings.Names,
+            Settings.Values
+        FROM system.query_log
+        WHERE event_date >= toDate(%(date_from)s)
+          AND event_date <= toDate(%(date_to)s)
+        SETTINGS s3_truncate_on_insert=1
+        """
+
+        context.log.info(f"Exporting query logs from {date_from} to {date_to} to {s3_path} on host {hostname}")
+
+        # Execute the query
+        return client.execute(
+            query,
+            {
+                "date_from": date_from.strftime(DateRange.FORMAT),
+                "date_to": date_to.strftime(DateRange.FORMAT),
+            },
+        )
+
+    # Execute the query on all hosts in the cluster
+    context.log.info(f"Starting export of query logs from {date_from} to {date_to} on all hosts")
+    results = cluster.map_all_hosts(generate_export_query).result()
+
+    # Log the results
+    for host, result in results.items():
+        context.log.info(f"Export completed on host {host}: {result}")
+
+    context.log.info(f"Query logs export completed successfully on all hosts")
+
+
+@dagster.job(resource_defs={"cluster": ClickhouseClusterResource()})
+def export_query_logs_to_s3():
+    export_query_logs()

--- a/dags/query_log_example.yaml
+++ b/dags/query_log_example.yaml
@@ -1,0 +1,16 @@
+ops:
+    export_query_logs:
+        config:
+            s3_path: query_logs
+            date_range:
+                date_from: 2020-01-01
+                date_to: 2025-03-31
+resources:
+    cluster:
+        config:
+            client_settings:
+                lightweight_deletes_sync: '0'
+                max_execution_time: '0'
+                max_memory_usage: '0'
+                mutations_sync: '0'
+                receive_timeout: '600'

--- a/posthog/settings/dagster.py
+++ b/posthog/settings/dagster.py
@@ -2,3 +2,4 @@ import os
 
 DAGSTER_S3_BUCKET: str = os.getenv("DAGSTER_S3_BUCKET", "posthog-dags")
 DAGSTER_DEFAULT_SLACK_ALERTS_CHANNEL: str = os.getenv("DAGSTER_DEFAULT_SLACK_ALERTS_CHANNEL", "#alerts-clickhouse")
+DAGSTER_DATA_EXPORT_S3_BUCKET: str = os.getenv("DAGSTER_DATA_EXPORT_S3_BUCKET", "dagster-data-export")

--- a/posthog/settings/object_storage.py
+++ b/posthog/settings/object_storage.py
@@ -6,7 +6,7 @@ from posthog.settings.base_variables import DEBUG, TEST
 from posthog.utils import str_to_bool
 
 if TEST or DEBUG:
-    OBJECT_STORAGE_ENDPOINT = os.getenv("OBJECT_STORAGE_ENDPOINT", "http://localhost:19000")
+    OBJECT_STORAGE_ENDPOINT = os.getenv("OBJECT_STORAGE_ENDPOINT", "http://objectstorage:19000")
     OBJECT_STORAGE_ACCESS_KEY_ID: Optional[str] = os.getenv("OBJECT_STORAGE_ACCESS_KEY_ID", "object_storage_root_user")
     OBJECT_STORAGE_SECRET_ACCESS_KEY: Optional[str] = os.getenv(
         "OBJECT_STORAGE_SECRET_ACCESS_KEY", "object_storage_root_password"


### PR DESCRIPTION
## Problem

I want to be able to view query logs in posthog instead of metabase. Also it's probably useful to keep the logs around.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes



<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
