### PR TITLE
fix(docker): include plugin-transpiler modules in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -209,6 +209,8 @@ COPY --from=plugin-server-build --chown=posthog:posthog /code/rust/cyclotron-nod
 COPY --from=plugin-server-build --chown=posthog:posthog /code/rust/cyclotron-node/package.json /code/rust/cyclotron-node/package.json
 COPY --from=plugin-server-build --chown=posthog:posthog /code/rust/cyclotron-node/index.node /code/rust/cyclotron-node/index.node
 COPY --from=plugin-server-build --chown=posthog:posthog /code/common/plugin_transpiler/dist /code/common/plugin_transpiler/dist
+COPY --from=plugin-server-build --chown=posthog:posthog /code/common/plugin_transpiler/node_modules /code/common/plugin_transpiler/node_modules
+COPY --from=plugin-server-build --chown=posthog:posthog /code/common/plugin_transpiler/package.json /code/common/plugin_transpiler/package.json
 COPY --from=plugin-server-build --chown=posthog:posthog /code/common/hogvm/typescript/dist /code/common/hogvm/typescript/dist
 COPY --from=plugin-server-build --chown=posthog:posthog /code/common/hogvm/typescript/node_modules /code/common/hogvm/typescript/node_modules
 COPY --from=plugin-server-build --chown=posthog:posthog /code/plugin-server/dist /code/plugin-server/dist


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/issues/29492

```
root@0a4f19062576:/code/common/plugin_transpiler/dist# ls -l
total 10388
-rw-r--r-- 1 posthog posthog 3012692 Feb 20 20:35 index-PQNTJSAW.js
-rw-r--r-- 1 posthog posthog 7610578 Feb 20 20:35 index-PQNTJSAW.js.map
-rw-r--r-- 1 posthog posthog    1298 Feb 20 20:35 index.js
-rw-r--r-- 1 posthog posthog     928 Feb 20 20:35 presets.js
root@0a4f19062576:/code/common/plugin_transpiler/dist# node ./index.js 
node:internal/modules/cjs/loader:1143
  throw err;
  ^

Error: Cannot find module '@babel/standalone'
Require stack:
- /code/common/plugin_transpiler/dist/index.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1140:15)
    at Module._load (node:internal/modules/cjs/loader:981:27)
    at Module.require (node:internal/modules/cjs/loader:1231:19)
    at require (node:internal/modules/helpers:177:18)
    at Object.<anonymous> (/code/common/plugin_transpiler/dist/index.js:3:22)
    at Module._compile (node:internal/modules/cjs/loader:1364:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1422:10)
    at Module.load (node:internal/modules/cjs/loader:1203:32)
    at Module._load (node:internal/modules/cjs/loader:1019:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:128:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/code/common/plugin_transpiler/dist/index.js' ]
}

Node.js v18.20.5
```

## Changes

🤞 

## How did you test this code?

WIP