### PR TITLE
feat(cdp): expose auto.commit.interval.ms in Rust kafka client config wrapper

### DIFF
--- a/rust/common/kafka/src/config.rs
+++ b/rust/common/kafka/src/config.rs
@@ -37,6 +37,11 @@ pub struct ConsumerConfig {
     // as their offsets should be committed via the transactional producer. All consumers
     // disable auto offset /storing/.
     pub kafka_consumer_auto_commit: bool,
+
+    // expose override config for interval (in milliseconds) between
+    // Kafka offset commit attempts
+    #[envconfig(default = "5000")]
+    pub kafka_consumer_auto_commit_interval_ms: i32,
 }
 
 impl ConsumerConfig {

--- a/rust/common/kafka/src/kafka_consumer.rs
+++ b/rust/common/kafka/src/kafka_consumer.rs
@@ -56,6 +56,9 @@ impl SingleTopicConsumer {
                 &consumer_config.kafka_consumer_offset_reset,
             );
 
+        // IMPORTANT: this means *by default* all consumers are
+        // responsible for storing their own offsets, regardless
+        // of whether automatic offset commit is enabled or disabled!
         client_config.set("enable.auto.offset.store", "false");
 
         if common_config.kafka_tls {
@@ -64,8 +67,13 @@ impl SingleTopicConsumer {
                 .set("enable.ssl.certificate.verification", "false");
         };
 
-        if !consumer_config.kafka_consumer_auto_commit {
-            client_config.set("enable.auto.offset.store", "false");
+        if consumer_config.kafka_consumer_auto_commit {
+            client_config.set("enable.auto.commit", "true").set(
+                "auto.commit.interval.ms",
+                consumer_config
+                    .kafka_consumer_auto_commit_interval_ms
+                    .to_string(),
+            );
         }
 
         let consumer: StreamConsumer = client_config.create()?;


### PR DESCRIPTION
## Problem
I want to extend this setting for the `property-defs-rs` service but we need to expose it first.

## Changes
* Registered new config key with default value
* Added logic to set the new key and value on the underlying `librdkafka` config when `kafka_consumer_auto_commit` is enabled

Let me know if you think I missed anything here 🙇 

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Local dev env + CI
