### PR TITLE
fix(err): improve chunk id handling

### DIFF
--- a/posthog/api/error_tracking.py
+++ b/posthog/api/error_tracking.py
@@ -324,12 +324,20 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSe
         data = request.data["file"].read()
         (storage_ptr, content_hash) = upload_content(bytearray(data))
 
-        ErrorTrackingSymbolSet.objects.create(
-            team=self.team,
-            storage_ptr=storage_ptr,
-            content_hash=content_hash,
-            ref=chunk_id,
-        )
+        with transaction.atomic():
+            # Use update_or_create for proper upsert behavior
+            symbol_set, created = ErrorTrackingSymbolSet.objects.update_or_create(
+                team=self.team,
+                ref=chunk_id,
+                defaults={
+                    "storage_ptr": storage_ptr,
+                    "content_hash": content_hash,
+                    "failure_reason": None,
+                },
+            )
+
+            # Delete any existing frames associated with this symbol set
+            ErrorTrackingStackFrame.objects.filter(team=self.team, symbol_set=symbol_set).delete()
 
         return Response({"ok": True}, status=status.HTTP_201_CREATED)
 

--- a/rust/cymbal/src/app_context.rs
+++ b/rust/cymbal/src/app_context.rs
@@ -109,7 +109,7 @@ impl AppContext {
         // We want to fetch each sourcemap from the outside world
         // exactly once, and if it isn't in the cache, load/parse
         // it from s3 exactly once too. Limiting the per symbol set
-        // reference concurreny to 1 ensures this.
+        // reference concurrency to 1 ensures this.
         let limited_layer = concurrency::AtMostOne::new(caching_layer);
 
         info!(

--- a/rust/cymbal/src/error.rs
+++ b/rust/cymbal/src/error.rs
@@ -14,19 +14,6 @@ pub enum Error {
     ResolutionError(#[from] FrameError),
 }
 
-// // Errors specifically in using chunk ID's. These are
-// // handled as distinct from general resolution errors,
-// // because we want to handle them differently.
-// #[derive(Debug, Error)]
-// pub enum ChunkIdError {
-//     #[error("Chunk ID not found {0}")]
-//     NotFound(String),
-//     #[error("Missing storage pointer {0}")]
-//     MissingStoragePtr(String),
-//     #[error(transparent)]
-//     Other(#[from] Error),
-// }
-
 #[derive(Debug, Error)]
 pub enum UnhandledError {
     #[error("Config error: {0}")]

--- a/rust/cymbal/src/frames/mod.rs
+++ b/rust/cymbal/src/frames/mod.rs
@@ -62,7 +62,7 @@ impl RawFrame {
     pub fn symbol_set_ref(&self) -> Option<String> {
         match self {
             RawFrame::JavaScriptWeb(frame) | RawFrame::LegacyJS(frame) => frame.symbol_set_ref(),
-            RawFrame::JavaScriptNode(_) => None, // Python frames don't have symbol sets
+            RawFrame::JavaScriptNode(_) => None, // Node.js frames don't have symbol sets
             RawFrame::Python(_) => None,         // Python frames don't have symbol sets
         }
     }

--- a/rust/cymbal/src/frames/mod.rs
+++ b/rust/cymbal/src/frames/mod.rs
@@ -61,9 +61,7 @@ impl RawFrame {
 
     pub fn symbol_set_ref(&self) -> Option<String> {
         match self {
-            RawFrame::JavaScriptWeb(frame) | RawFrame::LegacyJS(frame) => {
-                frame.source_url().map(String::from).ok()
-            }
+            RawFrame::JavaScriptWeb(frame) | RawFrame::LegacyJS(frame) => frame.symbol_set_ref(),
             RawFrame::JavaScriptNode(_) => None, // Python frames don't have symbol sets
             RawFrame::Python(_) => None,         // Python frames don't have symbol sets
         }

--- a/rust/cymbal/src/frames/resolver.rs
+++ b/rust/cymbal/src/frames/resolver.rs
@@ -130,24 +130,22 @@ mod test {
 
         let client = Arc::new(client);
 
-        let smp = SourcemapProvider::new(&config);
+        let chunk_id_smp = ChunkIdFetcher::new(
+            SourcemapProvider::new(&config),
+            client.clone(),
+            pool.clone(),
+            config.object_storage_bucket.clone(),
+        );
+
         let saving_smp = Saving::new(
-            smp,
+            chunk_id_smp,
             pool.clone(),
             client.clone(),
             config.object_storage_bucket.clone(),
             config.ss_prefix.clone(),
         );
 
-        let chunk_id_smp = SourcemapProvider::new(&config);
-        let chunk_id_smp = ChunkIdFetcher::new(
-            chunk_id_smp,
-            client,
-            pool,
-            config.object_storage_bucket.clone(),
-        );
-
-        let catalog = Catalog::new(saving_smp, chunk_id_smp);
+        let catalog = Catalog::new(saving_smp);
 
         (config, catalog, server)
     }

--- a/rust/cymbal/src/langs/js.rs
+++ b/rust/cymbal/src/langs/js.rs
@@ -103,11 +103,7 @@ impl RawJSFrame {
     pub fn symbol_set_ref(&self) -> Option<String> {
         // If we have a chunk ID for a frame, no matter where the data we save comes from, we save it with that
         // chunk id as the ref.
-        if let Some(id) = &self.chunk_id {
-            Some(id.clone())
-        } else {
-            self.source_url().ok().map(|u| u.path().to_string())
-        }
+        self.get_ref().ok().map(|r| r.to_string())
     }
 
     fn source_url(&self) -> Result<Url, JsResolveErr> {

--- a/rust/cymbal/src/langs/js.rs
+++ b/rust/cymbal/src/langs/js.rs
@@ -216,8 +216,8 @@ impl From<(&RawJSFrame, JsResolveErr, &FrameLocation)> for Frame {
 
         // TODO - extremely rough
         let was_minified = match err {
-            JsResolveErr::NoSourceUrl => false, // This frame's `source` was None
-            JsResolveErr::NoSourcemap(_) => false, // A total guess
+            JsResolveErr::NoSourceUrl | JsResolveErr::NoUrlOrChunkId => false, // This frame's `source` didn't exist
+            JsResolveErr::NoSourcemap(_) => false,                             // A total guess
             _ => true,
         };
 

--- a/rust/cymbal/src/symbol_store/chunk_id.rs
+++ b/rust/cymbal/src/symbol_store/chunk_id.rs
@@ -6,17 +6,14 @@ use std::{
 use axum::async_trait;
 use metrics::counter;
 use sqlx::PgPool;
-use tracing::{error, warn};
+use tracing::error;
 
 use crate::{
-    error::{ChunkIdError, Error, UnhandledError},
-    metric_consts::{CHUNK_ID_FAILURE_FETCHED, CHUNK_ID_FAILURE_SAVED, CHUNK_ID_NOT_FOUND},
+    error::{FrameError, UnhandledError},
+    metric_consts::{CHUNK_ID_FAILURE_FETCHED, CHUNK_ID_NOT_FOUND},
 };
 
-use super::{
-    saving::{Saveable, SymbolSetRecord},
-    Fetcher, Parser, S3Client,
-};
+use super::{saving::SymbolSetRecord, Fetcher, Parser, S3Client};
 
 pub struct ChunkIdFetcher<Parser> {
     pub inner: Parser,
@@ -36,122 +33,155 @@ impl<P> ChunkIdFetcher<P> {
     }
 }
 
-pub struct WithChunkId<R> {
-    pub inner: R,
-    pub chunk_id: ChunkId,
+pub enum OrChunkId<R> {
+    Inner(R),
+    ChunkId(String),
+    Both { inner: R, id: String },
 }
 
-#[derive(Debug, Clone)]
-pub struct ChunkId(pub String);
-
+// The chunk id handling layer is a little odd. In cases where users have uploaded the symbol set
+// with a chunk it, it'll never be hit, because the "saving" layer will fetch the data first, and in
+// cases where the user has injected the chunk ID but not uploaded the symbol set, it'll never resolve
+// the chunk, instead just fetching the data from the inner layer. This means, in normal practice, all
+// it does is strip off the chunk id and pass the inner request to the inner layer. We only make it able
+// to hit PG/S3 at all for testing cases.
+//
+// Most of the "cleverness" of this layer is actually that the `Display` implementation of `OrChunkId`
+// which returns the chunk ID if it's set, rather than the inner T's display implementation, which means
+// that the saving and caching layers, or any other layers above this one that rely on Fetcher::Ref: ToString
+// will use the chunk ID as the symbol set key, rather than the inner T's reference - which makes things like
+// deleting all saved frame resolution results for any frame with a chunk ID that were seen before the chunk id
+// symbol data was uploaded, possible using the chunk id directly.
 #[async_trait]
 impl<P> Fetcher for ChunkIdFetcher<P>
 where
-    P: Send + Sync + 'static,
+    P: Fetcher<Fetched = Vec<u8>>,
+    P::Ref: Send,
+    P::Err: From<UnhandledError> + From<FrameError>,
 {
-    type Ref = ChunkId;
-    type Fetched = Saveable;
-    type Err = ChunkIdError;
+    type Ref = OrChunkId<P::Ref>;
+    type Fetched = P::Fetched;
+    type Err = P::Err;
 
     async fn fetch(&self, team_id: i32, r: Self::Ref) -> Result<Self::Fetched, Self::Err> {
-        let id = r.0;
+        let (id, inner) = match r {
+            OrChunkId::Inner(inner) => {
+                // We have no chunk id, just strip off the wrapper and return the inner result
+                return self.inner.fetch(team_id, inner).await;
+            }
+            OrChunkId::ChunkId(id) => (id, None),
+            OrChunkId::Both { inner, id } => (id, Some(inner)),
+        };
 
         let Some(record) = SymbolSetRecord::load(&self.pool, team_id, &id).await? else {
             counter!(CHUNK_ID_NOT_FOUND).increment(1);
-            return Err(ChunkIdError::NotFound(id.clone()));
+            let Some(inner) = inner else {
+                return Err(FrameError::MissingChunkIdData(id).into());
+            };
+            // We have a chunk id, but it's not saved - fetch with the inner, knowing the OrChunkId's
+            // `Display` implementation will use the chunk id as the set reference everywhere else
+            return self.inner.fetch(team_id, inner).await;
         };
 
         // If we failed to parse this chunk's data in the past, we should not try again.
+        // Note that in situations where we're running beneath a `Saving` layer, we'll
+        // never reach this point, but we still handle the case for correctness sake
         if let Some(failure_reason) = record.failure_reason {
             counter!(CHUNK_ID_FAILURE_FETCHED).increment(1);
-            // TODO - see comment in `saving.rs` about whether we should simply delete records where
-            // we fail to parse the failure reason, but for now requiring manual intervention is fine
-            let error = serde_json::from_str(&failure_reason).map_err(UnhandledError::from)?;
-            return Err(Error::ResolutionError(error).into());
+            let error: FrameError =
+                serde_json::from_str(&failure_reason).map_err(UnhandledError::from)?;
+            return Err(error.into());
         }
 
         let Some(storage_ptr) = record.storage_ptr else {
-            // TODO: I think we should just panic on this, actually - it's never valid for us to
-            // have a symbol record for a chunk id with no storage pointer and no failure reason.
+            // It's never valid to have no failure reason and no storage pointer - if we hit this case, just panic
             error!("No storage pointer found for chunk id {}", id);
             panic!("No storage pointer found for chunk id {}", id);
         };
 
-        let data = self.client.get(&self.bucket, &storage_ptr).await?;
-
-        Ok(Saveable {
-            data,
-            storage_ptr: Some(storage_ptr),
-            team_id,
-            set_ref: id,
-        })
+        self.client
+            .get(&self.bucket, &storage_ptr)
+            .await
+            .map_err(|e| e.into())
     }
 }
 
+// Let the underlying parser handle decoding the data, not caring whether it was uploaded
+// or fetched from the internet
 #[async_trait]
 impl<P> Parser for ChunkIdFetcher<P>
 where
-    P: Parser<Source = Vec<u8>, Err = Error>,
+    P: Parser<Source = Vec<u8>>,
     P::Set: Send,
 {
-    type Source = Saveable;
+    type Source = P::Source;
     type Set = P::Set;
-    type Err = ChunkIdError;
+    type Err = P::Err;
 
     async fn parse(&self, data: Self::Source) -> Result<Self::Set, Self::Err> {
-        let (team_id, chunk_id, data) = (data.team_id, data.set_ref, data.data);
-        let res = self.inner.parse(data).await;
-
-        match res {
-            Ok(s) => Ok(s),
-            Err(Error::ResolutionError(e)) => {
-                if let Some(mut record) =
-                    SymbolSetRecord::load(&self.pool, team_id, &chunk_id).await?
-                {
-                    // If someone else has already deleted the chunk id record, that's fine, just return an error
-                    warn!("Saving a parse error for chunk id: {}", chunk_id);
-                    counter!(CHUNK_ID_FAILURE_SAVED).increment(1);
-                    record.storage_ptr = None;
-                    record.content_hash = None;
-                    record.failure_reason =
-                        Some(serde_json::to_string(&e).map_err(UnhandledError::from)?);
-                    record.save(&self.pool).await?;
-                };
-
-                Err(e.into())
-            }
-            Err(e) => Err(e.into()),
-        }
+        self.inner.parse(data).await
     }
 }
 
-impl<Ref> Debug for WithChunkId<Ref>
+impl<Ref> Debug for OrChunkId<Ref>
 where
     Ref: Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("WithChunkId")
-            .field("inner", &self.inner)
-            .field("chunk_id", &self.chunk_id)
-            .finish()
-    }
-}
-
-impl<Ref> Clone for WithChunkId<Ref>
-where
-    Ref: Clone,
-{
-    fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
-            chunk_id: self.chunk_id.clone(),
+        match self {
+            OrChunkId::Inner(inner) => write!(f, "Inner({:?})", inner),
+            OrChunkId::ChunkId(id) => write!(f, "ChunkId({})", id),
+            OrChunkId::Both { inner, id } => write!(f, "Both {{ inner: {:?}, id: {} }}", inner, id),
         }
     }
 }
 
-impl Display for ChunkId {
+impl<Ref> Clone for OrChunkId<Ref>
+where
+    Ref: Clone,
+{
+    fn clone(&self) -> Self {
+        match self {
+            OrChunkId::Inner(inner) => OrChunkId::Inner(inner.clone()),
+            OrChunkId::ChunkId(id) => OrChunkId::ChunkId(id.clone()),
+            OrChunkId::Both { inner, id } => OrChunkId::Both {
+                inner: inner.clone(),
+                id: id.clone(),
+            },
+        }
+    }
+}
+
+// The "cleverness" mentioned above - any time an OrChunkId is used as a symbol set reference,
+// and the chunk id is set, it will be used as the key when calling ToString, rather than the
+// inner T's display impl
+impl<R> Display for OrChunkId<R>
+where
+    R: Display,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
+        match self {
+            OrChunkId::Inner(inner) => inner.fmt(f),
+            OrChunkId::ChunkId(id) => write!(f, "{}", id),
+            OrChunkId::Both { inner: _, id } => write!(f, "{}", id),
+        }
+    }
+}
+
+impl<R> OrChunkId<R> {
+    pub fn inner(inner: R) -> Self {
+        Self::Inner(inner)
+    }
+
+    pub fn chunk_id(chunk_id: String) -> Self {
+        Self::ChunkId(chunk_id)
+    }
+
+    pub fn both(inner: R, chunk_id: String) -> Self {
+        Self::Both {
+            inner,
+            id: chunk_id,
+        }
     }
 }
 
@@ -174,7 +204,7 @@ mod test {
         frames::RawFrame,
         langs::js::RawJSFrame,
         symbol_store::{
-            chunk_id::{ChunkId, ChunkIdFetcher},
+            chunk_id::{ChunkIdFetcher, OrChunkId},
             saving::SymbolSetRecord,
             sourcemap::{OwnedSourceMapCache, SourcemapProvider},
             Catalog, Provider, S3Client,
@@ -258,10 +288,9 @@ mod test {
         let chunk_id_fetcher =
             ChunkIdFetcher::new(smp, client, db.clone(), config.object_storage_bucket);
 
-        chunk_id_fetcher
-            .lookup(1, ChunkId(chunk_id.clone()))
-            .await
-            .unwrap();
+        let r = OrChunkId::chunk_id(chunk_id);
+
+        chunk_id_fetcher.lookup(1, r).await.unwrap();
     }
 
     #[sqlx::test(migrations = "./tests/test_migrations")]
@@ -299,7 +328,7 @@ mod test {
         let chunk_id_fetcher =
             ChunkIdFetcher::new(smp, client, db.clone(), config.object_storage_bucket);
 
-        let catalog = Catalog::new(UnimplementedProvider, chunk_id_fetcher);
+        let catalog = Catalog::new(chunk_id_fetcher);
 
         let mut frame = get_example_frame();
         frame.chunk_id = Some(chunk_id.clone());

--- a/rust/cymbal/tests/resolve.rs
+++ b/rust/cymbal/tests/resolve.rs
@@ -5,13 +5,12 @@ use axum::async_trait;
 use common_types::ClickHouseEvent;
 use cymbal::{
     config::Config,
-    error::ChunkIdError,
     frames::{Frame, RawFrame},
     symbol_store::{
         caching::{Caching, SymbolSetCache},
-        chunk_id::ChunkId,
+        chunk_id::OrChunkId,
         sourcemap::{OwnedSourceMapCache, SourcemapProvider},
-        Catalog, Provider,
+        Catalog, Fetcher, Parser,
     },
     types::{RawErrProps, Stacktrace},
 };
@@ -25,16 +24,43 @@ const MINIFIED: &[u8] = include_bytes!("../tests/static/chunk-PGUQKT6S.js");
 const MAP: &[u8] = include_bytes!("../tests/static/chunk-PGUQKT6S.js.map");
 const EXAMPLE_EXCEPTION: &str = include_str!("../tests/static/raw_ch_exception_list.json");
 
-pub struct UnimplementedProvider;
+struct NoOpChunkIdFetcher<P> {
+    inner: P,
+}
 
 #[async_trait]
-impl Provider for UnimplementedProvider {
-    type Ref = ChunkId;
-    type Set = OwnedSourceMapCache;
-    type Err = ChunkIdError;
+impl<P> Fetcher for NoOpChunkIdFetcher<P>
+where
+    P: Fetcher,
+    P::Ref: Send,
+{
+    type Ref = OrChunkId<P::Ref>;
+    type Fetched = P::Fetched;
+    type Err = P::Err;
 
-    async fn lookup(&self, _team_id: i32, _r: Self::Ref) -> Result<Arc<Self::Set>, Self::Err> {
-        unimplemented!()
+    async fn fetch(&self, team_id: i32, r: Self::Ref) -> Result<Self::Fetched, Self::Err> {
+        let r = match r {
+            OrChunkId::Inner(r) => r,
+            OrChunkId::ChunkId(_) => panic!("Unexpected chunk id"),
+            OrChunkId::Both { inner, id: _ } => inner,
+        };
+
+        self.inner.fetch(team_id, r).await
+    }
+}
+
+#[async_trait]
+impl<P> Parser for NoOpChunkIdFetcher<P>
+where
+    P: Parser,
+    P::Source: Send,
+{
+    type Source = P::Source;
+    type Set = P::Set;
+    type Err = P::Err;
+
+    async fn parse(&self, source: Self::Source) -> Result<Self::Set, Self::Err> {
+        self.inner.parse(source).await
     }
 }
 
@@ -89,7 +115,9 @@ async fn end_to_end_resolver_test() {
         config.symbol_store_cache_max_bytes,
     )));
 
-    let catalog = Catalog::new(Caching::new(sourcemap, cache), UnimplementedProvider);
+    let wrapped = NoOpChunkIdFetcher { inner: sourcemap };
+
+    let catalog = Catalog::new(Caching::new(wrapped, cache));
 
     let mut resolved_frames = Vec::new();
     for frame in test_stack {


### PR DESCRIPTION
- Cleanup frames on chunk id upload
- Use the chunk id as the "ref" in PG even if we end up fetching from a URL
- Support frames with no URL, but with a chunk id (idk what might send these - nextjs? but we can handle them now).