### PR TITLE
fix: add defaults for masking setting check

### DIFF
--- a/frontend/src/scenes/settings/environment/SessionRecordingSettings.tsx
+++ b/frontend/src/scenes/settings/environment/SessionRecordingSettings.tsx
@@ -518,12 +518,17 @@ export function ReplayMaskingSettings(): JSX.Element {
         })
     }
 
+    const maskingConfig = {
+        maskAllInputs: currentTeam?.session_recording_masking_config?.maskAllInputs ?? true,
+        maskTextSelector: currentTeam?.session_recording_masking_config?.maskTextSelector,
+    }
+
     const maskingLevel =
-        currentTeam?.session_recording_masking_config?.maskTextSelector === '*'
+        maskingConfig.maskTextSelector === '*' && maskingConfig.maskAllInputs
             ? 'total-privacy'
-            : currentTeam?.session_recording_masking_config?.maskAllInputs
-            ? 'normal'
-            : 'free-love'
+            : maskingConfig.maskTextSelector === undefined && !maskingConfig.maskAllInputs
+            ? 'free-love'
+            : 'normal'
 
     return (
         <div>


### PR DESCRIPTION
## Problem

Currently the default option for the selector is incorrect, should default to normal.

## Changes

Defaults to normal if it's something we don't recognize.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Ran locally with an undefined masking config
