### PR TITLE
fix(data-warehouse): Fix merging using the partition predicate

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -146,6 +146,7 @@ class DeltaTableHelper:
                     source_alias="source",
                     target_alias="target",
                     predicate=" AND ".join(predicate_ops),
+                    streamed_exec=False,
                 )
                 .when_matched_update_all()
                 .when_not_matched_insert_all()

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -1780,4 +1780,5 @@ async def test_partition_folders_delta_merge_called_with_partition_predicate(
         "source_alias": "source",
         "target_alias": "target",
         "predicate": f"source.id = target.id AND source.{PARTITION_KEY} = target.{PARTITION_KEY}",
+        "streamed_exec": False,
     }


### PR DESCRIPTION
## Problem
- Merging into a deltalake table isn't taking advantage of partition filters

## Changes
- Set `streamed_exec` to `False` on the merge function - this is needed for the partition pruning to work. Have confirmed this with the merge stats that only the correct files are now scanned

