### PR TITLE
chore: Reinstate `changed-files` steps

### DIFF
--- a/.github/workflows/build-hogql-parser.yml
+++ b/.github/workflows/build-hogql-parser.yml
@@ -23,7 +23,7 @@ jobs:
 
             - name: Check if common/hogql_parser/ has changed
               id: changed-files
-              # uses: tj-actions/changed-files@v43 compromised
+              uses: step-security/changed-files@v45
               with:
                   since_last_remote_commit: true
                   files_yaml: |

--- a/.github/workflows/container-images-ci.yml
+++ b/.github/workflows/container-images-ci.yml
@@ -66,7 +66,7 @@ jobs:
 
             - name: Check if any Dockerfile has changed
               id: changed-files
-              # uses: tj-actions/changed-files@v43  compromised
+              uses: step-security/changed-files@v45
               with:
                   files: |
                       **/Dockerfile


### PR DESCRIPTION
Step Security released a new version of the action that's not compromised. It'll act as a substitute for now, allowing us to go back to using our CI

https://github.com/step-security/changed-files

Follow-up steps: pin all of our Actions following https://michaelheap.com/pin-your-github-actions/