### PR TITLE
chore: keep track of all queries run through /query

### DIFF
--- a/posthog/api/services/query.py
+++ b/posthog/api/services/query.py
@@ -83,7 +83,6 @@ def process_query_model(
 
     try:
         query_runner = get_query_runner(query, team, limit_context=limit_context)
-        query_runner.is_query_service = True
     except ValueError:  # This query doesn't run via query runner
         if hasattr(query, "source") and isinstance(query.source, BaseModel):
             result = process_query_model(
@@ -133,6 +132,7 @@ def process_query_model(
             query_runner.apply_dashboard_filters(dashboard_filters)
         if variables_override:
             query_runner.apply_variable_overrides(variables_override)
+        query_runner.is_query_service = True
         result = query_runner.run(
             execution_mode=execution_mode,
             user=user,

--- a/posthog/api/services/query.py
+++ b/posthog/api/services/query.py
@@ -83,6 +83,7 @@ def process_query_model(
 
     try:
         query_runner = get_query_runner(query, team, limit_context=limit_context)
+        query_runner.is_query_service = True
     except ValueError:  # This query doesn't run via query runner
         if hasattr(query, "source") and isinstance(query.source, BaseModel):
             result = process_query_model(

--- a/posthog/clickhouse/client/limit.py
+++ b/posthog/clickhouse/client/limit.py
@@ -13,7 +13,7 @@ from posthog.settings import TEST
 from posthog.utils import generate_short_id
 
 RUNNING_CLICKHOUSE_QUERIES = Gauge(
-    "posthog_clickhouse_running_queries",
+    "posthog_clickhouse_query_concurrent_per_team",
     "Number of concurrent queries",
     ["team_id", "access_method"],
 )

--- a/posthog/hogql_queries/hogql_query_runner.py
+++ b/posthog/hogql_queries/hogql_query_runner.py
@@ -1,6 +1,8 @@
 from typing import Optional, cast
 from collections.abc import Callable
 
+from posthog.clickhouse.client.limit import get_api_personal_rate_limiter
+from posthog.clickhouse.query_tagging import get_query_tag_value
 from posthog.hogql import ast
 from posthog.hogql.filters import replace_filters
 from posthog.hogql.parser import parse_select
@@ -57,16 +59,19 @@ class HogQLQueryRunner(QueryRunner):
             Callable[..., HogQLQueryResponse],
             execute_hogql_query if paginator is None else paginator.execute_hogql_query,
         )
-        response = func(
-            query_type="HogQLQuery",
-            query=query,
-            filters=self.query.filters,
-            modifiers=self.query.modifiers or self.modifiers,
-            team=self.team,
-            timings=self.timings,
-            variables=self.query.variables,
-            limit_context=self.limit_context,
-        )
+
+        is_api = get_query_tag_value("access_method") == "personal_api_key"
+        with get_api_personal_rate_limiter().run(is_api=is_api, team_id=self.team.pk, task_id=self.query_id):
+            response = func(
+                query_type="HogQLQuery",
+                query=query,
+                filters=self.query.filters,
+                modifiers=self.query.modifiers or self.modifiers,
+                team=self.team,
+                timings=self.timings,
+                variables=self.query.variables,
+                limit_context=self.limit_context,
+            )
         if paginator:
             response = response.model_copy(update={**paginator.response_params(), "results": paginator.results})
         return response

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -9,6 +9,7 @@ from prometheus_client import Counter
 from pydantic import BaseModel, ConfigDict
 from sentry_sdk import get_traceparent, push_scope, set_tag
 
+from posthog.clickhouse.client.limit import get_api_personal_rate_limiter
 from posthog.exceptions_capture import capture_exception
 from posthog.caching.utils import ThresholdMode, cache_target_age, is_stale, last_refresh_from_cached_result
 from posthog.clickhouse.client.execute_async import QueryNotFoundError, enqueue_process_query_task, get_query_status
@@ -517,6 +518,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
     timings: HogQLTimings
     modifiers: HogQLQueryModifiers
     limit_context: LimitContext
+    is_query_service: bool = False
 
     def __init__(
         self,
@@ -591,6 +593,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             query_json=self.query.model_dump(),
             query_id=self.query_id or cache_manager.cache_key,  # Use cache key as query ID to avoid duplicates
             refresh_requested=refresh_requested,
+            api_query_personal_key=self.query_endpoint_with_personal_key(),
         )
 
     def get_async_query_status(self, *, cache_key: str) -> Optional[QueryStatus]:
@@ -681,6 +684,9 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         # Nothing useful out of cache, nor async query status
         return None
 
+    def query_endpoint_with_personal_key(self):
+        return self.is_query_service and get_query_tag_value("access_method") == "personal_api_key"
+
     def run(
         self,
         execution_mode: ExecutionMode = ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
@@ -735,15 +741,18 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             self.modifiers = create_default_modifiers_for_user(user, self.team, self.modifiers)
             self.modifiers.useMaterializedViews = True
 
-        fresh_response_dict = {
-            **self.calculate().model_dump(),
-            "is_cached": False,
-            "last_refresh": last_refresh,
-            "next_allowed_client_refresh": last_refresh + self._refresh_frequency(),
-            "cache_key": cache_key,
-            "timezone": self.team.timezone,
-            "cache_target_age": target_age,
-        }
+        with get_api_personal_rate_limiter().run(
+            is_api=self.query_endpoint_with_personal_key(), team_id=self.team.pk, task_id=self.query_id
+        ):
+            fresh_response_dict = {
+                **self.calculate().model_dump(),
+                "is_cached": False,
+                "last_refresh": last_refresh,
+                "next_allowed_client_refresh": last_refresh + self._refresh_frequency(),
+                "cache_key": cache_key,
+                "timezone": self.team.timezone,
+                "cache_target_age": target_age,
+            }
         if get_query_tag_value("trigger"):
             fresh_response_dict["calculation_trigger"] = get_query_tag_value("trigger")
         fresh_response = CachedResponse(**fresh_response_dict)

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -65,14 +65,14 @@ def process_query_task(
     user_id: Optional[int],
     query_id: str,
     query_json: dict,
-    is_api: bool,
+    api_query_personal_key: bool,
     limit_context: Optional[LimitContext] = None,
 ) -> None:
     """
     Kick off query
     Once complete save results to redis
     """
-    with get_api_personal_rate_limiter().run(is_api=is_api, team_id=team_id, task_id=query_id):
+    with get_api_personal_rate_limiter().run(is_api=api_query_personal_key, team_id=team_id, task_id=query_id):
         from posthog.clickhouse.client import execute_process_query
 
         execute_process_query(


### PR DESCRIPTION
## Problem

Understand query limits better. 

Two conditions for query limit to apply:

 * request made through `/api/environments/{team_id}/query`
 * must use auth method: `personal_api_key`

## Changes

* Decrease a limit (with bypass enable for all teams),
* pass info from service into runner if it was fetched from query endpoint, this is alter used for both sync and async queries,
* Add limit for running queries only through `/query` endpoint with personal_api_key (but with bypass enabled),

## Does this work well for both Cloud and self-hosted?

yes.

## How did you test this code?

tested.
