### PR TITLE
feat(cdp): fix hog function deletion

### DIFF
--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionInputs.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionInputs.tsx
@@ -480,7 +480,7 @@ export function HogFunctionInputWithSchema({
                                         </span>
                                         <LemonButton
                                             onClick={() => {
-                                                onChange({ value: undefined })
+                                                onChange({ value: '' })
                                             }}
                                             size="small"
                                             type="secondary"

--- a/posthog/cdp/test/test_validation.py
+++ b/posthog/cdp/test/test_validation.py
@@ -348,3 +348,51 @@ class TestHogFunctionValidation(ClickhouseTestMixin, APIBaseTest, QueryMatchingT
         assert validated["A"].get("bytecode") is None
         assert validated["A"].get("transpiled") is None
         assert validated["A"].get("value") == "{inputs.X} + A"
+
+    def test_validate_inputs_with_secret_values(self):
+        inputs_schema = [
+            {"key": "secret_field", "type": "string", "required": True, "secret": True},
+        ]
+
+        existing_secret_inputs = {
+            "secret_field": {"value": "EXISTING_SECRET_VALUE", "order": 1},
+        }
+
+        for inputs, expected_result in [
+            (
+                {
+                    "secret_field": {},
+                },
+                {
+                    "secret_field": {"value": "EXISTING_SECRET_VALUE"},
+                },
+            ),
+            (
+                {
+                    "secret_field": {"value": "NEW_SECRET_VALUE"},
+                },
+                {
+                    "secret_field": {"value": "NEW_SECRET_VALUE"},
+                },
+            ),
+            (
+                {
+                    "secret_field": {"secret": True},
+                },
+                {
+                    "secret_field": {"value": "EXISTING_SECRET_VALUE"},
+                },
+            ),
+        ]:
+            serializer = MappingsSerializer(
+                data={
+                    "inputs_schema": inputs_schema,
+                    "inputs": inputs,
+                },
+                context={"function_type": "destination", "encrypted_inputs": existing_secret_inputs},
+            )
+            serializer.is_valid(raise_exception=True)
+            validated = serializer.validated_data["inputs"]
+
+            values_only = {k: {"value": v["value"]} for k, v in validated.items()}
+            assert values_only == expected_result

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -207,7 +207,7 @@ class InputsSerializer(serializers.DictField):
             value = data.get(key) or {}
 
             # We only load the existing secret if the schema is secret and the given value has "secret" set
-            if schema.get("secret") and existing_secret_inputs and value and value.get("secret"):
+            if schema.get("secret") and existing_secret_inputs and ((value and value.get("secret")) or value == {}):
                 value = existing_secret_inputs.get(schema["key"]) or {}
 
             self.context["schema"] = schema


### PR DESCRIPTION
## Problem

At the moment hog function deletion is broken. [The refactor caused the issue](https://github.com/PostHog/posthog/issues/29459), since we'll always call the input validation even when no inputs have been supplied. [Previously we skipped this step when no inputs where supplied](https://github.com/PostHog/posthog/pull/29459/files#diff-fbced250616f0d4245b1585f17a6713e1fad90c67cfbb1fb5afe1bb8098c0b84L211-L219).

## Changes

- If no secret value has been supplied we'll load the existing secret value
- Setting the secret value to an empty string after clicking edit to make sure we allow empty strings for optional secret fields

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
