### PR TITLE
fix: default option for sr masking in onboarding

### DIFF
--- a/frontend/src/scenes/session-recordings/utils.ts
+++ b/frontend/src/scenes/session-recordings/utils.ts
@@ -30,7 +30,7 @@ export const getMaskingLevelFromConfig = (config: SessionRecordingMaskingConfig)
         return 'total-privacy'
     }
 
-    if (config.maskTextSelector === undefined && !config.maskAllInputs) {
+    if (config.maskTextSelector === undefined && config.maskAllInputs === false) {
         return 'free-love'
     }
 


### PR DESCRIPTION
## Problem

The default for the select renders as "free love" rather than "normal" due to us not explicitely requiring `maskAllInputs` to be false. Clearly I cannot do defaults 🤦‍♂️

## Changes

Require it to be explicitly false

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Tested locally
