### PR TITLE
chore: clean up the usage report logging

### DIFF
--- a/posthog/tasks/report_utils.py
+++ b/posthog/tasks/report_utils.py
@@ -71,7 +71,7 @@ def capture_event(
             distinct_id,
             name,
             {**properties, "scope": "user"},
-            groups={"organization": organization_id, "instance": settings.SITE_URL},
+            groups={"organization": str(organization_id), "instance": settings.SITE_URL},
             timestamp=timestamp,
         )
     else:

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -7,7 +7,6 @@ from celery.schedules import crontab
 from django.conf import settings
 
 from posthog.caching.warming import schedule_warming_for_teams_task
-from posthog.utils import get_instance_region
 from posthog.tasks.alerts.checks import (
     alerts_backlog_task,
     check_alerts_task,
@@ -115,20 +114,11 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
     )
 
     # Send all instance usage to the Billing service
-    region = get_instance_region()
-    if region == "EU":
-        # Shift EU reports by 30 minutes to lighten the load
-        sender.add_periodic_task(
-            crontab(hour="3", minute="45"),
-            send_org_usage_reports.s(),
-            name="send instance usage report",
-        )
-    else:
-        sender.add_periodic_task(
-            crontab(hour="4", minute="15"),
-            send_org_usage_reports.s(),
-            name="send instance usage report",
-        )
+    sender.add_periodic_task(
+        crontab(hour="3", minute="45"),
+        send_org_usage_reports.s(),
+        name="send instance usage report",
+    )
 
     sender.add_periodic_task(
         crontab(hour="*", minute="30"),

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -45,7 +45,6 @@ from posthog.tasks.usage_report import (
     _get_team_report,
     _get_teams_for_usage_reports,
     capture_event,
-    capture_report,
     get_instance_metadata,
     send_all_org_usage_reports,
 )
@@ -1985,52 +1984,6 @@ class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
             timestamp="2021-10-10T23:01:00.00Z",
         )
         assert mock_client.capture.call_args[1]["timestamp"] == datetime(2021, 10, 10, 23, 1, tzinfo=tzutc())
-
-    @patch("posthog.tasks.usage_report.get_ph_client")
-    def test_capture_report_transforms_team_id_to_org_id(self, mock_client: MagicMock) -> None:
-        mock_posthog = MagicMock()
-        mock_client.return_value = mock_posthog
-
-        # Create a second team in the same organization to verify the mapping
-        team2 = Team.objects.create(organization=self.organization)
-
-        # Create a report with team-level data
-        report = {
-            "organization_name": "Test Org",
-            "date": "2024-01-01",
-        }
-
-        with self.is_cloud(True):
-            # Call capture_report
-            capture_report(capture_event_name="test event", team_id=team2.id, full_report_dict=report)
-
-        # Verify the capture call was made with the organization ID
-        mock_posthog.capture.assert_called_once_with(
-            self.user.distinct_id,
-            "test event",
-            {**report, "scope": "user"},
-            groups={"instance": "http://localhost:8010", "organization": str(self.organization.id)},
-            timestamp=None,
-        )
-
-        # now check with send_for_all_members=True
-        mock_posthog.reset_mock()
-
-        with self.is_cloud(True):
-            capture_report(
-                capture_event_name="test event",
-                team_id=self.team.id,
-                full_report_dict=report,
-                send_for_all_members=True,
-            )
-
-        mock_posthog.capture.assert_called_once_with(
-            self.user.distinct_id,
-            "test event",
-            {**report, "scope": "user"},
-            groups={"instance": "http://localhost:8010", "organization": str(self.organization.id)},
-            timestamp=None,
-        )
 
 
 class SendNoUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest):

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -1289,6 +1289,7 @@ def send_all_org_usage_reports(
             properties={
                 "total_orgs": total_orgs,
                 "total_orgs_sent": total_orgs_sent,
+                "region": get_instance_region(),
             },
         )
 
@@ -1333,6 +1334,7 @@ def send_all_org_usage_reports(
                 "total_orgs": total_orgs,
                 "total_orgs_sent": total_orgs_sent,
                 "total_time": time_since.total_seconds(),
+                "region": get_instance_region(),
             },
         )
 


### PR DESCRIPTION
## Changes

Improving some of the usage report changes we've made. 
- adding back the capture
- remove the capture from a celery task and doing it inline 
- adding new events that track total time for and number of orgs with usage 
- remove region offset since this doesn't put load on billing anymore

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Iit doesn't have an impact.

## How did you test this code?

Manually testing
