### PR TITLE
feat: New BigQuery DWH source without SQLAlchemy

### DIFF
--- a/posthog/settings/data_warehouse.py
+++ b/posthog/settings/data_warehouse.py
@@ -1,6 +1,6 @@
 import os
 
-from posthog.settings.utils import get_from_env, str_to_bool
+from posthog.settings.utils import get_from_env, get_list, str_to_bool
 
 AIRBYTE_API_KEY = os.getenv("AIRBYTE_API_KEY", None)
 AIRBYTE_BUCKET_REGION = os.getenv("AIRBYTE_BUCKET_REGION", None)
@@ -13,3 +13,5 @@ AIRBYTE_BUCKET_NAME = os.getenv("AIRBYTE_BUCKET_NAME", None)
 BUCKET = "test-pipeline"
 
 PYARROW_DEBUG_LOGGING = get_from_env("PYARROW_DEBUG_LOGGING", False, type_cast=str_to_bool)
+
+NEW_BIGQUERY_SOURCE_TEAM_IDS: list[str] = get_list(os.getenv("NEW_BIGQUERY_SOURCE_TEAM_IDS", ""))

--- a/posthog/settings/data_warehouse.py
+++ b/posthog/settings/data_warehouse.py
@@ -14,4 +14,6 @@ BUCKET = "test-pipeline"
 
 PYARROW_DEBUG_LOGGING = get_from_env("PYARROW_DEBUG_LOGGING", False, type_cast=str_to_bool)
 
-NEW_BIGQUERY_SOURCE_TEAM_IDS: list[str] = get_list(os.getenv("NEW_BIGQUERY_SOURCE_TEAM_IDS", ""))
+# Temporary, using it to maintain existing teams in old  bigquery source.
+# After further testing this will be removed and all teams moved to new source.
+OLD_BIGQUERY_SOURCE_TEAM_IDS: list[str] = get_list(os.getenv("OLD_BIGQUERY_SOURCE_TEAM_IDS", ""))

--- a/posthog/temporal/data_imports/pipelines/bigquery/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/bigquery/__init__.py
@@ -12,8 +12,6 @@ from posthog.warehouse.types import IncrementalFieldType
 @contextlib.contextmanager
 def bigquery_client(project_id: str, private_key: str, private_key_id: str, client_email: str, token_uri: str):
     """Manage a BigQuery client."""
-    from google.cloud import bigquery
-
     credentials = service_account.Credentials.from_service_account_info(
         {
             "private_key": private_key,

--- a/posthog/temporal/data_imports/pipelines/bigquery/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/bigquery/__init__.py
@@ -1,18 +1,19 @@
-from collections import defaultdict
 import contextlib
-from typing import Optional
-from google.oauth2 import service_account
+from collections import defaultdict
+
 from google.cloud import bigquery
+from google.oauth2 import service_account
+
+from posthog.exceptions_capture import capture_exception
 from posthog.temporal.common.logger import FilteringBoundLogger
 from posthog.warehouse.types import IncrementalFieldType
-from posthog.exceptions_capture import capture_exception
-
-# Actual data ingestion happens via the `sql_database` source. This is more for BigQuery utils
 
 
 @contextlib.contextmanager
 def bigquery_client(project_id: str, private_key: str, private_key_id: str, client_email: str, token_uri: str):
     """Manage a BigQuery client."""
+    from google.cloud import bigquery
+
     credentials = service_account.Credentials.from_service_account_info(
         {
             "private_key": private_key,
@@ -49,7 +50,7 @@ def delete_all_temp_destination_tables(
     private_key_id: str,
     client_email: str,
     token_uri: str,
-    logger: Optional[FilteringBoundLogger],
+    logger: None | FilteringBoundLogger,
 ) -> None:
     with bigquery_client(project_id, private_key, private_key_id, client_email, token_uri) as bq:
         try:

--- a/posthog/temporal/data_imports/pipelines/bigquery/bigquery.py
+++ b/posthog/temporal/data_imports/pipelines/bigquery/bigquery.py
@@ -1,0 +1,186 @@
+import collections.abc
+import contextlib
+import typing
+
+import pyarrow as pa
+from dlt.common.normalizers.naming.snake_case import NamingConvention
+from google.cloud import bigquery, bigquery_storage
+from google.cloud.bigquery.job import QueryJobConfig
+from google.oauth2 import service_account
+
+from posthog.temporal.data_imports.pipelines.bigquery import bigquery_client
+from posthog.temporal.data_imports.pipelines.helpers import incremental_type_to_initial_value
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from posthog.warehouse.types import IncrementalFieldType
+
+
+@contextlib.contextmanager
+def bigquery_storage_read_client(
+    project_id: str, private_key: str, private_key_id: str, client_email: str, token_uri: str
+):
+    """Manage a BigQuery Storage client."""
+    credentials = service_account.Credentials.from_service_account_info(
+        {
+            "private_key": private_key,
+            "private_key_id": private_key_id,
+            "token_uri": token_uri,
+            "client_email": client_email,
+            "project_id": project_id,
+        },
+        scopes=["https://www.googleapis.com/auth/cloud-platform"],
+    )
+
+    client = bigquery_storage.BigQueryReadClient(credentials=credentials)
+
+    try:
+        yield client
+    finally:
+        pass
+
+
+def get_primary_keys(table: bigquery.Table, client: bigquery.Client) -> list[str] | None:
+    """Attempt to fetch primary keys for a BigQuery table.
+
+    This function is compatible with SQLAlchemy source:
+    SQLAlchemy does not attempt to query table constraints, so we end up defaulting
+    to "id". We will also default to "id" if the column is present in `table`.
+
+    Otherwise, we will also attempt to look at table constraints to find primary keys.
+    """
+    existing_fields = {field.name for field in table.schema}
+    if "id" in existing_fields:
+        return ["id"]
+
+    query = f"""
+    SELECT constraint_name FROM `{table.dataset_id}`.INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+    WHERE table_name = '{table.table_id}'
+      AND constraint_type = 'PRIMARY KEY'
+    """
+
+    job_config = QueryJobConfig()
+    job = client.query(query, job_config=job_config)
+
+    primary_keys = []
+    for row in job.result():
+        field_name = row[0].removeprefix(f"{table.table_id}.")
+
+        if field_name not in existing_fields:
+            return None
+
+        primary_keys.append(field_name)
+
+    if not primary_keys:
+        return None
+    return primary_keys
+
+
+def bigquery_source(
+    project_id: str,
+    dataset_id: str,
+    table_name: str,
+    private_key: str,
+    private_key_id: str,
+    client_email: str,
+    token_uri: str,
+    is_incremental: bool,
+    bq_destination_table_id: str,
+    db_incremental_field_last_value: typing.Any,
+    incremental_field: str | None = None,
+    incremental_field_type: IncrementalFieldType | None = None,
+) -> SourceResponse:
+    """Produce a pipeline source for BigQuery.
+
+    This source will iterate through rows in `pyarrow.Table` objects using BigQuery's
+    Storage API as much as possible due to higher quotas and lower cost compared to
+    alternatives.
+    """
+    name = NamingConvention().normalize_identifier(table_name)
+    fully_qualified_table_name = f"{project_id}.{dataset_id}.{table_name}"
+
+    with bigquery_client(
+        project_id=project_id,
+        private_key=private_key,
+        private_key_id=private_key_id,
+        client_email=client_email,
+        token_uri=token_uri,
+    ) as bq_client:
+        bq_table = bq_client.get_table(fully_qualified_table_name)
+        primary_keys = get_primary_keys(bq_table, bq_client)
+
+    def get_rows() -> collections.abc.Iterator[pa.Table]:
+        with bigquery_client(
+            project_id=project_id,
+            private_key=private_key,
+            private_key_id=private_key_id,
+            client_email=client_email,
+            token_uri=token_uri,
+        ) as bq_client:
+            bq_table = bq_client.get_table(fully_qualified_table_name)
+
+            if is_incremental:
+                # This is only done because incremental syncs require progress tracking.
+                # This requirement means we need to enforce an order, as otherwise
+                # progress could move ahead of the current stream. Thus, we need to run
+                # a query job that moves all the data in `incremental_field` order to a
+                # temporary table given by `bq_destination_table_id`.
+                # TODO: Think about whether this is at all necessary. We (and our users)
+                # are paying a (potentially high) cost to run this query job and store
+                # this data, when we could instead give up tracking and read it.
+                if incremental_field is None or incremental_field_type is None:
+                    raise ValueError("incremental_field and incremental_field_type can't be None")
+
+                if db_incremental_field_last_value is None:
+                    last_value = incremental_type_to_initial_value(incremental_field_type)
+                else:
+                    last_value = db_incremental_field_last_value
+
+                query = f"""
+                SELECT * FROM `{bq_table.dataset_id}`.`{bq_table.table_id}`
+                WHERE `{incremental_field}` >= {last_value}
+                ORDER BY `{incremental_field}` ASC
+                """
+
+                destination_table = bigquery.Table(bq_destination_table_id)
+                job_config = QueryJobConfig(destination=destination_table)
+                job = bq_client.query(query, job_config=job_config)
+                _ = job.result()
+
+                bq_table = bq_client.get_table(destination_table)
+
+            requested_session = bigquery_storage.ReadSession(
+                table=bq_table.to_bqstorage(),
+                data_format=bigquery_storage.DataFormat.ARROW,
+                read_options=bigquery_storage.ReadSession.TableReadOptions(
+                    arrow_serialization_options=bigquery_storage.ArrowSerializationOptions(
+                        # LZ4 offers a good trade-off of low resource usage for compression, so
+                        # as an initial value without further testing it should do fine. That being said,
+                        # TODO: Evaluate if ZSTD is a better alternative for our use case.
+                        buffer_compression=bigquery_storage.ArrowSerializationOptions.CompressionCodec.LZ4_FRAME
+                    )
+                ),
+            )
+            with bigquery_storage_read_client(
+                project_id=project_id,
+                private_key=private_key,
+                private_key_id=private_key_id,
+                client_email=client_email,
+                token_uri=token_uri,
+            ) as bq_storage:
+                read_session = bq_storage.create_read_session(
+                    parent="projects/{}".format(bq_table.project),
+                    read_session=requested_session,
+                    # TODO: Currently, single stream. Could multi-thread here for performance.
+                    max_stream_count=1,
+                )
+
+                if not read_session.streams:
+                    return iter([])  # empty table, nothing to read
+
+                stream_name = read_session.streams[0].name
+                read_rows_stream = bq_storage.read_rows(stream_name)
+                rows_iterator = read_rows_stream.rows()
+
+                for page in rows_iterator.pages:
+                    yield pa.Table.from_batches([page.to_arrow()])
+
+    return SourceResponse(name=name, items=get_rows(), primary_keys=primary_keys)

--- a/posthog/temporal/data_imports/pipelines/bigquery/source.py
+++ b/posthog/temporal/data_imports/pipelines/bigquery/source.py
@@ -32,10 +32,7 @@ def bigquery_storage_read_client(
 
     client = bigquery_storage.BigQueryReadClient(credentials=credentials)
 
-    try:
-        yield client
-    finally:
-        pass
+    yield client
 
 
 def get_primary_keys(table: bigquery.Table, client: bigquery.Client) -> list[str] | None:
@@ -174,7 +171,8 @@ def bigquery_source(
                 )
 
                 if not read_session.streams:
-                    return iter([])  # empty table, nothing to read
+                    # Empty table, nothing to read
+                    return
 
                 stream_name = read_session.streams[0].name
                 read_rows_stream = bq_storage.read_rows(stream_name)

--- a/posthog/temporal/data_imports/pipelines/helpers.py
+++ b/posthog/temporal/data_imports/pipelines/helpers.py
@@ -1,9 +1,11 @@
-from posthog.warehouse.models import ExternalDataJob
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
 from django.db.models import F
+
+from posthog.warehouse.models import ExternalDataJob
 from posthog.warehouse.types import IncrementalFieldType
 from posthog.warehouse.util import database_sync_to_async
-from zoneinfo import ZoneInfo
-from datetime import datetime, date
 
 
 @database_sync_to_async

--- a/posthog/temporal/data_imports/util.py
+++ b/posthog/temporal/data_imports/util.py
@@ -1,10 +1,12 @@
 from typing import Optional
+
+from django.conf import settings
+from dlt.common.normalizers.naming.snake_case import NamingConvention
+
 from posthog.settings.utils import get_from_env
 from posthog.utils import str_to_bool
 from posthog.warehouse.models import ExternalDataJob
 from posthog.warehouse.s3 import get_s3_client
-from django.conf import settings
-from dlt.common.normalizers.naming.snake_case import NamingConvention
 
 
 def prepare_s3_files_for_querying(

--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Any, Optional
 
 from dateutil import parser
+from django.conf import settings
 from django.db import close_old_connections
 from django.db.models import Prefetch
 from dlt.sources import DltSource
@@ -513,7 +514,8 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
                 shutdown_monitor=shutdown_monitor,
             )
         elif model.pipeline.source_type == ExternalDataSource.Type.BIGQUERY:
-            from posthog.temporal.data_imports.pipelines.sql_database import bigquery_source
+            from posthog.temporal.data_imports.pipelines.bigquery.bigquery import bigquery_source
+            from posthog.temporal.data_imports.pipelines.sql_database import bigquery_source as sql_bigquery_source
 
             dataset_id = model.pipeline.job_inputs.get("dataset_id")
             project_id = model.pipeline.job_inputs.get("project_id")
@@ -552,23 +554,47 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
             )
 
             try:
-                source = bigquery_source(
-                    dataset_id=dataset_id,
-                    project_id=project_id,
-                    private_key=private_key,
-                    private_key_id=private_key_id,
-                    client_email=client_email,
-                    token_uri=token_uri,
-                    table_name=schema.name,
-                    bq_destination_table_id=destination_table,
-                    incremental_field=schema.sync_type_config.get("incremental_field")
-                    if schema.is_incremental
-                    else None,
-                    incremental_field_type=schema.sync_type_config.get("incremental_field_type")
-                    if schema.is_incremental
-                    else None,
-                    db_incremental_field_last_value=processed_incremental_last_value if schema.is_incremental else None,
-                )
+                if str(inputs.team_id) in settings.NEW_BIGQUERY_SOURCE_TEAM_IDS:
+                    source = bigquery_source(
+                        dataset_id=dataset_id,
+                        project_id=project_id,
+                        private_key=private_key,
+                        private_key_id=private_key_id,
+                        client_email=client_email,
+                        token_uri=token_uri,
+                        table_name=schema.name,
+                        is_incremental=schema.is_incremental,
+                        bq_destination_table_id=destination_table,
+                        incremental_field=schema.sync_type_config.get("incremental_field")
+                        if schema.is_incremental
+                        else None,
+                        incremental_field_type=schema.sync_type_config.get("incremental_field_type")
+                        if schema.is_incremental
+                        else None,
+                        db_incremental_field_last_value=processed_incremental_last_value
+                        if schema.is_incremental
+                        else None,
+                    )
+                else:
+                    source = sql_bigquery_source(
+                        dataset_id=dataset_id,
+                        project_id=project_id,
+                        private_key=private_key,
+                        private_key_id=private_key_id,
+                        client_email=client_email,
+                        token_uri=token_uri,
+                        table_name=schema.name,
+                        bq_destination_table_id=destination_table,
+                        incremental_field=schema.sync_type_config.get("incremental_field")
+                        if schema.is_incremental
+                        else None,
+                        incremental_field_type=schema.sync_type_config.get("incremental_field_type")
+                        if schema.is_incremental
+                        else None,
+                        db_incremental_field_last_value=processed_incremental_last_value
+                        if schema.is_incremental
+                        else None,
+                    )
 
                 _run(
                     job_inputs=job_inputs,

--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -554,8 +554,8 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
             )
 
             try:
-                if str(inputs.team_id) in settings.NEW_BIGQUERY_SOURCE_TEAM_IDS:
-                    source = bigquery_source(
+                if str(inputs.team_id) in settings.OLD_BIGQUERY_SOURCE_TEAM_IDS:
+                    source = sql_bigquery_source(
                         dataset_id=dataset_id,
                         project_id=project_id,
                         private_key=private_key,
@@ -563,7 +563,6 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
                         client_email=client_email,
                         token_uri=token_uri,
                         table_name=schema.name,
-                        is_incremental=schema.is_incremental,
                         bq_destination_table_id=destination_table,
                         incremental_field=schema.sync_type_config.get("incremental_field")
                         if schema.is_incremental
@@ -576,7 +575,7 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
                         else None,
                     )
                 else:
-                    source = sql_bigquery_source(
+                    source = bigquery_source(
                         dataset_id=dataset_id,
                         project_id=project_id,
                         private_key=private_key,
@@ -584,6 +583,7 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
                         client_email=client_email,
                         token_uri=token_uri,
                         table_name=schema.name,
+                        is_incremental=schema.is_incremental,
                         bq_destination_table_id=destination_table,
                         incremental_field=schema.sync_type_config.get("incremental_field")
                         if schema.is_incremental

--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -514,7 +514,7 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
                 shutdown_monitor=shutdown_monitor,
             )
         elif model.pipeline.source_type == ExternalDataSource.Type.BIGQUERY:
-            from posthog.temporal.data_imports.pipelines.bigquery.bigquery import bigquery_source
+            from posthog.temporal.data_imports.pipelines.bigquery.source import bigquery_source
             from posthog.temporal.data_imports.pipelines.sql_database import bigquery_source as sql_bigquery_source
 
             dataset_id = model.pipeline.job_inputs.get("dataset_id")

--- a/posthog/temporal/tests/batch_exports/test_import_data.py
+++ b/posthog/temporal/tests/batch_exports/test_import_data.py
@@ -1,6 +1,8 @@
 from typing import Any
 from unittest import mock
+
 import pytest
+
 from posthog.models.team.team import Team
 from posthog.temporal.data_imports.settings import import_data_activity_sync
 from posthog.temporal.data_imports.workflow_activities.import_data_sync import ImportDataActivityInputs

--- a/posthog/temporal/tests/data_imports/test_bigquery_source.py
+++ b/posthog/temporal/tests/data_imports/test_bigquery_source.py
@@ -303,7 +303,6 @@ def test_bigquery_source_incremental(
     inputs = setup_bigquery(team, bigquery_config, bigquery_dataset, bigquery_table, is_incremental=True)
 
     with override_settings(
-        NEW_BIGQUERY_SOURCE_TEAM_IDS=[str(team.pk)],
         AIRBYTE_BUCKET_KEY=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
         AIRBYTE_BUCKET_SECRET=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
         AIRBYTE_BUCKET_REGION="us-east-1",
@@ -347,7 +346,6 @@ def test_bigquery_source_incremental(
     _ = job.result()
 
     with override_settings(
-        NEW_BIGQUERY_SOURCE_TEAM_IDS=[str(team.pk)],
         AIRBYTE_BUCKET_KEY=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
         AIRBYTE_BUCKET_SECRET=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
         AIRBYTE_BUCKET_REGION="us-east-1",

--- a/posthog/temporal/tests/data_imports/test_bigquery_source.py
+++ b/posthog/temporal/tests/data_imports/test_bigquery_source.py
@@ -1,6 +1,6 @@
+import collections.abc
 import json
 import os
-import typing
 import uuid
 import warnings
 
@@ -46,7 +46,7 @@ def bigquery_config() -> dict[str, str]:
 
 
 @pytest.fixture
-def bigquery_client() -> typing.Generator[bigquery.Client, None, None]:
+def bigquery_client() -> collections.abc.Generator[bigquery.Client, None, None]:
     """Manage a bigquery.Client for testing."""
     client = bigquery.Client()
 
@@ -56,7 +56,7 @@ def bigquery_client() -> typing.Generator[bigquery.Client, None, None]:
 
 
 @pytest.fixture
-def bigquery_dataset(bigquery_config, bigquery_client) -> typing.Generator[bigquery.Dataset, None, None]:
+def bigquery_dataset(bigquery_config, bigquery_client) -> collections.abc.Generator[bigquery.Dataset, None, None]:
     """Manage a bigquery dataset for testing.
 
     We clean up the dataset after every test. Could be quite time expensive, but guarantees a clean slate.
@@ -79,7 +79,7 @@ def bigquery_dataset(bigquery_config, bigquery_client) -> typing.Generator[bigqu
 @pytest.fixture
 def bigquery_table(
     bigquery_config, bigquery_client, bigquery_dataset
-) -> typing.Generator[bigquery.Dataset, None, None]:
+) -> collections.abc.Generator[bigquery.Table, None, None]:
     """Manage a bigquery table for testing.
 
     We clean up the table after every test. Could be quite time expensive, but guarantees a clean slate.
@@ -167,8 +167,8 @@ def setup_bigquery(
         },
     )
     credentials = DataWarehouseCredential.objects.create(
-        access_key=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
-        access_secret=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
+        access_key=str(settings.OBJECT_STORAGE_ACCESS_KEY_ID),
+        access_secret=str(settings.OBJECT_STORAGE_SECRET_ACCESS_KEY),
         team=team,
     )
     warehouse_table = DataWarehouseTable.objects.create(
@@ -267,7 +267,7 @@ def test_bigquery_source_full_refresh(
 
     ids = []
     values = []
-    for row in result:  # type: ignore
+    for row in result:
         ids.append(row[0])
         values.append(row[1])
 
@@ -331,7 +331,7 @@ def test_bigquery_source_incremental(
 
     ids = []
     values = []
-    for row in result:  # type: ignore
+    for row in result:
         ids.append(row[0])
         values.append(row[1])
 
@@ -375,7 +375,7 @@ def test_bigquery_source_incremental(
 
     ids = []
     values = []
-    for row in result:  # type: ignore
+    for row in result:
         ids.append(row[0])
         values.append(row[1])
 

--- a/posthog/temporal/tests/data_imports/test_bigquery_source.py
+++ b/posthog/temporal/tests/data_imports/test_bigquery_source.py
@@ -1,0 +1,386 @@
+import json
+import os
+import typing
+import uuid
+import warnings
+
+import boto3
+import pytest
+from django.conf import settings
+from django.test import override_settings
+from google.cloud import bigquery
+
+from posthog.clickhouse.client import sync_execute
+from posthog.models import Team
+from posthog.temporal.data_imports.workflow_activities.import_data_sync import (
+    ImportDataActivityInputs,
+    import_data_activity_sync,
+)
+from posthog.warehouse.models.credential import DataWarehouseCredential
+from posthog.warehouse.models.external_data_job import ExternalDataJob
+from posthog.warehouse.models.external_data_schema import ExternalDataSchema
+from posthog.warehouse.models.external_data_source import ExternalDataSource
+from posthog.warehouse.models.table import DataWarehouseTable
+from posthog.warehouse.types import IncrementalFieldType
+
+SKIP_IF_MISSING_GOOGLE_APPLICATION_CREDENTIALS = pytest.mark.skipif(
+    "GOOGLE_APPLICATION_CREDENTIALS" not in os.environ,
+    reason="Google credentials not set in environment",
+)
+
+
+@pytest.fixture
+def bigquery_config() -> dict[str, str]:
+    """Return a BigQuery configuration dictionary to use in tests."""
+    credentials_file_path = os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
+    with open(credentials_file_path) as f:
+        credentials = json.load(f)
+
+    return {
+        "project_id": credentials["project_id"],
+        "private_key": credentials["private_key"],
+        "private_key_id": credentials["private_key_id"],
+        "token_uri": credentials["token_uri"],
+        "client_email": credentials["client_email"],
+    }
+
+
+@pytest.fixture
+def bigquery_client() -> typing.Generator[bigquery.Client, None, None]:
+    """Manage a bigquery.Client for testing."""
+    client = bigquery.Client()
+
+    yield client
+
+    client.close()
+
+
+@pytest.fixture
+def bigquery_dataset(bigquery_config, bigquery_client) -> typing.Generator[bigquery.Dataset, None, None]:
+    """Manage a bigquery dataset for testing.
+
+    We clean up the dataset after every test. Could be quite time expensive, but guarantees a clean slate.
+    """
+    dataset_id = f"{bigquery_config['project_id']}.ImportDataTest_{str(uuid.uuid4()).replace('-', '')}"
+
+    dataset = bigquery.Dataset(dataset_id)
+    dataset = bigquery_client.create_dataset(dataset)
+
+    yield dataset
+
+    try:
+        bigquery_client.delete_dataset(dataset_id, delete_contents=True, not_found_ok=True)
+    except Exception as exc:
+        warnings.warn(
+            f"Failed to clean up dataset: {dataset_id} due to '{exc.__class__.__name__}': {str(exc)}", stacklevel=1
+        )
+
+
+@pytest.fixture
+def bigquery_table(
+    bigquery_config, bigquery_client, bigquery_dataset
+) -> typing.Generator[bigquery.Dataset, None, None]:
+    """Manage a bigquery table for testing.
+
+    We clean up the table after every test. Could be quite time expensive, but guarantees a clean slate.
+    """
+    table_id = f"{bigquery_config['project_id']}.{bigquery_dataset.dataset_id}.test_bigquery_source"
+
+    table = bigquery.Table(
+        table_id,
+        schema=[
+            bigquery.SchemaField(name="id", field_type="INT64"),
+            bigquery.SchemaField("value", field_type="STRING"),
+        ],
+    )
+    table = bigquery_client.create_table(table)
+
+    job = bigquery_client.query(
+        f"INSERT INTO {table.dataset_id}.{table.table_id} (id, value) VALUES (0, 'a'), (1, 'b')"
+    )
+    job.result()
+
+    yield table
+
+    try:
+        bigquery_client.delete_table(table, not_found_ok=True)
+    except Exception as exc:
+        warnings.warn(
+            f"Failed to clean up table: {table_id} due to '{exc.__class__.__name__}': {str(exc)}", stacklevel=1
+        )
+
+
+@pytest.fixture
+def bucket_name(request) -> str:
+    """Name for a test MinIO bucket."""
+    try:
+        return request.param
+    except AttributeError:
+        return f"test-import-data-{str(uuid.uuid4())}"
+
+
+@pytest.fixture
+def minio_client(bucket_name):
+    """Manage a client to interact with a MinIO bucket.
+
+    Yields the client after creating a bucket. Upon resuming, we delete
+    the contents and the bucket itself.
+    """
+    session = boto3.Session()
+    minio_client = session.client(
+        "s3",
+        aws_access_key_id="object_storage_root_user",
+        aws_secret_access_key="object_storage_root_password",
+        endpoint_url=settings.OBJECT_STORAGE_ENDPOINT,
+    )
+    _ = minio_client.create_bucket(Bucket=bucket_name)
+
+    yield minio_client
+
+    response = minio_client.list_objects_v2(Bucket=bucket_name, Prefix="")
+    if "Contents" in response:
+        for obj in response["Contents"]:
+            if "Key" in obj:
+                _ = minio_client.delete_object(Bucket=bucket_name, Key=obj["Key"])
+
+    _ = minio_client.delete_bucket(Bucket=bucket_name)
+
+
+def setup_bigquery(
+    team: Team,
+    bigquery_config: dict[str, str],
+    bigquery_dataset: bigquery.Dataset,
+    bigquery_table: bigquery.Table,
+    is_incremental: bool,
+):
+    source = ExternalDataSource.objects.create(
+        team=team,
+        source_id="source_id",
+        connection_id="connection_id",
+        status=ExternalDataSource.Status.COMPLETED,
+        source_type=ExternalDataSource.Type.BIGQUERY,
+        job_inputs={
+            "dataset_id": bigquery_dataset.dataset_id,
+            "temporary_dataset_id": None,
+            "using_temporary_dataset": False,
+            **bigquery_config,
+        },
+    )
+    credentials = DataWarehouseCredential.objects.create(
+        access_key=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
+        access_secret=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
+        team=team,
+    )
+    warehouse_table = DataWarehouseTable.objects.create(
+        name=bigquery_table.table_id,
+        format="Parquet",
+        team=team,
+        external_data_source=source,
+        external_data_source_id=source.id,
+        credential=credentials,
+        url_pattern="https://bucket.s3/data/*",
+        columns={
+            "id": {"hogql": "IntegerDatabaseField", "clickhouse": "Nullable(Int64)", "schema_valid": True},
+            "value": {"hogql": "StringDatabaseField", "clickhouse": "Nullable(String)", "schema_valid": True},
+        },
+    )
+    schema = ExternalDataSchema.objects.create(
+        team=team,
+        name=bigquery_table.table_id,
+        source=source,
+        table=warehouse_table,
+        should_sync=True,
+        status=ExternalDataSchema.Status.COMPLETED,
+        last_synced_at="2024-01-01",
+        sync_type=ExternalDataSchema.SyncType.INCREMENTAL
+        if is_incremental
+        else ExternalDataSchema.SyncType.FULL_REFRESH,
+        sync_type_config={
+            "incremental_field": "id",
+            "incremental_field_type": IncrementalFieldType.Integer,
+            "incremental_field_last_value": None,
+        }
+        if ExternalDataSchema.SyncType.INCREMENTAL
+        else {},
+    )
+    job = ExternalDataJob.objects.create(
+        team=team,
+        pipeline=source,
+        schema=schema,
+        status=ExternalDataJob.Status.RUNNING,
+        rows_synced=0,
+        workflow_id="some_workflow_id",
+        pipeline_version=ExternalDataJob.PipelineVersion.V1,
+    )
+    return ImportDataActivityInputs(team_id=team.pk, schema_id=schema.pk, source_id=source.pk, run_id=str(job.pk))
+
+
+@SKIP_IF_MISSING_GOOGLE_APPLICATION_CREDENTIALS
+@pytest.mark.django_db(transaction=True)
+def test_bigquery_source_full_refresh(
+    activity_environment,
+    team,
+    bigquery_client,
+    bigquery_config,
+    bigquery_dataset,
+    bigquery_table,
+    bucket_name,
+    minio_client,
+):
+    """Test a full-refresh sync job with BigQuery source.
+
+    We generate some data and ensure that running `import_data_activity_sync`
+    results in the data loaded in S3, and query-able using ClickHouse table
+    function.
+
+    Finally, we assert the values correspond to the ones we have inserted in
+    BigQuery.
+    """
+    inputs = setup_bigquery(team, bigquery_config, bigquery_dataset, bigquery_table, is_incremental=False)
+
+    with override_settings(
+        NEW_BIGQUERY_SOURCE_TEAM_IDS=[str(team.pk)],
+        AIRBYTE_BUCKET_KEY=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
+        AIRBYTE_BUCKET_SECRET=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
+        AIRBYTE_BUCKET_REGION="us-east-1",
+        AIRBYTE_BUCKET_DOMAIN="objectstorage:19000",
+        BUCKET_URL=f"s3://{bucket_name}",
+        BUCKET=bucket_name,
+    ):
+        activity_environment.run(import_data_activity_sync, inputs)
+
+    objects = minio_client.list_objects_v2(Bucket=bucket_name, Prefix="")
+    assert objects.get("KeyCount", 0) > 0
+
+    table = DataWarehouseTable.objects.get(name=bigquery_table.table_id)
+    columns = table.get_columns()
+    assert "id" in columns
+    assert "value" in columns
+    assert columns["id"]["clickhouse"] == "Nullable(Int64)"  # type: ignore
+    assert columns["value"]["clickhouse"] == "Nullable(String)"  # type: ignore
+
+    function_call, context = table.get_function_call()
+    query = f"SELECT * FROM {function_call}"
+    result = sync_execute(query, args=context.values)
+    assert result is not None
+    assert len(result) == 2
+
+    ids = []
+    values = []
+    for row in result:  # type: ignore
+        ids.append(row[0])
+        values.append(row[1])
+
+    assert all(id in ids for id in [0, 1])
+    assert all(value in values for value in ["a", "b"])
+
+
+@SKIP_IF_MISSING_GOOGLE_APPLICATION_CREDENTIALS
+@pytest.mark.django_db(transaction=True)
+def test_bigquery_source_incremental(
+    activity_environment,
+    team,
+    bigquery_client,
+    bigquery_config,
+    bigquery_dataset,
+    bigquery_table,
+    bucket_name,
+    minio_client,
+):
+    """Test an incremental sync job with BigQuery source.
+
+    We generate some data and ensure that running `import_data_activity_sync`
+    results in the data loaded in S3, and query-able using ClickHouse table
+    function.
+
+    Afterwards, we generate a new incremental value in BigQuery and run
+    `import_data_activity_sync` again to ensure that is exported.
+
+    After each activity run, we assert the values correspond to the ones we
+    have inserted in BigQuery, and we verify the incremental configuration
+    is updated accordingly.
+    """
+    inputs = setup_bigquery(team, bigquery_config, bigquery_dataset, bigquery_table, is_incremental=True)
+
+    with override_settings(
+        NEW_BIGQUERY_SOURCE_TEAM_IDS=[str(team.pk)],
+        AIRBYTE_BUCKET_KEY=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
+        AIRBYTE_BUCKET_SECRET=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
+        AIRBYTE_BUCKET_REGION="us-east-1",
+        AIRBYTE_BUCKET_DOMAIN="objectstorage:19000",
+        BUCKET_URL=f"s3://{bucket_name}",
+        BUCKET=bucket_name,
+    ):
+        activity_environment.run(import_data_activity_sync, inputs)
+
+    objects = minio_client.list_objects_v2(Bucket=bucket_name, Prefix="")
+    assert objects.get("KeyCount", 0) > 0
+
+    table = DataWarehouseTable.objects.get(name=bigquery_table.table_id)
+    columns = table.get_columns()
+    assert "id" in columns
+    assert "value" in columns
+    assert columns["id"]["clickhouse"] == "Nullable(Int64)"  # type: ignore
+    assert columns["value"]["clickhouse"] == "Nullable(String)"  # type: ignore
+
+    function_call, context = table.get_function_call()
+    query = f"SELECT * FROM {function_call}"
+    result = sync_execute(query, args=context.values)
+    assert result is not None
+    assert len(result) == 2
+
+    ids = []
+    values = []
+    for row in result:  # type: ignore
+        ids.append(row[0])
+        values.append(row[1])
+
+    assert all(id in ids for id in [0, 1])
+    assert all(value in values for value in ["a", "b"])
+
+    schema = ExternalDataSchema.objects.get(name=bigquery_table.table_id)
+    assert schema.sync_type_config["incremental_field_last_value"] == 1
+
+    job = bigquery_client.query(
+        f"INSERT INTO {bigquery_table.dataset_id}.{bigquery_table.table_id} (id, value) VALUES (2, 'c')"
+    )
+    _ = job.result()
+
+    with override_settings(
+        NEW_BIGQUERY_SOURCE_TEAM_IDS=[str(team.pk)],
+        AIRBYTE_BUCKET_KEY=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
+        AIRBYTE_BUCKET_SECRET=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
+        AIRBYTE_BUCKET_REGION="us-east-1",
+        AIRBYTE_BUCKET_DOMAIN="objectstorage:19000",
+        BUCKET_URL=f"s3://{bucket_name}",
+        BUCKET=bucket_name,
+    ):
+        activity_environment.run(import_data_activity_sync, inputs)
+
+    objects = minio_client.list_objects_v2(Bucket=bucket_name, Prefix="")
+    assert objects.get("KeyCount", 0) > 0
+
+    table = DataWarehouseTable.objects.get(name=bigquery_table.table_id)
+    columns = table.get_columns()
+    assert "id" in columns
+    assert "value" in columns
+    assert columns["id"]["clickhouse"] == "Nullable(Int64)"  # type: ignore
+    assert columns["value"]["clickhouse"] == "Nullable(String)"  # type: ignore
+
+    function_call, context = table.get_function_call()
+    query = f"SELECT * FROM {function_call}"
+    result = sync_execute(query, args=context.values)
+    assert result is not None
+    assert len(result) == 3
+
+    ids = []
+    values = []
+    for row in result:  # type: ignore
+        ids.append(row[0])
+        values.append(row[1])
+
+    assert all(id in ids for id in [0, 1, 2])
+    assert all(value in values for value in ["a", "b", "c"])
+
+    schema = ExternalDataSchema.objects.get(name=bigquery_table.table_id)
+    assert schema.sync_type_config["incremental_field_last_value"] == 2

--- a/posthog/warehouse/models/table.py
+++ b/posthog/warehouse/models/table.py
@@ -1,10 +1,15 @@
 from datetime import datetime
 from typing import TYPE_CHECKING, Optional, TypeAlias
+from uuid import UUID
+
 from django.db import models
+from django.db.models import Q
 
 from posthog.clickhouse.client import sync_execute
 from posthog.errors import wrap_query_error
+from posthog.exceptions_capture import capture_exception
 from posthog.hogql import ast
+from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.models import (
     FieldOrTable,
 )
@@ -13,22 +18,23 @@ from posthog.models.team import Team
 from posthog.models.utils import (
     CreatedMetaFields,
     DeletedMetaFields,
-    UUIDModel,
     UpdatedMetaFields,
+    UUIDModel,
     sane_repr,
 )
 from posthog.schema import DatabaseSerializedFieldType, HogQLQueryModifiers
 from posthog.temporal.data_imports.pipelines.pipeline.consts import PARTITION_KEY
-from posthog.warehouse.models.util import remove_named_tuples
 from posthog.warehouse.models.external_data_schema import ExternalDataSchema
-from django.db.models import Q
-from .credential import DataWarehouseCredential
-from uuid import UUID
-from posthog.exceptions_capture import capture_exception
+from posthog.warehouse.models.util import (
+    CLICKHOUSE_HOGQL_MAPPING,
+    STR_TO_HOGQL_MAPPING,
+    clean_type,
+    remove_named_tuples,
+)
 from posthog.warehouse.util import database_sync_to_async
-from posthog.warehouse.models.util import CLICKHOUSE_HOGQL_MAPPING, clean_type, STR_TO_HOGQL_MAPPING
+
+from .credential import DataWarehouseCredential
 from .external_table_definitions import external_tables
-from posthog.hogql.context import HogQLContext
 
 if TYPE_CHECKING:
     pass
@@ -208,6 +214,22 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDModel, Delete
                 raise
 
         return result[0][0]
+
+    def get_function_call(self) -> tuple[str, HogQLContext]:
+        try:
+            placeholder_context = HogQLContext(team_id=self.team.pk)
+            s3_table_func = build_function_call(
+                url=self.url_pattern,
+                format=self.format,
+                access_key=self.credential.access_key,
+                access_secret=self.credential.access_secret,
+                context=placeholder_context,
+            )
+
+        except Exception as err:
+            capture_exception(err)
+            raise
+        return s3_table_func, placeholder_context
 
     def hogql_definition(self, modifiers: Optional[HogQLQueryModifiers] = None) -> S3Table:
         columns = self.columns or {}

--- a/posthog/warehouse/models/table.py
+++ b/posthog/warehouse/models/table.py
@@ -291,12 +291,18 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDModel, Delete
                 del fields[PARTITION_KEY]
                 fields = {**fields, **default_fields}
 
+        access_key: str | None = None
+        access_secret: str | None = None
+        if self.credential:
+            access_key = self.credential.access_key
+            access_secret = self.credential.access_secret
+
         return S3Table(
             name=self.name,
             url=self.url_pattern,
             format=self.format,
-            access_key=self.credential.access_key,
-            access_secret=self.credential.access_secret,
+            access_key=access_key,
+            access_secret=access_secret,
             fields=fields,
             structure=", ".join(structure),
         )


### PR DESCRIPTION
## Problem

Existing BigQuery DWH source uses SQLAlchemy, which works fine but it means relinquishing control over some implementation details that if fine-tuned could lead to performance and cost benefits.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Implement a new BigQuery source that directly interacts with BigQuery APIs. The source utilizes the BigQuery Storage API as it is the most cost-effective way to query large amounts of data. This is similar to what the old SQLAlchemy source does, but we were able to implement a couple of benefits:

* The BigQuery Storage API natively supports Arrow formatting. SQLAlchemy would convert these values to Python objects, which is unnecessary as we would later re-cast them to Arrow buffers. By directly using the buffers delivered by the Storage API, we save a lot of resources in copying data to and from Python types.
* The SQLAlchemy source required a temporary table as the Storage API cannot guarantee ordering. However, during full refresh syncs, we do not track progress as restarting the sync simply starts over from the beginning. Thus, for full refresh syncs, we can omit the requirement of a temporary table saving cost for our users and execution time.
  * These savings could be further expanded to incremental syncs if we can figure out how to as relax tracking requirements.

## Rollout

To avoid disruptions in case there are any problems with the new source, my plan was to test it with a subset of teams. Hence why the `NEW_BIGQUERY_SOURCE_TEAM_IDS` setting was introduced. If the test is successful, then that can be removed.

I am open to considering other rollout strategies.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

I couldn't find any test coverage for the BigQuery source, so new tests were added. This required a lot of boilerplate to setup some test data in BigQuery. Since we do not mock any external service (we use a real, 100% organic, BigQuery instance), these tests cannot run in CI. But they are passing :+1:.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
