### PR TITLE
fix(salesforce-schema-update): Making update + create synced via salesforce

### DIFF
--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -629,7 +629,7 @@ export const SOURCE_DETAILS: Record<ExternalDataSourceType, SourceConfig> = {
         name: 'Salesforce',
         fields: [
             {
-                name: 'integration_id',
+                name: 'salesforce_integration_id',
                 label: 'Salesforce account',
                 type: 'oauth',
                 required: true,

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -584,7 +584,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         payload = request.data["payload"]
         prefix = request.data.get("prefix", None)
         source_type = request.data["source_type"]
-        integration_id = payload.get("salesforce_integration_id")
+        salesforce_integration_id = payload.get("salesforce_integration_id")
 
         new_source_model = ExternalDataSource.objects.create(
             source_id=str(uuid.uuid4()),
@@ -595,7 +595,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             status="Running",
             source_type=source_type,
             job_inputs={
-                "salesforce_integration_id": integration_id,
+                "salesforce_integration_id": salesforce_integration_id,
             },
             prefix=prefix,
         )

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -584,7 +584,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         payload = request.data["payload"]
         prefix = request.data.get("prefix", None)
         source_type = request.data["source_type"]
-        integration_id = payload.get("integration_id")
+        integration_id = payload.get("salesforce_integration_id")
 
         new_source_model = ExternalDataSource.objects.create(
             source_id=str(uuid.uuid4()),


### PR DESCRIPTION
## Problem
In order for our forms to sync correctly between create and update (POST + PATCH) we require the names to match between what our api accepts. Salesforce was getting de-synced because of this on any kind of update since the form was sending `integration_id` instead of `salesforce_integration_id`.

## Changes
- [x] Form value updated
- [x] Create method now takes in the actual persisted field name for `job_inputs` 

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
No longer get the error `Salesforce integration not found for job xxxx`
