### PR TITLE
fix: fix bad href trim call

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/rrweb-types.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/rrweb-types.ts
@@ -75,8 +75,8 @@ export function isMouseActivity(event: RRWebEvent): boolean {
 }
 
 export function hrefFrom(event: RRWebEvent): string | undefined {
-    const metaHref = event.data?.href?.trim()
-    const customHref = event.data?.payload?.href?.trim()
+    const metaHref = event.data?.href?.trim?.()
+    const customHref = event.data?.payload?.href?.trim?.()
     return metaHref || customHref || undefined
 }
 


### PR DESCRIPTION
## Problem

Blobby V2 is failing with the following error:

```
TypeError: event.data?.payload?.href?.trim is not a function
```

This is due to the fact that we don't validate the href property.

## Changes

Calls trim only if it's present on the href property.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

