### PR TITLE
fix(max): trends prompt on date ranges and intervals

### DIFF
--- a/ee/hogai/eval/tests/test_eval_trends_generator.py
+++ b/ee/hogai/eval/tests/test_eval_trends_generator.py
@@ -84,21 +84,23 @@ def test_current_date(call_node):
 
 
 @pytest.mark.parametrize(
-    "query, expected_interval",
+    "query,expected_interval",
     [
-        ("$pageview trends for the last 10 years", "month"),
-        ("$pageview trends for the last 90 days", "week"),
-        ("$pageview trends for the last 45 days", "day"),
+        ("the last five years", "month"),
+        ("the last 80 days", "week"),
+        ("the last four weeks", "week"),
+        ("the last 15 days", "day"),
+        ("the last 12 hours", "hour"),
     ],
 )
 def test_granularity(call_node, query, expected_interval):
-    plan = """Series:
+    plan = f"""Series:
     - event: $pageview
         - math operation: total count
 
-    Time period: last 10 years
+    Time period: {query}
     """
-    query = call_node(query, plan)
+    query = call_node(f"$pageview trends for {query}", plan)
     assert query.interval == expected_interval
 
 

--- a/ee/hogai/eval/tests/test_eval_trends_generator.py
+++ b/ee/hogai/eval/tests/test_eval_trends_generator.py
@@ -129,7 +129,7 @@ def test_sets_default_30_days(call_node):
     test_case = LLMTestCase(
         input=query,
         expected_output="Last 30 days",
-        actual_output=schema.dateRange.model_dump_json(exclude_none=True) if schema.dateRange else "",
+        actual_output=schema.dateRange.model_dump_json(exclude_none=True),
     )
 
     assert_test(test_case, [date_metric])

--- a/ee/hogai/trends/prompts.py
+++ b/ee/hogai/trends/prompts.py
@@ -145,8 +145,8 @@ Use the time period from the plan. Otherwise, use the last 30 days if the user's
 Use the following default interval (granularity) unless the user has specified otherwise:
 - If the date range is less than a few days, use `hour` interval.
 - If the date range is less than a month, use `day` interval.
-- If the date range is less than three months, use `week` interval.
-- If the date range is more than three months, use `month` interval.
+- If the date range is less than a few months, use `week` interval.
+- Otherwise, use `month` interval.
 </visualization_interval>
 
 ## Schema Examples

--- a/ee/hogai/trends/prompts.py
+++ b/ee/hogai/trends/prompts.py
@@ -137,12 +137,25 @@ The user might want to get insights for groups. A group aggregates events based 
 
 You can determine if a feature flag is enabled by checking if it's set to true or 1 in the `$feature/...` property. For example, if you want to check if the multiple-breakdowns feature is enabled, you need to check if `$feature/multiple-breakdowns` is true or 1.
 
+<date_range>
+Use the time period from the plan. Otherwise, use the last 30 days if the user's question doesn't specify a time period. For example, the question "How many users do I have?" doesn't specify a time period, so use the default.
+</date_range>
+
+<visualization_interval>
+Use the following default interval (granularity) unless the user has specified otherwise:
+- If the date range is less than a few days, use `hour` interval.
+- If the date range is less than a month, use `day` interval.
+- If the date range is less than three months, use `week` interval.
+- If the date range is more than three months, use `month` interval.
+</visualization_interval>
+
 ## Schema Examples
 
 ### How many users do I have?
 
 ```
-{"dateRange":{"date_from":"all"},"interval":"month","kind":"TrendsQuery","series":[{"event":"user signed up","kind":"EventsNode","math":"total"}],"trendsFilter":{"display":"BoldNumber"}}
+
+{"dateRange":{"date_from":"-30d"},"interval":"month","kind":"TrendsQuery","series":[{"event":"user signed up","kind":"EventsNode","math":"total"}],"trendsFilter":{"display":"BoldNumber"}}
 ```
 
 ### Show a bar chart of the organic search traffic for the last month grouped by week.

--- a/ee/hogai/trends/prompts.py
+++ b/ee/hogai/trends/prompts.py
@@ -143,9 +143,9 @@ Use the time period from the plan. Otherwise, use the last 30 days if the user's
 
 <visualization_interval>
 Use the following default interval (granularity) unless the user has specified otherwise:
-- If the date range is less than a few days, use `hour` interval.
+- If the date range is less than two days, use `hour` interval.
 - If the date range is less than a month, use `day` interval.
-- If the date range is less than a few months, use `week` interval.
+- If the date range is less than three months, use `week` interval.
 - Otherwise, use `month` interval.
 </visualization_interval>
 


### PR DESCRIPTION
## Problem

Common feedback from users is that date filters in trends are sometimes inaccurate.

## Changes

Add additional prompts on date ranges and intervals.

## Does this work well for both Cloud and self-hosted?

No

## How did you test this code?

Evals and manual testing.
