### PR TITLE
chore(data-warehouse): Better error raised for missing env vars for dwh

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -28,6 +28,11 @@ class DeltaTableHelper:
         self._logger = logger
 
     def _get_credentials(self):
+        if not settings.AIRBYTE_BUCKET_KEY or not settings.AIRBYTE_BUCKET_SECRET or not settings.AIRBYTE_BUCKET_REGION:
+            raise KeyError(
+                "Missing env vars for data warehouse. Required vars: AIRBYTE_BUCKET_KEY, AIRBYTE_BUCKET_SECRET, AIRBYTE_BUCKET_REGION"
+            )
+
         if TEST:
             return {
                 "aws_access_key_id": settings.AIRBYTE_BUCKET_KEY,


### PR DESCRIPTION
## Problem
- The error message for missing env vars when starting a data warehouse job is super unclear

## Changes
- Make it way more clear 
