### PR TITLE
docs(readme): remove outdated ToC entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ We're constantly adding new features, and recently launched <a href="https://pos
 - [Get started for free](#get-started-for-free)
 - [Docs](#docs)
 - [Contributing](#contributing)
-- [Philosophy](#philosophy)
 - [Open-source vs paid](#open-source-vs-paid)
 
 ## Get started for free


### PR DESCRIPTION
## Problem

The ToC entry points to a non-existent heading. It has been removed in 62fc93c3d66cd0c3c4cc74ca805f029d4a564d0f.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
