### PR TITLE
feat(cdp): qol full zapier url is possible now

### DIFF
--- a/ee/api/test/test_hooks.py
+++ b/ee/api/test/test_hooks.py
@@ -124,7 +124,19 @@ class TestHooksAPI(ClickhouseTestMixin, APILicensedTest):
 
         assert hog_function.hog == snapshot(
             """\
-let res := fetch(f'https://hooks.zapier.com/{inputs.hook}', {
+let hook_path := inputs.hook;
+let prefix := 'https://hooks.zapier.com/';
+// Remove the prefix if it exists
+if (position(hook_path, prefix) == 1) {
+  hook_path := replaceOne(hook_path, prefix, '');
+}
+
+// Remove leading slash if present to avoid double slashes
+if (position(hook_path, '/') == 1) {
+  hook_path := replaceOne(hook_path, '/', '');
+}
+
+let res := fetch(f'https://hooks.zapier.com/{hook_path}', {
   'method': 'POST',
   'body': inputs.body
 });

--- a/posthog/cdp/templates/zapier/template_zapier.py
+++ b/posthog/cdp/templates/zapier/template_zapier.py
@@ -11,7 +11,13 @@ template: HogFunctionTemplate = HogFunctionTemplate(
     icon_url="/static/services/zapier.png",
     category=["Custom"],
     hog="""
-let res := fetch(f'https://hooks.zapier.com/{inputs.hook}', {
+let hook_path := inputs.hook;
+let prefix := 'https://hooks.zapier.com/';
+if (position(hook_path, prefix) == 1) {
+  hook_path := replaceOne(hook_path, prefix, '');
+}
+
+let res := fetch(f'https://hooks.zapier.com/{hook_path}', {
   'method': 'POST',
   'body': inputs.body
 });
@@ -26,7 +32,7 @@ if (inputs.debug) {
             "key": "hook",
             "type": "string",
             "label": "Zapier hook path",
-            "description": "The path of the Zapier webhook. This value should be the part of the webhook URL after https://hooks.zapier.com/ (for example: hooks/catch/12345678/2gygaul/). You can create your own or use our native Zapier integration https://zapier.com/apps/posthog/integrations",
+            "description": "Your Zapier webhook URL or just the path. You can create your own or use our native Zapier integration https://zapier.com/apps/posthog/integrations",
             "secret": False,
             "required": True,
             "hidden": False,

--- a/posthog/cdp/templates/zapier/template_zapier.py
+++ b/posthog/cdp/templates/zapier/template_zapier.py
@@ -13,8 +13,14 @@ template: HogFunctionTemplate = HogFunctionTemplate(
     hog="""
 let hook_path := inputs.hook;
 let prefix := 'https://hooks.zapier.com/';
+// Remove the prefix if it exists
 if (position(hook_path, prefix) == 1) {
   hook_path := replaceOne(hook_path, prefix, '');
+}
+
+// Remove leading slash if present to avoid double slashes
+if (position(hook_path, '/') == 1) {
+  hook_path := replaceOne(hook_path, '/', '');
 }
 
 let res := fetch(f'https://hooks.zapier.com/{hook_path}', {

--- a/posthog/cdp/templates/zapier/test_template_zapier.py
+++ b/posthog/cdp/templates/zapier/test_template_zapier.py
@@ -6,7 +6,8 @@ from posthog.cdp.templates.zapier.template_zapier import template as template_za
 class TestTemplateZapier(BaseHogFunctionTemplateTest):
     template = template_zapier
 
-    def test_function_works(self):
+    def test_function_works_with_path_only(self):
+        # Test with just the path
         self.run_function(
             inputs={
                 "hook": "hooks/1/2",
@@ -17,5 +18,21 @@ class TestTemplateZapier(BaseHogFunctionTemplateTest):
 
         assert self.get_mock_fetch_calls()[0] == snapshot(
             ("https://hooks.zapier.com/hooks/1/2", {"body": {"hello": "world"}, "method": "POST"})
+        )
+        assert self.get_mock_print_calls() == snapshot([])
+
+    def test_function_strips_url_prefix(self):
+        # Test with a full URL including the prefix
+        self.run_function(
+            inputs={
+                "hook": "https://hooks.zapier.com/hooks/catch/7363152/2l3ak6v/",
+                "body": {"hello": "world"},
+                "debug": False,
+            }
+        )
+
+        # The URL prefix should be stripped, so the fetch call should use just the path
+        assert self.get_mock_fetch_calls()[0] == snapshot(
+            ("https://hooks.zapier.com/hooks/catch/7363152/2l3ak6v/", {"body": {"hello": "world"}, "method": "POST"})
         )
         assert self.get_mock_print_calls() == snapshot([])

--- a/posthog/cdp/templates/zapier/test_template_zapier.py
+++ b/posthog/cdp/templates/zapier/test_template_zapier.py
@@ -25,7 +25,7 @@ class TestTemplateZapier(BaseHogFunctionTemplateTest):
         # Test with a full URL including the prefix
         self.run_function(
             inputs={
-                "hook": "https://hooks.zapier.com/hooks/catch/7363152/2l3ak6v/",
+                "hook": "https://hooks.zapier.com/hooks/catch/123456/abcdef/",
                 "body": {"hello": "world"},
                 "debug": False,
             }
@@ -33,7 +33,7 @@ class TestTemplateZapier(BaseHogFunctionTemplateTest):
 
         # The URL prefix should be stripped, so the fetch call should use just the path
         assert self.get_mock_fetch_calls()[0] == snapshot(
-            ("https://hooks.zapier.com/hooks/catch/7363152/2l3ak6v/", {"body": {"hello": "world"}, "method": "POST"})
+            ("https://hooks.zapier.com/hooks/catch/123456/abcdef/", {"body": {"hello": "world"}, "method": "POST"})
         )
         assert self.get_mock_print_calls() == snapshot([])
 
@@ -41,7 +41,7 @@ class TestTemplateZapier(BaseHogFunctionTemplateTest):
         # Test with a path that has a leading slash
         self.run_function(
             inputs={
-                "hook": "/hooks/catch/7363152/2l3ak6v/",
+                "hook": "/hooks/catch/123456/abcdef/",
                 "body": {"hello": "world"},
                 "debug": False,
             }
@@ -49,6 +49,6 @@ class TestTemplateZapier(BaseHogFunctionTemplateTest):
 
         # The leading slash should be removed to avoid double slashes
         assert self.get_mock_fetch_calls()[0] == snapshot(
-            ("https://hooks.zapier.com/hooks/catch/7363152/2l3ak6v/", {"body": {"hello": "world"}, "method": "POST"})
+            ("https://hooks.zapier.com/hooks/catch/123456/abcdef/", {"body": {"hello": "world"}, "method": "POST"})
         )
         assert self.get_mock_print_calls() == snapshot([])

--- a/posthog/cdp/templates/zapier/test_template_zapier.py
+++ b/posthog/cdp/templates/zapier/test_template_zapier.py
@@ -36,3 +36,19 @@ class TestTemplateZapier(BaseHogFunctionTemplateTest):
             ("https://hooks.zapier.com/hooks/catch/7363152/2l3ak6v/", {"body": {"hello": "world"}, "method": "POST"})
         )
         assert self.get_mock_print_calls() == snapshot([])
+
+    def test_function_handles_leading_slash(self):
+        # Test with a path that has a leading slash
+        self.run_function(
+            inputs={
+                "hook": "/hooks/catch/7363152/2l3ak6v/",
+                "body": {"hello": "world"},
+                "debug": False,
+            }
+        )
+
+        # The leading slash should be removed to avoid double slashes
+        assert self.get_mock_fetch_calls()[0] == snapshot(
+            ("https://hooks.zapier.com/hooks/catch/7363152/2l3ak6v/", {"body": {"hello": "world"}, "method": "POST"})
+        )
+        assert self.get_mock_print_calls() == snapshot([])


### PR DESCRIPTION
## Problem

- when pasting in the full zapier webhook url the destination was not working as it was expecting only the hook part.. so 

`https://hooks.zapier.com/hooks/catch/blaa/` was not working but only `hooks/catch/blaa/` this led to support ticket and is generally not great ux. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

destination now takes the full url or only the hooks part

- `https://hooks.zapier.com/hooks/catch/blaa/` 
- `hooks/catch/blaa/`

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

![2025-03-12 10 35 24](https://github.com/user-attachments/assets/f1e74177-e918-4d8b-a554-c55692115fa0)


- tested locally 
- added tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
