### PR TITLE
fix: fix double shutdowns in cdp

### DIFF
--- a/plugin-server/src/cdp/consumers/cdp-base.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-base.consumer.ts
@@ -165,7 +165,7 @@ export abstract class CdpConsumerBase {
         addSentryBreadcrumbsEventListeners(this.batchConsumer.consumer)
 
         this.batchConsumer.consumer.on('disconnected', async (err) => {
-            if (!this.isStopping) {
+            if (this.isStopping) {
                 return
             }
             // since we can't be guaranteed that the consumer will be stopped before some other code calls disconnect

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -351,7 +351,7 @@ export class IngestionConsumer {
         addSentryBreadcrumbsEventListeners(this.batchConsumer.consumer)
 
         this.batchConsumer.consumer.on('disconnected', async (err) => {
-            if (!this.isStopping) {
+            if (this.isStopping) {
                 return
             }
             // since we can't be guaranteed that the consumer will be stopped before some other code calls disconnect


### PR DESCRIPTION
## Problem

Due to a typo, we're stopping cdp consumers twice – once explicitly on shutdown, once from the kafka consumer disconnected callback. This causes some race conditions in tests, which makes them flaky.

## Changes

Fixes the wrong check in the kafka consumer callback.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Ran tests in a loop for about an hour.