### PR TITLE
fix(data-warehouse): Reset full refresh tables on sync

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -102,6 +102,10 @@ class PipelineNonDLT:
                 self._logger.debug("Deleting existing table due to reset_pipeline being set")
                 self._delta_table_helper.reset_table()
                 self._schema.update_sync_type_config_for_reset_pipeline()
+            elif self._schema.sync_type == ExternalDataSchema.SyncType.FULL_REFRESH:
+                # Avoid schema mismatches from existing data about to be overwritten
+                self._logger.debug("Deleting existing table due to sync being full refresh")
+                self._delta_table_helper.reset_table()
 
             for item in self._resource.items:
                 py_table = None

--- a/posthog/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/utils.py
@@ -181,10 +181,9 @@ def _evolve_pyarrow_schema(table: pa.Table, delta_schema: deltalake.Schema | Non
                 if (
                     isinstance(py_arrow_table_column.type, pa.Decimal128Type)
                     or isinstance(py_arrow_table_column.type, pa.Decimal256Type)
-                    and (
-                        field.type.precision > py_arrow_table_column.type.precision
-                        or field.type.scale > py_arrow_table_column.type.scale
-                    )
+                ) and (
+                    field.type.precision > py_arrow_table_column.type.precision
+                    or field.type.scale > py_arrow_table_column.type.scale
                 ):
                     field_index = table.schema.get_field_index(field.name)
 


### PR DESCRIPTION
## Problem
- We started to get a bunch of [invalid decimal precision errors again](https://posthog.sentry.io/issues/6254527972/events/) 🤯 
- For the ones I checked, the tables were full refresh syncs and we were trying to merge the existing deltalake schema with the new pyarrow table schema before deleting the deltalake table data - this merging was causing issues for some schemas

## Changes
- Just delete the deltalake table at the beginning of a full refresh sync - we don't need it and it just complicates the process by trying to keep the new datas schema compatible
- Also fixed a bug where we were mistakenly changing the scale of decimals due to missing parenthesis around an `if` clause

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Tested with real data locally 