### PR TITLE
fix(data-warehouse): Fix bucket size query

### DIFF
--- a/posthog/temporal/data_imports/pipelines/postgres/postgres.py
+++ b/posthog/temporal/data_imports/pipelines/postgres/postgres.py
@@ -130,7 +130,7 @@ class TableStructureRow:
 def _get_partition_bucket_size(cursor: psycopg.Cursor, schema: str, table_name: str) -> int | None:
     query = sql.SQL("""
         SELECT
-            CASE WHEN count(*) = 0 OR pg_table_size({schema_table_name_literal}) THEN NULL
+            CASE WHEN count(*) = 0 OR pg_table_size({schema_table_name_literal}) = 0 THEN NULL
             ELSE round({bytes_per_partition} / (pg_table_size({schema_table_name_literal}) / count(*))) END
         FROM {schema}.{table}""").format(
         bytes_per_partition=sql.Literal(DEFAULT_PARTITION_TARGET_SIZE_IN_BYTES),


### PR DESCRIPTION
## Problem
- We were getting two errors with this:
  - [UndefinedTable](https://posthog.sentry.io/issues/6367791523/events/daeac8f93b0d4084bd0b26a440d1366f/?project=4508444747956225&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=previous-event&statsPeriod=30d&stream_index=3)
  - [DivisionByZero](https://posthog.sentry.io/issues/6367808287/?project=4508444747956225&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=30d&stream_index=5)

## Changes
- Fix both issues. Some tables needed double quotes around them when calculating the table size
- Other tables return 0 for table_size when it's a foreign table or the table has been truncated, or in some other niche ways 
  - For this, check for it returning `0` first
- Wrap the whole thing in a try/catch - table partitioning is a nice to have and not a must for most tables

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Tested issues locally