### PR TITLE
fix(data-warehouse): Allow digit only identifiers in mysql

### DIFF
--- a/posthog/temporal/data_imports/pipelines/mysql/mysql.py
+++ b/posthog/temporal/data_imports/pipelines/mysql/mysql.py
@@ -1,4 +1,5 @@
 import dataclasses
+import re
 from typing import Any, Optional
 from collections.abc import Iterator
 from django.conf import settings
@@ -23,6 +24,10 @@ from dlt.common.normalizers.naming.snake_case import NamingConvention
 
 def _sanitize_identifier(identifier: str) -> str:
     if not identifier.isidentifier():
+        # Allow identifiers of just numbers
+        if re.match("^\\d+$", identifier):
+            return f"`{identifier}`"
+
         if identifier.startswith("$") or (len(identifier) > 0 and identifier[0].isdigit()):
             if not identifier[1:].replace(".", "").replace("_", "").replace("-", "").isidentifier():
                 raise ValueError(f"Invalid SQL identifier: {identifier}")

--- a/posthog/temporal/data_imports/pipelines/mysql/tests/test_mysql.py
+++ b/posthog/temporal/data_imports/pipelines/mysql/tests/test_mysql.py
@@ -1,0 +1,6 @@
+from posthog.temporal.data_imports.pipelines.mysql.mysql import _sanitize_identifier
+
+
+def test_sanitize_identifier_with_digits():
+    res = _sanitize_identifier("851")
+    assert res == "`851`"


### PR DESCRIPTION
## Problem
- We have a user with a schema with a name that is only digits - e.g. `851` - this was causing the pipeline to fail
- [zendesk ticket](https://posthoghelp.zendesk.com/agent/tickets/25859)

## Changes
- Allow only number identifiers 

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Added test