### PR TITLE
chore: add extra log_comment for usage_report celery queries.

### DIFF
--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -2,6 +2,8 @@
 
 import threading
 from typing import Any, Optional
+from collections.abc import Generator
+from contextlib import contextmanager
 
 thread_local_storage = threading.local()
 
@@ -49,3 +51,26 @@ class QueryCounter:
             return execute(*args, **kwargs)
         finally:
             self.total_query_time += time.perf_counter() - start_time
+
+
+@contextmanager
+def tags_context(**tags_to_set: Any) -> Generator[None, None, None]:
+    """
+    Context manager that saves all query tags on enter and restores them on exit.
+    Optionally accepts key-value pairs to set after saving the original tags.
+
+    Usage:
+    ```python
+    with tags_context(foo='bar', baz='qux'):
+        # tags are saved, new tags are set
+        # do stuff with tags
+        # tags will be restored to original state after context
+    ```
+    """
+    try:
+        original_tags = dict(get_query_tags())  # Make a copy of current tags
+        if tags_to_set:
+            tag_queries(**tags_to_set)
+        yield
+    finally:
+        thread_local_storage.query_tags = original_tags

--- a/posthog/clickhouse/test/test_query_tagging.py
+++ b/posthog/clickhouse/test/test_query_tagging.py
@@ -9,7 +9,7 @@ def test_tags_context():
     # Modify tags within context
     with tags_context(in_context="true"):
         tag_queries(test="test_value")
-        assert get_query_tags() == {"initial": "value", "test": "test_value"}
+        assert get_query_tags() == {"initial": "value", "test": "test_value", "in_context": "true"}
 
         # Modify more
         tag_queries(another="another_value", initial="not a value")

--- a/posthog/clickhouse/test/test_query_tagging.py
+++ b/posthog/clickhouse/test/test_query_tagging.py
@@ -1,0 +1,24 @@
+from posthog.clickhouse.query_tagging import tag_queries, get_query_tags, tags_context
+
+
+def test_tags_context():
+    # Set initial tags
+    tag_queries(initial="value")
+    assert get_query_tags() == {"initial": "value"}
+
+    # Modify tags within context
+    with tags_context(in_context="true"):
+        tag_queries(test="test_value")
+        assert get_query_tags() == {"initial": "value", "test": "test_value"}
+
+        # Modify more
+        tag_queries(another="another_value", initial="not a value")
+        assert get_query_tags() == {
+            "initial": "not a value",
+            "test": "test_value",
+            "another": "another_value",
+            "in_context": "true",
+        }
+
+    # Verify tags are restored
+    assert get_query_tags() == {"initial": "value"}

--- a/posthog/tasks/periodic_digest.py
+++ b/posthog/tasks/periodic_digest.py
@@ -3,12 +3,15 @@ from datetime import datetime, timedelta
 from typing import Any, Optional
 from zoneinfo import ZoneInfo
 
+import celery
 import structlog
 from celery import shared_task
 from dateutil import parser
 from django.db.models import QuerySet
 from django.utils import timezone
 from posthoganalytics.client import Client
+
+from posthog.clickhouse.query_tagging import tag_queries
 from posthog.exceptions_capture import capture_exception
 
 from posthog.models.dashboard import Dashboard
@@ -260,6 +263,7 @@ def _get_all_org_digest_reports(period_start: datetime, period_end: datetime) ->
 
 @shared_task(**USAGE_REPORT_TASK_KWARGS, max_retries=0)
 def send_all_periodic_digest_reports(
+    self: celery.Task,
     dry_run: bool = False,
     end_date: Optional[str] = None,
     begin_date: Optional[str] = None,
@@ -270,6 +274,8 @@ def send_all_periodic_digest_reports(
         else datetime.now(tz=ZoneInfo("UTC")).replace(hour=0, minute=0, second=0, microsecond=0)
     )
     period_start = parser.parse(begin_date) if begin_date else period_end - timedelta(days=7)
+
+    tag_queries(celery_request_id=self.request.id)
 
     try:
         org_reports = _get_all_org_digest_reports(period_start, period_end)

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -15,11 +15,12 @@ from django.db.models import Count, Q, Sum
 from posthoganalytics.client import Client
 from psycopg import sql
 from retry import retry
-from posthog.exceptions_capture import capture_exception
 
+from posthog.exceptions_capture import capture_exception
 from posthog import version_requirement
 from posthog.clickhouse.client.connection import Workload
 from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.query_tagging import tags_context
 from posthog.cloud_utils import get_cached_instance_license
 from posthog.constants import FlagRequestType
 from posthog.logging.timing import timed_log
@@ -351,17 +352,19 @@ def get_teams_with_billable_event_count_in_period(
         distinct_expression = "1"
 
     # We are excluding $exception events during the beta
-    result = sync_execute(
-        f"""
+    query = f"""
         SELECT team_id, count({distinct_expression}) as count
         FROM events
         WHERE timestamp between %(begin)s AND %(end)s AND event NOT IN ('$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception')
         GROUP BY team_id
-    """,
-        {"begin": begin, "end": end},
-        workload=Workload.OFFLINE,
-        settings=CH_BILLING_SETTINGS,
-    )
+    """
+    with tags_context(usage_report="get_teams_with_billable_event_count_in_period"):
+        result = sync_execute(
+            query,
+            {"begin": begin, "end": end},
+            workload=Workload.OFFLINE,
+            settings=CH_BILLING_SETTINGS,
+        )
     return result
 
 
@@ -381,35 +384,39 @@ def get_teams_with_billable_enhanced_persons_event_count_in_period(
     else:
         distinct_expression = "1"
 
-    result = sync_execute(
-        f"""
+    query = f"""
         SELECT team_id, count({distinct_expression}) as count
         FROM events
         WHERE timestamp between %(begin)s AND %(end)s AND event NOT IN ('$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception') AND person_mode IN ('full', 'force_upgrade')
         GROUP BY team_id
-    """,
-        {"begin": begin, "end": end},
-        workload=Workload.OFFLINE,
-        settings=CH_BILLING_SETTINGS,
-    )
+    """
+    with tags_context(usage_report="get_teams_with_billable_enhanced_persons_event_count_in_period"):
+        result = sync_execute(
+            query,
+            {"begin": begin, "end": end},
+            workload=Workload.OFFLINE,
+            settings=CH_BILLING_SETTINGS,
+        )
     return result
 
 
 @timed_log()
 @retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
 def get_teams_with_event_count_with_groups_in_period(begin: datetime, end: datetime) -> list[tuple[int, int]]:
-    result = sync_execute(
-        """
+    query = """
         SELECT team_id, count(1) as count
         FROM events
         WHERE timestamp between %(begin)s AND %(end)s
         AND ($group_0 != '' OR $group_1 != '' OR $group_2 != '' OR $group_3 != '' OR $group_4 != '')
         GROUP BY team_id
-    """,
-        {"begin": begin, "end": end},
-        workload=Workload.OFFLINE,
-        settings=CH_BILLING_SETTINGS,
-    )
+    """
+    with tags_context(usage_report="get_teams_with_event_count_with_groups_in_period"):
+        result = sync_execute(
+            query,
+            {"begin": begin, "end": end},
+            workload=Workload.OFFLINE,
+            settings=CH_BILLING_SETTINGS,
+        )
     return result
 
 
@@ -419,8 +426,7 @@ def get_all_event_metrics_in_period(begin: datetime, end: datetime) -> dict[str,
     # Check if $lib is materialized
     lib_expression, _ = get_property_string_expr("events", "$lib", "'$lib'", "properties")
 
-    results = sync_execute(
-        f"""
+    query = f"""
         SELECT
             team_id,
             multiIf(
@@ -448,11 +454,14 @@ def get_all_event_metrics_in_period(begin: datetime, end: datetime) -> dict[str,
         WHERE timestamp BETWEEN %(begin)s AND %(end)s
         GROUP BY team_id, metric
         HAVING metric != 'other'
-    """,
-        {"begin": begin, "end": end},
-        workload=Workload.OFFLINE,
-        settings=CH_BILLING_SETTINGS,
-    )
+    """
+    with tags_context(usage_report="get_all_event_metrics_in_period"):
+        results = sync_execute(
+            query,
+            {"begin": begin, "end": end},
+            workload=Workload.OFFLINE,
+            settings=CH_BILLING_SETTINGS,
+        )
 
     metrics: dict[str, list[tuple[int, int]]] = {
         "helicone_events": [],
@@ -487,8 +496,7 @@ def get_teams_with_recording_count_in_period(
 ) -> list[tuple[int, int]]:
     previous_begin = begin - (end - begin)
 
-    result = sync_execute(
-        """
+    query = """
         SELECT team_id, count(distinct session_id) as count
         FROM (
             SELECT any(team_id) as team_id, session_id
@@ -509,11 +517,14 @@ def get_teams_with_recording_count_in_period(
             GROUP BY session_id
         )
         GROUP BY team_id
-    """,
-        {"previous_begin": previous_begin, "begin": begin, "end": end, "snapshot_source": snapshot_source},
-        workload=Workload.OFFLINE,
-        settings=CH_BILLING_SETTINGS,
-    )
+    """
+    with tags_context(usage_report="get_teams_with_recording_count_in_period"):
+        result = sync_execute(
+            query,
+            {"previous_begin": previous_begin, "begin": begin, "end": end, "snapshot_source": snapshot_source},
+            workload=Workload.OFFLINE,
+            settings=CH_BILLING_SETTINGS,
+        )
 
     return result
 
@@ -523,8 +534,7 @@ def get_teams_with_recording_count_in_period(
 def get_teams_with_mobile_billable_recording_count_in_period(begin: datetime, end: datetime) -> list[tuple[int, int]]:
     previous_begin = begin - (end - begin)
 
-    result = sync_execute(
-        """
+    query = """
         SELECT team_id, count(distinct session_id) as count
         FROM (
             SELECT any(team_id) as team_id, session_id
@@ -546,11 +556,14 @@ def get_teams_with_mobile_billable_recording_count_in_period(begin: datetime, en
             GROUP BY session_id
         )
         GROUP BY team_id
-    """,
-        {"previous_begin": previous_begin, "begin": begin, "end": end},
-        workload=Workload.OFFLINE,
-        settings=CH_BILLING_SETTINGS,
-    )
+    """
+    with tags_context(usage_report="get_teams_with_mobile_billable_recording_count_in_period"):
+        result = sync_execute(
+            query,
+            {"previous_begin": previous_begin, "begin": begin, "end": end},
+            workload=Workload.OFFLINE,
+            settings=CH_BILLING_SETTINGS,
+        )
 
     return result
 
@@ -583,17 +596,18 @@ def get_teams_with_query_metric(
         AND access_method = %(access_method)s
         GROUP BY team_id
     """
-    result = sync_execute(
-        query,
-        {
-            "begin": begin,
-            "end": end,
-            "query_types": query_types,
-            "access_method": access_method,
-        },
-        workload=Workload.OFFLINE,
-        settings=CH_BILLING_SETTINGS,
-    )
+    with tags_context(usage_report="get_teams_with_query_metric"):
+        result = sync_execute(
+            query,
+            {
+                "begin": begin,
+                "end": end,
+                "query_types": query_types,
+                "access_method": access_method,
+            },
+            workload=Workload.OFFLINE,
+            settings=CH_BILLING_SETTINGS,
+        )
     return result
 
 
@@ -608,24 +622,26 @@ def get_teams_with_feature_flag_requests_count_in_period(
 
     target_event = "decide usage" if request_type == FlagRequestType.DECIDE else "local evaluation usage"
 
-    result = sync_execute(
-        """
+    query = """
         SELECT distinct_id as team, sum(JSONExtractInt(properties, 'count')) as sum
         FROM events
         WHERE team_id = %(team_to_query)s AND event=%(target_event)s AND timestamp between %(begin)s AND %(end)s
         AND has([%(validity_token)s], replaceRegexpAll(JSONExtractRaw(properties, 'token'), '^"|"$', ''))
         GROUP BY team
-    """,
-        {
-            "begin": begin,
-            "end": end,
-            "team_to_query": team_to_query,
-            "validity_token": validity_token,
-            "target_event": target_event,
-        },
-        workload=Workload.OFFLINE,
-        settings=CH_BILLING_SETTINGS,
-    )
+    """
+    with tags_context(usage_report="get_teams_with_feature_flag_requests_count_in_period"):
+        result = sync_execute(
+            query,
+            {
+                "begin": begin,
+                "end": end,
+                "team_to_query": team_to_query,
+                "validity_token": validity_token,
+                "target_event": target_event,
+            },
+            workload=Workload.OFFLINE,
+            settings=CH_BILLING_SETTINGS,
+        )
 
     return result
 
@@ -636,17 +652,19 @@ def get_teams_with_survey_responses_count_in_period(
     begin: datetime,
     end: datetime,
 ) -> list[tuple[int, int]]:
-    results = sync_execute(
-        """
+    query = """
         SELECT team_id, COUNT() as count
         FROM events
         WHERE event = 'survey sent' AND timestamp between %(begin)s AND %(end)s
         GROUP BY team_id
-    """,
-        {"begin": begin, "end": end},
-        workload=Workload.OFFLINE,
-        settings=CH_BILLING_SETTINGS,
-    )
+    """
+    with tags_context(usage_report="get_teams_with_survey_responses_count_in_period"):
+        results = sync_execute(
+            query,
+            {"begin": begin, "end": end},
+            workload=Workload.OFFLINE,
+            settings=CH_BILLING_SETTINGS,
+        )
 
     return results
 
@@ -657,17 +675,19 @@ def get_teams_with_ai_event_count_in_period(
     begin: datetime,
     end: datetime,
 ) -> list[tuple[int, int]]:
-    results = sync_execute(
-        """
+    query = """
         SELECT team_id, COUNT() as count
         FROM events
         WHERE event LIKE '$ai_%%' AND timestamp between %(begin)s AND %(end)s
         GROUP BY team_id
-    """,
-        {"begin": begin, "end": end},
-        workload=Workload.OFFLINE,
-        settings=CH_BILLING_SETTINGS,
-    )
+    """
+    with tags_context(usage_report="get_teams_with_ai_event_count_in_period"):
+        results = sync_execute(
+            query,
+            {"begin": begin, "end": end},
+            workload=Workload.OFFLINE,
+            settings=CH_BILLING_SETTINGS,
+        )
 
     return results
 
@@ -688,18 +708,20 @@ def get_teams_with_exceptions_captured_in_period(
     begin: datetime,
     end: datetime,
 ) -> list[tuple[int, int]]:
-    results = sync_execute(
-        """
+    query = """
         SELECT team_id, COUNT() as count
         FROM events
         WHERE event = '$exception' AND timestamp between %(begin)s AND %(end)s
         AND not(JSONHas(properties, '$sentry_event_id'))
         GROUP BY team_id
-    """,
-        {"begin": begin, "end": end},
-        workload=Workload.OFFLINE,
-        settings=CH_BILLING_SETTINGS,
-    )
+    """
+    with tags_context(usage_report="get_teams_with_exceptions_captured_in_period"):
+        results = sync_execute(
+            query,
+            {"begin": begin, "end": end},
+            workload=Workload.OFFLINE,
+            settings=CH_BILLING_SETTINGS,
+        )
 
     return results
 
@@ -710,17 +732,19 @@ def get_teams_with_hog_function_calls_in_period(
     begin: datetime,
     end: datetime,
 ) -> list[tuple[int, int]]:
-    results = sync_execute(
-        """
+    query = """
         SELECT team_id, SUM(count) as count
         FROM app_metrics2
         WHERE app_source='hog_function' AND metric_name IN ('succeeded','failed') AND timestamp between %(begin)s AND %(end)s
         GROUP BY team_id, metric_name
-    """,
-        {"begin": begin, "end": end},
-        workload=Workload.OFFLINE,
-        settings=CH_BILLING_SETTINGS,
-    )
+    """
+    with tags_context(usage_report="get_teams_with_hog_function_calls_in_period"):
+        results = sync_execute(
+            query,
+            {"begin": begin, "end": end},
+            workload=Workload.OFFLINE,
+            settings=CH_BILLING_SETTINGS,
+        )
 
     return results
 
@@ -731,17 +755,19 @@ def get_teams_with_hog_function_fetch_calls_in_period(
     begin: datetime,
     end: datetime,
 ) -> list[tuple[int, int]]:
-    results = sync_execute(
-        """
+    query = """
         SELECT team_id, SUM(count) as count
         FROM app_metrics2
         WHERE app_source='hog_function' AND metric_name IN ('fetch') AND timestamp between %(begin)s AND %(end)s
         GROUP BY team_id, metric_name
-    """,
-        {"begin": begin, "end": end},
-        workload=Workload.OFFLINE,
-        settings=CH_BILLING_SETTINGS,
-    )
+    """
+    with tags_context(usage_report="get_teams_with_hog_function_fetch_calls_in_period"):
+        results = sync_execute(
+            query,
+            {"begin": begin, "end": end},
+            workload=Workload.OFFLINE,
+            settings=CH_BILLING_SETTINGS,
+        )
 
     return results
 


### PR DESCRIPTION
## Problem

usage reporting takes a lot of time and it's slow

## Changes

1. mark all usage CH queries with a initiator function `log_comment(usage_billing=<func name>)`
2. pass celery request id to log comment: `log_comment(celery_request_id=self.request.id)`

those two changes gives us a better insight into usage update queries

## Does this work well for both Cloud and self-hosted?

yes

## How did you test this code?

