### PR TITLE
fix(cdp): fixes broken pop-up modal for re-ordering

### DIFF
--- a/frontend/src/scenes/pipeline/Overview.tsx
+++ b/frontend/src/scenes/pipeline/Overview.tsx
@@ -10,7 +10,7 @@ import { urls } from 'scenes/urls'
 import { PipelineStage, PipelineTab } from '~/types'
 
 import { DESTINATION_TYPES, TRANSFORMATION_TYPES } from './destinations/constants'
-import { DestinationsTable } from './destinations/Destinations'
+import { DestinationsTable, ReorderTransformationsModal } from './destinations/Destinations'
 
 export function Overview(): JSX.Element {
     const menuItems = [
@@ -37,6 +37,7 @@ export function Overview(): JSX.Element {
                     </div>
                 }
             />
+            <ReorderTransformationsModal types={TRANSFORMATION_TYPES} />
             <div className="deprecated-space-y-4">
                 <div>
                     <Link to={urls.pipeline(PipelineTab.Sources)}>

--- a/frontend/src/scenes/pipeline/Overview.tsx
+++ b/frontend/src/scenes/pipeline/Overview.tsx
@@ -10,7 +10,7 @@ import { urls } from 'scenes/urls'
 import { PipelineStage, PipelineTab } from '~/types'
 
 import { DESTINATION_TYPES, TRANSFORMATION_TYPES } from './destinations/constants'
-import { DestinationsTable, ReorderTransformationsModal } from './destinations/Destinations'
+import { DestinationsTable } from './destinations/Destinations'
 
 export function Overview(): JSX.Element {
     const menuItems = [
@@ -37,7 +37,6 @@ export function Overview(): JSX.Element {
                     </div>
                 }
             />
-            <ReorderTransformationsModal types={TRANSFORMATION_TYPES} />
             <div className="deprecated-space-y-4">
                 <div>
                     <Link to={urls.pipeline(PipelineTab.Sources)}>
@@ -67,6 +66,7 @@ export function Overview(): JSX.Element {
                         types={TRANSFORMATION_TYPES}
                         hideFeedback={true}
                         hideAddDestinationButton={false}
+                        hideChangeOrderButton={true}
                     />
                 </div>
                 <div>
@@ -77,7 +77,12 @@ export function Overview(): JSX.Element {
                         Send your data to destinations in real time or with batch exports. Only active Destinations are
                         shown here. <Link to={urls.pipeline(PipelineTab.Destinations)}>See all.</Link>
                     </p>
-                    <DestinationsTable types={DESTINATION_TYPES} hideFeedback={true} hideAddDestinationButton={false} />
+                    <DestinationsTable
+                        types={DESTINATION_TYPES}
+                        hideFeedback={true}
+                        hideAddDestinationButton={false}
+                        hideChangeOrderButton={true}
+                    />
                 </div>
             </div>
         </>

--- a/frontend/src/scenes/pipeline/destinations/Destinations.tsx
+++ b/frontend/src/scenes/pipeline/destinations/Destinations.tsx
@@ -93,12 +93,14 @@ export type DestinationsTableProps = {
     types: HogFunctionTypeType[]
     hideFeedback?: boolean
     hideAddDestinationButton?: boolean
+    hideChangeOrderButton?: boolean
 }
 
 export function DestinationsTable({
     hideFeedback,
     hideAddDestinationButton,
     types,
+    hideChangeOrderButton = false,
 }: DestinationsTableProps): JSX.Element {
     const { canConfigurePlugins, canEnableDestination } = useValues(pipelineAccessLogic)
     const { loading, filteredDestinations, destinations, hiddenDestinations } = useValues(
@@ -130,7 +132,7 @@ export function DestinationsTable({
                 hideAddDestinationButton={hideAddDestinationButton}
             />
 
-            {types.includes('transformation') && enabledTransformations.length > 1 && (
+            {types.includes('transformation') && enabledTransformations.length > 1 && !hideChangeOrderButton && (
                 <div className="flex items-center gap-2">
                     Processed sequentially.
                     <LemonButton

--- a/frontend/src/scenes/pipeline/destinations/Destinations.tsx
+++ b/frontend/src/scenes/pipeline/destinations/Destinations.tsx
@@ -344,7 +344,7 @@ export function DestinationsTable({
     )
 }
 
-function ReorderTransformationsModal({ types }: { types: HogFunctionTypeType[] }): JSX.Element {
+export function ReorderTransformationsModal({ types }: { types: HogFunctionTypeType[] }): JSX.Element {
     const { reorderTransformationsModalOpen, destinations, temporaryTransformationOrder, loading } = useValues(
         pipelineDestinationsLogic({ types })
     )

--- a/frontend/src/scenes/pipeline/destinations/Destinations.tsx
+++ b/frontend/src/scenes/pipeline/destinations/Destinations.tsx
@@ -346,7 +346,7 @@ export function DestinationsTable({
     )
 }
 
-export function ReorderTransformationsModal({ types }: { types: HogFunctionTypeType[] }): JSX.Element {
+function ReorderTransformationsModal({ types }: { types: HogFunctionTypeType[] }): JSX.Element {
     const { reorderTransformationsModalOpen, destinations, temporaryTransformationOrder, loading } = useValues(
         pipelineDestinationsLogic({ types })
     )


### PR DESCRIPTION
## Problem

the overview page is already cluttered and `change order` is something niche that should only exist on the transformation page. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- removed the `change order` button from the transformation page.

<img width="1017" alt="Screenshot 2025-03-12 at 10 01 25" src="https://github.com/user-attachments/assets/dd9a57b0-33fb-4a64-be1c-0882df52e6e3" />


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- locally

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
