### PR TITLE
fix(propdefs): refactor property datetime classification and "types" test suite

### DIFF
--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -311,7 +311,9 @@ impl Event {
     }
 }
 
-fn detect_property_type(key: &str, value: &Value) -> Option<PropertyValueType> {
+pub fn detect_property_type(key: &str, value: &Value) -> Option<PropertyValueType> {
+    let key = key.to_lowercase();
+
     // There are a whole set of special cases here, taken from the TS
     if key.starts_with("utm_") {
         // utm_ prefixed properties should always be detected as strings.
@@ -344,29 +346,28 @@ fn detect_property_type(key: &str, value: &Value) -> Option<PropertyValueType> {
         return Some(PropertyValueType::String);
     }
 
+    if detect_timestamp_property_by_key_and_value(&key, value) {
+        return Some(PropertyValueType::DateTime);
+    }
+
+    // OK, attempt to classify prop type on value alone
     match value {
         Value::String(s) => {
             let s = &s.trim();
             if *s == "true" || *s == "false" || *s == "TRUE" || *s == "FALSE" {
                 Some(PropertyValueType::Boolean)
             // Try to parse this as an ISO 8601 date, and if we can, use that as the type instead
-            } else if is_valid_date_string(s) {
+            } else if is_likely_date_string(s) {
                 Some(PropertyValueType::DateTime)
             } else {
                 Some(PropertyValueType::String)
             }
         }
         Value::Number(n) => {
-            // TODO - this is a divergence from the TS impl - the TS also checks if the contained number is
-            // "likely" to be a unix timestamp on the basis of the number of characters. I have mixed feelings about this,
-            // so I'm going to leave it as just checking the key for now. This means we're being /less/ strict with datetime
-            // detection here than in the TS (NOTE: updated by eli.r@posthog.com 3/2025)
-            let candidate = key.to_lowercase();
-            if DATETIME_PROPERTY_NAME_KEYWORDS
-                .iter()
-                .any(|kw| candidate.contains(*kw))
-                || is_likely_unix_timestamp(n)
-            {
+            // this is a more rigorous threshold to ensure we don't misclassify
+            // larger numerical values easily. It mimics (roughly) the old TS service
+            // classification but still may be too aggressive. TBD
+            if is_likely_unix_timestamp(n) {
                 Some(PropertyValueType::DateTime)
             } else {
                 Some(PropertyValueType::Numeric)
@@ -377,7 +378,22 @@ fn detect_property_type(key: &str, value: &Value) -> Option<PropertyValueType> {
     }
 }
 
-fn is_valid_date_string(s: &str) -> bool {
+fn detect_timestamp_property_by_key_and_value(key: &str, value: &Value) -> bool {
+    if DATETIME_PROPERTY_NAME_KEYWORDS
+        .iter()
+        .any(|kw| key.contains(*kw))
+    {
+        return match value {
+            Value::String(s) if is_likely_date_string(s) => true,
+            Value::Number(n) if is_likely_unix_timestamp(n) => true,
+            _ => false,
+        };
+    }
+
+    false
+}
+
+fn is_likely_date_string(s: &str) -> bool {
     if DateTime::parse_from_rfc3339(s).is_ok() || DateTime::parse_from_rfc2822(s).is_ok() {
         return true;
     }
@@ -564,373 +580,5 @@ impl EventProperty {
         metrics::counter!(UPDATES_ISSUED, &[("type", "event_property")]).increment(1);
 
         res
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use chrono::{Timelike, Utc};
-    use serde_json::Value;
-
-    use crate::types::{detect_property_type, get_floored_last_seen, PropertyValueType};
-
-    #[test]
-    fn test_date_flooring() {
-        let now = Utc::now();
-        let rounded = get_floored_last_seen();
-
-        // Time should be rounded to the nearest hour
-        assert_eq!(rounded.minute(), 0);
-        assert_eq!(rounded.second(), 0);
-        assert_eq!(rounded.nanosecond(), 0);
-        assert!(rounded <= now);
-
-        // The difference between now and rounded should be less than 1 hour
-        assert!(now - rounded < chrono::Duration::hours(1));
-    }
-
-    #[test]
-    fn test_rfc3339_timestamp_detection() {
-        // Test RFC 3339 timestamp detection for string values
-        assert_eq!(
-            detect_property_type(
-                "random_property",
-                &Value::String("2023-12-13T15:45:30Z".to_string())
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-
-        assert_eq!(
-            detect_property_type(
-                "random_property",
-                &Value::String("2023-12-13T15:45:30.123Z".to_string())
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-
-        assert_eq!(
-            detect_property_type(
-                "random_property",
-                &Value::String("2023-12-13T15:45:30+00:00".to_string())
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-
-        assert_eq!(
-            detect_property_type(
-                "random_property",
-                &Value::String("2023-12-13T15:45:30-07:00".to_string())
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-
-        assert_eq!(
-            detect_property_type(
-                "random_property",
-                &Value::String("2023/12/13 15:45:30Z".to_string())
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-
-        assert_eq!(
-            detect_property_type(
-                "random_property",
-                &Value::String("2023/12/13 15:45:30".to_string())
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-
-        assert_eq!(
-            detect_property_type(
-                "random_property",
-                &Value::String("12-13-2023 15:45:30-07:00".to_string())
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-
-        assert_eq!(
-            detect_property_type(
-                "random_property",
-                &Value::String("12/13/2023 15:45:30-07".to_string())
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-
-        assert_eq!(
-            detect_property_type(
-                "random_property",
-                &Value::String("2023/12/13 15:45:30".to_string())
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-
-        assert_eq!(
-            detect_property_type(
-                "random_property",
-                &Value::String("2023-13-12 15:45:30".to_string())
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-
-        assert_eq!(
-            detect_property_type(
-                "random_property",
-                &Value::String("12/13/2023T15:45:30".to_string())
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-
-        assert_eq!(
-            detect_property_type(
-                "random_property",
-                &Value::String("2023-13-12T15:45:30".to_string())
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-
-        assert_eq!(
-            detect_property_type("random_property", &Value::String("2023-12-13".to_string())),
-            Some(PropertyValueType::DateTime)
-        );
-
-        assert_eq!(
-            detect_property_type("random_property", &Value::String("2023/12/13".to_string())),
-            Some(PropertyValueType::DateTime)
-        );
-
-        assert_eq!(
-            detect_property_type("random_property", &Value::String("12-13-2023".to_string())),
-            Some(PropertyValueType::DateTime)
-        );
-
-        assert_eq!(
-            detect_property_type("random_property", &Value::String("12/13/2023".to_string())),
-            Some(PropertyValueType::DateTime)
-        );
-
-        // Test invalid timestamp formats (should be detected as String)
-        assert_eq!(
-            detect_property_type("random_property", &Value::String("15:45:30".to_string())),
-            Some(PropertyValueType::String)
-        );
-
-        assert_eq!(
-            detect_property_type("random_property", &Value::String("not a date".to_string())),
-            Some(PropertyValueType::String)
-        );
-
-        // Test property name-based detection for numeric values (should be DateTime)
-        assert_eq!(
-            detect_property_type(
-                "timestamp",
-                &Value::Number(serde_json::Number::from(
-                    Utc::now().timestamp_millis() as u64 / 1000u64
-                ))
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-
-        assert_eq!(
-            detect_property_type(
-                "created_time",
-                &Value::Number(serde_json::Number::from(
-                    Utc::now().timestamp_millis() as u64 / 1000u64
-                ))
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-
-        // this should also now be a DateTime classification due to the UNIX timestamp-like value
-        assert_eq!(
-            detect_property_type(
-                "sent_at",
-                &Value::Number(serde_json::Number::from(
-                    Utc::now().timestamp_millis() as u64 / 1000u64
-                ))
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-
-        // Test property name-based detection for string values (should NOT be DateTime)
-        assert_eq!(
-            detect_property_type("timestamp", &Value::String("any value".to_string())),
-            Some(PropertyValueType::String)
-        );
-
-        assert_eq!(
-            detect_property_type("created_time", &Value::String("any value".to_string())),
-            Some(PropertyValueType::String)
-        );
-
-        assert_eq!(
-            detect_property_type("sent_at", &Value::String("any value".to_string())),
-            Some(PropertyValueType::String)
-        );
-    }
-
-    #[test]
-    fn test_property_name_based_detection() {
-        // Test all timestamp-related keywords for numeric values
-
-        // Test property-name based matching. Note: the hardcoded UNIX timestamp
-        // value used in these unit tests is older than (now - 6 months)
-        // so shouldn't trigger a match based on numerical classification step.
-        assert_eq!(
-            detect_property_type(
-                "timestamp",
-                &Value::Number(serde_json::Number::from(1639400730))
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-        assert_eq!(
-            detect_property_type(
-                "TIMESTAMP",
-                &Value::Number(serde_json::Number::from(1639400730))
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-        assert_eq!(
-            detect_property_type(
-                "user_timestamp",
-                &Value::Number(serde_json::Number::from(1639400730))
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-        assert_eq!(
-            detect_property_type(
-                "user_TIMESTAMP",
-                &Value::Number(serde_json::Number::from(1639400730))
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-        assert_eq!(
-            detect_property_type(
-                "timestampValue",
-                &Value::Number(serde_json::Number::from(1639400730))
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-
-        // Test "time" in different positions and cases
-        assert_eq!(
-            detect_property_type("time", &Value::Number(serde_json::Number::from(1639400730))),
-            Some(PropertyValueType::DateTime)
-        );
-        assert_eq!(
-            detect_property_type("TIME", &Value::Number(serde_json::Number::from(1639400730))),
-            Some(PropertyValueType::DateTime)
-        );
-        assert_eq!(
-            detect_property_type(
-                "created_time",
-                &Value::Number(serde_json::Number::from(1639400730))
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-        assert_eq!(
-            detect_property_type(
-                "created_at",
-                &Value::Number(serde_json::Number::from(1639400730))
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-        assert_eq!(
-            detect_property_type(
-                "createdAt",
-                &Value::Number(serde_json::Number::from(1639400730))
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-        assert_eq!(
-            detect_property_type(
-                "updated_at",
-                &Value::Number(serde_json::Number::from(1639400730))
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-        assert_eq!(
-            detect_property_type(
-                "sent_at",
-                &Value::Number(serde_json::Number::from(1639400730))
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-        assert_eq!(
-            detect_property_type(
-                "signup_date",
-                &Value::Number(serde_json::Number::from(1639400730))
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-        assert_eq!(
-            detect_property_type(
-                "created_TIME",
-                &Value::Number(serde_json::Number::from(1639400730))
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-        assert_eq!(
-            detect_property_type(
-                "timeValue",
-                &Value::Number(serde_json::Number::from(1639400730))
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-        assert_eq!(
-            detect_property_type(
-                "sent-at",
-                &Value::Number(serde_json::Number::from(1639400730))
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-        assert_eq!(
-            detect_property_type(
-                "updated-at",
-                &Value::Number(serde_json::Number::from(1639400730))
-            ),
-            Some(PropertyValueType::DateTime)
-        );
-        assert_eq!(
-            detect_property_type(
-                "hedgehogs_enumerated",
-                &Value::Number(serde_json::Number::from(1639400730))
-            ),
-            Some(PropertyValueType::Numeric)
-        );
-        assert_eq!(
-            detect_property_type(
-                "not_a_thyme",
-                &Value::Number(serde_json::Number::from(1639400730))
-            ),
-            Some(PropertyValueType::Numeric)
-        );
-
-        // Test non-matching property names (should be Numeric)
-        assert_eq!(
-            detect_property_type("count", &Value::Number(serde_json::Number::from(42))),
-            Some(PropertyValueType::Numeric)
-        );
-        assert_eq!(
-            detect_property_type("amount", &Value::Number(serde_json::Number::from(100))),
-            Some(PropertyValueType::Numeric)
-        );
-
-        // Verify that string values are never detected as DateTime based on property name
-        assert_eq!(
-            detect_property_type("timestamp", &Value::String("not a date".to_string())),
-            Some(PropertyValueType::String)
-        );
-        assert_eq!(
-            detect_property_type("TIMESTAMP", &Value::String("not a date".to_string())),
-            Some(PropertyValueType::String)
-        );
-        assert_eq!(
-            detect_property_type("time", &Value::String("not a date".to_string())),
-            Some(PropertyValueType::String)
-        );
-        assert_eq!(
-            detect_property_type("TIME", &Value::String("not a date".to_string())),
-            Some(PropertyValueType::String)
-        );
     }
 }

--- a/rust/property-defs-rs/tests/types.rs
+++ b/rust/property-defs-rs/tests/types.rs
@@ -164,7 +164,7 @@ fn test_property_timestamp_detection() {
 
     assert_eq!(
         detect_property_type(
-            "udpatedAt",
+            "updatedAt",
             &Value::Number(Number::from(Utc::now().timestamp_millis() as u64 / 1000u64))
         ),
         Some(PropertyValueType::DateTime)

--- a/rust/property-defs-rs/tests/types.rs
+++ b/rust/property-defs-rs/tests/types.rs
@@ -1,0 +1,363 @@
+use chrono::Utc;
+use property_defs_rs::types::{detect_property_type, get_floored_last_seen, PropertyValueType};
+use serde_json::{Number, Value};
+
+#[test]
+fn test_date_flooring() {
+    use chrono::Timelike;
+
+    let now = Utc::now();
+    let rounded = get_floored_last_seen();
+
+    // Time should be rounded to the nearest hour
+    assert_eq!(rounded.minute(), 0);
+    assert_eq!(rounded.second(), 0);
+    assert_eq!(rounded.nanosecond(), 0);
+    assert!(rounded <= now);
+
+    // The difference between now and rounded should be less than 1 hour
+    assert!(now - rounded < chrono::Duration::hours(1));
+}
+
+#[test]
+fn test_property_timestamp_detection() {
+    // regardless of keys containing timestamp tokens or not, string values
+    // with an obvious attempt at a timestamp will be classified DateTimes
+    assert_eq!(
+        detect_property_type(
+            "random_property",
+            &Value::from("2025-03-11T09:48:12.863948+00:00")
+        ),
+        Some(PropertyValueType::DateTime)
+    );
+
+    assert_eq!(
+        detect_property_type("random_property", &Value::from("2023-12-13T15:45:30Z")),
+        Some(PropertyValueType::DateTime)
+    );
+
+    assert_eq!(
+        detect_property_type("random_property", &Value::from("2023-12-13T15:45:30.123Z")),
+        Some(PropertyValueType::DateTime)
+    );
+
+    assert_eq!(
+        detect_property_type("random_property", &Value::from("2023-12-13T15:45:30+00:00")),
+        Some(PropertyValueType::DateTime)
+    );
+
+    assert_eq!(
+        detect_property_type("random_property", &Value::from("2023-12-13T15:45:30-07:00")),
+        Some(PropertyValueType::DateTime)
+    );
+
+    assert_eq!(
+        detect_property_type("random_property", &Value::from("2023/12/13 15:45:30Z")),
+        Some(PropertyValueType::DateTime)
+    );
+
+    assert_eq!(
+        detect_property_type("random_property", &Value::from("2023/12/13 15:45:30")),
+        Some(PropertyValueType::DateTime)
+    );
+
+    assert_eq!(
+        detect_property_type("random_property", &Value::from("12-13-2023 15:45:30-07:00")),
+        Some(PropertyValueType::DateTime)
+    );
+
+    assert_eq!(
+        detect_property_type("random_property", &Value::from("12/13/2023 15:45:30-07")),
+        Some(PropertyValueType::DateTime)
+    );
+
+    assert_eq!(
+        detect_property_type("random_property", &Value::from("2023/12/13 15:45:30")),
+        Some(PropertyValueType::DateTime)
+    );
+
+    assert_eq!(
+        detect_property_type("random_property", &Value::from("2023-13-12 15:45:30")),
+        Some(PropertyValueType::DateTime)
+    );
+
+    assert_eq!(
+        detect_property_type("random_property", &Value::from("12/13/2023T15:45:30")),
+        Some(PropertyValueType::DateTime)
+    );
+
+    assert_eq!(
+        detect_property_type("random_property", &Value::from("2023-13-12T15:45:30")),
+        Some(PropertyValueType::DateTime)
+    );
+
+    // date fragments that show user intent this is a DateTime are accepted
+    assert_eq!(
+        detect_property_type("random_property", &Value::from("2023-12-13")),
+        Some(PropertyValueType::DateTime)
+    );
+
+    assert_eq!(
+        detect_property_type("random_property", &Value::from("2023/12/13")),
+        Some(PropertyValueType::DateTime)
+    );
+
+    assert_eq!(
+        detect_property_type("random_property", &Value::from("12-13-2023")),
+        Some(PropertyValueType::DateTime)
+    );
+
+    assert_eq!(
+        detect_property_type("random_property", &Value::from("12/13/2023")),
+        Some(PropertyValueType::DateTime)
+    );
+
+    // Test property name-based detection for numeric values (should be DateTime)
+    assert_eq!(
+        detect_property_type(
+            "time",
+            &Value::Number(Number::from(Utc::now().timestamp_millis() as u64 / 1000u64))
+        ),
+        Some(PropertyValueType::DateTime)
+    );
+
+    assert_eq!(
+        detect_property_type(
+            "timestamp",
+            &Value::Number(Number::from(Utc::now().timestamp_millis() as u64 / 1000u64))
+        ),
+        Some(PropertyValueType::DateTime)
+    );
+
+    assert_eq!(
+        detect_property_type(
+            "TIMESTAMP",
+            &Value::Number(Number::from(Utc::now().timestamp_millis() as u64 / 1000u64))
+        ),
+        Some(PropertyValueType::DateTime)
+    );
+
+    assert_eq!(
+        detect_property_type(
+            "created_time",
+            &Value::Number(Number::from(Utc::now().timestamp_millis() as u64 / 1000u64))
+        ),
+        Some(PropertyValueType::DateTime)
+    );
+
+    assert_eq!(
+        detect_property_type(
+            "sent_at",
+            &Value::Number(Number::from(Utc::now().timestamp_millis() as u64 / 1000u64))
+        ),
+        Some(PropertyValueType::DateTime)
+    );
+
+    // timestamp values with no obvious time token in key will be classified as DateTime
+    assert_eq!(
+        detect_property_type(
+            "random_property_has_datetime_value",
+            &Value::Number(Number::from(Utc::now().timestamp_millis() as u64 / 1000u64))
+        ),
+        Some(PropertyValueType::DateTime)
+    );
+
+    assert_eq!(
+        detect_property_type(
+            "udpatedAt",
+            &Value::Number(Number::from(Utc::now().timestamp_millis() as u64 / 1000u64))
+        ),
+        Some(PropertyValueType::DateTime)
+    );
+
+    assert_eq!(
+        detect_property_type(
+            "last-seen-at",
+            &Value::Number(Number::from(Utc::now().timestamp_millis() as u64 / 1000u64))
+        ),
+        Some(PropertyValueType::DateTime)
+    );
+
+    assert_eq!(
+        detect_property_type(
+            "sent_date",
+            &Value::Number(Number::from(Utc::now().timestamp_millis() as u64 / 1000u64))
+        ),
+        Some(PropertyValueType::DateTime)
+    );
+}
+
+#[test]
+fn test_property_timestamp_rejections() {
+    // non *date* time string values will be rejected even with timestamp tokens in keys
+    assert_eq!(
+        detect_property_type("timestamp", &Value::from("15:45:30")),
+        Some(PropertyValueType::String)
+    );
+
+    assert_eq!(
+        detect_property_type("signup_date", &Value::from("not a date")),
+        Some(PropertyValueType::String)
+    );
+
+    assert_eq!(
+        detect_property_type("created_at", &Value::from("not a date")),
+        Some(PropertyValueType::String)
+    );
+
+    // obviously non-timestamp values will not be classified DateTime on key tokens alone
+    assert_eq!(
+        detect_property_type("timestamp", &Value::from("any value")),
+        Some(PropertyValueType::String)
+    );
+
+    assert_eq!(
+        detect_property_type("created_time", &Value::from("any value")),
+        Some(PropertyValueType::String)
+    );
+
+    assert_eq!(
+        detect_property_type("sent_at", &Value::from("any value")),
+        Some(PropertyValueType::String)
+    );
+
+    assert_eq!(
+        detect_property_type("date_of_purchase", &Value::from("any value")),
+        Some(PropertyValueType::String)
+    );
+
+    assert_eq!(
+        detect_property_type(
+            "signup_date",
+            &Value::from("not a date but classified due to trigger tokens in key")
+        ),
+        Some(PropertyValueType::String)
+    );
+
+    // boolean values will be classified property even with timestamp tokens in key
+    assert_eq!(
+        detect_property_type("signup_date", &Value::from("true")),
+        Some(PropertyValueType::Boolean)
+    );
+
+    assert_eq!(
+        detect_property_type("timestamp", &Value::from("false")),
+        Some(PropertyValueType::Boolean)
+    );
+
+    assert_eq!(
+        detect_property_type("updatedAt", &Value::from("true")),
+        Some(PropertyValueType::Boolean)
+    );
+
+    assert_eq!(
+        detect_property_type("posthog_is_awesome", &Value::from("FALSE")),
+        Some(PropertyValueType::Boolean)
+    );
+
+    // even with timestamp tokens in the key, a UNIX stamp older than
+    // (now - 6 months) will not classify as DateTime
+    assert_eq!(
+        detect_property_type("timestamp", &Value::Number(Number::from(1639400730))),
+        Some(PropertyValueType::Numeric)
+    );
+
+    assert_eq!(
+        detect_property_type("TIMESTAMP", &Value::Number(Number::from(1639400730))),
+        Some(PropertyValueType::Numeric)
+    );
+
+    assert_eq!(
+        detect_property_type("user_timestamp", &Value::Number(Number::from(1639400730))),
+        Some(PropertyValueType::Numeric)
+    );
+
+    assert_eq!(
+        detect_property_type("user_TIMESTAMP", &Value::Number(Number::from(1639400730))),
+        Some(PropertyValueType::Numeric)
+    );
+
+    assert_eq!(
+        detect_property_type("timestampValue", &Value::Number(Number::from(1639400730))),
+        Some(PropertyValueType::Numeric)
+    );
+
+    assert_eq!(
+        detect_property_type("time", &Value::Number(Number::from(1639400730))),
+        Some(PropertyValueType::Numeric)
+    );
+
+    assert_eq!(
+        detect_property_type("TIME", &Value::Number(Number::from(1639400730))),
+        Some(PropertyValueType::Numeric)
+    );
+
+    assert_eq!(
+        detect_property_type("created_time", &Value::Number(Number::from(1639400730))),
+        Some(PropertyValueType::Numeric)
+    );
+
+    assert_eq!(
+        detect_property_type("created_at", &Value::Number(Number::from(1639400730))),
+        Some(PropertyValueType::Numeric)
+    );
+
+    assert_eq!(
+        detect_property_type("createdAt", &Value::Number(Number::from(1639400730))),
+        Some(PropertyValueType::Numeric)
+    );
+
+    assert_eq!(
+        detect_property_type("updated_at", &Value::Number(Number::from(1639400730))),
+        Some(PropertyValueType::Numeric)
+    );
+
+    assert_eq!(
+        detect_property_type("created_TIME", &Value::Number(Number::from(1639400730))),
+        Some(PropertyValueType::Numeric)
+    );
+
+    assert_eq!(
+        detect_property_type("timeValue", &Value::Number(Number::from(1639400730))),
+        Some(PropertyValueType::Numeric)
+    );
+
+    assert_eq!(
+        detect_property_type("sent-at", &Value::Number(Number::from(1639400730))),
+        Some(PropertyValueType::Numeric)
+    );
+
+    assert_eq!(
+        detect_property_type("updated-at", &Value::Number(Number::from(1639400730))),
+        Some(PropertyValueType::Numeric)
+    );
+
+    assert_eq!(
+        detect_property_type("was_detected_at", &Value::Number(Number::from(1639400730))),
+        Some(PropertyValueType::Numeric)
+    );
+
+    // without a keyword in the property key, these older
+    // UNIX timestamp values will be classified as a number
+    assert_eq!(
+        detect_property_type(
+            "hedgehogs_enumerated",
+            &Value::Number(serde_json::Number::from(1639400730))
+        ),
+        Some(PropertyValueType::Numeric)
+    );
+    assert_eq!(
+        detect_property_type("not_a_thyme", &Value::Number(Number::from(1639400730))),
+        Some(PropertyValueType::Numeric)
+    );
+
+    // obvious cases on Numerics will also classify properly
+    assert_eq!(
+        detect_property_type("count", &Value::Number(Number::from(42))),
+        Some(PropertyValueType::Numeric)
+    );
+    assert_eq!(
+        detect_property_type("amount", &Value::Number(Number::from(100))),
+        Some(PropertyValueType::Numeric)
+    );
+}

--- a/rust/property-defs-rs/tests/types.rs
+++ b/rust/property-defs-rs/tests/types.rs
@@ -77,7 +77,7 @@ fn test_property_timestamp_detection() {
     );
 
     assert_eq!(
-        detect_property_type("random_property", &Value::from("2023-13-12 15:45:30")),
+        detect_property_type("random_property", &Value::from("2023-12-13 15:45:30")),
         Some(PropertyValueType::DateTime)
     );
 


### PR DESCRIPTION
## Problem
After the first attempt to fix `PropertyValueType::DateTime` classification in `property-defs-rs`, support tickets kept landing about misclassifications.

## Changes
* Refactor `types` test suite so it runs locally and in CI ✅ 
* Small fixes to make `DateTime` classification more robust in the service ✅ 
* Refactor and improve unit test coverage to ensure the behavior is well documented if we need to tweak it further once it's working ✅ 

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally and in CI but with the suite running in full! 👍 
