### PR TITLE
feat: Use the real fetch for setupPlugin

### DIFF
--- a/plugin-server/src/cdp/services/legacy-onevent-compare.service.ts
+++ b/plugin-server/src/cdp/services/legacy-onevent-compare.service.ts
@@ -103,20 +103,19 @@ export class LegacyOneventCompareService {
         }
 
         // Clear the recorder before running the operation if recording is enabled
+        getHttpCallRecorder().clearCalls()
 
         let pluginConfigError: any = null
-        let recordedCalls: RecordedHttpCall[] = []
+
         try {
             // Execute the operation
             await onEvent(onEventPayload)
         } catch (e) {
             pluginConfigError = e
-        } finally {
-            recordedCalls = getHttpCallRecorder().getCalls()
-            getHttpCallRecorder().clearCalls()
         }
 
         try {
+            const recordedCalls = getHttpCallRecorder().getCalls()
             const hogFunctionResult = await this.runHogFunctionOnEvent(pluginConfig, event, recordedCalls)
             const comparer = new HttpCallRecorder()
 

--- a/plugin-server/src/cdp/services/legacy-plugin-executor.service.ts
+++ b/plugin-server/src/cdp/services/legacy-plugin-executor.service.ts
@@ -193,7 +193,7 @@ export class LegacyPluginExecutorService {
                         setupPromise = plugin.setupPlugin({
                             ...meta,
                             // Setup receives the real fetch always
-                            fetch: fetch,
+                            fetch: this.fetch,
                             storage: this.legacyStorage(invocation.hogFunction.team_id, legacyPluginConfigId),
                         })
                     }


### PR DESCRIPTION
## Problem

It turns out the way plugins get setup, it happens _before_ onEvent code is reached. This is a bit different locally which was confusing.

## Changes

* Clear the http logs beforehand
* Allow setupPlugin to use real fetch (checked it out and all the plugins do this statelessly enough to be safe

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
