### PR TITLE
feat(data-warehouse): Add metrics for data modeling workflow

### DIFF
--- a/posthog/temporal/data_modeling/metrics.py
+++ b/posthog/temporal/data_modeling/metrics.py
@@ -1,0 +1,12 @@
+from temporalio import workflow
+from temporalio.common import MetricCounter
+
+
+def get_data_modeling_finished_metric(status: str) -> MetricCounter:
+    return (
+        workflow.metric_meter()
+        .with_additional_attributes({"status": status})
+        .create_counter(
+            "data_modeling_finished", "Number of data modeling runs finished, for any reason (including failure)."
+        )
+    )


### PR DESCRIPTION
## Problem

We don't have any monitoring or alerting for our data modeling (materialization) workflow.

## Changes

Publish metrics to Prometheus to track finished workflows, with their status.

**TODO** update tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Not sure.

## How did you test this code?

Tested locally.
