### PR TITLE
chore(data-warehouse): Dont resync tables on incremental field change

### DIFF
--- a/frontend/src/scenes/data-warehouse/external/forms/SyncMethodForm.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/SyncMethodForm.tsx
@@ -35,24 +35,6 @@ interface SyncMethodFormProps {
         incrementalFieldType: string | null
     ) => void
     saveButtonIsLoading?: boolean
-    showRefreshMessageOnChange?: boolean
-}
-
-const hasInputChanged = (
-    newSchemaSyncType: ExternalDataSourceSyncSchema['sync_type'],
-    newSchemaIncrementalField: string | null,
-    originalSchemaSyncType: ExternalDataSourceSyncSchema['sync_type'],
-    originalSchemaIncrementalField: string | null
-): boolean => {
-    if (originalSchemaSyncType !== newSchemaSyncType) {
-        return true
-    }
-
-    if (newSchemaSyncType === 'incremental' && newSchemaIncrementalField !== originalSchemaIncrementalField) {
-        return true
-    }
-
-    return false
 }
 
 const getSaveDisabledReason = (
@@ -68,16 +50,7 @@ const getSaveDisabledReason = (
     }
 }
 
-export const SyncMethodForm = ({
-    schema,
-    onClose,
-    onSave,
-    saveButtonIsLoading,
-    showRefreshMessageOnChange,
-}: SyncMethodFormProps): JSX.Element => {
-    const [originalSchemaSyncType] = useState(schema.sync_type ?? null)
-    const [originalSchemaIncrementalField] = useState(schema.incremental_field ?? null)
-
+export const SyncMethodForm = ({ schema, onClose, onSave, saveButtonIsLoading }: SyncMethodFormProps): JSX.Element => {
     const [radioValue, setRadioValue] = useState(schema.sync_type ?? undefined)
     const [incrementalFieldValue, setIncrementalFieldValue] = useState(schema.incremental_field ?? null)
 
@@ -87,14 +60,6 @@ export const SyncMethodForm = ({
     }, [schema.table])
 
     const incrementalSyncSupported = getIncrementalSyncSupported(schema)
-
-    const inputChanged = hasInputChanged(
-        radioValue ?? null,
-        incrementalFieldValue,
-        originalSchemaSyncType,
-        originalSchemaIncrementalField
-    )
-    const showRefreshMessage = inputChanged && showRefreshMessageOnChange
 
     return (
         <>
@@ -160,11 +125,6 @@ export const SyncMethodForm = ({
                 ]}
                 onChange={(newValue) => setRadioValue(newValue)}
             />
-            {showRefreshMessage && (
-                <p className="text-danger">
-                    Note: Changing the sync type or incremental replication field will trigger a full table refresh
-                </p>
-            )}
             <div className="flex flex-row justify-end w-full">
                 <LemonButton className="mr-3" type="secondary" onClick={onClose}>
                     Close

--- a/frontend/src/scenes/data-warehouse/settings/source/Schemas.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/Schemas.tsx
@@ -395,7 +395,6 @@ const SyncMethodModal = ({ schema }: { schema: ExternalDataSourceSchema }): JSX.
             )}
             {showForm && (
                 <SyncMethodForm
-                    showRefreshMessageOnChange={currentSyncMethodModalSchema.sync_type !== null}
                     saveButtonIsLoading={saveButtonIsLoading}
                     schema={{
                         table: currentSyncMethodModalSchema.name,

--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -106,6 +106,7 @@ class PipelineNonDLT:
                 # Avoid schema mismatches from existing data about to be overwritten
                 self._logger.debug("Deleting existing table due to sync being full refresh")
                 self._delta_table_helper.reset_table()
+                self._schema.update_sync_type_config_for_reset_pipeline()
 
             for item in self._resource.items:
                 py_table = None

--- a/posthog/warehouse/api/test/test_external_data_schema.py
+++ b/posthog/warehouse/api/test/test_external_data_schema.py
@@ -6,6 +6,7 @@ import pytest
 from asgiref.sync import sync_to_async
 import pytest_asyncio
 from posthog.test.base import APIBaseTest
+from posthog.warehouse.models import DataWarehouseTable
 from posthog.warehouse.models.external_data_schema import ExternalDataSchema
 from posthog.warehouse.models.external_data_source import ExternalDataSource
 from django.conf import settings
@@ -183,14 +184,16 @@ class TestExternalDataSchema(APIBaseTest):
             )
 
             assert response.status_code == 200
-            mock_trigger_external_data_workflow.assert_called_once()
+            mock_trigger_external_data_workflow.assert_not_called()
             schema.refresh_from_db()
-            assert schema.sync_type_config.get("reset_pipeline") is True
+            assert schema.sync_type_config.get("reset_pipeline") is None
+            assert schema.sync_type == ExternalDataSchema.SyncType.FULL_REFRESH
 
     def test_update_schema_change_sync_type_incremental_field(self):
         source = ExternalDataSource.objects.create(
             team=self.team, source_type=ExternalDataSource.Type.STRIPE, job_inputs={}
         )
+        table = DataWarehouseTable.objects.create(team=self.team)
         schema = ExternalDataSchema.objects.create(
             name="BalanceTransaction",
             team=self.team,
@@ -198,25 +201,30 @@ class TestExternalDataSchema(APIBaseTest):
             should_sync=True,
             status=ExternalDataSchema.Status.COMPLETED,
             sync_type=ExternalDataSchema.SyncType.INCREMENTAL,
-            sync_type_config={"incremental_field": "some_other_field", "incremental_field_type": "datetime"},
+            sync_type_config={"incremental_field": "some_other_field", "incremental_field_type": "integer"},
+            table=table,
         )
 
-        with mock.patch(
-            "posthog.warehouse.api.external_data_schema.trigger_external_data_workflow"
-        ) as mock_trigger_external_data_workflow:
+        with (
+            mock.patch(
+                "posthog.warehouse.api.external_data_schema.trigger_external_data_workflow"
+            ) as mock_trigger_external_data_workflow,
+            mock.patch.object(DataWarehouseTable, "get_max_value_for_column", return_value=1),
+        ):
             response = self.client.patch(
                 f"/api/projects/{self.team.pk}/external_data_schemas/{schema.id}",
                 data={"sync_type": "incremental", "incremental_field": "field", "incremental_field_type": "integer"},
             )
 
             assert response.status_code == 200
-            mock_trigger_external_data_workflow.assert_called_once()
+            mock_trigger_external_data_workflow.assert_not_called()
 
             schema.refresh_from_db()
 
-            assert schema.sync_type_config.get("reset_pipeline") is True
+            assert schema.sync_type_config.get("reset_pipeline") is None
             assert schema.sync_type_config.get("incremental_field") == "field"
             assert schema.sync_type_config.get("incremental_field_type") == "integer"
+            assert schema.sync_type_config.get("incremental_field_last_value") == 1
 
     def test_update_schema_change_should_sync_off(self):
         source = ExternalDataSource.objects.create(

--- a/posthog/warehouse/models/external_data_schema.py
+++ b/posthog/warehouse/models/external_data_schema.py
@@ -174,7 +174,7 @@ class ExternalDataSchema(CreatedMetaFields, UpdatedMetaFields, UUIDModel, Delete
         self.sync_type_config.pop("partitioning_keys", None)
         self.save()
 
-    def update_incremental_field_last_value(self, last_value: Any) -> None:
+    def update_incremental_field_last_value(self, last_value: Any, save: bool = True) -> None:
         incremental_field_type = self.sync_type_config.get("incremental_field_type")
 
         last_value_py = last_value.item() if isinstance(last_value, numpy.generic) else last_value
@@ -205,7 +205,9 @@ class ExternalDataSchema(CreatedMetaFields, UpdatedMetaFields, UUIDModel, Delete
             last_value_json = str(last_value_py)
 
         self.sync_type_config["incremental_field_last_value"] = last_value_json
-        self.save()
+
+        if save:
+            self.save()
 
     def soft_delete(self):
         self.deleted = True


### PR DESCRIPTION
## Problem
- A requirement from the good ol' DLT days was that when we changed a table to go from incremental -> full refresh (or vice versa), or updated the incremental field on a table, the table required to be fully synced again

<img width="1080" alt="image" src="https://github.com/user-attachments/assets/9260506b-254c-4a28-bc0f-f13a33953ed0" />

## Changes
- This is no longer a constraint we have to fulfill - when updating the tables sync type or config, we just update the appropriate fields and allow the table to sync as normal on its next scheduled run
- When changing to incremental or updating the incremental field, we use clickhouse to get the `max(..)` value for that incremental field, ready for the next sync

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Tested a bunch locally + updated some tests