### PR TITLE
chore: limit kill query execution time

### DIFF
--- a/posthog/clickhouse/cancel.py
+++ b/posthog/clickhouse/cancel.py
@@ -21,7 +21,7 @@ def cancel_query_on_cluster(team_id: int, client_query_id: str) -> None:
             """,
             {"client_query_id": f"{team_id}_{client_query_id}%"},
         )
-        initiator_host, query_id = result[0] if result else None
+        initiator_host, query_id = result[0] if result else (None, None)
     except Exception as e:
         logger.info("Failed to find initiator host for query %s: %s", client_query_id, e)
         statsd.incr("clickhouse.query.cancellation.no_initiator_host", tags={"team_id": team_id})

--- a/posthog/clickhouse/cancel.py
+++ b/posthog/clickhouse/cancel.py
@@ -10,29 +10,32 @@ from posthog.settings import CLICKHOUSE_CLUSTER
 def cancel_query_on_cluster(team_id: int, client_query_id: str) -> None:
     initiator_host = None
 
+    statsd.incr("clickhouse.query.cancellation.requested", tags={"team_id": team_id})
     try:
         result = sync_execute(
             f"""
-            SELECT hostname()
+            SELECT hostname(), query_id
             FROM clusterAllReplicas(posthog, system.processes)
             WHERE query_id LIKE %(client_query_id)s
-            SETTINGS max_execution_time = 5
+            SETTINGS max_execution_time = 2
             """,
             {"client_query_id": f"{team_id}_{client_query_id}%"},
         )
-        initiator_host = result[0][0] if result else None
+        initiator_host, query_id = result[0] if result else None
     except Exception as e:
         logger.info("Failed to find initiator host for query %s: %s", client_query_id, e)
+        statsd.incr("clickhouse.query.cancellation.no_initiator_host", tags={"team_id": team_id})
 
     if initiator_host:
         logger.debug("Found initiator host for query %s, cancelling query on host", initiator_host, client_query_id)
         with default_client(host=initiator_host) as client:
             result = sync_execute(
-                f"KILL QUERY WHERE query_id LIKE %(client_query_id)s",
-                {"client_query_id": f"{team_id}_{client_query_id}%"},
+                f"KILL QUERY WHERE query_id=%(query_id)s SETTINGS max_execution_time = 5",
+                {"query_id": query_id},
                 sync_client=client,
             )
         logger.info("Cancelled query %s for team %s, result: %s", client_query_id, team_id, result)
+        statsd.incr("clickhouse.query.cancellation.ok", tags={"team_id": team_id})
     elif settings.CLICKHOUSE_FALLBACK_CANCEL_QUERY_ON_CLUSTER:
         logger.debug("No initiator host found for query %s, cancelling query on cluster", client_query_id)
         result = sync_execute(
@@ -40,5 +43,4 @@ def cancel_query_on_cluster(team_id: int, client_query_id: str) -> None:
             {"client_query_id": f"{team_id}_{client_query_id}%"},
         )
         logger.info("Cancelled query %s for team %s, result: %s", client_query_id, team_id, result)
-
-    statsd.incr("clickhouse.query.cancellation_requested", tags={"team_id": team_id})
+        statsd.incr("clickhouse.query.cancellation.on_cluster", tags={"team_id": team_id})

--- a/posthog/clickhouse/cancel.py
+++ b/posthog/clickhouse/cancel.py
@@ -13,7 +13,7 @@ def cancel_query_on_cluster(team_id: int, client_query_id: str) -> None:
     statsd.incr("clickhouse.query.cancellation.requested", tags={"team_id": team_id})
     try:
         result = sync_execute(
-            f"""
+            """
             SELECT hostname(), query_id
             FROM clusterAllReplicas(posthog, system.processes)
             WHERE query_id LIKE %(client_query_id)s
@@ -30,7 +30,7 @@ def cancel_query_on_cluster(team_id: int, client_query_id: str) -> None:
         logger.debug("Found initiator host for query %s, cancelling query on host", initiator_host, client_query_id)
         with default_client(host=initiator_host) as client:
             result = sync_execute(
-                f"KILL QUERY WHERE query_id=%(query_id)s SETTINGS max_execution_time = 5",
+                "KILL QUERY WHERE query_id=%(query_id)s SETTINGS max_execution_time = 5",
                 {"query_id": query_id},
                 sync_client=client,
             )


### PR DESCRIPTION
## Problem

Sometimes canceling query gets stuck

## Changes

* limit time for getting the initiator node, it should be instant.
* limit how long it may take to kill a query on initiator node
* add extra statsd counters

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Run locally