### PR TITLE
feat: show supported versions of SDKs in replay config

### DIFF
--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -281,7 +281,13 @@ function EventTriggerOptions(): JSX.Element | null {
 export function ReplayTriggers(): JSX.Element {
     return (
         <div className="deprecated-space-y-2">
-            <SupportedPlatforms android={false} ios={false} flutter={false} web={true} reactNative={false} />
+            <SupportedPlatforms
+                android={false}
+                ios={false}
+                flutter={false}
+                web={{ version: '1.186.0', note: 'url trigger is supported since version 1.171.0' }}
+                reactNative={false}
+            />
             <p>
                 Use the settings below to control when recordings are started or paused. If no triggers are selected,
                 then recordings will always start if enabled.

--- a/frontend/src/scenes/settings/environment/SessionRecordingIngestionSettings.tsx
+++ b/frontend/src/scenes/settings/environment/SessionRecordingIngestionSettings.tsx
@@ -58,7 +58,13 @@ function LinkedFlagSelector(): JSX.Element | null {
                 <LemonLabel className="text-base">
                     Enable recordings using feature flag {featureFlagLoading && <Spinner />}
                 </LemonLabel>
-                <SupportedPlatforms web={true} ios={true} android={true} reactNative={true} flutter={true} />
+                <SupportedPlatforms
+                    web={{ version: '1.110.0' }}
+                    ios={{ version: '3.11.0' }}
+                    android={{ version: '3.11.0' }}
+                    reactNative={{ version: '3.6.3' }}
+                    flutter={{ version: '4.7.0' }}
+                />
                 <p>Linking a flag means that recordings will only be collected for users who have the flag enabled.</p>
                 <div className="flex flex-row justify-start">
                     <FlagSelector
@@ -246,7 +252,7 @@ export function SessionRecordingIngestionSettings(): JSX.Element | null {
                                 }
                             />
                         </div>
-                        <SupportedPlatforms web={true} />
+                        <SupportedPlatforms web={{ version: '1.85.0' }} />
                         <p>
                             Use this setting to restrict the percentage of sessions that will be recorded. This is
                             useful if you want to reduce the amount of data you collect. 100% means all sessions will be
@@ -268,7 +274,7 @@ export function SessionRecordingIngestionSettings(): JSX.Element | null {
                                 value={currentTeam?.session_recording_minimum_duration_milliseconds}
                             />
                         </div>
-                        <SupportedPlatforms web={true} />
+                        <SupportedPlatforms web={{ version: '1.85.0' }} />
                         <p>
                             Setting a minimum session duration will ensure that only sessions that last longer than that
                             value are collected. This helps you avoid collecting sessions that are too short to be

--- a/frontend/src/scenes/settings/environment/SessionRecordingSettings.tsx
+++ b/frontend/src/scenes/settings/environment/SessionRecordingSettings.tsx
@@ -177,7 +177,8 @@ function CanvasCaptureSettings(): JSX.Element | null {
                     version: '4.7.0',
                     note: (
                         <>
-                            If you're using the <code>canvaskit</code> renderer on Flutter Web, you must also enable canvas capture
+                            If you're using the <code>canvaskit</code> renderer on Flutter Web, you must also enable
+                            canvas capture
                         </>
                     ),
                 }}

--- a/frontend/src/scenes/settings/environment/SessionRecordingSettings.tsx
+++ b/frontend/src/scenes/settings/environment/SessionRecordingSettings.tsx
@@ -177,7 +177,7 @@ function CanvasCaptureSettings(): JSX.Element | null {
                     version: '4.7.0',
                     note: (
                         <>
-                            If you're using the `canvaskit` renderer on Flutter Web, you must also enable canvas capture
+                            If you're using the <code>canvaskit</code> renderer on Flutter Web, you must also enable canvas capture
                         </>
                     ),
                 }}

--- a/frontend/src/scenes/settings/environment/SessionRecordingSettings.tsx
+++ b/frontend/src/scenes/settings/environment/SessionRecordingSettings.tsx
@@ -48,9 +48,9 @@ function SupportedPlatform(props: SupportedPlatformProps): JSX.Element {
     let tooltip = null
     if (props.supportedSinceVersion || props.note) {
         tooltip = (
-            <div>
-                {props.supportedSinceVersion && <>Since version {props.supportedSinceVersion}</>}
-                {props.note && props.note}
+            <div className="flex flex-col gap-1">
+                {props.supportedSinceVersion && <div>Since version {props.supportedSinceVersion}</div>}
+                {props.note && <div>{props.note}</div>}
             </div>
         )
     }

--- a/frontend/src/scenes/settings/environment/SessionRecordingSettings.tsx
+++ b/frontend/src/scenes/settings/environment/SessionRecordingSettings.tsx
@@ -30,33 +30,42 @@ import { SessionRecordingAIConfig, type SessionRecordingMaskingLevel } from '~/t
 interface SupportedPlatformProps {
     note?: ReactNode
     label: string
-    supported: boolean
+    supportedSinceVersion: false | string
 }
 
 function SupportedPlatform(props: SupportedPlatformProps): JSX.Element {
     const node = (
         <div
             className={clsx(
-                props.supported ? 'bg-fill-success-highlight' : 'bg-fill-error-highlight',
+                props.supportedSinceVersion ? 'bg-fill-success-highlight' : 'bg-fill-error-highlight',
                 'px-1 py-0.5',
                 props.note && 'cursor-pointer'
             )}
         >
-            {props.note ? <IconInfo /> : props.supported ? <IconCheck /> : <IconX />} {props.label}
+            {props.note ? <IconInfo /> : props.supportedSinceVersion ? <IconCheck /> : <IconX />} {props.label}
         </div>
     )
-    if (props.note) {
-        return <Tooltip title={props.note}>{node}</Tooltip>
+    let tooltip = null
+    if (props.supportedSinceVersion || props.note) {
+        tooltip = (
+            <div>
+                {props.supportedSinceVersion && <>Since version {props.supportedSinceVersion}</>}
+                {props.note && props.note}
+            </div>
+        )
+    }
+    if (tooltip) {
+        return <Tooltip title={tooltip}>{node}</Tooltip>
     }
     return node
 }
 
 export function SupportedPlatforms(props: {
-    web?: boolean | { note?: ReactNode }
-    android?: boolean | { note?: ReactNode }
-    ios?: boolean | { note?: ReactNode }
-    reactNative?: boolean | { note?: ReactNode }
-    flutter?: boolean | { note?: ReactNode }
+    web?: false | { note?: ReactNode; version?: string }
+    android?: false | { note?: ReactNode; version?: string }
+    ios?: false | { note?: ReactNode; version?: string }
+    reactNative?: false | { note?: ReactNode; version?: string }
+    flutter?: false | { note?: ReactNode; version?: string }
 }): JSX.Element {
     return (
         <div className="text-xs inline-flex flex-row bg-primary rounded items-center border overflow-hidden mb-2 w-fit">
@@ -65,35 +74,51 @@ export function SupportedPlatforms(props: {
             <SupportedPlatform
                 note={isObject(props.web) ? props.web.note : undefined}
                 label="Web"
-                supported={!!props.web}
+                supportedSinceVersion={
+                    isObject(props.web) && typeof props.web?.version === 'string' ? props.web.version : false
+                }
             />
 
             <LemonDivider vertical className="h-full" />
             <SupportedPlatform
                 note={isObject(props.android) ? props.android.note : undefined}
                 label="Android"
-                supported={!!props.android}
+                supportedSinceVersion={
+                    isObject(props.android) && typeof props.android?.version === 'string'
+                        ? props.android.version
+                        : false
+                }
             />
 
             <LemonDivider vertical className="h-full" />
             <SupportedPlatform
                 note={isObject(props.ios) ? props.ios.note : undefined}
                 label="iOS"
-                supported={!!props.ios}
+                supportedSinceVersion={
+                    isObject(props.ios) && typeof props.ios?.version === 'string' ? props.ios.version : false
+                }
             />
 
             <LemonDivider vertical className="h-full" />
             <SupportedPlatform
                 note={isObject(props.reactNative) ? props.reactNative.note : undefined}
                 label="React Native"
-                supported={!!props.reactNative}
+                supportedSinceVersion={
+                    isObject(props.reactNative) && typeof props.reactNative?.version === 'string'
+                        ? props.reactNative.version
+                        : false
+                }
             />
 
             <LemonDivider vertical className="h-full" />
             <SupportedPlatform
                 note={isObject(props.flutter) ? props.flutter.note : undefined}
                 label="Flutter"
-                supported={!!props.flutter}
+                supportedSinceVersion={
+                    isObject(props.flutter) && typeof props.flutter?.version === 'string'
+                        ? props.flutter.version
+                        : false
+                }
             />
         </div>
     )
@@ -106,7 +131,13 @@ function LogCaptureSettings(): JSX.Element {
     return (
         <div>
             <h3>Log capture</h3>
-            <SupportedPlatforms android={true} ios={false} flutter={false} web={true} reactNative={true} />
+            <SupportedPlatforms
+                android={{ version: '0.0.0' }}
+                ios={false}
+                flutter={false}
+                web={{ version: '1.18.0' }}
+                reactNative={{ version: '3.9.0' }}
+            />
             <p>
                 This setting controls if browser console logs will be captured as a part of recordings. The console logs
                 will be shown in the recording player to help you debug any issues.
@@ -143,13 +174,14 @@ function CanvasCaptureSettings(): JSX.Element | null {
                 android={false}
                 ios={false}
                 flutter={{
+                    version: '4.7.0',
                     note: (
                         <>
                             If you're using the `canvaskit` renderer on Flutter Web, you must also enable canvas capture
                         </>
                     ),
                 }}
-                web={true}
+                web={{ version: '1.101.0' }}
                 reactNative={false}
             />
             <p>
@@ -212,10 +244,10 @@ export function NetworkCaptureSettings(): JSX.Element {
     return (
         <>
             <SupportedPlatforms
-                android={true}
-                ios={true}
+                android={{ version: '3.1.0' }}
+                ios={{ version: '3.12.6' }}
                 flutter={false}
-                web={true}
+                web={{ version: '1.39.0' }}
                 reactNative={{ note: <>RN network capture is only supported on iOS</> }}
             />
             <p>
@@ -250,7 +282,13 @@ export function NetworkCaptureSettings(): JSX.Element {
                 <LemonBanner type="info" className="mb-4">
                     <PayloadWarning />
                 </LemonBanner>
-                <SupportedPlatforms android={false} ios={false} flutter={false} web={true} reactNative={false} />
+                <SupportedPlatforms
+                    android={false}
+                    ios={false}
+                    flutter={false}
+                    web={{ version: '1.104.4' }}
+                    reactNative={false}
+                />
                 <div className="flex flex-row deprecated-space-x-2">
                     <LemonSwitch
                         data-attr="opt-in-capture-network-headers-switch"
@@ -331,7 +369,13 @@ export function NetworkCaptureSettings(): JSX.Element {
 export function ReplayAuthorizedDomains(): JSX.Element {
     return (
         <div className="deprecated-space-y-2">
-            <SupportedPlatforms android={false} ios={false} flutter={false} web={true} reactNative={false} />
+            <SupportedPlatforms
+                android={false}
+                ios={false}
+                flutter={false}
+                web={{ version: '1.5.0' }}
+                reactNative={false}
+            />
             <p>
                 Use the settings below to restrict the domains where recordings will be captured. If no domains are
                 selected, then there will be no domain restriction.
@@ -532,7 +576,7 @@ export function ReplayMaskingSettings(): JSX.Element {
 
     return (
         <div>
-            <SupportedPlatforms web={true} />
+            <SupportedPlatforms web={{ version: '1.227.0' }} />
             <p>This controls what data is masked during session recordings.</p>
             <p>
                 You can configure more advanced settings or change masking for other platforms directly in code.{' '}
@@ -575,7 +619,13 @@ export function ReplayGeneral(): JSX.Element {
     return (
         <div className="flex flex-col gap-4">
             <div>
-                <SupportedPlatforms android={true} ios={true} flutter={true} web={true} reactNative={true} />
+                <SupportedPlatforms
+                    android={{ version: '3.11.0' }}
+                    ios={{ version: '3.19.2' }}
+                    flutter={{ version: '4.7.0' }}
+                    web={{ version: '1.5.0' }}
+                    reactNative={{ version: '3.9.0' }}
+                />
                 <p>
                     Watch recordings of how users interact with your web app to see what can be improved.{' '}
                     <Link

--- a/frontend/src/scenes/settings/environment/SessionRecordingSettings.tsx
+++ b/frontend/src/scenes/settings/environment/SessionRecordingSettings.tsx
@@ -132,7 +132,7 @@ function LogCaptureSettings(): JSX.Element {
         <div>
             <h3>Log capture</h3>
             <SupportedPlatforms
-                android={{ version: '0.0.0' }}
+                android={{ version: '1.0.0' }}
                 ios={false}
                 flutter={false}
                 web={{ version: '1.18.0' }}

--- a/frontend/src/scenes/settings/environment/SessionRecordingSettings.tsx
+++ b/frontend/src/scenes/settings/environment/SessionRecordingSettings.tsx
@@ -39,7 +39,7 @@ function SupportedPlatform(props: SupportedPlatformProps): JSX.Element {
             className={clsx(
                 props.supportedSinceVersion ? 'bg-fill-success-highlight' : 'bg-fill-error-highlight',
                 'px-1 py-0.5',
-                props.note && 'cursor-pointer'
+                props.note && props.supportedSinceVersion && 'cursor-pointer'
             )}
         >
             {props.note ? <IconInfo /> : props.supportedSinceVersion ? <IconCheck /> : <IconX />} {props.label}


### PR DESCRIPTION
We show config support in the UI but not what version of the SDK you have to be running.

Let's at least show that so some folk can self-serve

Where it wasn't clear what version a feature was added I opted for relatively recent releases since better that someone updates than not

![2025-03-11 22 13 07](https://github.com/user-attachments/assets/02577658-a8c6-4125-884a-b75034dc6823)
