### PR TITLE
fix: add the sectionId to the heatmaps setting panel

### DIFF
--- a/frontend/src/scenes/heatmaps/HeatmapsBrowser.tsx
+++ b/frontend/src/scenes/heatmaps/HeatmapsBrowser.tsx
@@ -341,7 +341,7 @@ function Warnings(): JSX.Element | null {
             action={{
                 type: 'secondary',
                 icon: <IconGear />,
-                onClick: () => openSettingsPanel({ settingId: 'heatmaps' }),
+                onClick: () => openSettingsPanel({ sectionId: 'environment-autocapture', settingId: 'heatmaps' }),
                 children: 'Configure',
             }}
             dismissKey="heatmaps-might-be-disabled-warning"


### PR DESCRIPTION
## Problem

During an onboarding call with a user they were trying to enable heatmaps, but the prompt to turn it on led them to a settings page where they couldn't see that setting

## Changes

Show the heatmaps setting when it opens

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Ran it locally
