### PR TITLE
fix: cohort person_id

### DIFF
--- a/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
@@ -275,7 +275,7 @@
             WHERE person_id IN
                 (SELECT person.person_id AS id
                  FROM
-                   (SELECT pdi.person_id AS person_id,
+                   (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                            countIf(timestamp > now() - INTERVAL 2 year
                                    AND timestamp < now()
                                    AND event = '$pageview'

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -204,6 +204,34 @@
                                                                                            join_algorithm = 'auto'
   '''
 # ---
+# name: TestCohortQuery.test_performed_event_poe_override
+  '''
+  
+  SELECT behavior_query.person_id AS id
+  FROM
+    (SELECT if(not(empty(overrides.distinct_id)), overrides.person_id, e.person_id) AS person_id,
+            countIf(timestamp > 'explicit_redacted_timestamp'
+                    AND timestamp < now()
+                    AND event = '$pageview'
+                    AND 1=1) > 0 AS performed_event_condition_None_level_level_0_level_0_0
+     FROM events e
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0)) AS overrides ON e.distinct_id = overrides.distinct_id
+     WHERE team_id = 99999
+       AND event IN ['$pageview']
+       AND timestamp <= now()
+       AND timestamp >= now() - INTERVAL 8 day
+     GROUP BY person_id) behavior_query
+  WHERE 1 = 1
+    AND (((performed_event_condition_None_level_level_0_level_0_0))) SETTINGS optimize_aggregation_in_order = 1,
+                                                                              join_algorithm = 'auto'
+  '''
+# ---
 # name: TestCohortQuery.test_performed_event_sequence
   '''
   

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -4,7 +4,7 @@
   
   SELECT person.person_id AS id
   FROM
-    (SELECT pdi.person_id AS person_id,
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
             countIf(timestamp > now() - INTERVAL 1 day
                     AND timestamp < now()
                     AND event = '$pageview'
@@ -127,7 +127,7 @@
   
   SELECT person.person_id AS id
   FROM
-    (SELECT pdi.person_id AS person_id,
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
             countIf(timestamp > now() - INTERVAL 1 week
                     AND timestamp < now()
                     AND event = '$pageview'
@@ -170,7 +170,7 @@
   
   SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
   FROM
-    (SELECT pdi.person_id AS person_id,
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
             countIf(timestamp > now() - INTERVAL 1 week
                     AND timestamp < now()
                     AND event = '$pageview'
@@ -366,7 +366,7 @@
   
   SELECT behavior_query.person_id AS id
   FROM
-    (SELECT pdi.person_id AS person_id,
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
             countIf(timestamp > 'explicit_redacted_timestamp'
                     AND timestamp < now()
                     AND event = '$pageview'
@@ -394,7 +394,7 @@
   
   SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
   FROM
-    (SELECT pdi.person_id AS person_id,
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
             countIf(timestamp > now() - INTERVAL 1 week
                     AND timestamp < now()
                     AND event = '$pageview'
@@ -433,7 +433,7 @@
   
   SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
   FROM
-    (SELECT pdi.person_id AS person_id,
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
             countIf(timestamp > now() - INTERVAL 1 week
                     AND timestamp < now()
                     AND event = '$pageview'
@@ -472,7 +472,7 @@
   
   SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
   FROM
-    (SELECT pdi.person_id AS person_id,
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
             countIf(timestamp > now() - INTERVAL 1 day
                     AND timestamp < now()
                     AND event = '$pageview'
@@ -691,7 +691,7 @@
   
   SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
   FROM
-    (SELECT pdi.person_id AS person_id,
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
             countIf(timestamp > now() - INTERVAL 1 week
                     AND timestamp < now()
                     AND event = '$pageview'
@@ -733,7 +733,7 @@
   
   SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
   FROM
-    (SELECT pdi.person_id AS person_id,
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
             countIf(timestamp > now() - INTERVAL 1 week
                     AND timestamp < now()
                     AND event = '$pageview'
@@ -784,7 +784,7 @@
   
   SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
   FROM
-    (SELECT pdi.person_id AS person_id,
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
             countIf(timestamp > now() - INTERVAL 7 day
                     AND timestamp < now()
                     AND event = '$new_view'

--- a/posthog/api/test/__snapshots__/test_cohort.ambr
+++ b/posthog/api/test/__snapshots__/test_cohort.ambr
@@ -21,7 +21,7 @@
   FROM
     (SELECT if(behavior_query.person_id = '00000000-0000-0000-0000-000000000000', person.person_id, behavior_query.person_id) AS id
      FROM
-       (SELECT pdi.person_id AS person_id,
+       (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                countIf(timestamp > now() - INTERVAL 1 day
                        AND timestamp < now()
                        AND event = '$pageview'


### PR DESCRIPTION
## Problem

Cohorts were not using overridden person_ids if they were available

## Changes

Make them

## Does this work well for both Cloud and self-hosted?

Yes
