### PR TITLE
chore: Add retries to some node tests

### DIFF
--- a/plugin-server/tests/router.test.ts
+++ b/plugin-server/tests/router.test.ts
@@ -4,6 +4,7 @@ import { PluginServer } from '../src/server'
 import { PluginServerMode } from '../src/types'
 
 describe('router', () => {
+    jest.retryTimes(3) // Flakey due to reliance on kafka/clickhouse
     let server: PluginServer
 
     beforeAll(async () => {

--- a/plugin-server/tests/server.test.ts
+++ b/plugin-server/tests/server.test.ts
@@ -7,6 +7,7 @@ import { resetTestDatabase } from './helpers/sql'
 jest.setTimeout(20000) // 20 sec timeout - longer indicates an issue
 
 describe('server', () => {
+    jest.retryTimes(3) // Flakey due to reliance on kafka/clickhouse
     let pluginsServer: PluginServer | null = null
 
     beforeEach(async () => {

--- a/plugin-server/tests/worker/ingestion/postgres-parity.test.ts
+++ b/plugin-server/tests/worker/ingestion/postgres-parity.test.ts
@@ -17,13 +17,14 @@ import { resetKafka } from '../../helpers/kafka'
 import { createUserTeamAndOrganization, resetTestDatabase } from '../../helpers/sql'
 
 jest.mock('../../../src/utils/status')
-jest.setTimeout(60000) // 60 sec timeout
+jest.setTimeout(30000)
 
 const extraServerConfig: Partial<PluginsServerConfig> = {
     LOG_LEVEL: LogLevel.Log,
 }
 
 describe('postgres parity', () => {
+    jest.retryTimes(5) // Flakey due to reliance on kafka/clickhouse
     let hub: Hub
     let server: PluginServer
     let teamId = 10 // Incremented every test. Avoids late ingestion causing issues


### PR DESCRIPTION
## Problem

Whilst we are improving these things we may as well try and save us some pain for the tests we know are flakey

## Changes

* Adds retries to the ones i see failing most commonly

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
