### PR TITLE
feat(cli): add query check command

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -961,6 +961,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3379,6 +3388,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3758,6 +3773,37 @@ dependencies = [
  "num_cpus",
  "quanta 0.12.2",
  "sketches-ddsketch",
+]
+
+[[package]]
+name = "miette"
+version = "7.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a955165f87b37fd1862df2a59547ac542c77ef6d17c666f619d1ad22dd89484"
+dependencies = [
+ "backtrace",
+ "backtrace-ext",
+ "cfg-if",
+ "miette-derive",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "thiserror 1.0.69",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf45bf44ab49be92fd1227a3be6fc6f617f1a337c06af54981048574d8783147"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -4246,6 +4292,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "owo-colors"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
+
+[[package]]
 name = "p256"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4531,6 +4583,7 @@ dependencies = [
  "dirs",
  "inquire",
  "magic_string",
+ "miette",
  "posthog-symbol-data 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ratatui",
  "reqwest 0.12.3",
@@ -4538,6 +4591,7 @@ dependencies = [
  "serde_json",
  "sourcemap 9.1.2",
  "test-log",
+ "thiserror 1.0.69",
  "tracing",
  "tracing-subscriber",
  "tui-textarea",
@@ -6065,6 +6119,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0a1e5168041f5f3ff68ff7d95dcb9c8749df29f6e7e89ada40dd4c9de404ee"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+
+[[package]]
 name = "swc_atoms"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6400,6 +6475,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
+dependencies = [
+ "rustix 0.38.41",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6425,6 +6510,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.89",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+dependencies = [
+ "unicode-linebreak",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -6913,6 +7008,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"

--- a/rust/posthog-cli/Cargo.toml
+++ b/rust/posthog-cli/Cargo.toml
@@ -33,6 +33,8 @@ crossterm = "0.28.1"
 tui-textarea = "0.7.0"
 sourcemap = "9.1.2"
 magic_string = "0.3.4"
+miette = { version = "7.5.0", features = ["fancy"] }
+thiserror.workspace = true
 
 [dev-dependencies]
 test-log = "0.2.17"

--- a/rust/posthog-cli/src/commands/query.rs
+++ b/rust/posthog-cli/src/commands/query.rs
@@ -1,9 +1,13 @@
 use anyhow::Error;
 use clap::Subcommand;
+use miette::{Diagnostic, SourceSpan};
 
 use crate::{
     tui::query::start_query_editor,
-    utils::{auth::load_token, query::run_query},
+    utils::{
+        auth::load_token,
+        query::{check_query, run_query, MetadataResponse, Notice},
+    },
 };
 
 #[derive(Debug, Subcommand)]
@@ -27,6 +31,14 @@ pub enum QueryCommand {
         #[arg(long)]
         /// Print the returned json, rather than just the results
         debug: bool,
+    },
+    /// Syntax and type-check a query, without running it
+    Check {
+        /// The query to check
+        query: String,
+        /// Print the raw response from the server as json
+        #[arg(long)]
+        raw: bool,
     },
 }
 
@@ -62,7 +74,119 @@ pub fn query_command(host: &str, query: &QueryCommand) -> Result<(), Error> {
                 }
             }
         }
+        QueryCommand::Check { query, raw } => {
+            let query_endpoint = format!("{}/api/environments/{}/query", host, creds.env_id);
+            let res = check_query(&query_endpoint, &creds.token, query)?;
+            if *raw {
+                println!("{}", serde_json::to_string_pretty(&res)?);
+            } else {
+                pretty_print_check_response(query, res)?;
+            }
+        }
     }
 
     Ok(())
+}
+
+#[derive(thiserror::Error, Debug, Diagnostic)]
+#[error("Query checked")]
+#[diagnostic()]
+struct CheckDiagnostic {
+    #[source_code]
+    source_code: String,
+
+    #[related]
+    errors: Vec<CheckError>,
+    #[related]
+    warnings: Vec<CheckWarning>,
+    #[related]
+    notices: Vec<CheckNotice>,
+}
+
+#[derive(thiserror::Error, Debug, Diagnostic)]
+#[error("Error")]
+#[diagnostic(severity(Error))]
+struct CheckError {
+    #[help]
+    message: String,
+    #[label]
+    err_span: SourceSpan,
+}
+
+#[derive(thiserror::Error, Debug, Diagnostic)]
+#[error("Warning")]
+#[diagnostic(severity(Warning))]
+struct CheckWarning {
+    #[help]
+    message: String,
+    #[label]
+    err_span: SourceSpan,
+}
+
+#[derive(thiserror::Error, Debug, Diagnostic)]
+#[error("Notice")]
+#[diagnostic(severity(Info))]
+struct CheckNotice {
+    #[help]
+    message: String,
+    #[label]
+    err_span: SourceSpan,
+}
+
+// We use miette to pretty print notices, warnings and errors across the original query.
+fn pretty_print_check_response(query: &str, res: MetadataResponse) -> Result<(), Error> {
+    let errors = res.errors.into_iter().map(CheckError::from).collect();
+    let warnings = res.warnings.into_iter().map(CheckWarning::from).collect();
+    let notices = res.notices.into_iter().map(CheckNotice::from).collect();
+
+    let diagnostic: miette::Error = CheckDiagnostic {
+        source_code: query.to_string(),
+        errors,
+        warnings,
+        notices,
+    }
+    .into();
+
+    println!("{:?}", diagnostic);
+
+    Ok(())
+}
+
+impl From<Notice> for CheckNotice {
+    fn from(notice: Notice) -> Self {
+        let (start, len) = match notice.span {
+            Some(span) => (span.start, span.end - span.start),
+            None => (0, 0),
+        };
+        Self {
+            message: notice.message,
+            err_span: SourceSpan::new(start.into(), len),
+        }
+    }
+}
+
+impl From<Notice> for CheckWarning {
+    fn from(notice: Notice) -> Self {
+        let (start, len) = match notice.span {
+            Some(span) => (span.start, span.end - span.start),
+            None => (0, 0),
+        };
+        Self {
+            message: notice.message,
+            err_span: SourceSpan::new(start.into(), len),
+        }
+    }
+}
+
+impl From<Notice> for CheckError {
+    fn from(notice: Notice) -> Self {
+        let (start, len) = match notice.span {
+            Some(span) => (span.start, span.end - span.start),
+            None => (0, 0),
+        };
+        Self {
+            message: notice.message,
+            err_span: SourceSpan::new(start.into(), len),
+        }
+    }
 }

--- a/rust/posthog-cli/src/utils/query.rs
+++ b/rust/posthog-cli/src/utils/query.rs
@@ -7,19 +7,35 @@ use serde_json::Value;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueryRequest {
     pub query: Query,
-    pub refresh: QueryRefresh,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh: Option<QueryRefresh>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind")]
 pub enum Query {
     HogQLQuery { query: String },
+    HogQLMetadata(MetadataQuery),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryRefresh {
     Blocking,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetadataQuery {
+    pub language: MetadataLanguage,
+    pub query: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<Box<Query>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum MetadataLanguage {
+    #[serde(rename = "hogQL")]
+    HogQL,
 }
 
 pub type HogQLQueryResult = Result<HogQLQueryResponse, HogQLQueryErrorResponse>;
@@ -66,6 +82,46 @@ pub struct Timing {
     pub t: f64,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct MetadataResponse {
+    #[serde(default, deserialize_with = "null_is_empty")]
+    pub errors: Vec<Notice>,
+    #[serde(default, deserialize_with = "null_is_empty")]
+    pub notices: Vec<Notice>,
+    #[serde(default, deserialize_with = "null_is_empty")]
+    pub warnings: Vec<Notice>,
+    #[serde(default, rename = "isUsingIndices")]
+    pub is_using_indices: Option<IndicesUsage>,
+    #[serde(default, deserialize_with = "null_is_false", rename = "isValid")]
+    pub is_valid: bool,
+    #[serde(default, deserialize_with = "null_is_false")]
+    pub is_valid_view: bool,
+    #[serde(default, deserialize_with = "null_is_empty")]
+    pub table_names: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum IndicesUsage {
+    Undecisive,
+    No,
+    Partial,
+    Yes,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Notice {
+    pub message: String,
+    #[serde(flatten)]
+    pub span: Option<NoticeSpan>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct NoticeSpan {
+    pub start: usize,
+    pub end: usize,
+}
+
 fn null_is_empty<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -96,7 +152,7 @@ pub fn run_query(endpoint: &str, token: &str, to_run: &str) -> Result<HogQLQuery
         query: Query::HogQLQuery {
             query: to_run.to_string(),
         },
-        refresh: QueryRefresh::Blocking,
+        refresh: Some(QueryRefresh::Blocking),
     };
 
     let response = client
@@ -118,6 +174,43 @@ pub fn run_query(endpoint: &str, token: &str, to_run: &str) -> Result<HogQLQuery
     // NOTE: We don't do any pagination here, because the HogQLQuery runner doesn't support it
     let response: HogQLQueryResponse = serde_json::from_value(value)?;
     Ok(Ok(response))
+}
+
+pub fn check_query(endpoint: &str, token: &str, to_run: &str) -> Result<MetadataResponse, Error> {
+    let client = reqwest::blocking::Client::new();
+
+    let query = MetadataQuery {
+        language: MetadataLanguage::HogQL,
+        query: to_run.to_string(),
+        source: None, // TODO - allow for this to be set? Idk if it matters much
+    };
+
+    let query = Query::HogQLMetadata(query);
+
+    let request = QueryRequest {
+        query,
+        refresh: None,
+    };
+
+    let response = client
+        .post(endpoint)
+        .json(&request)
+        .bearer_auth(token)
+        .send()?;
+
+    let code = response.status();
+    let body = response.text()?;
+
+    let value: Value = serde_json::from_str(&body)?;
+
+    if !code.is_success() {
+        let error: MetadataResponse = serde_json::from_value(value)?;
+        return Ok(error);
+    }
+
+    let response: MetadataResponse = serde_json::from_value(value)?;
+
+    Ok(response)
 }
 
 impl std::error::Error for HogQLQueryErrorResponse {}

--- a/rust/posthog-cli/src/utils/query.rs
+++ b/rust/posthog-cli/src/utils/query.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::Error;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -66,6 +68,8 @@ pub struct HogQLQueryResponse {
     pub results: Vec<Vec<Value>>,
     #[serde(default, deserialize_with = "null_is_empty")]
     pub timings: Vec<Timing>,
+    #[serde(flatten, skip_serializing_if = "HashMap::is_empty")]
+    pub other: HashMap<String, Value>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -74,6 +78,8 @@ pub struct HogQLQueryErrorResponse {
     pub detail: String,
     #[serde(rename = "type")]
     pub error_type: String,
+    #[serde(flatten, skip_serializing_if = "HashMap::is_empty")]
+    pub other: HashMap<String, Value>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -98,6 +104,8 @@ pub struct MetadataResponse {
     pub is_valid_view: bool,
     #[serde(default, deserialize_with = "null_is_empty")]
     pub table_names: Vec<String>,
+    #[serde(flatten, skip_serializing_if = "HashMap::is_empty")]
+    pub other: HashMap<String, Value>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -114,6 +122,8 @@ pub struct Notice {
     pub message: String,
     #[serde(flatten)]
     pub span: Option<NoticeSpan>,
+    #[serde(flatten, skip_serializing_if = "HashMap::is_empty")]
+    pub other: HashMap<String, Value>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]


### PR DESCRIPTION
Output looks like this (the log lines are written to stderr, only the error highlight is written to stdout, as with `query run`):
<img width="1271" alt="image" src="https://github.com/user-attachments/assets/fc9b0d54-d999-4492-91c4-9d3ff99e5538" />

There's a raw mode too ofc, for use in potentially other tooling
