### PR TITLE
feat(data-warehouse): Use optimised merging

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -4,6 +4,7 @@ from conditional_cache import lru_cache
 from typing import Any
 import deltalake.exceptions
 import pyarrow as pa
+import pyarrow.compute as pc
 from dlt.common.libs.deltalake import ensure_delta_compatible_arrow_schema
 from dlt.common.normalizers.naming.snake_case import NamingConvention
 import deltalake as deltalake
@@ -140,20 +141,49 @@ class DeltaTableHelper:
             if use_partitioning:
                 predicate_ops.append(f"source.{PARTITION_KEY} = target.{PARTITION_KEY}")
 
-            merge_stats = (
-                delta_table.merge(
-                    source=data,
-                    source_alias="source",
-                    target_alias="target",
-                    predicate=" AND ".join(predicate_ops),
-                    streamed_exec=False,
-                )
-                .when_matched_update_all()
-                .when_not_matched_insert_all()
-                .execute()
-            )
+                # Group the table by the partition key and merge multiple times with streamed_exec=True for optimised merging
+                unique_partitions = pc.unique(data[PARTITION_KEY])  # type: ignore
 
-            self._logger.debug(f"Delta Merge Stats: {json.dumps(merge_stats)}")
+                self._logger.debug(f"Running {len(unique_partitions)} optimised merges")
+
+                for partition in unique_partitions:
+                    partition_predicate_ops = predicate_ops.copy()
+                    partition_predicate_ops.append(f"target.{PARTITION_KEY} = '{partition}'")
+                    predicate = " AND ".join(partition_predicate_ops)
+
+                    filtered_table = data.filter(pc.equal(data[PARTITION_KEY], partition))
+
+                    self._logger.debug(f"Merging partition={partition} with predicate={predicate}")
+
+                    merge_stats = (
+                        delta_table.merge(
+                            source=filtered_table,
+                            source_alias="source",
+                            target_alias="target",
+                            predicate=predicate,
+                            streamed_exec=True,
+                        )
+                        .when_matched_update_all()
+                        .when_not_matched_insert_all()
+                        .execute()
+                    )
+
+                    self._logger.debug(f"Delta Merge Stats: {json.dumps(merge_stats)}")
+            else:
+                merge_stats = (
+                    delta_table.merge(
+                        source=data,
+                        source_alias="source",
+                        target_alias="target",
+                        predicate=" AND ".join(predicate_ops),
+                        streamed_exec=False,
+                    )
+                    .when_matched_update_all()
+                    .when_not_matched_insert_all()
+                    .execute()
+                )
+                self._logger.debug(f"Delta Merge Stats: {json.dumps(merge_stats)}")
+
         else:
             mode = "append"
             schema_mode = "merge"

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -1739,8 +1739,8 @@ async def test_partition_folders_delta_merge_called_with_partition_predicate(
         "source": mock.ANY,
         "source_alias": "source",
         "target_alias": "target",
-        "predicate": f"source.id = target.id AND source.{PARTITION_KEY} = target.{PARTITION_KEY}",
-        "streamed_exec": False,
+        "predicate": f"source.id = target.id AND source.{PARTITION_KEY} = target.{PARTITION_KEY} AND target.{PARTITION_KEY} = '0'",
+        "streamed_exec": True,
     }
 
 


### PR DESCRIPTION
## Problem
- I had to turn off an optimisation of deltalake merging called `streamed_exec`:
  - `Will execute MERGE using a LazyMemoryExec plan, this improves memory pressure for large source tables. Enabling streamed_exec implicitly disables source table stats to derive an early_pruning_predicate`

## Changes
- Using `streamed_exec` means we need a merge predicted that has the partition key hard coded, causing us to need to merge each partition individually (the same occurs when we try to merge a source table with multiple partitions anyway)

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
- tested locally and  updated unit tests
