### PR TITLE
fix: use cached cluster only in migrations

### DIFF
--- a/posthog/clickhouse/client/migration_tools.py
+++ b/posthog/clickhouse/client/migration_tools.py
@@ -1,3 +1,4 @@
+from functools import cache
 import logging
 
 from infi.clickhouse_orm import migrations
@@ -9,12 +10,17 @@ from posthog.settings.data_stores import CLICKHOUSE_MIGRATIONS_CLUSTER
 logger = logging.getLogger("migrations")
 
 
+@cache
+def get_migrations_cluster():
+    return get_cluster(cluster=CLICKHOUSE_MIGRATIONS_CLUSTER)
+
+
 def run_sql_with_exceptions(sql: str, node_role: NodeRole = NodeRole.DATA, sharded: bool = False):
     """
     migrations.RunSQL does not raise exceptions, so we need to wrap it in a function that does.
     node_role is set to DATA by default to keep compatibility with the old migrations.
     """
-    cluster = get_cluster(cluster=CLICKHOUSE_MIGRATIONS_CLUSTER)
+    cluster = get_migrations_cluster()
 
     def run_migration():
         query = Query(sql)

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import abc
-from functools import cache
 import itertools
 import logging
 import time
@@ -312,7 +311,6 @@ class ClickhouseCluster:
             return FuturesMap({host: executor.submit(self.__get_task_function(host, fn)) for host in hosts})
 
 
-@cache
 def get_cluster(
     logger: logging.Logger | None = None,
     client_settings: Mapping[str, str] | None = None,


### PR DESCRIPTION
## Problem

Adding the cache decorator to the function breaks Dagster resource.

## Changes

Cache the cluster only in the migrations.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Locally.