### PR TITLE
fix(data-warehouse): Always delete via s3

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -98,7 +98,10 @@ class DeltaTableHelper:
         delta_uri = self._get_delta_table_uri()
 
         s3 = get_s3_client()
-        s3.delete(delta_uri, recursive=True)
+        try:
+            s3.delete(delta_uri, recursive=True)
+        except FileNotFoundError:
+            pass
 
         self.get_delta_table.cache_clear()
 

--- a/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -96,18 +96,20 @@ class DeltaTableHelper:
 
     def reset_table(self):
         table = self.get_delta_table()
-        if table is None:
-            return
+
+        if table is not None:
+            table.delete()
+        else:
+            self._logger.debug("reset_table: Table does not exist. Continuing to delete via S3")
 
         delta_uri = self._get_delta_table_uri()
-
-        table.delete()
 
         s3 = get_s3_client()
         s3.delete(delta_uri, recursive=True)
 
         self.get_delta_table.cache_clear()
 
+        self._logger.debug("reset_table: _is_first_sync=True")
         self._is_first_sync = True
 
     def write_to_deltalake(

--- a/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -95,13 +95,6 @@ class DeltaTableHelper:
         return None
 
     def reset_table(self):
-        table = self.get_delta_table()
-
-        if table is not None:
-            table.delete()
-        else:
-            self._logger.debug("reset_table: Table does not exist. Continuing to delete via S3")
-
         delta_uri = self._get_delta_table_uri()
 
         s3 = get_s3_client()

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -1224,7 +1224,6 @@ async def test_postgres_nan_numerical_values(team, postgres_config, postgres_con
 @pytest.mark.asyncio
 async def test_delete_table_on_reset(team, stripe_balance_transaction):
     with (
-        mock.patch.object(DeltaTable, "delete") as mock_delta_table_delete,
         mock.patch.object(s3fs.S3FileSystem, "delete") as mock_s3_delete,
     ):
         workflow_id, inputs = await _run(
@@ -1246,7 +1245,6 @@ async def test_delete_table_on_reset(team, stripe_balance_transaction):
 
         await _execute_run(str(uuid.uuid4()), inputs, stripe_balance_transaction["data"])
 
-    mock_delta_table_delete.assert_called()
     mock_s3_delete.assert_called()
 
     await sync_to_async(schema.refresh_from_db)()


### PR DESCRIPTION
## Problem
- `self.get_delta_table()` can return `None` if the deltalake table is in a bad shape, the parsing of the delta table from the rust lib is very fragile, causing us to try to create a new table when the old one still technically exists on disk
- [sentry error](https://posthog.sentry.io/issues/6193508865/?project=4508444747956225&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=1)

## Changes
- There's no need to delete the table via deltalake `DELETE` command **AND** then delete all the S3 files anway, may as well just run the s3 delete

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Local testing + unit test