### PR TITLE
fix: last seen on date range not inclusive

### DIFF
--- a/frontend/src/scenes/error-tracking/errorTrackingIssueSceneLogic.ts
+++ b/frontend/src/scenes/error-tracking/errorTrackingIssueSceneLogic.ts
@@ -63,14 +63,16 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
                     return { ...values.issue, ...response }
                 },
                 loadClickHouseIssue: async (firstSeen: string) => {
-                    const dateRange = {
-                        date_from: firstSeen,
-                        date_to: values.issue?.last_seen || dayjs().toISOString(),
-                    }
+                    const hasLastSeen = values.issue && values.issue.last_seen
+                    const lastSeen = hasLastSeen ? dayjs(values.issue?.last_seen).add(1, 'minute') : dayjs()
+
                     const response = await api.query(
                         errorTrackingIssueQuery({
                             issueId: props.id,
-                            dateRange: dateRange,
+                            dateRange: {
+                                date_from: firstSeen,
+                                date_to: lastSeen.toISOString(),
+                            },
                             customVolume: values.customSparklineConfig,
                         }),
                         {},

--- a/frontend/src/scenes/error-tracking/errorTrackingIssueSceneLogic.ts
+++ b/frontend/src/scenes/error-tracking/errorTrackingIssueSceneLogic.ts
@@ -64,13 +64,13 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
                 },
                 loadClickHouseIssue: async (firstSeen: string) => {
                     const hasLastSeen = values.issue && values.issue.last_seen
-                    const lastSeen = hasLastSeen ? dayjs(values.issue?.last_seen).add(1, 'minute') : dayjs()
+                    const lastSeen = hasLastSeen ? dayjs(values.issue?.last_seen).endOf('minute') : dayjs()
 
                     const response = await api.query(
                         errorTrackingIssueQuery({
                             issueId: props.id,
                             dateRange: {
-                                date_from: firstSeen,
+                                date_from: dayjs(firstSeen).startOf('minute').toISOString(),
                                 date_to: lastSeen.toISOString(),
                             },
                             customVolume: values.customSparklineConfig,


### PR DESCRIPTION
## Problem

Originally reported in https://posthog.slack.com/archives/C07AA937K9A/p1741082854232959

We were being too clever and limiting the time range lookup for the latest event. In cases where the event only happens once the first and last timestamp will be equal. The date range calculation is not inclusive (e.g. uses < rather than <=) and hence the only event (from which we pull the stacktrace) is not returned.

This is only a problem when navigating from the list page where we know the last_seen time. In the case where you refresh the issue page we don't know the last_seen and just use the current time.

## Changes

Clamp lookup to start / end of the minute
