### PR TITLE
fix: get_cluster inside migration run

### DIFF
--- a/posthog/clickhouse/client/migration_tools.py
+++ b/posthog/clickhouse/client/migration_tools.py
@@ -8,14 +8,13 @@ from posthog.settings.data_stores import CLICKHOUSE_MIGRATIONS_CLUSTER
 
 logger = logging.getLogger("migrations")
 
-cluster = get_cluster(cluster=CLICKHOUSE_MIGRATIONS_CLUSTER)
-
 
 def run_sql_with_exceptions(sql: str, node_role: NodeRole = NodeRole.DATA, sharded: bool = False):
     """
     migrations.RunSQL does not raise exceptions, so we need to wrap it in a function that does.
     node_role is set to DATA by default to keep compatibility with the old migrations.
     """
+    cluster = get_cluster(cluster=CLICKHOUSE_MIGRATIONS_CLUSTER)
 
     def run_migration():
         query = Query(sql)

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import abc
+from functools import cache
 import itertools
 import logging
 import time
@@ -311,6 +312,7 @@ class ClickhouseCluster:
             return FuturesMap({host: executor.submit(self.__get_task_function(host, fn)) for host in hosts})
 
 
+@cache
 def get_cluster(
     logger: logging.Logger | None = None,
     client_settings: Mapping[str, str] | None = None,


### PR DESCRIPTION
## Problem

Everytime migrations are run, we instantiate the ClickHouseCluster, which makes a query to ClickHouse, even when migrations are already run.

## Changes

Call it only when migrating, and add cache it.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Run migrations locally.
