### PR TITLE
Chore: change early access button

### DIFF
--- a/products/early_access_features/frontend/EarlyAccessFeature.tsx
+++ b/products/early_access_features/frontend/EarlyAccessFeature.tsx
@@ -192,7 +192,7 @@ export function EarlyAccessFeature({ id }: { id?: string } = {}): JSX.Element {
                                         tooltip="Make beta feature available"
                                         type="primary"
                                     >
-                                        Release beta
+                                        Publish
                                     </LemonButton>
                                 )}
                                 <LemonDivider vertical />

--- a/products/early_access_features/frontend/EarlyAccessFeature.tsx
+++ b/products/early_access_features/frontend/EarlyAccessFeature.tsx
@@ -189,7 +189,7 @@ export function EarlyAccessFeature({ id }: { id?: string } = {}): JSX.Element {
                                 {earlyAccessFeature.stage == EarlyAccessFeatureStage.Draft && (
                                     <LemonButton
                                         onClick={() => updateStage(EarlyAccessFeatureStage.Beta)}
-                                        tooltip="Make beta feature available"
+                                        tooltip="Publish this feature to make it available"
                                         type="primary"
                                     >
                                         Publish


### PR DESCRIPTION
## Problem

It doesn't really make sense to 'Release beta' given we now have multiple stages. And 'Release' on its own is misleading if things can exist as 'Concept'. 

So: 'Publish'

## Changes

Changes the 'Release beta' button in Early access management to 'Publish' 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Probs

## How did you test this code?

I got it to complete an SAT exam. 