### PR TITLE
fix(crm): Persist group URLs on refresh

### DIFF
--- a/frontend/src/scenes/persons-management/personsManagementSceneLogic.tsx
+++ b/frontend/src/scenes/persons-management/personsManagementSceneLogic.tsx
@@ -31,7 +31,7 @@ export type PersonsManagementTabs = Record<
 export const personsManagementSceneLogic = kea<personsManagementSceneLogicType>([
     path(['scenes', 'persons-management', 'personsManagementSceneLogic']),
     connect({
-        values: [groupsModel, ['aggregationLabel', 'groupTypes', 'groupsAccessStatus']],
+        values: [groupsModel, ['aggregationLabel', 'groupTypes', 'groupTypesLoading', 'groupsAccessStatus']],
     }),
     actions({
         setTabKey: (tabKey: string) => ({ tabKey }),
@@ -137,12 +137,18 @@ export const personsManagementSceneLogic = kea<personsManagementSceneLogicType>(
     }),
     actionToUrl(({ values }) => ({
         setTabKey: ({ tabKey }) => {
-            const tab = values.tabs.find((x) => x.key === tabKey)
-            if (!tab) {
+            let tabUrl = values.tabs.find((x) => x.key === tabKey)?.url
+            if (!tabUrl && values.groupTypesLoading) {
+                const groupMatch = tabKey.match(/^groups-(\d+)$/)
+                if (groupMatch) {
+                    tabUrl = urls.groups(parseInt(groupMatch[1]))
+                }
+            }
+            if (!tabUrl) {
                 return values.tabs[0].url
             }
             // Preserve existing search params when changing tabs
-            return [tab.url, router.values.searchParams, router.values.hashParams, { replace: true }]
+            return [tabUrl, router.values.searchParams, router.values.hashParams, { replace: true }]
         },
     })),
     urlToAction(({ actions }) => {


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/29881

## Changes

Ensures `/project/1/groups/2` persists on refresh, instead of redirecting to `/persons`. `groupTypes` apparently isn't loaded before `setTabKey` executes.

**Before**

https://github.com/user-attachments/assets/f2ab3ec4-1f1f-435f-a492-74bc71946c6e


**After**

https://github.com/user-attachments/assets/46acc99a-5d11-49ad-9fc4-db52ae970410

## How did you test this code?

Manually tested.