### PR TITLE
feat(crm): Switch `/persons` to blocking requests

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -248,7 +248,6 @@ export const FEATURE_FLAGS = {
     WEB_ANALYTICS_HIDE_MODAL_ACTORS: 'web-analytics-hide-modal-actors', // owner: @lricoy #team-web-analytics
     SUPPORT_FORM_IN_ONBOARDING: 'support-form-in-onboarding', // owner: @joshsny #team-growth
     AI_SETUP_WIZARD: 'ai-setup-wizard', // owner: @joshsny #team-growth
-    CRM_BLOCKING_QUERIES: 'crm-blocking-queries', // owner: @danielbachhuber #team-crm
     RECORDINGS_BLOBBY_V2_REPLAY: 'recordings-blobby-v2-replay', // owner: @pl #team-cdp
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]

--- a/frontend/src/scenes/persons-management/tabs/Persons.tsx
+++ b/frontend/src/scenes/persons-management/tabs/Persons.tsx
@@ -1,6 +1,4 @@
 import { useActions, useValues } from 'kea'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { personsSceneLogic } from 'scenes/persons-management/tabs/personsSceneLogic'
 
 import { Query } from '~/queries/Query/Query'
@@ -9,14 +7,5 @@ export function Persons(): JSX.Element {
     const { query } = useValues(personsSceneLogic)
     const { setQuery } = useActions(personsSceneLogic)
 
-    const { featureFlags } = useValues(featureFlagLogic)
-
-    return (
-        <Query
-            query={query}
-            setQuery={setQuery}
-            context={{ refresh: featureFlags[FEATURE_FLAGS.CRM_BLOCKING_QUERIES] === 'test' ? 'blocking' : true }}
-            dataAttr="persons-table"
-        />
-    )
+    return <Query query={query} setQuery={setQuery} context={{ refresh: 'blocking' }} dataAttr="persons-table" />
 }


### PR DESCRIPTION
See https://posthog.slack.com/archives/C0113360FFV/p1741952961546759

## Changes

`'blocking'` is the clear winner with a ~33% speed improvement.

## How did you test this code?

Loaded the page and verified it still rendered.