### PR TITLE
fix: return realtime when v2 sources are present

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -702,7 +702,6 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, U
                         "blob_key": str(i),
                     }
                 )
-            might_have_realtime = False
         if recording.object_storage_path:
             blob_prefix = recording.object_storage_path
             blob_keys = object_storage.list_objects(cast(str, blob_prefix))


### PR DESCRIPTION
## Problem

By accident we're returning might have realtime source as false when blobby v2 sources are present.

## Changes

Stops setting it to false for v2 sources.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

