### PR TITLE
fix: change type for snapshot_source

### DIFF
--- a/posthog/clickhouse/migrations/0104_session_replay_events_v2_test_alter_snapshot_source.py
+++ b/posthog/clickhouse/migrations/0104_session_replay_events_v2_test_alter_snapshot_source.py
@@ -1,17 +1,8 @@
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
-from posthog.session_recordings.sql.session_replay_event_v2_test_sql import (
-    SESSION_REPLAY_EVENTS_V2_TEST_DATA_TABLE,
-)
-
-ALTER_SNAPSHOT_SOURCE_SQL = (
-    lambda: """
-ALTER TABLE {table_name}
-    MODIFY COLUMN `snapshot_source` AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))
-""".format(
-        table_name=SESSION_REPLAY_EVENTS_V2_TEST_DATA_TABLE,
-    )
+from posthog.session_recordings.sql.session_replay_event_v2_test_migrations_sql import (
+    REMOVE_SNAPSHOT_SOURCE_LOW_CARDINALITY_SQL,
 )
 
 operations = [
-    run_sql_with_exceptions(ALTER_SNAPSHOT_SOURCE_SQL(), sharded=True),
+    run_sql_with_exceptions(REMOVE_SNAPSHOT_SOURCE_LOW_CARDINALITY_SQL(on_cluster=True)),
 ]

--- a/posthog/clickhouse/migrations/0104_session_replay_events_v2_test_alter_snapshot_source.py
+++ b/posthog/clickhouse/migrations/0104_session_replay_events_v2_test_alter_snapshot_source.py
@@ -1,0 +1,13 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.session_recordings.sql.session_replay_event_v2_test_sql import (
+    SESSION_REPLAY_EVENTS_V2_TEST_DATA_TABLE,
+)
+
+ALTER_SNAPSHOT_SOURCE_SQL = f"""
+ALTER TABLE {SESSION_REPLAY_EVENTS_V2_TEST_DATA_TABLE}
+    MODIFY COLUMN `snapshot_source` AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))
+"""
+
+operations = [
+    run_sql_with_exceptions(ALTER_SNAPSHOT_SOURCE_SQL(), sharded=True),
+]

--- a/posthog/clickhouse/migrations/0104_session_replay_events_v2_test_alter_snapshot_source.py
+++ b/posthog/clickhouse/migrations/0104_session_replay_events_v2_test_alter_snapshot_source.py
@@ -3,10 +3,14 @@ from posthog.session_recordings.sql.session_replay_event_v2_test_sql import (
     SESSION_REPLAY_EVENTS_V2_TEST_DATA_TABLE,
 )
 
-ALTER_SNAPSHOT_SOURCE_SQL = f"""
-ALTER TABLE {SESSION_REPLAY_EVENTS_V2_TEST_DATA_TABLE}
+ALTER_SNAPSHOT_SOURCE_SQL = (
+    lambda: """
+ALTER TABLE {table_name}
     MODIFY COLUMN `snapshot_source` AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))
-"""
+""".format(
+        table_name=SESSION_REPLAY_EVENTS_V2_TEST_DATA_TABLE,
+    )
+)
 
 operations = [
     run_sql_with_exceptions(ALTER_SNAPSHOT_SOURCE_SQL(), sharded=True),

--- a/posthog/session_recordings/sql/session_replay_event_v2_test_migrations_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_v2_test_migrations_sql.py
@@ -35,6 +35,12 @@ DROP_KAFKA_SESSION_REPLAY_EVENTS_V2_TEST_SQL_TEMPLATE = """
     DROP TABLE IF EXISTS kafka_session_replay_events_v2_test {on_cluster_clause}
 """
 
+# Remove the low cardinality constraint from the snapshot_source column
+REMOVE_SNAPSHOT_SOURCE_LOW_CARDINALITY_SQL_TEMPLATE = """
+    ALTER TABLE {table_name} {on_cluster_clause}
+        MODIFY COLUMN `snapshot_source` AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))
+"""
+
 
 def ADD_MISSING_COLUMNS_DISTRIBUTED_SESSION_REPLAY_EVENTS_V2_TEST_TABLE_SQL(on_cluster=True):
     return ALTER_SESSION_REPLAY_V2_TEST_ADD_MISSING_COLUMNS.format(
@@ -65,5 +71,12 @@ def DROP_SESSION_REPLAY_EVENTS_V2_TEST_MV_TABLE_SQL(on_cluster=True):
 
 def DROP_KAFKA_SESSION_REPLAY_EVENTS_V2_TEST_TABLE_SQL(on_cluster=True):
     return DROP_KAFKA_SESSION_REPLAY_EVENTS_V2_TEST_SQL_TEMPLATE.format(
+        on_cluster_clause=ON_CLUSTER_CLAUSE(on_cluster),
+    )
+
+
+def REMOVE_SNAPSHOT_SOURCE_LOW_CARDINALITY_SQL(on_cluster=True):
+    return REMOVE_SNAPSHOT_SOURCE_LOW_CARDINALITY_SQL_TEMPLATE.format(
+        table_name=SESSION_REPLAY_EVENTS_V2_TEST_DATA_TABLE,
         on_cluster_clause=ON_CLUSTER_CLAUSE(on_cluster),
     )


### PR DESCRIPTION
## Problem

It seems that ClickHouse is not able to store data properly in the `snapshot_source` column when using a LowCardinality type inside an `argMax` function.

The replication queue is stuck for this table, and is increasing load in ZooKeeper.

## Changes

Use AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')) instead, as it's done in the `sharded_session_replay_events` table.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes.
