### PR TITLE
feat(max): Use Claude 3.7 Sonnet instead of GPT-4o

### DIFF
--- a/ee/hogai/root/prompts.py
+++ b/ee/hogai/root/prompts.py
@@ -30,10 +30,10 @@ The word "prickly" has many negative connotations, so use it ONLY to describe yo
 </agent_info>
 
 <basic_functionality>
-You have access to two main tools:
+You have access to the following tools:
 1. `create_and_query_insight` for retrieving data about events/users/customers/revenue/overall data
 2. `search_documentation` for answering questions about PostHog features, concepts, and usage
-Before using a tool, say what you're about to do, in one sentence.
+Before using a tool, say what you're about to do in one brief sentence.
 
 When a question is about the human's data, proactively use `create_and_query_insight` for retrieving concrete results.
 When a question is about how to use PostHog, its features, or understanding concepts, use `search_documentation` to provide accurate answers from the documentation.

--- a/ee/hogai/schema_generator/nodes.py
+++ b/ee/hogai/schema_generator/nodes.py
@@ -11,7 +11,7 @@ from langchain_core.messages import (
 )
 from langchain_core.prompts import ChatPromptTemplate, HumanMessagePromptTemplate
 from langchain_core.runnables import RunnableConfig
-from langchain_openai import ChatOpenAI
+from langchain_anthropic import ChatAnthropic
 from pydantic import BaseModel, ValidationError
 
 from ee.hogai.schema_generator.parsers import (
@@ -51,7 +51,9 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
 
     @property
     def _model(self):
-        return ChatOpenAI(model="gpt-4o", temperature=0, disable_streaming=True).with_structured_output(
+        return ChatAnthropic(
+            model="claude-3-7-sonnet-latest", temperature=0, disable_streaming=True
+        ).with_structured_output(
             self.OUTPUT_SCHEMA,
             method="function_calling",
             include_raw=False,

--- a/ee/hogai/taxonomy_agent/nodes.py
+++ b/ee/hogai/taxonomy_agent/nodes.py
@@ -13,7 +13,7 @@ from langchain_core.messages import (
 )
 from langchain_core.prompts import ChatPromptTemplate, HumanMessagePromptTemplate
 from langchain_core.runnables import RunnableConfig
-from langchain_openai import ChatOpenAI
+from langchain_anthropic import ChatAnthropic
 from pydantic import ValidationError
 
 from ee.hogai.taxonomy_agent.parsers import (
@@ -128,8 +128,8 @@ class TaxonomyAgentPlannerNode(AssistantNode):
         )
 
     @property
-    def _model(self) -> ChatOpenAI:
-        return ChatOpenAI(model="gpt-4o", temperature=0, streaming=True, stream_usage=True)
+    def _model(self) -> ChatAnthropic:
+        return ChatAnthropic(model="claude-3-7-sonnet-latest", temperature=0, streaming=True, stream_usage=True)
 
     def _get_react_format_prompt(self, toolkit: TaxonomyAgentToolkit) -> str:
         return cast(

--- a/ee/hogai/utils/test.py
+++ b/ee/hogai/utils/test.py
@@ -8,7 +8,7 @@ from pydantic import Field
 
 
 class TokenCounterMixin:
-    def get_num_tokens_from_messages(self, messages: list[BaseMessage], tools: Sequence | None = None) -> int:
+    def get_num_openai_tokens_from_messages(self, messages: list[BaseMessage], tools: Sequence | None = None) -> int:
         chat = ChatOpenAI(model=self.openai_model, api_key="no-key")
         return chat.get_num_tokens_from_messages(messages, tools)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,6 @@ aiohttp==3.11.10
     #   aioresponses
     #   datasets
     #   fsspec
-    #   langchain
     #   langchain-community
 aioresponses==0.7.6
     # via -r requirements-dev.in
@@ -245,7 +244,7 @@ jsonschema-specifications==2023.12.1
     #   -c requirements.txt
     #   jsonschema
     #   openapi-schema-validator
-langchain==0.3.9
+langchain==0.3.20
     # via
     #   -c requirements.txt
     #   deepeval
@@ -255,7 +254,7 @@ langchain-community==0.3.2
     # via
     #   -c requirements.txt
     #   ragas
-langchain-core==0.3.21
+langchain-core==0.3.41
     # via
     #   -c requirements.txt
     #   deepeval
@@ -269,7 +268,7 @@ langchain-openai==0.2.11
     #   -c requirements.txt
     #   deepeval
     #   ragas
-langchain-text-splitters==0.3.0
+langchain-text-splitters==0.3.6
     # via
     #   -c requirements.txt
     #   langchain
@@ -328,7 +327,6 @@ numpy==1.23.3
     # via
     #   -c requirements.txt
     #   datasets
-    #   langchain
     #   langchain-community
     #   pandas
     #   ragas
@@ -632,7 +630,6 @@ tenacity==8.4.2
     # via
     #   -c requirements.txt
     #   deepeval
-    #   langchain
     #   langchain-community
     #   langchain-core
 tiktoken==0.9.0

--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@
 aiohttp==3.11.10
 aioboto3==12.0.0
 aiokafka>=0.8
-anthropic==0.44.0
+anthropic==0.49.0
 antlr4-python3-runtime==4.13.1
 beautifulsoup4==4.12.3
 boto3==1.28.16
@@ -55,9 +55,10 @@ infi-clickhouse-orm@ git+https://github.com/PostHog/infi.clickhouse_orm@9578c79f
 jsonref==1.1.0
 kafka-python==2.0.2
 kombu==5.3.2
-langchain==0.3.9
+langchain==0.3.20
 langchain-community==0.3.2
 langchain-openai==0.2.11
+langchain-anthropic==0.3.9
 langgraph==0.2.56
 lzstring==1.0.4
 multidict==6.0.5 # Not used by us directly, but code won't run on Ubuntu 24.04 unless we resolve this to 6.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ aioboto3==12.0.0
 aiobotocore==2.7.0
     # via
     #   aioboto3
-    #   aiobotocore
     #   s3fs
 aiohappyeyeballs==2.4.4
     # via aiohttp
@@ -14,7 +13,6 @@ aiohttp==3.11.10
     #   -r requirements.in
     #   aiobotocore
     #   geoip2
-    #   langchain
     #   langchain-community
     #   s3fs
 aioitertools==0.11.0
@@ -29,8 +27,10 @@ amqp==5.1.1
     # via kombu
 annotated-types==0.7.0
     # via pydantic
-anthropic==0.44.0
-    # via -r requirements.in
+anthropic==0.49.0
+    # via
+    #   -r requirements.in
+    #   langchain-anthropic
 antlr4-python3-runtime==4.13.1
     # via
     #   -r requirements.in
@@ -298,7 +298,6 @@ giturlparse==0.12.0
     # via dlt
 google-api-core==2.11.1
     # via
-    #   google-api-core
     #   google-cloud-bigquery
     #   google-cloud-bigquery-storage
     #   google-cloud-core
@@ -424,15 +423,18 @@ kombu==5.3.2
     # via
     #   -r requirements.in
     #   celery
-langchain==0.3.9
+langchain==0.3.20
     # via
     #   -r requirements.in
     #   langchain-community
+langchain-anthropic==0.3.9
+    # via -r requirements.in
 langchain-community==0.3.2
     # via -r requirements.in
-langchain-core==0.3.21
+langchain-core==0.3.41
     # via
     #   langchain
+    #   langchain-anthropic
     #   langchain-community
     #   langchain-openai
     #   langchain-text-splitters
@@ -440,7 +442,7 @@ langchain-core==0.3.21
     #   langgraph-checkpoint
 langchain-openai==0.2.11
     # via -r requirements.in
-langchain-text-splitters==0.3.0
+langchain-text-splitters==0.3.6
     # via langchain
 langgraph==0.2.56
     # via -r requirements.in
@@ -508,7 +510,6 @@ nh3==0.2.14
 numpy==1.23.3
     # via
     #   -r requirements.in
-    #   langchain
     #   langchain-community
     #   pandas
     #   scikit-learn
@@ -621,6 +622,7 @@ pydantic==2.9.2
     #   anthropic
     #   dagster
     #   langchain
+    #   langchain-anthropic
     #   langchain-core
     #   langsmith
     #   openai
@@ -862,7 +864,6 @@ tenacity==8.4.2
     #   -r requirements.in
     #   celery-redbeat
     #   dlt
-    #   langchain
     #   langchain-community
     #   langchain-core
 threadpoolctl==3.3.0


### PR DESCRIPTION
## Problem

Claude 3.7 does great in coding benchmarks, and generally is tuned in a more _agentic_ way than 3.5, or GPT-4o. Let's try it out.

## Changes

This swaps out GPT-4o in our core nodes (root + insight generation) for Claude 3.7. This means `ANTHROPIC_API_KEY` is now required for Max, but we already have it in production as we were previously using Claude on docs.

## How did you test this code?

Existing tests should continue to pass.