### PR TITLE
fix: playlist counting error validating some template duration filters

### DIFF
--- a/ee/session_recordings/test/test_recordings_that_match_playlist_filters.py
+++ b/ee/session_recordings/test/test_recordings_that_match_playlist_filters.py
@@ -276,3 +276,64 @@ class TestRecordingsThatMatchPlaylistFilters(APIBaseTest):
                 call(playlist1.id),
                 call(playlist2.id),
             ]
+
+    @patch("posthoganalytics.capture_exception")
+    @patch("ee.session_recordings.playlist_counters.recordings_that_match_playlist_filters.list_recordings_from_query")
+    def test_template_rageclick_filter_should_process(
+        self, mock_list_recordings_from_query: MagicMock, mock_capture_exception: MagicMock
+    ) -> None:
+        """
+        This is a regression test, we saw this failing in prod
+        """
+        playlist = SessionRecordingPlaylist.objects.create(
+            team=self.team,
+            name="test",
+            filters={
+                "order": "start_time",
+                "date_to": None,
+                "duration": [{"key": "active_seconds", "type": "recording", "value": 5, "operator": "gt"}],
+                "date_from": "-3d",
+                "filter_group": {
+                    "type": "AND",
+                    "values": [{"type": "AND", "values": [{"id": "$rageclick", "type": "events", "order": 0}]}],
+                },
+                "filter_test_accounts": False,
+            },
+        )
+
+        mock_list_recordings_from_query.return_value = ([], False, None)
+        count_recordings_that_match_playlist_filters(playlist.id)
+        mock_capture_exception.assert_not_called()
+
+        assert mock_list_recordings_from_query.call_args[0] == (
+            RecordingsQuery(
+                actions=[],
+                console_log_filters=[],
+                date_from="-3d",
+                date_to=None,
+                events=[
+                    {
+                        "id": "$rageclick",
+                        "type": "events",
+                        "order": 0,
+                    }
+                ],
+                filter_test_accounts=False,
+                having_predicates=[
+                    RecordingPropertyFilter(
+                        key="active_seconds", label=None, operator=PropertyOperator.GT, type="recording", value=5.0
+                    )
+                ],
+                kind="RecordingsQuery",
+                limit=None,
+                modifiers=None,
+                offset=None,
+                operand=FilterLogicalOperator.AND_,
+                order=RecordingOrder.START_TIME,
+                person_uuid=None,
+                properties=[],
+                response=None,
+                session_ids=None,
+                user_modified_filters=None,
+            ),
+        )


### PR DESCRIPTION
this adds a test
a speculative fix
and some extra logging

the rageclick template playlist is pretty consistently failing validation
but copying the filters out of one of the playlists that is failing
and putting it into a test
does not generate a failing test