### PR TITLE
fix(sql): update event definition sql

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -99,14 +99,7 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
             createEmptyListStorage('', true),
             {
                 loadRemoteItems: async ({ offset, limit }, breakpoint) => {
-                    // avoid the 150ms delay on first load
-                    if (!values.remoteItems.first) {
-                        await breakpoint(500)
-                    } else {
-                        // These connected values below might be read before they are available due to circular logic mounting.
-                        // Adding a slight delay (breakpoint) fixes this.
-                        await breakpoint(1)
-                    }
+                    await breakpoint(1)
 
                     const {
                         isExpanded,

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -311,7 +311,7 @@ def create_event_definitions_sql(
             SELECT {",".join(event_definition_fields)}
             FROM posthog_eventdefinition
             {enterprise_join}
-            WHERE coalesce(project_id, team_id) = %(project_id)s {conditions}
+            WHERE project_id = %(project_id)s OR (project_id IS NULL AND team_id = %(project_id)s) {conditions}
             ORDER BY {additional_ordering}name ASC
         """
 


### PR DESCRIPTION
## Problem

calls to `/event_definitions` are taking up ~5s on average, even though there are index on team id / project id.

seems the issue is in coalesce which can't use the index. 

![image](https://github.com/user-attachments/assets/1db01a12-44db-4f7f-9682-7b07a8167872)

![image](https://github.com/user-attachments/assets/4f0a6a19-6423-40e4-8753-fd857606f3e9)


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

update sql to use or for checking between team/project id, reducing the api call response time to 20 ms (250x improvement)
<img width="1070" alt="image" src="https://github.com/user-attachments/assets/a6c0a268-9872-427f-ba42-b7a582b0dafb" />


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
