### PR TITLE
feat: mark all QaaS queries

### DIFF
--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -30,6 +30,13 @@ def tag_queries(**kwargs):
         thread_local_storage.query_tags = tags
 
 
+def clear_tag(key):
+    try:
+        thread_local_storage.query_tags.pop(key, None)
+    except AttributeError:
+        pass
+
+
 def reset_query_tags():
     thread_local_storage.query_tags = {}
 

--- a/posthog/clickhouse/test/test_query_tagging.py
+++ b/posthog/clickhouse/test/test_query_tagging.py
@@ -1,7 +1,20 @@
-from posthog.clickhouse.query_tagging import tag_queries, get_query_tags, tags_context
+from posthog.clickhouse.query_tagging import tag_queries, get_query_tags, tags_context, clear_tag, reset_query_tags
+
+
+def test_clear_tag():
+    clear_tag("some")
+    reset_query_tags()
+    assert get_query_tags() == {}
+    tag_queries(qaas=True)
+    assert get_query_tags() == {"qaas": True}
+    clear_tag("some")
+    assert get_query_tags() == {"qaas": True}
+    clear_tag("qaas")
+    assert get_query_tags() == {}
 
 
 def test_tags_context():
+    reset_query_tags()
     # Set initial tags
     tag_queries(initial="value")
     assert get_query_tags() == {"initial": "value"}

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -13,7 +13,7 @@ from posthog.clickhouse.client.limit import get_api_personal_rate_limiter
 from posthog.exceptions_capture import capture_exception
 from posthog.caching.utils import ThresholdMode, cache_target_age, is_stale, last_refresh_from_cached_result
 from posthog.clickhouse.client.execute_async import QueryNotFoundError, enqueue_process_query_task, get_query_status
-from posthog.clickhouse.query_tagging import get_query_tag_value, tag_queries
+from posthog.clickhouse.query_tagging import get_query_tag_value, tag_queries, clear_tag
 from posthog.hogql import ast
 from posthog.hogql.constants import LimitContext
 from posthog.hogql.context import HogQLContext
@@ -754,9 +754,16 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             self.modifiers = create_default_modifiers_for_user(user, self.team, self.modifiers)
             self.modifiers.useMaterializedViews = True
 
-        with get_api_personal_rate_limiter().run(
-            is_api=self.query_endpoint_with_personal_key(), team_id=self.team.pk, task_id=self.query_id
+        with (
+            get_api_personal_rate_limiter().run(
+                is_api=self.query_endpoint_with_personal_key(), team_id=self.team.pk, task_id=self.query_id
+            ),
         ):
+            if self.query_endpoint_with_personal_key():
+                tag_queries(qaas=True)
+            else:
+                clear_tag("qaas")
+
             fresh_response_dict = {
                 **self.calculate().model_dump(),
                 "is_cached": False,

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -754,10 +754,8 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             self.modifiers = create_default_modifiers_for_user(user, self.team, self.modifiers)
             self.modifiers.useMaterializedViews = True
 
-        with (
-            get_api_personal_rate_limiter().run(
-                is_api=self.query_endpoint_with_personal_key(), team_id=self.team.pk, task_id=self.query_id
-            ),
+        with get_api_personal_rate_limiter().run(
+            is_api=self.query_endpoint_with_personal_key(), team_id=self.team.pk, task_id=self.query_id
         ):
             if self.query_endpoint_with_personal_key():
                 tag_queries(qaas=True)


### PR DESCRIPTION
## Problem

For the refresh=sync queries we can check log_comment: kind=request, route_id=/query/, but queries with refresh=async have celery there.

## Changes

Mark all queries qualifying to QaaS as so in log_comment["qaas"]=True.

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Tested locally.
