### PR TITLE
fix: improper identification of rate limiting context

### DIFF
--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -129,6 +129,7 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
                 execution_mode=execution_mode,
                 query_id=client_query_id,
                 user=request.user,
+                is_query_service=True,
             )
             if isinstance(result, BaseModel):
                 result = result.model_dump(by_alias=True)

--- a/posthog/api/services/query.py
+++ b/posthog/api/services/query.py
@@ -78,6 +78,7 @@ def process_query_model(
     query_id: Optional[str] = None,
     insight_id: Optional[int] = None,
     dashboard_id: Optional[int] = None,
+    is_query_service: bool = False,
 ) -> dict | BaseModel:
     result: dict | BaseModel
 
@@ -132,7 +133,7 @@ def process_query_model(
             query_runner.apply_dashboard_filters(dashboard_filters)
         if variables_override:
             query_runner.apply_variable_overrides(variables_override)
-        query_runner.is_query_service = True
+        query_runner.is_query_service = is_query_service
         result = query_runner.run(
             execution_mode=execution_mode,
             user=user,

--- a/posthog/clickhouse/client/limit.py
+++ b/posthog/clickhouse/client/limit.py
@@ -159,7 +159,7 @@ def get_api_personal_rate_limiter():
             get_task_name=lambda *args, **kwargs: f"api:query:per-team:{kwargs.get('team_id')}",
             get_task_id=lambda *args, **kwargs: current_task.request.id
             if current_task
-            else kwargs.get("task_id", generate_short_id()),
+            else (kwargs.get("task_id") or generate_short_id()),
             ttl=600,
             bypass_all=True,
         )


### PR DESCRIPTION
## Problem

Rate limiter incorrectly considers running inside /query endpoint handler

## Changes

Pass info directly from QueryViewSet

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

querie