### PR TITLE
chore: make source wizard easier to use

### DIFF
--- a/frontend/src/scenes/data-warehouse/external/forms/SchemaForm.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/SchemaForm.tsx
@@ -1,137 +1,153 @@
-import { LemonButton, LemonCheckbox, LemonModal, LemonTable } from '@posthog/lemon-ui'
+import { LemonSelect, LemonSwitch, LemonTable, LemonTag } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 
+import { ExternalDataSourceSyncSchema } from '~/types'
+
 import { sourceWizardLogic } from '../../new/sourceWizardLogic'
-import { SyncMethodForm } from './SyncMethodForm'
+
+const getIncrementalSyncDisabledReason = (schema: ExternalDataSourceSyncSchema): string | undefined => {
+    if (!schema.incremental_available) {
+        return "Incremental replication isn't supported on this table"
+    }
+
+    if (schema.incremental_fields.length === 0) {
+        return 'No incremental fields found on table'
+    }
+    return undefined
+}
 
 export default function SchemaForm(): JSX.Element {
-    const { toggleSchemaShouldSync, openSyncMethodModal } = useActions(sourceWizardLogic)
+    const { updateSchema } = useActions(sourceWizardLogic)
     const { databaseSchema } = useValues(sourceWizardLogic)
 
     return (
-        <>
-            <div className="flex flex-col gap-2">
-                <div>
-                    <LemonTable
-                        emptyState="No schemas found"
-                        dataSource={databaseSchema}
-                        columns={[
-                            {
-                                width: 0,
-                                key: 'enabled',
-                                render: (_, schema) => {
-                                    return (
-                                        <LemonCheckbox
-                                            checked={schema.should_sync}
-                                            onChange={(checked) => {
-                                                if (schema.sync_type === null) {
-                                                    openSyncMethodModal(schema)
-                                                    return
-                                                }
-                                                toggleSchemaShouldSync(schema, checked)
-                                            }}
-                                        />
-                                    )
-                                },
-                            },
-                            {
-                                title: 'Table',
-                                key: 'table',
-                                render: function RenderTable(_, schema) {
-                                    return <span className="font-mono">{schema.table}</span>
-                                },
-                            },
-                            {
-                                title: 'Rows',
-                                key: 'rows',
-                                isHidden: !databaseSchema.some((schema) => schema.rows),
-                                render: (_, schema) => {
-                                    return schema.rows != null ? schema.rows : 'Unknown'
-                                },
-                            },
-
-                            {
-                                key: 'sync_type',
-                                title: 'Sync method',
-                                align: 'right',
-                                tooltip:
-                                    'Full refresh will refresh the full table on every sync, whereas incremental will only sync new and updated rows since the last sync',
-                                render: (_, schema) => {
-                                    if (!schema.sync_type) {
-                                        return (
-                                            <div className="justify-end flex">
-                                                <LemonButton
-                                                    className="my-1"
-                                                    type="primary"
-                                                    onClick={() => openSyncMethodModal(schema)}
-                                                    size="small"
-                                                >
-                                                    Configure
-                                                </LemonButton>
-                                            </div>
-                                        )
+        <div className="flex flex-col gap-4">
+            <LemonTable
+                emptyState="No schemas found"
+                dataSource={databaseSchema}
+                columns={[
+                    {
+                        title: 'Table',
+                        key: 'table',
+                        render: function RenderTable(_, schema) {
+                            return <span className="font-mono">{schema.table}</span>
+                        },
+                    },
+                    {
+                        title: 'Rows',
+                        key: 'rows',
+                        isHidden: !databaseSchema.some((s) => s.rows),
+                        render: (_, schema) => (schema.rows != null ? schema.rows : 'Unknown'),
+                    },
+                    {
+                        key: 'sync_type',
+                        title: 'Sync method',
+                        tooltip:
+                            'Full refresh will refresh the full table on every sync, whereas incremental will only sync new/updated rows.',
+                        render: (_, schema) => {
+                            const incrementalSyncDisabledReason = getIncrementalSyncDisabledReason(schema)
+                            return (
+                                <div className="py-2">
+                                    <LemonSelect
+                                        value={schema.sync_type ?? null}
+                                        onChange={(val) => updateSchema({ ...schema, sync_type: val })}
+                                        options={[
+                                            { value: 'full_refresh', label: 'Full refresh' },
+                                            {
+                                                value: 'incremental',
+                                                label: (
+                                                    <>
+                                                        Incremental
+                                                        {!incrementalSyncDisabledReason && (
+                                                            <LemonTag type="success" className="ml-2">
+                                                                Recommended
+                                                            </LemonTag>
+                                                        )}
+                                                    </>
+                                                ),
+                                                disabledReason: incrementalSyncDisabledReason,
+                                            },
+                                        ]}
+                                        placeholder="Configure"
+                                    />
+                                </div>
+                            )
+                        },
+                    },
+                    {
+                        key: 'incremental_field',
+                        tooltip:
+                            "When using incremental replication, we'll store the max value of the chosen field on each sync and only sync rows with a greater or equal value on the next run.\nYou should pick a field that increments or updates each time the row is updated, such as an updated_at timestamp.",
+                        title: 'Incremental field',
+                        render: (_, schema) => {
+                            const incrementalSyncDisabledReason = getIncrementalSyncDisabledReason(schema)
+                            const isIncremental = schema.sync_type === 'incremental'
+                            return (
+                                <div className="py-2">
+                                    <LemonSelect
+                                        value={schema.incremental_field ?? null}
+                                        onChange={(val) =>
+                                            updateSchema({
+                                                ...schema,
+                                                incremental_field: val,
+                                                incremental_field_type:
+                                                    schema.incremental_fields.find((f) => f.field === val)
+                                                        ?.field_type ?? null,
+                                            })
+                                        }
+                                        options={
+                                            schema.incremental_fields?.map((f) => ({
+                                                value: f.field,
+                                                label: (
+                                                    <>
+                                                        {f.label}
+                                                        <LemonTag type="success" className="ml-2">
+                                                            {f.type}
+                                                        </LemonTag>
+                                                    </>
+                                                ),
+                                            })) ?? []
+                                        }
+                                        disabledReason={
+                                            !isIncremental ? 'Select incremental first' : incrementalSyncDisabledReason
+                                        }
+                                        placeholder="None"
+                                    />
+                                </div>
+                            )
+                        },
+                    },
+                    {
+                        width: 0,
+                        key: 'enabled',
+                        render: (_, schema) => {
+                            const incrementalSyncDisabledReason = getIncrementalSyncDisabledReason(schema)
+                            const defaultSyncType = incrementalSyncDisabledReason ? 'full_refresh' : 'incremental'
+                            const defaultIncrementalField = incrementalSyncDisabledReason
+                                ? null
+                                : schema.incremental_fields[0]?.field ?? null
+                            const defaultIncrementalFieldType = incrementalSyncDisabledReason
+                                ? null
+                                : schema.incremental_fields[0]?.field_type ?? null
+                            return (
+                                <LemonSwitch
+                                    checked={schema.should_sync}
+                                    onChange={(checked) =>
+                                        updateSchema({
+                                            ...schema,
+                                            should_sync: checked,
+                                            sync_type: schema.sync_type ?? defaultSyncType,
+                                            incremental_field: schema.incremental_field ?? defaultIncrementalField,
+                                            incremental_field_type:
+                                                schema.incremental_field_type ?? defaultIncrementalFieldType,
+                                        })
                                     }
-
-                                    return (
-                                        <div className="justify-end flex">
-                                            <LemonButton
-                                                className="my-1"
-                                                size="small"
-                                                type="secondary"
-                                                onClick={() => openSyncMethodModal(schema)}
-                                            >
-                                                {schema.sync_type === 'full_refresh' ? 'Full refresh' : 'Incremental'}
-                                            </LemonButton>
-                                        </div>
-                                    )
-                                },
-                            },
-                        ]}
-                    />
-                </div>
-            </div>
-            <SyncMethodModal />
-        </>
-    )
-}
-
-const SyncMethodModal = (): JSX.Element => {
-    const { cancelSyncMethodModal, updateSchemaSyncType, toggleSchemaShouldSync } = useActions(sourceWizardLogic)
-    const { syncMethodModalOpen, currentSyncMethodModalSchema } = useValues(sourceWizardLogic)
-
-    if (!currentSyncMethodModalSchema) {
-        return <></>
-    }
-
-    return (
-        <LemonModal
-            title={
-                <>
-                    Sync method for <span className="font-mono">{currentSyncMethodModalSchema.table}</span>
-                </>
-            }
-            isOpen={syncMethodModalOpen}
-            onClose={cancelSyncMethodModal}
-        >
-            <SyncMethodForm
-                schema={currentSyncMethodModalSchema}
-                onClose={cancelSyncMethodModal}
-                onSave={(syncType, incrementalField, incrementalFieldType) => {
-                    if (syncType === 'incremental') {
-                        updateSchemaSyncType(
-                            currentSyncMethodModalSchema,
-                            syncType,
-                            incrementalField,
-                            incrementalFieldType
-                        )
-                    } else {
-                        updateSchemaSyncType(currentSyncMethodModalSchema, syncType ?? null, null, null)
-                    }
-
-                    toggleSchemaShouldSync(currentSyncMethodModalSchema, true)
-                    cancelSyncMethodModal()
-                }}
+                                />
+                            )
+                        },
+                    },
+                ]}
             />
-        </LemonModal>
+        </div>
     )
 }

--- a/frontend/src/scenes/data-warehouse/external/forms/SchemaForm.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/SchemaForm.tsx
@@ -46,11 +46,25 @@ export default function SchemaForm(): JSX.Element {
                             'Full refresh will refresh the full table on every sync, whereas incremental will only sync new/updated rows.',
                         render: (_, schema) => {
                             const incrementalSyncDisabledReason = getIncrementalSyncDisabledReason(schema)
+                            const defaultIncrementalField = incrementalSyncDisabledReason
+                                ? null
+                                : schema.incremental_fields[0]?.field ?? null
+                            const defaultIncrementalFieldType = incrementalSyncDisabledReason
+                                ? null
+                                : schema.incremental_fields[0]?.field_type ?? null
+
                             return (
                                 <div className="py-2">
                                     <LemonSelect
                                         value={schema.sync_type ?? null}
-                                        onChange={(val) => updateSchema({ ...schema, sync_type: val })}
+                                        onChange={(val) =>
+                                            updateSchema({
+                                                ...schema,
+                                                sync_type: val,
+                                                incremental_field: defaultIncrementalField,
+                                                incremental_field_type: defaultIncrementalFieldType,
+                                            })
+                                        }
                                         options={[
                                             { value: 'full_refresh', label: 'Full refresh' },
                                             {

--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -797,18 +797,7 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
         onNext: true,
         onSubmit: true,
         setDatabaseSchemas: (schemas: ExternalDataSourceSyncSchema[]) => ({ schemas }),
-        toggleSchemaShouldSync: (schema: ExternalDataSourceSyncSchema, shouldSync: boolean) => ({ schema, shouldSync }),
-        updateSchemaSyncType: (
-            schema: ExternalDataSourceSyncSchema,
-            syncType: ExternalDataSourceSyncSchema['sync_type'],
-            incrementalField: string | null,
-            incrementalFieldType: string | null
-        ) => ({
-            schema,
-            syncType,
-            incrementalField,
-            incrementalFieldType,
-        }),
+        updateSchema: (schema: ExternalDataSourceSyncSchema) => ({ schema }),
         clearSource: true,
         updateSource: (source: Partial<ExternalDataSourceCreatePayload>) => ({ source }),
         createSource: true,
@@ -872,20 +861,8 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
             [] as ExternalDataSourceSyncSchema[],
             {
                 setDatabaseSchemas: (_, { schemas }) => schemas,
-                toggleSchemaShouldSync: (state, { schema, shouldSync }) => {
-                    return state.map((s) => ({
-                        ...s,
-                        should_sync: s.table === schema.table ? shouldSync : s.should_sync,
-                    }))
-                },
-                updateSchemaSyncType: (state, { schema, syncType, incrementalField, incrementalFieldType }) => {
-                    return state.map((s) => ({
-                        ...s,
-                        sync_type: s.table === schema.table ? syncType : s.sync_type,
-                        incremental_field: s.table === schema.table ? incrementalField : s.incremental_field,
-                        incremental_field_type:
-                            s.table === schema.table ? incrementalFieldType : s.incremental_field_type,
-                    }))
+                updateSchema: (state, { schema }) => {
+                    return state.map((s) => (s.table === schema.table ? schema : s))
                 },
             },
         ],


### PR DESCRIPTION
## Problem

It was a lot of work to configure the sync method and incremental fields for lots of tables, and the UX was confusing users during onboarding.

## Changes

- Allow users to select tables quickly, and default to the best sync method available
- Move the sync method selection out of a modal for the source wizard, add it and the incremental field to the table instead

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

I tested it locally for Stripe, and checked it didn't break existing tests for the wizard. I'm low on context here, so would appreciate someone else's view.
