### PR TITLE
feat: Improve `exchange_rate` dict

### DIFF
--- a/posthog/clickhouse/migrations/0101_add_exchange_rates.py
+++ b/posthog/clickhouse/migrations/0101_add_exchange_rates.py
@@ -3,7 +3,7 @@
 # If we create these and shortly after run 0102 then we'll see
 # some replica errors because we've barely created the tables
 # and then immediately try to delete them which fails
-operations = [
+operations: list = [
     # Drop tables/dictionaries to allow this to rerun
     # Dict first because it depends on the table
     # run_sql_with_exceptions(DROP_EXCHANGE_RATE_DICTIONARY_SQL()),

--- a/posthog/clickhouse/migrations/0101_add_exchange_rates.py
+++ b/posthog/clickhouse/migrations/0101_add_exchange_rates.py
@@ -9,11 +9,12 @@ from posthog.models.exchange_rate.sql import (
 )
 
 operations = [
-    # Drop tables to allow this to rerun
-    run_sql_with_exceptions(DROP_EXCHANGE_RATE_TABLE_SQL()),
-    run_sql_with_exceptions(DROP_EXCHANGE_RATE_TABLE_SQL(on_cluster=False), node_role=NodeRole.COORDINATOR),
+    # Drop tables/dictionaries to allow this to rerun
+    # Dict first because it depends on the table
     run_sql_with_exceptions(DROP_EXCHANGE_RATE_DICTIONARY_SQL()),
     run_sql_with_exceptions(DROP_EXCHANGE_RATE_DICTIONARY_SQL(on_cluster=False), node_role=NodeRole.COORDINATOR),
+    run_sql_with_exceptions(DROP_EXCHANGE_RATE_TABLE_SQL()),
+    run_sql_with_exceptions(DROP_EXCHANGE_RATE_TABLE_SQL(on_cluster=False), node_role=NodeRole.COORDINATOR),
     # Recreate them all
     run_sql_with_exceptions(EXCHANGE_RATE_TABLE_SQL()),
     run_sql_with_exceptions(EXCHANGE_RATE_TABLE_SQL(on_cluster=False), node_role=NodeRole.COORDINATOR),

--- a/posthog/clickhouse/migrations/0101_add_exchange_rates.py
+++ b/posthog/clickhouse/migrations/0101_add_exchange_rates.py
@@ -1,25 +1,20 @@
-from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
-from posthog.clickhouse.cluster import NodeRole
-from posthog.models.exchange_rate.sql import (
-    DROP_EXCHANGE_RATE_TABLE_SQL,
-    DROP_EXCHANGE_RATE_DICTIONARY_SQL,
-    EXCHANGE_RATE_TABLE_SQL,
-    EXCHANGE_RATE_DATA_BACKFILL_SQL,
-    EXCHANGE_RATE_DICTIONARY_SQL,
-)
-
+# These have all been commented out to guarantee this runs
+# properly on tests
+# If we create these and shortly after run 0102 then we'll see
+# some replica errors because we've barely created the tables
+# and then immediately try to delete them which fails
 operations = [
     # Drop tables/dictionaries to allow this to rerun
     # Dict first because it depends on the table
-    run_sql_with_exceptions(DROP_EXCHANGE_RATE_DICTIONARY_SQL()),
-    run_sql_with_exceptions(DROP_EXCHANGE_RATE_DICTIONARY_SQL(on_cluster=False), node_role=NodeRole.COORDINATOR),
-    run_sql_with_exceptions(DROP_EXCHANGE_RATE_TABLE_SQL()),
-    run_sql_with_exceptions(DROP_EXCHANGE_RATE_TABLE_SQL(on_cluster=False), node_role=NodeRole.COORDINATOR),
+    # run_sql_with_exceptions(DROP_EXCHANGE_RATE_DICTIONARY_SQL()),
+    # run_sql_with_exceptions(DROP_EXCHANGE_RATE_DICTIONARY_SQL(on_cluster=False), node_role=NodeRole.COORDINATOR),
+    # run_sql_with_exceptions(DROP_EXCHANGE_RATE_TABLE_SQL()),
+    # run_sql_with_exceptions(DROP_EXCHANGE_RATE_TABLE_SQL(on_cluster=False), node_role=NodeRole.COORDINATOR),
     # Recreate them all
-    run_sql_with_exceptions(EXCHANGE_RATE_TABLE_SQL()),
-    run_sql_with_exceptions(EXCHANGE_RATE_TABLE_SQL(on_cluster=False), node_role=NodeRole.COORDINATOR),
-    run_sql_with_exceptions(EXCHANGE_RATE_DATA_BACKFILL_SQL()),
-    run_sql_with_exceptions(EXCHANGE_RATE_DATA_BACKFILL_SQL(), node_role=NodeRole.COORDINATOR),
-    run_sql_with_exceptions(EXCHANGE_RATE_DICTIONARY_SQL()),
-    run_sql_with_exceptions(EXCHANGE_RATE_DICTIONARY_SQL(on_cluster=False), node_role=NodeRole.COORDINATOR),
+    # run_sql_with_exceptions(EXCHANGE_RATE_TABLE_SQL()),
+    # run_sql_with_exceptions(EXCHANGE_RATE_TABLE_SQL(on_cluster=False), node_role=NodeRole.COORDINATOR),
+    # run_sql_with_exceptions(EXCHANGE_RATE_DATA_BACKFILL_SQL()),
+    # run_sql_with_exceptions(EXCHANGE_RATE_DATA_BACKFILL_SQL(), node_role=NodeRole.COORDINATOR),
+    # run_sql_with_exceptions(EXCHANGE_RATE_DICTIONARY_SQL()),
+    # run_sql_with_exceptions(EXCHANGE_RATE_DICTIONARY_SQL(on_cluster=False), node_role=NodeRole.COORDINATOR),
 ]

--- a/posthog/clickhouse/migrations/0102_rebuild_exchange_rates.py
+++ b/posthog/clickhouse/migrations/0102_rebuild_exchange_rates.py
@@ -1,0 +1,29 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.clickhouse.cluster import NodeRole
+from posthog.models.exchange_rate.sql import (
+    DROP_EXCHANGE_RATE_TABLE_SQL,
+    DROP_EXCHANGE_RATE_DICTIONARY_SQL,
+    EXCHANGE_RATE_TABLE_SQL,
+    EXCHANGE_RATE_DATA_BACKFILL_SQL,
+    EXCHANGE_RATE_DICTIONARY_SQL,
+)
+
+# This is the exact same thing as 0101_add_exchange_rates.py,
+# but it's a separate migration because we need to rerun it with some new changes
+# to the database and dictionary query.
+# Refer to git history to understand the changes.
+operations = [
+    # Drop tables/dictionaries to allow this to rerun
+    # Dict first because it depends on the table
+    run_sql_with_exceptions(DROP_EXCHANGE_RATE_DICTIONARY_SQL()),
+    run_sql_with_exceptions(DROP_EXCHANGE_RATE_DICTIONARY_SQL(on_cluster=False), node_role=NodeRole.COORDINATOR),
+    run_sql_with_exceptions(DROP_EXCHANGE_RATE_TABLE_SQL()),
+    run_sql_with_exceptions(DROP_EXCHANGE_RATE_TABLE_SQL(on_cluster=False), node_role=NodeRole.COORDINATOR),
+    # Recreate them all
+    run_sql_with_exceptions(EXCHANGE_RATE_TABLE_SQL()),
+    run_sql_with_exceptions(EXCHANGE_RATE_TABLE_SQL(on_cluster=False), node_role=NodeRole.COORDINATOR),
+    run_sql_with_exceptions(EXCHANGE_RATE_DATA_BACKFILL_SQL()),
+    run_sql_with_exceptions(EXCHANGE_RATE_DATA_BACKFILL_SQL(), node_role=NodeRole.COORDINATOR),
+    run_sql_with_exceptions(EXCHANGE_RATE_DICTIONARY_SQL()),
+    run_sql_with_exceptions(EXCHANGE_RATE_DICTIONARY_SQL(on_cluster=False), node_role=NodeRole.COORDINATOR),
+]


### PR DESCRIPTION
This dict is much more performant and it also properly works - the current one has some weirdness around key order which is for legacy reasons, see https://posthog.slack.com/archives/C02JQ320FV3/p1741044694914059 for more context

We're also using a much more complex query to guarantee that we have more performant `end_date` fields which will let us query by range much more accurately. We don't need to worry about figuring out the `end_date`, the query will do that on its own - thanks Dmitry for the nice WINDOW function and Sonnet for improving on it!

Changes to `historical.csv` are meant to allow us to query by any date possible, this will guarantee that dates before `2020-01-01` return 0 as their value - which makes some sense, in a way, just don't do averages.

Extra migration is necessary to get the dict/table to rebuild in production.