### PR TITLE
fix(sql): add parentheses to the or condition

### DIFF
--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -311,7 +311,7 @@ def create_event_definitions_sql(
             SELECT {",".join(event_definition_fields)}
             FROM posthog_eventdefinition
             {enterprise_join}
-            WHERE project_id = %(project_id)s OR (project_id IS NULL AND team_id = %(project_id)s) {conditions}
+            WHERE (project_id = %(project_id)s OR (project_id IS NULL AND team_id = %(project_id)s)) {conditions}
             ORDER BY {additional_ordering}name ASC
         """
 


### PR DESCRIPTION
## Problem

since we replaces coalesce with or clause, the rest of the condition was not being applied correctly. 

```sql
            WHERE project_id = %(project_id)s OR (project_id IS NULL AND team_id = %(project_id)s) {conditions}
```

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

add parentheses
```sql
            WHERE (project_id = %(project_id)s OR (project_id IS NULL AND team_id = %(project_id)s)) {conditions}
```

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
