### PR TITLE
chore: Use ruff from our python env

### DIFF
--- a/bin/ruff.sh
+++ b/bin/ruff.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+source env/bin/activate
+python -m ruff "$@" 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "dev:migrate:postgres": "export DEBUG=1 && source env/bin/activate && python manage.py migrate",
         "dev:migrate:clickhouse": "export DEBUG=1 && source env/bin/activate && python manage.py migrate_clickhouse",
         "mypy-baseline-sync": "mypy -p posthog | mypy-baseline sync",
-        "format:backend": "ruff .",
+        "format:backend": "./bin/ruff.sh .",
         "format:frontend": "pnpm --filter=@posthog/frontend run format",
         "format": "pnpm format:backend && pnpm format:frontend"
     },
@@ -117,8 +117,8 @@
             "pnpm --dir plugin-server exec prettier --write"
         ],
         "!(posthog/hogql/grammar/*)*.{py,pyi}": [
-            "ruff check --fix",
-            "ruff format"
+            "./bin/ruff.sh check --fix",
+            "./bin/ruff.sh format"
         ]
     },
     "browserslist": {


### PR DESCRIPTION
## Problem

Different versions of ruff can produce different outputs. This can be a real pain when your system version of ruff is different from the version (currently `0.8.1`) our CI uses. We run a post-commit hook that validates that changes are formatted correctly. In some scenarios, the post commit hook uses the system `ruff`.

For example, I like to use GitHub desktop to make commits. When it runs the post-commit hook, it uses system ruff. If ruff isn't installed, it fails.

## Changes

This changes our post commit hook to explicitly use the version of `ruff` in our python env. It does this by calling a new `bin/ruff.sh` script which sources our env. This ensures that local commits are using the same `ruff`. It also ensures committing works even without a system `ruff` installed.

## Does this work well for both Cloud and self-hosted?

No impact. This change only affects local development tools.

## How did you test this code?

Uninstalled my system `ruff`. Made a commit using GitHub Desktop.