### PR TITLE
chore: redirect general questions to maxai if flag is enabled

### DIFF
--- a/frontend/src/scenes/session-recordings/components/AiFilter/aiFilterLogic.ts
+++ b/frontend/src/scenes/session-recordings/components/AiFilter/aiFilterLogic.ts
@@ -113,7 +113,7 @@ export const aiFilterLogic = kea<aiFilterLogicType>([
                             {
                                 role: 'assistant',
                                 content:
-                                    'It looks like you are asking not about Session Replay, so I redirect you to Max AI Senior.',
+                                    'It looks like you are asking about something other than session replay, so I redirect you to Max.',
                             } as ChatCompletionAssistantMessageParam,
                         ])
                         posthog.capture('ai_filter_redirect_maxai')

--- a/frontend/src/scenes/session-recordings/components/AiFilter/aiFilterLogic.ts
+++ b/frontend/src/scenes/session-recordings/components/AiFilter/aiFilterLogic.ts
@@ -1,5 +1,7 @@
 import { actions, kea, listeners, path, props, reducers } from 'kea'
 import api from 'lib/api'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import {
     ChatCompletionAssistantMessageParam,
     ChatCompletionSystemMessageParam,
@@ -7,7 +9,9 @@ import {
 } from 'openai/resources/chat/completions'
 import posthog from 'posthog-js'
 
-import { RecordingUniversalFilters } from '~/types'
+import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
+import { maxLogic } from '~/scenes/max/maxLogic'
+import { RecordingUniversalFilters, SidePanelTab } from '~/types'
 
 import type { aiFilterLogicType } from './aiFilterLogicType'
 
@@ -17,11 +21,11 @@ export interface AiFilterLogicProps {
 }
 
 interface AiFilterResponse {
-    result: 'filter' | 'question'
+    result: 'filter' | 'question' | 'maxai'
     data: any
 }
 
-const TIMEOUT_LIMIT = 10000
+const TIMEOUT_LIMIT = 15000
 
 export const aiFilterLogic = kea<aiFilterLogicType>([
     path(['lib', 'components', 'AiFilter', 'aiFilterLogicType']),
@@ -78,6 +82,7 @@ export const aiFilterLogic = kea<aiFilterLogicType>([
             ]
             actions.setMessages(newMessages)
             actions.handleAi(newMessages)
+
             actions.setInput('')
         },
         handleAi: async ({ newMessages }) => {
@@ -95,6 +100,27 @@ export const aiFilterLogic = kea<aiFilterLogicType>([
                     if (content.result === 'filter') {
                         props.setFilters(content.data)
                         posthog.capture('ai_filter_success')
+                    }
+
+                    if (
+                        content.result === 'maxai' &&
+                        featureFlagLogic.values.featureFlags[FEATURE_FLAGS.ARTIFICIAL_HOG]
+                    ) {
+                        sidePanelStateLogic.actions.openSidePanel(SidePanelTab.Max)
+                        maxLogic.actions.askMax(newMessages[newMessages.length - 1].content as string)
+                        actions.setMessages([
+                            ...newMessages,
+                            {
+                                role: 'assistant',
+                                content:
+                                    'It looks like you are asking not about Session Replay, so I redirect you to Max AI Senior.',
+                            } as ChatCompletionAssistantMessageParam,
+                        ])
+                        posthog.capture('ai_filter_redirect_maxai')
+                        actions.setIsLoading(false)
+
+                        //Do not do anything else
+                        return
                     }
 
                     actions.setMessages([

--- a/posthog/session_recordings/ai_data/ai_filter_prompts.py
+++ b/posthog/session_recordings/ai_data/ai_filter_prompts.py
@@ -61,7 +61,7 @@ AI_FILTER_INITIAL_PROMPT = """
     {
         "result": "maxai",
         "data": {
-            "question": "Please ask only about Session Replay."
+            "question": "Please ask questions only about Session Replay."
     }
     Notes:
     1. Replace <date_from> and <date_to> with valid date strings.

--- a/posthog/session_recordings/ai_data/ai_filter_prompts.py
+++ b/posthog/session_recordings/ai_data/ai_filter_prompts.py
@@ -6,12 +6,12 @@ AI_FILTER_INITIAL_PROMPT = """
 
     Key Points:
     1. Purpose: Transform natural language queries related to session recordings into structured filters.
-    2. Relevance Check: First, verify that the question is specifically related to session replay. If the question is off-topic—for example, asking about the weather, the AI model, or any subject not related to session replay—the agent should respond with a clarifying message: "Please ask questions only about session replay."
+    2. Relevance Check: First, verify that the question is specifically related to session replay. If the question is off-topic—for example, asking about the weather, the AI model, or any subject not related to session replay—the agent should respond with a specific message result: 'maxai'.
     3. Ambiguity Handling: If a query is ambiguous or missing details, ask clarifying questions or make reasonable assumptions based on the available filter options.
 
     Strictly follow this algorithm:
     1. Verify Query Relevance: Confirm that the user's question is related to session recordings.
-    2. Handle Irrelevant Queries: If the question is not related, return a response with result: 'question' that explains why the query is outside the scope.
+    2. Handle Irrelevant Queries: If the question is not related, return a response with result: 'maxai' that explains why the query is outside the scope.
     3. Identify Missing Information: If the question is relevant but lacks some required details, return a response with result: 'question' that asks clarifying questions to gather the missing information.
     4. Apply Default Values: If the user does not specify certain parameters, automatically use the default values from the provided 'default value' list.
     5. Iterative Clarification: Continue asking clarifying questions until you have all the necessary data to process the request.
@@ -55,6 +55,13 @@ AI_FILTER_INITIAL_PROMPT = """
                 },
             ]
         }
+    }
+    3. Wrong Query Response Format
+    If the query is not related to session replay, return with the following format:
+    {
+        "result": "maxai",
+        "data": {
+            "question": "Please ask only about Session Replay."
     }
     Notes:
     1. Replace <date_from> and <date_to> with valid date strings.

--- a/posthog/session_recordings/ai_data/ai_filter_schema.py
+++ b/posthog/session_recordings/ai_data/ai_filter_schema.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 class ResultEnum(str, Enum):
     QUESTION = "question"
     FILTER = "filter"
+    MAXAI = "maxai"
 
 
 class FilterOperatorEnum(str, Enum):


### PR DESCRIPTION
## Problem

At this moment, when you ask Max AI in "Chat with recordings" about something that is not related to SR you get "Please ask questions only about Session Replay" 

Let's call the big brother to answer them.

P.S. we check the max ai feature flag. if it's false we still show "Please ask questions only about Session Replay"

### Before
<img width="857" alt="Screenshot 2025-03-10 at 16 26 43" src="https://github.com/user-attachments/assets/94324e1e-3220-4652-a68a-0df0ef3392ef" />


### After
<img width="1670" alt="Screenshot 2025-03-10 at 16 26 12" src="https://github.com/user-attachments/assets/5f8fc2c6-f776-4d5a-a3f2-8acda12ce4a3" />

