### PR TITLE
fix: Dagster export job + add fixedstring support

### DIFF
--- a/dags/query_log_example.yaml
+++ b/dags/query_log_example.yaml
@@ -3,7 +3,7 @@ ops:
         config:
             s3_path: query_logs
             date_range:
-                date_from: 2020-01-01
+                date_from: 2025-03-01
                 date_to: 2025-03-31
 resources:
     cluster:

--- a/posthog/warehouse/models/util.py
+++ b/posthog/warehouse/models/util.py
@@ -81,6 +81,7 @@ CLICKHOUSE_HOGQL_MAPPING = {
     "Map": StringJSONDatabaseField,
     "Bool": BooleanDatabaseField,
     "Decimal": FloatDatabaseField,
+    "FixedString": StringDatabaseField,
 }
 
 STR_TO_HOGQL_MAPPING = {


### PR DESCRIPTION
## Problem

FixedString wasn't supported by warehouse. I also realised it'd be easier to add is_initial_query to the hive partitioning as we'll be doing a lot of querying on that.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
