### PR TITLE
fix: Use schema ID in table prefix

### DIFF
--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -516,15 +516,15 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
                 model.pipeline.job_inputs.get("using_temporary_dataset", False) and temporary_dataset_id is not None
             )
 
-            # Including the workflow ID in table prefix ensures we only delete tables
-            # from this workflow execution.
+            # Including the schema ID in table prefix ensures we only delete tables
+            # from this schema, and that if we fail we will clean up any previous
+            # execution's tables.
             # Table names in BigQuery can have up to 1024 bytes, so we can be pretty
-            # relaxed with using a relatively long workflow ID as part of the prefix.
-            # Some special characters do need to be replaced (pretty much only '_' is
-            # allowed).
-            workflow_id = activity.info().workflow_id
-            workflow_id = workflow_id.replace("-", "_").replace(":", "_")
-            destination_table_prefix = f"__posthog_import_{workflow_id}"
+            # relaxed with using a relatively long UUID as part of the prefix.
+            # Some special characters do need to be replaced, so we use the hex
+            # representation of the UUID.
+            schema_id = inputs.schema_id.hex
+            destination_table_prefix = f"__posthog_import_{schema_id}"
 
             destination_table_dataset_id = temporary_dataset_id if using_temporary_dataset else dataset_id
             destination_table = f"{project_id}.{destination_table_dataset_id}.{destination_table_prefix}{inputs.run_id}_{str(datetime.now().timestamp()).replace('.', '')}"

--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -1,26 +1,26 @@
 import dataclasses
 import uuid
 from datetime import datetime
-from dateutil import parser
 from typing import Any, Optional
 
+from dateutil import parser
 from django.db import close_old_connections
 from django.db.models import Prefetch
 from dlt.sources import DltSource
+from structlog.typing import FilteringBoundLogger
 from temporalio import activity
 
 from posthog.models.integration import Integration
 from posthog.temporal.common.heartbeat_sync import HeartbeaterSync
+from posthog.temporal.common.logger import bind_temporal_worker_logger_sync
 from posthog.temporal.data_imports.pipelines.bigquery import delete_all_temp_destination_tables, delete_table
-from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from posthog.temporal.data_imports.pipelines.pipeline.pipeline import PipelineNonDLT
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from posthog.temporal.data_imports.pipelines.pipeline_sync import PipelineInputs
 from posthog.warehouse.models import (
     ExternalDataJob,
     ExternalDataSource,
 )
-from posthog.temporal.common.logger import bind_temporal_worker_logger_sync
-from structlog.typing import FilteringBoundLogger
 from posthog.warehouse.models.external_data_schema import ExternalDataSchema
 from posthog.warehouse.models.ssh_tunnel import SSHTunnel
 from posthog.warehouse.types import IncrementalFieldType
@@ -178,9 +178,9 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
             ExternalDataSource.Type.MYSQL,
             ExternalDataSource.Type.MSSQL,
         ]:
-            from posthog.temporal.data_imports.pipelines.sql_database import sql_source_for_type
-            from posthog.temporal.data_imports.pipelines.postgres.postgres import postgres_source
             from posthog.temporal.data_imports.pipelines.mysql.mysql import mysql_source
+            from posthog.temporal.data_imports.pipelines.postgres.postgres import postgres_source
+            from posthog.temporal.data_imports.pipelines.sql_database import sql_source_for_type
 
             host = model.pipeline.job_inputs.get("host")
             port = model.pipeline.job_inputs.get("port")
@@ -516,7 +516,16 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
                 model.pipeline.job_inputs.get("using_temporary_dataset", False) and temporary_dataset_id is not None
             )
 
-            destination_table_prefix = "__posthog_import_"
+            # Including the workflow ID in table prefix ensures we only delete tables
+            # from this workflow execution.
+            # Table names in BigQuery can have up to 1024 bytes, so we can be pretty
+            # relaxed with using a relatively long workflow ID as part of the prefix.
+            # Some special characters do need to be replaced (pretty much only '_' is
+            # allowed).
+            workflow_id = activity.info().workflow_id
+            workflow_id = workflow_id.replace("-", "_").replace(":", "_")
+            destination_table_prefix = f"__posthog_import_{workflow_id}"
+
             destination_table_dataset_id = temporary_dataset_id if using_temporary_dataset else dataset_id
             destination_table = f"{project_id}.{destination_table_dataset_id}.{destination_table_prefix}{inputs.run_id}_{str(datetime.now().timestamp()).replace('.', '')}"
 


### PR DESCRIPTION
## Problem

If multiple `external-data-job` workflows for a BigQuery source are running simultaneously, they can conflict with each other by deleting each other's tables.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Include ~workflow~ schema ID in database table prefix. This way, tables are now exclusive to the ~workflow~ schema we are running, and can be cleaned up safely.

A previous iteration of this PR used Workflow ID, but that included a timestamp component that changes over time. If we fail, we want to make sure that the next run cleans up failed tables, so we use the schema ID that doesn't contain that timestamp component.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
