### PR TITLE
feat: add admin button for quota limiting

### DIFF
--- a/posthog/admin/admins/organization_admin.py
+++ b/posthog/admin/admins/organization_admin.py
@@ -9,6 +9,7 @@ from posthog.admin.inlines.team_inline import TeamInline
 from posthog.admin.paginators.no_count_paginator import NoCountPaginator
 from django.utils import timezone
 from datetime import timedelta
+from posthog.tasks.tasks import run_quota_limiting
 
 from posthog.models.organization import Organization
 from django.urls import path
@@ -97,6 +98,11 @@ class OrganizationAdmin(admin.ModelAdmin):
                 "send-usage-report/", self.admin_site.admin_view(self.send_usage_report_view), name="send-usage-report"
             ),
             path(
+                "run-quota-limiting/",
+                self.admin_site.admin_view(self.run_quota_limiting_view),
+                name="run-quota-limiting",
+            ),
+            path(
                 "<str:organization_id>/run-rbac-team-migration/",
                 self.admin_site.admin_view(self.run_rbac_team_migration),
                 name="run-rbac-team-migration",
@@ -126,9 +132,22 @@ class OrganizationAdmin(admin.ModelAdmin):
 
         return render(request, "admin/posthog/organization/send_usage_report.html", {"form": form})
 
+    def run_quota_limiting_view(self, request):
+        if not request.user.groups.filter(name="Billing Team").exists():
+            messages.error(request, "You are not authorized to run quota limiting.")
+            return redirect(reverse("admin:posthog_organization_changelist"))
+
+        if request.method == "POST":
+            run_quota_limiting.delay()
+            messages.success(request, "Quota limiting process has been initiated.")
+            return redirect(reverse("admin:posthog_organization_changelist"))
+
+        return render(request, "admin/posthog/organization/run_quota_limiting.html", {})
+
     def changelist_view(self, request, extra_context=None):
         extra_context = extra_context or {}
         extra_context["show_usage_report_button"] = True
+        extra_context["show_run_quota_limiting_button"] = True
         return super().changelist_view(request, extra_context=extra_context)
 
     def run_rbac_team_migration(self, request, organization_id):

--- a/posthog/templates/admin/posthog/organization/change_list.html
+++ b/posthog/templates/admin/posthog/organization/change_list.html
@@ -7,5 +7,10 @@
             <a href="{% url 'admin:send-usage-report' %}">Send Usage Report</a>
         </li>
     {% endif %}
+    {% if show_run_quota_limiting_button %}
+        <li>
+            <a href="{% url 'admin:run-quota-limiting' %}">Run Quota Limiting</a>
+        </li>
+    {% endif %}
     {{ block.super }}
 {% endblock %}

--- a/posthog/templates/admin/posthog/organization/run_quota_limiting.html
+++ b/posthog/templates/admin/posthog/organization/run_quota_limiting.html
@@ -1,0 +1,14 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls %}
+
+{% block content %}
+<div id="content-main">
+    <form method="post">
+        <p>This will run the quota limiting process for all organizations.</p>
+        {% csrf_token %}
+        <div class="submit-row">
+            <input type="submit" value="Run Quota Limiting" class="default" name="_run_quota_limiting">
+        </div>
+    </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Changes

Adding a button to run quota limiting. This will allow us to run it manually. 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

N/A
