### PR TITLE
fix(data-warehouse): Fix schema sync type react error

### DIFF
--- a/frontend/src/scenes/data-warehouse/settings/source/Schemas.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/Schemas.tsx
@@ -309,7 +309,7 @@ const SyncMethodModal = ({ schema }: { schema: ExternalDataSourceSchema }): JSX.
         <LemonModal
             title={
                 <>
-                    Sync method for <span className="font-mono">{currentSyncMethodModalSchema.table}</span>
+                    Sync method for <span className="font-mono">{currentSyncMethodModalSchema.table?.name}</span>
                 </>
             }
             isOpen={syncMethodModalIsOpen}

--- a/frontend/src/scenes/data-warehouse/settings/source/Schemas.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/Schemas.tsx
@@ -309,7 +309,7 @@ const SyncMethodModal = ({ schema }: { schema: ExternalDataSourceSchema }): JSX.
         <LemonModal
             title={
                 <>
-                    Sync method for <span className="font-mono">{currentSyncMethodModalSchema.table?.name}</span>
+                    Sync method for <span className="font-mono">{currentSyncMethodModalSchema.name}</span>
                 </>
             }
             isOpen={syncMethodModalIsOpen}


### PR DESCRIPTION
## Problem
- Opening the sync type modal on warehouse schemas throws a react error if the table hasn't been synced before
- Introduced by https://github.com/PostHog/posthog/pull/29431

https://github.com/user-attachments/assets/981575c8-8a8a-444a-8125-70ef851f37e9


## Changes
- Make sure we're not trying to render an object into the DOM