### PR TITLE
chore: make quota limits run every 2 hours

### DIFF
--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -132,9 +132,8 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
             name="send instance usage report",
         )
 
-    # Update local usage info for rate limiting purposes - offset by 30 minutes to not clash with the above
     sender.add_periodic_task(
-        crontab(minute="*/30"),
+        crontab(hour="*/2"),
         update_quota_limiting.s(),
         name="update quota limiting",
     )


### PR DESCRIPTION
## Changes

Run the quote limiting every 2 hours - allow the job more time to run

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

It doesn't have an impact.

## How did you test this code?

N/A
