### PR TITLE
fix(err): set OBJECT_STORAGE_ENDPOINT when starting backend

### DIFF
--- a/bin/start-backend
+++ b/bin/start-backend
@@ -1,4 +1,6 @@
 #!/bin/bash
 set -e
 
+export OBJECT_STORAGE_ENDPOINT=http://localhost:19000
+
 uvicorn --reload posthog.asgi:application --host 0.0.0.0 --log-level debug --reload-include "posthog/" --reload-include "ee/" --reload-include "products/"


### PR DESCRIPTION
## Problem

Backend fails to upload sourcemap to objectstorage locally because the url used is http://objectstorage:1900 and this host is only accessible from a docker environment. 

## Changes

Set an env variable when starting the backend to avoid using the default URL.

@timgl I don't have enough context to know if this will have side effects or if this is the best place, but it seems to fix the issue for the sourcemap upload at least.