### PR TITLE
fix: handle cases when just a part of index was used

### DIFF
--- a/posthog/clickhouse/test/__snapshots__/test_explain.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_explain.ambr
@@ -1,0 +1,575 @@
+# serializer version: 1
+# name: test_full_queries[a proper query with all filters on events]
+  '''
+  [
+    {
+      "Plan": {
+        "Node Type": "Union",
+        "Plans": [
+          {
+            "Node Type": "Expression",
+            "Description": "(Projection + Before ORDER BY)",
+            "Plans": [
+              {
+                "Node Type": "Expression",
+                "Plans": [
+                  {
+                    "Node Type": "ReadFromMergeTree",
+                    "Description": "posthog.sharded_events",
+                    "Indexes": [
+                      {
+                        "Type": "MinMax",
+                        "Keys": [
+                          "timestamp"
+                        ],
+                        "Condition": "(timestamp in ('1735828351', +Inf))",
+                        "Initial Parts": 2799,
+                        "Selected Parts": 222,
+                        "Initial Granules": 173418552,
+                        "Selected Granules": 26462626
+                      },
+                      {
+                        "Type": "Partition",
+                        "Keys": [
+                          "toYYYYMM(timestamp)"
+                        ],
+                        "Condition": "(toYYYYMM(timestamp) in [202501, +Inf))",
+                        "Initial Parts": 222,
+                        "Selected Parts": 222,
+                        "Initial Granules": 26462626,
+                        "Selected Granules": 26462626
+                      },
+                      {
+                        "Type": "PrimaryKey",
+                        "Keys": [
+                          "team_id",
+                          "toDate(timestamp)",
+                          "event"
+                        ],
+                        "Condition": "and((toDate(timestamp) in [20090, +Inf)), and((event in ['$pageview', '$pageview']), (team_id in [2, 2])))",
+                        "Initial Parts": 222,
+                        "Selected Parts": 181,
+                        "Initial Granules": 26462626,
+                        "Selected Granules": 35950
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "Node Type": "ReadFromRemote",
+            "Description": "Read from remote replica"
+          }
+        ]
+      }
+    }
+  ]
+  
+  '''
+# ---
+# name: test_full_queries[a proper query with all filters on events].1
+  1
+# ---
+# name: test_full_queries[a proper query with all filters on events].2
+  list([
+    ReadIndexUsage(table='posthog.sharded_events', use=<QueryIndexUsage.YES: 'yes'>),
+  ])
+# ---
+# name: test_full_queries[a proper query with all filters on events].3
+  <QueryIndexUsage.YES: 'yes'>
+# ---
+# name: test_full_queries[local query little granules, using index]
+  '''
+  
+  [
+    {
+      "Plan": {
+        "Node Type": "Expression",
+        "Description": "(Project names + Projection)",
+        "Plans": [
+          {
+            "Node Type": "Limit",
+            "Description": "preliminary LIMIT (without OFFSET)",
+            "Plans": [
+              {
+                "Node Type": "Expression",
+                "Plans": [
+                  {
+                    "Node Type": "ReadFromMergeTree",
+                    "Description": "default.sharded_events",
+                    "Indexes": [
+                      {
+                        "Type": "MinMax",
+                        "Keys": ["timestamp"],
+                        "Condition": "(toTimezone(timestamp, 'UTC') in ('1735831217', +Inf))",
+                        "Initial Parts": 11,
+                        "Selected Parts": 6,
+                        "Initial Granules": 38,
+                        "Selected Granules": 32
+                      },
+                      {
+                        "Type": "Partition",
+                        "Condition": "true",
+                        "Initial Parts": 6,
+                        "Selected Parts": 6,
+                        "Initial Granules": 32,
+                        "Selected Granules": 32
+                      },
+                      {
+                        "Type": "PrimaryKey",
+                        "Keys": ["team_id"],
+                        "Condition": "(team_id in [1, 1])",
+                        "Initial Parts": 6,
+                        "Selected Parts": 5,
+                        "Initial Granules": 32,
+                        "Selected Granules": 27
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+  
+  '''
+# ---
+# name: test_full_queries[local query little granules, using index].1
+  1
+# ---
+# name: test_full_queries[local query little granules, using index].2
+  list([
+    ReadIndexUsage(table='default.sharded_events', use=<QueryIndexUsage.YES: 'yes'>),
+  ])
+# ---
+# name: test_full_queries[local query little granules, using index].3
+  <QueryIndexUsage.YES: 'yes'>
+# ---
+# name: test_full_queries[local query little granules]
+  '''
+  
+  [
+    {
+      "Plan": {
+        "Node Type": "Expression",
+        "Description": "(Project names + Projection)",
+        "Plans": [
+          {
+            "Node Type": "Limit",
+            "Description": "preliminary LIMIT (without OFFSET)",
+            "Plans": [
+              {
+                "Node Type": "Expression",
+                "Plans": [
+                  {
+                    "Node Type": "ReadFromMergeTree",
+                    "Description": "default.sharded_events",
+                    "Indexes": [
+                      {
+                        "Type": "MinMax",
+                        "Condition": "true",
+                        "Initial Parts": 12,
+                        "Selected Parts": 12,
+                        "Initial Granules": 39,
+                        "Selected Granules": 39
+                      },
+                      {
+                        "Type": "Partition",
+                        "Condition": "true",
+                        "Initial Parts": 12,
+                        "Selected Parts": 12,
+                        "Initial Granules": 39,
+                        "Selected Granules": 39
+                      },
+                      {
+                        "Type": "PrimaryKey",
+                        "Keys": ["team_id"],
+                        "Condition": "(team_id in [1, 1])",
+                        "Initial Parts": 12,
+                        "Selected Parts": 9,
+                        "Initial Granules": 39,
+                        "Selected Granules": 32
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+  
+  '''
+# ---
+# name: test_full_queries[local query little granules].1
+  1
+# ---
+# name: test_full_queries[local query little granules].2
+  list([
+    ReadIndexUsage(table='default.sharded_events', use=<QueryIndexUsage.NO: 'no'>),
+  ])
+# ---
+# name: test_full_queries[local query little granules].3
+  <QueryIndexUsage.NO: 'no'>
+# ---
+# name: test_full_queries[missing timestamp condition]
+  '''
+  
+  [
+    {
+      "Plan": {
+        "Node Type": "Union",
+        "Plans": [
+          {
+            "Node Type": "Expression",
+            "Description": "(Projection + Before ORDER BY)",
+            "Plans": [
+              {
+                "Node Type": "Expression",
+                "Plans": [
+                  {
+                    "Node Type": "ReadFromMergeTree",
+                    "Description": "posthog.sharded_events",
+                    "Indexes": [
+                      {
+                        "Type": "MinMax",
+                        "Condition": "true",
+                        "Initial Parts": 2972,
+                        "Selected Parts": 2972,
+                        "Initial Granules": 171921031,
+                        "Selected Granules": 171921031
+                      },
+                      {
+                        "Type": "Partition",
+                        "Condition": "true",
+                        "Initial Parts": 2972,
+                        "Selected Parts": 2972,
+                        "Initial Granules": 171921031,
+                        "Selected Granules": 171921031
+                      },
+                      {
+                        "Type": "PrimaryKey",
+                        "Keys": [
+                          "team_id",
+                          "event"
+                        ],
+                        "Condition": "and((event in ['$pageview', '$pageview']), (team_id in [2, 2]))",
+                        "Initial Parts": 2972,
+                        "Selected Parts": 1002,
+                        "Initial Granules": 171921031,
+                        "Selected Granules": 245218
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "Node Type": "ReadFromRemote",
+            "Description": "Read from remote replica"
+          }
+        ]
+      }
+    }
+  ]
+  
+  '''
+# ---
+# name: test_full_queries[missing timestamp condition].1
+  1
+# ---
+# name: test_full_queries[missing timestamp condition].2
+  list([
+    ReadIndexUsage(table='posthog.sharded_events', use=<QueryIndexUsage.NO: 'no'>),
+  ])
+# ---
+# name: test_full_queries[missing timestamp condition].3
+  <QueryIndexUsage.NO: 'no'>
+# ---
+# name: test_full_queries[production query often failing cause ClickHouse not using index]
+  '''
+  
+  [
+    {
+      "Plan": {
+        "Node Type": "Expression",
+        "Description": "Projection",
+        "Plans": [
+          {
+            "Node Type": "Limit",
+            "Description": "preliminary LIMIT (without OFFSET)",
+            "Plans": [
+              {
+                "Node Type": "Sorting",
+                "Description": "Sorting for ORDER BY",
+                "Plans": [
+                  {
+                    "Node Type": "Expression",
+                    "Description": "Before ORDER BY",
+                    "Plans": [
+                      {
+                        "Node Type": "Aggregating",
+                        "Plans": [
+                          {
+                            "Node Type": "Expression",
+                            "Description": "(Before GROUP BY + (Projection + Before ORDER BY))",
+                            "Plans": [
+                              {
+                                "Node Type": "MergingAggregated",
+                                "Plans": [
+                                  {
+                                    "Node Type": "Union",
+                                    "Plans": [
+                                      {
+                                        "Node Type": "Aggregating",
+                                        "Plans": [
+                                          {
+                                            "Node Type": "Expression",
+                                            "Description": "(Before GROUP BY + )",
+                                            "Plans": [
+                                              {
+                                                "Node Type": "Join",
+                                                "Description": "JOIN FillRightFirst",
+                                                "Plans": [
+                                                  {
+                                                    "Node Type": "Expression",
+                                                    "Plans": [
+                                                      {
+                                                        "Node Type": "ReadFromMergeTree",
+                                                        "Description": "posthog.sharded_events",
+                                                        "Indexes": [
+                                                          {
+                                                            "Type": "MinMax",
+                                                            "Condition": "true",
+                                                            "Initial Parts": 2759,
+                                                            "Selected Parts": 2759,
+                                                            "Initial Granules": 173438060,
+                                                            "Selected Granules": 173438060
+                                                          },
+                                                          {
+                                                            "Type": "Partition",
+                                                            "Condition": "true",
+                                                            "Initial Parts": 2759,
+                                                            "Selected Parts": 2759,
+                                                            "Initial Granules": 173438060,
+                                                            "Selected Granules": 173438060
+                                                          },
+                                                          {
+                                                            "Type": "PrimaryKey",
+                                                            "Keys": [
+                                                              "team_id"
+                                                            ],
+                                                            "Condition": "(team_id in [16617, 16617])",
+                                                            "Initial Parts": 2759,
+                                                            "Selected Parts": 1699,
+                                                            "Initial Granules": 173438060,
+                                                            "Selected Granules": 1877152
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "Node Type": "Expression",
+                                                    "Description": "(Joined actions + (Rename joined columns + (Projection + Before ORDER BY)))",
+                                                    "Plans": [
+                                                      {
+                                                        "Node Type": "Filter",
+                                                        "Description": "HAVING",
+                                                        "Plans": [
+                                                          {
+                                                            "Node Type": "Aggregating",
+                                                            "Plans": [
+                                                              {
+                                                                "Node Type": "Expression",
+                                                                "Description": "Before GROUP BY",
+                                                                "Plans": [
+                                                                  {
+                                                                    "Node Type": "Expression",
+                                                                    "Plans": [
+                                                                      {
+                                                                        "Node Type": "ReadFromMergeTree",
+                                                                        "Description": "posthog.person_distinct_id_overrides",
+                                                                        "Indexes": [
+                                                                          {
+                                                                            "Type": "PrimaryKey",
+                                                                            "Keys": [
+                                                                              "team_id"
+                                                                            ],
+                                                                            "Condition": "(team_id in [16617, 16617])",
+                                                                            "Initial Parts": 18,
+                                                                            "Selected Parts": 18,
+                                                                            "Initial Granules": 155239,
+                                                                            "Selected Granules": 18
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "Node Type": "ReadFromRemote",
+                                        "Description": "Read from remote replica"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+  
+  '''
+# ---
+# name: test_full_queries[production query often failing cause ClickHouse not using index].1
+  2
+# ---
+# name: test_full_queries[production query often failing cause ClickHouse not using index].2
+  list([
+    ReadIndexUsage(table='posthog.sharded_events', use=<QueryIndexUsage.NO: 'no'>),
+    ReadIndexUsage(table='posthog.person_distinct_id_overrides', use=<QueryIndexUsage.YES: 'yes'>),
+  ])
+# ---
+# name: test_full_queries[production query often failing cause ClickHouse not using index].3
+  <QueryIndexUsage.PARTIAL: 'partial'>
+# ---
+# name: test_full_queries[session query not using indices]
+  '''
+  
+  [
+     {
+        "Plan" : {
+           "Description" : "(Projection + (Before ORDER BY + (WHERE + (Projection + Before ORDER BY))))",
+           "Node Type" : "Expression",
+           "Plans" : [
+              {
+                 "Description" : "preliminary LIMIT (without OFFSET)",
+                 "Node Type" : "Limit",
+                 "Plans" : [
+                    {
+                       "Description" : "((WHERE + (Projection + Before ORDER BY)))[split]",
+                       "Node Type" : "Filter",
+                       "Plans" : [
+                          {
+                             "Description" : "HAVING",
+                             "Node Type" : "Filter",
+                             "Plans" : [
+                                {
+                                   "Node Type" : "MergingAggregated",
+                                   "Plans" : [
+                                      {
+                                         "Node Type" : "Union",
+                                         "Plans" : [
+                                            {
+                                               "Node Type" : "Aggregating",
+                                               "Plans" : [
+                                                  {
+                                                     "Description" : "Before GROUP BY",
+                                                     "Node Type" : "Expression",
+                                                     "Plans" : [
+                                                        {
+                                                           "Node Type" : "Expression",
+                                                           "Plans" : [
+                                                              {
+                                                                 "Description" : "posthog.sharded_raw_sessions",
+                                                                 "Indexes" : [
+                                                                    {
+                                                                       "Condition" : "true",
+                                                                       "Initial Granules" : 4238362,
+                                                                       "Initial Parts" : 1516,
+                                                                       "Selected Granules" : 4238362,
+                                                                       "Selected Parts" : 1516,
+                                                                       "Type" : "MinMax"
+                                                                    },
+                                                                    {
+                                                                       "Condition" : "true",
+                                                                       "Initial Granules" : 4238362,
+                                                                       "Initial Parts" : 1516,
+                                                                       "Selected Granules" : 4238362,
+                                                                       "Selected Parts" : 1516,
+                                                                       "Type" : "Partition"
+                                                                    },
+                                                                    {
+                                                                       "Condition" : "(team_id in [2, 2])",
+                                                                       "Initial Granules" : 4238362,
+                                                                       "Initial Parts" : 1516,
+                                                                       "Keys" : [
+                                                                          "team_id"
+                                                                       ],
+                                                                       "Selected Granules" : 7616,
+                                                                       "Selected Parts" : 150,
+                                                                       "Type" : "PrimaryKey"
+                                                                    }
+                                                                 ],
+                                                                 "Node Type" : "ReadFromMergeTree"
+                                                              }
+                                                           ]
+                                                        }
+                                                     ]
+                                                  }
+                                               ]
+                                            },
+                                            {
+                                               "Description" : "Read from remote replica",
+                                               "Node Type" : "ReadFromRemote"
+                                            }
+                                         ]
+                                      }
+                                   ]
+                                }
+                             ]
+                          }
+                       ]
+                    }
+                 ]
+              }
+           ]
+        }
+     }
+  ]
+  
+  '''
+# ---
+# name: test_full_queries[session query not using indices].1
+  1
+# ---
+# name: test_full_queries[session query not using indices].2
+  list([
+    ReadIndexUsage(table='posthog.sharded_raw_sessions', use=<QueryIndexUsage.PARTIAL: 'partial'>),
+  ])
+# ---
+# name: test_full_queries[session query not using indices].3
+  <QueryIndexUsage.PARTIAL: 'partial'>
+# ---

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -22,7 +22,7 @@ django-linear-migrations==2.16.*
 Faker==17.5.0
 fakeredis[lua]==2.23.3
 freezegun==1.2.2
-inline-snapshot==0.12.*
+inline-snapshot==0.19.*
 multidict==6.0.5 # Not used by us directly, but code won't run on Ubuntu 24.04 unless we resolve this to 6.0.5
 packaging==24.1
 black~=23.9.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -52,7 +52,6 @@ black==23.9.1
     # via
     #   -r requirements-dev.in
     #   datamodel-code-generator
-    #   inline-snapshot
 boto3-stubs==1.34.84
     # via -r requirements-dev.in
 botocore-stubs==1.34.84
@@ -78,7 +77,6 @@ click==8.1.7
     # via
     #   -c requirements.txt
     #   black
-    #   inline-snapshot
     #   typer
 colorama==0.4.4
     # via pytest-watch
@@ -138,7 +136,7 @@ email-validator==2.0.0.post2
     # via pydantic
 execnet==2.1.1
     # via pytest-xdist
-executing==2.0.1
+executing==2.2.0
     # via inline-snapshot
 faker==17.5.0
     # via -r requirements-dev.in
@@ -215,7 +213,7 @@ inflect==5.6.2
     # via datamodel-code-generator
 iniconfig==1.1.1
     # via pytest
-inline-snapshot==0.12.1
+inline-snapshot==0.19.3
     # via -r requirements-dev.in
 isort==5.2.2
     # via datamodel-code-generator
@@ -643,9 +641,7 @@ tiktoken==0.9.0
     #   langchain-openai
     #   ragas
 toml==0.10.2
-    # via
-    #   coverage
-    #   inline-snapshot
+    # via coverage
 tomli==2.2.1
     # via
     #   -c requirements.txt
@@ -693,8 +689,6 @@ types-retry==0.9.9.4
     # via -r requirements-dev.in
 types-s3transfer==0.10.1
     # via boto3-stubs
-types-toml==0.10.8.20240310
-    # via inline-snapshot
 types-tzlocal==5.1.0.1
     # via -r requirements-dev.in
 types-urllib3==1.26.25.14
@@ -707,7 +701,6 @@ typing-extensions==4.12.2
     #   django-stubs-ext
     #   djangorestframework-stubs
     #   huggingface-hub
-    #   inline-snapshot
     #   langchain-core
     #   mypy
     #   mypy-boto3-s3


### PR DESCRIPTION
## Problem

For some queries index usage was YES instead of partial and instead PARTIAL was UNDECISIVE

HogQL query: `select * from sessions where $start_timestamp > today()` should have `PARTIAL` index use, but had `YES`

## Changes

Add test case and fix handling the unknown table.

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Added unit test