### PR TITLE
fix: dark mode for dashboard templates

### DIFF
--- a/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateVariables.tsx
+++ b/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateVariables.tsx
@@ -327,7 +327,7 @@ export function DashboardTemplateVariables({
                             iframeRef={iframeRef}
                         />
                     ),
-                    className: 'p-4 bg-white',
+                    className: 'p-4 bg-primary',
                     onHeaderClick: () => {
                         setActiveVariableIndex(i)
                         disableElementSelector()


### PR DESCRIPTION
## Problem

Couldn't see anything in the onboarding dashboard templates step due to dark mode

## Changes

Fix the dark mode

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Ran locally
