### PR TITLE
fix: Docker compose endpoint for cdp api

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -158,6 +158,7 @@ services:
             PGUSER: posthog
             PGPASSWORD: posthog
             DEPLOYMENT: hobby
+            CDP_API_URL: 'http://plugins:6738'
 
     web:
         <<: *worker

--- a/posthog/plugins/plugin_server_api.py
+++ b/posthog/plugins/plugin_server_api.py
@@ -3,7 +3,7 @@ from typing import Union
 import requests
 import structlog
 from posthog.redis import get_client
-from posthog.settings import CDP_FUNCTION_EXECUTOR_API_URL, PLUGINS_RELOAD_PUBSUB_CHANNEL, PLUGINS_RELOAD_REDIS_URL
+from posthog.settings import CDP_API_URL, PLUGINS_RELOAD_PUBSUB_CHANNEL, PLUGINS_RELOAD_REDIS_URL
 from posthog.models.utils import UUIDT
 
 
@@ -64,23 +64,21 @@ def populate_plugin_capabilities_on_workers(plugin_id: str):
 def create_hog_invocation_test(team_id: int, hog_function_id: str, payload: dict) -> requests.Response:
     logger.info(f"Creating hog invocation test for hog function {hog_function_id} on workers")
     return requests.post(
-        CDP_FUNCTION_EXECUTOR_API_URL + f"/api/projects/{team_id}/hog_functions/{hog_function_id}/invocations",
+        CDP_API_URL + f"/api/projects/{team_id}/hog_functions/{hog_function_id}/invocations",
         json=payload,
     )
 
 
 def get_hog_function_status(team_id: int, hog_function_id: UUIDT) -> requests.Response:
-    return requests.get(
-        CDP_FUNCTION_EXECUTOR_API_URL + f"/api/projects/{team_id}/hog_functions/{hog_function_id}/status"
-    )
+    return requests.get(CDP_API_URL + f"/api/projects/{team_id}/hog_functions/{hog_function_id}/status")
 
 
 def patch_hog_function_status(team_id: int, hog_function_id: UUIDT, state: int) -> requests.Response:
     return requests.patch(
-        CDP_FUNCTION_EXECUTOR_API_URL + f"/api/projects/{team_id}/hog_functions/{hog_function_id}/status",
+        CDP_API_URL + f"/api/projects/{team_id}/hog_functions/{hog_function_id}/status",
         json={"state": state},
     )
 
 
 def get_hog_function_templates() -> requests.Response:
-    return requests.get(CDP_FUNCTION_EXECUTOR_API_URL + f"/api/hog_function_templates")
+    return requests.get(CDP_API_URL + f"/api/hog_function_templates")

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -327,12 +327,10 @@ REDIS_READER_URL = os.getenv("REDIS_READER_URL", None)
 PLUGINS_RELOAD_REDIS_URL = os.getenv("PLUGINS_RELOAD_REDIS_URL", REDIS_URL)
 
 
-CDP_FUNCTION_EXECUTOR_API_URL = get_from_env("CDP_FUNCTION_EXECUTOR_API_URL", "")
+CDP_API_URL = get_from_env("CDP_API_URL", "")
 
-if not CDP_FUNCTION_EXECUTOR_API_URL:
-    CDP_FUNCTION_EXECUTOR_API_URL = (
-        "http://localhost:6738" if DEBUG else "http://ingestion-cdp-api.posthog.svc.cluster.local"
-    )
+if not CDP_API_URL:
+    CDP_API_URL = "http://localhost:6738" if DEBUG else "http://ingestion-cdp-api.posthog.svc.cluster.local"
 
 CACHES = {
     "default": {


### PR DESCRIPTION
## Problem

The config for loading templates from the node service is based on local env or k8s - not docker compose

## Changes

* Fixes the naming
* Adds the url to the docker compose env

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
