### PR TITLE
fix(cdp): fix hogfn creation with null filters

### DIFF
--- a/ee/api/test/test_hooks.py
+++ b/ee/api/test/test_hooks.py
@@ -225,7 +225,7 @@ if (inputs.debug) {
                 id=hook_id,
                 user=self.user,
                 team=self.team,
-                resource_id=20,
+                resource_id=self.action.id,
                 target=f"https://hooks.zapier.com/hooks/standard/{hook_id}",
             )
 

--- a/posthog/api/hog_function.py
+++ b/posthog/api/hog_function.py
@@ -162,7 +162,7 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
         data["inputs"] = data.get("inputs", instance.inputs if instance else {})
 
         # Always ensure filters is initialized as an empty object if it's null
-        data["filters"] = data.get("filters") or {}
+        data["filters"] = data.get("filters", instance.filters if instance else {}) or {}
 
         # Set some context variables that are used in the sub validators
         self.context["function_type"] = data["type"]

--- a/posthog/api/hog_function.py
+++ b/posthog/api/hog_function.py
@@ -161,6 +161,9 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
         data["inputs_schema"] = data.get("inputs_schema", instance.inputs_schema if instance else [])
         data["inputs"] = data.get("inputs", instance.inputs if instance else {})
 
+        # Always ensure filters is initialized as an empty object if it's null
+        data["filters"] = data.get("filters") or {}
+
         # Set some context variables that are used in the sub validators
         self.context["function_type"] = data["type"]
         self.context["encrypted_inputs"] = instance.encrypted_inputs if instance else {}
@@ -196,7 +199,6 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
             data["inputs_schema"] = template.inputs_schema
         if is_create:
             # Set defaults for new functions
-            data["filters"] = data.get("filters") or {}
             data["inputs_schema"] = data.get("inputs_schema") or []
             data["inputs"] = data.get("inputs") or {}
             data["mappings"] = data.get("mappings") or None

--- a/posthog/api/test/test_hog_function.py
+++ b/posthog/api/test/test_hog_function.py
@@ -189,6 +189,10 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             mock_get_templates.return_value.json.return_value = MOCK_NODE_TEMPLATES
             HogFunctionTemplates._load_templates()  # Cache templates to simplify tests
 
+        # Create the action referenced in EXAMPLE_FULL
+        if not Action.objects.filter(id=9, team=self.team).exists():
+            Action.objects.create(id=9, name="Test Action", team=self.team, created_by=self.user)
+
     def _get_function_activity(
         self,
         function_id: Optional[int] = None,

--- a/posthog/cdp/filters.py
+++ b/posthog/cdp/filters.py
@@ -46,8 +46,7 @@ def hog_function_filters_to_expr(filters: dict, team: Team, actions: dict[int, A
                     action = Action.objects.get(id=action_id, team__project_id=team.project_id)
                 exprs.append(action_to_expr(action))
             except KeyError:
-                # If an action doesn't exist, we want to return no events
-                exprs.append(parse_expr("1 = 2"))
+                exprs.append(parse_expr("1 = 2"))  # No events match
 
         # Properties
         if filter.get("properties"):

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -277,6 +277,9 @@ class HogFunctionFiltersSerializer(serializers.Serializer):
         # If we have a bytecode, we need to validate the transpiled
         if function_type in TYPES_WITH_COMPILED_FILTERS:
             data = compile_filters_bytecode(data, team)
+            # Check if bytecode compilation resulted in an error
+            if data.get("bytecode_error"):
+                raise serializers.ValidationError(f"Invalid filter configuration: {data['bytecode_error']}")
         elif function_type in TYPES_WITH_TRANSPILED_FILTERS:
             compiler = JavaScriptCompiler()
             code = compiler.visit(compile_filters_expr(data, team))

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -257,7 +257,7 @@ class HogFunctionFiltersSerializer(serializers.Serializer):
     actions = serializers.ListField(child=serializers.DictField(), required=False)
     events = serializers.ListField(child=serializers.DictField(), required=False)
     properties = serializers.ListField(child=serializers.DictField(), required=False)
-    bytecode = serializers.JSONField(required=False)
+    bytecode = serializers.JSONField(required=False, allow_null=True)
     transpiled = serializers.JSONField(required=False)
     filter_test_accounts = serializers.BooleanField(required=False)
     bytecode_error = serializers.CharField(required=False)
@@ -270,6 +270,9 @@ class HogFunctionFiltersSerializer(serializers.Serializer):
     def validate(self, data):
         function_type = self.context["function_type"]
         team = self.context["get_team"]()
+
+        # Ensure data is initialized as an empty dict if it's None
+        data = data or {}
 
         # If we have a bytecode, we need to validate the transpiled
         if function_type in TYPES_WITH_COMPILED_FILTERS:


### PR DESCRIPTION
## Problem

Within filters of hogfunctions we have this bug: Can't use cohorts in real-time filters. Please inline the relevant expressions (which is wanted) _but_ ...
1. When saving the function we actually should fail but it still succeeds and gets created
2.  if we remove cohort temporary for solving issue 1, we are faced with this issue, Upsert hog function failed: This field may not be null.

![2025-03-07 11 47 29](https://github.com/user-attachments/assets/9e4ac78b-1cf0-4fdf-9e75-8548d2c21d0e)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- function does not get saved when we have a `filter.bytecode_error` anymore
- we do not show the banner on the top as we prevent the function from being created in the first place
- Backend handles `null` values in the filter so removing filters in the FE and saving is working again
- frontend is showing the correct error now and not only `Upsert hog function failed` 

![2025-03-07 11 50 37](https://github.com/user-attachments/assets/49e621ef-6d69-4dda-91c0-a2139ddc5741)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- added a test
- tested locally

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
