### PR TITLE
fix(cdp): Comparison findings for onevent

### DIFF
--- a/plugin-server/src/cdp/consumers/cdp-cyclotron-plugins-worker.test.ts
+++ b/plugin-server/src/cdp/consumers/cdp-cyclotron-plugins-worker.test.ts
@@ -129,7 +129,7 @@ describe('CdpCyclotronWorkerPlugins', () => {
                   "$set_once": undefined,
                   "distinct_id": "distinct_id",
                   "event": "mycustomevent",
-                  "ip": undefined,
+                  "ip": null,
                   "person": {
                     "created_at": "",
                     "properties": {

--- a/plugin-server/src/cdp/services/legacy-onevent-compare.service.ts
+++ b/plugin-server/src/cdp/services/legacy-onevent-compare.service.ts
@@ -5,6 +5,7 @@ import { Hub, PluginConfig, PluginMethodsConcrete, PostIngestionEvent } from '..
 import { Response } from '../../utils/fetch'
 import { getHttpCallRecorder, HttpCallRecorder, RecordedHttpCall, recordFetchRequest } from '../../utils/recorded-fetch'
 import { status } from '../../utils/status'
+import { cloneObject } from '../../utils/utils'
 import { DESTINATION_PLUGINS } from '../legacy-plugins'
 import { HogFunctionInvocation, HogFunctionInvocationResult, HogFunctionType } from '../types'
 import { createInvocation } from '../utils'
@@ -107,6 +108,8 @@ export class LegacyOneventCompareService {
 
         let pluginConfigError: any = null
 
+        const clonedEvent = cloneObject(event) // NOTE: The hog function can modify the event so we need to clone it
+
         try {
             // Execute the operation
             await onEvent(onEventPayload)
@@ -116,7 +119,8 @@ export class LegacyOneventCompareService {
 
         try {
             const recordedCalls = getHttpCallRecorder().getCalls()
-            const hogFunctionResult = await this.runHogFunctionOnEvent(pluginConfig, event, recordedCalls)
+
+            const hogFunctionResult = await this.runHogFunctionOnEvent(pluginConfig, clonedEvent, recordedCalls)
             const comparer = new HttpCallRecorder()
             const comparison = comparer.compareCalls(recordedCalls, hogFunctionResult.recordedCalls)
 

--- a/plugin-server/src/cdp/services/legacy-plugin-executor.service.test.ts
+++ b/plugin-server/src/cdp/services/legacy-plugin-executor.service.test.ts
@@ -182,7 +182,7 @@ describe('LegacyPluginExecutorService', () => {
                   "$set_once": undefined,
                   "distinct_id": "distinct_id",
                   "event": "mycustomevent",
-                  "ip": undefined,
+                  "ip": null,
                   "person": {
                     "created_at": "",
                     "properties": {

--- a/plugin-server/src/cdp/services/legacy-plugin-executor.service.ts
+++ b/plugin-server/src/cdp/services/legacy-plugin-executor.service.ts
@@ -239,6 +239,7 @@ export class LegacyPluginExecutorService {
                 // Destination style
                 const processedEvent: ProcessedPluginEvent = {
                     ...event,
+                    ip: null, // convertToOnEventPayload removes this so we should too
                     person,
                     properties: event.properties || {},
                 }

--- a/plugin-server/src/utils/recorded-fetch.ts
+++ b/plugin-server/src/utils/recorded-fetch.ts
@@ -41,7 +41,7 @@ export interface ComparisonResult {
     }
 }
 
-const PROPERTY_DIFFS_TO_IGNORE = new Set(['sent_at'])
+const PROPERTY_DIFFS_TO_IGNORE = new Set(['sentAt'])
 
 export class HttpCallRecorder {
     private calls: RecordedHttpCall[] = []

--- a/plugin-server/src/utils/recorded-fetch.ts
+++ b/plugin-server/src/utils/recorded-fetch.ts
@@ -41,6 +41,8 @@ export interface ComparisonResult {
     }
 }
 
+const PROPERTY_DIFFS_TO_IGNORE = new Set(['sent_at'])
+
 export class HttpCallRecorder {
     private calls: RecordedHttpCall[] = []
 
@@ -216,6 +218,10 @@ export class HttpCallRecorder {
                         path ? `${path}.${key}` : key
                     }: [legacy] ${JSON.stringify(obj1[key])} ≠ [hogfn] undefined`
                 )
+                continue
+            }
+
+            if (PROPERTY_DIFFS_TO_IGNORE.has(key)) {
                 continue
             }
 


### PR DESCRIPTION
## Changes

* Fixes to not pass IP (the old one doesn't)
* Added way to ignore props that have a known diff (like sentAt that is basically `now()`)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
