### PR TITLE
chore: add basic token storing and retrieval

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1197,7 +1197,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "tokio",
  "tower",
@@ -1256,7 +1256,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1354,7 +1354,7 @@ dependencies = [
  "rdkafka",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "tokio",
  "tracing",
@@ -1376,7 +1376,7 @@ name = "common-symbol-data"
 version = "0.1.0"
 dependencies = [
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1593,7 +1593,7 @@ dependencies = [
  "futures",
  "serde",
  "sqlx",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "uuid",
@@ -1621,7 +1621,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "tokio",
  "tracing",
@@ -1696,7 +1696,7 @@ dependencies = [
  "sourcemap 9.0.0",
  "sqlx",
  "symbolic",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1853,6 +1853,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1863,13 +1872,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "dirs-sys-next"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.5",
  "winapi",
 ]
 
@@ -2151,7 +2172,7 @@ dependencies = [
  "sha1",
  "sqlx",
  "strum",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tower",
  "tower-http",
@@ -2260,7 +2281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
 dependencies = [
  "nonempty",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2468,7 +2489,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
- "windows-targets 0.52.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2731,7 +2752,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "tokio",
  "tracing",
@@ -2756,7 +2777,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "tokio",
  "tracing",
@@ -2784,7 +2805,7 @@ dependencies = [
  "reqwest 0.12.3",
  "serde_json",
  "sqlx",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "tokio",
  "tracing",
@@ -3353,7 +3374,7 @@ dependencies = [
  "swc_common",
  "swc_ecma_parser",
  "swc_ecma_visit",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -3440,7 +3461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.0",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3625,7 +3646,7 @@ dependencies = [
  "metrics",
  "metrics-util",
  "quanta 0.12.2",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -3742,7 +3763,7 @@ dependencies = [
  "rustc_version 0.4.1",
  "smallvec",
  "tagptr",
- "thiserror",
+ "thiserror 1.0.69",
  "triomphe",
  "uuid",
 ]
@@ -4022,7 +4043,7 @@ dependencies = [
  "js-sys",
  "once_cell",
  "pin-project-lite",
- "thiserror",
+ "thiserror 1.0.69",
  "urlencoding",
 ]
 
@@ -4040,7 +4061,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "prost",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tonic",
 ]
@@ -4080,10 +4101,16 @@ dependencies = [
  "ordered-float",
  "percent-encoding",
  "rand",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -4180,7 +4207,7 @@ dependencies = [
  "maybe-owned",
  "pdb",
  "range-collections",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4394,6 +4421,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "clap",
+ "dirs",
  "inquire",
  "serde",
  "serde_json",
@@ -4501,7 +4529,7 @@ dependencies = [
  "serde_json",
  "serve-metrics",
  "sqlx",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "tokio",
  "tracing",
@@ -4753,7 +4781,18 @@ checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
  "getrandom 0.2.12",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+dependencies = [
+ "getrandom 0.2.12",
+ "libredox",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -5593,7 +5632,7 @@ dependencies = [
  "sha2",
  "smallvec",
  "sqlformat",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -5678,7 +5717,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "uuid",
  "whoami",
@@ -5718,7 +5757,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "uuid",
  "whoami",
@@ -6029,7 +6068,7 @@ dependencies = [
  "smallvec",
  "symbolic-common",
  "symbolic-ppdb",
- "thiserror",
+ "thiserror 1.0.69",
  "wasmparser",
  "zip",
  "zstd",
@@ -6046,7 +6085,7 @@ dependencies = [
  "serde",
  "serde_json",
  "symbolic-common",
- "thiserror",
+ "thiserror 1.0.69",
  "uuid",
  "watto",
 ]
@@ -6061,7 +6100,7 @@ dependencies = [
  "js-source-scopes",
  "sourcemap 8.0.1",
  "symbolic-common",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "watto",
 ]
@@ -6191,7 +6230,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -6199,6 +6247,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6901,7 +6960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6746b5315e417144282a047ebb82260d45c92d09bf653fa9ec975e3809be942b"
 dependencies = [
  "leb128",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6973,7 +7032,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6991,7 +7050,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7011,17 +7079,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -7032,9 +7101,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -7044,9 +7113,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7056,9 +7125,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7068,9 +7143,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7080,9 +7155,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7092,9 +7167,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7104,9 +7179,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -7302,7 +7377,7 @@ dependencies = [
  "flate2",
  "indexmap 2.7.1",
  "memchr",
- "thiserror",
+ "thiserror 1.0.69",
  "zopfli",
 ]
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -399,9 +399,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1261,23 +1261,36 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.27"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1508,6 +1521,31 @@ name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -1857,6 +1895,12 @@ name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "e2e-lag-exporter"
@@ -2374,6 +2418,24 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -3166,6 +3228,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "inquire"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fddf93031af70e75410a2511ec04d49e758ed2f26dad3404a934e0fb45cc12a"
+dependencies = [
+ "bitflags 2.6.0",
+ "crossterm",
+ "dyn-clone",
+ "fuzzy-matcher",
+ "fxhash",
+ "newline-converter",
+ "once_cell",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3613,6 +3692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
@@ -3716,6 +3796,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "newline-converter"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "no-std-compat"
@@ -4302,6 +4391,15 @@ checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 [[package]]
 name = "posthog-cli"
 version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "clap",
+ "inquire",
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "posthog-rs"
@@ -5237,6 +5335,27 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -6389,9 +6508,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -6401,9 +6520,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6412,9 +6531,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -6451,9 +6570,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -6530,6 +6649,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"

--- a/rust/posthog-cli/Cargo.toml
+++ b/rust/posthog-cli/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow.workspace = true
 clap = { version = "4.5.31", features = ["derive"] }
+dirs = "6.0.0"
 inquire = "0.7.5"
 serde.workspace = true
 serde_json.workspace = true

--- a/rust/posthog-cli/Cargo.toml
+++ b/rust/posthog-cli/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Olly <oliver@posthog.com>",
     "Hugues <hugues@posthog.com>",
 ]
-description = "THE command line interface for PostHog"
+description = "The command line interface for PostHog 🦔"
 homepage = "https://posthog.com"
 license = "MIT"
 edition = "2021"
@@ -16,6 +16,13 @@ name = "posthog-cli"
 path = "src/main.rs"
 
 [dependencies]
+anyhow.workspace = true
+clap = { version = "4.5.31", features = ["derive"] }
+inquire = "0.7.5"
+serde.workspace = true
+serde_json.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [lints]
 workspace = true

--- a/rust/posthog-cli/src/commands/auth.rs
+++ b/rust/posthog-cli/src/commands/auth.rs
@@ -4,7 +4,7 @@ use tracing::info;
 
 use crate::{
     types::Token,
-    utils::{ensure_homdir_exists, posthog_home_dir},
+    utils::{ensure_homedir_exists, posthog_home_dir},
 };
 
 pub trait CredentialProvider {
@@ -29,7 +29,7 @@ impl CredentialProvider for HomeDirProvider {
 
     fn store_credentials(&self, token: Token) -> Result<(), Error> {
         let home = posthog_home_dir();
-        ensure_homdir_exists()?;
+        ensure_homedir_exists()?;
         let file = home.join("credentials.json");
         let token = serde_json::to_string(&token).context("While trying to serialize token")?;
         std::fs::write(file.clone(), token).context(format!(

--- a/rust/posthog-cli/src/commands/auth.rs
+++ b/rust/posthog-cli/src/commands/auth.rs
@@ -18,9 +18,9 @@ pub struct HomeDirProvider;
 impl CredentialProvider for HomeDirProvider {
     fn get_credentials(&self) -> Result<Token, Error> {
         let home = posthog_home_dir();
-        let file = format!("{}/credentials.json", home);
+        let file = home.join("credentials.json");
         let token = std::fs::read_to_string(file.clone()).context(format!(
-            "While trying to read credentials from file {}",
+            "While trying to read credentials from file {:?}",
             file
         ))?;
         let token = serde_json::from_str(&token).context("While trying to parse token")?;
@@ -30,17 +30,20 @@ impl CredentialProvider for HomeDirProvider {
     fn store_credentials(&self, token: Token) -> Result<(), Error> {
         let home = posthog_home_dir();
         ensure_homdir_exists()?;
-        let file = format!("{}/credentials.json", home);
+        let file = home.join("credentials.json");
         let token = serde_json::to_string(&token).context("While trying to serialize token")?;
         std::fs::write(file.clone(), token).context(format!(
-            "While trying to write credentials to file {}",
+            "While trying to write credentials to file {:?}",
             file
         ))?;
         Ok(())
     }
 
     fn report_location(&self) -> String {
-        format!("{}/credentials.json", posthog_home_dir())
+        posthog_home_dir()
+            .join("credentials.json")
+            .to_string_lossy()
+            .to_string()
     }
 }
 

--- a/rust/posthog-cli/src/commands/auth.rs
+++ b/rust/posthog-cli/src/commands/auth.rs
@@ -1,0 +1,90 @@
+use anyhow::{Context, Error};
+use inquire::{validator::Validation, CustomUserError, Text};
+use tracing::info;
+
+use crate::{
+    types::Token,
+    utils::{ensure_homdir_exists, posthog_home_dir},
+};
+
+pub trait CredentialProvider {
+    fn get_credentials(&self) -> Result<Token, Error>;
+    fn store_credentials(&self, token: Token) -> Result<(), Error>;
+    fn report_location(&self) -> String;
+}
+
+pub struct HomeDirProvider;
+
+impl CredentialProvider for HomeDirProvider {
+    fn get_credentials(&self) -> Result<Token, Error> {
+        let home = posthog_home_dir();
+        let file = format!("{}/credentials.json", home);
+        let token = std::fs::read_to_string(file.clone()).context(format!(
+            "While trying to read credentials from file {}",
+            file
+        ))?;
+        let token = serde_json::from_str(&token).context("While trying to parse token")?;
+        Ok(token)
+    }
+
+    fn store_credentials(&self, token: Token) -> Result<(), Error> {
+        let home = posthog_home_dir();
+        ensure_homdir_exists()?;
+        let file = format!("{}/credentials.json", home);
+        let token = serde_json::to_string(&token).context("While trying to serialize token")?;
+        std::fs::write(file.clone(), token).context(format!(
+            "While trying to write credentials to file {}",
+            file
+        ))?;
+        Ok(())
+    }
+
+    fn report_location(&self) -> String {
+        format!("{}/credentials.json", posthog_home_dir())
+    }
+}
+
+/// Tries to read the token from the env var `POSTHOG_CLI_TOKEN`
+pub struct EnvVarProvider;
+
+impl CredentialProvider for EnvVarProvider {
+    fn get_credentials(&self) -> Result<Token, Error> {
+        let token = std::env::var("POSTHOG_CLI_TOKEN").context("While trying to read env var")?;
+        Ok(Token { token })
+    }
+
+    fn store_credentials(&self, _token: Token) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn report_location(&self) -> String {
+        unimplemented!("We should never try to save a credential to the env");
+    }
+}
+
+fn token_validator(token: &str) -> Result<Validation, CustomUserError> {
+    if token.is_empty() {
+        return Ok(Validation::Invalid("Token cannot be empty".into()));
+    };
+
+    if !token.starts_with("phx_") {
+        return Ok(Validation::Invalid(
+            "Token looks wrong, must start with 'phx_'".into(),
+        ));
+    }
+
+    Ok(Validation::Valid)
+}
+
+pub fn login() -> Result<(), Error> {
+    let token = Text::new(
+        "Enter your personal API token (see posthog.com/docs/api#private-endpoint-authentication)",
+    )
+    .with_validator(token_validator)
+    .prompt()?;
+    let token = Token { token };
+    let provider = HomeDirProvider;
+    provider.store_credentials(token)?;
+    info!("Token saved to: {}", provider.report_location());
+    Ok(())
+}

--- a/rust/posthog-cli/src/commands/mod.rs
+++ b/rust/posthog-cli/src/commands/mod.rs
@@ -1,0 +1,35 @@
+pub mod auth;
+use clap::{Parser, Subcommand};
+
+use crate::error::CapturedError;
+
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+pub struct Cli {
+    /// The PostHog host to connect to
+    #[arg(long, default_value = "https://us.posthog.com")]
+    host: String,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Authenticate with PostHog, storing a personal API token locally
+    Login,
+}
+
+impl Cli {
+    pub fn run() -> Result<(), CapturedError> {
+        let command = Cli::parse();
+
+        match &command.command {
+            Commands::Login => {
+                auth::login()?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/rust/posthog-cli/src/error.rs
+++ b/rust/posthog-cli/src/error.rs
@@ -1,0 +1,15 @@
+use anyhow::Error;
+
+pub struct CapturedError {
+    pub inner: Error,
+    pub exception_id: Option<String>,
+}
+
+impl From<Error> for CapturedError {
+    fn from(inner: Error) -> Self {
+        Self {
+            inner,
+            exception_id: None,
+        }
+    }
+}

--- a/rust/posthog-cli/src/lib.rs
+++ b/rust/posthog-cli/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod commands;
+pub mod error;
+pub mod types;
+pub mod utils;
+
+pub mod cmd {
+    pub use super::commands::Cli;
+}

--- a/rust/posthog-cli/src/main.rs
+++ b/rust/posthog-cli/src/main.rs
@@ -11,6 +11,7 @@ fn main() {
                 None => format!("Oops! {:?}", e.inner),
             };
             error!(msg);
+            std::process::exit(1);
         }
     }
 }

--- a/rust/posthog-cli/src/main.rs
+++ b/rust/posthog-cli/src/main.rs
@@ -1,3 +1,16 @@
+use posthog_cli::cmd;
+use tracing::{error, info};
+
 fn main() {
-    println!("Hello, from posthog!");
+    tracing_subscriber::fmt::init();
+    match cmd::Cli::run() {
+        Ok(_) => info!("All done, happy hogging!"),
+        Err(e) => {
+            let msg = match e.exception_id {
+                Some(id) => format!("Oops! {} (ID: {})", e.inner, id),
+                None => format!("Oops! {:?}", e.inner),
+            };
+            error!(msg);
+        }
+    }
 }

--- a/rust/posthog-cli/src/types.rs
+++ b/rust/posthog-cli/src/types.rs
@@ -1,0 +1,6 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Token {
+    pub token: String,
+}

--- a/rust/posthog-cli/src/utils.rs
+++ b/rust/posthog-cli/src/utils.rs
@@ -1,0 +1,19 @@
+use anyhow::{Context, Error};
+
+// IF `POSTHOG_HOME` is set, use that, otherwise use $HOME/.posthog
+pub fn posthog_home_dir() -> String {
+    match std::env::var("POSTHOG_HOME") {
+        Ok(home) => home,
+        Err(_) => {
+            let home = std::env::var("HOME").expect("Could not determine home directory");
+            format!("{}/.posthog", home)
+        }
+    }
+}
+
+pub fn ensure_homdir_exists() -> Result<(), Error> {
+    let home = posthog_home_dir();
+    std::fs::create_dir_all(home.clone())
+        .context(format!("While trying to create directory {}", home))?;
+    Ok(())
+}

--- a/rust/posthog-cli/src/utils.rs
+++ b/rust/posthog-cli/src/utils.rs
@@ -16,7 +16,7 @@ pub fn posthog_home_dir() -> PathBuf {
 
 pub fn ensure_homdir_exists() -> Result<(), Error> {
     let home = posthog_home_dir();
-    std::fs::create_dir_all(home.clone())
+    std::fs::create_dir_all(&home)
         .context(format!("While trying to create directory {:?}", home))?;
     Ok(())
 }

--- a/rust/posthog-cli/src/utils.rs
+++ b/rust/posthog-cli/src/utils.rs
@@ -14,7 +14,7 @@ pub fn posthog_home_dir() -> PathBuf {
     }
 }
 
-pub fn ensure_homdir_exists() -> Result<(), Error> {
+pub fn ensure_homedir_exists() -> Result<(), Error> {
     let home = posthog_home_dir();
     std::fs::create_dir_all(&home)
         .context(format!("While trying to create directory {:?}", home))?;

--- a/rust/posthog-cli/src/utils.rs
+++ b/rust/posthog-cli/src/utils.rs
@@ -1,12 +1,15 @@
+use std::path::PathBuf;
+
 use anyhow::{Context, Error};
 
 // IF `POSTHOG_HOME` is set, use that, otherwise use $HOME/.posthog
-pub fn posthog_home_dir() -> String {
+pub fn posthog_home_dir() -> PathBuf {
     match std::env::var("POSTHOG_HOME") {
-        Ok(home) => home,
+        Ok(home) => PathBuf::from(home),
         Err(_) => {
-            let home = std::env::var("HOME").expect("Could not determine home directory");
-            format!("{}/.posthog", home)
+            let mut home = dirs::home_dir().expect("Could not find home directory");
+            home.push(".posthog");
+            home
         }
     }
 }
@@ -14,6 +17,6 @@ pub fn posthog_home_dir() -> String {
 pub fn ensure_homdir_exists() -> Result<(), Error> {
     let home = posthog_home_dir();
     std::fs::create_dir_all(home.clone())
-        .context(format!("While trying to create directory {}", home))?;
+        .context(format!("While trying to create directory {:?}", home))?;
     Ok(())
 }


### PR DESCRIPTION
```
The command line interface for PostHog 🦔

Usage: posthog-cli [OPTIONS] <COMMAND>

Commands:
  login  Authenticate with PostHog, storing a personal API token locally
  help   Print this message or the help of the given subcommand(s)

Options:
      --host <HOST>  The PostHog host to connect to [default: https://us.posthog.com]
  -h, --help         Print help
  -V, --version      Print version
```