### PR TITLE
feat: add event_number table to speed up usage reporting.

### DIFF
--- a/posthog/clickhouse/migrations/0105_event_count_for_reporting.py
+++ b/posthog/clickhouse/migrations/0105_event_count_for_reporting.py
@@ -1,0 +1,16 @@
+# Create 3 helper clickhouse objects, the first sharded_event_number_mv is a materialized view using aggregating engine
+# for robust team,event,date event counting, the second event_number is a distributed table making it one table
+# and the third event_number_v is a view making querying easier (using countMerge under the hood).
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.models.event.sql import (
+    TEAM_EVENT_NUMBER_DIST_SQL,
+    SHARDED_TEAM_EVENT_NUMBER_MV_SQL,
+    TEAM_EVENT_NUMBER_VIEW_SQL,
+)
+
+operations = [
+    run_sql_with_exceptions(SHARDED_TEAM_EVENT_NUMBER_MV_SQL(), node_role=NodeRole.DATA, sharded=True),
+    run_sql_with_exceptions(TEAM_EVENT_NUMBER_DIST_SQL(), node_role=NodeRole.ALL),
+    run_sql_with_exceptions(TEAM_EVENT_NUMBER_VIEW_SQL(), node_role=NodeRole.ALL),
+]

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -13,6 +13,7 @@ from posthog.clickhouse.kafka_engine import (
 from posthog.clickhouse.property_groups import property_groups
 from posthog.clickhouse.cluster import ON_CLUSTER_CLAUSE
 from posthog.clickhouse.table_engines import (
+    AggregatingMergeTree,
     Distributed,
     ReplacingMergeTree,
     ReplicationScheme,
@@ -559,7 +560,7 @@ SHARDED_TEAM_EVENT_NUMBER_TABLE = "sharded_event_number_mv"
 def SHARDED_TEAM_EVENT_NUMBER_MV_SQL(on_cluster=False):
     return f"""
 CREATE MATERIALIZED VIEW IF NOT EXISTS {SHARDED_TEAM_EVENT_NUMBER_TABLE} {ON_CLUSTER_CLAUSE(on_cluster)}
-ENGINE = AggregatingMergeTree()
+ENGINE = {AggregatingMergeTree(SHARDED_TEAM_EVENT_NUMBER_TABLE, replication_scheme=ReplicationScheme.SHARDED)}
 PARTITION BY toYYYYMMDD(date)
 ORDER BY (team_id, event, date)
 AS


### PR DESCRIPTION
## Problem

Need to know number of event type by a team quickly

## Changes

Create a materialized view table to count it.


## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Run data generation, check numbers.
