### PR TITLE
fix: Apply better key to path clean filters

### DIFF
--- a/frontend/src/lib/components/PathCleanFilters/PathCleanFilters.tsx
+++ b/frontend/src/lib/components/PathCleanFilters/PathCleanFilters.tsx
@@ -13,6 +13,10 @@ export interface PathCleanFiltersProps {
     setFilters: (filters: PathCleaningFilter[]) => void
 }
 
+const keyFromFilter = (filter: PathCleaningFilter): string => {
+    return `${filter.alias}-${filter.regex}`
+}
+
 export function PathCleanFilters({ filters = [], setFilters }: PathCleanFiltersProps): JSX.Element {
     const [localFilters, setLocalFilters] = useState(filters)
 
@@ -69,13 +73,10 @@ export function PathCleanFilters({ filters = [], setFilters }: PathCleanFiltersP
                     collisionDetection={closestCenter}
                     modifiers={[restrictToParentElement]}
                 >
-                    <SortableContext
-                        items={localFilters.map((filter) => String(filter.alias))}
-                        strategy={rectSortingStrategy}
-                    >
+                    <SortableContext items={localFilters.map(keyFromFilter)} strategy={rectSortingStrategy}>
                         {localFilters.map((filter, index) => (
                             <PathCleanFilterItem
-                                key={filter.alias}
+                                key={keyFromFilter(filter)}
                                 filter={filter}
                                 onChange={(filter) => onEditFilter(index, filter)}
                                 onRemove={() => onRemoveFilter(index)}

--- a/frontend/src/lib/components/PathCleanFilters/PathRegexModal.tsx
+++ b/frontend/src/lib/components/PathCleanFilters/PathRegexModal.tsx
@@ -1,6 +1,6 @@
 import { LemonButton, LemonInput, LemonModal, Link } from '@posthog/lemon-ui'
 import { isValidRegexp } from 'lib/utils/regexp'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { AiRegexHelperButton } from 'scenes/session-recordings/components/AiRegexHelper/AiRegexHelper'
 import { AiRegexHelper } from 'scenes/session-recordings/components/AiRegexHelper/AiRegexHelper'
 
@@ -25,6 +25,14 @@ export function PathRegexModal({ filter, isOpen, onSave, onClose }: PathRegexMod
         : !isValidRegexp(regex)
         ? 'Malformed regex'
         : null
+
+    // Reset state when reopening the modal with a different filter (or none)
+    useEffect(() => {
+        if (isOpen) {
+            setAlias(filter?.alias ?? '')
+            setRegex(filter?.regex ?? '')
+        }
+    }, [isOpen, filter])
 
     return (
         <LemonModal isOpen={isOpen} onClose={onClose}>
@@ -84,7 +92,9 @@ export function PathRegexModal({ filter, isOpen, onSave, onClose }: PathRegexMod
                             </LemonButton>
                             <LemonButton
                                 type="primary"
-                                onClick={() => onSave({ alias, regex })}
+                                onClick={() => {
+                                    onSave({ alias: alias.trim(), regex: regex.trim() })
+                                }}
                                 disabledReason={disabledReason}
                             >
                                 Save


### PR DESCRIPTION
Some people are using the same alias for more than one path (understandable) and that's crashing the UI big time, let's fix it by making it crash less often - only in case of duplicate queries.

Also, reset `PathRegexModal`'s state when reopening it