### PR TITLE
fix: Check for existence of result values prior to getting size data in retentionTableLogic

### DIFF
--- a/frontend/src/scenes/retention/retentionTableLogic.ts
+++ b/frontend/src/scenes/retention/retentionTableLogic.ts
@@ -76,7 +76,9 @@ export const retentionTableLogic = kea<retentionTableLogicType>([
                             firstColumn = currentDate.format('MMM D')
                     }
 
-                    const secondColumn = hideSizeColumn ? [] : [currentResult.values[0].count]
+                    const secondColumn = hideSizeColumn
+                        ? []
+                        : [currentResult.values[0] ? currentResult.values[0].count : 0]
                     const otherColumns = currentResult.values
 
                     return [firstColumn, ...secondColumn, ...otherColumns]


### PR DESCRIPTION
## Problem

Failure to check for the existence of values in results was causing the retention insight to break in cases where a particular time period didn't have any data.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
Fixes : https://posthoghelp.zendesk.com/agent/tickets/26350 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/28502)

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
