### PR TITLE
chore: Raise error if private key not included in job inputs

### DIFF
--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -524,6 +524,9 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
             client_email = model.pipeline.job_inputs.get("client_email")
             token_uri = model.pipeline.job_inputs.get("token_uri")
 
+            if not private_key:
+                raise ValueError(f"Missing private key for BigQuery: '{model.id}'")
+
             temporary_dataset_id = model.pipeline.job_inputs.get("temporary_dataset_id")
             using_temporary_dataset = (
                 model.pipeline.job_inputs.get("using_temporary_dataset", False) and temporary_dataset_id is not None

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -274,6 +274,13 @@ class ExternalDataSourceSerializers(serializers.ModelSerializer):
         return ExternalDataSchemaSerializer(instance.schemas, many=True, read_only=True, context=self.context).data
 
     def update(self, instance: ExternalDataSource, validated_data: Any) -> Any:
+        """Update source ensuring we merge with existing job inputs to allow partial updates."""
+        existing_job_inputs = instance.job_inputs
+
+        if existing_job_inputs:
+            new_job_inputs = validated_data.get("job_inputs", {})
+            validated_data["job_inputs"] = {**existing_job_inputs, **new_job_inputs}
+
         updated_source: ExternalDataSource = super().update(instance, validated_data)
 
         return updated_source

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -8,24 +8,21 @@ from dateutil import parser
 from django.db.models import Prefetch, Q
 from psycopg2 import OperationalError
 from rest_framework import filters, serializers, status, viewsets
+from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
-from posthog.exceptions_capture import capture_exception
 from snowflake.connector.errors import DatabaseError, ForbiddenError, ProgrammingError
 from sshtunnel import BaseSSHTunnelForwarderError
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
 from posthog.cloud_utils import is_cloud
-from posthog.models.user import User
+from posthog.exceptions_capture import capture_exception
 from posthog.hogql.database.database import create_hogql_database
+from posthog.models.user import User
 from posthog.temporal.data_imports.pipelines.bigquery import (
     filter_incremental_fields as filter_bigquery_incremental_fields,
-)
-from posthog.temporal.data_imports.pipelines.bigquery import (
     get_schemas as get_bigquery_schemas,
-)
-from posthog.temporal.data_imports.pipelines.bigquery import (
     validate_credentials as validate_bigquery_credentials,
 )
 from posthog.temporal.data_imports.pipelines.chargebee import (
@@ -71,9 +68,9 @@ from posthog.warehouse.models.external_data_schema import (
     filter_mysql_incremental_fields,
     filter_postgres_incremental_fields,
     filter_snowflake_incremental_fields,
+    get_postgres_row_count,
     get_snowflake_schemas,
     get_sql_schemas_for_source_type,
-    get_postgres_row_count,
 )
 from posthog.warehouse.models.ssh_tunnel import SSHTunnel
 
@@ -789,6 +786,25 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         using_temporary_dataset = temporary_dataset.get("enabled", False)
         temporary_dataset_id = temporary_dataset.get("temporary_dataset_id", None)
 
+        job_inputs = {
+            "dataset_id": dataset_id,
+            "project_id": project_id,
+            "private_key": private_key,
+            "private_key_id": private_key_id,
+            "client_email": client_email,
+            "token_uri": token_uri,
+            "using_temporary_dataset": using_temporary_dataset,
+            "temporary_dataset_id": temporary_dataset_id,
+        }
+
+        required_inputs = {"private_key", "private_key_id", "client_email", "dataset_id", "project_id", "token_uri"}
+        have_all_required = all(job_inputs.get(input_name, None) is not None for input_name in required_inputs)
+
+        if not have_all_required:
+            included_inputs = {k for k, v in job_inputs.items() if v is not None}
+            missing = ", ".join(f"'{job_input}'" for job_input in required_inputs - included_inputs)
+            raise ValidationError(f"Missing required BigQuery inputs: {missing}")
+
         new_source_model = ExternalDataSource.objects.create(
             source_id=str(uuid.uuid4()),
             connection_id=str(uuid.uuid4()),
@@ -797,16 +813,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             created_by=request.user if isinstance(request.user, User) else None,
             status="Running",
             source_type=source_type,
-            job_inputs={
-                "dataset_id": dataset_id,
-                "project_id": project_id,
-                "private_key": private_key,
-                "private_key_id": private_key_id,
-                "client_email": client_email,
-                "token_uri": token_uri,
-                "using_temporary_dataset": using_temporary_dataset,
-                "temporary_dataset_id": temporary_dataset_id,
-            },
+            job_inputs=job_inputs,
             prefix=prefix,
         )
 

--- a/posthog/warehouse/api/test/test_external_data_source.py
+++ b/posthog/warehouse/api/test/test_external_data_source.py
@@ -392,6 +392,63 @@ class TestExternalDataSource(APIBaseTest):
         assert "'private_key'" in response.json()["detail"]
         assert "'private_key_id'" in response.json()["detail"]
 
+    def test_partial_update_of_bigquery_external_data_source(self):
+        """Test we can partially update a BigQuery source."""
+        with patch("posthog.warehouse.api.external_data_source.get_bigquery_schemas") as mocked_get_bigquery_schemas:
+            mocked_get_bigquery_schemas.return_value = {"my_schema": "something"}
+
+            response = self.client.post(
+                f"/api/projects/{self.team.pk}/external_data_sources/",
+                data={
+                    "source_type": "BigQuery",
+                    "payload": {
+                        "schemas": [
+                            {
+                                "name": "my_schema",
+                                "should_sync": True,
+                                "sync_type": "incremental",
+                                "incremental_field": "id",
+                                "incremental_field_type": "integer",
+                            },
+                        ],
+                        "dataset_id": "my_project.my_dataset",
+                        "key_file": {
+                            "project_id": "my_project",
+                            "private_key": "my private_key",
+                            "private_key_id": "my_private_key_id",
+                            "token_uri": "https://google.com",
+                            "client_email": "test@posthog.com",
+                        },
+                    },
+                },
+            )
+        assert response.status_code == 201
+        assert len(ExternalDataSource.objects.all()) == 1
+
+        source = response.json()
+        source_model = ExternalDataSource.objects.get(id=source["id"])
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.pk}/external_data_sources/{str(source_model.pk)}/",
+            data={
+                "source_type": "BigQuery",
+                "payload": {
+                    "dataset_id": "my_dataset",
+                    "key_file": {
+                        "project_id": "my_project",
+                        "token_uri": "https://google.com",
+                    },
+                },
+            },
+        )
+
+        assert response.status_code == 200
+        assert len(ExternalDataSource.objects.all()) == 1
+        source_model.refresh_from_db()
+        source_model.job_inputs["dataset_id"] = "my_dataset"
+        source_model.job_inputs["private_key"] = "my private_key"
+        source_model.job_inputs["private_key_id"] = "my private_key_id"
+
     def test_list_external_data_source(self):
         self._create_external_data_source()
         self._create_external_data_source()


### PR DESCRIPTION
## Problem

We don't do any kind of input validation when creating or running a BigQuery Source. Unclear what's causing inputs to be empty.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

For now, raise errors to attempt to locate the problem:
* Validate required inputs in the API.
* Raise error before starting pipeline if no private key is included.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Added unit test.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
