### PR TITLE
feat(cdp): Account for events and properties in Definition views

### DIFF
--- a/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionEdit.tsx
@@ -82,7 +82,7 @@ export function DefinitionEdit(props: DefinitionLogicProps = {}): JSX.Element {
                     <div>
                         <h1>Editing "{getFilterLabel(editDefinition.name, TaxonomicFilterGroupType.Events) || ''}"</h1>
                         <div className="flex flex-wrap items-center gap-2 text-secondary">
-                            <div>Raw event name:</div>
+                            <div>{isProperty ? 'Property' : 'Event'} name:</div>
                             <LemonTag className="font-mono">{editDefinition.name}</LemonTag>
                         </div>
                     </div>

--- a/frontend/src/scenes/data-management/definition/DefinitionView.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionView.tsx
@@ -215,7 +215,7 @@ export function DefinitionView(props: DefinitionLogicProps = {}): JSX.Element {
 
                 <UserActivityIndicator at={definition.updated_at} by={definition.updated_by} />
                 <div className="flex flex-wrap items-center gap-2 text-secondary">
-                    <div>Raw event name:</div>
+                    <div>{isProperty ? 'Property' : 'Event'} name:</div>
                     <LemonTag className="font-mono">{definition.name}</LemonTag>
                 </div>
             </div>


### PR DESCRIPTION
## Problem
We currently render the event or property name in these views as "Raw event name:" whether the attribute in question is an event or a property.

## Changes
* Update `DefinitionView` to render different text for `EventDefinition` vs `PropertyDefinition` name display
* Same for `DefinitionEdit`

## Does this work well for both Cloud and self-hosted?
Sure

## How did you test this code?
Locally and in CI
