### PR TITLE
fix(devex): attempt to fix cert issue with building tailwind

### DIFF
--- a/common/tailwind/package.json
+++ b/common/tailwind/package.json
@@ -1,8 +1,8 @@
 {
     "name": "@posthog/tailwind",
     "scripts": {
-        "build": "pnpm dlx @tailwindcss/cli -i ./tailwind.css -o ./dist/tailwind.css",
-        "start": "pnpm dlx @tailwindcss/cli -i ./tailwind.css -o ./dist/tailwind.css --watch"
+        "build": "npx @tailwindcss/cli -i ./tailwind.css -o ./dist/tailwind.css",
+        "start": "npx @tailwindcss/cli -i ./tailwind.css -o ./dist/tailwind.css --watch"
     },
     "dependencies": {
         "tailwindcss": "4.0.7",


### PR DESCRIPTION
## Problem
People are experiencing:

```@PostHog/tailwind:build:  WARN  GET https://registry.npmjs.org/@tailwindcss%2Fcli error (UNABLE_TO_GET_ISSUER_CERT_LOCALLY). Will retry in 10 seconds. 2 retries left```

## Changes
Change from `pnpm dlx @tailwindcss/cli` to `npx @tailwindcss/cli`

## Does this work well for both Cloud and self-hosted?
Yes?

## How did you test this code?
Cleared all node_modules, clean install