### PR TITLE
chore(flags): add exception logging during DatabaseError handling in flag matching logic

### DIFF
--- a/posthog/models/feature_flag/flag_matching.py
+++ b/posthog/models/feature_flag/flag_matching.py
@@ -125,7 +125,8 @@ class FlagsMatcherCache:
                     project_id=self.project_id
                 )
                 return {row.group_type: cast(GroupTypeIndex, row.group_type_index) for row in group_type_mapping_rows}
-        except DatabaseError:
+        except DatabaseError as e:
+            logger.exception("group_types_to_indexes database error", error=str(e), exc_info=True)
             self.failed_to_fetch_flags = True
             raise
 
@@ -668,7 +669,8 @@ class FeatureFlagMatcher:
                                     ), f"Expected 1 group query result, got {len(group_query)}"
                                     all_conditions = {**all_conditions, **group_query[0]}
                     return all_conditions
-        except DatabaseError:
+        except DatabaseError as e:
+            logger.exception("query_conditions database error", error=str(e), exc_info=True)
             self.failed_to_fetch_conditions = True
             raise
         except Exception:


### PR DESCRIPTION


## Problem

Context: https://posthog.slack.com/archives/C08G5CFHC3V/p1741798684938329?thread_ts=1741620851.975329&cid=C08G5CFHC3V

## Changes

Just two exception logs 

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Existing coverage sufficient for validating syntax
