### PR TITLE
fix: make usage report tasks future proof

### DIFF
--- a/posthog/management/commands/send_usage_report.py
+++ b/posthog/management/commands/send_usage_report.py
@@ -36,17 +36,17 @@ class Command(BaseCommand):
 
         if run_async:
             send_all_org_usage_reports.delay(
-                dry_run,
-                date,
-                event_name,
+                dry_run=dry_run,
+                at=date,
+                capture_event_name=event_name,
                 skip_capture_event=skip_capture_event,
                 only_organization_id=organization_id,
             )
         else:
             send_all_org_usage_reports(
-                dry_run,
-                date,
-                event_name,
+                dry_run=dry_run,
+                at=date,
+                capture_event_name=event_name,
                 skip_capture_event=skip_capture_event,
                 only_organization_id=organization_id,
             )

--- a/posthog/tasks/periodic_digest.py
+++ b/posthog/tasks/periodic_digest.py
@@ -264,6 +264,7 @@ def _get_all_org_digest_reports(period_start: datetime, period_end: datetime) ->
 @shared_task(**USAGE_REPORT_TASK_KWARGS, max_retries=0)
 def send_all_periodic_digest_reports(
     self: celery.Task,
+    *,
     dry_run: bool = False,
     end_date: Optional[str] = None,
     begin_date: Optional[str] = None,

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -306,7 +306,7 @@ def send_report_to_billing_service(self: celery.Task, org_id: str, report: dict[
 
     # hack to process old entries, remove after 2025.03.12
     if isinstance(self, str):
-        report = org_id
+        report = org_id  # type: ignore
         org_id = self
         self = None
 

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -825,6 +825,7 @@ def get_teams_with_recording_bytes_in_period(
 
 @shared_task(**USAGE_REPORT_TASK_KWARGS, max_retries=0)
 def capture_report(
+    self: celery.Task,
     *,
     capture_event_name: str,
     org_id: Optional[str] = None,


### PR DESCRIPTION
## Problem

Tasks scheduled in past have position sensitive arguments

## Changes

Name all 

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

run
