### PR TITLE
feat: store event count in session metadata

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.test.ts
@@ -1343,6 +1343,91 @@ describe('SessionBatchRecorder', () => {
             const batchId = mockMetadataStore.storeSessionBlocks.mock.calls[0][0][0].batchId
             expect(uuidValidate(batchId)).toBe(true)
         })
+
+        it('should store event counts from session block recorders', async () => {
+            const messages = [
+                createMessage('session1', [
+                    {
+                        type: EventType.FullSnapshot,
+                        timestamp: 1000,
+                        data: { source: 1 },
+                    },
+                    {
+                        type: EventType.IncrementalSnapshot,
+                        timestamp: 2000,
+                        data: { source: 2 },
+                    },
+                ]),
+                createMessage('session2', [
+                    {
+                        type: EventType.Meta,
+                        timestamp: 1500,
+                        data: { href: 'https://example.com' },
+                    },
+                ]),
+            ]
+
+            for (const message of messages) {
+                await recorder.record(message)
+            }
+            await recorder.flush()
+
+            expect(mockMetadataStore.storeSessionBlocks).toHaveBeenCalledWith(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        sessionId: 'session1',
+                        eventCount: 2,
+                    }),
+                    expect.objectContaining({
+                        sessionId: 'session2',
+                        eventCount: 1,
+                    }),
+                ])
+            )
+        })
+
+        it('should reset event counts after flush', async () => {
+            const message1 = createMessage('session1', [
+                {
+                    type: EventType.FullSnapshot,
+                    timestamp: 1000,
+                    data: { source: 1 },
+                },
+                {
+                    type: EventType.IncrementalSnapshot,
+                    timestamp: 2000,
+                    data: { source: 2 },
+                },
+            ])
+
+            await recorder.record(message1)
+            await recorder.flush()
+
+            expect(mockMetadataStore.storeSessionBlocks).toHaveBeenLastCalledWith([
+                expect.objectContaining({
+                    sessionId: 'session1',
+                    eventCount: 2,
+                }),
+            ])
+
+            const message2 = createMessage('session1', [
+                {
+                    type: EventType.Meta,
+                    timestamp: 3000,
+                    data: { href: 'https://example.com' },
+                },
+            ])
+
+            await recorder.record(message2)
+            await recorder.flush()
+
+            expect(mockMetadataStore.storeSessionBlocks).toHaveBeenLastCalledWith([
+                expect.objectContaining({
+                    sessionId: 'session1',
+                    eventCount: 1,
+                }),
+            ])
+        })
     })
 
     describe('error handling', () => {

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.ts
@@ -218,6 +218,7 @@ export class SessionBatchRecorder {
                         snapshotSource,
                         snapshotLibrary,
                         batchId,
+                        eventCount,
                     })
 
                     totalEvents += eventCount

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-block-metadata.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-block-metadata.ts
@@ -21,6 +21,8 @@ export interface SessionBlockMetadata {
     firstUrl: string | null
     /** All URLs visited in the session */
     urls: string[]
+    /** Number of events in the session */
+    eventCount: number
     /** Number of click events in the session */
     clickCount: number
     /** Number of keypress events in the session */

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-metadata-store.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-metadata-store.test.ts
@@ -24,6 +24,7 @@ describe('SessionMetadataStore', () => {
                 distinctId: 'user1',
                 batchId: 'batch123',
                 blockLength: 100,
+                eventCount: 25,
                 startDateTime: DateTime.fromISO('2025-01-01T10:00:00.000Z'),
                 endDateTime: DateTime.fromISO('2025-01-01T10:00:02.000Z'),
                 blockUrl: 's3://bucket/file1?range=bytes=0-99',
@@ -47,6 +48,7 @@ describe('SessionMetadataStore', () => {
                 distinctId: 'user2',
                 batchId: 'batch123',
                 blockLength: 150,
+                eventCount: 15,
                 startDateTime: DateTime.fromISO('2025-01-01T10:00:01.500Z'),
                 endDateTime: DateTime.fromISO('2025-01-01T10:00:03.500Z'),
                 blockUrl: 's3://bucket/file1?range=bytes=100-249',
@@ -70,6 +72,7 @@ describe('SessionMetadataStore', () => {
                 distinctId: 'user1',
                 batchId: 'batch123',
                 blockLength: 200,
+                eventCount: 35,
                 startDateTime: DateTime.fromISO('2025-01-01T10:00:03.000Z'),
                 endDateTime: DateTime.fromISO('2025-01-01T10:00:05.000Z'),
                 blockUrl: 's3://bucket/file1?range=bytes=250-449',
@@ -120,6 +123,7 @@ describe('SessionMetadataStore', () => {
                 message_count: 50,
                 snapshot_source: 'web',
                 snapshot_library: 'rrweb@1.0.0',
+                event_count: 25,
             },
             {
                 uuid: expect.any(String),
@@ -143,6 +147,7 @@ describe('SessionMetadataStore', () => {
                 message_count: 30,
                 snapshot_source: 'web',
                 snapshot_library: 'rrweb@1.0.0',
+                event_count: 15,
             },
             {
                 uuid: expect.any(String),
@@ -166,6 +171,7 @@ describe('SessionMetadataStore', () => {
                 message_count: 70,
                 snapshot_source: 'web',
                 snapshot_library: 'rrweb@1.0.0',
+                event_count: 35,
             },
         ])
 
@@ -201,6 +207,7 @@ describe('SessionMetadataStore', () => {
                 distinctId: 'user1',
                 batchId: 'batch123',
                 blockLength: 100,
+                eventCount: 10,
                 startDateTime: DateTime.fromISO('2025-01-01T10:00:00.000Z'),
                 endDateTime: DateTime.fromISO('2025-01-01T10:00:02.000Z'),
                 blockUrl: null,
@@ -231,6 +238,7 @@ describe('SessionMetadataStore', () => {
                 distinctId: 'user1',
                 batchId: 'batch123',
                 blockLength: 100,
+                eventCount: 8,
                 startDateTime: DateTime.fromISO('2025-01-01T10:00:00.000Z'),
                 endDateTime: DateTime.fromISO('2025-01-01T10:00:02.000Z'),
                 blockUrl: null,
@@ -254,6 +262,7 @@ describe('SessionMetadataStore', () => {
 
         const queuedMessage = mockProducer.queueMessages.mock.calls[0][0] as TopicMessage
         const parsedEvent = JSON.parse(queuedMessage.messages[0].value as string)
+        expect(parsedEvent.event_count).toBe(8)
         expect(parsedEvent.block_url).toBeNull()
         expect(parsedEvent.distinct_id).toBe('user1')
         expect(parsedEvent.first_url).toBe('https://example.com')
@@ -280,6 +289,7 @@ describe('SessionMetadataStore', () => {
                 distinctId: 'user1',
                 batchId: 'batch1',
                 blockLength: 100,
+                eventCount: 12,
                 startDateTime: DateTime.fromISO('2025-01-01T10:00:00.000Z'),
                 endDateTime: DateTime.fromISO('2025-01-01T10:00:02.000Z'),
                 blockUrl: 's3://bucket/file1',
@@ -303,6 +313,7 @@ describe('SessionMetadataStore', () => {
                 distinctId: 'user2',
                 batchId: 'batch2',
                 blockLength: 200,
+                eventCount: 18,
                 startDateTime: DateTime.fromISO('2025-01-01T10:00:03.000Z'),
                 endDateTime: DateTime.fromISO('2025-01-01T10:00:05.000Z'),
                 blockUrl: 's3://bucket/file2',
@@ -332,6 +343,7 @@ describe('SessionMetadataStore', () => {
         expect(parsedEvents[0]).toMatchObject({
             first_url: 'https://example.com',
             urls: ['https://example.com'],
+            event_count: 12,
             click_count: 1,
             keypress_count: 2,
             mouse_activity_count: 3,
@@ -347,6 +359,7 @@ describe('SessionMetadataStore', () => {
         expect(parsedEvents[1]).toMatchObject({
             first_url: 'https://example.com/other',
             urls: ['https://example.com/other'],
+            event_count: 18,
             click_count: 4,
             keypress_count: 5,
             mouse_activity_count: 6,
@@ -373,6 +386,7 @@ describe('SessionMetadataStore', () => {
                 distinctId: 'user1',
                 batchId: 'batch1',
                 blockLength: 100,
+                eventCount: 15,
                 startDateTime: DateTime.fromISO('2025-01-01T10:00:00.000Z'),
                 endDateTime: DateTime.fromISO('2025-01-01T10:00:02.000Z'),
                 blockUrl: 's3://bucket/file1',

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-metadata-store.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-metadata-store.ts
@@ -37,6 +37,7 @@ export class SessionMetadataStore {
             message_count: metadata.messageCount || 0,
             snapshot_source: metadata.snapshotSource,
             snapshot_library: metadata.snapshotLibrary,
+            event_count: metadata.eventCount || 0,
         }))
 
         await this.producer.queueMessages({


### PR DESCRIPTION
## Problem

While adding new session metadata columns to blobby v2, I forgot to push event counts to Clickhouse.

## Changes

Passes the computed event counts to the session metadata store.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added unit tests.