### PR TITLE
chore(admin): Allow project to be changed for envs

### DIFF
--- a/posthog/admin/admins/team_admin.py
+++ b/posthog/admin/admins/team_admin.py
@@ -33,12 +33,12 @@ class TeamAdmin(admin.ModelAdmin):
         "id",
         "uuid",
         "organization",
-        "project",
         "primary_dashboard",
         "test_account_filters",
         "created_at",
         "updated_at",
     ]
+    autocomplete_fields = ["project"]
 
     inlines = [GroupTypeMappingInline, ActionInline]
     fieldsets = [


### PR DESCRIPTION
## Problem

We need to be able to move some environments between projects, very manually, so admin only.

## Changes

Restored `project` as an autocomplete editable field of team admin.