### PR TITLE
feat: Don't force upgrade persons if team setting is opted out

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
@@ -1,7 +1,7 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 
 import { eventDroppedCounter } from '../../../main/ingestion-queues/metrics'
-import { PipelineEvent } from '../../../types'
+import { PipelineEvent, Team } from '../../../types'
 import { sanitizeString } from '../../../utils/db/utils'
 import { UUID } from '../../../utils/utils'
 import { captureIngestionWarning } from '../utils'
@@ -11,7 +11,7 @@ import { EventPipelineRunner } from './runner'
 export async function populateTeamDataStep(
     runner: EventPipelineRunner,
     event: PipelineEvent
-): Promise<PluginEvent | null> {
+): Promise<{ eventWithTeam: PluginEvent; team: Team } | null> {
     /**
      * Implements team_id resolution and applies the team's ingestion settings (dropping event.ip if requested).
      * Resolution can fail if PG is unavailable, leading to the consumer taking lag until retries succeed.
@@ -85,10 +85,10 @@ export async function populateTeamDataStep(
         }
     }
 
-    event = {
+    const eventWithTeam: PluginEvent = {
         ...event,
         team_id: team.id,
     }
 
-    return event as PluginEvent
+    return { eventWithTeam, team }
 }

--- a/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
@@ -1,7 +1,7 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 import { DateTime } from 'luxon'
 
-import { Person } from '~/src/types'
+import { Person, Team } from '~/src/types'
 
 import { PersonState } from '../person-state'
 import { EventPipelineRunner } from './runner'
@@ -9,12 +9,13 @@ import { EventPipelineRunner } from './runner'
 export async function processPersonsStep(
     runner: EventPipelineRunner,
     event: PluginEvent,
+    team: Team,
     timestamp: DateTime,
     processPerson: boolean
 ): Promise<[PluginEvent, Person, Promise<void>]> {
     const [person, kafkaAck] = await new PersonState(
         event,
-        event.team_id,
+        team,
         String(event.distinct_id),
         timestamp,
         processPerson,

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -124,7 +124,7 @@ export class EventPipelineRunner {
             let result: EventPipelineResult
             const { eventWithTeam, team } =
                 (await this.runStep(populateTeamDataStep, [this, event], event.team_id || -1)) ?? {}
-            if (eventWithTeam != null) {
+            if (eventWithTeam != null && team != null) {
                 result = await this.runEventPipelineSteps(eventWithTeam, team)
             } else {
                 result = this.registerLastStep('populateTeamDataStep', [event])

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -154,7 +154,10 @@ export class PersonState {
                 // Ensure person properties don't propagate elsewhere, such as onto the event itself.
                 person.properties = {}
 
-                if (this.timestamp > person.created_at.plus({ minutes: 1 })) {
+                // If the team has opted out then we never force the upgrade.
+                const teamHasNotOptedOut = !this.team.person_processing_opt_out
+
+                if (teamHasNotOptedOut && this.timestamp > person.created_at.plus({ minutes: 1 })) {
                     // See documentation on the field.
                     //
                     // Note that we account for timestamp vs person creation time (with a little

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -5,7 +5,7 @@ import { Counter } from 'prom-client'
 
 import { ONE_HOUR } from '../../config/constants'
 import { TopicMessage } from '../../kafka/producer'
-import { InternalPerson, Person, PropertyUpdateOperation } from '../../types'
+import { InternalPerson, Person, PropertyUpdateOperation, Team } from '../../types'
 import { DB } from '../../utils/db/db'
 import { PostgresUse, TransactionClient } from '../../utils/db/postgres'
 import { eventToPersonProperties, initialEventToPersonProperties, timeoutGuard } from '../../utils/db/utils'
@@ -105,7 +105,7 @@ export class PersonState {
 
     constructor(
         private event: PluginEvent,
-        private teamId: number,
+        private team: Team,
         private distinctId: string,
         private timestamp: DateTime,
         private processPerson: boolean, // $process_person_profile flag from the event
@@ -120,7 +120,7 @@ export class PersonState {
 
     async update(): Promise<[Person, Promise<void>]> {
         if (!this.processPerson) {
-            let existingPerson = await this.db.fetchPerson(this.teamId, this.distinctId, { useReadReplica: true })
+            let existingPerson = await this.db.fetchPerson(this.team.id, this.distinctId, { useReadReplica: true })
 
             if (!existingPerson) {
                 // See the comment in `mergeDistinctIds`. We are inserting a row into `posthog_personlessdistinctid`
@@ -128,9 +128,9 @@ export class PersonState {
                 // so that later, during a merge, we can decide whether we need to write out an override
                 // or not.
 
-                const personlessDistinctIdCacheKey = `${this.teamId}|${this.distinctId}`
+                const personlessDistinctIdCacheKey = `${this.team.id}|${this.distinctId}`
                 if (!PERSONLESS_DISTINCT_ID_INSERTED_CACHE.get(personlessDistinctIdCacheKey)) {
-                    const personIsMerged = await this.db.addPersonlessDistinctId(this.teamId, this.distinctId)
+                    const personIsMerged = await this.db.addPersonlessDistinctId(this.team.id, this.distinctId)
 
                     // We know the row is in PG now, and so future events for this Distinct ID can
                     // skip the PG I/O.
@@ -141,7 +141,7 @@ export class PersonState {
                         // has been updated by a merge (either since we called `fetchPerson` above, plus
                         // replication lag). We need to check `fetchPerson` again (this time using the leader)
                         // so that we properly associate this event with the Person we got merged into.
-                        existingPerson = await this.db.fetchPerson(this.teamId, this.distinctId, {
+                        existingPerson = await this.db.fetchPerson(this.team.id, this.distinctId, {
                             useReadReplica: false,
                         })
                     }
@@ -174,9 +174,9 @@ export class PersonState {
             const createdAt = DateTime.utc(1970, 1, 1, 0, 0, 5)
 
             const fakePerson: Person = {
-                team_id: this.teamId,
+                team_id: this.team.id,
                 properties: {},
-                uuid: uuidFromDistinctId(this.teamId, this.distinctId),
+                uuid: uuidFromDistinctId(this.team.id, this.distinctId),
                 created_at: createdAt,
             }
             return [fakePerson, Promise.resolve()]
@@ -220,7 +220,7 @@ export class PersonState {
      * @returns [Person, boolean that indicates if properties were already handled or not]
      */
     private async createOrGetPerson(): Promise<[InternalPerson, boolean]> {
-        let person = await this.db.fetchPerson(this.teamId, this.distinctId)
+        let person = await this.db.fetchPerson(this.team.id, this.distinctId)
         if (person) {
             return [person, false]
         }
@@ -236,7 +236,7 @@ export class PersonState {
             this.timestamp,
             properties || {},
             propertiesOnce || {},
-            this.teamId,
+            this.team.id,
             null,
             // :NOTE: This should never be set in this branch, but adding this for logical consistency
             this.updateIsIdentified,
@@ -414,20 +414,20 @@ export class PersonState {
                 return await this.merge(
                     String(this.eventProperties['alias']),
                     this.distinctId,
-                    this.teamId,
+                    this.team.id,
                     this.timestamp
                 )
             } else if (this.event.event === '$identify' && '$anon_distinct_id' in this.eventProperties) {
                 return await this.merge(
                     String(this.eventProperties['$anon_distinct_id']),
                     this.distinctId,
-                    this.teamId,
+                    this.team.id,
                     this.timestamp
                 )
             }
         } catch (e) {
             captureException(e, {
-                tags: { team_id: this.teamId, pipeline_step: 'processPersonsStep' },
+                tags: { team_id: this.team.id, pipeline_step: 'processPersonsStep' },
                 extra: {
                     location: 'handleIdentifyOrAlias',
                     distinctId: this.distinctId,
@@ -539,7 +539,7 @@ export class PersonState {
                 async (tx) => {
                     // See comment above about `distinctIdVersion`
                     const insertedDistinctId = await this.db.addPersonlessDistinctIdForMerge(
-                        this.teamId,
+                        this.team.id,
                         distinctIdToAdd,
                         tx
                     )
@@ -575,14 +575,14 @@ export class PersonState {
                 async (tx) => {
                     // See comment above about `distinctIdVersion`
                     const insertedDistinctId1 = await this.db.addPersonlessDistinctIdForMerge(
-                        this.teamId,
+                        this.team.id,
                         distinctId1,
                         tx
                     )
 
                     // See comment above about `distinctIdVersion`
                     const insertedDistinctId2 = await this.db.addPersonlessDistinctIdForMerge(
-                        this.teamId,
+                        this.team.id,
                         distinctId2,
                         tx
                     )
@@ -656,7 +656,7 @@ export class PersonState {
         if (!mergeAllowed) {
             await captureIngestionWarning(
                 this.db.kafkaProducer,
-                this.teamId,
+                this.team.id,
                 'cannot_merge_already_identified',
                 {
                     sourcePersonDistinctId: otherPersonDistinctId,

--- a/plugin-server/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
@@ -79,6 +79,10 @@ exports[`EventPipelineRunner runEventPipeline() runs steps starting from populat
         "timestamp": "2020-02-23T02:15:00.000Z",
         "uuid": "uuid1",
       },
+      {
+        "id": 2,
+        "person_processing_opt_out": false,
+      },
       "2020-02-23T02:15:00.000Z",
       true,
     ],

--- a/plugin-server/tests/worker/ingestion/event-pipeline/populateTeamDataStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/populateTeamDataStep.test.ts
@@ -88,7 +88,7 @@ describe('populateTeamDataStep()', () => {
     it('event with a valid token gets assigned a team_id keeps its ip', async () => {
         const response = await populateTeamDataStep(runner, { ...pipelineEvent, token: teamTwoToken })
 
-        expect(response).toEqual({ ...pipelineEvent, token: teamTwoToken, team_id: 2, ip: '127.0.0.1' })
+        expect(response?.eventWithTeam).toEqual({ ...pipelineEvent, token: teamTwoToken, team_id: 2, ip: '127.0.0.1' })
         expect(await getMetricValues('ingestion_event_dropped_total')).toEqual([])
     })
 
@@ -98,26 +98,27 @@ describe('populateTeamDataStep()', () => {
         jest.mocked(runner.hub.teamManager.getTeamByToken).mockReturnValue({ ...teamTwo, anonymize_ips: true })
         const response = await populateTeamDataStep(runner, { ...pipelineEvent, token: teamTwoToken })
 
-        expect(response).toEqual({ ...pipelineEvent, token: teamTwoToken, team_id: 2, ip: '127.0.0.1' })
+        expect(response?.eventWithTeam).toEqual({ ...pipelineEvent, token: teamTwoToken, team_id: 2, ip: '127.0.0.1' })
         expect(await getMetricValues('ingestion_event_dropped_total')).toEqual([])
     })
 
     it('event with a team_id value is returned unchanged', async () => {
         const input = { ...pipelineEvent, team_id: 2 }
         const response = await populateTeamDataStep(runner, input)
-        expect(response).toEqual(input)
+        expect(response?.eventWithTeam).toEqual(input)
     })
 
     it('event with a team_id whose team is opted-out from person processing', async () => {
         const input = { ...pipelineEvent, team_id: 3 }
         const response = await populateTeamDataStep(runner, input)
-        expect(response?.properties?.$process_person_profile).toBe(false)
+        expect(response?.team.person_processing_opt_out).toBe(true)
+        expect(response?.eventWithTeam.properties?.$process_person_profile).toBe(false)
     })
 
     it('event that is in the skip list', async () => {
         const input = { ...pipelineEvent, team_id: 2, distinct_id: 'distinct_id_to_drop' }
         const response = await populateTeamDataStep(runner, input)
-        expect(response?.properties?.$process_person_profile).toBe(false)
+        expect(response?.eventWithTeam.properties?.$process_person_profile).toBe(false)
     })
 
     it('PG errors are propagated up to trigger retries', async () => {

--- a/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
@@ -10,6 +10,7 @@ import {
     PreIngestionEvent,
     ProjectId,
     RawKafkaEvent,
+    Team,
 } from '../../../../src/types'
 import { createEventsToDropByToken } from '../../../../src/utils/db/hub'
 import { cookielessServerHashStep } from '../../../../src/worker/ingestion/event-pipeline/cookielessServerHashStep'
@@ -49,10 +50,10 @@ class TestEventPipelineRunner extends EventPipelineRunner {
     }
 }
 
-const team: Team = {
+const team = {
     id: 2,
     person_processing_opt_out: false,
-}
+} as Team
 
 const pipelineEvent: PipelineEvent = {
     distinct_id: 'my_id',

--- a/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
@@ -142,7 +142,10 @@ describe('EventPipelineRunner', () => {
 
         runner = new TestEventPipelineRunner(hub, pluginEvent)
 
-        jest.mocked(populateTeamDataStep).mockResolvedValue(pluginEvent)
+        jest.mocked(populateTeamDataStep).mockResolvedValue({
+            eventWithTeam: pluginEvent,
+            team: { id: 2, person_processing_opt_out: false } as any,
+        })
         jest.mocked(cookielessServerHashStep).mockResolvedValue([pluginEvent])
         jest.mocked(pluginsProcessEventStep).mockResolvedValue(pluginEvent)
 
@@ -329,7 +332,10 @@ describe('EventPipelineRunner', () => {
                     team_id: 9,
                 }
 
-                jest.mocked(populateTeamDataStep).mockResolvedValue(event)
+                jest.mocked(populateTeamDataStep).mockResolvedValue({
+                    eventWithTeam: event,
+                    team: { id: 9, person_processing_opt_out: true } as any,
+                })
 
                 await runner.runEventPipeline(event)
                 expect(runner.steps).toEqual(['populateTeamDataStep'])
@@ -454,7 +460,10 @@ describe('EventPipelineRunner', () => {
                     event: eventName,
                     team_id: 9,
                 }
-                jest.mocked(populateTeamDataStep).mockResolvedValue(event)
+                jest.mocked(populateTeamDataStep).mockResolvedValue({
+                    eventWithTeam: event,
+                    team: { id: 9, person_processing_opt_out: true } as any,
+                })
 
                 await runner.runEventPipeline(event)
                 expect(runner.steps).toEqual(['populateTeamDataStep'])

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -1,7 +1,9 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 import { DateTime } from 'luxon'
 
-import { Database, Hub, InternalPerson } from '../../../src/types'
+import { fetchTeam } from '~/src/worker/ingestion/team-manager'
+
+import { Database, Hub, InternalPerson, Team } from '../../../src/types'
 import { DependencyUnavailableError } from '../../../src/utils/db/error'
 import { closeHub, createHub } from '../../../src/utils/db/hub'
 import { PostgresUse } from '../../../src/utils/db/postgres'
@@ -22,6 +24,7 @@ describe('PersonState.update()', () => {
     let hub: Hub
 
     let teamId: number
+    let team: Team
     let organizationId: string
 
     // Common Distinct IDs (and their deterministic UUIDs) used in tests below.
@@ -43,6 +46,7 @@ describe('PersonState.update()', () => {
 
     beforeEach(async () => {
         teamId = await createTeam(hub.db.postgres, organizationId)
+        team = await fetchTeam(hub.db.postgres, teamId)
 
         newUserUuid = uuidFromDistinctId(teamId, newUserDistinctId)
         oldUserUuid = uuidFromDistinctId(teamId, oldUserDistinctId)
@@ -79,7 +83,7 @@ describe('PersonState.update()', () => {
 
         return new PersonState(
             fullEvent as any,
-            teamId,
+            team,
             event.distinct_id!,
             timestampParam,
             processPerson,

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -46,7 +46,7 @@ describe('PersonState.update()', () => {
 
     beforeEach(async () => {
         teamId = await createTeam(hub.db.postgres, organizationId)
-        team = await fetchTeam(hub.db.postgres, teamId)
+        team = (await fetchTeam(hub.db.postgres, teamId))!
 
         newUserUuid = uuidFromDistinctId(teamId, newUserDistinctId)
         oldUserUuid = uuidFromDistinctId(teamId, oldUserDistinctId)


### PR DESCRIPTION
## Problem

We have a team setting designed to fully turn off profile processing. But it still leads to "force_upgrade" happening which isn't ideal

## Changes

- [x] Refactors minimum possible steps to get this through to the force upgrade path
- [x] Adds the check there
- [x] Adds test coverage

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
