### PR TITLE
feat(temporal): Add PostHog error tracking to temporal workers

### DIFF
--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -8,6 +8,7 @@ from temporalio.runtime import PrometheusConfig, Runtime, TelemetryConfig
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
 from posthog.temporal.common.client import connect
+from posthog.temporal.common.posthog_client import PostHogClientInterceptor
 from posthog.temporal.common.sentry import SentryInterceptor
 
 
@@ -52,7 +53,7 @@ async def start_worker(
         activities=activities,
         workflow_runner=UnsandboxedWorkflowRunner(),
         graceful_shutdown_timeout=timedelta(minutes=5),
-        interceptors=[SentryInterceptor()],
+        interceptors=[SentryInterceptor(), PostHogClientInterceptor()],
         activity_executor=ThreadPoolExecutor(max_workers=max_concurrent_activities or 50),
         max_concurrent_activities=max_concurrent_activities or 50,
         max_concurrent_workflow_tasks=max_concurrent_workflow_tasks,


### PR DESCRIPTION
## Problem

Adding PostHog error tracking to our Temporal workers.

This was originally added [in this PR](https://github.com/PostHog/posthog/pull/27237) but was [reverted](https://github.com/PostHog/posthog/pull/27342) as it was causing issues.

## Changes

This implementation is slightly different, and follows how we capture exceptions in other places (will post them to the local PostHog instance when running locally, otherwise will use the API key in other envs).

Everything worked fine locally, so will have to deploy it and check how it works in production. If we see jobs backing up we will need to revert

## How did you test this code?

Ran workflows locally, introduced some errors and checked these were being tracked as expected.
