### PR TITLE
feat(cdp): more unit tests for new property-defs-rs API

### DIFF
--- a/rust/property-defs-rs/src/api/v1/errors.rs
+++ b/rust/property-defs-rs/src/api/v1/errors.rs
@@ -7,7 +7,7 @@ use axum::{
 use serde::Serialize;
 use thiserror::Error;
 
-#[derive(Clone, Error, Debug)]
+#[derive(Clone, Error, Debug, PartialEq, Eq)]
 pub enum ApiError {
     #[error("invalid request parameter: {0}")]
     InvalidRequestParam(String),

--- a/rust/property-defs-rs/tests/queries.rs
+++ b/rust/property-defs-rs/tests/queries.rs
@@ -1,21 +1,21 @@
-use property_defs_rs::api::v1::{query::Manager, routing::Params};
+use property_defs_rs::{
+    api::v1::errors::ApiError,
+    api::v1::{query::Manager, routing::Params},
+    types::PropertyParentType,
+};
 
 use chrono::{DateTime, Utc};
 use sqlx::{postgres::PgArguments, Arguments, Executor, PgPool, Row};
 use uuid::Uuid;
 
 #[sqlx::test(migrations = "./tests/test_migrations")]
-async fn test_property_definitions_queries(test_pool: PgPool) {
+async fn test_event_property_definitions_queries(test_pool: PgPool) {
     // seed the test DB
     bootstrap_seed_data(test_pool.clone()).await.unwrap();
 
     // plumbing that won't change during the test suite exec
     let qmgr = Manager::new(test_pool.clone()).await.unwrap();
     let project_id = 1;
-
-    //
-    // unit tests
-    //
 
     // PropertyParentType::Event scoped tests
     query_type_event_no_filters(&qmgr, project_id).await;
@@ -25,6 +25,40 @@ async fn test_property_definitions_queries(test_pool: PgPool) {
     query_type_event_is_numerical_filter(&qmgr, project_id).await;
     query_type_event_is_feature_flag_filter(&qmgr, project_id).await;
     query_type_event_is_not_feature_flag_filter(&qmgr, project_id).await;
+    query_event_with_group_type_index_fails().await;
+    query_non_event_type_with_event_names_param().await;
+}
+
+#[sqlx::test(migrations = "./tests/test_migrations")]
+async fn test_person_property_definitions_queries(test_pool: PgPool) {
+    // seed the test DB
+    bootstrap_seed_data(test_pool.clone()).await.unwrap();
+
+    // plumbing that won't change during the test suite exec
+    let qmgr = Manager::new(test_pool.clone()).await.unwrap();
+    let project_id = 1;
+
+    // PropertyParentType::Person scoped tests
+    query_type_person_no_filters(&qmgr, project_id).await;
+    query_type_person_simple_search_filter(&qmgr, project_id).await;
+}
+
+#[sqlx::test(migrations = "./tests/test_migrations")]
+async fn test_group_property_definitions_queries(test_pool: PgPool) {
+    // seed the test DB
+    bootstrap_seed_data(test_pool.clone()).await.unwrap();
+
+    // plumbing that won't change during the test suite exec
+    let qmgr = Manager::new(test_pool.clone()).await.unwrap();
+    let project_id = 1;
+
+    // PropertyParentType::Session scoped tests
+    query_type_group_index_zero(&qmgr, project_id).await;
+    query_type_group_index_one(&qmgr, project_id).await;
+    query_type_group_index_two(&qmgr, project_id).await;
+    query_type_group_index_three(&qmgr, project_id).await;
+    query_type_group_index_four(&qmgr, project_id).await;
+    query_with_illegal_group_type_index_fails().await;
 }
 
 // fetch all PropertyParentType::Event records without filtering
@@ -32,7 +66,6 @@ async fn query_type_event_no_filters(qmgr: &Manager, project_id: i32) {
     let mut qb = sqlx::QueryBuilder::new("");
     let params = Params::default();
 
-    // sanity check query with default arguments; TODO: exercise filter params, corner cases, etc.
     let count_events_unfiltered = qmgr.count_query(&mut qb, project_id, &params);
     let result = qmgr.pool.fetch_one(count_events_unfiltered).await;
     assert!(result.is_ok());
@@ -240,6 +273,55 @@ async fn query_type_event_is_not_feature_flag_filter(qmgr: &Manager, project_id:
     }
 }
 
+// only PropertyParentType::Event query can include an event_names filter parameter
+async fn query_non_event_type_with_event_names_param() {
+    let params_invalid_event_names = Params {
+        parent_type: PropertyParentType::Session,
+        event_names: vec!["$pageview".to_string()],
+        ..Default::default()
+    };
+    assert_eq!(
+        Err(ApiError::InvalidRequestParam(
+            "parameter 'event_names' is only allowed with property_type 'event'".to_string()
+        )),
+        params_invalid_event_names.valid()
+    );
+}
+
+async fn query_event_with_group_type_index_fails() {
+    let params_invalid_group_1 = Params {
+        parent_type: PropertyParentType::Event,
+        group_type_index: 2, // non PropertyParentType::Group must have index == -1
+        ..Default::default()
+    };
+    assert_eq!(
+        Err(ApiError::InvalidRequestParam(
+            "parameter 'group_type_index' is only allowed with property_type 'group'".to_string()
+        )),
+        params_invalid_group_1.valid()
+    );
+
+    let params_invalid_group_2 = Params {
+        parent_type: PropertyParentType::Person,
+        group_type_index: 3,
+        ..Default::default()
+    };
+    assert_eq!(
+        Err(ApiError::InvalidRequestParam(
+            "parameter 'group_type_index' is only allowed with property_type 'group'".to_string()
+        )),
+        params_invalid_group_2.valid()
+    );
+
+    // for non-group queries, group_type_index must be -1
+    let params_invalid_group_3 = Params {
+        parent_type: PropertyParentType::Event,
+        group_type_index: -1,
+        ..Default::default()
+    };
+    assert_eq!(Ok(()), params_invalid_group_3.valid());
+}
+
 // the property names of all PropertyParentType::Event rows
 fn expected_event_props_all() -> [&'static str; 9] {
     [
@@ -253,6 +335,267 @@ fn expected_event_props_all() -> [&'static str; 9] {
         "$dead_clicks_enabled_server_side",
         "$feature/foo-bar-baz",
     ]
+}
+
+// fetch all PropertyParentType::Person records without filtering
+async fn query_type_person_no_filters(qmgr: &Manager, project_id: i32) {
+    let mut qb = sqlx::QueryBuilder::new("");
+    let params = Params {
+        parent_type: PropertyParentType::Person,
+        ..Default::default()
+    };
+
+    let count_persons_unfiltered = qmgr.count_query(&mut qb, project_id, &params);
+    let result = qmgr.pool.fetch_one(count_persons_unfiltered).await;
+    assert!(result.is_ok());
+
+    let total_count: i64 = result.unwrap().get(0);
+    let expected_person_rows: i64 = 8;
+    assert_eq!(expected_person_rows, total_count);
+
+    let mut qb = sqlx::QueryBuilder::new("");
+    let fetch_persons_unfiltered = qmgr.property_definitions_query(&mut qb, project_id, &params);
+    let results = qmgr.pool.fetch_all(fetch_persons_unfiltered).await;
+    assert!(results.is_ok());
+    for row in results.unwrap() {
+        let prop_name: String = row.get("name");
+        assert!(expected_person_props_all().contains(&prop_name.as_str()))
+    }
+}
+
+// fetch all PropertyParentType::Person records where props or description contain search term
+async fn query_type_person_simple_search_filter(qmgr: &Manager, project_id: i32) {
+    let mut qb = sqlx::QueryBuilder::new("");
+    let params = Params {
+        parent_type: PropertyParentType::Person,
+        // this is a weird hack in the "search" params that filters
+        // "initial" events in the legacy prop defs query
+        search_terms: vec!["company".to_string()],
+        ..Default::default()
+    };
+
+    let count_persons_search_filter = qmgr.count_query(&mut qb, project_id, &params);
+    let result = qmgr.pool.fetch_one(count_persons_search_filter).await;
+    assert!(result.is_ok());
+
+    let total_count: i64 = result.unwrap().get(0);
+    let expected_person_rows: i64 = 1;
+    assert_eq!(expected_person_rows, total_count);
+
+    let mut qb = sqlx::QueryBuilder::new("");
+    let fetch_persons_search_filter = qmgr.property_definitions_query(&mut qb, project_id, &params);
+    let results = qmgr.pool.fetch_all(fetch_persons_search_filter).await;
+    assert!(results.is_ok());
+    for row in results.unwrap() {
+        let prop_name: String = row.get("name");
+        assert!(["company_type"].contains(&prop_name.as_str()))
+    }
+}
+
+// the property names of all PropertyParentType::Event rows
+fn expected_person_props_all() -> [&'static str; 8] {
+    [
+        "$feature_enrollment/artificial-hog",
+        "$survey_dismissed/abc123",
+        "company_type",
+        "$os_version",
+        "created_at",
+        "hire_date",
+        "$initial_geoip_postal_code",
+        "$initial_geoip_longitude",
+    ]
+}
+
+// fetch all PropertyParentType::Group records of group_type_index = 0
+async fn query_type_group_index_zero(qmgr: &Manager, project_id: i32) {
+    let mut qb = sqlx::QueryBuilder::new("");
+    let params = Params {
+        parent_type: PropertyParentType::Group,
+        group_type_index: 0,
+        ..Default::default()
+    };
+
+    let count_group_zero = qmgr.count_query(&mut qb, project_id, &params);
+    let result = qmgr.pool.fetch_one(count_group_zero).await;
+    assert!(result.is_ok());
+
+    let total_count: i64 = result.unwrap().get(0);
+    let expected_group_rows: i64 = 4;
+    assert_eq!(expected_group_rows, total_count);
+
+    let mut qb = sqlx::QueryBuilder::new("");
+    let fetch_group_zero = qmgr.property_definitions_query(&mut qb, project_id, &params);
+    let results = qmgr.pool.fetch_all(fetch_group_zero).await;
+    assert!(results.is_ok());
+
+    let expected_group_zero: [&str; 4] = [
+        "instance_name",
+        "total_registrations",
+        "signup_date",
+        "ingested_event",
+    ];
+    for row in results.unwrap() {
+        let prop_name: String = row.get("name");
+        assert!(expected_group_zero.contains(&prop_name.as_str()))
+    }
+}
+
+// fetch all PropertyParentType::Group records of group_type_index = 1
+async fn query_type_group_index_one(qmgr: &Manager, project_id: i32) {
+    let mut qb = sqlx::QueryBuilder::new("");
+    let params = Params {
+        parent_type: PropertyParentType::Group,
+        group_type_index: 1,
+        ..Default::default()
+    };
+
+    let count_group_one = qmgr.count_query(&mut qb, project_id, &params);
+    let result = qmgr.pool.fetch_one(count_group_one).await;
+    assert!(result.is_ok());
+
+    let total_count: i64 = result.unwrap().get(0);
+    let expected_group_rows: i64 = 4;
+    assert_eq!(expected_group_rows, total_count);
+
+    let mut qb = sqlx::QueryBuilder::new("");
+    let fetch_group_one = qmgr.property_definitions_query(&mut qb, project_id, &params);
+    let results = qmgr.pool.fetch_all(fetch_group_one).await;
+    assert!(results.is_ok());
+
+    let expected_group_one: [&str; 4] = [
+        "project_name",
+        "web_events_count_in_period",
+        "last_recorded_date",
+        "isIssueRiskSet",
+    ];
+    for row in results.unwrap() {
+        let prop_name: String = row.get("name");
+        assert!(expected_group_one.contains(&prop_name.as_str()))
+    }
+}
+
+// fetch all PropertyParentType::Group records of group_type_index = 2
+async fn query_type_group_index_two(qmgr: &Manager, project_id: i32) {
+    let mut qb = sqlx::QueryBuilder::new("");
+    let params = Params {
+        parent_type: PropertyParentType::Group,
+        group_type_index: 2,
+        ..Default::default()
+    };
+
+    let count_group_two = qmgr.count_query(&mut qb, project_id, &params);
+    let result = qmgr.pool.fetch_one(count_group_two).await;
+    assert!(result.is_ok());
+
+    let total_count: i64 = result.unwrap().get(0);
+    let expected_group_rows: i64 = 4;
+    assert_eq!(expected_group_rows, total_count);
+
+    let mut qb = sqlx::QueryBuilder::new("");
+    let fetch_group_two = qmgr.property_definitions_query(&mut qb, project_id, &params);
+    let results = qmgr.pool.fetch_all(fetch_group_two).await;
+    assert!(results.is_ok());
+
+    let expected_group_two: [&str; 4] = [
+        "timezone",
+        "group_types_total",
+        "group_createdAt",
+        "features.supplier360.products.1.enabled",
+    ];
+    for row in results.unwrap() {
+        let prop_name: String = row.get("name");
+        assert!(expected_group_two.contains(&prop_name.as_str()))
+    }
+}
+
+// fetch all PropertyParentType::Group records of group_type_index = 3
+async fn query_type_group_index_three(qmgr: &Manager, project_id: i32) {
+    let mut qb = sqlx::QueryBuilder::new("");
+    let params = Params {
+        parent_type: PropertyParentType::Group,
+        group_type_index: 3,
+        ..Default::default()
+    };
+
+    let count_group_three = qmgr.count_query(&mut qb, project_id, &params);
+    let result = qmgr.pool.fetch_one(count_group_three).await;
+    assert!(result.is_ok());
+
+    let total_count: i64 = result.unwrap().get(0);
+    let expected_group_rows: i64 = 4;
+    assert_eq!(expected_group_rows, total_count);
+
+    let mut qb = sqlx::QueryBuilder::new("");
+    let fetch_group_three = qmgr.property_definitions_query(&mut qb, project_id, &params);
+    let results = qmgr.pool.fetch_all(fetch_group_three).await;
+    assert!(results.is_ok());
+
+    let expected_group_three: [&str; 4] =
+        ["city", "min_age", "subscription_end", "is_project_demo"];
+    for row in results.unwrap() {
+        let prop_name: String = row.get("name");
+        assert!(expected_group_three.contains(&prop_name.as_str()))
+    }
+}
+
+// fetch all PropertyParentType::Group records of group_type_index = 4
+async fn query_type_group_index_four(qmgr: &Manager, project_id: i32) {
+    let mut qb = sqlx::QueryBuilder::new("");
+    let params = Params {
+        parent_type: PropertyParentType::Group,
+        group_type_index: 4,
+        ..Default::default()
+    };
+
+    let count_group_four = qmgr.count_query(&mut qb, project_id, &params);
+    let result = qmgr.pool.fetch_one(count_group_four).await;
+    assert!(result.is_ok());
+
+    let total_count: i64 = result.unwrap().get(0);
+    let expected_group_rows: i64 = 4;
+    assert_eq!(expected_group_rows, total_count);
+
+    let mut qb = sqlx::QueryBuilder::new("");
+    let fetch_group_four = qmgr.property_definitions_query(&mut qb, project_id, &params);
+    let results = qmgr.pool.fetch_all(fetch_group_four).await;
+    assert!(results.is_ok());
+
+    let expected_group_four: [&str; 4] = [
+        "integration_id",
+        "PlanValue",
+        "subscription_next_refresh",
+        "subscription_is_trial",
+    ];
+    for row in results.unwrap() {
+        let prop_name: String = row.get("name");
+        assert!(expected_group_four.contains(&prop_name.as_str()))
+    }
+}
+
+async fn query_with_illegal_group_type_index_fails() {
+    let params_invalid_group_1 = Params {
+        parent_type: PropertyParentType::Group,
+        group_type_index: 5,
+        ..Default::default()
+    };
+    assert_eq!(
+        Err(ApiError::InvalidRequestParam(
+            "property_type 'group' requires valid 'group_type_index' parameter".to_string()
+        )),
+        params_invalid_group_1.valid()
+    );
+
+    let params_invalid_group_2 = Params {
+        parent_type: PropertyParentType::Group,
+        group_type_index: -1,
+        ..Default::default()
+    };
+    assert_eq!(
+        Err(ApiError::InvalidRequestParam(
+            "property_type 'group' requires valid 'group_type_index' parameter".to_string()
+        )),
+        params_invalid_group_2.valid()
+    );
 }
 
 async fn bootstrap_seed_data(test_pool: PgPool) -> Result<(), sqlx::Error> {

--- a/rust/property-defs-rs/tests/queries.rs
+++ b/rust/property-defs-rs/tests/queries.rs
@@ -596,6 +596,13 @@ async fn query_with_illegal_group_type_index_fails() {
         )),
         params_invalid_group_2.valid()
     );
+
+    let params_valid_group_3 = Params {
+        parent_type: PropertyParentType::Group,
+        group_type_index: 0,
+        ..Default::default()
+    };
+    assert_eq!(Ok(()), params_valid_group_3.valid());
 }
 
 async fn bootstrap_seed_data(test_pool: PgPool) -> Result<(), sqlx::Error> {

--- a/rust/property-defs-rs/tests/queries.rs
+++ b/rust/property-defs-rs/tests/queries.rs
@@ -233,7 +233,7 @@ async fn query_type_event_is_feature_flag_filter(qmgr: &Manager, project_id: i32
     let results = qmgr.pool.fetch_all(fetch_events_ex_props_filter).await;
     assert!(results.is_ok());
 
-    // should only return PropertyParentType::Event records of property_type="Numeric"
+    // should only return feature flag properties
     for row in results.unwrap() {
         let prop_type: String = row.get("name");
         assert!(prop_type == "$feature/foo-bar-baz");


### PR DESCRIPTION
## Problem
The [Django monolith property defs API](https://github.com/PostHog/posthog/blob/bc90718a7ab103af29133106dfe006f4000d2693/posthog/taxonomy/property_definition_api.py#L99-L306) we're migrating to the `property-defs-rs` service has a lot of filtering parameters we want to exercise and document via unit tests.

## Changes
I'm adding a series of unit tests for the new REST API's backing query path. This will help us document the behavior of the query parameters and filter capabilities, and prevent regressions as we discover (or rethink!) out-of-parity behavior with the legacy API.

## Does this work well for both Cloud and self-hosted?
N/A

## How did you test this code?
Locally and in CI w/new tests 👍 
