### PR TITLE
feat: implement recording v2 object storage

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -54,7 +54,7 @@ from posthog.session_recordings.realtime_snapshots import (
     get_realtime_snapshots,
     publish_subscription,
 )
-from posthog.storage import object_storage
+from posthog.storage import object_storage, session_recording_v2_object_storage
 from posthog.session_recordings.ai_data.ai_filter_schema import AiFilterSchema
 from posthog.session_recordings.ai_data.ai_regex_schema import AiRegexSchema
 from posthog.session_recordings.ai_data.ai_regex_prompts import AI_REGEX_PROMPTS
@@ -936,7 +936,9 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, U
                 raise exceptions.NotFound("Invalid byte range")
 
             expected_length = end_byte - start_byte + 1
-            compressed_block = object_storage.read_bytes(key, first_byte=start_byte, last_byte=end_byte)
+            compressed_block = session_recording_v2_object_storage.client().read_bytes(
+                key, first_byte=start_byte, last_byte=end_byte
+            )
 
             if not compressed_block:
                 raise exceptions.NotFound("Block content not found")

--- a/posthog/settings/__init__.py
+++ b/posthog/settings/__init__.py
@@ -42,6 +42,7 @@ from posthog.settings.temporal import *
 from posthog.settings.web import *
 from posthog.settings.data_warehouse import *
 from posthog.settings.session_replay import *
+from posthog.settings.session_replay_v2 import *
 from posthog.settings.integrations import *
 from posthog.settings.pagerduty import *
 

--- a/posthog/settings/session_replay_v2.py
+++ b/posthog/settings/session_replay_v2.py
@@ -1,0 +1,29 @@
+import os
+from typing import Optional
+
+from posthog.settings import get_from_env
+from posthog.settings.base_variables import DEBUG, TEST
+from posthog.settings.utils import str_to_bool
+
+if TEST or DEBUG:
+    SESSION_RECORDING_V2_S3_ENDPOINT = os.getenv("SESSION_RECORDING_V2_S3_ENDPOINT", "http://objectstorage:19000")
+    SESSION_RECORDING_V2_S3_ACCESS_KEY_ID: Optional[str] = os.getenv(
+        "SESSION_RECORDING_V2_S3_ACCESS_KEY_ID", "object_storage_root_user"
+    )
+    SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY: Optional[str] = os.getenv(
+        "SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY", "object_storage_root_password"
+    )
+else:
+    SESSION_RECORDING_V2_S3_ENDPOINT = os.getenv("SESSION_RECORDING_V2_S3_ENDPOINT", "")
+    # To enable us to specify that the AWS provided credentials for e.g. the EC2
+    # or Fargate task, we default to `None` rather than "" as this will, when
+    # passed to boto, result in the correct credentials being used.
+    SESSION_RECORDING_V2_S3_ACCESS_KEY_ID = os.getenv("SESSION_RECORDING_V2_S3_ACCESS_KEY_ID", "") or None
+    SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY = os.getenv("SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY", "") or None
+
+SESSION_RECORDING_V2_S3_ENABLED = get_from_env(
+    "SESSION_RECORDING_V2_S3_ENABLED", True if DEBUG else False, type_cast=str_to_bool
+)
+SESSION_RECORDING_V2_S3_REGION = os.getenv("SESSION_RECORDING_V2_S3_REGION", "us-east-1")
+SESSION_RECORDING_V2_S3_BUCKET = os.getenv("SESSION_RECORDING_V2_S3_BUCKET", "posthog")
+SESSION_RECORDING_V2_S3_PREFIX = os.getenv("SESSION_RECORDING_V2_S3_PREFIX", "session_recordings_v2")

--- a/posthog/storage/object_storage.py
+++ b/posthog/storage/object_storage.py
@@ -34,9 +34,7 @@ class ObjectStorageClient(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def read_bytes(
-        self, bucket: str, key: str, first_byte: Optional[int] = None, last_byte: Optional[int] = None
-    ) -> Optional[bytes]:
+    def read_bytes(self, bucket: str, key: str) -> Optional[bytes]:
         pass
 
     @abc.abstractmethod
@@ -68,9 +66,7 @@ class UnavailableStorage(ObjectStorageClient):
     def read(self, bucket: str, key: str) -> Optional[str]:
         return None
 
-    def read_bytes(
-        self, bucket: str, key: str, first_byte: Optional[int] = None, last_byte: Optional[int] = None
-    ) -> Optional[bytes]:
+    def read_bytes(self, bucket: str, key: str) -> Optional[bytes]:
         return None
 
     def tag(self, bucket: str, key: str, tags: dict[str, str]) -> None:
@@ -131,18 +127,10 @@ class ObjectStorage(ObjectStorageClient):
         else:
             return None
 
-    def read_bytes(
-        self, bucket: str, key: str, first_byte: Optional[int] = None, last_byte: Optional[int] = None
-    ) -> Optional[bytes]:
+    def read_bytes(self, bucket: str, key: str) -> Optional[bytes]:
         s3_response = {}
         try:
-            kwargs = {"Bucket": bucket, "Key": key}
-            if first_byte is not None and last_byte is not None:
-                kwargs["Range"] = f"bytes={first_byte}-{last_byte}"
-            elif first_byte is not None:
-                kwargs["Range"] = f"bytes={first_byte}-"
-
-            s3_response = self.aws_client.get_object(**kwargs)
+            s3_response = self.aws_client.get_object(Bucket=bucket, Key=key)
             return s3_response["Body"].read()
         except Exception as e:
             logger.exception(
@@ -247,11 +235,9 @@ def read(file_name: str, bucket: str | None = None) -> Optional[str]:
     return object_storage_client().read(bucket=bucket or settings.OBJECT_STORAGE_BUCKET, key=file_name)
 
 
-def read_bytes(
-    file_name: str, bucket: str | None = None, first_byte: Optional[int] = None, last_byte: Optional[int] = None
-) -> Optional[bytes]:
+def read_bytes(file_name: str, bucket: str | None = None) -> Optional[bytes]:
     bucket = bucket or settings.OBJECT_STORAGE_BUCKET
-    return object_storage_client().read_bytes(bucket, file_name, first_byte, last_byte)
+    return object_storage_client().read_bytes(bucket, file_name)
 
 
 def list_objects(prefix: str) -> Optional[list[str]]:

--- a/posthog/storage/session_recording_v2_object_storage.py
+++ b/posthog/storage/session_recording_v2_object_storage.py
@@ -1,0 +1,78 @@
+import abc
+import structlog
+from boto3 import client as boto3_client
+from botocore.client import Config
+from django.conf import settings
+
+logger = structlog.get_logger(__name__)
+
+
+class SessionRecordingV2ObjectStorageBase(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def read_bytes(self, key: str, first_byte: int, last_byte: int) -> bytes | None:
+        pass
+
+
+class UnavailableSessionRecordingV2ObjectStorage(SessionRecordingV2ObjectStorageBase):
+    def read_bytes(self, key: str, first_byte: int, last_byte: int) -> bytes | None:
+        return None
+
+
+class SessionRecordingV2ObjectStorage(SessionRecordingV2ObjectStorageBase):
+    def __init__(self, aws_client, bucket: str) -> None:
+        self.aws_client = aws_client
+        self.bucket = bucket
+
+    def read_bytes(self, key: str, first_byte: int, last_byte: int) -> bytes | None:
+        s3_response = {}
+        try:
+            kwargs = {
+                "Bucket": self.bucket,
+                "Key": key,
+                "Range": f"bytes={first_byte}-{last_byte}",
+            }
+            s3_response = self.aws_client.get_object(**kwargs)
+            return s3_response["Body"].read()
+        except Exception as e:
+            logger.exception(
+                "session_recording_v2_object_storage.read_failed",
+                bucket=self.bucket,
+                file_name=key,
+                error=e,
+                s3_response=s3_response,
+            )
+            return None
+
+
+_client = UnavailableSessionRecordingV2ObjectStorage()
+
+
+def client() -> SessionRecordingV2ObjectStorageBase:
+    global _client
+
+    required_settings = [
+        settings.SESSION_RECORDING_V2_S3_ENDPOINT,
+        settings.SESSION_RECORDING_V2_S3_REGION,
+        settings.SESSION_RECORDING_V2_S3_BUCKET,
+    ]
+
+    if not all(required_settings):
+        _client = UnavailableSessionRecordingV2ObjectStorage()
+    elif isinstance(_client, UnavailableSessionRecordingV2ObjectStorage):
+        _client = SessionRecordingV2ObjectStorage(
+            boto3_client(
+                "s3",
+                endpoint_url=settings.SESSION_RECORDING_V2_S3_ENDPOINT,
+                aws_access_key_id=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
+                aws_secret_access_key=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
+                config=Config(
+                    signature_version="s3v4",
+                    connect_timeout=1,
+                    retries={"max_attempts": 1},
+                ),
+                region_name=settings.SESSION_RECORDING_V2_S3_REGION,
+            ),
+            bucket=settings.SESSION_RECORDING_V2_S3_BUCKET,
+        )
+
+    return _client

--- a/posthog/storage/session_recording_v2_object_storage.py
+++ b/posthog/storage/session_recording_v2_object_storage.py
@@ -44,7 +44,7 @@ class SessionRecordingV2ObjectStorage(SessionRecordingV2ObjectStorageBase):
             return None
 
 
-_client = UnavailableSessionRecordingV2ObjectStorage()
+_client: SessionRecordingV2ObjectStorageBase = UnavailableSessionRecordingV2ObjectStorage()
 
 
 def client() -> SessionRecordingV2ObjectStorageBase:
@@ -66,9 +66,9 @@ def client() -> SessionRecordingV2ObjectStorageBase:
                 aws_access_key_id=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
                 aws_secret_access_key=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
                 config=Config(
-                    signature_version="s3v4",
-                    connect_timeout=1,
-                    retries={"max_attempts": 1},
+                    signature_version="s3v4",  # type: ignore[attr-defined]
+                    connect_timeout=1,  # type: ignore[attr-defined]
+                    retries={"max_attempts": 1},  # type: ignore[attr-defined]
                 ),
                 region_name=settings.SESSION_RECORDING_V2_S3_REGION,
             ),

--- a/posthog/storage/session_recording_v2_object_storage.py
+++ b/posthog/storage/session_recording_v2_object_storage.py
@@ -63,8 +63,8 @@ def client() -> SessionRecordingV2ObjectStorageBase:
             boto3_client(
                 "s3",
                 endpoint_url=settings.SESSION_RECORDING_V2_S3_ENDPOINT,
-                aws_access_key_id=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
-                aws_secret_access_key=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
+                aws_access_key_id=settings.SESSION_RECORDING_V2_S3_ACCESS_KEY_ID,
+                aws_secret_access_key=settings.SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY,
                 config=Config(
                     signature_version="s3v4",  # type: ignore[attr-defined]
                     connect_timeout=1,  # type: ignore[attr-defined]

--- a/posthog/storage/test/test_session_recording_v2_object_storage.py
+++ b/posthog/storage/test/test_session_recording_v2_object_storage.py
@@ -1,0 +1,103 @@
+from unittest.mock import patch, MagicMock
+
+from botocore.client import Config
+
+from posthog.settings.session_replay_v2 import (
+    SESSION_RECORDING_V2_S3_ACCESS_KEY_ID,
+    SESSION_RECORDING_V2_S3_BUCKET,
+    SESSION_RECORDING_V2_S3_ENDPOINT,
+    SESSION_RECORDING_V2_S3_REGION,
+    SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY,
+)
+from posthog.storage.session_recording_v2_object_storage import (
+    client,
+    SessionRecordingV2ObjectStorage,
+)
+from posthog.test.base import APIBaseTest
+
+TEST_BUCKET = "test_session_recording_v2_bucket"
+
+
+class TestSessionRecordingV2Storage(APIBaseTest):
+    def teardown_method(self, method) -> None:
+        pass
+
+    @patch("posthog.storage.session_recording_v2_object_storage.boto3_client")
+    def test_client_constructor_uses_correct_settings(self, patched_boto3_client) -> None:
+        storage_client = client()
+
+        # Check that boto3_client was called once
+        assert patched_boto3_client.call_count == 1
+        call_args = patched_boto3_client.call_args[0]
+        call_kwargs = patched_boto3_client.call_args[1]
+
+        # Check positional args
+        assert call_args == ("s3",)
+
+        # Check kwargs except config
+        assert call_kwargs["endpoint_url"] == SESSION_RECORDING_V2_S3_ENDPOINT
+        assert call_kwargs["aws_access_key_id"] == SESSION_RECORDING_V2_S3_ACCESS_KEY_ID
+        assert call_kwargs["aws_secret_access_key"] == SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY
+        assert call_kwargs["region_name"] == SESSION_RECORDING_V2_S3_REGION
+
+        # Check config parameters separately
+        config = call_kwargs["config"]
+        assert isinstance(config, Config)
+        assert config.signature_version == "s3v4"
+        assert config.connect_timeout == 1
+        assert config.retries == {"max_attempts": 1}
+
+        # Check the returned client
+        assert isinstance(storage_client, SessionRecordingV2ObjectStorage)
+        assert storage_client.bucket == SESSION_RECORDING_V2_S3_BUCKET
+
+    @patch("posthog.storage.session_recording_v2_object_storage.boto3_client")
+    def test_does_not_create_client_if_required_settings_missing(self, patched_s3_client) -> None:
+        test_cases = [
+            {"SESSION_RECORDING_V2_S3_BUCKET": ""},
+            {"SESSION_RECORDING_V2_S3_ENDPOINT": ""},
+            {"SESSION_RECORDING_V2_S3_REGION": ""},
+            {
+                "SESSION_RECORDING_V2_S3_BUCKET": "",
+                "SESSION_RECORDING_V2_S3_ENDPOINT": "",
+                "SESSION_RECORDING_V2_S3_REGION": "",
+            },
+        ]
+
+        for settings_override in test_cases:
+            with self.settings(**settings_override):
+                storage_client = client()
+                patched_s3_client.assert_not_called()
+                assert storage_client.read_bytes("any_key", 0, 100) is None
+
+    def test_read_bytes_with_byte_range(self):
+        mock_client = MagicMock()
+        mock_body = MagicMock()
+        mock_body.read.return_value = b"test content"
+        mock_client.get_object.return_value = {"Body": mock_body}
+        storage = SessionRecordingV2ObjectStorage(mock_client, TEST_BUCKET)
+
+        storage.read_bytes("test-key", 5, 10)
+        mock_client.get_object.assert_called_with(Bucket=TEST_BUCKET, Key="test-key", Range="bytes=5-10")
+
+    def test_read_specific_byte_range(self):
+        mock_client = MagicMock()
+        mock_body = MagicMock()
+        mock_body.read.return_value = b"bcdefghijab"
+        mock_client.get_object.return_value = {"Body": mock_body}
+        storage = SessionRecordingV2ObjectStorage(mock_client, TEST_BUCKET)
+
+        result = storage.read_bytes("test-key", 91, 101)
+
+        mock_client.get_object.assert_called_with(Bucket=TEST_BUCKET, Key="test-key", Range="bytes=91-101")
+        assert result == b"bcdefghijab"
+        assert len(result) == 11
+
+    def test_read_returns_none_on_error(self):
+        mock_client = MagicMock()
+        mock_client.get_object.side_effect = Exception("error")
+        storage = SessionRecordingV2ObjectStorage(mock_client, TEST_BUCKET)
+
+        result = storage.read_bytes("non_existent_file", 0, 100)
+        assert result is None
+        mock_client.get_object.assert_called_with(Bucket=TEST_BUCKET, Key="non_existent_file", Range="bytes=0-100")


### PR DESCRIPTION
## Problem

We can't use the original object storage class in replay v2 because we're using a different S3 bucket than the rest of the web app.

## Changes

- Implements an object storage class specific to session recordings v2
- Uses new environment variables (consistent with the ingestion) for S3 configuration
- Removes the unnecessary arguments from the original object storage class, as they are not used anymore

## Does this work well for both Cloud and self-hosted?

Yes, uses same defaults as replay v1 for self-hosted.

## How did you test this code?

- Added some unit tests
- Tested locally