### PR TITLE
fix: change billing limit input step to 1

### DIFF
--- a/frontend/src/scenes/billing/BillingLimit.tsx
+++ b/frontend/src/scenes/billing/BillingLimit.tsx
@@ -96,7 +96,7 @@ export const BillingLimit = ({ product }: { product: BillingProductV2Type }): JS
                                         prefix={<b>$</b>}
                                         disabled={billingLoading}
                                         min={0}
-                                        step={10}
+                                        step={1}
                                         suffix={<>/ {billing?.billing_period?.interval}</>}
                                         size="small"
                                     />


### PR DESCRIPTION
## Problem

It's not possible to save billing amounts that aren't 0 or increments of 10 and this is only validated generically via HTML (`step` passed to `input`) so the validation error is generic and doesn't indicate what a valid amount is.

<img width="413" alt="image" src="https://github.com/user-attachments/assets/c65d5fe9-84c3-4846-aaa8-d1dd7dbc6446" />

## Changes

Changes the `step` from `10` to `1`, as there doesn't seem to be a reason why we shouldn't allow users to specify such values.

If there is a reason why we shouldn't allow increments of 1, then we could show a more helpful message but such arbitrary limitation doesn't seem necessary.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manually tested entering and saving limits that are increments of 1 but are not increments of 10.
