### PR TITLE
fix(temporal): float values serialization in CH queries

### DIFF
--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -34,6 +34,8 @@ def encode_clickhouse_data(data: typing.Any, quote_char="'") -> bytes:
             return f"{quote_char}{data}{quote_char}".encode()
 
         case int() | float():
+            if isinstance(data, float) and data.is_integer():
+                return f"{int(data)}".encode()
             return f"{data}".encode()
 
         case dt.datetime():

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -34,7 +34,7 @@ def encode_clickhouse_data(data: typing.Any, quote_char="'") -> bytes:
             return f"{quote_char}{data}{quote_char}".encode()
 
         case int() | float():
-            return b"%d" % data
+            return f"{data}".encode()
 
         case dt.datetime():
             timezone_arg = ""

--- a/posthog/temporal/tests/test_clickhouse.py
+++ b/posthog/temporal/tests/test_clickhouse.py
@@ -31,7 +31,7 @@ from posthog.temporal.common.clickhouse import encode_clickhouse_data
             dt.datetime(2023, 7, 14, 0, 0, 0, 5555, tzinfo=dt.UTC),
             b"toDateTime64('2023-07-14 00:00:00.005555', 6, 'UTC')",
         ),
-        ([1.1666, [0.132, -0.2390]], b"[1.1666,[0.132,-0.239]]"),
+        ([1.1666, [0.132, -0.2390], 0.0], b"[1.1666,[0.132,-0.239],0]"),
     ],
 )
 def test_encode_clickhouse_data(data, expected):

--- a/posthog/temporal/tests/test_clickhouse.py
+++ b/posthog/temporal/tests/test_clickhouse.py
@@ -31,6 +31,7 @@ from posthog.temporal.common.clickhouse import encode_clickhouse_data
             dt.datetime(2023, 7, 14, 0, 0, 0, 5555, tzinfo=dt.UTC),
             b"toDateTime64('2023-07-14 00:00:00.005555', 6, 'UTC')",
         ),
+        ([1.1666, [0.132, -0.2390]], b"[1.1666,[0.132,-0.239]]"),
     ],
 )
 def test_encode_clickhouse_data(data, expected):


### PR DESCRIPTION
## Problem

If you use the Temporal's ClickHouse client with floats, it truncates the fractional part.

For example:
```
INSERT INTO table (embedding) VALUES ([0.053, -0.12])
```

Inserts:
```
([0, 0])
```

## Changes

Stringify the number using the `str()` function, so we don't loose the fractional part.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Unit tests
