### PR TITLE
fix(frontend): Restore our toast styling

### DIFF
--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -1,6 +1,5 @@
 // Global components
 @import 'vars';
-@import '../../node_modules/react-toastify/dist/ReactToastify';
 @import 'functions';
 @import 'mixins';
 @import 'utilities-legacy'; // TODO: Remove all legacy utilities
@@ -978,6 +977,10 @@
 }
 
 @layer base {
+    /* stylelint-disable-next-line no-invalid-position-at-import-rule */ // allowing @import to be inside layer
+    @import '../../node_modules/react-toastify/dist/ReactToastify'; // Toastify is in base so that we can override
+
+    /* stylelint-disable-next-line order/order */ // allowing @import to be first
     *,
     ::after,
     ::before,


### PR DESCRIPTION
## Problem

This is not how things were before the recent Tailwind upgrade:

<img width="426" alt="Screenshot 2025-03-10 at 12 56 25" src="https://github.com/user-attachments/assets/a8f658d3-c40f-4f54-8d86-1a555cd25d59" />

## Changes

This is how things should be:

<img width="454" alt="Screenshot 2025-03-10 at 13 01 37" src="https://github.com/user-attachments/assets/db9d28c7-ac33-4acf-a84d-57ed6a5f0d4c" />

