### PR TITLE
fix(cdp): Add missing metrics

### DIFF
--- a/plugin-server/src/cdp/consumers/cdp-base.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-base.consumer.ts
@@ -1,5 +1,5 @@
 import { Message } from 'node-rdkafka'
-import { Counter, Gauge, Histogram } from 'prom-client'
+import { Counter, Histogram } from 'prom-client'
 
 import { BatchConsumer, startBatchConsumer } from '../../kafka/batch-consumer'
 import { createRdConnectionConfigFromEnvVars } from '../../kafka/config'
@@ -31,28 +31,10 @@ export const histogramKafkaBatchSizeKb = new Histogram({
     buckets: [0, 128, 512, 1024, 5120, 10240, 20480, 51200, 102400, 204800, Infinity],
 })
 
-export const counterFunctionInvocation = new Counter({
-    name: 'cdp_function_invocation',
-    help: 'A function invocation was evaluated with an outcome',
-    labelNames: ['outcome'], // One of 'failed', 'succeeded', 'overflowed', 'disabled', 'filtered'
-})
-
 export const counterParseError = new Counter({
     name: 'cdp_function_parse_error',
     help: 'A function invocation was parsed with an error',
     labelNames: ['error'],
-})
-
-export const gaugeBatchUtilization = new Gauge({
-    name: 'cdp_cyclotron_batch_utilization',
-    help: 'Indicates how big batches are we are processing compared to the max batch size. Useful as a scaling metric',
-    labelNames: ['queue'],
-})
-
-export const counterJobsProcessed = new Counter({
-    name: 'cdp_cyclotron_jobs_processed',
-    help: 'The number of jobs we are managing to process',
-    labelNames: ['queue'],
 })
 
 export interface TeamIDWithConfig {

--- a/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
@@ -85,7 +85,7 @@ export class CdpCyclotronWorker extends CdpConsumerBase {
     }
 
     private async handleJobBatch(jobs: CyclotronJob[]) {
-        cyclotronBatchUtilizationGuage
+        cyclotronBatchUtilizationGauge
             .labels({ queue: this.queue })
             .set(jobs.length / this.hub.CDP_CYCLOTRON_BATCH_SIZE)
         if (!this.cyclotronWorker) {

--- a/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
@@ -7,7 +7,7 @@ import { HogFunctionInvocation, HogFunctionInvocationResult, HogFunctionTypeType
 import { cyclotronJobToInvocation, invocationToCyclotronJobUpdate } from '../utils'
 import { CdpConsumerBase } from './cdp-base.consumer'
 
-const cyclotronBatchUtilizationGuage = new Gauge({
+const cyclotronBatchUtilizationGauge = new Gauge({
     name: 'cdp_cyclotron_batch_utilization',
     help: 'Indicates how big batches are we are processing compared to the max batch size. Useful as a scaling metric',
     labelNames: ['queue'],

--- a/plugin-server/src/cdp/services/hog-function-monitoring.service.ts
+++ b/plugin-server/src/cdp/services/hog-function-monitoring.service.ts
@@ -1,3 +1,5 @@
+import { Counter } from 'prom-client'
+
 import { KAFKA_APP_METRICS_2, KAFKA_EVENTS_PLUGIN_INGESTION, KAFKA_LOG_ENTRIES } from '../../config/kafka-topics'
 import { runInstrumentedFunction } from '../../main/utils'
 import { AppMetric2Type, Hub, TimestampFormat } from '../../types'
@@ -12,6 +14,12 @@ import {
 } from '../types'
 import { fixLogDeduplication } from '../utils'
 import { convertToCaptureEvent } from '../utils'
+
+export const counterHogFunctionMetric = new Counter({
+    name: 'cdp_hog_function_metric',
+    help: 'A function invocation was evaluated with an outcome',
+    labelNames: ['metric_kind', 'metric_name'],
+})
 
 export class HogFunctionMonitoringService {
     messagesToProduce: HogFunctionMessageToProduce[] = []
@@ -45,6 +53,8 @@ export class HogFunctionMonitoringService {
             ...metric,
             timestamp: castTimestampOrNow(null, TimestampFormat.ClickHouse),
         }
+
+        counterHogFunctionMetric.labels(metric.metric_kind, metric.metric_name).inc(appMetric.count)
 
         this.messagesToProduce.push({
             topic: KAFKA_APP_METRICS_2,


### PR DESCRIPTION
## Problem

Somewhere in the refactoring we lost a couple of metrics, crucially the copy of the app metrics one that is useful for reporting

## Changes

* Fixes this up to add back in the metric
* Refactors the other ones to be more co-located with their usage

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
