### PR TITLE
fix: limit the size of snapshot metadata fields

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/snappy-session-recorder.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/snappy-session-recorder.test.ts
@@ -331,6 +331,46 @@ describe('SnappySessionRecorder', () => {
             expect(result.urls).toEqual(['https://example.com'])
         })
 
+        it('should limit URL length to 4KB', async () => {
+            // Create a URL that exceeds the 4KB limit
+            const longUrl = 'https://example.com/' + 'a'.repeat(5000)
+
+            const events = [
+                {
+                    type: RRWebEventType.Meta,
+                    timestamp: 1000,
+                    data: { href: longUrl },
+                },
+            ]
+            const message = createMessage('window1', events)
+
+            recorder.recordMessage(message)
+            const result = await recorder.end()
+
+            // URL should be truncated to 4KB (4096 characters)
+            expect(result.firstUrl?.length).toBe(4096)
+            expect(result.urls?.[0].length).toBe(4096)
+        })
+
+        it('should limit the number of URLs to 25', async () => {
+            // Create 30 different URLs
+            const events = Array.from({ length: 30 }, (_, i) => ({
+                type: RRWebEventType.Meta,
+                timestamp: 1000 + i * 100,
+                data: { href: `https://example${i}.com` },
+            }))
+
+            const message = createMessage('window1', events)
+
+            recorder.recordMessage(message)
+            const result = await recorder.end()
+
+            // Only the first 25 URLs should be stored
+            expect(result.urls?.length).toBe(25)
+            // First URL should be the first one in the events array
+            expect(result.firstUrl).toBe('https://example0.com')
+        })
+
         it('should accumulate URLs from multiple messages', async () => {
             const message1 = createMessage('window1', [
                 {

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/snappy-session-recorder.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/snappy-session-recorder.test.ts
@@ -874,6 +874,26 @@ describe('SnappySessionRecorder', () => {
             expect(result.snapshotLibrary).toBe('posthog-android')
         })
 
+        it('should limit snapshot source and library fields to 1000 characters', async () => {
+            const message = createMessage('window1', [
+                {
+                    type: RRWebEventType.Meta,
+                    timestamp: 1000,
+                    data: {},
+                },
+            ])
+
+            const longString = 'a'.repeat(2000)
+            message.snapshot_source = longString
+            message.snapshot_library = longString
+
+            recorder.recordMessage(message)
+            const result = await recorder.end()
+
+            expect(result.snapshotSource).toBe('a'.repeat(1000))
+            expect(result.snapshotLibrary).toBe('a'.repeat(1000))
+        })
+
         it('should use values from first message when multiple messages have different values', async () => {
             const message1 = createMessage('window1', [
                 {

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/snappy-session-recorder.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/snappy-session-recorder.ts
@@ -1,11 +1,14 @@
 import { DateTime } from 'luxon'
 import snappy from 'snappy'
 
+import { status } from '../../../../utils/status'
 import { ParsedMessageData } from '../kafka/types'
 import { ConsoleLogLevel, getConsoleLogLevel, hrefFrom, isClick, isKeypress, isMouseActivity } from '../rrweb-types'
 import { activeMillisecondsFromSegmentationEvents, SegmentationEvent, toSegmentationEvent } from '../segmentation'
 
 const MAX_SNAPSHOT_FIELD_LENGTH = 1000
+const MAX_URL_LENGTH = 4 * 1024 // 4KB
+const MAX_URLS_COUNT = 25
 
 export interface EndResult {
     /** The complete compressed session block */
@@ -89,6 +92,7 @@ export class SnappySessionRecorder {
     private consoleWarnCount: number = 0
     private consoleErrorCount: number = 0
     private segmentationEvents: SegmentationEvent[] = []
+    private droppedUrlsCount: number = 0
 
     constructor(public readonly sessionId: string, public readonly teamId: number, public readonly batchId: string) {}
 
@@ -138,10 +142,7 @@ export class SnappySessionRecorder {
 
                 const eventUrl = hrefFrom(event)
                 if (eventUrl) {
-                    this.urls.add(eventUrl)
-                    if (this.firstUrl === null) {
-                        this.firstUrl = eventUrl
-                    }
+                    this.addUrl(eventUrl)
                 }
 
                 if (isClick(event)) {
@@ -176,6 +177,33 @@ export class SnappySessionRecorder {
         this.rawBytesWritten += rawBytesWritten
         this.messageCount += 1
         return rawBytesWritten
+    }
+
+    private addUrl(url: string): void {
+        if (!url) {
+            return
+        }
+
+        const truncatedUrl = url.length > MAX_URL_LENGTH ? url.slice(0, MAX_URL_LENGTH) : url
+        if (url.length > MAX_URL_LENGTH) {
+            status.warn(
+                '🔗',
+                `Truncating URL from ${url.length} to ${MAX_URL_LENGTH} characters for session ${this.sessionId}`
+            )
+        }
+
+        if (!this.firstUrl) {
+            this.firstUrl = truncatedUrl
+        }
+        if (this.urls.size < MAX_URLS_COUNT) {
+            this.urls.add(truncatedUrl)
+        } else {
+            this.droppedUrlsCount++
+            status.warn(
+                '🔗',
+                `Dropping URL (count limit reached) for session ${this.sessionId}, dropped ${this.droppedUrlsCount} URLs`
+            )
+        }
     }
 
     /**

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/snappy-session-recorder.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/snappy-session-recorder.ts
@@ -5,6 +5,8 @@ import { ParsedMessageData } from '../kafka/types'
 import { ConsoleLogLevel, getConsoleLogLevel, hrefFrom, isClick, isKeypress, isMouseActivity } from '../rrweb-types'
 import { activeMillisecondsFromSegmentationEvents, SegmentationEvent, toSegmentationEvent } from '../segmentation'
 
+const MAX_SNAPSHOT_FIELD_LENGTH = 1000
+
 export interface EndResult {
     /** The complete compressed session block */
     buffer: Buffer
@@ -108,10 +110,12 @@ export class SnappySessionRecorder {
         }
 
         if (!this.snapshotSource) {
-            this.snapshotSource = message.snapshot_source || 'web'
+            this.snapshotSource = (message.snapshot_source || 'web').slice(0, MAX_SNAPSHOT_FIELD_LENGTH)
         }
         if (!this.snapshotLibrary) {
-            this.snapshotLibrary = message.snapshot_library || null
+            this.snapshotLibrary = message.snapshot_library
+                ? message.snapshot_library.slice(0, MAX_SNAPSHOT_FIELD_LENGTH)
+                : null
         }
 
         let rawBytesWritten = 0


### PR DESCRIPTION
## Problem

We're not limiting the size of the strings in session metadata, which can be exploited to crash blobby v2 by exceeding the maximum size for the Kafka producer.

## Changes

Puts limits on the snapshot source fields, url size and count.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added unit tests.