### PR TITLE
chore: case insensitive checks for verified domains

### DIFF
--- a/ee/api/test/test_authentication.py
+++ b/ee/api/test/test_authentication.py
@@ -445,6 +445,61 @@ class TestEESAMLAuthenticationAPI(APILicensedTest):
         _session = self.client.session
         self.assertEqual(_session.get("_auth_user_id"), str(user.pk))
 
+    @freeze_time("2021-08-25T23:37:55.345Z")
+    def test_saml_jit_provisioning_with_case_insensitive_domain(self):
+        """
+        Tests that JIT provisioning works with case-insensitive domain matching.
+        This verifies that users with email domains that differ only in case from
+        the verified domain in the system can still be provisioned automatically.
+        """
+
+        # Create a new domain with uppercase characters
+        original_domain = self.organization_domain.domain
+        uppercase_email = f"engineering@{original_domain.upper()}"
+
+        response = self.client.get(f"/login/saml/?email={uppercase_email}")
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+
+        _session = self.client.session
+        _session.update({"saml_state": "ONELOGIN_87856a50b5490e643b1ebef9cb5bf6e78225a3c6"})
+        _session.save()
+
+        with open(
+            os.path.join(CURRENT_FOLDER, "fixtures/saml_login_response_alt_attribute_names"),
+            encoding="utf_8",
+        ) as f:
+            saml_response = f.read()
+
+        user_count = User.objects.count()
+
+        response = self.client.post(
+            "/complete/saml/",
+            {
+                "SAMLResponse": saml_response,
+                "RelayState": str(self.organization_domain.id),
+            },
+            format="multipart",
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)  # because `follow=True`
+        self.assertRedirects(response, "/")  # redirect to the home page
+
+        # User is created despite the case difference in domain
+        self.assertEqual(User.objects.count(), user_count + 1)
+        user = cast(User, User.objects.last())
+        self.assertEqual(user.email, uppercase_email.lower())  # The SSO middleware will make this lowercase
+        self.assertEqual(user.organization, self.organization)
+        self.assertEqual(user.team, self.team)
+        self.assertEqual(user.organization_memberships.count(), 1)
+        self.assertEqual(
+            cast(OrganizationMembership, user.organization_memberships.first()).level,
+            OrganizationMembership.Level.MEMBER,
+        )
+
+        _session = self.client.session
+        self.assertEqual(_session.get("_auth_user_id"), str(user.pk))
+
     @freeze_time("2021-08-25T22:09:14.252Z")
     def test_cannot_login_with_improperly_signed_payload(self):
         self.organization_domain.saml_x509_cert = """MIIDPjCCAiYCCQC864/0fftWQTANBgkqhkiG9w0BAQsFADBhMQswCQYDVQQGEwJV

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -444,7 +444,7 @@ def process_social_domain_jit_provisioning_signup(
     domain = email.split("@")[-1]
     try:
         logger.info(f"process_social_domain_jit_provisioning_signup", domain=domain)
-        domain_instance = OrganizationDomain.objects.get(domain=domain)
+        domain_instance = OrganizationDomain.objects.get(domain__iexact=domain)
     except OrganizationDomain.DoesNotExist:
         logger.info(
             f"process_social_domain_jit_provisioning_signup_domain_does_not_exist",

--- a/posthog/models/organization_domain.py
+++ b/posthog/models/organization_domain.py
@@ -29,7 +29,7 @@ class OrganizationDomainManager(models.Manager):
         using the domain of the email address
         """
         domain = email[email.index("@") + 1 :]
-        return self.verified_domains().filter(domain=domain).first()
+        return self.verified_domains().filter(domain__iexact=domain).first()
 
     def get_is_saml_available_for_email(self, email: str) -> bool:
         """
@@ -38,7 +38,7 @@ class OrganizationDomainManager(models.Manager):
         domain = email[email.index("@") + 1 :]
         query = (
             self.verified_domains()
-            .filter(domain=domain)
+            .filter(domain__iexact=domain)
             .exclude(
                 models.Q(saml_entity_id="")
                 | models.Q(saml_acs_url="")
@@ -69,7 +69,7 @@ class OrganizationDomainManager(models.Manager):
         domain = email[email.index("@") + 1 :]
         query = (
             self.verified_domains()
-            .filter(domain=domain)
+            .filter(domain__iexact=domain)
             .exclude(sso_enforcement="")
             .values("sso_enforcement", "organization_id", "organization__available_product_features")
             .first()


### PR DESCRIPTION
## Problem

Verified domains allow customers to support jit provisioning but right now it does exact case sensitive checks on the email returned from the IdP so if the email in the IdP has a different casing then the user can't join the organization.

Based on request from customer: https://posthog.slack.com/archives/C06QZ97A6KH/p1741637563158379

## Changes

The PR makes the verified domain checks case insensitive so it doesn't change any logic or any data we store, simply changes the SQL queries. 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added a test
