### PR TITLE
chore(flags): add better exception logging for postgres_healthcheck

### DIFF
--- a/posthog/database_healthcheck.py
+++ b/posthog/database_healthcheck.py
@@ -53,8 +53,10 @@ class DatabaseHealthcheck:
             with connections[DATABASE_FOR_FLAG_MATCHING].cursor() as cursor:
                 cursor.execute("SELECT 1")
             return True
-        except Exception:
-            logger.exception("postgres_connection_failure")
+        except Exception as e:
+            logger.exception(
+                "postgres_connection_failure", error=str(e), database=DATABASE_FOR_FLAG_MATCHING, exc_info=True
+            )
             return False
 
 


### PR DESCRIPTION
## Problem

Context:
https://posthog.slack.com/archives/C08G5CFHC3V/p1741306748762629?thread_ts=1741279292.094749&cid=C08G5CFHC3V

## Changes

Adds more fields to exception log when postgres_healthcheck fails

## Does this work well for both Cloud and self-hosted?

Yes


