### PR TITLE
fix(hogql): Fix dateAdd and dateSub types

### DIFF
--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -541,7 +541,7 @@ HOGQL_CLICKHOUSE_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
         2,
         3,
         signatures=[
-            ((DateType(), UnknownType())),
+            ((DateType(), UnknownType()), DateType()),
             ((StringType(), UnknownType()), DateType()),
         ],
     ),

--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -542,7 +542,7 @@ HOGQL_CLICKHOUSE_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
         3,
         signatures=[
             ((DateType(), UnknownType()), DateType()),
-            ((StringType(), UnknownType()), DateType()),
+            ((StringType(), UnknownType(), DateType()), DateType()),
         ],
     ),
     "timeStampAdd": HogQLFunctionMeta("timeStampAdd", 2, 2),

--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -527,8 +527,24 @@ HOGQL_CLICKHOUSE_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
     "age": HogQLFunctionMeta("age", 3, 3),
     "dateDiff": HogQLFunctionMeta("dateDiff", 3, 3),
     "dateTrunc": HogQLFunctionMeta("dateTrunc", 2, 2),
-    "dateAdd": HogQLFunctionMeta("dateAdd", 2, 2),
-    "dateSub": HogQLFunctionMeta("dateSub", 3, 3),
+    "dateAdd": HogQLFunctionMeta(
+        "dateAdd",
+        2,
+        3,
+        signatures=[
+            ((DateType(), UnknownType())),
+            ((StringType(), UnknownType()), DateType()),
+        ],
+    ),
+    "dateSub": HogQLFunctionMeta(
+        "dateSub",
+        2,
+        3,
+        signatures=[
+            ((DateType(), UnknownType())),
+            ((StringType(), UnknownType()), DateType()),
+        ],
+    ),
     "timeStampAdd": HogQLFunctionMeta("timeStampAdd", 2, 2),
     "timeStampSub": HogQLFunctionMeta("timeStampSub", 2, 2),
     "now": HogQLFunctionMeta(

--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -532,8 +532,8 @@ HOGQL_CLICKHOUSE_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
         2,
         3,
         signatures=[
-            ((DateType(), UnknownType())),
-            ((StringType(), UnknownType()), DateType()),
+            ((DateType(), UnknownType()), DateType()),
+            ((StringType(), UnknownType(), DateType()), DateType()),
         ],
     ),
     "dateSub": HogQLFunctionMeta(


### PR DESCRIPTION
## Problem

date add and date sub only supported `date_add(date, INTERVAL value unit)`, not `date_add(unit, value, date)` (which is the more obvious value).
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
support both

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
