### PR TITLE
refactor: add s3 timeout to session batch writer

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -233,6 +233,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         SESSION_RECORDING_V2_S3_REGION: 'us-east-1',
         SESSION_RECORDING_V2_S3_ACCESS_KEY_ID: 'object_storage_root_user',
         SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY: 'object_storage_root_password',
+        SESSION_RECORDING_V2_S3_TIMEOUT_MS: 5000,
 
         // Cookieless
         COOKIELESS_FORCE_STATELESS_MODE: false,

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -233,7 +233,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         SESSION_RECORDING_V2_S3_REGION: 'us-east-1',
         SESSION_RECORDING_V2_S3_ACCESS_KEY_ID: 'object_storage_root_user',
         SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY: 'object_storage_root_password',
-        SESSION_RECORDING_V2_S3_TIMEOUT_MS: 5000,
+        SESSION_RECORDING_V2_S3_TIMEOUT_MS: 30000,
 
         // Cookieless
         COOKIELESS_FORCE_STATELESS_MODE: false,

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
@@ -33,6 +33,7 @@ import { SessionRecordingIngesterMetrics } from './metrics'
 import { PromiseScheduler } from './promise-scheduler'
 import { BlackholeSessionBatchFileStorage } from './sessions/blackhole-session-batch-writer'
 import { S3SessionBatchFileStorage } from './sessions/s3-session-batch-writer'
+import { SessionBatchFileStorage } from './sessions/session-batch-file-storage'
 import { SessionBatchManager } from './sessions/session-batch-manager'
 import { SessionBatchRecorder } from './sessions/session-batch-recorder'
 import { SessionMetadataStore } from './sessions/session-metadata-store'
@@ -60,6 +61,7 @@ export class SessionRecordingIngester {
     private readonly kafkaParser: KafkaMessageParser
     private readonly teamFilter: TeamFilter
     private readonly libVersionMonitor?: LibVersionMonitor
+    private readonly fileStorage: SessionBatchFileStorage
 
     constructor(
         private config: PluginsServerConfig,
@@ -112,7 +114,7 @@ export class SessionRecordingIngester {
 
         const offsetManager = new KafkaOffsetManager(this.commitOffsets.bind(this), this.topic)
         const metadataStore = new SessionMetadataStore(producer)
-        const fileStorage = s3Client
+        this.fileStorage = s3Client
             ? new S3SessionBatchFileStorage(
                   s3Client,
                   this.config.SESSION_RECORDING_V2_S3_BUCKET!,
@@ -124,7 +126,7 @@ export class SessionRecordingIngester {
             maxBatchSizeBytes: this.config.SESSION_RECORDING_MAX_BATCH_SIZE_KB * 1024,
             maxBatchAgeMs: this.config.SESSION_RECORDING_MAX_BATCH_AGE_MS,
             offsetManager,
-            fileStorage,
+            fileStorage: this.fileStorage,
             metadataStore,
         })
 
@@ -241,6 +243,10 @@ export class SessionRecordingIngester {
             librdKafkaVersion: librdkafkaVersion,
             kafkaCapabilities: features,
         })
+
+        // Check that the storage backend is healthy before starting the consumer
+        // This is especially important in local dev with minio
+        await this.fileStorage.checkHealth()
 
         this.batchConsumer = await this.batchConsumerFactory.createBatchConsumer(
             this.consumerGroupId,

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
@@ -117,8 +117,9 @@ export class SessionRecordingIngester {
         this.fileStorage = s3Client
             ? new S3SessionBatchFileStorage(
                   s3Client,
-                  this.config.SESSION_RECORDING_V2_S3_BUCKET!,
-                  this.config.SESSION_RECORDING_V2_S3_PREFIX!
+                  this.config.SESSION_RECORDING_V2_S3_BUCKET,
+                  this.config.SESSION_RECORDING_V2_S3_PREFIX,
+                  this.config.SESSION_RECORDING_V2_S3_TIMEOUT_MS
               )
             : new BlackholeSessionBatchFileStorage()
 

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/blackhole-session-batch-writer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/blackhole-session-batch-writer.ts
@@ -21,4 +21,9 @@ export class BlackholeSessionBatchFileStorage implements SessionBatchFileStorage
         status.debug('🔁', 'blackhole_writer_creating_batch')
         return new BlackholeBatchFileWriter()
     }
+
+    public checkHealth(): Promise<boolean> {
+        status.debug('🔁', 'blackhole_writer_healthcheck')
+        return Promise.resolve(true)
+    }
 }

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/s3-session-batch-writer.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/s3-session-batch-writer.test.ts
@@ -213,4 +213,32 @@ describe('S3SessionBatchFileStorage', () => {
             await expect(finishPromise).rejects.toThrow('S3 upload timed out after 2000ms')
         })
     })
+
+    describe('checkHealth', () => {
+        it('should return true when bucket is accessible', async () => {
+            mockS3Client.send = jest.fn().mockResolvedValue({})
+
+            const result = await storage.checkHealth()
+
+            expect(result).toBe(true)
+            expect(mockS3Client.send).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    input: { Bucket: 'test-bucket' },
+                })
+            )
+        })
+
+        it('should return false when bucket is not accessible', async () => {
+            mockS3Client.send = jest.fn().mockRejectedValue(new Error('Bucket not found'))
+
+            const result = await storage.checkHealth()
+
+            expect(result).toBe(false)
+            expect(mockS3Client.send).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    input: { Bucket: 'test-bucket' },
+                })
+            )
+        })
+    })
 })

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/s3-session-batch-writer.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/s3-session-batch-writer.test.ts
@@ -35,7 +35,7 @@ describe('S3SessionBatchFileStorage', () => {
         })
         jest.mocked(Upload).mockImplementation(mockUpload)
 
-        storage = new S3SessionBatchFileStorage(mockS3Client, 'test-bucket', 'test-prefix')
+        storage = new S3SessionBatchFileStorage(mockS3Client, 'test-bucket', 'test-prefix', 5000)
     })
 
     afterEach(() => {

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/s3-session-batch-writer.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/s3-session-batch-writer.test.ts
@@ -6,6 +6,8 @@ import { S3SessionBatchFileStorage } from './s3-session-batch-writer'
 jest.mock('@aws-sdk/lib-storage')
 jest.mock('../../../../utils/status')
 
+jest.setTimeout(1000)
+
 describe('S3SessionBatchFileStorage', () => {
     let storage: S3SessionBatchFileStorage
     let mockUpload: jest.Mock
@@ -143,6 +145,72 @@ describe('S3SessionBatchFileStorage', () => {
             for (const key of keys) {
                 expect(key).toMatch(/^test-prefix\/\d+-[a-z0-9]+$/)
             }
+        })
+    })
+
+    describe('timeout', () => {
+        beforeEach(() => {
+            jest.useFakeTimers()
+        })
+
+        afterEach(() => {
+            jest.useRealTimers()
+        })
+
+        it('should timeout if upload takes too long', async () => {
+            // Mock a slow upload that never resolves
+            mockUpload = jest.fn().mockImplementation((_) => {
+                const done = async () => {
+                    return new Promise(() => {})
+                }
+
+                mockUploadDone = jest.fn().mockImplementation(done)
+                return { done: mockUploadDone }
+            })
+            jest.mocked(Upload).mockImplementation(mockUpload)
+
+            const writer = storage.newBatch()
+            const testData = Buffer.from('test data')
+            await writer.writeSession(testData)
+
+            const finishPromise = writer.finish()
+
+            // Advance timers past the default 5s timeout
+            jest.advanceTimersByTime(6000)
+
+            await expect(finishPromise).rejects.toThrow('S3 upload timed out after 5000ms')
+        })
+
+        it('should clear timeout on successful upload', async () => {
+            const writer = storage.newBatch()
+            const testData = Buffer.from('test data')
+            await writer.writeSession(testData)
+            await writer.finish()
+
+            // Advance timers - should not throw since timeout was cleared
+            jest.advanceTimersByTime(6000)
+        })
+
+        it('should respect custom timeout value', async () => {
+            // Mock a slow upload that never resolves
+            mockUpload.mockImplementationOnce(() => ({
+                done: () => new Promise(() => {}),
+            }))
+
+            const customTimeout = 2000
+            storage = new S3SessionBatchFileStorage(mockS3Client, 'test-bucket', 'test-prefix', customTimeout)
+            const writer = storage.newBatch()
+            const testData = Buffer.from('test data')
+            await writer.writeSession(testData)
+
+            const finishPromise = writer.finish()
+
+            // Advance timers just before timeout
+            jest.advanceTimersByTime(1999)
+
+            // Advance past timeout
+            jest.advanceTimersByTime(2)
+            await expect(finishPromise).rejects.toThrow('S3 upload timed out after 2000ms')
         })
     })
 })

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/s3-session-batch-writer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/s3-session-batch-writer.ts
@@ -19,7 +19,7 @@ class S3SessionBatchFileWriter implements SessionBatchFileWriter {
         private readonly s3: S3Client,
         private readonly bucket: string,
         private readonly prefix: string,
-        private readonly timeout: number = 5000
+        private readonly timeout: number
     ) {
         this.stream = new PassThrough()
         this.key = this.generateKey()

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/s3-session-batch-writer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/s3-session-batch-writer.ts
@@ -57,6 +57,10 @@ class S3SessionBatchFileWriter implements SessionBatchFileWriter {
             this.error = error
             this.rejectCallbacks.forEach((reject) => reject(error))
             this.rejectCallbacks = []
+            if (this.timeoutId) {
+                clearTimeout(this.timeoutId)
+                this.timeoutId = null
+            }
         }
     }
 

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/s3-session-batch-writer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/s3-session-batch-writer.ts
@@ -119,6 +119,7 @@ class S3SessionBatchFileWriter implements SessionBatchFileWriter {
                 await this.uploadPromise
                 if (this.timeoutId) {
                     clearTimeout(this.timeoutId)
+                    this.timeoutId = null
                 }
             } catch (error) {
                 status.error('🔄', 's3_session_batch_writer_upload_error', { key: this.key, error })

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/s3-session-batch-writer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/s3-session-batch-writer.ts
@@ -1,4 +1,4 @@
-import { CompleteMultipartUploadCommandOutput, S3Client } from '@aws-sdk/client-s3'
+import { CompleteMultipartUploadCommandOutput, HeadBucketCommand, S3Client } from '@aws-sdk/client-s3'
 import { Upload } from '@aws-sdk/lib-storage'
 import { randomBytes } from 'crypto'
 import { PassThrough } from 'stream'
@@ -139,5 +139,19 @@ export class S3SessionBatchFileStorage implements SessionBatchFileStorage {
 
     public newBatch(): SessionBatchFileWriter {
         return new S3SessionBatchFileWriter(this.s3, this.bucket, this.prefix, this.timeout)
+    }
+
+    public async checkHealth(): Promise<boolean> {
+        try {
+            const command = new HeadBucketCommand({ Bucket: this.bucket })
+            await this.s3.send(command)
+            return true
+        } catch (error) {
+            status.error('🔁', 's3_session_batch_writer_healthcheck_error', {
+                bucket: this.bucket,
+                error,
+            })
+            return false
+        }
     }
 }

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-file-format.integration.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-file-format.integration.test.ts
@@ -46,17 +46,20 @@ describe('session recording integration', () => {
     let mockStorage: jest.Mocked<SessionBatchFileStorage>
     let mockWriter: jest.Mocked<SessionBatchFileWriter>
     let mockMetadataStore: jest.Mocked<SessionMetadataStore>
-    let batchBuffer: Buffer
+    let batchBuffer: Uint8Array
     let currentOffset: number
 
     beforeEach(() => {
         currentOffset = 0
-        batchBuffer = Buffer.alloc(0)
+        batchBuffer = new Uint8Array()
 
         mockWriter = {
             writeSession: jest.fn().mockImplementation(async (buffer: Buffer) => {
                 const startOffset = currentOffset
-                batchBuffer = Buffer.concat([batchBuffer, buffer])
+                const newBuffer = new Uint8Array(batchBuffer.length + buffer.length)
+                newBuffer.set(batchBuffer)
+                newBuffer.set(new Uint8Array(buffer), batchBuffer.length)
+                batchBuffer = newBuffer
                 currentOffset += buffer.length
                 return Promise.resolve({
                     bytesWritten: buffer.length,
@@ -68,6 +71,7 @@ describe('session recording integration', () => {
 
         mockStorage = {
             newBatch: jest.fn().mockReturnValue(mockWriter),
+            checkHealth: jest.fn().mockResolvedValue(true),
         } as jest.Mocked<SessionBatchFileStorage>
 
         mockOffsetManager = {
@@ -128,7 +132,7 @@ describe('session recording integration', () => {
         const startOffset = parseInt(match[1])
         const endOffset = parseInt(match[2])
 
-        const sessionBuffer = batchBuffer.subarray(startOffset, endOffset + 1)
+        const sessionBuffer = Buffer.from(batchBuffer.subarray(startOffset, endOffset + 1))
         const decompressed = await snappy.uncompress(sessionBuffer)
         return decompressed
             .toString()

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-file-storage.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-file-storage.ts
@@ -47,4 +47,10 @@ export interface SessionBatchFileStorage {
      * ```
      */
     newBatch(): SessionBatchFileWriter
+
+    /**
+     * Checks the health of the storage backend
+     * Returns true if the storage backend is healthy, false otherwise
+     */
+    checkHealth(): Promise<boolean>
 }

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -344,6 +344,7 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
     SESSION_RECORDING_V2_S3_REGION: string
     SESSION_RECORDING_V2_S3_ACCESS_KEY_ID: string
     SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY: string
+    SESSION_RECORDING_V2_S3_TIMEOUT_MS: number
 
     // Destination Migration Diffing
     DESTINATION_MIGRATION_DIFFING_ENABLED: boolean


### PR DESCRIPTION
## Problem

Due to lack of timeouts, S3 uploads can hang indefinitely. We also don't check if the S3 bucket is accessible when starting the server.

## Changes

- Adds a timeout to the S3 batch file writer, set to 5s by default.
- Adds a healthcheck to the file storage classes, in S3 it sends a HEAD request to the S3 bucket

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added unit tests, tested locally.
