### PR TITLE
chore: set the quote limiting scheduler to min 0

### DIFF
--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -704,6 +704,7 @@ def get_team_attribute_by_quota_resource(organization: Organization) -> list[str
 
 def report_quota_limiting_event(event_type: str, properties: dict) -> None:
     posthoganalytics.capture("internal_billing_events", event_type, properties=properties)
+    posthoganalytics.flush()  # Ensure the event is sent
 
 
 def update_organization_usage_field(organization: Organization, resource: QuotaResource, key: str, value: Any) -> None:

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -133,7 +133,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         )
 
     sender.add_periodic_task(
-        crontab(hour="*/2"),
+        crontab(hour="*/2", minute="0"),
         update_quota_limiting.s(),
         name="update quota limiting",
     )


### PR DESCRIPTION
## Changes

It's running more often when workers are spun up. Setting to only run on min 0

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

N/A
