### PR TITLE
feat(cdp): create plugin if hogfunction creation fails

### DIFF
--- a/posthog/api/test/test_plugin.py
+++ b/posthog/api/test/test_plugin.py
@@ -1664,11 +1664,11 @@ class TestPluginAPI(APIBaseTest, QueryMatchingTest):
 
                 # Verify plugin config was created despite hog function failure
                 assert PluginConfig.objects.count() == 1
-                plugin_config = PluginConfig.objects.first()
-                assert plugin_config.plugin_id == mock_plugin.id
-                assert plugin_config.enabled is True
-                assert plugin_config.order == 0
-                assert plugin_config.config == {"test": "value"}
+                plugin_config = PluginConfig.objects.get(plugin_id=mock_plugin.id)
+                self.assertEqual(plugin_config.plugin_id, mock_plugin.id)
+                self.assertEqual(plugin_config.enabled, True)
+                self.assertEqual(plugin_config.order, 0)
+                self.assertEqual(plugin_config.config, {"test": "value"})
 
                 # Verify no hog function was created
                 assert HogFunction.objects.count() == 0

--- a/posthog/api/test/test_plugin.py
+++ b/posthog/api/test/test_plugin.py
@@ -1635,6 +1635,44 @@ class TestPluginAPI(APIBaseTest, QueryMatchingTest):
                 },
             }
 
+    def test_create_plugin_config_when_hog_function_fails(self, mock_get, mock_reload):
+        mock_plugin = Plugin.objects.create(
+            organization=self.organization,
+            plugin_type="local",
+            name="Test Plugin",
+            description="Test plugin that should create plugin config even if hog function fails",
+            url="https://github.com/PostHog/test-plugin",
+        )
+
+        with self.settings(CREATE_HOG_FUNCTION_FROM_PLUGIN_CONFIG=True):
+            # Mock the hog_function_from_plugin_config to raise an exception
+            with patch("posthog.cdp.legacy_plugins.hog_function_from_plugin_config") as mock_hog_function:
+                mock_hog_function.side_effect = Exception("Failed to create hog function")
+
+                response = self.client.post(
+                    "/api/plugin_config/",
+                    {
+                        "plugin": mock_plugin.id,
+                        "enabled": True,
+                        "order": 0,
+                        "config": json.dumps({"test": "value"}),
+                    },
+                    format="multipart",
+                )
+
+                assert response.status_code == 201, response.json()
+
+                # Verify plugin config was created despite hog function failure
+                assert PluginConfig.objects.count() == 1
+                plugin_config = PluginConfig.objects.first()
+                assert plugin_config.plugin_id == mock_plugin.id
+                assert plugin_config.enabled is True
+                assert plugin_config.order == 0
+                assert plugin_config.config == {"test": "value"}
+
+                # Verify no hog function was created
+                assert HogFunction.objects.count() == 0
+
     @patch("posthog.api.plugin.validate_plugin_job_payload")
     @patch("posthog.api.plugin.connections")
     def test_job_trigger(self, db_connections, mock_validate_plugin_job_payload, mock_get, mock_reload):


### PR DESCRIPTION
## Problem

Currently we see that legacy site apps creation is being broken because we polyfilled the old legacy plugins api to create hogFunctions instead. As site-apps are not yet ready to be migrated this fails and breaks this functionality.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- if hogFunction creation fails we create the plugin instead

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- added test
- locally

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
