### PR TITLE
feat(cdp): Testing topic destination for ingestion

### DIFF
--- a/plugin-server/src/ingestion/ingestion-consumer.test.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.test.ts
@@ -775,4 +775,32 @@ describe('IngestionConsumer', () => {
             TRANSFORMATION_TEST_TIMEOUT
         )
     })
+
+    describe('testing topic', () => {
+        it('should emit to the testing topic', async () => {
+            hub.INGESTION_CONSUMER_TESTING_TOPIC = 'testing_topic'
+            ingester = new IngestionConsumer(hub)
+            await ingester.start()
+
+            const messages = createKafkaMessages([createEvent()])
+            await ingester.handleKafkaBatch(messages)
+
+            expect(forSnapshot(getProducedKafkaMessages())).toMatchInlineSnapshot(`
+                [
+                  {
+                    "key": null,
+                    "topic": "testing_topic",
+                    "value": {
+                      "data": "{"distinct_id":"user-1","uuid":"<REPLACED-UUID-1>","token":"THIS IS NOT A TOKEN FOR TEAM 2","ip":"127.0.0.1","site_url":"us.posthog.com","now":"2025-01-01T00:00:00.000Z","event":"$pageview","properties":{"$current_url":"http://localhost:8000"}}",
+                      "distinct_id": "user-1",
+                      "ip": "127.0.0.1",
+                      "now": "2025-01-01T00:00:00.000Z",
+                      "token": "THIS IS NOT A TOKEN FOR TEAM 2",
+                      "uuid": "<REPLACED-UUID-0>",
+                    },
+                  },
+                ]
+            `)
+        })
+    })
 })

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -58,6 +58,7 @@ export class IngestionConsumer {
     protected topic: string
     protected dlqTopic: string
     protected overflowTopic?: string
+    protected testingTopic?: string
 
     batchConsumer?: BatchConsumer
     isStopping = false
@@ -81,6 +82,7 @@ export class IngestionConsumer {
                 | 'INGESTION_CONSUMER_CONSUME_TOPIC'
                 | 'INGESTION_CONSUMER_OVERFLOW_TOPIC'
                 | 'INGESTION_CONSUMER_DLQ_TOPIC'
+                | 'INGESTION_CONSUMER_TESTING_TOPIC'
             >
         > = {}
     ) {
@@ -91,6 +93,7 @@ export class IngestionConsumer {
         this.dlqTopic = overrides.INGESTION_CONSUMER_DLQ_TOPIC ?? hub.INGESTION_CONSUMER_DLQ_TOPIC
         this.tokensToDrop = hub.DROP_EVENTS_BY_TOKEN.split(',').filter((x) => !!x)
         this.tokenDistinctIdsToDrop = hub.DROP_EVENTS_BY_TOKEN_DISTINCT_ID.split(',').filter((x) => !!x)
+        this.testingTopic = overrides.INGESTION_CONSUMER_TESTING_TOPIC ?? hub.INGESTION_CONSUMER_TESTING_TOPIC
 
         this.name = `ingestion-consumer-${this.topic}`
         this.overflowRateLimiter = new MemoryRateLimiter(
@@ -207,6 +210,12 @@ export class IngestionConsumer {
                 const eventKey = `${event.token}:${event.distinct_id}`
                 // Check the rate limiter and emit to overflow if necessary
                 const isBelowRateLimit = this.overflowRateLimiter.consume(eventKey, 1, message.timestamp)
+
+                if (this.testingTopic) {
+                    void this.scheduleWork(this.emitToTestingTopic([message]))
+                    continue
+                }
+
                 if (this.overflowEnabled() && !isBelowRateLimit) {
                     status.debug('🔁', `Sending to overflow`, {
                         event,
@@ -418,7 +427,11 @@ export class IngestionConsumer {
     }
 
     private overflowEnabled() {
-        return !!this.hub.INGESTION_CONSUMER_OVERFLOW_TOPIC && this.hub.INGESTION_CONSUMER_OVERFLOW_TOPIC !== this.topic
+        return (
+            !!this.hub.INGESTION_CONSUMER_OVERFLOW_TOPIC &&
+            this.hub.INGESTION_CONSUMER_OVERFLOW_TOPIC !== this.topic &&
+            !this.testingTopic
+        )
     }
 
     private async emitToOverflow(kafkaMessages: Message[]) {
@@ -444,6 +457,24 @@ export class IngestionConsumer {
                     // (extremely) unlikely event that it is, set it to ``null``
                     // instead as that behavior is safer.
                     key: useRandomPartitioning ? null : message.key ?? null,
+                    headers: message.headers,
+                })
+            )
+        )
+    }
+
+    private async emitToTestingTopic(kafkaMessages: Message[]) {
+        const testingTopic = this.testingTopic
+        if (!testingTopic) {
+            throw new Error('No testing topic configured')
+        }
+
+        await Promise.all(
+            kafkaMessages.map((message) =>
+                this.kafkaOverflowProducer!.produce({
+                    topic: this.testingTopic!,
+                    value: message.value,
+                    key: message.key ?? null,
                     headers: message.headers,
                 })
             )

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -207,14 +207,15 @@ export class IngestionConsumer {
                 status.debug('🔁', `Processing event`, {
                     event,
                 })
-                const eventKey = `${event.token}:${event.distinct_id}`
-                // Check the rate limiter and emit to overflow if necessary
-                const isBelowRateLimit = this.overflowRateLimiter.consume(eventKey, 1, message.timestamp)
 
                 if (this.testingTopic) {
                     void this.scheduleWork(this.emitToTestingTopic([message]))
                     continue
                 }
+
+                const eventKey = `${event.token}:${event.distinct_id}`
+                // Check the rate limiter and emit to overflow if necessary
+                const isBelowRateLimit = this.overflowRateLimiter.consume(eventKey, 1, message.timestamp)
 
                 if (this.overflowEnabled() && !isBelowRateLimit) {
                     status.debug('🔁', `Sending to overflow`, {

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -131,6 +131,8 @@ export type IngestionConsumerConfig = {
     INGESTION_CONSUMER_DLQ_TOPIC: string
     /** If set then overflow routing is enabled and the topic is used for overflow events */
     INGESTION_CONSUMER_OVERFLOW_TOPIC?: string
+    /** If set the ingestion consumer doesn't process events the usual way but rather just writes to a dummy topic */
+    INGESTION_CONSUMER_TESTING_TOPIC?: string
 }
 
 export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig {


### PR DESCRIPTION
## Problem

We want to load test some different kafka configurations in production without affecting existing ingestion.


## Changes

* Sets up a new config var that when set bypasses normal event processing and instead just writes to a target topic

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
