### PR TITLE
chore: do we need to sleep before tailwind

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
         "build:esbuild": "DEBUG=0 node ./build.mjs",
         "build:tailwind": "pnpm --filter=@posthog/tailwind build",
         "watch:tailwind": "pnpm --filter=@posthog/tailwind start",
-        "start": "concurrently -n ESBUILD,TYPEGEN,TAILWIND -c yellow,green,blue \"pnpm start-http\" \"pnpm run typegen:watch\" \"sleep 40 && pnpm watch:tailwind\"",
+        "start": "concurrently -n ESBUILD,TYPEGEN,TAILWIND -c yellow,green,blue \"pnpm start-http\" \"pnpm run typegen:watch\" \"pnpm watch:tailwind\"",
         "start-http": "pnpm clean && pnpm copy-scripts && pnpm build:esbuild --dev",
         "start-docker": "pnpm start-http --host 0.0.0.0",
         "typegen:write": "cd .. && kea-typegen write --delete --show-ts-errors",


### PR DESCRIPTION
My FE build wasn't working... I think that removing `sleep 40` fixed it
i did a bunch of node modules removing so it could be coincidence
but I don't _think_ we should be waiting 40 seconds during build 🤷 