### PR TITLE
fix: Installing pymssql in flox

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -45,6 +45,7 @@ nodemon = { pkg-path = "nodemon" }
 xmlsec = { pkg-path = "xmlsec", version = "1.3.6" }
 openssl = { pkg-path = "openssl", version = "3.4.1", pkg-group = "openssl" }
 cmake = { pkg-path = "cmake", version = "3.31.5", pkg-group = "cmake" }
+freetds = { pkg-path = "freetds" }
 
 # Set environment variables in the `[vars]` section. These variables may not
 # reference one another, and are added to the environment without first
@@ -93,7 +94,7 @@ echo -e "Python interpreter path, for your code editor: \033[33m.flox/cache/venv
 source "$PYTHON_DIR/bin/activate"
 
 # Install Python dependencies (this is practically instant thanks to uv)
-uv pip install -q -r requirements.txt -r requirements-dev.txt
+uv pip install -q --no-binary=pymssql -r requirements.txt -r requirements-dev.txt
 
 # Install top-level Node dependencies (only if not present all yet, because this takes almost a second even with pnpm)
 # This also sets up pre-commit hooks via Husky


### PR DESCRIPTION
## Problem

In flox environments on macOS, we run into the following error when trying to setup certain data pipeline imports:

```
symbol not found in flat namespace '_bcp_batch'
```

This is related to the issue [we've identified in the past](https://github.com/PostHog/posthog/blob/master/posthog/warehouse/README.md)

## Changes

The fix is to install `pymssql` using the `--no-binary` option and to ensure `freetds` is installed as part of the flox environment (rather than trying to use the version from Homebrew)

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Nuke and rebuild flox environment.