### PR TITLE
security: Pin GH Actions to a specific version

### DIFF
--- a/.github/actions/build-n-cache-image/action.yml
+++ b/.github/actions/build-n-cache-image/action.yml
@@ -45,20 +45,20 @@ runs:
     using: 'composite'
     steps:
         - name: Checkout
-          uses: actions/checkout@v4
+          uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
         - name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@v3
+          uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
 
         - name: Set up QEMU
-          uses: docker/setup-qemu-action@v3
+          uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
 
         - name: Set up Depot CLI
-          uses: depot/setup-action@v1
+          uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1
 
         - name: Configure AWS credentials
           if: ${{ inputs.push-image == 'true' }}
-          uses: aws-actions/configure-aws-credentials@v4
+          uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
           with:
               aws-access-key-id: ${{ inputs.aws-access-key }}
               aws-secret-access-key: ${{ inputs.aws-access-secret }}
@@ -66,7 +66,7 @@ runs:
 
         - name: Login to DockerHub
           if: ${{ inputs.push-image == 'true' }}
-          uses: docker/login-action@v3
+          uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
           with:
               username: ${{ inputs.dockerhub-username }}
               password: ${{ inputs.dockerhub-password }}
@@ -74,7 +74,7 @@ runs:
         - name: Login to Amazon ECR
           if: ${{ inputs.push-image == 'true' }}
           id: aws-ecr
-          uses: aws-actions/amazon-ecr-login@v2
+          uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
 
         - name: Emit image tag
           id: emit
@@ -91,7 +91,7 @@ runs:
 
         - name: Build image
           id: build
-          uses: depot/build-push-action@v1
+          uses: depot/build-push-action@636daae76684e38c301daa0c5eca1c095b24e780 # v1
           with:
               context: .
               buildx-fallback: false # buildx is so slow it's better to just fail

--- a/.github/actions/get-pr-labels/action.yml
+++ b/.github/actions/get-pr-labels/action.yml
@@ -14,7 +14,7 @@ runs:
     steps:
         - name: Get PR associated with the last commit
           id: pr-info
-          uses: octokit/request-action@v2.x
+          uses: octokit/request-action@05a2312de9f8207044c4c9e41fe19703986acc13 # v2.x
           with:
               route: GET /repos/${{ github.repository }}/commits/${{ github.sha }}/pulls
           env:

--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -46,7 +46,7 @@ runs:
           run: echo "127.0.0.1 kafka clickhouse" | sudo tee -a /etc/hosts
 
         - name: Set up Python
-          uses: actions/setup-python@v5
+          uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
           with:
               python-version: ${{ inputs.python-version }}
               cache: pip
@@ -72,10 +72,10 @@ runs:
               sudo apt-get update && sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
         - name: Install pnpm
-          uses: pnpm/action-setup@v4
+          uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
 
         - name: Set up Node.js
-          uses: actions/setup-node@v3
+          uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3
           with:
               node-version: 18.12.1
               cache: pnpm
@@ -84,7 +84,7 @@ runs:
         # with exit code 134 _after passing_ all tests
         # this appears to fix it
         # absolute wild tbh https://stackoverflow.com/a/75503402
-        - uses: tlambert03/setup-qt-libs@v1
+        - uses: tlambert03/setup-qt-libs@19e4ef2d781d81f5f067182e228b54ec90d23b76 # v1
 
         - name: Install plugin_transpiler
           shell: bash
@@ -208,7 +208,7 @@ runs:
           run: docker compose -f docker-compose.dev.yml logs
 
         - name: Upload updated timing data as artifacts
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
           if: ${{ inputs.person-on-events != 'true' && inputs.clickhouse-server-image == 'clickhouse/clickhouse-server:24.8.7.41' }}
           with:
               name: timing_data-${{ inputs.segment }}-${{ inputs.group }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -34,7 +34,7 @@ jobs:
             - id: automergeStep
               name: Automerge
               if: env.IS_POSTHOG_BOT_AVAILABLE == 'true'
-              uses: pascalgn/automerge-action@v0.16.3
+              uses: pascalgn/automerge-action@d1203c0bf94a827b991e5de69d662e9163304fa0 # v0.16.3
               env:
                   GITHUB_TOKEN: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,13 +34,13 @@ jobs:
             BENCHMARK: '1'
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
               with:
                   # Checkout repo with full history
                   fetch-depth: 0
 
             - name: Check out PostHog/benchmarks-results repo
-              uses: actions/checkout@v3
+              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
               with:
                   path: ee/benchmarks/results
                   repository: PostHog/benchmark-results
@@ -52,7 +52,7 @@ jobs:
                   docker compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
               with:
                   python-version: 3.11.9
                   cache: 'pip'
@@ -102,7 +102,7 @@ jobs:
 
             - name: Commit update for benchmark results
               if: ${{ github.repository == 'PostHog/posthog' && github.ref == 'refs/heads/master' }}
-              uses: stefanzweifel/git-auto-commit-action@v5
+              uses: stefanzweifel/git-auto-commit-action@e348103e9026cc0eee72ae06630dbe30c8bf7a79 # v5
               with:
                   repository: ee/benchmarks/results
                   branch: master
@@ -112,7 +112,7 @@ jobs:
                   commit_author: PostHog Bot <hey@posthog.com>
 
             - name: Upload results as artifacts
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
               with:
                   name: benchmarks
                   path: |
@@ -122,20 +122,20 @@ jobs:
             - name: Read benchmark output
               if: ${{ github.event_name == 'pull_request' }}
               id: pr_vs_master_changed
-              uses: juliangruber/read-file-action@v1
+              uses: juliangruber/read-file-action@b549046febe0fe86f8cb4f93c24e284433f9ab58 # v1
               with:
                   path: pr_vs_master_changed.txt
 
             - name: Read benchmark output (full)
               if: ${{ github.event_name == 'pull_request' }}
               id: pr_vs_master
-              uses: juliangruber/read-file-action@v1
+              uses: juliangruber/read-file-action@b549046febe0fe86f8cb4f93c24e284433f9ab58 # v1
               with:
                   path: pr_vs_master.txt
 
             - name: Find Comment
               if: ${{ github.event_name == 'pull_request' }}
-              uses: peter-evans/find-comment@v2
+              uses: peter-evans/find-comment@a54c31d7fa095754bfef525c0c8e5e5674c4b4b1 # v2
               id: fc
               with:
                   issue-number: ${{ github.event.number }}
@@ -144,7 +144,7 @@ jobs:
 
             - name: Create or update comment
               if: ${{ github.event_name == 'pull_request' }}
-              uses: peter-evans/create-or-update-comment@v3
+              uses: peter-evans/create-or-update-comment@23ff15729ef2fc348714a3bb66d2f655ca9066f2 # v3
               with:
                   comment-id: ${{ steps.fc.outputs.comment-id }}
                   issue-number: ${{ github.event.number }}

--- a/.github/workflows/browserslist.yml
+++ b/.github/workflows/browserslist.yml
@@ -1,4 +1,4 @@
-name: Update Browserslist database
+name: Browserslist
 
 on:
     schedule:
@@ -14,7 +14,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
               with:
                   fetch-depth: 0
 
@@ -24,16 +24,16 @@ jobs:
                   git config --global user.name "Browserslist Update Action"
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
 
             - name: Set up Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
               with:
                   node-version: 18.12.1
                   cache: 'pnpm'
 
             - name: Update Browserslist database and create PR if applies
-              uses: c2corg/browserslist-update-action@v2
+              uses: c2corg/browserslist-update-action@a76abb476199caea5399f9e28ff3f16e491ec566 # v2
               with:
                   github_token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }} # This token has permission to open PRs
                   commit_message: 'build: update Browserslist db'

--- a/.github/workflows/build-hogql-parser.yml
+++ b/.github/workflows/build-hogql-parser.yml
@@ -17,13 +17,13 @@ jobs:
         outputs:
             parser-release-needed: ${{ steps.version.outputs.parser-release-needed }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
               with:
                   fetch-depth: 0 # Fetching all for comparison since last push (not just last commit)
 
             - name: Check if common/hogql_parser/ has changed
               id: changed-files
-              uses: step-security/changed-files@v45
+              uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45
               with:
                   since_last_remote_commit: true
                   files_yaml: |
@@ -62,9 +62,9 @@ jobs:
                 os: [ubuntu-22.04, buildjet-2vcpu-ubuntu-2204-arm, macos-13]
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-            - uses: actions/setup-python@v4
+            - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
               with:
                   python-version: '3.11'
 
@@ -81,7 +81,7 @@ jobs:
                   MACOSX_DEPLOYMENT_TARGET: '13' # A modern target allows us to use C++20
 
             - name: Upload wheels artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
               with:
                   name: wheels-${{ matrix.os }}
                   path: |
@@ -98,27 +98,27 @@ jobs:
         runs-on: ubuntu-22.04
         steps:
             - name: Download wheels from ubuntu-22.04
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
               with:
                   name: wheels-ubuntu-22.04
                   path: dist
 
             - name: Download wheels from buildjet-2vcpu-ubuntu-2204-arm
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
               with:
                   name: wheels-buildjet-2vcpu-ubuntu-2204-arm
                   path: dist
 
             - name: Download wheels from macos-13
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
               with:
                   name: wheels-macos-13
                   path: dist
 
             - name: Publish package to PyPI
-              uses: pypa/gh-action-pypi-publish@release/v1
+              uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # release/v1
 
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
               with:
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
                   ref: ${{ github.event.pull_request.head.ref }}
@@ -130,7 +130,7 @@ jobs:
                   sed -i "s/hogql-parser==.*/hogql-parser==${local}/g" requirements.in
                   sed -i "s/hogql-parser==.*/hogql-parser==${local}/g" requirements.txt
 
-            - uses: EndBug/add-and-commit@v9
+            - uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9
               with:
                   add: '["requirements.in", "requirements.txt"]'
                   message: 'Use new hogql-parser version'

--- a/.github/workflows/ci-backend-update-test-timing.yml
+++ b/.github/workflows/ci-backend-update-test-timing.yml
@@ -21,7 +21,7 @@ jobs:
         name: Run Django tests and save test durations
         runs-on: ubuntu-24.04
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
             - uses: ./.github/actions/run-backend-tests
               with:
@@ -34,7 +34,7 @@ jobs:
                   person-on-events: false
 
             - name: Upload updated timing data as artifacts
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
               if: ${{ inputs.person-on-events != 'true' && inputs.clickhouse-server-image == 'clickhouse/clickhouse-server:24.8.7.41' }}
               with:
                   name: timing_data-${{ inputs.segment }}-${{ inputs.group }}

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -52,9 +52,9 @@ jobs:
         steps:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-            - uses: dorny/paths-filter@v2
+            - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
               id: filter
               with:
                   filters: |
@@ -100,17 +100,17 @@ jobs:
         steps:
             # If this run wasn't initiated by the bot (meaning: snapshot update) and we've determined
             # there are backend changes, cancel previous runs
-            - uses: n1hility/cancel-previous-runs@v3
+            - uses: n1hility/cancel-previous-runs@e709d8e41b16d5d0b8d529d293c5e126c57dc022 # v3
               if: github.actor != 'posthog-bot' && needs.changes.outputs.backend == 'true'
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
 
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
               with:
                   fetch-depth: 1
 
             - name: Set up Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
               with:
                   python-version: 3.11.9
                   cache: 'pip'
@@ -157,7 +157,7 @@ jobs:
         runs-on: depot-ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
             - name: Stop/Start stack with Docker Compose
               run: |
@@ -165,7 +165,7 @@ jobs:
                   docker compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
               with:
                   python-version: 3.11.9
                   cache: 'pip'
@@ -182,7 +182,7 @@ jobs:
 
             # First running migrations from master, to simulate the real-world scenario
             - name: Checkout master
-              uses: actions/checkout@v3
+              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
               with:
                   ref: master
 
@@ -196,7 +196,7 @@ jobs:
 
             # Now we can consider this PR's migrations
             - name: Checkout this PR
-              uses: actions/checkout@v3
+              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
             - name: Install python dependencies for this PR
               run: |
@@ -265,7 +265,7 @@ jobs:
             # The first step is the only one that should run if `needs.changes.outputs.backend == 'false'`.
             # All the other ones should rely on `needs.changes.outputs.backend` directly or indirectly, so that they're
             # effectively skipped if backend code is unchanged. See https://github.com/PostHog/posthog/pull/15174.
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
               with:
                   fetch-depth: 1
                   repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -284,8 +284,7 @@ jobs:
                   group: ${{ matrix.group }}
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
 
-            - uses: EndBug/add-and-commit@v9
-              # Skip on forks
+            - uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9
               # Also skip for persons-on-events runs, as we want to ignore snapshots diverging there
               if: ${{ github.event.pull_request.head.repo.full_name == 'PostHog/posthog' && needs.changes.outputs.backend == 'true' && !matrix.person-on-events }}
               with:
@@ -314,7 +313,7 @@ jobs:
                   exit 1
 
             - name: Archive email renders
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
               if: needs.changes.outputs.backend == 'true' && matrix.segment == 'Core' && matrix.person-on-events == false
               with:
                   name: email_renders-${{ matrix.segment }}-${{ matrix.person-on-events }}
@@ -332,7 +331,7 @@ jobs:
         runs-on: depot-ubuntu-latest
         steps:
             - name: 'Checkout repo'
-              uses: actions/checkout@v3
+              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
               with:
                   fetch-depth: 1
 
@@ -343,7 +342,7 @@ jobs:
                   docker compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
               with:
                   python-version: 3.11.9
                   cache: 'pip'

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -23,7 +23,7 @@ jobs:
             shouldRun: ${{ steps.changes.outputs.shouldRun }}
         steps:
             # For pull requests it's not necessary to check out the code
-            - uses: dorny/paths-filter@v2
+            - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
               id: changes
               with:
                   filters: |
@@ -65,7 +65,7 @@ jobs:
         steps:
             - name: Checkout
               if: needs.changes.outputs.shouldRun == 'true'
-              uses: actions/checkout@v3
+              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
             - name: Build the Docker image with Depot
               if: needs.changes.outputs.shouldRun == 'true'
               # Build the container image in preparation for the E2E tests
@@ -87,15 +87,15 @@ jobs:
         steps:
             - name: Checkout
               if: needs.changes.outputs.shouldRun == 'true'
-              uses: actions/checkout@v3
+              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
             - name: Install pnpm
               if: needs.changes.outputs.shouldRun == 'true'
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
 
             - name: Set up Node.js
               if: needs.changes.outputs.shouldRun == 'true'
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
               with:
                   node-version: 18.12.1
                   cache: 'pnpm'
@@ -105,7 +105,7 @@ jobs:
               id: pnpm-cache-dir
               run: echo "PNPM_STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-            - uses: actions/cache@v4
+            - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
               if: needs.changes.outputs.shouldRun == 'true'
               id: pnpm-cache
               with:
@@ -137,11 +137,11 @@ jobs:
 
             - name: Install Depot CLI
               if: needs.changes.outputs.shouldRun == 'true'
-              uses: depot/setup-action@v1
+              uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1
 
             - name: Get Docker image cached in Depot
               if: needs.changes.outputs.shouldRun == 'true'
-              uses: depot/pull-action@v1
+              uses: depot/pull-action@8a922bdade29cf5facf3a13020cccd3b7a8127c2 # v1
               with:
                   build-id: ${{ needs.container.outputs.build-id }}
                   tags: ${{ needs.container.outputs.tag }}
@@ -193,7 +193,7 @@ jobs:
               # this action might be abandoned - but v1 doesn't point to latest of v1 (which it should)
               # so pointing to v1.1.0 to remove warnings about node version with v1
               # todo check https://github.com/iFaxity/wait-on-action/releases for new releases
-              uses: iFaxity/wait-on-action@v1.2.1
+              uses: iFaxity/wait-on-action@a7d13170ec542bdca4ef8ac4b15e9c6aa00a6866 # v1.2.1
               timeout-minutes: 3
               with:
                   verbose: true
@@ -210,7 +210,7 @@ jobs:
                   GITHUB_ACTION_RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
             - name: Archive report
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
               with:
                   name: playwright-report
                   path: playwright/playwright-report/

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -22,7 +22,7 @@ jobs:
             shouldTriggerCypress: ${{ steps.changes.outputs.shouldTriggerCypress }}
         steps:
             # For pull requests it's not necessary to check out the code
-            - uses: dorny/paths-filter@v2
+            - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
               id: changes
               with:
                   filters: |
@@ -56,7 +56,7 @@ jobs:
             chunks: ${{ steps.chunk.outputs.chunks }}
         steps:
             - name: Check out
-              uses: actions/checkout@v3
+              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
             - name: Group spec files into chunks of three
               id: chunk
@@ -101,7 +101,7 @@ jobs:
         steps:
             - name: Checkout
               if: needs.changes.outputs.shouldTriggerCypress == 'true'
-              uses: actions/checkout@v3
+              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
             - name: Build the Docker image with Depot
               if: needs.changes.outputs.shouldTriggerCypress == 'true'
               # Build the container image in preparation for the E2E tests
@@ -131,15 +131,15 @@ jobs:
         steps:
             - name: Checkout
               if: needs.changes.outputs.shouldTriggerCypress == 'true'
-              uses: actions/checkout@v3
+              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
             - name: Install pnpm
               if: needs.changes.outputs.shouldTriggerCypress == 'true'
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
 
             - name: Set up Node.js
               if: needs.changes.outputs.shouldTriggerCypress == 'true'
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
               with:
                   node-version: 18.12.1
                   cache: 'pnpm'
@@ -154,7 +154,7 @@ jobs:
               id: cypress-cache-dir
               run: echo "CYPRESS_BIN_PATH=$(npx cypress cache path)" >> $GITHUB_OUTPUT
 
-            - uses: actions/cache@v4
+            - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
               if: needs.changes.outputs.shouldTriggerCypress == 'true'
               id: pnpm-cache
               with:
@@ -188,11 +188,11 @@ jobs:
 
             - name: Install Depot CLI
               if: needs.changes.outputs.shouldTriggerCypress == 'true'
-              uses: depot/setup-action@v1
+              uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1
 
             - name: Get Docker image cached in Depot
               if: needs.changes.outputs.shouldTriggerCypress == 'true'
-              uses: depot/pull-action@v1
+              uses: depot/pull-action@8a922bdade29cf5facf3a13020cccd3b7a8127c2 # v1
               with:
                   build-id: ${{ needs.container.outputs.build-id }}
                   tags: ${{ needs.container.outputs.tag }}
@@ -245,7 +245,7 @@ jobs:
               # this action might be abandoned - but v1 doesn't point to latest of v1 (which it should)
               # so pointing to v1.1.0 to remove warnings about node version with v1
               # todo check https://github.com/iFaxity/wait-on-action/releases for new releases
-              uses: iFaxity/wait-on-action@v1.2.1
+              uses: iFaxity/wait-on-action@a7d13170ec542bdca4ef8ac4b15e9c6aa00a6866 # v1.2.1
               timeout-minutes: 3
               with:
                   verbose: true
@@ -255,7 +255,7 @@ jobs:
             - name: Cypress run
               # these are required checks so, we can't skip entire sections
               if: needs.changes.outputs.shouldTriggerCypress == 'true'
-              uses: cypress-io/github-action@v6
+              uses: cypress-io/github-action@108b8684ae52e735ff7891524cbffbcd4be5b19f # v6
               with:
                   install-command: 'pnpm --filter=@posthog/cypress... install --frozen-lockfile'
                   command: 'pnpm --filter=@posthog/cypress exec cypress run --config-file cypress.e2e.config.ts --spec ${{ matrix.chunk }} --headed'
@@ -267,21 +267,21 @@ jobs:
                   GITHUB_ACTION_RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
             - name: Archive test screenshots
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
               with:
                   name: screenshots-${{ strategy.job-index }}
                   path: cypress/screenshots
               if: ${{ failure() }}
 
             - name: Archive test downloads
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
               with:
                   name: downloads-${{ strategy.job-index }}
                   path: cypress/downloads
               if: ${{ failure() }}
 
             - name: Archive test videos
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
               with:
                   name: videos-${{ strategy.job-index }}
                   path: cypress/videos
@@ -289,7 +289,7 @@ jobs:
 
             - name: Archive accessibility violations
               if: needs.changes.outputs.shouldTriggerCypress == 'true'
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
               with:
                   name: accessibility-violations-${{ strategy.job-index }}
                   path: '**/a11y/'
@@ -297,7 +297,7 @@ jobs:
 
             - name: Show logs on failure
               # use artefact here, as I think the output will be too large for display in an action
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
               with:
                   name: logs-${{ strategy.job-index }}
                   path: /tmp/logs

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -24,9 +24,9 @@ jobs:
         steps:
             # For pull requests it's not necessary to check out the code, but we
             # also want this to run on master, so we need to check out
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-            - uses: dorny/paths-filter@v2
+            - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
               id: filter
               with:
                   filters: |
@@ -61,15 +61,15 @@ jobs:
         runs-on: depot-ubuntu-24.04-4
         steps:
             # we need at least one thing to run to make sure we include everything for required jobs
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
             - name: Install pnpm
               if: needs.changes.outputs.frontend == 'true'
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
 
             - name: Set up Node.js
               if: needs.changes.outputs.frontend == 'true'
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
               with:
                   node-version: 18.12.1
                   cache: 'pnpm'
@@ -79,7 +79,7 @@ jobs:
               id: pnpm-cache-dir
               run: echo "PNPM_STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-            - uses: actions/cache@v4
+            - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
               if: needs.changes.outputs.frontend == 'true'
               id: pnpm-cache
               with:
@@ -123,7 +123,7 @@ jobs:
 
             - name: Check toolbar bundle size
               if: needs.changes.outputs.frontend == 'true'
-              uses: preactjs/compressed-size-action@v2
+              uses: preactjs/compressed-size-action@946a292cd35bd1088e0d7eb92b69d1a8d5b5d76a # v2
               with:
                   build-script: '--filter=@posthog/frontend build'
                   install-script: 'pnpm --filter=@posthog/frontend... install'
@@ -146,7 +146,7 @@ jobs:
 
         steps:
             # we need at least one thing to run to make sure we include everything for required jobs
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
             - name: Remove ee
               if: needs.changes.outputs.frontend == 'true' && matrix.segment == 'FOSS'
@@ -154,11 +154,11 @@ jobs:
 
             - name: Install pnpm
               if: needs.changes.outputs.frontend == 'true'
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
 
             - name: Set up Node.js
               if: needs.changes.outputs.frontend == 'true'
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
               with:
                   node-version: 18.12.1
                   cache: pnpm

--- a/.github/workflows/ci-hobby.yml
+++ b/.github/workflows/ci-hobby.yml
@@ -26,8 +26,8 @@ jobs:
         timeout-minutes: 30
         name: Setup DO Hobby Instance and test
         steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-python@v4
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
               with:
                   python-version: '3.8'
                   cache: 'pip' # caching pip dependencies

--- a/.github/workflows/ci-hog.yml
+++ b/.github/workflows/ci-hog.yml
@@ -29,9 +29,9 @@ jobs:
         steps:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-            - uses: dorny/paths-filter@v2
+            - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
               id: filter
               with:
                   filters: |
@@ -55,17 +55,17 @@ jobs:
         steps:
             # If this run wasn't initiated by the bot (meaning: snapshot update) and we've determined
             # there are backend changes, cancel previous runs
-            - uses: n1hility/cancel-previous-runs@v3
+            - uses: n1hility/cancel-previous-runs@e709d8e41b16d5d0b8d529d293c5e126c57dc022 # v3
               if: github.actor != 'posthog-bot'
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
 
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
               with:
                   fetch-depth: 1
 
             - name: Set up Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
               with:
                   python-version: 3.11.9
                   cache: 'pip'
@@ -85,10 +85,10 @@ jobs:
                   uv pip install --system -r requirements.txt -r requirements-dev.txt
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
 
             - name: Set up Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
               with:
                   node-version: 18
                   cache: 'pnpm'
@@ -148,7 +148,7 @@ jobs:
             is-new-version: ${{ steps.check-package-version.outputs.is-new-version }}
         steps:
             - name: Checkout the repository
-              uses: actions/checkout@v2
+              uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
             - name: Check package version and detect an update
               id: check-package-version
               uses: PostHog/check-package-version@v2
@@ -165,12 +165,12 @@ jobs:
             PUBLISHED_VERSION: ${{ needs.check-package-version.outputs.published-version }}
         steps:
             - name: Checkout the repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
               with:
                   fetch-depth: 1
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
             - name: Set up Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
               with:
                   python-version: 3.11.9
                   cache: 'pip'
@@ -185,9 +185,9 @@ jobs:
               run: |
                   uv pip install --system -r requirements.txt -r requirements-dev.txt
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
             - name: Set up Node 18
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
               with:
                   node-version: 18
                   cache: 'pnpm'

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -32,9 +32,9 @@ jobs:
         steps:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-            - uses: dorny/paths-filter@v2
+            - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
               id: filter
               with:
                   filters: |
@@ -55,13 +55,13 @@ jobs:
         if: needs.changes.outputs.plugin-server == 'true'
         runs-on: depot-ubuntu-24.04-4
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
 
             - name: Set up Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
               with:
                   node-version: 18.12.1
                   cache: pnpm
@@ -97,7 +97,7 @@ jobs:
             - name: Code check out
               # NOTE: We need this check on every step so that it still runs if skipped as we need it to suceed for the CI
               if: needs.changes.outputs.plugin-server == 'true'
-              uses: actions/checkout@v3
+              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
             - name: Stop/Start stack with Docker Compose
               if: needs.changes.outputs.plugin-server == 'true'
@@ -111,7 +111,7 @@ jobs:
 
             - name: Set up Python
               if: needs.changes.outputs.plugin-server == 'true'
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
               with:
                   python-version: 3.11.9
                   cache: 'pip'
@@ -123,9 +123,9 @@ jobs:
 
             - name: Install rust
               if: needs.changes.outputs.plugin-server == 'true'
-              uses: dtolnay/rust-toolchain@1.82
+              uses: dtolnay/rust-toolchain@2d6ac6e12ff6f69821a786a25ca0db906b4e4ba2 # 1.82
 
-            - uses: actions/cache@v4
+            - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
               with:
                   path: |
                       ~/.cargo/registry
@@ -152,11 +152,11 @@ jobs:
 
             - name: Install pnpm
               if: needs.changes.outputs.plugin-server == 'true'
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
 
             - name: Set up Node.js
               if: needs.changes.outputs.plugin-server == 'true'
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
               with:
                   node-version: 18.12.1
                   cache: pnpm
@@ -214,7 +214,7 @@ jobs:
         steps:
             - name: Code check out
               if: needs.changes.outputs.plugin-server == 'true'
-              uses: actions/checkout@v3
+              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
             - name: Stop/Start stack with Docker Compose
               if: needs.changes.outputs.plugin-server == 'true'
@@ -228,7 +228,7 @@ jobs:
 
             - name: Set up Python
               if: needs.changes.outputs.plugin-server == 'true'
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
               with:
                   python-version: 3.11.9
                   cache: 'pip'
@@ -252,11 +252,11 @@ jobs:
 
             - name: Install pnpm
               if: needs.changes.outputs.plugin-server == 'true'
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
 
             - name: Set up Node.js
               if: needs.changes.outputs.plugin-server == 'true'
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
               with:
                   node-version: 18.12.1
                   cache: pnpm
@@ -290,7 +290,7 @@ jobs:
                   ./bin/ci_functional_tests.sh
 
             - name: Upload coverage report
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
               if: needs.changes.outputs.plugin-server == 'true'
               with:
                   name: functional-coverage

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -23,8 +23,8 @@ jobs:
         steps:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
-            - uses: actions/checkout@v3
-            - uses: dorny/paths-filter@v2
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
               id: filter
               with:
                   filters: |
@@ -52,7 +52,7 @@ jobs:
             # Checkout project code
             # Use sparse checkout to only select files in rust directory
             # Turning off cone mode ensures that files in the project root are not included during checkout
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
               if: needs.changes.outputs.rust == 'true'
               with:
                   sparse-checkout: 'rust/'
@@ -60,11 +60,11 @@ jobs:
 
             - name: Install rust
               if: needs.changes.outputs.rust == 'true'
-              uses: dtolnay/rust-toolchain@1.82
+              uses: dtolnay/rust-toolchain@2d6ac6e12ff6f69821a786a25ca0db906b4e4ba2 # 1.82
 
             - name: Install sccache
               if: needs.changes.outputs.rust == 'true'
-              uses: mozilla-actions/sccache-action@v0.0.4
+              uses: mozilla-actions/sccache-action@2e7f9ec7921547d4b46598398ca573513895d0bd # v0.0.4
 
             - name: Configure sccache
               if: needs.changes.outputs.rust == 'true'
@@ -95,14 +95,14 @@ jobs:
             # Checkout project code
             # Use sparse checkout to only select files in rust directory
             # Turning off cone mode ensures that files in the project root are not included during checkout
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
               if: needs.changes.outputs.rust == 'true' && matrix.package == 'others'
               with:
                   sparse-checkout: 'rust/'
                   sparse-checkout-cone-mode: false
 
             # For flags checkout entire repository
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
               if: needs.changes.outputs.rust == 'true' && matrix.package == 'feature-flags'
 
             - name: Setup main repo dependencies for flags
@@ -119,13 +119,14 @@ jobs:
                   docker compose up setup_test_db
                   echo "127.0.0.1 kafka clickhouse" | sudo tee -a /etc/hosts
 
+            # please keep the tag version here in sync with rust-version in rust/*/Cargo.toml
             - name: Install rust
               if: needs.changes.outputs.rust == 'true'
-              uses: dtolnay/rust-toolchain@1.82 # please keep this in sync with rust-version in rust/*/Cargo.toml
+              uses: dtolnay/rust-toolchain@2d6ac6e12ff6f69821a786a25ca0db906b4e4ba2 # 1.82
 
             - name: Install sccache
               if: needs.changes.outputs.rust == 'true'
-              uses: mozilla-actions/sccache-action@v0.0.4
+              uses: mozilla-actions/sccache-action@2e7f9ec7921547d4b46598398ca573513895d0bd # v0.0.4
 
             - name: Configure sccache
               if: needs.changes.outputs.rust == 'true'
@@ -135,7 +136,7 @@ jobs:
 
             - name: Set up Python
               if: needs.changes.outputs.rust == 'true' && matrix.package == 'feature-flags'
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
               with:
                   python-version: 3.11.9
                   cache: 'pip'
@@ -192,7 +193,7 @@ jobs:
             # Checkout project code
             # Use sparse checkout to only select files in rust directory
             # Turning off cone mode ensures that files in the project root are not included during checkout
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
               if: needs.changes.outputs.rust == 'true'
               with:
                   sparse-checkout: 'rust/'
@@ -200,13 +201,13 @@ jobs:
 
             - name: Install rust
               if: needs.changes.outputs.rust == 'true'
-              uses: dtolnay/rust-toolchain@1.82
+              uses: dtolnay/rust-toolchain@2d6ac6e12ff6f69821a786a25ca0db906b4e4ba2 # 1.82
               with:
                   components: clippy,rustfmt
 
             - name: Install sccache
               if: needs.changes.outputs.rust == 'true'
-              uses: mozilla-actions/sccache-action@v0.0.4
+              uses: mozilla-actions/sccache-action@2e7f9ec7921547d4b46598398ca573513895d0bd # v0.0.4
 
             - name: Configure sccache
               if: needs.changes.outputs.rust == 'true'
@@ -239,7 +240,7 @@ jobs:
             # Checkout project code
             # Use sparse checkout to only select files in rust directory
             # Turning off cone mode ensures that files in the project root are not included during checkout
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
               if: needs.changes.outputs.rust == 'true'
               with:
                   sparse-checkout: 'rust/'
@@ -247,7 +248,7 @@ jobs:
 
             - name: Install cargo-binstall
               if: needs.changes.outputs.rust == 'true'
-              uses: cargo-bins/cargo-binstall@main
+              uses: cargo-bins/cargo-binstall@89e50159140fdba08fc64e36186a014c5c253d33 # main
 
             - name: Install cargo-shear
               if: needs.changes.outputs.rust == 'true'

--- a/.github/workflows/ci-turbo.yml
+++ b/.github/workflows/ci-turbo.yml
@@ -15,7 +15,7 @@ jobs:
 
         steps:
             - name: Check out code
-              uses: actions/checkout@v3
+              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
               with:
                   # Just fetch the current commit/PR head
                   fetch-depth: 1
@@ -38,7 +38,7 @@ jobs:
                   fi
 
             - name: Set up Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
               with:
                   python-version: 3.11.9
                   cache: 'pip'
@@ -48,16 +48,16 @@ jobs:
             - run: pip install uv
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
 
             - name: Set up Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
               with:
                   node-version: 18
                   cache: 'pnpm'
 
             - name: Cache node-gyp artifacts
-              uses: actions/cache@v3
+              uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # v3
               with:
                   path: ~/.cache/node-gyp
                   key: ${{ runner.os }}-${{ env.ARCH }}-node-gyp-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/ci-vector.yml
+++ b/.github/workflows/ci-vector.yml
@@ -1,4 +1,4 @@
-name: Vector Replay Capture Tests
+name: Vector Replay Capture CI
 
 on:
     workflow_dispatch:
@@ -21,7 +21,7 @@ jobs:
             KAFKA_OVERFLOW_TOPIC: session_recording_snapshot_item_overflow
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
             - name: Install Vector
               run: |

--- a/.github/workflows/clickhouse-udfs.yml
+++ b/.github/workflows/clickhouse-udfs.yml
@@ -1,4 +1,4 @@
-name: Trigger UDFs Workflow
+name: ClickHouse UDFs
 
 on:
     push:
@@ -12,7 +12,7 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             - name: Trigger UDFs Workflow
-              uses: benc-uk/workflow-dispatch@v1
+              uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1
               with:
                   workflow: .github/workflows/clickhouse-udfs.yml
                   repo: posthog/posthog-cloud-infra

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -68,11 +68,11 @@ jobs:
                 # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
             # Initializes the CodeQL tools for scanning.
             - name: Initialize CodeQL
-              uses: github/codeql-action/init@v3
+              uses: github/codeql-action/init@6bb031afdd8eb862ea3fc1848194185e076637e5 # v3
               with:
                   languages: ${{ matrix.language }}
                   build-mode: ${{ matrix.build-mode }}
@@ -100,6 +100,6 @@ jobs:
                   exit 1
 
             - name: Perform CodeQL Analysis
-              uses: github/codeql-action/analyze@v3
+              uses: github/codeql-action/analyze@6bb031afdd8eb862ea3fc1848194185e076637e5 # v3
               with:
                   category: '/language:${{matrix.language}}'

--- a/.github/workflows/codespaces.yml
+++ b/.github/workflows/codespaces.yml
@@ -1,13 +1,13 @@
 name: GitHub Codespaces image build
 
-# Run only on master branch. We could also build on branch but this seems like
-# an optimization that can be done as and when desired. The main use case we're
-# handling is creating and working off a branch from master, so it doesn't seem
-# like an immediate requirement to have branches as well.
+# Run only on master branch. We could also build on branch but this seems like
+# an optimization that can be done as and when desired. The main use case we're
+# handling is creating and working off a branch from master, so it doesn't seem
+# like an immediate requirement to have branches as well.
 #
 # NOTE: the job is setup to also push branch images as well, and using branch
-# and master as caching, so if we want to add the optimisation for branches we
-# can just remove the master branch restriction.
+# and master as caching, so if we want to add the optimisation for branches we
+# can just remove the master branch restriction.
 on:
     push:
         branches:
@@ -27,7 +27,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'codespaces-build')  }}
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
               with:
                   fetch-depth: 1
 
@@ -42,7 +42,7 @@ jobs:
             # for more details
             - name: Docker image metadata
               id: meta
-              uses: docker/metadata-action@v5
+              uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
               with:
                   images: ghcr.io/${{ steps.lowercase.outputs.repository }}/codespaces
                   tags: |
@@ -54,7 +54,7 @@ jobs:
             # This creates a scope similar to the github cache action scoping
             - name: Docker cache-from/cache-to metadata
               id: meta-for-cache
-              uses: docker/metadata-action@v5
+              uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
               with:
                   images: ghcr.io/${{ steps.lowercase.outputs.repository }}/codespaces
                   tags: |
@@ -62,20 +62,20 @@ jobs:
 
             # Install QEMU so we can target x86_64 (github codespaces)
             - name: Set up QEMU
-              uses: docker/setup-qemu-action@v3
+              uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v2
+              uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
 
             - name: Login to GitHub Container Registry
-              uses: docker/login-action@v3
+              uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Build and push
-              uses: docker/build-push-action@v2
+              uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
               with:
                   context: .
                   file: .devcontainer/Dockerfile

--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -30,21 +30,21 @@ jobs:
 
         steps:
             - name: Check out
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
               with:
                   fetch-depth: 2
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
+              uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
 
             - name: Set up QEMU
-              uses: docker/setup-qemu-action@v3
+              uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
 
             - name: Set up Depot CLI
-              uses: depot/setup-action@v1
+              uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1
 
             - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@v4
+              uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
               with:
                   aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -52,17 +52,17 @@ jobs:
 
             - name: Login to Amazon ECR
               id: aws-ecr
-              uses: aws-actions/amazon-ecr-login@v2
+              uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
 
             - name: Login to DockerHub
-              uses: docker/login-action@v3
+              uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
               with:
                   username: ${{ secrets.DOCKERHUB_USER }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
             - name: Build and push container image
               id: build
-              uses: depot/build-push-action@v1
+              uses: depot/build-push-action@636daae76684e38c301daa0c5eca1c095b24e780 # v1
               with:
                   buildx-fallback: false # the fallback is so slow it's better to just fail
                   push: true
@@ -80,7 +80,7 @@ jobs:
 
             - name: get deployer token
               id: deployer
-              uses: getsentry/action-github-app-token@v3
+              uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3
               with:
                   app_id: ${{ secrets.DEPLOYER_APP_ID }}
                   private_key: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}
@@ -92,7 +92,7 @@ jobs:
                   token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Trigger PostHog Cloud deployment from Charts
-              uses: peter-evans/repository-dispatch@v3
+              uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
               with:
                   token: ${{ steps.deployer.outputs.token }}
                   repository: PostHog/charts
@@ -118,7 +118,7 @@ jobs:
 
             - name: Trigger Ingestion Cloud deployment
               if: steps.check_changes_plugins.outputs.changed == 'true'
-              uses: peter-evans/repository-dispatch@v3
+              uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
               with:
                   token: ${{ steps.deployer.outputs.token }}
                   repository: PostHog/charts
@@ -144,7 +144,7 @@ jobs:
 
             - name: Trigger Batch Exports Sync Temporal Worker Cloud deployment
               if: steps.check_changes_batch_exports_temporal_worker.outputs.changed == 'true'
-              uses: peter-evans/repository-dispatch@v3
+              uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
               with:
                   token: ${{ steps.deployer.outputs.token }}
                   repository: PostHog/charts
@@ -165,7 +165,7 @@ jobs:
 
             - name: Trigger Batch Exports Temporal Worker Cloud deployment
               if: steps.check_changes_batch_exports_temporal_worker.outputs.changed == 'true'
-              uses: peter-evans/repository-dispatch@v3
+              uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
               with:
                   token: ${{ steps.deployer.outputs.token }}
                   repository: PostHog/charts
@@ -191,7 +191,7 @@ jobs:
 
             - name: Trigger General Purpose Temporal Worker Cloud deployment
               if: steps.check_changes_general_purpose_temporal_worker.outputs.changed == 'true'
-              uses: peter-evans/repository-dispatch@v3
+              uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
               with:
                   token: ${{ steps.deployer.outputs.token }}
                   repository: PostHog/charts
@@ -217,7 +217,7 @@ jobs:
 
             - name: Trigger Data Warehouse Temporal Worker Cloud deployment
               if: steps.check_changes_data_warehouse_temporal_worker.outputs.changed == 'true'
-              uses: peter-evans/repository-dispatch@v3
+              uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
               with:
                   token: ${{ steps.deployer.outputs.token }}
                   repository: PostHog/charts
@@ -238,7 +238,7 @@ jobs:
 
             - name: Trigger Data Warehouse Compaction Temporal Worker Cloud deployment
               if: steps.check_changes_data_warehouse_temporal_worker.outputs.changed == 'true'
-              uses: peter-evans/repository-dispatch@v3
+              uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
               with:
                   token: ${{ steps.deployer.outputs.token }}
                   repository: PostHog/charts
@@ -264,7 +264,7 @@ jobs:
 
             - name: Trigger Dagster Code Location Reload
               if: steps.check_changes_dagster_code_location.outputs.changed == 'true'
-              uses: peter-evans/repository-dispatch@v3
+              uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
               with:
                   token: ${{ steps.deployer.outputs.token }}
                   repository: PostHog/charts

--- a/.github/workflows/container-images-ci.yml
+++ b/.github/workflows/container-images-ci.yml
@@ -23,20 +23,20 @@ jobs:
             # If this run wasn't initiated by PostHog Bot (meaning: snapshot update),
             # cancel previous runs of snapshot update-inducing workflows
 
-            - uses: n1hility/cancel-previous-runs@v3
+            - uses: n1hility/cancel-previous-runs@e709d8e41b16d5d0b8d529d293c5e126c57dc022 # v3
               if: github.actor != 'posthog-bot'
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   workflow: .github/workflows/storybook-chromatic.yml
 
-            - uses: n1hility/cancel-previous-runs@v3
+            - uses: n1hility/cancel-previous-runs@e709d8e41b16d5d0b8d529d293c5e126c57dc022 # v3
               if: github.actor != 'posthog-bot'
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   workflow: .github/workflows/ci-backend.yml
 
             - name: Check out
-              uses: actions/checkout@v3
+              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
             - name: Build and cache Docker image in Depot
               uses: ./.github/actions/build-n-cache-image
@@ -62,13 +62,13 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             - name: Check out
-              uses: actions/checkout@v3
+              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
               with:
                   fetch-depth: 0
 
             - name: Check if any Dockerfile has changed
               id: changed-files
-              uses: step-security/changed-files@v45
+              uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45
               with:
                   files: |
                       **/Dockerfile
@@ -77,7 +77,7 @@ jobs:
                   separator: ' '
 
             - name: Lint changed Dockerfile(s) with Hadolint
-              uses: jbergstroem/hadolint-gh-action@v1
+              uses: jbergstroem/hadolint-gh-action@39e57273ed8f513872326b228217828be6a42730 # v1
               if: steps.changed-files.outputs.any_changed == 'true'
               with:
                   dockerfile: '${{ steps.changed-files.outputs.all_modified_files }}'

--- a/.github/workflows/foss-sync.yml
+++ b/.github/workflows/foss-sync.yml
@@ -1,4 +1,4 @@
-name: Sync PostHog FOSS
+name: PostHog FOSS Sync
 
 on:
     push:
@@ -27,7 +27,7 @@ jobs:
                   destination_repo: 'https://posthog-bot:${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}@github.com/posthog/posthog-foss.git'
                   destination_branch: 'refs/tags/*'
             - name: Checkout posthog-foss
-              uses: actions/checkout@v3
+              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
               with:
                   repository: 'posthog/posthog-foss'
                   ref: master
@@ -42,7 +42,7 @@ jobs:
                   ls | grep -v foss-release-image-publish.yml | xargs rm
 
             - name: Commit "Sync and remove all non-FOSS parts"
-              uses: EndBug/add-and-commit@v9
+              uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9
               with:
                   message: 'Sync and remove all non-FOSS parts'
                   remove: '["-r ee/"]'

--- a/.github/workflows/livestream-docker-image.yml
+++ b/.github/workflows/livestream-docker-image.yml
@@ -22,13 +22,13 @@ jobs:
 
         steps:
             - name: Check out livestream code
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
               with:
                   sparse-checkout: 'livestream/'
                   sparse-checkout-cone-mode: false
 
             - name: Log in to the Container registry
-              uses: docker/login-action@v3
+              uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
@@ -37,17 +37,17 @@ jobs:
 
             - name: Extract metadata (tags, labels) for Docker
               id: meta
-              uses: docker/metadata-action@v5
+              uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
               with:
                   images: ghcr.io/posthog/posthog/livestream
 
             - name: Set up Depot CLI
-              uses: depot/setup-action@v1
+              uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1
 
             - name: Build and push Docker image
               id: push
               if: github.ref == 'refs/heads/master'
-              uses: depot/build-push-action@v1
+              uses: depot/build-push-action@636daae76684e38c301daa0c5eca1c095b24e780 # v1
               with:
                   context: ./livestream/
                   file: livestream/Dockerfile
@@ -63,13 +63,13 @@ jobs:
         steps:
             - name: get deployer token
               id: deployer
-              uses: getsentry/action-github-app-token@v3
+              uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3
               with:
                   app_id: ${{ secrets.DEPLOYER_APP_ID }}
                   private_key: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}
 
             - name: Trigger livestream deployment
-              uses: peter-evans/repository-dispatch@v3
+              uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
               with:
                   token: ${{ steps.deployer.outputs.token }}
                   repository: PostHog/charts

--- a/.github/workflows/livestream.yml
+++ b/.github/workflows/livestream.yml
@@ -1,4 +1,4 @@
-name: Go Test (for livestream service)
+name: Livestream
 
 on:
     pull_request:
@@ -11,10 +11,10 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
             - name: Set up Go
-              uses: actions/setup-go@v2
+              uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
               with:
                   go-version: 1.22
 

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -1,4 +1,4 @@
-name: Report PR Age
+name: Closed PR
 
 on:
     pull_request:

--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -1,4 +1,4 @@
-name: Lint new PR
+name: Opened PR
 
 on:
     pull_request:

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -1,11 +1,10 @@
-# This workflow cleans up Preview deploys once a pull request is closed
-
 name: PR - Preview Deploy Cleanup
 
 on:
     pull_request:
         types: [closed]
 
+# This workflow cleans up Preview deploys once a pull request is closed
 jobs:
     deploy_preview_cleanup:
         name: Deploy Preview Cleanup
@@ -19,9 +18,9 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-            - uses: aws-actions/configure-aws-credentials@v4
+            - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
               with:
                   aws-region: us-east-1
                   role-to-assume: arn:aws:iam::169684386827:role/github-terraform-infra-role
@@ -29,10 +28,10 @@ jobs:
 
             - name: Login to Amazon ECR
               id: aws-ecr
-              uses: aws-actions/amazon-ecr-login@v2
+              uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
 
             - name: connect to tailscale
-              uses: tailscale/github-action@8b804aa882ac3429b804a2a22f9803a2101a0db9
+              uses: tailscale/github-action@8b804aa882ac3429b804a2a22f9803a2101a0db9 # 8b804aa882ac3429b804a2a22f9803a2101a0db9
               env:
                   TS_EXPERIMENT_OAUTH_AUTHKEY: true
               with:
@@ -62,7 +61,7 @@ jobs:
                   kubectl -n $NAMESPACE delete -f .github/pr-deploy/hobby.yaml || true
 
             - name: delete deployment
-              uses: bobheadxi/deployments@v1.4.0
+              uses: bobheadxi/deployments@88ce5600046c82542f8246ac287d0a53c461bca3 # v1.4.0
               id: deployment
               with:
                   step: deactivate-env

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -19,31 +19,31 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v2
+              uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
 
             - name: Set up QEMU
-              uses: docker/setup-qemu-action@v3
+              uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
 
             - name: Set up Depot CLI
-              uses: depot/setup-action@v1
+              uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1
 
             - name: Login to DockerHub
-              uses: docker/login-action@v3
+              uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
               with:
                   username: ${{ secrets.DOCKERHUB_USER }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-            - uses: aws-actions/configure-aws-credentials@v4
+            - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
               with:
                   aws-region: us-east-1
                   role-to-assume: arn:aws:iam::169684386827:role/github-terraform-infra-role
                   role-duration-seconds: 3600
 
             - name: connect to tailscale
-              uses: tailscale/github-action@8b804aa882ac3429b804a2a22f9803a2101a0db9
+              uses: tailscale/github-action@8b804aa882ac3429b804a2a22f9803a2101a0db9 # 8b804aa882ac3429b804a2a22f9803a2101a0db9
               env:
                   TS_EXPERIMENT_OAUTH_AUTHKEY: true
               with:
@@ -53,11 +53,11 @@ jobs:
 
             - name: Login to Amazon ECR
               id: aws-ecr
-              uses: aws-actions/amazon-ecr-login@v2
+              uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
 
             - name: Build and push PR test image
               id: build
-              uses: depot/build-push-action@v1
+              uses: depot/build-push-action@636daae76684e38c301daa0c5eca1c095b24e780 # v1
               with:
                   context: .
                   buildx-fallback: false # the fallback is so slow it's better to just fail
@@ -67,7 +67,7 @@ jobs:
                   build-args: COMMIT_HASH=${{ github.event.pull_request.head.sha }}
 
             - name: start deployment
-              uses: bobheadxi/deployments@v1.4.0
+              uses: bobheadxi/deployments@88ce5600046c82542f8246ac287d0a53c461bca3 # v1.4.0
               id: deployment
               with:
                   step: start
@@ -99,7 +99,7 @@ jobs:
                   echo "url=$HOSTNAME.dev.posthog.dev" >> $GITHUB_OUTPUT
 
             - name: update deployment status
-              uses: bobheadxi/deployments@v1
+              uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
               with:
                   step: finish
                   status: ${{ job.status }}

--- a/.github/workflows/pr-updated.yml
+++ b/.github/workflows/pr-updated.yml
@@ -1,4 +1,4 @@
-name: Lint PR
+name: Updated PR
 
 on:
     pull_request:
@@ -12,6 +12,6 @@ jobs:
         name: Validate PR title against Conventional Commits
         runs-on: ubuntu-24.04
         steps:
-            - uses: amannn/action-semantic-pull-request@v5
+            - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -75,22 +75,22 @@ jobs:
               # Checkout project code
               # Use sparse checkout to only select files in rust directory
               # Turning off cone mode ensures that files in the project root are not included during checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
               with:
                   sparse-checkout: 'rust/'
                   sparse-checkout-cone-mode: false
 
             - name: Set up Depot CLI
-              uses: depot/setup-action@v1
+              uses: depot/setup-action@b0b1ea4f69e92ebf5dea3f8713a1b0c37b2126a5 # v1
 
             - name: Set up QEMU
-              uses: docker/setup-qemu-action@v3
+              uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
               with:
                   image: tonistiigi/binfmt:latest
                   platforms: all
 
             - name: Login to ghcr.io
-              uses: docker/login-action@v3
+              uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
@@ -99,7 +99,7 @@ jobs:
 
             - name: Docker meta
               id: meta
-              uses: docker/metadata-action@v5
+              uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
               with:
                   images: ghcr.io/posthog/posthog/${{ matrix.image }}
                   tags: |
@@ -111,7 +111,7 @@ jobs:
 
             - name: Set up Docker Buildx
               id: buildx
-              uses: docker/setup-buildx-action@v2
+              uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
 
             - name: Retrieve sccache configuration
               id: sccache
@@ -122,7 +122,7 @@ jobs:
 
             - name: Build and push image
               id: docker_build
-              uses: depot/build-push-action@v1
+              uses: depot/build-push-action@636daae76684e38c301daa0c5eca1c095b24e780 # v1
               with:
                   project: ${{ matrix.project }}
                   context: ./rust/
@@ -194,13 +194,13 @@ jobs:
         steps:
             - name: get deployer token
               id: deployer
-              uses: getsentry/action-github-app-token@v3
+              uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3
               with:
                   app_id: ${{ secrets.DEPLOYER_APP_ID }}
                   private_key: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}
 
             - name: trigger ${{ matrix.release }} deployment
-              uses: peter-evans/repository-dispatch@v3
+              uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
               with:
                   token: ${{ steps.deployer.outputs.token }}
                   repository: PostHog/charts

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,0 +1,18 @@
+on:
+    push:
+        branches:
+            - master
+    pull_request:
+
+name: Security
+
+jobs:
+    ensure-pinned-actions:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+            - name: Ensure SHA pinned actions
+              uses: zgosalvez/github-actions-ensure-sha-pinned-actions@25ed13d0628a1601b4b44048e63cc4328ed03633 # v3
+              with:
+                  allowlist: PostHog/ # It's a string, parsed by splitting on \r\n but we only have one entry

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -1,4 +1,4 @@
-name: Notify Sentry
+name: Sentry
 
 #
 # Comment the `on:` section below if you want to stop deploys
@@ -12,15 +12,15 @@ on:
             - 'livestream/**'
 
 jobs:
-    sentry:
+    notify_sentry:
         name: Notify Sentry of a production release
         runs-on: ubuntu-20.04
         if: github.repository == 'PostHog/posthog'
         steps:
             - name: Checkout master
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
             - name: Notify Sentry
-              uses: getsentry/action-release@v1
+              uses: getsentry/action-release@a74facf8a080ecbdf1cb355f16743530d712abb7 # v1
               env:
                   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
                   SENTRY_ORG: posthog

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -9,7 +9,7 @@ jobs:
         if: ${{ github.repository == 'PostHog/posthog' }}
         runs-on: ubuntu-24.04
         steps:
-            - uses: actions/stale@v9
+            - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
               with:
                   days-before-issue-stale: 730
                   days-before-issue-close: 14

--- a/.github/workflows/storybook-chromatic.yml
+++ b/.github/workflows/storybook-chromatic.yml
@@ -28,15 +28,15 @@ jobs:
         outputs:
             storybook-url: ${{ steps.publish.outputs.storybookUrl }}
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
               with:
                   fetch-depth: 0 # 👈 Required to retrieve git history (https://www.chromatic.com/docs/github-actions)
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
 
             - name: Set up Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
               with:
                   node-version: 18.12.1
                   cache: pnpm
@@ -48,7 +48,7 @@ jobs:
                   pnpm install -w -D chromatic
 
             - name: Publish to Chromatic
-              uses: chromaui/action@v11
+              uses: chromaui/action@c93e0bc3a63aa176e14a75b61a31847cbfdd341c # v11
               id: publish
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
@@ -121,7 +121,7 @@ jobs:
             firefox-3-total: ${{ steps.diff.outputs.firefox-3-total }}
             firefox-3-commitHash: ${{ steps.commit-hash.outputs.firefox-3-commitHash }}
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
               with:
                   fetch-depth: 1
                   repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -130,10 +130,10 @@ jobs:
                   token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN || github.token }}
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
 
             - name: Set up Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
               with:
                   node-version: 18.12.1
                   cache: pnpm
@@ -202,7 +202,7 @@ jobs:
 
             - name: Archive failure screenshots
               if: ${{ failure() }}
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
               with:
                   name: failure-screenshots-${{ matrix.browser }}-${{ matrix.shard }}
                   path: frontend/__snapshots__/__failures__/
@@ -258,7 +258,7 @@ jobs:
                   echo "${{ matrix.browser }}-${{ matrix.shard }}-total=$TOTAL" >> $GITHUB_OUTPUT
 
             - name: Commit updated snapshots
-              uses: EndBug/add-and-commit@v9
+              uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9
               if: github.event.pull_request.head.repo.full_name == github.repository
               id: commit
               with:
@@ -283,7 +283,7 @@ jobs:
         steps:
             - name: Post comment about updated snapshots
               if: github.event.pull_request.head.repo.full_name == github.repository
-              uses: actions/github-script@v6
+              uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
               with:
                   github-token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN || github.token }}
                   script: |

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -12,18 +12,18 @@ jobs:
         if: github.repository == 'PostHog/posthog'
         steps:
             - name: Check out PostHog/posthog repo
-              uses: actions/checkout@v3
+              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
               with:
                   path: posthog
                   fetch-depth: 0
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
               with:
                   package_json_file: posthog/package.json
 
             - name: Set up Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
               with:
                   node-version: 18.12.1
                   cache: pnpm
@@ -36,7 +36,7 @@ jobs:
               run: cd posthog && bin/turbo --filter=@posthog/storybook build
 
             - name: Check out PostHog/storybook-build repo
-              uses: actions/checkout@v3
+              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
               with:
                   path: storybook-build
                   repository: PostHog/storybook-build
@@ -54,7 +54,7 @@ jobs:
               run: echo "msg=Storybook build for ${{ github.sha }}" >> $GITHUB_OUTPUT
 
             - name: Commit update
-              uses: stefanzweifel/git-auto-commit-action@v5
+              uses: stefanzweifel/git-auto-commit-action@e348103e9026cc0eee72ae06630dbe30c8bf7a79 # v5
               with:
                   repository: storybook-build
                   commit_message: ${{ steps.commit-message.outputs.msg }}

--- a/.github/workflows/vector-docker-build-deploy.yml
+++ b/.github/workflows/vector-docker-build-deploy.yml
@@ -30,13 +30,13 @@ jobs:
               # Checkout project code
               # Use sparse checkout to only select files in vector directory
               # Turning off cone mode ensures that files in the project root are not included during checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
               with:
                   sparse-checkout: 'vector/'
                   sparse-checkout-cone-mode: false
 
             - name: Login to ghcr.io
-              uses: docker/login-action@v2
+              uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
@@ -44,11 +44,11 @@ jobs:
                   logout: false
 
             - name: Set up QEMU
-              uses: docker/setup-qemu-action@v3
+              uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
 
             - name: Docker meta
               id: meta
-              uses: docker/metadata-action@v5
+              uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
               with:
                   images: ghcr.io/posthog/posthog/replay-capture
                   tags: |
@@ -60,11 +60,11 @@ jobs:
 
             - name: Set up Docker Buildx
               id: buildx
-              uses: docker/setup-buildx-action@v2
+              uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
 
             - name: Build and push image
               id: docker_build
-              uses: docker/build-push-action@v5
+              uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
               with:
                   context: ./vector/replay-capture/
                   file: ./vector/replay-capture/Dockerfile
@@ -80,13 +80,13 @@ jobs:
         steps:
             - name: get deployer token
               id: deployer
-              uses: getsentry/action-github-app-token@v3
+              uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3
               with:
                   app_id: ${{ secrets.DEPLOYER_APP_ID }}
                   private_key: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}
 
             - name: Trigger livestream deployment
-              uses: peter-evans/repository-dispatch@v3
+              uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
               with:
                   token: ${{ steps.deployer.outputs.token }}
                   repository: PostHog/charts


### PR DESCRIPTION
To avoid future toolchain attacks, we're now fixing all of our actions to a specific commit hash AND adding a new CI check (`security.yml`) that asserts these continue pinned in the future.

This is a response to https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised
Follow-up to #30000 