### PR TITLE
feat(cdp): meta ads: add fbc as a default user data key

### DIFF
--- a/posthog/cdp/templates/meta_ads/template_meta_ads.py
+++ b/posthog/cdp/templates/meta_ads/template_meta_ads.py
@@ -141,6 +141,7 @@ if (res.status >= 400) {
                 "em": "{sha256Hex(person.properties.email)}",
                 "fn": "{sha256Hex(person.properties.first_name)}",
                 "ln": "{sha256Hex(person.properties.last_name)}",
+                "fbc": "{not empty(person.properties.fbclid ?? person.properties.$initial_fbclid) ? f'fb.1.{toUnixTimestampMilli(now())}.{person.properties.fbclid ?? person.properties.$initial_fbclid}' : ''}",
             },
             "secret": False,
             "required": True,

--- a/posthog/cdp/templates/meta_ads/template_meta_ads.py
+++ b/posthog/cdp/templates/meta_ads/template_meta_ads.py
@@ -23,6 +23,10 @@ let body := {
     'access_token': inputs.accessToken
 }
 
+if (not empty(inputs.testEventCode)) {
+    body.test_event_code := inputs.testEventCode
+}
+
 for (let key, value in inputs.userData) {
     if (not empty(value)) {
         body.data.1.user_data[key] := value
@@ -149,6 +153,15 @@ if (res.status >= 400) {
             "default": {"currency": "USD", "price": "{event.properties.price}"},
             "secret": False,
             "required": True,
+        },
+        {
+            "key": "testEventCode",
+            "type": "string",
+            "label": "Test Event Code",
+            "description": "Use this field to specify that events should be test events rather than actual traffic. You'll want to remove your Test Event Code when sending real traffic through this integration.",
+            "default": "",
+            "secret": False,
+            "required": False,
         },
     ],
     filters={

--- a/posthog/cdp/templates/meta_ads/template_meta_ads.py
+++ b/posthog/cdp/templates/meta_ads/template_meta_ads.py
@@ -14,6 +14,7 @@ let body := {
     'data': [
         {
             'event_name': inputs.eventName,
+            'event_id': inputs.eventId,
             'event_time': inputs.eventTime,
             'action_source': inputs.actionSource,
             'user_data': {},
@@ -73,6 +74,15 @@ if (res.status >= 400) {
             "label": "Event name",
             "description": "A standard event or custom event name.",
             "default": "{event.event}",
+            "secret": False,
+            "required": True,
+        },
+        {
+            "key": "eventId",
+            "type": "string",
+            "label": "Event ID",
+            "description": "The ID of the event.",
+            "default": "{event.uuid}",
             "secret": False,
             "required": True,
         },

--- a/posthog/cdp/templates/meta_ads/test_template_meta_ads.py
+++ b/posthog/cdp/templates/meta_ads/test_template_meta_ads.py
@@ -14,6 +14,7 @@ class TestTemplateMetaAds(BaseHogFunctionTemplateTest):
             "pixelId": "123451234512345",
             "eventName": "checkout",
             "eventTime": "1728812163",
+            "eventId": "eventId12345",
             "actionSource": "website",
             "userData": {
                 "em": "3edfaed7454eedb3c72bad566901af8bfbed1181816dde6db91dfff0f0cffa98",
@@ -43,6 +44,7 @@ class TestTemplateMetaAds(BaseHogFunctionTemplateTest):
                         "data": [
                             {
                                 "event_name": "checkout",
+                                "event_id": "eventId12345",
                                 "event_time": "1728812163",
                                 "action_source": "website",
                                 "user_data": {"em": "3edfaed7454eedb3c72bad566901af8bfbed1181816dde6db91dfff0f0cffa98"},


### PR DESCRIPTION
## Problem

People want to send the `fbclid` value back to meta ads

https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/fbp-and-fbc#4--send-fbc-parameter-with-conversions-api-events

## Changes

- Add testing code for easier testing
- Add an eventId input
- add `fbc` as a default user data key
 
## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
