### PR TITLE
feat: Introduce new polyfill for emoji flags on Windows

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -116,6 +116,7 @@
         "classnames": "^2.5.1",
         "clsx": "^1.1.1",
         "core-js": "^3.32.0",
+        "country-flag-emoji-polyfill": "^0.1.8",
         "crypto-browserify": "^3.12.0",
         "d3": "^7.9.0",
         "d3-sankey": "^0.12.3",

--- a/frontend/src/exporter/Exporter.scss
+++ b/frontend/src/exporter/Exporter.scss
@@ -46,9 +46,9 @@ html.export-type-image {
     }
 
     body {
-        // We put Inter first so that rendered images are the same no matter which platform it is rendered on.
-        font-family: Inter, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
-            'Segoe UI Symbol';
+        // Put Inter high on the list so that rendered images are the same no matter which platform it is rendered on.
+        font-family: 'Emoji Flags Polyfill', Inter, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif,
+            'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
     }
 }
 

--- a/frontend/src/exporter/index.tsx
+++ b/frontend/src/exporter/index.tsx
@@ -1,6 +1,7 @@
 import '~/styles'
 import './Exporter.scss'
 
+import { polyfillCountryFlagEmojis } from 'country-flag-emoji-polyfill'
 import { createRoot } from 'react-dom/client'
 
 import { Exporter } from '~/exporter/Exporter'
@@ -17,6 +18,13 @@ window.JS_POSTHOG_API_KEY = undefined
 
 loadPostHogJS()
 initKea()
+
+// On Chrome + Windows, the country flag emojis don't render correctly. This is a polyfill for that.
+// It won't be applied on other platforms.
+//
+// NOTE: The first argument is the name of the polyfill to use. This is used to set the font family in our CSS.
+// Make sure to update the font family in the CSS if you change this.
+polyfillCountryFlagEmojis('Emoji Flags Polyfill')
 
 const exportedData: ExportedData = window.POSTHOG_EXPORTED_DATA
 

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,5 +1,6 @@
 import '~/styles'
 
+import { polyfillCountryFlagEmojis } from 'country-flag-emoji-polyfill'
 import { getContext } from 'kea'
 import posthog from 'posthog-js'
 import { PostHogProvider } from 'posthog-js/react'
@@ -12,6 +13,13 @@ import { loadPostHogJS } from './loadPostHogJS'
 
 loadPostHogJS()
 initKea()
+
+// On Chrome + Windows, the country flag emojis don't render correctly. This is a polyfill for that.
+// It won't be applied on other platforms.
+//
+// NOTE: The first argument is the name of the polyfill to use. This is used to set the font family in our CSS.
+// Make sure to update the font family in the CSS if you change this.
+polyfillCountryFlagEmojis('Emoji Flags Polyfill')
 
 // Expose `window.getReduxState()` to make snapshots to storybook easy
 if (typeof window !== 'undefined') {

--- a/frontend/src/layout.html
+++ b/frontend/src/layout.html
@@ -8,12 +8,12 @@
 
     <script>
         const posthogJSApiKey = "{{ js_posthog_api_key|escapejs }}";
-            let posthogHost = "{{ js_posthog_host|escapejs }}";
-            if (posthogHost.trim().length === 0) {
-                posthogHost = window.location.origin;
-            }
-        !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId setPersonProperties".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-        posthog.init(posthogJSApiKey, { api_host: posthogHost, persistence: 'localStorage+cookie'})
+        let posthogHost = "{{ js_posthog_host|escapejs }}";
+        if (posthogHost.trim().length === 0) {
+            posthogHost = window.location.origin;
+        }
+        !function (t, e) { var o, n, p, r; e.__SV || (window.posthog = e, e._i = [], e.init = function (i, s, a) { function g(t, e) { var o = e.split("."); 2 == o.length && (t = t[o[0]], e = o[1]), t[e] = function () { t.push([e].concat(Array.prototype.slice.call(arguments, 0))) } } (p = t.createElement("script")).type = "text/javascript", p.crossOrigin = "anonymous", p.async = !0, p.src = s.api_host.replace(".i.posthog.com", "-assets.i.posthog.com") + "/static/array.js", (r = t.getElementsByTagName("script")[0]).parentNode.insertBefore(p, r); var u = e; for (void 0 !== a ? u = e[a] = [] : a = "posthog", u.people = u.people || [], u.toString = function (t) { var e = "posthog"; return "posthog" !== a && (e += "." + a), t || (e += " (stub)"), e }, u.people.toString = function () { return u.toString(1) + ".people (stub)" }, o = "capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId setPersonProperties".split(" "), n = 0; n < o.length; n++)g(u, o[n]); e._i.push([i, s, a]) }, e.__SV = 1) }(document, window.posthog || []);
+        posthog.init(posthogJSApiKey, { api_host: posthogHost, persistence: 'localStorage+cookie' })
     </script>
     <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" rel="stylesheet"
         crossorigin="anonymous" />
@@ -199,7 +199,7 @@
             color: rgb(21, 21, 21);
             cursor: pointer;
             display: block;
-            font-family: MatterVF, -apple-system, "system-ui", "avenir next", avenir, "segoe ui", "helvetica neue", helvetica, Ubuntu, roboto, noto, arial, "sans-serif";
+            font-family: 'Emoji Flags Polyfill', MatterVF, -apple-system, "system-ui", "avenir next", avenir, "segoe ui", "helvetica neue", helvetica, Ubuntu, roboto, noto, arial, "sans-serif";
             font-feature-settings: normal;
             font-variant-ligatures: none;
             font-variant-numeric: normal;
@@ -247,7 +247,7 @@
             color: rgb(21, 21, 21);
             cursor: pointer;
             display: block;
-            font-family: MatterVF, -apple-system, "system-ui", "avenir next", avenir, "segoe ui", "helvetica neue", helvetica, Ubuntu, roboto, noto, arial, "sans-serif";
+            font-family: 'Emoji Flags Polyfill', MatterVF, -apple-system, "system-ui", "avenir next", avenir, "segoe ui", "helvetica neue", helvetica, Ubuntu, roboto, noto, arial, "sans-serif";
             font-feature-settings: normal;
             font-size: 15px;
             font-variant-ligatures: none;

--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -557,11 +557,12 @@
     --opacity-disabled: 0.65;
     --font-medium: 500;
     --font-semibold: 600;
-    --font-sans: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', 'Roboto', 'Helvetica Neue', helvetica, arial,
-        sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
-    --font-title: 'MatterSQ', -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', 'Roboto', 'Helvetica Neue',
-        helvetica, arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
-    --font-mono: ui-monospace, 'SFMono-Regular', 'SF Mono', 'Menlo', 'Consolas', 'Liberation Mono', monospace;
+    --font-sans: 'Emoji Flags Polyfill', -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', 'Roboto',
+        'Helvetica Neue', helvetica, arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+    --font-title: 'Emoji Flags Polyfill', 'MatterSQ', -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', 'Roboto',
+        'Helvetica Neue', helvetica, arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+    --font-mono: 'Emoji Flags Polyfill', ui-monospace, 'SFMono-Regular', 'SF Mono', 'Menlo', 'Consolas',
+        'Liberation Mono', monospace;
 
     // Dashboard item colors
     --blue: #597dce;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -733,6 +733,9 @@ importers:
       core-js:
         specifier: ^3.32.0
         version: 3.40.0
+      country-flag-emoji-polyfill:
+        specifier: ^0.1.8
+        version: 0.1.8
       crypto-browserify:
         specifier: ^3.12.0
         version: 3.12.1
@@ -8175,6 +8178,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  country-flag-emoji-polyfill@0.1.8:
+    resolution: {integrity: sha512-Mbah52sADS3gshUYhK5142gtUuJpHYOXlXtLFI3Ly4RqgkmPMvhX9kMZSTqDM8P7UqtSW99eHKFphhQSGXA3Cg==}
 
   create-ecdh@4.0.4:
     resolution: {integrity: sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==}
@@ -24310,6 +24316,8 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 4.9.5
+
+  country-flag-emoji-polyfill@0.1.8: {}
 
   create-ecdh@4.0.4:
     dependencies:


### PR DESCRIPTION
Long story: https://geyer.dev/blog/windows-flag-emojis/

Short story: Windows + Chrome don't render flags like they should, they instead render the code symbol for the flag which looks crazy ugly in our UI - specially on Web Analytics, but also on our currency dropdown.

The fix is to load a special font uniquely for those emoji codepoints when we detect that we're on Windows + Chrome. We're adding a library to do that for us because they'll know how to check it better than us. Warning: don't read how they do it, it's very very cursed (hint: canvas color detection).

![image](https://github.com/user-attachments/assets/e9480da8-5268-4833-a802-5a7ddbb98dfe)

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Looking at it on a Windows machine :)

Closes #29797