### PR TITLE
fix(propdefs): improve point-write Update error handling

### DIFF
--- a/rust/property-defs-rs/src/app_context.rs
+++ b/rust/property-defs-rs/src/app_context.rs
@@ -122,10 +122,10 @@ impl AppContext {
     }
 
     fn is_pg_constraint_error(&self, pg_code: &Option<Cow<'_, str>>) -> bool {
-        return match pg_code {
+        match pg_code {
             Some(code) => PG_CONSTRAINT_CODES.contains(&code.as_ref()),
             None => false,
-        };
+        }
     }
 
     async fn resolve_group_types_indexes(&self, updates: &mut [Update]) -> Result<(), sqlx::Error> {


### PR DESCRIPTION
## Problem
When a single `Update` point-write fails in the `property-defs-rs` service, it is not always correctly classified as a DB constraint (unretryable) error. In this case, the service retries the whole batch for no reason, and drops it when retries are exhausted.

Prior to refactoring to move the retry behavior to operate on single `Update`s, we also need to instrument the batch retry and `Update` fail mode behavior to determine why we're misclassifying and bubbling up errors we're supposed to be handling.

## Changes
* Improve our attempt to classify DB constraint errors on point-writes
* Instrument the whole point write => batch fail process better to guide our next steps

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally and in CI
