### PR TITLE
fix: Hog function api listing by type

### DIFF
--- a/posthog/api/hog_function.py
+++ b/posthog/api/hog_function.py
@@ -2,7 +2,7 @@ import json
 from typing import Optional, cast
 import structlog
 from django_filters.rest_framework import DjangoFilterBackend
-from django_filters import BaseInFilter, CharFilter, FilterSet, BooleanFilter
+from django_filters import BaseInFilter, CharFilter, FilterSet
 from django.db.models import QuerySet
 from loginas.utils import is_impersonated_session
 from django.db import transaction

--- a/posthog/api/hog_function.py
+++ b/posthog/api/hog_function.py
@@ -2,9 +2,11 @@ import json
 from typing import Optional, cast
 import structlog
 from django_filters.rest_framework import DjangoFilterBackend
+from django_filters import BaseInFilter, CharFilter, FilterSet, BooleanFilter
 from django.db.models import QuerySet
 from loginas.utils import is_impersonated_session
 from django.db import transaction
+
 
 from rest_framework import serializers, viewsets, exceptions
 from rest_framework.serializers import BaseSerializer
@@ -315,14 +317,25 @@ class HogFunctionInvocationSerializer(serializers.Serializer):
     invocation_id = serializers.CharField(required=False, allow_null=True)
 
 
+class CommaSeparatedListFilter(BaseInFilter, CharFilter):
+    pass
+
+
+class HogFunctionFilterSet(FilterSet):
+    type = CommaSeparatedListFilter(field_name="type", lookup_expr="in")
+
+    class Meta:
+        model = HogFunction
+        fields = ["type", "enabled", "id", "created_by", "created_at", "updated_at"]
+
+
 class HogFunctionViewSet(
     TeamAndOrgViewSetMixin, LogEntryMixin, AppMetricsMixin, ForbidDestroyModel, viewsets.ModelViewSet
 ):
     scope_object = "INTERNAL"  # Keep internal until we are happy to release this GA
     queryset = HogFunction.objects.all()
     filter_backends = [DjangoFilterBackend]
-    filterset_fields = ["id", "created_by", "enabled", "type"]
-
+    filterset_class = HogFunctionFilterSet
     log_source = "hog_function"
     app_source = "hog_function"
 

--- a/posthog/api/test/test_hog_function.py
+++ b/posthog/api/test/test_hog_function.py
@@ -1133,7 +1133,7 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         assert len(response.json()["results"]) == 1
         assert response.json()["results"][0]["id"] == transformation_id
 
-        response = self.client.get(f"/api/projects/{self.team.id}/hog_functions/?types=destination,transformation")
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_functions/?type=destination,transformation")
         assert len(response.json()["results"]) == 2
 
     def test_create_hog_function_with_site_app_type(self):

--- a/posthog/api/test/test_hog_function.py
+++ b/posthog/api/test/test_hog_function.py
@@ -1136,6 +1136,47 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         response = self.client.get(f"/api/projects/{self.team.id}/hog_functions/?type=destination,transformation")
         assert len(response.json()["results"]) == 2
 
+    def test_list_with_enabled_filter(self, *args):
+        response_destination = self.client.post(
+            f"/api/projects/{self.team.id}/hog_functions/",
+            data={
+                **EXAMPLE_FULL,
+                "filters": {
+                    "events": [{"id": "$pageview", "name": "$pageview", "type": "events", "order": 0}],
+                },
+            },
+        )
+
+        destination_id = response_destination.json()["id"]
+
+        response_transform = self.client.post(
+            f"/api/projects/{self.team.id}/hog_functions/",
+            data={
+                "name": "HogTransform",
+                "hog": "return event",
+                "type": "transformation",
+                "template_id": "template-geoip",
+                "enabled": False,
+            },
+        )
+
+        transformation_id = response_transform.json()["id"]
+
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_functions/")
+        assert len(response.json()["results"]) == 2
+
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_functions/?enabled=true")
+
+        assert len(response.json()["results"]) == 1
+        assert response.json()["results"][0]["id"] == destination_id
+
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_functions/?enabled=false")
+        assert len(response.json()["results"]) == 1
+        assert response.json()["results"][0]["id"] == transformation_id
+
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_functions/?enabled=true,false")
+        assert len(response.json()["results"]) == 2
+
     def test_create_hog_function_with_site_app_type(self):
         response = self.client.post(
             f"/api/projects/{self.team.id}/hog_functions/",

--- a/posthog/api/test/test_hog_function.py
+++ b/posthog/api/test/test_hog_function.py
@@ -1133,6 +1133,10 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         assert len(response.json()["results"]) == 1
         assert response.json()["results"][0]["id"] == transformation_id
 
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_functions/?type=destination,site_app")
+        assert len(response.json()["results"]) == 1
+        assert response.json()["results"][0]["id"] == destination_id
+
         response = self.client.get(f"/api/projects/{self.team.id}/hog_functions/?type=destination,transformation")
         assert len(response.json()["results"]) == 2
 


### PR DESCRIPTION
## Problem

A bug in the tests was testing the wrong thing making it looked like it worked

## Changes

* Fixed by setting up our own filterset and modifying the types one to use "in" as its checker

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
