### PR TITLE
feat(data-warehouse): Optimised merged for numerical primary keys

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/utils.py
@@ -6,7 +6,7 @@ import json
 import math
 import uuid
 from collections.abc import Iterator, Sequence
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 import deltalake as deltalake
 import numpy as np
@@ -301,15 +301,27 @@ def append_partition_key_to_table(
 
     partition_array: list[str] = []
 
+    mode: Literal["md5"] | Literal["numerical"] = "md5"
+
+    # If there is only one primary key and it's a numerical ID, then bucket by the ID itself instead of hashing it
+    if len(normalized_primary_keys) == 1 and pa.types.is_integer(table.field(normalized_primary_keys[0]).type):
+        mode = "numerical"
+
     for batch in table.to_batches():
         for row in batch.to_pylist():
-            primary_key_values = [str(row[key]) for key in normalized_primary_keys]
-            delimited_primary_key_value = "|".join(primary_key_values)
+            if mode == "md5":
+                primary_key_values = [str(row[key]) for key in normalized_primary_keys]
+                delimited_primary_key_value = "|".join(primary_key_values)
 
-            hash_value = int(hashlib.md5(delimited_primary_key_value.encode()).hexdigest(), 16)
-            partition = hash_value % partition_count
+                hash_value = int(hashlib.md5(delimited_primary_key_value.encode()).hexdigest(), 16)
+                partition = hash_value % partition_count
 
-            partition_array.append(str(partition))
+                partition_array.append(str(partition))
+            else:
+                key = normalized_primary_keys[0]
+                partition = row[key] % partition_count
+
+                partition_array.append(str(partition))
 
     new_column = pa.array(partition_array, type=pa.string())
     logger.debug(f"Partition key added")

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -1477,7 +1477,8 @@ async def test_partition_folders_with_int_id(team, postgres_config, postgres_con
 
     s3_objects = await minio_client.list_objects_v2(Bucket=BUCKET_NAME, Prefix=f"{folder_path}/test_partition_folders/")
 
-    assert any(PARTITION_KEY in obj["Key"] for obj in s3_objects["Contents"])
+    # Using numerical primary key causes partitions not be md5'd
+    assert any(f"{PARTITION_KEY}=0" in obj["Key"] for obj in s3_objects["Contents"])
 
     schema = await ExternalDataSchema.objects.aget(id=inputs.external_data_schema_id)
     assert schema.partitioning_enabled is True


### PR DESCRIPTION
## Problem
- On a large table, the partitions are equally distributed throughout the data, meaning on any merge, we'll likely have to merge into _every_ partition

## Changes
- Because a lot of tables have incrementing integer primary keys, we can optimise the partitioning logic so that we're bucketing by ID ranges instead of using hashes. This means newer data will be constrained to far fewer partitions and thus be able to merge data much faster. 


- It would be nice to figure out a way to do this for all primary key types, as currently having to merge into every partition kinda defeats the purpose of using merging, but at least it merges sequentially and so we shouldn't OOM

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Updated test