### PR TITLE
fix: toolbar love, darkmode element info was broken + small updates

### DIFF
--- a/frontend/src/toolbar/actions/ActionAttribute.tsx
+++ b/frontend/src/toolbar/actions/ActionAttribute.tsx
@@ -71,7 +71,7 @@ export function ActionAttribute({
                 />
             )}
             <div className="text-secondary text-xl">{icon}</div>
-            <div className="grow">{text}</div>
+            <div className="text-primary grow">{text}</div>
         </div>
     )
 }

--- a/frontend/src/toolbar/actions/ActionsListView.tsx
+++ b/frontend/src/toolbar/actions/ActionsListView.tsx
@@ -15,7 +15,7 @@ export function ActionsListView({ actions }: ActionsListViewProps): JSX.Element 
     const { selectAction } = useActions(actionsTabLogic)
 
     return (
-        <div className="flex flex-col h-full overflow-y-scoll space-y-px">
+        <div className="flex flex-col h-full overflow-y-scoll space-y-px mb-2">
             {actions.length ? (
                 actions.map((action, index) => (
                     <>

--- a/frontend/src/toolbar/elements/ElementInfo.tsx
+++ b/frontend/src/toolbar/elements/ElementInfo.tsx
@@ -31,9 +31,9 @@ export function ElementInfo(): JSX.Element | null {
             </div>
 
             {position ? (
-                <div className="p-3 border-l-[5px] border-l-danger bg-bg-3000">
+                <div className="p-3 border-l-[5px] border-l-danger bg-surface-primary text-primary">
                     <h1 className="section-title">Stats</h1>
-                    <p>
+                    <p className="">
                         <IconCalendar /> <u>{dateRange}</u>
                     </p>
                     <div className="grid grid-cols-[auto_1fr] gap-4">
@@ -51,13 +51,13 @@ export function ElementInfo(): JSX.Element | null {
                 </div>
             ) : null}
 
-            <div className="p-3 border-l-[5px] border-l-success bg-bg-3000">
+            <div className="p-3 border-l-[5px] border-l-success bg-surface-secondary">
                 {!automaticActionCreationEnabled && (
                     <>
                         <h1 className="section-title">Actions ({activeMeta.actions.length})</h1>
 
                         {activeMeta.actions.length === 0 ? (
-                            <p>No actions include this element</p>
+                            <p className="text-primary">No actions include this element</p>
                         ) : (
                             <ActionsListView actions={activeMeta.actions.map((a) => a.action)} />
                         )}

--- a/frontend/src/toolbar/elements/ElementInfoWindow.tsx
+++ b/frontend/src/toolbar/elements/ElementInfoWindow.tsx
@@ -81,7 +81,7 @@ export function ElementInfoWindow(): JSX.Element | null {
             {onClose ? (
                 <div
                     onClick={onClose}
-                    className="absolute origin-top-left bg-bg-3000 rounded-full w-6 h-6 z-[7] flex items-center justify-around text-center cursor-pointer"
+                    className="absolute origin-top-left bg-bg-3000 rounded-full w-6 h-6 z-[7] flex items-center justify-around text-center cursor-pointer text-primary"
                     // eslint-disable-next-line react/forbid-dom-props
                     style={{
                         pointerEvents: pointerEvents ? 'all' : 'none',
@@ -93,7 +93,7 @@ export function ElementInfoWindow(): JSX.Element | null {
                 </div>
             ) : null}
             <div
-                className="overflow-auto rounded-lg"
+                className="overflow-auto rounded-lg border border-secondary"
                 // eslint-disable-next-line react/forbid-dom-props
                 style={{ minHeight, maxHeight }}
             >

--- a/frontend/src/toolbar/flags/FlagsToolbarMenu.tsx
+++ b/frontend/src/toolbar/flags/FlagsToolbarMenu.tsx
@@ -125,7 +125,7 @@ export const FlagsToolbarMenu = (): JSX.Element => {
                                                 />
                                             ) : null}
 
-                                            <div className={clsx('py-1', hasVariants && 'pl-4')}>
+                                            <div className={clsx(hasVariants && 'py-1 pl-4')}>
                                                 {openPayloadEditors[feature_flag.key] ? (
                                                     <div className="flex gap-2 items-start mt-1">
                                                         <LemonTextArea


### PR DESCRIPTION
## Problem
Toolbar darkmode for Element info was broken, also found other issues along the way.

* Toolbar flags when had to no variants, spacing was added to the DOM.
* Toolbar close X was not showing correctly

<img width="349" alt="image" src="https://github.com/user-attachments/assets/69437854-d782-411d-a016-13bfab27d847" />
<img width="360" alt="image" src="https://github.com/user-attachments/assets/966213e2-34a8-4b95-aefe-04f97466501c" />

![2025-03-03 23 35 51](https://github.com/user-attachments/assets/a09b15c4-707b-4fed-912e-7e7e8af3436d)


## Changes
* Add text color to element info text elements
* Add new bg colors to Element Info
* Add color to X to close Element Info
* Add border around Element info for better contrast.
* Move padding into condition so toolbar feature flag didn't create empty space 
* Add spacing below Element action list
<img width="344" alt="image" src="https://github.com/user-attachments/assets/cbdb7920-0790-4037-8836-c52d1b9140da" />

## Does this work well for both Cloud and self-hosted?
Should

## How did you test this code?
Locally
