### PR TITLE
feat(propdefs): expire all Update types promptly

### DIFF
--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -115,9 +115,10 @@ pub struct PropertyDefinition {
     pub property_type: Option<PropertyValueType>,
     pub event_type: PropertyParentType,
     pub group_type_index: Option<GroupType>,
+    pub last_seen_at: DateTime<Utc>, // Not a DB attribute; for local cache expiry only
     pub property_type_format: Option<String>, // Deprecated
-    pub volume_30_day: Option<i64>,           // Deprecated
-    pub query_usage_30_day: Option<i64>,      // Deprecated
+    pub volume_30_day: Option<i64>,  // Deprecated
+    pub query_usage_30_day: Option<i64>, // Deprecated
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -125,16 +126,18 @@ pub struct EventDefinition {
     pub name: String,
     pub team_id: i32,
     pub project_id: i64,
+    // Not a DB attribute; for local cache expiry only
     pub last_seen_at: DateTime<Utc>, // Always floored to our update rate for last_seen, so this Eq derive is safe for deduping
 }
 
 // Derived hash since these are keyed on all fields in the DB
-#[derive(Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct EventProperty {
     pub team_id: i32,
     pub project_id: i64,
     pub event: String,
     pub property: String,
+    pub last_seen_at: DateTime<Utc>, // Not a DB attribute; for local cache expiry only
 }
 
 // Represents a generic update, but comparable, allowing us to dedupe and cache updates
@@ -290,6 +293,7 @@ impl Event {
                 project_id: self.project_id,
                 event: self.event.clone(),
                 property: key.clone(),
+                last_seen_at: get_floored_last_seen(),
             }));
 
             let property_type = detect_property_type(key, value);
@@ -303,6 +307,7 @@ impl Event {
                 property_type,
                 event_type: parent_type,
                 group_type_index: group_type.clone(),
+                last_seen_at: get_floored_last_seen(),
                 property_type_format: None,
                 volume_30_day: None,
                 query_usage_30_day: None,
@@ -413,14 +418,26 @@ impl Hash for PropertyDefinition {
         self.name.hash(state);
         self.event_type.hash(state);
         self.group_type_index.hash(state);
+        self.last_seen_at.hash(state); // ensure the cache expires these fairly quickly
     }
 }
 
 impl Hash for EventDefinition {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.team_id.hash(state);
+        // project_id is not populated in posthog_eventdefinition
         self.name.hash(state);
-        self.last_seen_at.hash(state)
+        self.last_seen_at.hash(state); // ensure the cache expires these fairly quickly
+    }
+}
+
+impl Hash for EventProperty {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.team_id.hash(state);
+        // project_id is not consistently populated in posthog_eventproperty
+        self.event.hash(state);
+        self.property.hash(state);
+        self.last_seen_at.hash(state); // ensure the cache expires these fairly quickly
     }
 }
 


### PR DESCRIPTION
## Problem
`property-defs-rs` extracts 3 types of `Update` from each ingested event. Right now, `EventDefinition` expires from the cache in 1 hour due to a floored hour-granularity timestamp added to the cache key.

However,  `PropertyDefinition` and `EventProperty` do not, which means on batch write fail, or other data loss scenarios, they can last until the next deploy, or until the cache churns them out.

## Changes
Add the `last_seen_at` timestamp to all 3 `Update` types in every batch, floored to 1 hour to force prompt cache expiration.

This should be observed in production as it will cause some increased cache churn, but given the wide expiration window of an hour, I don't suspect the additional load on Postgres to be a good tradeoff for decreasing (and bounding) the time in which a lost event or property can be resubmitted and captured.

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally and in CI, but it's pretty simple. The aggregate behavior at scale when deployed will be the real test here.

