### PR TITLE
feat(cdp): Improve & instrument property-defs-rs batch write path retries

### DIFF
--- a/rust/property-defs-rs/src/app_context.rs
+++ b/rust/property-defs-rs/src/app_context.rs
@@ -80,10 +80,6 @@ impl AppContext {
                         // If we hit a constraint violation, we just skip the update. We see
                         // this in production for group-type-indexes not being resolved, and it's
                         // not worth aborting the whole batch for.
-                        //
-                        // NOTE(eli): we are also seeing this for missing team_id against the posthog_team
-                        // table. TODO: investigate further the same teams show up in the logs a lot.
-                        // https://grafana.prod-us.posthog.dev/a/grafana-lokiexplore-app/explore/service/property-defs-rs/logs?patterns=%5B%5D&from=now-24h&to=now&var-ds=P8E80F9AEF21F6940&var-filters=job%7C%3D%7Cposthog%2Fproperty-defs-rs&var-filters=service_name%7C%3D%7Cproperty-defs-rs&var-fields=&var-levels=&var-metadata=&var-patterns=&var-lineFilterV2=&timezone=browser&var-all-fields=&urlColumns=%5B%5D&visualizationType=%22logs%22&displayedFields=%5B%5D&sortOrder=%22Descending%22&wrapLogMessage=false&var-lineFilters=caseInsensitive,0%7C__gfp__%3D%7CPgDatabaseError
                         metrics::counter!(UPDATES_SKIPPED, &[("reason", "constraint_violation")])
                             .increment(1);
                         warn!("Failed to issue update: {:?}", e);

--- a/rust/property-defs-rs/src/app_context.rs
+++ b/rust/property-defs-rs/src/app_context.rs
@@ -80,6 +80,10 @@ impl AppContext {
                         // If we hit a constraint violation, we just skip the update. We see
                         // this in production for group-type-indexes not being resolved, and it's
                         // not worth aborting the whole batch for.
+                        //
+                        // NOTE(eli): we are also seeing this for missing team_id against the posthog_team
+                        // table. TODO: investigate further the same teams show up in the logs a lot.
+                        // https://grafana.prod-us.posthog.dev/a/grafana-lokiexplore-app/explore/service/property-defs-rs/logs?patterns=%5B%5D&from=now-24h&to=now&var-ds=P8E80F9AEF21F6940&var-filters=job%7C%3D%7Cposthog%2Fproperty-defs-rs&var-filters=service_name%7C%3D%7Cproperty-defs-rs&var-fields=&var-levels=&var-metadata=&var-patterns=&var-lineFilterV2=&timezone=browser&var-all-fields=&urlColumns=%5B%5D&visualizationType=%22logs%22&displayedFields=%5B%5D&sortOrder=%22Descending%22&wrapLogMessage=false&var-lineFilters=caseInsensitive,0%7C__gfp__%3D%7CPgDatabaseError
                         metrics::counter!(UPDATES_SKIPPED, &[("reason", "constraint_violation")])
                             .increment(1);
                         warn!("Failed to issue update: {:?}", e);

--- a/rust/property-defs-rs/src/config.rs
+++ b/rust/property-defs-rs/src/config.rs
@@ -17,11 +17,13 @@ pub struct Config {
     #[envconfig(nested = true)]
     pub consumer: ConsumerConfig,
 
+    // TODO(eli): after observing retry change, consider reducing potential tx contention by 20% (to "8")
     #[envconfig(default = "10")]
     pub max_concurrent_transactions: usize,
 
     // We issue writes (UPSERTS) to postgres in batches of this size.
     // Total concurrent DB ops is max_concurrent_transactions * update_batch_size
+    // TODO(eli): after observing retry change, consider reducing "unchunked" batch size by 20% (to "800")
     #[envconfig(default = "1000")]
     pub update_batch_size: usize,
 

--- a/rust/property-defs-rs/src/metrics_consts.rs
+++ b/rust/property-defs-rs/src/metrics_consts.rs
@@ -20,6 +20,7 @@ pub const CACHE_WARMING_STATE: &str = "prop_defs_cache_state";
 pub const UPDATE_TRANSACTION_TIME: &str = "prop_defs_update_transaction_time_ms";
 pub const GROUP_TYPE_RESOLVE_TIME: &str = "prop_defs_group_type_resolve_time_ms";
 pub const UPDATES_SKIPPED: &str = "prop_defs_skipped_updates";
+pub const UPDATES_DROPPED: &str = "prop_defs_dropped_updates";
 pub const GROUP_TYPE_READS: &str = "prop_defs_group_type_reads";
 pub const SKIPPED_DUE_TO_TEAM_FILTER: &str = "prop_defs_skipped_due_to_team_filter";
 pub const ISSUE_FAILED: &str = "prop_defs_issue_failed";


### PR DESCRIPTION
## Problem
As stated above. Details in parent tracking issue. This would at least partially explain some reports of missing property definitions after successful event ingest, and I've observed the batch retries being exhausted a few 10's of times per day recently.

## Changes
* Add more typical retry delay pattern in addition to existing jitter
* Slightly increase total retry attempts
* Better instrumentation of retries vs. failures

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally + CI
