### PR TITLE
chore(data-warehouse): Add Prometheus counter for tracking data imports

### DIFF
--- a/posthog/temporal/data_imports/external_data_job.py
+++ b/posthog/temporal/data_imports/external_data_job.py
@@ -188,6 +188,7 @@ class ExternalDataJobWorkflow(PostHogWorkflow):
             source_id=str(inputs.external_data_source_id),
         )
 
+        source_type = None
         try:
             # create external data job and trigger activity
             create_external_data_job_inputs = CreateExternalDataJobModelActivityInputs(

--- a/posthog/temporal/data_imports/metrics.py
+++ b/posthog/temporal/data_imports/metrics.py
@@ -1,0 +1,10 @@
+from temporalio import workflow
+from temporalio.common import MetricCounter
+
+
+def get_data_import_finished_metric(source_type: str, status: str) -> MetricCounter:
+    return (
+        workflow.metric_meter()
+        .with_additional_attributes({"source_type": source_type, "status": status})
+        .create_counter("data_import_finished", "Number of data imports finished, for any reason (including failure).")
+    )

--- a/posthog/temporal/data_imports/metrics.py
+++ b/posthog/temporal/data_imports/metrics.py
@@ -2,7 +2,8 @@ from temporalio import workflow
 from temporalio.common import MetricCounter
 
 
-def get_data_import_finished_metric(source_type: str, status: str) -> MetricCounter:
+def get_data_import_finished_metric(source_type: str | None, status: str) -> MetricCounter:
+    source_type = source_type or "unknown"
     return (
         workflow.metric_meter()
         .with_additional_attributes({"source_type": source_type, "status": status})

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -1,22 +1,22 @@
-from concurrent.futures import ThreadPoolExecutor
 import functools
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Optional, cast
 from unittest import mock
 
 import aioboto3
-from deltalake import DeltaTable
 import deltalake
 import posthoganalytics
 import psycopg
 import pytest
 import pytest_asyncio
+import s3fs
 from asgiref.sync import sync_to_async
+from deltalake import DeltaTable
 from django.conf import settings
 from django.test import override_settings
 from dlt.common.configuration.specs.aws_credentials import AwsCredentials
 from dlt.sources.helpers.rest_client.client import RESTClient
-import s3fs
 from temporalio.common import RetryPolicy
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
@@ -140,9 +140,14 @@ async def _run(
         billable=billable if billable is not None else True,
     )
 
-    with mock.patch(
-        "posthog.temporal.data_imports.pipelines.pipeline.pipeline.trigger_compaction_job"
-    ) as mock_trigger_compaction_job:
+    with (
+        mock.patch(
+            "posthog.temporal.data_imports.pipelines.pipeline.pipeline.trigger_compaction_job"
+        ) as mock_trigger_compaction_job,
+        mock.patch(
+            "posthog.temporal.data_imports.external_data_job.get_data_import_finished_metric"
+        ) as mock_get_data_import_finished_metric,
+    ):
         await _execute_run(workflow_id, inputs, mock_data_response)
 
     if not ignore_assertions:
@@ -152,6 +157,9 @@ async def _run(
         assert run.status == ExternalDataJob.Status.COMPLETED
 
         mock_trigger_compaction_job.assert_called()
+        mock_get_data_import_finished_metric.assert_called_with(
+            source_type=source_type, status=ExternalDataJob.Status.COMPLETED.lower()
+        )
 
         await sync_to_async(schema.refresh_from_db)()
 


### PR DESCRIPTION
## Problem

We want to be able to set up monitoring and alerting for data import jobs, particularly when a given source type experiences a certain rate of failures.

## Changes

Add a new Prometheus counter, similarly how we do in batch exports. This allows us to track the number of completed data imports by status and by source type. We can then set up alerts based on these metrics.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Tested locally that can see the metric via the `localhost:8001/metrics` endpoint.
Also updated existing tests.
