### PR TITLE
fix: Yield larger tables in BigQuery source

### DIFF
--- a/posthog/temporal/data_imports/pipelines/bigquery/source.py
+++ b/posthog/temporal/data_imports/pipelines/bigquery/source.py
@@ -13,6 +13,8 @@ from posthog.temporal.data_imports.pipelines.helpers import incremental_type_to_
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from posthog.warehouse.types import IncrementalFieldType
 
+DEFAULT_TABLE_SIZE_BYTES = 150 * 1024 * 1024  # 150 MB
+
 
 @contextlib.contextmanager
 def bigquery_storage_read_client(
@@ -104,7 +106,7 @@ def bigquery_source(
         bq_table = bq_client.get_table(fully_qualified_table_name)
         primary_keys = get_primary_keys(bq_table, bq_client)
 
-    def get_rows() -> collections.abc.Iterator[pa.Table]:
+    def get_rows(max_table_size: int) -> collections.abc.Iterator[pa.Table]:
         with bigquery_client(
             project_id=project_id,
             private_key=private_key,
@@ -178,7 +180,20 @@ def bigquery_source(
                 read_rows_stream = bq_storage.read_rows(stream_name)
                 rows_iterator = read_rows_stream.rows()
 
+                record_batches = []
+                table_size_bytes = 0
                 for page in rows_iterator.pages:
-                    yield pa.Table.from_batches([page.to_arrow()])
+                    record_batch = page.to_arrow()
+                    # TODO: Perhaps we should support slicing record batches like we do in batch exports.
+                    table_size_bytes += record_batch.get_total_buffer_size()
+                    record_batches.append(record_batch)
 
-    return SourceResponse(name=name, items=get_rows(), primary_keys=primary_keys)
+                    if table_size_bytes > max_table_size:
+                        yield pa.Table.from_batches(record_batches)
+                        record_batches = []
+                        table_size_bytes = 0
+
+                if record_batches:
+                    yield pa.Table.from_batches(record_batches)
+
+    return SourceResponse(name=name, items=get_rows(DEFAULT_TABLE_SIZE_BYTES), primary_keys=primary_keys)

--- a/posthog/temporal/data_imports/pipelines/bigquery/source.py
+++ b/posthog/temporal/data_imports/pipelines/bigquery/source.py
@@ -10,10 +10,9 @@ from google.oauth2 import service_account
 
 from posthog.temporal.data_imports.pipelines.bigquery import bigquery_client
 from posthog.temporal.data_imports.pipelines.helpers import incremental_type_to_initial_value
+from posthog.temporal.data_imports.pipelines.pipeline.consts import DEFAULT_TABLE_SIZE_BYTES
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from posthog.warehouse.types import IncrementalFieldType
-
-DEFAULT_TABLE_SIZE_BYTES = 150 * 1024 * 1024  # 150 MB
 
 
 @contextlib.contextmanager

--- a/posthog/temporal/data_imports/pipelines/pipeline/consts.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/consts.py
@@ -1,1 +1,2 @@
+DEFAULT_TABLE_SIZE_BYTES = 150 * 1024 * 1024  # 150 MB
 PARTITION_KEY = "_ph_partition_key"


### PR DESCRIPTION
## Problem

Syncs can be slow.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We can afford to buffer more data and speed this up by yielding larger tables from a BigQuery source.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
