### PR TITLE
chore: count errors by type

### DIFF
--- a/ee/session_recordings/playlist_counters/recordings_that_match_playlist_filters.py
+++ b/ee/session_recordings/playlist_counters/recordings_that_match_playlist_filters.py
@@ -294,6 +294,7 @@ def count_recordings_that_match_playlist_filters(playlist_id: int) -> None:
         )
         REPLAY_TEAM_PLAYLIST_COUNT_UNKNOWN.inc()
     except Exception as e:
+        query_json: dict[str, Any]
         try:
             query_json = query.model_dump_json() if query else None
         except Exception:

--- a/ee/session_recordings/playlist_counters/recordings_that_match_playlist_filters.py
+++ b/ee/session_recordings/playlist_counters/recordings_that_match_playlist_filters.py
@@ -294,6 +294,11 @@ def count_recordings_that_match_playlist_filters(playlist_id: int) -> None:
         )
         REPLAY_TEAM_PLAYLIST_COUNT_UNKNOWN.inc()
     except Exception as e:
+        try:
+            query_json = query.model_dump_json() if query else None
+        except Exception:
+            query_json = {"malformed": True}
+
         posthoganalytics.capture_exception(
             e,
             properties={
@@ -301,7 +306,7 @@ def count_recordings_that_match_playlist_filters(playlist_id: int) -> None:
                 "playlist_short_id": playlist.short_id if playlist else None,
                 "posthog_feature": "session_replay_playlist_counters",
                 "filters": playlist.filters if playlist else None,
-                "query": query.model_dump_json() if query else None,
+                "query": query_json,
             },
         )
         logger.exception(
@@ -309,7 +314,7 @@ def count_recordings_that_match_playlist_filters(playlist_id: int) -> None:
             playlist_id=playlist_id,
             playlist_short_id=playlist.short_id if playlist else None,
             filters=playlist.filters if playlist else None,
-            query=query.model_dump_json() if query else None,
+            query=query_json,
             error=e,
         )
         REPLAY_TEAM_PLAYLIST_COUNT_FAILED.labels(error=e.__class__.__name__).inc()

--- a/ee/session_recordings/playlist_counters/recordings_that_match_playlist_filters.py
+++ b/ee/session_recordings/playlist_counters/recordings_that_match_playlist_filters.py
@@ -33,6 +33,7 @@ REPLAY_TEAM_PLAYLIST_COUNT_SUCCEEDED = Counter(
 REPLAY_TEAM_PLAYLIST_COUNT_FAILED = Counter(
     "replay_playlist_count_failed",
     "when a count task for a playlist fails",
+    labelnames=["error"],
 )
 
 REPLAY_TEAM_PLAYLIST_COUNT_UNKNOWN = Counter(
@@ -300,7 +301,7 @@ def count_recordings_that_match_playlist_filters(playlist_id: int) -> None:
                 "playlist_short_id": playlist.short_id if playlist else None,
                 "posthog_feature": "session_replay_playlist_counters",
                 "filters": playlist.filters if playlist else None,
-                "query": query,
+                "query": query.model_dump_json() if query else None,
             },
         )
         logger.exception(
@@ -308,10 +309,10 @@ def count_recordings_that_match_playlist_filters(playlist_id: int) -> None:
             playlist_id=playlist_id,
             playlist_short_id=playlist.short_id if playlist else None,
             filters=playlist.filters if playlist else None,
-            query=query,
+            query=query.model_dump_json() if query else None,
             error=e,
         )
-        REPLAY_TEAM_PLAYLIST_COUNT_FAILED.inc()
+        REPLAY_TEAM_PLAYLIST_COUNT_FAILED.labels(error=e.__class__.__name__).inc()
 
 
 def enqueue_recordings_that_match_playlist_filters() -> None:

--- a/ee/session_recordings/playlist_counters/recordings_that_match_playlist_filters.py
+++ b/ee/session_recordings/playlist_counters/recordings_that_match_playlist_filters.py
@@ -294,9 +294,9 @@ def count_recordings_that_match_playlist_filters(playlist_id: int) -> None:
         )
         REPLAY_TEAM_PLAYLIST_COUNT_UNKNOWN.inc()
     except Exception as e:
-        query_json: dict[str, Any]
+        query_json: dict[str, Any] | None = None
         try:
-            query_json = query.model_dump_json() if query else None
+            query_json = query.model_dump() if query else None
         except Exception:
             query_json = {"malformed": True}
 

--- a/ee/session_recordings/test/test_recordings_that_match_playlist_filters.py
+++ b/ee/session_recordings/test/test_recordings_that_match_playlist_filters.py
@@ -3,6 +3,7 @@ import json
 from unittest import mock
 from unittest.mock import MagicMock, patch
 from ee.session_recordings.playlist_counters.recordings_that_match_playlist_filters import (
+    DEFAULT_RECORDING_FILTERS,
     count_recordings_that_match_playlist_filters,
 )
 from posthog.redis import get_client
@@ -213,3 +214,15 @@ class TestRecordingsThatMatchPlaylistFilters(APIBaseTest):
                 user_modified_filters=None,
             ),
         )
+
+    @patch("posthoganalytics.capture_exception")
+    @patch("ee.session_recordings.playlist_counters.recordings_that_match_playlist_filters.list_recordings_from_query")
+    def test_skips_default_filters(self, mock_list_recordings_from_query: MagicMock, mock_capture_exception: MagicMock):
+        playlist = SessionRecordingPlaylist.objects.create(
+            team=self.team,
+            name="test",
+            filters=DEFAULT_RECORDING_FILTERS,
+        )
+        count_recordings_that_match_playlist_filters(playlist.id)
+        mock_capture_exception.assert_not_called()
+        mock_list_recordings_from_query.assert_not_called()


### PR DESCRIPTION
When I see some counts have failed I have to go spelunking in logs to see why

Let's split the count by exception class name to make life a little easier