### PR TITLE
style(data-warehouse): Make setup more intuitive

### DIFF
--- a/frontend/src/scenes/data-warehouse/external/forms/SchemaForm.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/SchemaForm.tsx
@@ -24,13 +24,12 @@ export default function SchemaForm(): JSX.Element {
                                         <LemonCheckbox
                                             checked={schema.should_sync}
                                             onChange={(checked) => {
+                                                if (schema.sync_type === null) {
+                                                    openSyncMethodModal(schema)
+                                                    return
+                                                }
                                                 toggleSchemaShouldSync(schema, checked)
                                             }}
-                                            disabledReason={
-                                                schema.sync_type === null
-                                                    ? 'Please set up a sync method first'
-                                                    : undefined
-                                            }
                                         />
                                     )
                                 },
@@ -39,7 +38,7 @@ export default function SchemaForm(): JSX.Element {
                                 title: 'Table',
                                 key: 'table',
                                 render: function RenderTable(_, schema) {
-                                    return schema.table
+                                    return <span className="font-mono">{schema.table}</span>
                                 },
                             },
                             {
@@ -65,8 +64,9 @@ export default function SchemaForm(): JSX.Element {
                                                     className="my-1"
                                                     type="primary"
                                                     onClick={() => openSyncMethodModal(schema)}
+                                                    size="small"
                                                 >
-                                                    Set up
+                                                    Configure
                                                 </LemonButton>
                                             </div>
                                         )
@@ -105,7 +105,11 @@ const SyncMethodModal = (): JSX.Element => {
 
     return (
         <LemonModal
-            title={`Sync method for ${currentSyncMethodModalSchema.table}`}
+            title={
+                <>
+                    Sync method for <span className="font-mono">{currentSyncMethodModalSchema.table}</span>
+                </>
+            }
             isOpen={syncMethodModalOpen}
             onClose={cancelSyncMethodModal}
         >

--- a/frontend/src/scenes/data-warehouse/external/forms/SourceForm.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/SourceForm.tsx
@@ -227,7 +227,7 @@ export function SourceFormComponent({
                 )}
             </Group>
             {showPrefix && (
-                <LemonField name="prefix" label="Table Prefix (optional)">
+                <LemonField name="prefix" label="Table prefix (optional)">
                     {({ value, onChange }) => (
                         <>
                             <LemonInput

--- a/frontend/src/scenes/data-warehouse/external/forms/SyncMethodForm.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/SyncMethodForm.tsx
@@ -107,18 +107,18 @@ export const SyncMethodForm = ({
                         disabledReason:
                             (incrementalSyncSupported.disabled && incrementalSyncSupported.disabledReason) || undefined,
                         label: (
-                            <div className="mb-6 font-normal">
-                                <div className="items-center flex leading-[normal] overflow-hidden mb-2.5">
-                                    <h2 className="mb-0 mr-2">Incremental replication</h2>
+                            <div className="mb-4 font-normal">
+                                <div className="items-center flex leading-[normal] overflow-hidden mb-1">
+                                    <h4 className="mb-0 mr-2 text-base font-semibold">Incremental replication</h4>
                                     {!incrementalSyncSupported.disabled && (
                                         <LemonTag type="success">Recommended</LemonTag>
                                     )}
                                 </div>
-                                <p>
+                                <p className="mb-1">
                                     When using incremental replication, we'll store the max value of the below field on
                                     each sync and only sync rows with greater or equal value on the next run.
                                 </p>
-                                <p>
+                                <p className="mb-1">
                                     You should pick a field that increments or updates each time the row is updated,
                                     such as a <code>updated_at</code> timestamp.
                                 </p>
@@ -147,10 +147,10 @@ export const SyncMethodForm = ({
                         value: 'full_refresh',
                         label: (
                             <div className="mb-6 font-normal">
-                                <div className="items-center flex leading-[normal] overflow-hidden mb-2.5">
-                                    <h2 className="mb-0 mr-2">Full table replication</h2>
+                                <div className="items-center flex leading-[normal] overflow-hidden mb-1">
+                                    <h4 className="mb-0 mr-2 text-base font-semibold">Full table replication</h4>
                                 </div>
-                                <p>
+                                <p className="m-0">
                                     We'll replicate the whole table on every sync. This can take longer to sync and
                                     increase your monthly billing.
                                 </p>

--- a/frontend/src/scenes/data-warehouse/new/NewSourceWizard.tsx
+++ b/frontend/src/scenes/data-warehouse/new/NewSourceWizard.tsx
@@ -187,7 +187,7 @@ function FirstStep(): JSX.Element {
                 ]}
             />
 
-            <h2 className="mt-4">Self Managed</h2>
+            <h2 className="mt-4">Self-managed</h2>
 
             <p>
                 Data will be queried directly from your data source that you manage.{' '}

--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -84,7 +84,7 @@ export const SOURCE_DETAILS: Record<ExternalDataSourceType, SourceConfig> = {
         fields: [
             {
                 name: 'connection_string',
-                label: 'Connection String (optional)',
+                label: 'Connection string (optional)',
                 type: 'text',
                 required: false,
                 placeholder: 'postgresql://user:password@localhost:5432/database',
@@ -1172,7 +1172,7 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
                     source_type: values.selectedConnector.name,
                 })
 
-                lemonToast.success('New Data Resource Created')
+                lemonToast.success('New data resource created')
 
                 activationLogic.findMounted()?.actions.markTaskAsCompleted(ActivationTask.ConnectSource)
 

--- a/frontend/src/scenes/data-warehouse/settings/source/Schemas.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/Schemas.tsx
@@ -307,7 +307,11 @@ const SyncMethodModal = ({ schema }: { schema: ExternalDataSourceSchema }): JSX.
 
     return (
         <LemonModal
-            title={`Sync method for ${currentSyncMethodModalSchema.name}`}
+            title={
+                <>
+                    Sync method for <span className="font-mono">{currentSyncMethodModalSchema.table}</span>
+                </>
+            }
             isOpen={syncMethodModalIsOpen}
             onClose={closeSyncMethodModal}
             footer={

--- a/frontend/src/scenes/data-warehouse/settings/source/Syncs.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/Syncs.tsx
@@ -77,7 +77,7 @@ export const Syncs = ({ id }: SyncsProps): JSX.Element => {
             footer={
                 <LemonButton
                     onClick={loadMoreJobs}
-                    type="secondary"
+                    type="tertiary"
                     fullWidth
                     center
                     disabledReason={!canLoadMoreJobs ? "There's nothing more to load" : undefined}

--- a/frontend/src/scenes/pipeline/sources/Sources.tsx
+++ b/frontend/src/scenes/pipeline/sources/Sources.tsx
@@ -37,7 +37,7 @@ export function Sources(): JSX.Element {
                     <DataWarehouseManagedSourcesTable />
                 </div>
                 <div>
-                    <h2>Self managed sources</h2>
+                    <h2>Self-managed sources</h2>
                     <p>Connect to your own data sources, making them queryable in PostHog</p>
                     <DataWarehouseSelfManagedSourcesTable />
                 </div>


### PR DESCRIPTION
## Problem

Was just setting up data warehouse locally to test it with multiple environments. Found one unexpected thing slowing me down in the flow: in schema selection (Postgres source) you can't click a table's checkbox before clicking "Set up" – but "Set up" is way on the right, and much less natural to click at first sight than the checkbox. The checkbox should serve as "Set up" too.

Also found some other rough edges in the UI, like clunky font styling and odd margins.

## Changes

The table checkbox is now always clickable for a smooth flow. Polished styling overall there.
