### PR TITLE
chore(flags): decrease DecideRateThrottle bucket_capacity to 10

### DIFF
--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -196,7 +196,7 @@ class DecideRateThrottle(BaseThrottle):
     However, note that this throttle is per process, and not global.
     """
 
-    def __init__(self, replenish_rate: float = 5, bucket_capacity=100) -> None:
+    def __init__(self, replenish_rate: float = 5, bucket_capacity=10) -> None:
         self.limiter = Limiter(
             rate=replenish_rate,
             capacity=bucket_capacity,


### PR DESCRIPTION
## Problem

We currently throttle decide requests using an in-memory python Limiter (see https://github.com/PostHog/posthog/pull/15523/files for original PR). The Limiter tracks requests using team ID as a key.

The current limit allows for 5 req/s, with a bucket capacity (i.e. wait queue size) of 100. For our very high volume customers, this leads to high wait times when large bursts of decide requests are made by any of their SDKs. 

From python's limiter documentation:

```
rate (float): Number of tokens per second to add to the
            bucket. Over time, the number of tokens that can be
            consumed is limited by this rate. Each token represents
            some percentage of a finite resource that may be
            utilized by a consumer.
capacity (int): Maximum number of tokens that the bucket
            can hold. Once the bucket is full, additional tokens
            are discarded.

            The bucket capacity has a direct impact on burst duration.
            Let M be the maximum possible token request rate, r the
            token generation rate (tokens/sec), and b the bucket
            capacity.

            If r < M the maximum burst duration, in seconds, is:

                T = b / (M - r)

            Otherwise, if r >= M, it is not possible to exceed the
            replenishment rate, and therefore a consumer can burst
            at full speed indefinitely.

            The maximum number of tokens that any one burst may
            consume is:

                T * M
```

## Changes

By decreasing our bucket capacity from 100%->10%, we're effectively decreasing our tail latency by more immediately rate limiting customers instead. This effect is more desirable for both us and our end users as a 429 is a more clear signal and is much more debuggable.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Existing unit tests on DecideRateThrottle are sufficient