### PR TITLE
chore: Perf testing for legacy plugins

### DIFF
--- a/plugin-server/src/cdp/consumers/cdp-cyclotron-plugins-worker.test.ts
+++ b/plugin-server/src/cdp/consumers/cdp-cyclotron-plugins-worker.test.ts
@@ -130,15 +130,6 @@ describe('CdpCyclotronWorkerPlugins', () => {
                   "distinct_id": "distinct_id",
                   "event": "mycustomevent",
                   "ip": null,
-                  "person": {
-                    "created_at": "",
-                    "properties": {
-                      "email": "test@posthog.com",
-                      "first_name": "Pumpkin",
-                    },
-                    "team_id": 2,
-                    "uuid": "uuid",
-                  },
                   "properties": {
                     "email": "test@posthog.com",
                   },

--- a/plugin-server/src/cdp/legacy-plugins/_destinations/customerio/index.ts
+++ b/plugin-server/src/cdp/legacy-plugins/_destinations/customerio/index.ts
@@ -257,9 +257,6 @@ function isEmail(email: string): boolean {
 }
 
 function getEmailFromEvent(event: ProcessedPluginEvent): string | null {
-    if (event.person?.properties?.email) {
-        return event.person.properties.email
-    }
     const setAttribute = event.$set
     if (typeof setAttribute !== 'object' || !setAttribute['email']) {
         return null

--- a/plugin-server/src/cdp/services/legacy-plugin-executor.service.test.ts
+++ b/plugin-server/src/cdp/services/legacy-plugin-executor.service.test.ts
@@ -254,6 +254,35 @@ describe('LegacyPluginExecutorService', () => {
             `)
         })
 
+        it('should mock out fetch if it is a test function', async () => {
+            jest.spyOn(customerIoPlugin, 'onEvent')
+
+            const invocation = createInvocation(fn, globals)
+            invocation.hogFunction.name = 'My function [CDP-TEST-HIDDEN]'
+            invocation.globals.event.event = 'mycustomevent'
+            invocation.globals.event.properties = {
+                email: 'test@posthog.com',
+            }
+
+            const res = await service.execute(invocation)
+
+            // NOTE: Setup call is not mocked
+            expect(mockFetch).toHaveBeenCalledTimes(1)
+
+            expect(customerIoPlugin.onEvent).toHaveBeenCalledTimes(1)
+
+            expect(forSnapshot(res.logs.map((l) => l.message))).toMatchInlineSnapshot(`
+                [
+                  "Successfully authenticated with Customer.io. Completing setupPlugin.",
+                  "Detected email, test@posthog.com",
+                  "{"status":{},"existsAlready":false,"email":"test@posthog.com"}",
+                  "true",
+                  "Fetch called but mocked due to test function",
+                  "Fetch called but mocked due to test function",
+                ]
+            `)
+        })
+
         it('should handle and collect errors', async () => {
             jest.spyOn(customerIoPlugin, 'onEvent')
 

--- a/plugin-server/src/cdp/services/legacy-plugin-executor.service.test.ts
+++ b/plugin-server/src/cdp/services/legacy-plugin-executor.service.test.ts
@@ -183,15 +183,6 @@ describe('LegacyPluginExecutorService', () => {
                   "distinct_id": "distinct_id",
                   "event": "mycustomevent",
                   "ip": null,
-                  "person": {
-                    "created_at": "",
-                    "properties": {
-                      "email": "test@posthog.com",
-                      "first_name": "Pumpkin",
-                    },
-                    "team_id": 2,
-                    "uuid": "uuid",
-                  },
                   "properties": {
                     "email": "test@posthog.com",
                   },
@@ -219,7 +210,7 @@ describe('LegacyPluginExecutorService', () => {
                   [
                     "https://track.customer.io/api/v1/customers/distinct_id",
                     {
-                      "body": "{"_update":false,"identifier":"distinct_id","email":"test@posthog.com"}",
+                      "body": "{"_update":false,"identifier":"distinct_id"}",
                       "headers": {
                         "Authorization": "Basic MTIzNDU2Nzg5MDpjaW8tdG9rZW4=",
                         "Content-Type": "application/json",
@@ -247,8 +238,8 @@ describe('LegacyPluginExecutorService', () => {
             expect(res.logs.map((l) => l.message)).toMatchInlineSnapshot(`
                 [
                   "Successfully authenticated with Customer.io. Completing setupPlugin.",
-                  "Detected email, test@posthog.com",
-                  "{"status":{},"existsAlready":false,"email":"test@posthog.com"}",
+                  "Detected email, null",
+                  "{"status":{},"existsAlready":false,"email":null}",
                   "true",
                 ]
             `)
@@ -274,8 +265,8 @@ describe('LegacyPluginExecutorService', () => {
             expect(forSnapshot(res.logs.map((l) => l.message))).toMatchInlineSnapshot(`
                 [
                   "Successfully authenticated with Customer.io. Completing setupPlugin.",
-                  "Detected email, test@posthog.com",
-                  "{"status":{},"existsAlready":false,"email":"test@posthog.com"}",
+                  "Detected email, null",
+                  "{"status":{},"existsAlready":false,"email":null}",
                   "true",
                   "Fetch called but mocked due to test function",
                   "Fetch called but mocked due to test function",
@@ -311,8 +302,8 @@ describe('LegacyPluginExecutorService', () => {
             expect(forSnapshot(res.logs.map((l) => l.message))).toMatchInlineSnapshot(`
                 [
                   "Successfully authenticated with Customer.io. Completing setupPlugin.",
-                  "Detected email, test@posthog.com",
-                  "{"status":{},"existsAlready":false,"email":"test@posthog.com"}",
+                  "Detected email, null",
+                  "{"status":{},"existsAlready":false,"email":null}",
                   "true",
                   "Plugin execution failed: Received a potentially intermittent error from the Customer.io API. Response 500: {}",
                 ]

--- a/plugin-server/src/cdp/services/legacy-plugin-executor.service.ts
+++ b/plugin-server/src/cdp/services/legacy-plugin-executor.service.ts
@@ -237,15 +237,6 @@ export class LegacyPluginExecutorService {
 
             const start = performance.now()
 
-            const person: ProcessedPluginEvent['person'] = invocation.globals.person
-                ? {
-                      uuid: invocation.globals.person.id,
-                      team_id: invocation.hogFunction.team_id,
-                      properties: invocation.globals.person.properties,
-                      created_at: '', // NOTE: We don't have this anymore - see if any plugin uses it...
-                  }
-                : undefined
-
             const event = {
                 distinct_id: invocation.globals.event.distinct_id,
                 ip: invocation.globals.event.properties.$ip,
@@ -263,7 +254,6 @@ export class LegacyPluginExecutorService {
                 const processedEvent: ProcessedPluginEvent = {
                     ...event,
                     ip: null, // convertToOnEventPayload removes this so we should too
-                    person,
                     properties: event.properties || {},
                 }
 

--- a/plugin-server/src/utils/recorded-fetch.ts
+++ b/plugin-server/src/utils/recorded-fetch.ts
@@ -1,8 +1,14 @@
 import { Headers, RequestInfo, RequestInit, Response } from 'node-fetch'
+import { Counter } from 'prom-client'
 
 import { defaultConfig } from '../config/config'
 import { trackedFetch } from './fetch'
 import { UUIDT } from './utils'
+
+const pluginFetchCounter = new Counter({
+    name: 'plugin_fetch_count',
+    help: 'The number of plugin fetches',
+})
 
 export interface RecordedRequest {
     url: string
@@ -272,6 +278,8 @@ export async function recordedFetch(url: RequestInfo, init?: RequestInit): Promi
     // Check if recording should be enabled based on config flags
     const shouldRecordHttpCalls =
         defaultConfig.DESTINATION_MIGRATION_DIFFING_ENABLED === true && defaultConfig.TASKS_PER_WORKER === 1
+
+    pluginFetchCounter.inc()
 
     // If recording is disabled, just use trackedFetch directly
     if (!shouldRecordHttpCalls) {


### PR DESCRIPTION
## Problem

I want to get a sense of the number of fetch requests we are currently performing in onevnet

## Changes

* Adds a counter for this
* Adds back in the fake fetching for non-get requests so we can load test this all on cyclotron
* Also removes the person passing in

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
