### PR TITLE
fix: move reset filters outside to be visible

### DIFF
--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFilters.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFilters.tsx
@@ -237,14 +237,22 @@ export const RecordingsUniversalFilters = ({
                         >
                             <RecordingsUniversalFilterGroup size="xsmall" />
                         </UniversalFilters>
-                        {resetFilters && (totalFiltersCount ?? 0) > 0 && (
-                            <LemonButton type="tertiary" size="xsmall" onClick={resetFilters} icon={<IconRevert />}>
-                                Reset
-                            </LemonButton>
-                        )}
                     </div>
                 </div>
             </div>
+            {resetFilters && (totalFiltersCount ?? 0) > 0 && (
+                <div className="flex justify-start mt-2">
+                    <LemonButton
+                        type="tertiary"
+                        size="xsmall"
+                        onClick={resetFilters}
+                        icon={<IconRevert />}
+                        tooltip="Reset any changes you've made to the filters"
+                    >
+                        Reset filters
+                    </LemonButton>
+                </div>
+            )}
             <div className="flex gap-2 mt-2 justify-between">
                 <HideRecordingsMenu />
                 <SettingsMenu


### PR DESCRIPTION
## Problem

As filters are not toggled some users struggled to find how to reset the filters. Let's move the outside of the collapsable part.

### Before
<img width="328" alt="Screenshot 2025-03-07 at 15 28 24" src="https://github.com/user-attachments/assets/fe8f469c-d450-4a04-bf8d-6db350f81b8e" />
<img width="336" alt="Screenshot 2025-03-07 at 15 28 17" src="https://github.com/user-attachments/assets/ec971f31-614c-4cbf-b823-b2ac1dad5e87" />


### After
<img width="331" alt="Screenshot 2025-03-07 at 15 28 34" src="https://github.com/user-attachments/assets/8dfd38a7-06fe-4eee-b013-b1b58685900c" />
<img width="331" alt="Screenshot 2025-03-07 at 15 28 30" src="https://github.com/user-attachments/assets/fe5aab6d-f8a5-4fd3-a89c-9c349961808b" />

