### PR TITLE
fix(max): format reminder regression

### DIFF
--- a/ee/hogai/taxonomy_agent/nodes.py
+++ b/ee/hogai/taxonomy_agent/nodes.py
@@ -26,6 +26,7 @@ from ee.hogai.taxonomy_agent.prompts import (
     REACT_DEFINITIONS_PROMPT,
     REACT_FOLLOW_UP_PROMPT,
     REACT_FORMAT_PROMPT,
+    REACT_FORMAT_REMINDER_PROMPT,
     REACT_HELP_REQUEST_PROMPT,
     REACT_HUMAN_IN_THE_LOOP_PROMPT,
     REACT_MALFORMED_JSON_PROMPT,
@@ -215,6 +216,7 @@ class TaxonomyAgentPlannerNode(AssistantNode):
         conversation.append(
             HumanMessagePromptTemplate.from_template(new_insight_prompt, template_format="mustache").format(
                 question=state.root_tool_insight_plan,
+                react_format_reminder=REACT_FORMAT_REMINDER_PROMPT,
             )
         )
 

--- a/ee/hogai/taxonomy_agent/test/test_nodes.py
+++ b/ee/hogai/taxonomy_agent/test/test_nodes.py
@@ -123,6 +123,15 @@ class TestTaxonomyAgentPlannerNode(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(history[4].type, "human")
         self.assertIn("Question 3", history[4].content)
 
+    def test_adds_format_reminder(self):
+        node = self._get_node()
+        history = node._construct_messages(
+            AssistantState(messages=[HumanMessage(content="Message")], root_tool_insight_plan="Text")
+        )
+        self.assertEqual(len(history), 1)
+        self.assertEqual(history[0].type, "human")
+        self.assertIn("Reminder", history[0].content)
+
     def test_agent_filters_out_low_count_events(self):
         _create_person(distinct_ids=["test"], team=self.team)
         for i in range(26):


### PR DESCRIPTION
## Problem

The format reminder aims to band-aid hallucinations of the ReAct agent, but I accidentally removed it in previous PRs.

## Changes

Revert the change.

## Does this work well for both Cloud and self-hosted?

No

## How did you test this code?

Manual testing & added the unit test.
