### PR TITLE
fix: toolbar z-indexes

### DIFF
--- a/frontend/src/toolbar/elements/Elements.tsx
+++ b/frontend/src/toolbar/elements/Elements.tsx
@@ -59,29 +59,34 @@ export function Elements(): JSX.Element {
                 <Heatmap />
                 {highlightElementMeta?.rect ? <FocusRect rect={highlightElementMeta.rect} /> : null}
 
-                {elementsToDisplay.map(({ rect, element }, index) => (
-                    <AutocaptureElement
-                        key={`inspect-${index}`}
-                        rect={rect}
-                        style={{
-                            pointerEvents: heatmapPointerEvents,
-                            cursor: 'pointer',
-                            zIndex: hoverElement === element ? 2 : 1,
-                            opacity:
-                                (!hoverElement && !selectedElement) ||
-                                selectedElement === element ||
-                                hoverElement === element
-                                    ? 1
-                                    : 0.4,
-                            transition: 'opacity 0.2s, box-shadow 0.2s',
-                            borderRadius: 5,
-                            ...getBoxColors('blue', hoverElement === element || selectedElement === element),
-                        }}
-                        onClick={() => selectElement(element)}
-                        onMouseOver={() => selectedElement === null && setHoverElement(element)}
-                        onMouseOut={() => selectedElement === null && setHoverElement(null)}
-                    />
-                ))}
+                {elementsToDisplay.map(({ rect, element }, index) => {
+                    // being able to hover over elements might rely on their original z-index
+                    // so we copy it over to the toolbar element
+                    const elementZIndex = getComputedStyle(element).zIndex
+                    return (
+                        <AutocaptureElement
+                            key={`inspect-${index}`}
+                            rect={rect}
+                            style={{
+                                pointerEvents: heatmapPointerEvents,
+                                cursor: 'pointer',
+                                zIndex: elementZIndex ? elementZIndex : hoverElement === element ? 2 : 1,
+                                opacity:
+                                    (!hoverElement && !selectedElement) ||
+                                    selectedElement === element ||
+                                    hoverElement === element
+                                        ? 1
+                                        : 0.4,
+                                transition: 'opacity 0.2s, box-shadow 0.2s',
+                                borderRadius: 5,
+                                ...getBoxColors('blue', hoverElement === element || selectedElement === element),
+                            }}
+                            onClick={() => selectElement(element)}
+                            onMouseOver={() => selectedElement === null && setHoverElement(element)}
+                            onMouseOut={() => selectedElement === null && setHoverElement(null)}
+                        />
+                    )
+                })}
 
                 {heatmapElements.map(({ rect, count, clickCount, rageclickCount, element }, index) => {
                     return (


### PR DESCRIPTION
the toolbar set all highlight elements to the same z-index
but for some layouts the z-indices are essential for interactions to make sense

so we copy the z-indexes across

| before | after | 
| - | - |
| ![2025-03-14 23 38 04](https://github.com/user-attachments/assets/5a3f7ba1-2724-47bd-9233-ccc56c8fa1a5)|![2025-03-14 23 36 54](https://github.com/user-attachments/assets/113be94c-e5b5-408b-8881-ce8ba858dbbc)|
