### PR TITLE
chore(err): align cli/cymbal with release posthog-cli stuff

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1387,14 +1387,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "common-symbol-data"
-version = "0.1.0"
-dependencies = [
- "serde",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "common-types"
 version = "0.1.0"
 dependencies = [
@@ -1724,7 +1716,6 @@ dependencies = [
  "common-dns",
  "common-kafka",
  "common-metrics",
- "common-symbol-data",
  "common-types",
  "envconfig",
  "health",
@@ -1733,6 +1724,7 @@ dependencies = [
  "mockall",
  "moka",
  "posthog-rs",
+ "posthog-symbol-data 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdkafka",
  "reqwest 0.12.3",
  "serde",
@@ -4516,10 +4508,10 @@ version = "0.0.2"
 dependencies = [
  "anyhow",
  "clap",
- "common-symbol-data",
  "crossterm 0.28.1",
  "dirs",
  "inquire",
+ "posthog-symbol-data 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ratatui",
  "reqwest 0.12.3",
  "serde",
@@ -4546,6 +4538,24 @@ dependencies = [
  "serde",
  "serde_json",
  "uuid",
+]
+
+[[package]]
+name = "posthog-symbol-data"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "posthog-symbol-data"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "155615f55dabf848e8e69d7081412e424afbea5060a49bb9582f48d0f8141f64"
+dependencies = [
+ "serde",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/rust/common/symbol_data/Cargo.toml
+++ b/rust/common/symbol_data/Cargo.toml
@@ -1,7 +1,16 @@
 [package]
-name = "common-symbol-data"
+name = "posthog-common-symbol-data"
 version = "0.1.0"
+authors = [
+    "David <david@posthog.com>",
+    "Olly <oliver@posthog.com>",
+    "Hugues <hugues@posthog.com>",
+]
+description = "A shared library for serialising/deserialising PostHog symbol data"
 edition = "2021"
+license = "MIT"
+homepage = "https://posthog.com"
+
 
 [lints]
 workspace = true

--- a/rust/common/symbol_data/Cargo.toml
+++ b/rust/common/symbol_data/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "posthog-common-symbol-data"
+name = "posthog-symbol-data"
 version = "0.1.0"
 authors = [
     "David <david@posthog.com>",

--- a/rust/common/symbol_data/README.md
+++ b/rust/common/symbol_data/README.md
@@ -1,3 +1,0 @@
-# Common types
-
-For types used across our projects, like events, persons, etc. Each time you go to copy a type from somewhere, put it here instead.

--- a/rust/common/symbol_data/tests/test.rs
+++ b/rust/common/symbol_data/tests/test.rs
@@ -1,4 +1,4 @@
-use common_symbol_data::{read_symbol_data, write_symbol_data, SourceAndMap};
+use posthog_symbol_data::{read_symbol_data, write_symbol_data, SourceAndMap};
 
 #[test]
 fn test_source_and_map_reading() {

--- a/rust/cymbal/Cargo.toml
+++ b/rust/cymbal/Cargo.toml
@@ -16,7 +16,7 @@ common-alloc = { path = "../common/alloc" }
 common-kafka = { path = "../common/kafka" }
 common-types = { path = "../common/types" }
 common-dns = { path = "../common/dns" }
-common-symbol-data = { path = "../common/symbol_data" }
+posthog-symbol-data = "0.1.0"
 thiserror = { workspace = true }
 sqlx = { workspace = true }
 serde_json = { workspace = true }

--- a/rust/cymbal/src/error.rs
+++ b/rust/cymbal/src/error.rs
@@ -1,6 +1,6 @@
 use aws_sdk_s3::primitives::ByteStreamError;
 use common_kafka::kafka_producer::KafkaProduceError;
-use common_symbol_data::SymbolDataError;
+use posthog_symbol_data::SymbolDataError;
 use rdkafka::error::KafkaError;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;

--- a/rust/cymbal/src/symbol_store/chunk_id.rs
+++ b/rust/cymbal/src/symbol_store/chunk_id.rs
@@ -161,9 +161,9 @@ mod test {
 
     use axum::async_trait;
     use chrono::Utc;
-    use common_symbol_data::write_symbol_data;
     use common_types::ClickHouseEvent;
     use mockall::predicate;
+    use posthog_symbol_data::write_symbol_data;
     use reqwest::Url;
     use sqlx::PgPool;
     use uuid::Uuid;
@@ -200,7 +200,7 @@ mod test {
     }
 
     fn get_symbol_data_bytes() -> Vec<u8> {
-        write_symbol_data(common_symbol_data::SourceAndMap {
+        write_symbol_data(posthog_symbol_data::SourceAndMap {
             minified_source: String::from_utf8(MINIFIED.to_vec()).unwrap(),
             sourcemap: String::from_utf8(MAP.to_vec()).unwrap(),
         })

--- a/rust/cymbal/src/symbol_store/saving.rs
+++ b/rust/cymbal/src/symbol_store/saving.rs
@@ -312,9 +312,9 @@ impl SymbolSetRecord {
 mod test {
     use std::sync::Arc;
 
-    use common_symbol_data::write_symbol_data;
     use httpmock::MockServer;
     use mockall::predicate;
+    use posthog_symbol_data::write_symbol_data;
     use reqwest::Url;
     use sqlx::PgPool;
 
@@ -332,7 +332,7 @@ mod test {
     const MAP: &[u8] = include_bytes!("../../tests/static/chunk-PGUQKT6S.js.map");
 
     fn get_symbol_data_bytes() -> Vec<u8> {
-        write_symbol_data(common_symbol_data::SourceAndMap {
+        write_symbol_data(posthog_symbol_data::SourceAndMap {
             minified_source: String::from_utf8(MINIFIED.to_vec()).unwrap(),
             sourcemap: String::from_utf8(MAP.to_vec()).unwrap(),
         })

--- a/rust/cymbal/src/symbol_store/sourcemap.rs
+++ b/rust/cymbal/src/symbol_store/sourcemap.rs
@@ -2,7 +2,7 @@ use std::{sync::Arc, time::Duration};
 
 use axum::async_trait;
 use base64::Engine;
-use common_symbol_data::{read_symbol_data, write_symbol_data, SourceAndMap};
+use posthog_symbol_data::{read_symbol_data, write_symbol_data, SourceAndMap};
 use reqwest::Url;
 use symbolic::sourcemapcache::{SourceMapCache, SourceMapCacheWriter};
 use tracing::{info, warn};

--- a/rust/cymbal/tests/resolve.rs
+++ b/rust/cymbal/tests/resolve.rs
@@ -2,7 +2,6 @@ use core::str;
 use std::sync::Arc;
 
 use axum::async_trait;
-use common_symbol_data::{read_symbol_data, SourceAndMap};
 use common_types::ClickHouseEvent;
 use cymbal::{
     config::Config,
@@ -17,6 +16,7 @@ use cymbal::{
     types::{RawErrProps, Stacktrace},
 };
 use httpmock::MockServer;
+use posthog_symbol_data::{read_symbol_data, SourceAndMap};
 use symbolic::sourcemapcache::SourcePosition;
 use tokio::sync::Mutex;
 

--- a/rust/posthog-cli/Cargo.toml
+++ b/rust/posthog-cli/Cargo.toml
@@ -26,7 +26,7 @@ serde_json.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true
-common-symbol-data = { path = "../common/symbol_data" }
+posthog-symbol-data = "0.1.0"
 walkdir = "2.5.0"
 ratatui = "0.29.0"
 crossterm = "0.28.1"

--- a/rust/posthog-cli/src/utils/sourcemaps.rs
+++ b/rust/posthog-cli/src/utils/sourcemaps.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, bail, Context, Ok, Result};
-use common_symbol_data::{write_symbol_data, SourceAndMap};
 use core::str;
+use posthog_symbol_data::{write_symbol_data, SourceAndMap};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{


### PR DESCRIPTION
Had to publish common-symbol-data to publish the CLI, so that's done now too.