### PR TITLE
fix: chunking remove increment in the timestamp

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.test.ts
@@ -478,7 +478,7 @@ describe('sessionRecordingDataLogic', () => {
 
             // Middle chunk
             expect(chunks[1]).toMatchObject({
-                timestamp: 1001,
+                timestamp: 1000,
                 data: {
                     adds: expect.arrayContaining([expect.any(Object)]),
                     removes: [],
@@ -490,7 +490,7 @@ describe('sessionRecordingDataLogic', () => {
 
             // Last chunk
             expect(chunks[2]).toMatchObject({
-                timestamp: 1002,
+                timestamp: 1000,
                 data: {
                     adds: expect.arrayContaining([expect.any(Object)]),
                     removes: [],
@@ -509,7 +509,7 @@ describe('sessionRecordingDataLogic', () => {
 
             expect(chunks.length).toBe(2)
             expect(chunks[0].delay).toBe(100)
-            expect(chunks[1].delay).toBe(101)
+            expect(chunks[1].delay).toBe(100)
         })
 
         it('does not chunk non-mutation snapshots', () => {

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -236,7 +236,7 @@ export function chunkMutationSnapshot(snapshot: RecordingSnapshot): RecordingSna
 
         const chunkSnapshot: RecordingSnapshot = {
             ...snapshot,
-            timestamp: snapshot.timestamp + i, // Just increment by 1ms for each chunk
+            timestamp: snapshot.timestamp,
             data: {
                 ...snapshot.data,
                 adds: adds.slice(startIdx, endIdx),
@@ -250,7 +250,7 @@ export function chunkMutationSnapshot(snapshot: RecordingSnapshot): RecordingSna
 
         // If delay was present in the original snapshot, increment it by 1 for each chunk
         if ('delay' in snapshot) {
-            chunkSnapshot.delay = (snapshot.delay || 0) + i
+            chunkSnapshot.delay = snapshot.delay || 0
         }
 
         chunks.push(chunkSnapshot)


### PR DESCRIPTION
Removing the timestamp increment in the chunking method to prevent conflicts when multiple large chunks arrive consecutively.