### PR TITLE
chore(flags): initialize DatabaseHealthcheck to True for decide pods starting up

### DIFF
--- a/posthog/database_healthcheck.py
+++ b/posthog/database_healthcheck.py
@@ -19,7 +19,7 @@ class DatabaseHealthcheck:
     """
 
     def __init__(self, time_interval: int = 20) -> None:
-        self.connected: bool = False
+        self.connected: bool = True
         self.last_check: Optional[int] = None
         self.time_interval = time_interval
         self.hits = 0


### PR DESCRIPTION


## Problem

Context: https://posthog.slack.com/archives/C08G5CFHC3V/p1741370475644539?thread_ts=1741279292.094749&cid=C08G5CFHC3V

This may be the remaining cause of healthcheck failures during decide deployments

## Changes

Have the decide PG healthcheck assume it is connected upon startup (this is a fair assumption as it would already have had to run a `SELECT 1` in its `/_readyz` to take on traffic)

## Does this work well for both Cloud and self-hosted?

Yes


