### PR TITLE
fix: Remove prefix from dataset_id if present

### DIFF
--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -781,9 +781,14 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         prefix = request.data.get("prefix", None)
         source_type = request.data["source_type"]
 
-        dataset_id = payload.get("dataset_id")
         key_file = payload.get("key_file", {})
         project_id = key_file.get("project_id")
+
+        dataset_id = payload.get("dataset_id")
+        # Very common to include the project_id as a prefix of the dataset_id.
+        # We remove it if it's there.
+        dataset_id = dataset_id.removeprefix(f"{project_id}.")
+
         private_key = key_file.get("private_key")
         private_key_id = key_file.get("private_key_id")
         client_email = key_file.get("client_email")

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -787,7 +787,8 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         dataset_id = payload.get("dataset_id")
         # Very common to include the project_id as a prefix of the dataset_id.
         # We remove it if it's there.
-        dataset_id = dataset_id.removeprefix(f"{project_id}.")
+        if dataset_id:
+            dataset_id = dataset_id.removeprefix(f"{project_id}.")
 
         private_key = key_file.get("private_key")
         private_key_id = key_file.get("private_key_id")


### PR DESCRIPTION
## Problem

It's very common to include the `project_id` in the `dataset_id` when creating a BigQuery source. Including `project_id` as a prefix in `dataset_id` can cause the workflow to fail at a later point, as we later assume each component to be the individual id. Even though this could be seen as incorrect, it is a very common case, so we should support it.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

* Remove `project_id` if present in `dataset_id` as a prefix.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Added unit test.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
