### PR TITLE
chore(tune-memory-saved-query): Bump memory usage for saved query further

### DIFF
--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -383,8 +383,8 @@ def hogql_table(query: str, team: Team, table_name: str, table_columns: dlt_typi
 
     async def get_hogql_rows():
         settings = HogQLGlobalSettings(
-            max_execution_time=60 * 20, max_memory_usage=90 * 1000 * 1000 * 1000
-        )  # 20 mins, 90GB, 2x as the /query endpoint async workers
+            max_execution_time=60 * 20, max_memory_usage=135 * 1000 * 1000 * 1000
+        )  # 20 mins, 135gb, 2x execution_time, 3x max_memory_usage as the /query endpoint async workers
 
         response = await asyncio.to_thread(
             execute_hogql_query, query, team, settings=settings, limit_context=LimitContext.SAVED_QUERY

--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -383,8 +383,8 @@ def hogql_table(query: str, team: Team, table_name: str, table_columns: dlt_typi
 
     async def get_hogql_rows():
         settings = HogQLGlobalSettings(
-            max_execution_time=60 * 20, max_memory_usage=135 * 1000 * 1000 * 1000
-        )  # 20 mins, 135gb, 2x execution_time, 3x max_memory_usage as the /query endpoint async workers
+            max_execution_time=60 * 20, max_memory_usage=180 * 1000 * 1000 * 1000
+        )  # 20 mins, 180gb, 2x execution_time, 4x max_memory_usage as the /query endpoint async workers
 
         response = await asyncio.to_thread(
             execute_hogql_query, query, team, settings=settings, limit_context=LimitContext.SAVED_QUERY


### PR DESCRIPTION
## Problem
We still need to tune our saved_query and further raise memory limits.

```
DB::Exception: Memory limit (total) exceeded: would use 111.23 GiB (attempt to allocate chunk of 4194480 bytes), maximum: 111.19 GiB
```

## Changes

Bumping 90gb --> 135gb limits