### PR TITLE
refactor: improve blobby v2 message validation

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/kafka/message-parser.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/kafka/message-parser.test.ts
@@ -160,9 +160,33 @@ describe('KafkaMessageParser', () => {
             )
         })
 
+        it('filters out message with missing distinct_id', async () => {
+            const messages = [
+                createMessage({
+                    data: JSON.stringify({
+                        event: '$snapshot_items',
+                        properties: {
+                            $session_id: 'session1',
+                            $window_id: 'window1',
+                            $snapshot_items: [{ timestamp: 1, type: 2 }],
+                        },
+                    }),
+                }),
+            ]
+
+            const results = await parser.parseBatch(messages)
+
+            expect(results).toHaveLength(0)
+            expect(KafkaMetrics.incrementMessageDropped).toHaveBeenCalledWith(
+                'session_recordings_blob_ingestion',
+                'invalid_message_payload'
+            )
+        })
+
         it('filters out non-snapshot message', async () => {
             const messages = [
                 createMessage({
+                    distinct_id: 'user123',
                     data: JSON.stringify({
                         event: 'not_a_snapshot',
                         properties: {
@@ -189,6 +213,7 @@ describe('KafkaMessageParser', () => {
         it('processes multiple messages in parallel', async () => {
             const messages = [
                 createMessage({
+                    distinct_id: 'user123',
                     data: JSON.stringify({
                         event: '$snapshot_items',
                         properties: {
@@ -199,6 +224,7 @@ describe('KafkaMessageParser', () => {
                     }),
                 }),
                 createMessage({
+                    distinct_id: 'user123',
                     data: JSON.stringify({
                         event: '$snapshot_items',
                         properties: {
@@ -226,6 +252,7 @@ describe('KafkaMessageParser', () => {
             ]
             const messages = [
                 createMessage({
+                    distinct_id: 'user123',
                     data: JSON.stringify({
                         event: '$snapshot_items',
                         properties: {
@@ -261,6 +288,7 @@ describe('KafkaMessageParser', () => {
             ]
             const messages = [
                 createMessage({
+                    distinct_id: 'user123',
                     data: JSON.stringify({
                         event: '$snapshot_items',
                         properties: {

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/kafka/message-parser.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/kafka/message-parser.ts
@@ -3,25 +3,31 @@ import { promisify } from 'node:util'
 import { Message } from 'node-rdkafka'
 import { gunzip } from 'zlib'
 
-import { PipelineEvent, RawEventMessage, RRWebEvent } from '../../../../types'
 import { status } from '../../../../utils/status'
 import { KafkaMetrics } from './metrics'
-import { ParsedMessageData } from './types'
+import { EventSchema, ParsedMessageData, RawEventMessageSchema, SnapshotEvent, SnapshotEventSchema } from './types'
 
 const GZIP_HEADER = Uint8Array.from([0x1f, 0x8b, 0x08, 0x00])
 const decompressWithGzip = promisify(gunzip)
 
-function getValidEvents(events: RRWebEvent[]): {
-    validEvents: RRWebEvent[]
+function getValidEvents(events: unknown[]): {
+    validEvents: SnapshotEvent[]
     startDateTime: DateTime
     endDateTime: DateTime
 } | null {
     const eventsWithDates = events
-        .filter((event) => (event?.timestamp || -1) > 0)
-        .map((event) => ({
-            event,
-            dateTime: DateTime.fromMillis(event.timestamp),
-        }))
+        .map((event) => {
+            const parseResult = SnapshotEventSchema.safeParse(event)
+            if (!parseResult.success || parseResult.data.timestamp <= 0) {
+                return null
+            }
+            return {
+                event: parseResult.data,
+                dateTime: DateTime.fromMillis(parseResult.data.timestamp),
+            }
+        })
+        .filter((x): x is { event: SnapshotEvent; dateTime: DateTime } => x !== null)
+        .filter(({ dateTime }) => dateTime.isValid)
 
     const validEventsAndDates = eventsWithDates.filter(({ dateTime }) => dateTime.isValid)
 
@@ -50,7 +56,7 @@ function getValidEvents(events: RRWebEvent[]): {
 export class KafkaMessageParser {
     public async parseBatch(messages: Message[]): Promise<ParsedMessageData[]> {
         const parsedMessages = await Promise.all(messages.map((message) => this.parseMessage(message)))
-        return parsedMessages.filter((msg) => msg !== null) as ParsedMessageData[]
+        return parsedMessages.filter((msg): msg is ParsedMessageData => msg !== null)
     }
 
     private async parseMessage(message: Message): Promise<ParsedMessageData | null> {
@@ -70,9 +76,6 @@ export class KafkaMessageParser {
             return dropMessage('message_value_or_timestamp_is_empty')
         }
 
-        let messagePayload: RawEventMessage
-        let event: PipelineEvent
-
         let messageUnzipped = message.value
         try {
             if (this.isGzipped(message.value)) {
@@ -84,16 +87,33 @@ export class KafkaMessageParser {
             return dropMessage('invalid_gzip_data', { error })
         }
 
+        let rawPayload: unknown
         try {
-            messagePayload = JSON.parse(messageUnzipped.toString())
-            event = JSON.parse(messagePayload.data)
+            rawPayload = JSON.parse(messageUnzipped.toString())
         } catch (error) {
             return dropMessage('invalid_json', { error })
         }
 
-        const { $snapshot_items, $session_id, $window_id, $snapshot_source, $snapshot_library } = event.properties || {}
+        const messageResult = RawEventMessageSchema.safeParse(rawPayload)
+        if (!messageResult.success) {
+            return dropMessage('invalid_message_payload', { error: messageResult.error })
+        }
 
-        if (event.event !== '$snapshot_items' || !$snapshot_items || !$session_id) {
+        let eventData: unknown
+        try {
+            eventData = JSON.parse(messageResult.data.data)
+        } catch (error) {
+            return dropMessage('received_non_snapshot_message', { error })
+        }
+        const eventResult = EventSchema.safeParse(eventData)
+        if (!eventResult.success) {
+            return dropMessage('received_non_snapshot_message', { error: eventResult.error })
+        }
+
+        const { $snapshot_items, $session_id, $window_id, $snapshot_source, $snapshot_library } =
+            eventResult.data.properties
+
+        if (eventResult.data.event !== '$snapshot_items' || !$snapshot_items || !$session_id) {
             return dropMessage('received_non_snapshot_message')
         }
 
@@ -112,7 +132,7 @@ export class KafkaMessageParser {
                 timestamp: message.timestamp,
             },
             headers: message.headers,
-            distinct_id: messagePayload.distinct_id,
+            distinct_id: messageResult.data.distinct_id,
             session_id: $session_id,
             eventsByWindowId: {
                 [$window_id ?? '']: validEvents,

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/kafka/message-parser.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/kafka/message-parser.ts
@@ -29,15 +29,13 @@ function getValidEvents(events: unknown[]): {
         .filter((x): x is { event: SnapshotEvent; dateTime: DateTime } => x !== null)
         .filter(({ dateTime }) => dateTime.isValid)
 
-    const validEventsAndDates = eventsWithDates.filter(({ dateTime }) => dateTime.isValid)
-
-    if (!validEventsAndDates.length) {
+    if (!eventsWithDates.length) {
         return null
     }
 
-    let startDateTime = validEventsAndDates[0].dateTime
-    let endDateTime = validEventsAndDates[0].dateTime
-    for (const { dateTime } of validEventsAndDates) {
+    let startDateTime = eventsWithDates[0].dateTime
+    let endDateTime = eventsWithDates[0].dateTime
+    for (const { dateTime } of eventsWithDates) {
         if (dateTime < startDateTime) {
             startDateTime = dateTime
         }
@@ -47,7 +45,7 @@ function getValidEvents(events: unknown[]): {
     }
 
     return {
-        validEvents: validEventsAndDates.map(({ event }) => event),
+        validEvents: eventsWithDates.map(({ event }) => event),
         startDateTime,
         endDateTime,
     }

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/kafka/types.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/kafka/types.ts
@@ -1,24 +1,70 @@
 import { DateTime } from 'luxon'
 import { MessageHeader } from 'node-rdkafka'
+import { z } from 'zod'
 
-import { RRWebEvent } from '../../../../types'
+const dateTimeSchema = z.custom<DateTime>((val) => val instanceof DateTime)
 
-export interface ParsedMessageData {
-    distinct_id: string
-    session_id: string
-    eventsByWindowId: { [key: string]: RRWebEvent[] }
-    eventsRange: {
-        start: DateTime
-        end: DateTime
-    }
-    snapshot_source: string | null
-    snapshot_library: string | null
-    headers?: MessageHeader[]
-    metadata: {
-        partition: number
-        topic: string
-        rawSize: number
-        offset: number
-        timestamp: number
-    }
-}
+// This is the schema for the raw event message from Kafka
+
+export const RawEventMessageSchema = z.object({
+    distinct_id: z.string(),
+    data: z.string(),
+})
+
+export type RawEventMessage = z.infer<typeof RawEventMessageSchema>
+
+// This is the schema for the message metadata from Kafka
+
+export const MessageMetadataSchema = z.object({
+    partition: z.number(),
+    topic: z.string(),
+    rawSize: z.number(),
+    offset: z.number(),
+    timestamp: z.number(),
+})
+
+export type MessageMetadata = z.infer<typeof MessageMetadataSchema>
+
+// The following schemas are for the parsed session recording events
+
+const EventsRangeSchema = z.object({
+    start: dateTimeSchema,
+    end: dateTimeSchema,
+})
+
+const EventPropertiesSchema = z
+    .object({
+        $snapshot_items: z.array(z.unknown()).optional(),
+        $session_id: z.string().optional(),
+        $window_id: z.string().optional(),
+        $snapshot_source: z.string().optional(),
+        $snapshot_library: z.string().optional(),
+    })
+    .partial()
+    .passthrough()
+
+export const SnapshotEventSchema = z
+    .object({
+        timestamp: z.number(),
+    })
+    .passthrough()
+
+export const EventSchema = z.object({
+    event: z.string(),
+    properties: EventPropertiesSchema,
+})
+
+export const ParsedMessageDataSchema = z.object({
+    distinct_id: z.string(),
+    session_id: z.string(),
+    eventsByWindowId: z.record(z.string(), z.array(SnapshotEventSchema)),
+    eventsRange: EventsRangeSchema,
+    snapshot_source: z.string().nullable(),
+    snapshot_library: z.string().nullable(),
+    headers: z.array(z.custom<MessageHeader>()).optional(),
+    metadata: MessageMetadataSchema,
+})
+
+export type Event = z.infer<typeof EventSchema>
+export type SnapshotEvent = z.infer<typeof SnapshotEventSchema>
+export type ParsedMessageData = z.infer<typeof ParsedMessageDataSchema>

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/rrweb-types.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/rrweb-types.ts
@@ -1,4 +1,4 @@
-import { RRWebEvent } from '~/src/types'
+import { SnapshotEvent } from './kafka/types'
 
 export enum RRWebEventType {
     DomContentLoaded = 0,
@@ -56,27 +56,31 @@ const MOUSE_ACTIVITY_SOURCES = [
     RRWebEventSource.TouchMove,
 ]
 
-export function isClick(event: RRWebEvent): boolean {
+export function isClick(inputEvent: SnapshotEvent): boolean {
+    const event = inputEvent as { type?: number; data?: { source?: number; type?: number } } | undefined
     return (
-        event.type === RRWebEventType.IncrementalSnapshot &&
-        event.data?.source === RRWebEventSource.MouseInteraction &&
-        CLICK_TYPES.includes(event.data?.type || -1)
+        event?.type === RRWebEventType.IncrementalSnapshot &&
+        event?.data?.source === RRWebEventSource.MouseInteraction &&
+        CLICK_TYPES.includes(event?.data?.type ?? -1)
     )
 }
 
-export function isKeypress(event: RRWebEvent): boolean {
-    return event.type === RRWebEventType.IncrementalSnapshot && event.data?.source === RRWebEventSource.Input
+export function isKeypress(inputEvent: SnapshotEvent): boolean {
+    const event = inputEvent as { type?: number; data?: { source?: number } } | undefined
+    return event?.type === RRWebEventType.IncrementalSnapshot && event?.data?.source === RRWebEventSource.Input
 }
 
-export function isMouseActivity(event: RRWebEvent): boolean {
+export function isMouseActivity(inputEvent: SnapshotEvent): boolean {
+    const event = inputEvent as { type?: number; data?: { source?: number } } | undefined
     return (
-        event.type === RRWebEventType.IncrementalSnapshot && MOUSE_ACTIVITY_SOURCES.includes(event.data?.source || -1)
+        event?.type === RRWebEventType.IncrementalSnapshot && MOUSE_ACTIVITY_SOURCES.includes(event?.data?.source ?? -1)
     )
 }
 
-export function hrefFrom(event: RRWebEvent): string | undefined {
-    const metaHref = event.data?.href?.trim?.()
-    const customHref = event.data?.payload?.href?.trim?.()
+export function hrefFrom(inputEvent: SnapshotEvent): string | undefined {
+    const event = inputEvent as { type?: number; data?: { href?: string; payload?: { href?: string } } } | undefined
+    const metaHref = event?.data?.href?.trim?.()
+    const customHref = event?.data?.payload?.href?.trim?.()
     return metaHref || customHref || undefined
 }
 
@@ -90,9 +94,12 @@ export enum ConsoleLogLevel {
 /**
  * Checks if an event is a console event and returns its log level, or null if it's not a console event
  */
-export function getConsoleLogLevel(event: RRWebEvent): ConsoleLogLevel | null {
-    if (event.type === RRWebEventType.Plugin && event.data?.plugin === 'rrweb/console@1') {
-        const level = event.data?.payload?.level
+export function getConsoleLogLevel(inputEvent: SnapshotEvent): ConsoleLogLevel | null {
+    const event = inputEvent as
+        | { type?: number; data?: { plugin?: string; payload?: { level?: ConsoleLogLevel } } }
+        | undefined
+    if (event?.type === RRWebEventType.Plugin && event?.data?.plugin === 'rrweb/console@1') {
+        const level = event?.data?.payload?.level
         if (level === ConsoleLogLevel.Log) {
             return ConsoleLogLevel.Log
         } else if (level === ConsoleLogLevel.Warn) {

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/segmentation.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/segmentation.ts
@@ -6,7 +6,7 @@
  * Any changes may need to be sync'd between the two
  */
 
-import { RRWebEvent } from '../../../types'
+import { SnapshotEvent } from './kafka/types'
 import { RRWebEventSource, RRWebEventType } from './rrweb-types'
 
 const activeSources = [
@@ -48,14 +48,18 @@ interface RecordingSegment {
 /**
  * Checks if an event is an active event (indicates user activity)
  */
-const isActiveEvent = (event: RRWebEvent): boolean => {
-    return event.type === RRWebEventType.IncrementalSnapshot && activeSources.includes(event.data?.source || -1)
+const isActiveEvent = (event: SnapshotEvent): boolean => {
+    const eventData = event as { type?: number; data?: { source?: number } } | undefined
+    const type = eventData?.type
+    const source = eventData?.data?.source
+
+    return type === RRWebEventType.IncrementalSnapshot && activeSources.includes(source ?? -1)
 }
 
 /**
  * Converts an RRWebEvent to a simplified SegmentationEvent with just timestamp and activity status
  */
-export const toSegmentationEvent = (event: RRWebEvent): SegmentationEvent => {
+export const toSegmentationEvent = (event: SnapshotEvent): SegmentationEvent => {
     return {
         timestamp: event.timestamp,
         isActive: isActiveEvent(event),

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.test.ts
@@ -3,6 +3,7 @@ import { validate as uuidValidate } from 'uuid'
 
 import { KafkaOffsetManager } from '../kafka/offset-manager'
 import { ParsedMessageData } from '../kafka/types'
+import { SnapshotEvent } from '../kafka/types'
 import { MessageWithTeam } from '../teams/types'
 import { SessionBatchMetrics } from './metrics'
 import { SessionBatchFileStorage, SessionBatchFileWriter } from './session-batch-file-storage'
@@ -165,7 +166,7 @@ describe('SessionBatchRecorder', () => {
 
     const createMessage = (
         sessionId: string,
-        events: RRWebEvent[],
+        events: SnapshotEvent[],
         metadata: MessageMetadata = {},
         teamId: number = 1,
         distinctId: string = 'distinct_id'


### PR DESCRIPTION
## Problem

In blobby we're receiving mildly processed messages from capture, we make some assertions, but the types seem quite sketchy. For example, we cast events to RRWeb event types, but we don't really validate the fields.

## Changes

Implements message validation using zod and tightens types.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

There were plenty of unit tests to cover for regressions.
Added some new tests for new cases.