### PR TITLE
fix(batch-exports): Retry with no encryption on empty passphrase

### DIFF
--- a/posthog/temporal/batch_exports/snowflake_batch_export.py
+++ b/posthog/temporal/batch_exports/snowflake_batch_export.py
@@ -177,6 +177,7 @@ def load_private_key(private_key: str, passphrase: str | None) -> bytes:
                 try:
                     p_key = load_private_key(private_key, None)
                 except (ValueError, TypeError):
+                    # Proceed with top level handling
                     pass
                 else:
                     return p_key

--- a/posthog/temporal/batch_exports/snowflake_batch_export.py
+++ b/posthog/temporal/batch_exports/snowflake_batch_export.py
@@ -162,17 +162,26 @@ def load_private_key(private_key: str, passphrase: str | None) -> bytes:
     try:
         p_key = serialization.load_pem_private_key(
             private_key.encode("utf-8"),
-            password=passphrase.encode() if passphrase is not None and passphrase != "" else None,
+            password=passphrase.encode() if passphrase is not None else None,
             backend=default_backend(),
         )
     except (ValueError, TypeError) as e:
         msg = "Invalid private key"
+
         if passphrase is not None and "Incorrect password?" in str(e):
             msg = "Could not load private key: incorrect passphrase?"
         elif "Password was not given but private key is encrypted" in str(e):
             msg = "Could not load private key: passphrase was not given but private key is encrypted"
         elif "Password was given but private key is not encrypted" in str(e):
+            if passphrase == "":
+                try:
+                    p_key = load_private_key(private_key, None)
+                except (ValueError, TypeError):
+                    pass
+                else:
+                    return p_key
             msg = "Could not load private key: passphrase was given but private key is not encrypted"
+
         raise InvalidPrivateKeyError(msg)
 
     return p_key.private_bytes(

--- a/posthog/temporal/batch_exports/snowflake_batch_export.py
+++ b/posthog/temporal/batch_exports/snowflake_batch_export.py
@@ -162,7 +162,7 @@ def load_private_key(private_key: str, passphrase: str | None) -> bytes:
     try:
         p_key = serialization.load_pem_private_key(
             private_key.encode("utf-8"),
-            password=passphrase.encode() if passphrase is not None else None,
+            password=passphrase.encode() if passphrase is not None and passphrase != "" else None,
             backend=default_backend(),
         )
     except (ValueError, TypeError) as e:
@@ -171,6 +171,8 @@ def load_private_key(private_key: str, passphrase: str | None) -> bytes:
             msg = "Could not load private key: incorrect passphrase?"
         elif "Password was not given but private key is encrypted" in str(e):
             msg = "Could not load private key: passphrase was not given but private key is encrypted"
+        elif "Password was given but private key is not encrypted" in str(e):
+            msg = "Could not load private key: passphrase was given but private key is not encrypted"
         raise InvalidPrivateKeyError(msg)
 
     return p_key.private_bytes(

--- a/posthog/temporal/batch_exports/snowflake_batch_export.py
+++ b/posthog/temporal/batch_exports/snowflake_batch_export.py
@@ -175,12 +175,12 @@ def load_private_key(private_key: str, passphrase: str | None) -> bytes:
         elif "Password was given but private key is not encrypted" in str(e):
             if passphrase == "":
                 try:
-                    p_key = load_private_key(private_key, None)
+                    loaded = load_private_key(private_key, None)
                 except (ValueError, TypeError):
                     # Proceed with top level handling
                     pass
                 else:
-                    return p_key
+                    return loaded
             msg = "Could not load private key: passphrase was given but private key is not encrypted"
 
         raise InvalidPrivateKeyError(msg)

--- a/posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py
@@ -2008,11 +2008,24 @@ def test_load_private_key_raises_error_if_passphrase_missing():
     assert "passphrase was not given but private key is encrypted" in str(exc_info.value)
 
 
+def test_load_private_key_passes_with_empty_passphrase_and_no_encryption():
+    """Test we succeed in loading a passphrase without encryption and an empty passphrase."""
+    key = paramiko.RSAKey.generate(2048)
+    buffer = io.StringIO()
+    key.write_private_key(buffer, password=None)
+    _ = buffer.seek(0)
+
+    loaded = load_private_key(buffer.read(), "")
+
+    assert loaded
+
+
 @pytest.mark.parametrize("passphrase", ["a-passphrase", None, ""])
 def test_load_private_key(passphrase: str | None):
     """Test we can load a private key.
 
-    We treat `None` and empty string the same (no passphrase).
+    We treat `None` and empty string the same (no passphrase) because paramiko does
+    not support passphrases smaller than 1 byte.
     """
     key = paramiko.RSAKey.generate(2048)
     buffer = io.StringIO()


### PR DESCRIPTION
## Problem

If you input a passphrase for a key that has none, there is no way to clear that. The most you can do is set it to empty string, but we treat that as it's own passphrase.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

If your key is not encrypted and the passphrase provided is `""`, retry the load call without a passphrase.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Added handful of unit tests.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
