### PR TITLE
ci: move off of `ubuntu-20.04`

### DIFF
--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -14,7 +14,7 @@ on:
 jobs:
     notify_sentry:
         name: Notify Sentry of a production release
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         if: github.repository == 'PostHog/posthog'
         steps:
             - name: Checkout master


### PR DESCRIPTION
## Problem

The Ubuntu 20.04 Actions runner image will begin deprecation on 2025-02-01 and will be fully unsupported by 2025-04-01

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Closes #29994

## Changes

This change moves away from `Ubuntu 20.04`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

It shouldn't have an impact.

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

I ran these changes on a fork of this repository.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->