### PR TITLE
fix(cdp): improved DateTime event property type classification

### DIFF
--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -346,7 +346,7 @@ fn detect_property_type(key: &str, value: &Value) -> Option<PropertyValueType> {
             // TODO - this is a divergence from the TS impl - the TS also checks if the contained number is
             // "likely" to be a unix timestamp on the basis of the number of characters. I have mixed feelings about this,
             // so I'm going to leave it as just checking the key for now. This means we're being /less/ strict with datetime
-            // detection here than in the TS
+            // detection here than in the TS (NOTE: updated by eli.r@posthog.com 3/2025)
             let candidate = key.to_lowercase();
             if DATETIME_PROPERTY_NAME_KEYWORDS
                 .iter()
@@ -372,7 +372,7 @@ fn is_valid_date_string(s: &str) -> bool {
     // a string prefix of their value. While this doesn't enforce compliance to standard formats,
     // it does represent a pretty strong indication of the user's intent, for the purposes of
     // *property definition capture only* especially when a bad decision "locks" the property name
-    // to the wrong type forever. Try it here: https://rustexp.lpil.uk/ and review the unit tests.
+    // to the wrong type. Try it here: https://rustexp.lpil.uk/ and review the unit tests.
     // Also notable: post-capture, PostHog displays timestamps in a variety formats:
     // https://github.com/PostHog/posthog/blob/master/posthog/models/property_definition.py#L18-L30
     let datetime_prefix_pattern: Regex = regex::Regex::new(

--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -769,9 +769,9 @@ mod test {
     fn test_property_name_based_detection() {
         // Test all timestamp-related keywords for numeric values
 
-        // Test "timestamp" in different positions and cases. Note: the
-        // hardcoded UNIX timestamp value below is older than (now - 6 months)
-        // so shouldn't trigger based on numerical value classification step.
+        // Test property-name based matching. Note: the hardcoded UNIX timestamp
+        // value used in these unit tests is older than (now - 6 months)
+        // so shouldn't trigger a match based on numerical classification step.
         assert_eq!(
             detect_property_type(
                 "timestamp",
@@ -875,7 +875,7 @@ mod test {
         );
         assert_eq!(
             detect_property_type(
-                "sent_at",
+                "sent-at",
                 &Value::Number(serde_json::Number::from(1639400730))
             ),
             Some(PropertyValueType::DateTime)
@@ -886,6 +886,20 @@ mod test {
                 &Value::Number(serde_json::Number::from(1639400730))
             ),
             Some(PropertyValueType::DateTime)
+        );
+        assert_eq!(
+            detect_property_type(
+                "updated_never",
+                &Value::Number(serde_json::Number::from(1639400730))
+            ),
+            Some(PropertyValueType::String)
+        );
+        assert_eq!(
+            detect_property_type(
+                "not_a_thyme",
+                &Value::Number(serde_json::Number::from(1639400730))
+            ),
+            Some(PropertyValueType::String)
         );
 
         // Test non-matching property names (should be Numeric)

--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -889,17 +889,17 @@ mod test {
         );
         assert_eq!(
             detect_property_type(
-                "updated_never",
+                "hedgehogs_enumerated",
                 &Value::Number(serde_json::Number::from(1639400730))
             ),
-            Some(PropertyValueType::String)
+            Some(PropertyValueType::Numeric)
         );
         assert_eq!(
             detect_property_type(
                 "not_a_thyme",
                 &Value::Number(serde_json::Number::from(1639400730))
             ),
-            Some(PropertyValueType::String)
+            Some(PropertyValueType::Numeric)
         );
 
         // Test non-matching property names (should be Numeric)

--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -13,6 +13,7 @@ use crate::metrics_consts::{EVENTS_SKIPPED, UPDATES_ISSUED, UPDATES_SKIPPED};
 // We skip updates for events we generate
 pub const EVENTS_WITHOUT_PROPERTIES: [&str; 1] = ["$$plugin_metrics"];
 
+pub const SIX_MONTHS_AGO_SECS: u64 = 15768000;
 // These properties have special meaning, and are ignored
 pub const SKIP_PROPERTIES: [&str; 9] = [
     "$set",
@@ -389,9 +390,8 @@ fn is_valid_date_string(s: &str) -> bool {
 fn is_likely_unix_timestamp(n: &serde_json::Number) -> bool {
     if let Some(value) = n.as_u64() {
         // we could go more conservative here, but you get the idea
-        let unix_secs_six_months_ago: u64 =
-            (Utc::now().timestamp_millis() as u64 / 1000u64) - 15768000;
-        if value >= unix_secs_six_months_ago {
+        let threshold: u64 = (Utc::now().timestamp_millis() as u64 / 1000u64) - SIX_MONTHS_AGO_SECS;
+        if value >= threshold {
             return true;
         }
     }

--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -26,8 +26,15 @@ pub const SKIP_PROPERTIES: [&str; 9] = [
     "$groups",
 ];
 
-const DATETIME_PROPERTY_NAME_KEYWORDS: [&str; 6] =
-    ["time", "timestamp", "date", "_at", "createdat", "updatedat"];
+const DATETIME_PROPERTY_NAME_KEYWORDS: [&str; 7] = [
+    "time",
+    "timestamp",
+    "date",
+    "_at",
+    "-at",
+    "createdat",
+    "updatedat",
+];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub enum PropertyParentType {
@@ -866,6 +873,20 @@ mod test {
             ),
             Some(PropertyValueType::DateTime)
         );
+        assert_eq!(
+            detect_property_type(
+                "sent_at",
+                &Value::Number(serde_json::Number::from(1639400730))
+            ),
+            Some(PropertyValueType::DateTime)
+        );
+        assert_eq!(
+            detect_property_type(
+                "updated-at",
+                &Value::Number(serde_json::Number::from(1639400730))
+            ),
+            Some(PropertyValueType::DateTime)
+        );
 
         // Test non-matching property names (should be Numeric)
         assert_eq!(
@@ -874,13 +895,6 @@ mod test {
         );
         assert_eq!(
             detect_property_type("amount", &Value::Number(serde_json::Number::from(100))),
-            Some(PropertyValueType::Numeric)
-        );
-        assert_eq!(
-            detect_property_type(
-                "sent_at",
-                &Value::Number(serde_json::Number::from(1639400730))
-            ),
             Some(PropertyValueType::Numeric)
         );
 

--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -1,6 +1,7 @@
 use std::{fmt, hash::Hash, str::FromStr};
 
 use chrono::{DateTime, Duration, DurationRound, RoundingError, Utc};
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use sqlx::{Executor, Postgres};
@@ -24,6 +25,9 @@ pub const SKIP_PROPERTIES: [&str; 9] = [
     "$group_4",
     "$groups",
 ];
+
+const DATETIME_PROPERTY_NAME_KEYWORDS: [&str; 6] =
+    ["time", "timestamp", "date", "_at", "createdat", "updatedat"];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub enum PropertyParentType {
@@ -325,21 +329,22 @@ fn detect_property_type(key: &str, value: &Value) -> Option<PropertyValueType> {
             if *s == "true" || *s == "false" || *s == "TRUE" || *s == "FALSE" {
                 Some(PropertyValueType::Boolean)
             // Try to parse this as an ISO 8601 date, and if we can, use that as the type instead
-            } else if DateTime::parse_from_rfc3339(s).is_ok() {
+            } else if is_valid_date_string(s) {
                 Some(PropertyValueType::DateTime)
             } else {
                 Some(PropertyValueType::String)
             }
         }
-        Value::Number(_) => {
+        Value::Number(n) => {
             // TODO - this is a divergence from the TS impl - the TS also checks if the contained number is
             // "likely" to be a unix timestamp on the basis of the number of characters. I have mixed feelings about this,
             // so I'm going to leave it as just checking the key for now. This means we're being /less/ strict with datetime
             // detection here than in the TS
-            if key.contains("timestamp")
-                || key.contains("TIMESTAMP")
-                || key.contains("time")
-                || key.contains("TIME")
+            let candidate = key.to_lowercase();
+            if DATETIME_PROPERTY_NAME_KEYWORDS
+                .iter()
+                .any(|kw| candidate.contains(*kw))
+                || is_likely_unix_timestamp(n)
             {
                 Some(PropertyValueType::DateTime)
             } else {
@@ -349,6 +354,42 @@ fn detect_property_type(key: &str, value: &Value) -> Option<PropertyValueType> {
         Value::Bool(_) => Some(PropertyValueType::Boolean),
         _ => None,
     }
+}
+
+fn is_valid_date_string(s: &str) -> bool {
+    if DateTime::parse_from_rfc3339(s).is_ok() || DateTime::parse_from_rfc2822(s).is_ok() {
+        return true;
+    }
+
+    // TRICKY: the pattern below is a best-effort attempt to classify likely DateTime properties by
+    // a string prefix of their value. While this doesn't enforce compliance to standard formats,
+    // it does represent a pretty strong indication of the user's intent, for the purposes of
+    // *property definition capture only* especially when a bad decision "locks" the property name
+    // to the wrong type forever. Try it here: https://rustexp.lpil.uk/ and review the unit tests.
+    // Also notable: post-capture, PostHog displays timestamps in a variety formats:
+    // https://github.com/PostHog/posthog/blob/master/posthog/models/property_definition.py#L18-L30
+    let datetime_prefix_pattern: Regex = regex::Regex::new(
+    r#"^(([0-9]{4}[/-][0-2][0-9][/-][0-3][0-9])|([0-2][0-9][/-][0-3][0-9][/-][0-9]{4}))([ T][0-2][0-9]:[0-6][0-9]:[0-6][0-9].*)?$"#
+    ).unwrap();
+    if datetime_prefix_pattern.is_match(s) {
+        return true;
+    }
+
+    false
+}
+
+// frought with peril if folks are pushing big(ish) numbers into event prop values...
+fn is_likely_unix_timestamp(n: &serde_json::Number) -> bool {
+    if let Some(value) = n.as_u64() {
+        // we could go more conservative here, but you get the idea
+        let unix_secs_six_months_ago: u64 =
+            (Utc::now().timestamp_millis() as u64 / 1000u64) - 15768000;
+        if value >= unix_secs_six_months_ago {
+            return true;
+        }
+    }
+
+    false
 }
 
 fn sanitize_event_name(event_name: &str) -> String {
@@ -573,12 +614,91 @@ mod test {
             Some(PropertyValueType::DateTime)
         );
 
-        // Test invalid timestamp formats (should be detected as String)
         assert_eq!(
-            detect_property_type("random_property", &Value::String("2023-12-13".to_string())),
-            Some(PropertyValueType::String)
+            detect_property_type(
+                "random_property",
+                &Value::String("2023/12/13 15:45:30Z".to_string())
+            ),
+            Some(PropertyValueType::DateTime)
         );
 
+        assert_eq!(
+            detect_property_type(
+                "random_property",
+                &Value::String("2023/12/13 15:45:30".to_string())
+            ),
+            Some(PropertyValueType::DateTime)
+        );
+
+        assert_eq!(
+            detect_property_type(
+                "random_property",
+                &Value::String("12-13-2023 15:45:30-07:00".to_string())
+            ),
+            Some(PropertyValueType::DateTime)
+        );
+
+        assert_eq!(
+            detect_property_type(
+                "random_property",
+                &Value::String("12/13/2023 15:45:30-07".to_string())
+            ),
+            Some(PropertyValueType::DateTime)
+        );
+
+        assert_eq!(
+            detect_property_type(
+                "random_property",
+                &Value::String("2023/12/13 15:45:30".to_string())
+            ),
+            Some(PropertyValueType::DateTime)
+        );
+
+        assert_eq!(
+            detect_property_type(
+                "random_property",
+                &Value::String("2023-13-12 15:45:30".to_string())
+            ),
+            Some(PropertyValueType::DateTime)
+        );
+
+        assert_eq!(
+            detect_property_type(
+                "random_property",
+                &Value::String("12/13/2023T15:45:30".to_string())
+            ),
+            Some(PropertyValueType::DateTime)
+        );
+
+        assert_eq!(
+            detect_property_type(
+                "random_property",
+                &Value::String("2023-13-12T15:45:30".to_string())
+            ),
+            Some(PropertyValueType::DateTime)
+        );
+
+        assert_eq!(
+            detect_property_type("random_property", &Value::String("2023-12-13".to_string())),
+            Some(PropertyValueType::DateTime)
+        );
+
+        assert_eq!(
+            detect_property_type("random_property", &Value::String("2023/12/13".to_string())),
+            Some(PropertyValueType::DateTime)
+        );
+
+        assert_eq!(
+            detect_property_type("random_property", &Value::String("12-13-2023".to_string())),
+            Some(PropertyValueType::DateTime)
+        );
+
+        assert_eq!(
+            detect_property_type("random_property", &Value::String("12/13/2023".to_string())),
+            Some(PropertyValueType::DateTime)
+        );
+
+        // Test invalid timestamp formats (should be detected as String)
         assert_eq!(
             detect_property_type("random_property", &Value::String("15:45:30".to_string())),
             Some(PropertyValueType::String)
@@ -593,7 +713,9 @@ mod test {
         assert_eq!(
             detect_property_type(
                 "timestamp",
-                &Value::Number(serde_json::Number::from(1639400730))
+                &Value::Number(serde_json::Number::from(
+                    Utc::now().timestamp_millis() as u64 / 1000u64
+                ))
             ),
             Some(PropertyValueType::DateTime)
         );
@@ -601,17 +723,22 @@ mod test {
         assert_eq!(
             detect_property_type(
                 "created_time",
-                &Value::Number(serde_json::Number::from(1639400730))
+                &Value::Number(serde_json::Number::from(
+                    Utc::now().timestamp_millis() as u64 / 1000u64
+                ))
             ),
             Some(PropertyValueType::DateTime)
         );
 
+        // this should also now be a DateTime classification due to the UNIX timestamp-like value
         assert_eq!(
             detect_property_type(
                 "sent_at",
-                &Value::Number(serde_json::Number::from(1639400730))
+                &Value::Number(serde_json::Number::from(
+                    Utc::now().timestamp_millis() as u64 / 1000u64
+                ))
             ),
-            Some(PropertyValueType::Numeric)
+            Some(PropertyValueType::DateTime)
         );
 
         // Test property name-based detection for string values (should NOT be DateTime)
@@ -635,7 +762,9 @@ mod test {
     fn test_property_name_based_detection() {
         // Test all timestamp-related keywords for numeric values
 
-        // Test "timestamp" in different positions and cases
+        // Test "timestamp" in different positions and cases. Note: the
+        // hardcoded UNIX timestamp value below is older than (now - 6 months)
+        // so shouldn't trigger based on numerical value classification step.
         assert_eq!(
             detect_property_type(
                 "timestamp",
@@ -684,6 +813,41 @@ mod test {
         assert_eq!(
             detect_property_type(
                 "created_time",
+                &Value::Number(serde_json::Number::from(1639400730))
+            ),
+            Some(PropertyValueType::DateTime)
+        );
+        assert_eq!(
+            detect_property_type(
+                "created_at",
+                &Value::Number(serde_json::Number::from(1639400730))
+            ),
+            Some(PropertyValueType::DateTime)
+        );
+        assert_eq!(
+            detect_property_type(
+                "createdAt",
+                &Value::Number(serde_json::Number::from(1639400730))
+            ),
+            Some(PropertyValueType::DateTime)
+        );
+        assert_eq!(
+            detect_property_type(
+                "updated_at",
+                &Value::Number(serde_json::Number::from(1639400730))
+            ),
+            Some(PropertyValueType::DateTime)
+        );
+        assert_eq!(
+            detect_property_type(
+                "sent_at",
+                &Value::Number(serde_json::Number::from(1639400730))
+            ),
+            Some(PropertyValueType::DateTime)
+        );
+        assert_eq!(
+            detect_property_type(
+                "signup_date",
                 &Value::Number(serde_json::Number::from(1639400730))
             ),
             Some(PropertyValueType::DateTime)


### PR DESCRIPTION
## Problem
We are misclassifying incoming event property types as `String` or `Number` at times when the customer intends them to be registered as `DateTime`.

This PR makes a shift in bias to classify `DateTime`s more aggressively, and more in parity with the legacy TS app.

IMO this seems appropriate, since the classifications are sticky and lock the related property name to the type "forever" (or until the user realizes they must manually fix it in Data Management?) once a poor decision is recorded. 

On the other hand, if a user makes an erroneous attempt to define a new `DateTime` property and the value is corrupt at first, if the definition is captured properly, we can always pick up valid values for it in future events as they fix their submission process.

☝️ if anyone is concerned by this change, I can update the PR to nerf and instrument the new decision logic so we can see how often (and log a sample of which?) properties would be reclassified, and observe before moving on this in prod. Let me know.

## Changes
* More robust (aggressive!) attempts to classify `DateTime` props by value
* Slightly enriches list of event property name keywords to classify by
* More & updated unit tests

## Does this work well for both Cloud and self-hosted?
Yes, if it works at all :)

## How did you test this code?
Unit tests + CI, so far