### PR TITLE
feat: cache PostHog client for usage reporting

### DIFF
--- a/posthog/tasks/periodic_digest.py
+++ b/posthog/tasks/periodic_digest.py
@@ -8,7 +8,6 @@ from celery import shared_task
 from dateutil import parser
 from django.db.models import QuerySet
 from django.utils import timezone
-from posthoganalytics.client import Client
 from posthog.exceptions_capture import capture_exception
 
 from posthog.models.dashboard import Dashboard
@@ -29,7 +28,7 @@ from posthog.tasks.report_utils import (
     capture_event,
     get_user_team_lookup,
 )
-from posthog.tasks.usage_report import USAGE_REPORT_TASK_KWARGS, get_instance_metadata
+from posthog.tasks.usage_report import USAGE_REPORT_TASK_KWARGS, get_instance_metadata, get_ph_client
 from posthog.warehouse.models.external_data_source import ExternalDataSource
 
 logger = structlog.get_logger(__name__)
@@ -352,10 +351,9 @@ def send_digest_notifications(
     """
     Sends a single notification for digest reports.
     """
-    pha_client = Client("sTMFPsFhdP1Ssg")
 
     capture_event(
-        pha_client=pha_client,
+        pha_client=get_ph_client(),
         name=event_name,
         organization_id=organization_id,
         team_id=None,
@@ -363,4 +361,4 @@ def send_digest_notifications(
         timestamp=timestamp,
         distinct_id=distinct_id,
     )
-    pha_client.group_identify("organization", organization_id, properties)
+    get_ph_client().group_identify("organization", organization_id, properties)

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -1877,7 +1877,7 @@ class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
             f"{BILLING_SERVICE_URL}/api/usage",
             json=full_report_as_dict,
             headers={"Authorization": f"Bearer {token}"},
-            timeout=15,
+            timeout=30,
         )
 
         mock_posthog.capture.assert_any_call(
@@ -1917,7 +1917,7 @@ class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
                 f"{BILLING_SERVICE_URL}/api/usage",
                 json=full_report_as_dict,
                 headers={"Authorization": f"Bearer {token}"},
-                timeout=15,
+                timeout=30,
             )
 
             mock_posthog.capture.assert_any_call(

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -876,7 +876,7 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
 
     @freeze_time("2022-01-10T00:01:00Z")
     @patch("os.environ", {"DEPLOYMENT": "tests"})
-    @patch("posthog.tasks.usage_report.Client")
+    @patch("posthog.tasks.usage_report.get_ph_client")
     @patch("requests.post")
     def test_unlicensed_usage_report(self, mock_post: MagicMock, mock_client: MagicMock) -> None:
         self.expected_properties = {}
@@ -1110,7 +1110,7 @@ class TestFeatureFlagsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickh
         self.org_2_team_3 = Team.objects.create(pk=5, organization=self.org_2, name="Team 3 org 2")
 
     @snapshot_clickhouse_queries
-    @patch("posthog.tasks.usage_report.Client")
+    @patch("posthog.tasks.usage_report.get_ph_client")
     @patch("posthog.tasks.usage_report.send_report_to_billing_service")
     def test_usage_report_decide_requests(self, billing_task_mock: MagicMock, posthog_capture_mock: MagicMock) -> None:
         self._setup_teams()
@@ -1188,7 +1188,7 @@ class TestFeatureFlagsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickh
         assert org_2_report["teams"]["5"]["decide_requests_count_in_period"] == 0
         assert org_2_report["teams"]["5"]["billable_feature_flag_requests_count_in_period"] == 0
 
-    @patch("posthog.tasks.usage_report.Client")
+    @patch("posthog.tasks.usage_report.get_ph_client")
     @patch("posthog.tasks.usage_report.send_report_to_billing_service")
     def test_usage_report_local_evaluation_requests(
         self, billing_task_mock: MagicMock, posthog_capture_mock: MagicMock
@@ -1288,7 +1288,7 @@ class TestSurveysUsageReport(ClickhouseDestroyTablesMixin, TestCase, ClickhouseT
         self.org_1_team_2 = Team.objects.create(pk=4, organization=self.org_1, name="Team 2 org 1")
         self.org_2_team_3 = Team.objects.create(pk=5, organization=self.org_2, name="Team 3 org 2")
 
-    @patch("posthog.tasks.usage_report.Client")
+    @patch("posthog.tasks.usage_report.get_ph_client")
     @patch("posthog.tasks.usage_report.send_report_to_billing_service")
     def test_usage_report_survey_responses(self, billing_task_mock: MagicMock, posthog_capture_mock: MagicMock) -> None:
         self._setup_teams()
@@ -1366,7 +1366,7 @@ class TestSurveysUsageReport(ClickhouseDestroyTablesMixin, TestCase, ClickhouseT
         assert org_2_report["survey_responses_count_in_period"] == 1
         assert org_2_report["teams"]["5"]["survey_responses_count_in_period"] == 1
 
-    @patch("posthog.tasks.usage_report.Client")
+    @patch("posthog.tasks.usage_report.get_ph_client")
     @patch("posthog.tasks.usage_report.send_report_to_billing_service")
     def test_survey_events_are_not_double_charged(
         self, billing_task_mock: MagicMock, posthog_capture_mock: MagicMock
@@ -1423,7 +1423,7 @@ class TestExternalDataSyncUsageReport(ClickhouseDestroyTablesMixin, TestCase, Cl
         self.org_1_team_2 = Team.objects.create(pk=4, organization=self.org_1, name="Team 2 org 1")
         self.org_2_team_3 = Team.objects.create(pk=5, organization=self.org_2, name="Team 3 org 2")
 
-    @patch("posthog.tasks.usage_report.Client")
+    @patch("posthog.tasks.usage_report.get_ph_client")
     @patch("posthog.tasks.usage_report.send_report_to_billing_service")
     def test_external_data_rows_synced_response(
         self, billing_task_mock: MagicMock, posthog_capture_mock: MagicMock
@@ -1481,7 +1481,7 @@ class TestExternalDataSyncUsageReport(ClickhouseDestroyTablesMixin, TestCase, Cl
         assert org_2_report["organization_name"] == "Org 2"
         assert org_2_report["rows_synced_in_period"] == 0
 
-    @patch("posthog.tasks.usage_report.Client")
+    @patch("posthog.tasks.usage_report.get_ph_client")
     @patch("posthog.tasks.usage_report.send_report_to_billing_service")
     def test_external_data_rows_synced_response_with_v2_jobs(
         self, billing_task_mock: MagicMock, posthog_capture_mock: MagicMock
@@ -1553,7 +1553,7 @@ class TestHogFunctionUsageReports(ClickhouseDestroyTablesMixin, TestCase, Clickh
         self.org_1_team_1 = Team.objects.create(pk=3, organization=self.org_1, name="Team 1 org 1")
         self.org_1_team_2 = Team.objects.create(pk=4, organization=self.org_1, name="Team 2 org 1")
 
-    @patch("posthog.tasks.usage_report.Client")
+    @patch("posthog.tasks.usage_report.get_ph_client")
     @patch("posthog.tasks.usage_report.send_report_to_billing_service")
     def test_hog_function_usage_metrics(self, billing_task_mock: MagicMock, posthog_capture_mock: MagicMock) -> None:
         self._setup_teams()
@@ -1597,7 +1597,7 @@ class TestErrorTrackingUsageReport(ClickhouseDestroyTablesMixin, TestCase, Click
         self.org_1_team_2 = Team.objects.create(pk=4, organization=self.org_1, name="Team 2 org 1")
         self.org_2_team_3 = Team.objects.create(pk=5, organization=self.org_2, name="Team 3 org 2")
 
-    @patch("posthog.tasks.usage_report.Client")
+    @patch("posthog.tasks.usage_report.get_ph_client")
     @patch("posthog.tasks.usage_report.send_report_to_billing_service")
     def test_posthog_exceptions_captured_response(
         self, billing_task_mock: MagicMock, posthog_capture_mock: MagicMock
@@ -1685,7 +1685,7 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
         self.org_1 = Organization.objects.create(name="Org 1")
         self.org_1_team_1 = Team.objects.create(pk=3, organization=self.org_1, name="Team 1 org 1")
 
-    @patch("posthog.tasks.usage_report.Client")
+    @patch("posthog.tasks.usage_report.get_ph_client")
     @patch("posthog.tasks.usage_report.send_report_to_billing_service")
     def test_llm_observability_usage_metrics(
         self, billing_task_mock: MagicMock, posthog_capture_mock: MagicMock
@@ -1853,7 +1853,7 @@ class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
         }
 
     @freeze_time("2021-10-10T23:01:00Z")
-    @patch("posthog.tasks.usage_report.Client")
+    @patch("posthog.tasks.usage_report.get_ph_client")
     @patch("requests.post")
     def test_send_usage(self, mock_post: MagicMock, mock_client: MagicMock) -> None:
         mockresponse = Mock()
@@ -1889,7 +1889,7 @@ class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
         )
 
     @freeze_time("2021-10-10T23:01:00Z")
-    @patch("posthog.tasks.usage_report.Client")
+    @patch("posthog.tasks.usage_report.get_ph_client")
     @patch("requests.post")
     def test_send_usage_cloud(self, mock_post: MagicMock, mock_client: MagicMock) -> None:
         with self.is_cloud(True):
@@ -1934,7 +1934,7 @@ class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
     @freeze_time("2021-10-10T23:01:00Z")
     @patch("posthog.tasks.usage_report.capture_exception")
     @patch("posthog.tasks.usage_report.sync_execute", side_effect=Exception())
-    @patch("posthog.tasks.usage_report.Client")
+    @patch("posthog.tasks.usage_report.get_ph_client")
     @patch("requests.post")
     def test_send_usage_cloud_exception(
         self,
@@ -1955,7 +1955,7 @@ class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
         assert mock_capture_exception.call_count == 1
 
     @freeze_time("2021-10-10T23:01:00Z")
-    @patch("posthog.tasks.usage_report.Client")
+    @patch("posthog.tasks.usage_report.get_ph_client")
     @patch("requests.post")
     def test_send_usage_billing_service_not_reachable(self, mock_post: MagicMock, mock_client: MagicMock) -> None:
         with pytest.raises(Exception):
@@ -1979,7 +1979,7 @@ class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
             )
 
     @freeze_time("2021-10-10T23:01:00Z")
-    @patch("posthog.tasks.usage_report.Client")
+    @patch("posthog.tasks.usage_report.get_ph_client")
     @patch("requests.post")
     def test_org_usage_updated_correctly(self, mock_post: MagicMock, mock_client: MagicMock) -> None:
         mockresponse = Mock()
@@ -2001,7 +2001,7 @@ class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
             "period": ["2021-10-01T00:00:00Z", "2021-10-31T00:00:00Z"],
         }
 
-    @patch("posthog.tasks.usage_report.Client")
+    @patch("posthog.tasks.usage_report.get_ph_client")
     def test_capture_event_called_with_string_timestamp(self, mock_client: MagicMock) -> None:
         organization = Organization.objects.create()
         mock_posthog = MagicMock()
@@ -2015,7 +2015,7 @@ class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
         )
         assert mock_client.capture.call_args[1]["timestamp"] == datetime(2021, 10, 10, 23, 1, tzinfo=tzutc())
 
-    @patch("posthog.tasks.usage_report.Client")
+    @patch("posthog.tasks.usage_report.get_ph_client")
     def test_capture_report_transforms_team_id_to_org_id(self, mock_client: MagicMock) -> None:
         mock_posthog = MagicMock()
         mock_client.return_value = mock_posthog
@@ -2064,7 +2064,7 @@ class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
 
 class SendNoUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest):
     @freeze_time("2021-10-10T23:01:00Z")
-    @patch("posthog.tasks.usage_report.Client")
+    @patch("posthog.tasks.usage_report.get_ph_client")
     @patch("requests.post")
     def test_usage_not_sent_if_zero(self, mock_post: MagicMock, mock_client: MagicMock) -> None:
         mock_posthog = MagicMock()
@@ -2077,7 +2077,7 @@ class SendNoUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTe
 
 class SendUsageNoLicenseTest(APIBaseTest):
     @freeze_time("2021-10-10T23:01:00Z")
-    @patch("posthog.tasks.usage_report.Client")
+    @patch("posthog.tasks.usage_report.get_ph_client")
     @patch("requests.post")
     def test_no_license(self, mock_post: MagicMock, mock_client: MagicMock) -> None:
         TEST_clear_instance_license_cache()

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -291,7 +291,7 @@ def get_org_user_count(organization_id: str) -> int:
 
 
 @cached(cache={})
-def get_ph_client(*args, **kwargs) -> PostHogClient:
+def get_ph_client(*args: Any, **kwargs: Any) -> PostHogClient:
     return PostHogClient("sTMFPsFhdP1Ssg", *args, **kwargs)
 
 

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -808,31 +808,30 @@ def capture_report(
     at_date: Optional[datetime] = None,
     send_for_all_members: bool = False,
 ) -> None:
-    return
-    # if not org_id and not team_id:
-    #     raise ValueError("Either org_id or team_id must be provided")
-    # pha_client = get_ph_client(sync_mode=True)
-    # try:
-    #     capture_event(
-    #         pha_client=pha_client,
-    #         name=capture_event_name,
-    #         organization_id=org_id,
-    #         team_id=team_id,
-    #         properties=full_report_dict,
-    #         timestamp=at_date,
-    #     )
-    #     logger.info(f"UsageReport sent to PostHog for organization {org_id}")
-    # except Exception as err:
-    #     logger.exception(
-    #         f"UsageReport sent to PostHog for organization {org_id} failed: {str(err)}",
-    #     )
-    #     capture_event(
-    #         pha_client=pha_client,
-    #         name=f"{capture_event_name} failure",
-    #         organization_id=org_id,
-    #         team_id=team_id,
-    #         properties={"error": str(err)},
-    #     )
+    if not org_id and not team_id:
+        raise ValueError("Either org_id or team_id must be provided")
+    pha_client = get_ph_client(sync_mode=True)
+    try:
+        capture_event(
+            pha_client=pha_client,
+            name=capture_event_name,
+            organization_id=org_id,
+            team_id=team_id,
+            properties=full_report_dict,
+            timestamp=at_date,
+        )
+        logger.info(f"UsageReport sent to PostHog for organization {org_id}")
+    except Exception as err:
+        logger.exception(
+            f"UsageReport sent to PostHog for organization {org_id} failed: {str(err)}",
+        )
+        capture_event(
+            pha_client=pha_client,
+            name=f"{capture_event_name} failure",
+            organization_id=org_id,
+            team_id=team_id,
+            properties={"error": str(err)},
+        )
 
 
 # extend this with future usage based products

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -7,12 +7,13 @@ from typing import Any, Literal, Optional, TypedDict, Union
 
 import requests
 import structlog
+from cachetools import cached
 from celery import shared_task
 from dateutil import parser
 from django.conf import settings
 from django.db import connection
 from django.db.models import Count, Q, Sum
-from posthoganalytics.client import Client
+from posthoganalytics.client import Client as PostHogClient
 from psycopg import sql
 from retry import retry
 from posthog.exceptions_capture import capture_exception
@@ -289,6 +290,11 @@ def get_org_user_count(organization_id: str) -> int:
     return OrganizationMembership.objects.filter(organization_id=organization_id).count()
 
 
+@cached(cache={})
+def get_ph_client(*args, **kwargs) -> PostHogClient:
+    return PostHogClient("sTMFPsFhdP1Ssg", *args, **kwargs)
+
+
 @shared_task(**USAGE_REPORT_TASK_KWARGS, max_retries=3, rate_limit="5/s")
 def send_report_to_billing_service(org_id: str, report: dict[str, Any]) -> None:
     if not settings.EE_AVAILABLE:
@@ -333,9 +339,8 @@ def send_report_to_billing_service(org_id: str, report: dict[str, Any]) -> None:
             f"[Send Usage Report To Billing] Usage Report failed sending to Billing for organization: {org_id}: {err}"
         )
         capture_exception(err)
-        pha_client = Client("sTMFPsFhdP1Ssg", sync_mode=True)
         capture_event(
-            pha_client=pha_client,
+            pha_client=get_ph_client(sync_mode=True),
             name=f"organization usage report to billing service failure",
             organization_id=org_id,
             properties={"err": str(err)},
@@ -806,7 +811,7 @@ def capture_report(
     return
     # if not org_id and not team_id:
     #     raise ValueError("Either org_id or team_id must be provided")
-    # pha_client = Client("sTMFPsFhdP1Ssg", sync_mode=True)
+    # pha_client = get_ph_client(sync_mode=True)
     # try:
     #     capture_event(
     #         pha_client=pha_client,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -175,6 +175,10 @@ googleapis-common-protos==1.60.0
     # via
     #   -c requirements.txt
     #   opentelemetry-exporter-otlp-proto-grpc
+greenlet==3.1.1
+    # via
+    #   -c requirements.txt
+    #   sqlalchemy
 grpcio==1.63.2
     # via
     #   -c requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -126,3 +126,4 @@ tenacity~=8.4.2  # Version constrained so that `deepeval` can be installed in in
 markdown-it-py~=3.0.0
 tzlocal~=5.1
 cohere==5.14.0
+types-cachetools==5.5.0.20240820

--- a/requirements.txt
+++ b/requirements.txt
@@ -341,6 +341,8 @@ graphql-core==3.2.5
     #   graphql-relay
 graphql-relay==3.2.0
     # via graphene
+greenlet==3.1.1
+    # via sqlalchemy
 grpcio==1.63.2
     # via
     #   -r requirements.in
@@ -913,6 +915,8 @@ trio==0.26.0
     #   trio-websocket
 trio-websocket==0.11.1
     # via selenium
+types-cachetools==5.5.0.20240820
+    # via -r requirements.in
 types-protobuf==4.22.0.0
     # via temporalio
 types-requests==2.31.0.6


### PR DESCRIPTION
## Problem

No need to recreate a client all the time.

## Changes

Add get_posthog_client and cache result.

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Run.
