### PR TITLE
feat: upgrade legacy filters as we count them

### DIFF
--- a/ee/session_recordings/playlist_counters/recordings_that_match_playlist_filters.py
+++ b/ee/session_recordings/playlist_counters/recordings_that_match_playlist_filters.py
@@ -45,6 +45,12 @@ REPLAY_TEAM_PLAYLIST_COUNT_SKIPPED = Counter(
     "when a count task for a playlist is skipped because the cooldown period has not passed",
 )
 
+REPLAY_PLAYLIST_LEGACY_FILTERS_CONVERTED = Counter(
+    "replay_playlist_legacy_filters_converted",
+    "when a count task for a playlist converts legacy filters to universal filters",
+)
+
+
 REPLAY_PLAYLIST_COUNT_TIMER = Histogram(
     "replay_playlist_with_filters_count_timer_seconds",
     "Time spent loading session recordings that match filters in a playlist in seconds",
@@ -155,6 +161,7 @@ def convert_filters_to_recordings_query(playlist: SessionRecordingPlaylist) -> R
             filters = convert_legacy_filters_to_universal_filters(filters)
             playlist.filters = filters
             playlist.save(update_fields=["filters"])
+            REPLAY_PLAYLIST_LEGACY_FILTERS_CONVERTED.inc()
 
     # Extract filters from the filter group
     extracted_filters = []

--- a/ee/session_recordings/playlist_counters/recordings_that_match_playlist_filters.py
+++ b/ee/session_recordings/playlist_counters/recordings_that_match_playlist_filters.py
@@ -132,11 +132,13 @@ def convert_legacy_filters_to_universal_filters(filters: Optional[dict[str, Any]
     }
 
 
-def convert_filters_to_recordings_query(filters: dict[str, Any]) -> RecordingsQuery:
+def convert_filters_to_recordings_query(playlist: SessionRecordingPlaylist) -> RecordingsQuery:
     """
     Convert universal filters to a RecordingsQuery object.
     This is the Python equivalent of the frontend's convertUniversalFiltersToRecordingsQuery function.
     """
+
+    filters = playlist.filters
 
     # we used to send `version` and it's not part of query, so we pop to make sure
     filters.pop("version", None)
@@ -151,6 +153,8 @@ def convert_filters_to_recordings_query(filters: dict[str, Any]) -> RecordingsQu
             # then we have a legacy filter
             # because we know we don't have a query
             filters = convert_legacy_filters_to_universal_filters(filters)
+            playlist.filters = filters
+            playlist.save(update_fields=["filters"])
 
     # Extract filters from the filter group
     extracted_filters = []
@@ -256,7 +260,7 @@ def count_recordings_that_match_playlist_filters(playlist_id: int) -> None:
                     REPLAY_TEAM_PLAYLIST_COUNT_SKIPPED.inc()
                     return
 
-            query = convert_filters_to_recordings_query(playlist.filters)
+            query = convert_filters_to_recordings_query(playlist)
             (recordings, more_recordings_available, _) = list_recordings_from_query(
                 query, user=None, team=playlist.team
             )

--- a/ee/session_recordings/test/test_recordings_that_match_playlist_filters.py
+++ b/ee/session_recordings/test/test_recordings_that_match_playlist_filters.py
@@ -147,21 +147,45 @@ class TestRecordingsThatMatchPlaylistFilters(APIBaseTest):
         """
         This is a regression test, we have playlists with legacy filters that we want to make sure still work
         """
+        legacy_filters = {
+            "events": [],
+            "actions": [],
+            "date_from": "-21d",
+            "properties": [],
+            "session_recording_duration": {"key": "duration", "type": "recording", "value": 60, "operator": "gt"},
+        }
+
         playlist = SessionRecordingPlaylist.objects.create(
             team=self.team,
             name="test",
-            filters={
-                "events": [],
-                "actions": [],
-                "date_from": "-21d",
-                "properties": [],
-                "session_recording_duration": {"key": "duration", "type": "recording", "value": 60, "operator": "gt"},
-            },
+            filters=legacy_filters,
         )
         mock_list_recordings_from_query.return_value = ([], False, None)
 
         count_recordings_that_match_playlist_filters(playlist.id)
         mock_capture_exception.assert_not_called()
+
+        playlist.refresh_from_db()
+        assert playlist.filters == {
+            "date_from": "-21d",
+            "date_to": None,
+            "duration": [
+                {
+                    "key": "duration",
+                    "type": "recording",
+                    "value": 60,
+                    "operator": "gt",
+                }
+            ],
+            "filter_group": {
+                "type": FilterLogicalOperator.AND_,
+                "values": [
+                    {"type": FilterLogicalOperator.AND_, "values": []},
+                ],
+            },
+            "filter_test_accounts": False,
+            "order": RecordingOrder.START_TIME,
+        }
 
         assert mock_list_recordings_from_query.call_args[0] == (
             RecordingsQuery(


### PR DESCRIPTION
there's no point running the conversion over and over again

* save the filters when we convert them
* add a counter so we can see if it is happening