### PR TITLE
chore: turn tracking started status of celery query task

### DIFF
--- a/posthog/caching/warming.py
+++ b/posthog/caching/warming.py
@@ -191,7 +191,7 @@ def schedule_warming_for_teams_task():
     ignore_result=True,
     expires=60 * 60,
     autoretry_for=(CHQueryErrorTooManySimultaneousQueries,),
-    retry_backoff=1,
+    retry_backoff=2,
     retry_backoff_max=3,
     max_retries=3,
 )

--- a/posthog/tasks/exporter.py
+++ b/posthog/tasks/exporter.py
@@ -49,7 +49,7 @@ EXPORT_TIMER = Histogram(
     time_limit=HOGQL_INCREASED_MAX_EXECUTION_TIME + 120,
     queue=CeleryQueue.EXPORTS.value,
     autoretry_for=(CHQueryErrorTooManySimultaneousQueries,),
-    retry_backoff=1,
+    retry_backoff=2,
     retry_backoff_max=3,
     max_retries=3,
 )

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -52,6 +52,7 @@ def redis_heartbeat() -> None:
     max_retries=10,
     expires=60 * 10,  # Do not run queries that got stuck for more than this
     reject_on_worker_lost=True,
+    track_started=True,
 )
 @limit_concurrency(150, limit_name="global")  # Do not go above what CH can handle (max_concurrent_queries)
 @limit_concurrency(


### PR DESCRIPTION
## Problem

Not great visibility of celery tasks

## Changes

Update status for started tasks (by default off).
Give cache queries a bit more cool down period.

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Tested.