### PR TITLE
fix: Point to Web Analytics direct URL

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activation/activationLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activation/activationLogic.tsx
@@ -257,7 +257,7 @@ export const activationLogic = kea<activationLogicType>([
 
                 // Web Analytics
                 case ActivationTask.AddAuthorizedDomain:
-                    router.actions.push(urls.settings('environment-details', 'authorized-urls'))
+                    router.actions.push(urls.settings('environment', 'web-analytics-authorized-urls'))
                     break
                 case ActivationTask.SetUpWebVitals:
                     router.actions.push(urls.settings('environment-autocapture', 'web-vitals-autocapture'))


### PR DESCRIPTION
## Changes

We have some problems with environments URLs sometimes, so let's use a more generic link here

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Click click