### PR TITLE
fix: bypass a limit of 5 concurrent queries for whitelisted teams

### DIFF
--- a/posthog/clickhouse/client/limit.py
+++ b/posthog/clickhouse/client/limit.py
@@ -9,7 +9,6 @@ from celery import current_task
 from prometheus_client import Counter
 
 from posthog import redis
-from posthog.rate_limit import team_is_allowed_to_bypass_throttle
 from posthog.settings import TEST
 from posthog.utils import generate_short_id
 
@@ -97,6 +96,8 @@ class RateLimit:
             )
             == 0
         ):
+            from posthog.rate_limit import team_is_allowed_to_bypass_throttle
+
             bypass = team_is_allowed_to_bypass_throttle(kwargs.get("team_id", None))
             result = "allow" if bypass else "block"
 

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -46,6 +46,9 @@ def get_team_allow_list(_ttl: int) -> list[str]:
 
 
 def team_is_allowed_to_bypass_throttle(team_id: Optional[int]) -> bool:
+    """
+    Check if a given team_id belongs to a throttle bypass allow list.
+    """
     allow_list = get_team_allow_list(round(time.time() / 60))
     return team_id is not None and str(team_id) in allow_list
 


### PR DESCRIPTION
## Problem

customers depend on no concurrency limit

## Changes

allow to bypass it, but track it

## Does this work well for both Cloud and self-hosted?

yes

## How did you test this code?

locally