### PR TITLE
feat: Added instrumented tracking for fetch calls

### DIFF
--- a/plugin-server/src/cdp/services/hog-function-monitoring.service.ts
+++ b/plugin-server/src/cdp/services/hog-function-monitoring.service.ts
@@ -110,6 +110,10 @@ export class HogFunctionMonitoringService {
                             }))
                         )
 
+                        if (result.metrics) {
+                            this.produceAppMetrics(result.metrics)
+                        }
+
                         // Clear the logs so we don't pass them on to the next invocation
                         result.logs = []
 

--- a/plugin-server/src/cdp/services/legacy-plugin-executor.service.ts
+++ b/plugin-server/src/cdp/services/legacy-plugin-executor.service.ts
@@ -121,6 +121,7 @@ export class LegacyPluginExecutorService {
             finished: true,
             capturedPostHogEvents: [],
             logs: [],
+            metrics: [],
         }
 
         const addLog = (level: 'debug' | 'warn' | 'error' | 'info', ...args: any[]) => {
@@ -222,6 +223,14 @@ export class LegacyPluginExecutorService {
                     addLog('info', 'Fetch called but mocked due to test function', {
                         url: args[0],
                         method,
+                    })
+
+                    result.metrics!.push({
+                        team_id: invocation.hogFunction.team_id,
+                        app_source_id: invocation.hogFunction.id,
+                        metric_kind: 'other',
+                        metric_name: 'fetch',
+                        count: 1,
                     })
                     // Simulate a mini bit of fetch delay
                     await new Promise((resolve) => setTimeout(resolve, 200))

--- a/plugin-server/src/cdp/types.ts
+++ b/plugin-server/src/cdp/types.ts
@@ -232,6 +232,7 @@ export type HogFunctionInvocationResult = {
     error?: any
     // asyncFunctionRequest?: HogFunctionAsyncFunctionRequest
     logs: LogEntry[]
+    metrics?: HogFunctionAppMetric[]
     capturedPostHogEvents?: HogFunctionCapturedEvent[]
     execResult?: unknown
 }

--- a/plugin-server/src/utils/fetch.ts
+++ b/plugin-server/src/utils/fetch.ts
@@ -11,6 +11,7 @@ import { URL } from 'url'
 
 export type { Response }
 
+import { runInstrumentedFunction } from '../main/utils'
 import { isProdEnv } from './env-utils'
 import { runInSpan } from './sentry'
 
@@ -54,7 +55,11 @@ export async function trackedFetch(url: RequestInfo, init?: RequestInit): Promis
                             : new https.Agent({ lookup: staticLookup }),
                 })
             }
-            return await fetch(url, init)
+
+            return runInstrumentedFunction({
+                statsKey: 'trackedFetch',
+                func: () => fetch(url, init),
+            })
         }
     )
 }


### PR DESCRIPTION
## Problem

I want to know how long fetch calls take as well as how many a legacy plugin did.

## Changes

* Instruments fetch
* Adds support for pulling metrics off of an invocation result
* Adds fetch metrics


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
