### PR TITLE
fix: remove unnecessary logic from onboarding step

### DIFF
--- a/frontend/src/scenes/onboarding/OnboardingStep.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingStep.tsx
@@ -4,10 +4,8 @@ import { useActions, useValues } from 'kea'
 import { supportLogic } from 'lib/components/Support/supportLogic'
 import { IconChevronRight } from 'lib/lemon-ui/icons'
 import React from 'react'
-import { urls } from 'scenes/urls'
 
 import { breadcrumbExcludeSteps, onboardingLogic, OnboardingStepKey, stepKeyToTitle } from './onboardingLogic'
-import { onboardingTemplateConfigLogic } from './productAnalyticsSteps/onboardingTemplateConfigLogic'
 
 export const OnboardingStep = ({
     stepKey,
@@ -45,7 +43,6 @@ export const OnboardingStep = ({
     const { hasNextStep, onboardingStepKeys, currentOnboardingStep } = useValues(onboardingLogic)
     const { completeOnboarding, goToNextStep, setStepKey } = useActions(onboardingLogic)
     const { openSupportForm } = useActions(supportLogic)
-    const { dashboardCreatedDuringOnboarding } = useValues(onboardingTemplateConfigLogic)
 
     if (!stepKey) {
         throw new Error('stepKey is required in any OnboardingStep')
@@ -117,14 +114,7 @@ export const OnboardingStep = ({
                             type="secondary"
                             onClick={() => {
                                 onSkip && onSkip()
-                                !hasNextStep
-                                    ? completeOnboarding(
-                                          undefined,
-                                          dashboardCreatedDuringOnboarding
-                                              ? urls.dashboard(dashboardCreatedDuringOnboarding.id)
-                                              : undefined
-                                      )
-                                    : goToNextStep()
+                                !hasNextStep ? completeOnboarding() : goToNextStep()
                             }}
                             data-attr="onboarding-skip-button"
                         >
@@ -140,14 +130,7 @@ export const OnboardingStep = ({
                             data-attr="onboarding-continue"
                             onClick={() => {
                                 onContinue?.()
-                                !hasNextStep
-                                    ? completeOnboarding(
-                                          undefined,
-                                          dashboardCreatedDuringOnboarding
-                                              ? urls.dashboard(dashboardCreatedDuringOnboarding.id)
-                                              : undefined
-                                      )
-                                    : goToNextStep()
+                                !hasNextStep ? completeOnboarding() : goToNextStep()
                             }}
                             sideIcon={hasNextStep ? <IconArrowRight /> : null}
                             disabledReason={continueDisabledReason}


### PR DESCRIPTION
## Problem

This logic is causing a lot of unnecessary errors in onboarding - removing it might help

## Changes

Remove the logic, since the redirect is handled elsewhere already.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Ran through it locally with and without the dashboard template flag on
