### PR TITLE
feat: publish empty metadata for v2 recordings

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.ts
@@ -158,7 +158,25 @@ export class SessionBatchRecorder {
         try {
             for (const sessions of this.partitionSessions.values()) {
                 for (const recorder of sessions.values()) {
-                    const { buffer, eventCount, startDateTime, endDateTime } = await recorder.end()
+                    const {
+                        buffer,
+                        eventCount,
+                        startDateTime,
+                        endDateTime,
+                        firstUrl,
+                        urls,
+                        clickCount,
+                        keypressCount,
+                        mouseActivityCount,
+                        activeMilliseconds,
+                        consoleLogCount,
+                        consoleWarnCount,
+                        consoleErrorCount,
+                        size,
+                        messageCount,
+                        snapshotSource,
+                        snapshotLibrary,
+                    } = await recorder.end()
                     const { bytesWritten, url } = await writer.writeSession(buffer)
 
                     // Track block metadata
@@ -170,6 +188,19 @@ export class SessionBatchRecorder {
                         startDateTime,
                         endDateTime,
                         blockUrl: url,
+                        firstUrl,
+                        urls,
+                        clickCount,
+                        keypressCount,
+                        mouseActivityCount,
+                        activeMilliseconds,
+                        consoleLogCount,
+                        consoleWarnCount,
+                        consoleErrorCount,
+                        size,
+                        messageCount,
+                        snapshotSource,
+                        snapshotLibrary,
                     })
 
                     totalEvents += eventCount

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-block-metadata.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-block-metadata.ts
@@ -15,4 +15,30 @@ export interface SessionBlockMetadata {
     endDateTime: DateTime
     /** URL to the block data with byte range query parameter, if available */
     blockUrl: string | null
+    /** First URL in the session */
+    firstUrl?: string | null
+    /** All URLs visited in the session */
+    urls?: string[]
+    /** Number of click events in the session */
+    clickCount?: number
+    /** Number of keypress events in the session */
+    keypressCount?: number
+    /** Number of mouse activity events in the session */
+    mouseActivityCount?: number
+    /** Number of milliseconds the user was active */
+    activeMilliseconds?: number
+    /** Number of console.log events in the session */
+    consoleLogCount?: number
+    /** Number of console.warn events in the session */
+    consoleWarnCount?: number
+    /** Number of console.error events in the session */
+    consoleErrorCount?: number
+    /** Size of the session data in bytes */
+    size?: number
+    /** Number of messages in the session */
+    messageCount?: number
+    /** Source of the snapshot */
+    snapshotSource?: string | null
+    /** Library used for the snapshot */
+    snapshotLibrary?: string | null
 }

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-metadata-store.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-metadata-store.ts
@@ -23,6 +23,19 @@ export class SessionMetadataStore {
             first_timestamp: castTimestampOrNow(metadata.startDateTime, TimestampFormat.ClickHouse),
             last_timestamp: castTimestampOrNow(metadata.endDateTime, TimestampFormat.ClickHouse),
             block_url: metadata.blockUrl,
+            first_url: metadata.firstUrl,
+            urls: metadata.urls || [],
+            click_count: metadata.clickCount || 0,
+            keypress_count: metadata.keypressCount || 0,
+            mouse_activity_count: metadata.mouseActivityCount || 0,
+            active_milliseconds: metadata.activeMilliseconds || 0,
+            console_log_count: metadata.consoleLogCount || 0,
+            console_warn_count: metadata.consoleWarnCount || 0,
+            console_error_count: metadata.consoleErrorCount || 0,
+            size: metadata.size || 0,
+            message_count: metadata.messageCount || 0,
+            snapshot_source: metadata.snapshotSource,
+            snapshot_library: metadata.snapshotLibrary,
         }))
 
         await this.producer.queueMessages({

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/snappy-session-recorder.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/snappy-session-recorder.test.ts
@@ -236,6 +236,37 @@ describe('SnappySessionRecorder', () => {
         })
     })
 
+    describe('metadata', () => {
+        it('should return default metadata', async () => {
+            const events = [
+                {
+                    type: EventType.FullSnapshot,
+                    timestamp: 1000,
+                    data: { source: 1 },
+                },
+            ]
+            const message = createMessage('window1', events)
+
+            recorder.recordMessage(message)
+            const result = await recorder.end()
+
+            // Check that all new fields are included with default values
+            expect(result.firstUrl).toBeNull()
+            expect(result.urls).toEqual([])
+            expect(result.clickCount).toBe(0)
+            expect(result.keypressCount).toBe(0)
+            expect(result.mouseActivityCount).toBe(0)
+            expect(result.activeMilliseconds).toBe(0)
+            expect(result.consoleLogCount).toBe(0)
+            expect(result.consoleWarnCount).toBe(0)
+            expect(result.consoleErrorCount).toBe(0)
+            expect(result.size).toBe(result.buffer.length)
+            expect(result.messageCount).toBe(0)
+            expect(result.snapshotSource).toBeNull()
+            expect(result.snapshotLibrary).toBeNull()
+        })
+    })
+
     describe('distinctId', () => {
         it('should throw error when accessing distinctId before recording any messages', () => {
             expect(() => recorder.distinctId).toThrow('No distinct_id set. No messages recorded yet.')

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/snappy-session-recorder.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/snappy-session-recorder.ts
@@ -12,6 +12,32 @@ export interface EndResult {
     startDateTime: DateTime
     /** Timestamp of the last event in the session block */
     endDateTime: DateTime
+    /** First URL of the session */
+    firstUrl?: string | null
+    /** All URLs visited in the session */
+    urls?: string[]
+    /** Number of clicks in the session */
+    clickCount?: number
+    /** Number of keypresses in the session */
+    keypressCount?: number
+    /** Number of mouse activity events in the session */
+    mouseActivityCount?: number
+    /** Active time in milliseconds */
+    activeMilliseconds?: number
+    /** Number of console log messages */
+    consoleLogCount?: number
+    /** Number of console warning messages */
+    consoleWarnCount?: number
+    /** Number of console error messages */
+    consoleErrorCount?: number
+    /** Size of the session data in bytes */
+    size?: number
+    /** Number of messages in the session */
+    messageCount?: number
+    /** Source of the snapshot (Web/Mobile) */
+    snapshotSource?: string | null
+    /** Library used for the snapshot */
+    snapshotLibrary?: string | null
 }
 
 /**
@@ -104,9 +130,9 @@ export class SnappySessionRecorder {
     }
 
     /**
-     * Finalizes and returns the compressed session block
+     * Finalizes the session recording and returns the compressed buffer with metadata
      *
-     * @returns The complete compressed session block and event count
+     * @returns The compressed session recording block with metadata
      * @throws If called more than once
      */
     public async end(): Promise<EndResult> {
@@ -124,6 +150,19 @@ export class SnappySessionRecorder {
             eventCount: this.eventCount,
             startDateTime: this.startDateTime ?? DateTime.fromMillis(0),
             endDateTime: this.endDateTime ?? DateTime.fromMillis(0),
+            firstUrl: null,
+            urls: [],
+            clickCount: 0,
+            keypressCount: 0,
+            mouseActivityCount: 0,
+            activeMilliseconds: 0,
+            consoleLogCount: 0,
+            consoleWarnCount: 0,
+            consoleErrorCount: 0,
+            size: buffer.length,
+            messageCount: 0,
+            snapshotSource: null,
+            snapshotLibrary: null,
         }
     }
 }


### PR DESCRIPTION
## Problem

Before adding the missing columns to `session_replay_events_v2_test`, we need to start publishing events in a compliant format.

## Changes

Publshes session block metadata with empty values, so that we can run the migrations and later implement the actual computations for the metadata.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

- Tested locally against the new database schema
- Added unit tests