### PR TITLE
feat(cdp): Conditionally apply simdjson_nodejs in property-defs-node event consumer

### DIFF
--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -92,6 +92,7 @@
         "prom-client": "^14.2.0",
         "re2": "^1.20.3",
         "safe-stable-stringify": "^2.4.0",
+        "simdjson": "^0.9.2",
         "snappy": "^7.2.2",
         "tail": "^2.2.6",
         "tldts": "^6.1.57",

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -225,7 +225,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         PROPERTY_DEFS_CONSUMER_CONSUME_TOPIC: KAFKA_EVENTS_JSON,
         PROPERTY_DEFS_CONSUMER_ENABLED_TEAMS: isDevEnv() ? '*' : '',
         PROPERTY_DEFS_WRITE_DISABLED: isProdEnv() ? true : false, // For now we don't want to do writes on prod - only count them
-        PROPERTY_DEFS_USE_SIMDJSON: isProdEnv() ? true : false, // testing this only in property-defs-node service for eval
+        PROPERTY_DEFS_USE_SIMDJSON: isProdEnv() ? false : true, // testing this only in dev env on property-defs-node service for eval
 
         // Session recording V2
         SESSION_RECORDING_MAX_BATCH_SIZE_KB: 100 * 1024, // 100MB

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -225,6 +225,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         PROPERTY_DEFS_CONSUMER_CONSUME_TOPIC: KAFKA_EVENTS_JSON,
         PROPERTY_DEFS_CONSUMER_ENABLED_TEAMS: isDevEnv() ? '*' : '',
         PROPERTY_DEFS_WRITE_DISABLED: isProdEnv() ? true : false, // For now we don't want to do writes on prod - only count them
+        PROPERTY_DEFS_USE_SIMDJSON: isProdEnv() ? true : false, // testing this only in property-defs-node service for eval
 
         // Session recording V2
         SESSION_RECORDING_MAX_BATCH_SIZE_KB: 100 * 1024, // 100MB

--- a/plugin-server/src/property-defs/property-defs-consumer.ts
+++ b/plugin-server/src/property-defs/property-defs-consumer.ts
@@ -21,7 +21,7 @@ import {
     RawClickHouseEvent,
     ValueMatcher,
 } from '../types'
-import { parseRawClickHouseEvent } from '../utils/event'
+import { parseRawClickHouseEventConditionalJson } from '../utils/event'
 import { status } from '../utils/status'
 import { UUIDT } from '../utils/utils'
 import { GroupTypeManager, GroupTypesByProjectId } from '../worker/ingestion/group-type-manager'
@@ -388,7 +388,7 @@ export class PropertyDefsConsumer {
 
         messages.forEach((message) => {
             try {
-                const clickHouseEvent = parseRawClickHouseEvent(
+                const clickHouseEvent = parseRawClickHouseEventConditionalJson(
                     simdjson_parse(message.value!.toString()) as RawClickHouseEvent,
                     true
                 )

--- a/plugin-server/src/property-defs/property-defs-consumer.ts
+++ b/plugin-server/src/property-defs/property-defs-consumer.ts
@@ -21,7 +21,7 @@ import {
     RawClickHouseEvent,
     ValueMatcher,
 } from '../types'
-import { parseRawClickHouseEventConditionalJson } from '../utils/event'
+import { parseRawClickHouseEvent } from '../utils/event'
 import { status } from '../utils/status'
 import { UUIDT } from '../utils/utils'
 import { GroupTypeManager, GroupTypesByProjectId } from '../worker/ingestion/group-type-manager'
@@ -390,7 +390,7 @@ export class PropertyDefsConsumer {
 
         messages.forEach((message) => {
             try {
-                const clickHouseEvent = parseRawClickHouseEventConditionalJson(
+                const clickHouseEvent = parseRawClickHouseEvent(
                     simdjson_parse(message.value!.toString()) as RawClickHouseEvent,
                     this.hub.PROPERTY_DEFS_USE_SIMDJSON
                 )

--- a/plugin-server/src/property-defs/property-defs-consumer.ts
+++ b/plugin-server/src/property-defs/property-defs-consumer.ts
@@ -91,6 +91,7 @@ export class PropertyDefsConsumer {
     protected promises: Set<Promise<any>> = new Set()
     private propDefsEnabledProjects: ValueMatcher<number>
     private writeDisabled: boolean
+    private useSimdJson: boolean
 
     constructor(private hub: Hub) {
         this.groupId = hub.PROPERTY_DEFS_CONSUMER_GROUP_ID
@@ -100,6 +101,7 @@ export class PropertyDefsConsumer {
         this.groupTypeManager = new GroupTypeManager(hub.postgres, this.teamManager)
         this.propDefsEnabledProjects = buildIntegerMatcher(hub.PROPERTY_DEFS_CONSUMER_ENABLED_TEAMS, true)
         this.writeDisabled = hub.PROPERTY_DEFS_WRITE_DISABLED
+        this.useSimdJson = hub.PROPERTY_DEFS_USE_SIMDJSON
     }
 
     public get service(): PluginServerService {
@@ -390,7 +392,7 @@ export class PropertyDefsConsumer {
             try {
                 const clickHouseEvent = parseRawClickHouseEventConditionalJson(
                     simdjson_parse(message.value!.toString()) as RawClickHouseEvent,
-                    true
+                    this.hub.PROPERTY_DEFS_USE_SIMDJSON
                 )
 
                 events.push(clickHouseEvent)

--- a/plugin-server/src/property-defs/property-defs-consumer.ts
+++ b/plugin-server/src/property-defs/property-defs-consumer.ts
@@ -1,6 +1,7 @@
 import { DateTime } from 'luxon'
 import { Message } from 'node-rdkafka'
 import { Counter } from 'prom-client'
+import { parse as simdjson_parse } from 'simdjson'
 
 import { buildIntegerMatcher } from '../config/config'
 import { BatchConsumer, startBatchConsumer } from '../kafka/batch-consumer'
@@ -388,7 +389,8 @@ export class PropertyDefsConsumer {
         messages.forEach((message) => {
             try {
                 const clickHouseEvent = parseRawClickHouseEvent(
-                    JSON.parse(message.value!.toString()) as RawClickHouseEvent
+                    simdjson_parse(message.value!.toString()) as RawClickHouseEvent,
+                    true
                 )
 
                 events.push(clickHouseEvent)

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -344,10 +344,12 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
     // Destination Migration Diffing
     DESTINATION_MIGRATION_DIFFING_ENABLED: boolean
 
+    // property-defs-node configs (some temporary!)
     PROPERTY_DEFS_CONSUMER_GROUP_ID: string
     PROPERTY_DEFS_CONSUMER_CONSUME_TOPIC: string
     PROPERTY_DEFS_CONSUMER_ENABLED_TEAMS: string
     PROPERTY_DEFS_WRITE_DISABLED: boolean
+    PROPERTY_DEFS_USE_SIMDJSON: boolean
 }
 
 export interface Hub extends PluginsServerConfig {

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -1008,7 +1008,7 @@ export class DB {
         const queryResult = await this.clickhouseQuery<RawClickHouseEvent>(
             `SELECT * FROM events ORDER BY timestamp ASC`
         )
-        return queryResult.data.map(parseRawClickHouseEvent)
+        return queryResult.data.map((evt) => parseRawClickHouseEvent(evt, false))
     }
 
     public async fetchDeadLetterQueueEvents(): Promise<DeadLetterQueueEvent[]> {

--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -77,8 +77,13 @@ export function convertToHookPayload(event: PostIngestionEvent): HookPayload['da
     }
 }
 
-/** Parse an event row SELECTed from ClickHouse into a more malleable form. */
-export function parseRawClickHouseEvent(rawEvent: RawClickHouseEvent, use_simdjson: bool = false): ClickHouseEvent {
+// poor-man's partial application to keep parseRawClickHouseEvent compatible with map calls like this:
+// https://github.com/PostHog/posthog/blob/master/plugin-server/src/utils/db/db.ts#L1011
+// obviously, we'll remove this nonsense once the simdjson_nodejs eval is completed
+export function parseRawClickHouseEventConditionalJson(
+    rawEvent: RawClickHouseEvent,
+    use_simdjson: bool
+): ClickHouseEvent {
     return {
         ...rawEvent,
         timestamp: clickHouseTimestampToDateTime(rawEvent.timestamp),
@@ -135,6 +140,12 @@ export function parseRawClickHouseEvent(rawEvent: RawClickHouseEvent, use_simdjs
             : null,
     }
 }
+
+/** Parse an event row SELECTed from ClickHouse into a more malleable form. */
+export function parseRawClickHouseEvent(rawEvent: RawClickHouseEvent): ClickHouseEvent {
+    return parseRawClickHouseEventConditionalJson(rawEvent, false)
+}
+
 export function convertToPostHogEvent(event: PostIngestionEvent): PostHogEvent {
     return {
         uuid: event.eventUuid,

--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -1,6 +1,8 @@
 import { PluginEvent, PostHogEvent, ProcessedPluginEvent } from '@posthog/plugin-scaffold'
+import { bool } from 'aws-sdk/clients/signer'
 import { Message } from 'node-rdkafka'
 import { Counter } from 'prom-client'
+import { parse as simdjson_parse } from 'simdjson'
 
 import { setUsageInNonPersonEventsCounter } from '../main/ingestion-queues/metrics'
 import {
@@ -76,7 +78,7 @@ export function convertToHookPayload(event: PostIngestionEvent): HookPayload['da
 }
 
 /** Parse an event row SELECTed from ClickHouse into a more malleable form. */
-export function parseRawClickHouseEvent(rawEvent: RawClickHouseEvent): ClickHouseEvent {
+export function parseRawClickHouseEvent(rawEvent: RawClickHouseEvent, use_simdjson: bool = false): ClickHouseEvent {
     return {
         ...rawEvent,
         timestamp: clickHouseTimestampToDateTime(rawEvent.timestamp),
@@ -86,12 +88,36 @@ export function parseRawClickHouseEvent(rawEvent: RawClickHouseEvent): ClickHous
         person_created_at: rawEvent.person_created_at
             ? clickHouseTimestampToDateTime(rawEvent.person_created_at)
             : null,
-        person_properties: rawEvent.person_properties ? JSON.parse(rawEvent.person_properties) : {},
-        group0_properties: rawEvent.group0_properties ? JSON.parse(rawEvent.group0_properties) : {},
-        group1_properties: rawEvent.group1_properties ? JSON.parse(rawEvent.group1_properties) : {},
-        group2_properties: rawEvent.group2_properties ? JSON.parse(rawEvent.group2_properties) : {},
-        group3_properties: rawEvent.group3_properties ? JSON.parse(rawEvent.group3_properties) : {},
-        group4_properties: rawEvent.group4_properties ? JSON.parse(rawEvent.group4_properties) : {},
+        person_properties: rawEvent.person_properties
+            ? use_simdjson
+                ? simdjson_parse(rawEvent.person_properties)
+                : JSON.parse(rawEvent.person_properties)
+            : {},
+        group0_properties: rawEvent.group0_properties
+            ? use_simdjson
+                ? simdjson_parse(rawEvent.group0_properties)
+                : JSON.parse(rawEvent.group0_properties)
+            : {},
+        group1_properties: rawEvent.group1_properties
+            ? use_simdjson
+                ? simdjson_parse(rawEvent.group1_properties)
+                : JSON.parse(rawEvent.group1_properties)
+            : {},
+        group2_properties: rawEvent.group2_properties
+            ? use_simdjson
+                ? simdjson_parse(rawEvent.group2_properties)
+                : JSON.parse(rawEvent.group2_properties)
+            : {},
+        group3_properties: rawEvent.group3_properties
+            ? use_simdjson
+                ? simdjson_parse(rawEvent.group3_properties)
+                : JSON.parse(rawEvent.group3_properties)
+            : {},
+        group4_properties: rawEvent.group4_properties
+            ? use_simdjson
+                ? simdjson_parse(rawEvent.group4_properties)
+                : JSON.parse(rawEvent.group4_properties)
+            : {},
         group0_created_at: rawEvent.group0_created_at
             ? clickHouseTimestampToDateTime(rawEvent.group0_created_at)
             : null,

--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -77,13 +77,8 @@ export function convertToHookPayload(event: PostIngestionEvent): HookPayload['da
     }
 }
 
-// poor-man's partial application to keep parseRawClickHouseEvent compatible with map calls like this:
-// https://github.com/PostHog/posthog/blob/master/plugin-server/src/utils/db/db.ts#L1011
-// obviously, we'll remove this nonsense once the simdjson_nodejs eval is completed
-export function parseRawClickHouseEventConditionalJson(
-    rawEvent: RawClickHouseEvent,
-    use_simdjson: bool
-): ClickHouseEvent {
+/** Parse an event row SELECTed from ClickHouse into a more malleable form. */
+export function parseRawClickHouseEvent(rawEvent: RawClickHouseEvent, use_simdjson: bool = false): ClickHouseEvent {
     return {
         ...rawEvent,
         timestamp: clickHouseTimestampToDateTime(rawEvent.timestamp),
@@ -139,11 +134,6 @@ export function parseRawClickHouseEventConditionalJson(
             ? clickHouseTimestampToDateTime(rawEvent.group4_created_at)
             : null,
     }
-}
-
-/** Parse an event row SELECTed from ClickHouse into a more malleable form. */
-export function parseRawClickHouseEvent(rawEvent: RawClickHouseEvent): ClickHouseEvent {
-    return parseRawClickHouseEventConditionalJson(rawEvent, false)
 }
 
 export function convertToPostHogEvent(event: PostIngestionEvent): PostHogEvent {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,7 +66,7 @@ importers:
         version: 2.29.0(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)
       eslint-plugin-jest:
         specifier: ^28.6.0
-        version: 28.6.0(@typescript-eslint/eslint-plugin@7.1.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(jest@29.7.0)(typescript@4.9.5)
+        version: 28.6.0(@typescript-eslint/eslint-plugin@7.1.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(jest@29.7.0(@types/node@18.18.4)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@18.18.4)(typescript@4.9.5)))(typescript@4.9.5)
       eslint-plugin-posthog:
         specifier: workspace:*
         version: link:common/eslint_rules
@@ -99,7 +99,7 @@ importers:
         version: 4.3.0(stylelint@15.11.0(typescript@4.9.5))
       stylelint-config-standard-scss:
         specifier: ^11.1.0
-        version: 11.1.0(postcss@8.5.3)(stylelint@15.11.0(typescript@4.9.5))
+        version: 11.1.0(postcss@8.4.31)(stylelint@15.11.0(typescript@4.9.5))
       stylelint-order:
         specifier: ^6.0.3
         version: 6.0.3(stylelint@15.11.0(typescript@4.9.5))
@@ -198,7 +198,7 @@ importers:
         version: 3.12.1
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@18.18.4)(ts-node@10.9.1(@swc/core@1.10.14(@swc/helpers@0.5.15))(@types/node@18.18.4)(typescript@4.9.5))
+        version: 29.7.0(@types/node@18.18.4)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@18.18.4)(typescript@4.9.5))
       parcel:
         specifier: ^2.13.3
         version: 2.13.3(@swc/helpers@0.5.15)(cssnano@7.0.6(postcss@8.5.3))(postcss@8.5.3)(relateurl@0.2.7)(svgo@3.3.2)(terser@5.19.1)(typescript@4.9.5)
@@ -1187,7 +1187,7 @@ importers:
         version: 4.3.0(stylelint@15.11.0(typescript@4.9.5))
       stylelint-config-standard-scss:
         specifier: ^11.1.0
-        version: 11.1.0(postcss@8.4.31)(stylelint@15.11.0(typescript@4.9.5))
+        version: 11.1.0(postcss@8.5.3)(stylelint@15.11.0(typescript@4.9.5))
       stylelint-order:
         specifier: ^6.0.3
         version: 6.0.3(stylelint@15.11.0(typescript@4.9.5))
@@ -1374,6 +1374,9 @@ importers:
       safe-stable-stringify:
         specifier: ^2.4.0
         version: 2.5.0
+      simdjson:
+        specifier: ^0.9.2
+        version: 0.9.2
       snappy:
         specifier: ^7.2.2
         version: 7.2.2
@@ -1710,7 +1713,7 @@ importers:
         version: link:../../common/eslint_rules
       jest:
         specifier: '*'
-        version: 29.7.0(@types/node@18.18.4)(ts-node@10.9.1(@swc/core@1.10.14(@swc/helpers@0.5.15))(@types/node@18.18.4)(typescript@4.9.5))
+        version: 29.7.0(@types/node@18.18.4)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@18.18.4)(typescript@4.9.5))
       kea:
         specifier: '*'
         version: 3.1.5(react@18.2.0)
@@ -12118,6 +12121,9 @@ packages:
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
 
+  node-addon-api@2.0.2:
+    resolution: {integrity: sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==}
+
   node-addon-api@6.1.0:
     resolution: {integrity: sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==}
 
@@ -14412,6 +14418,9 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  simdjson@0.9.2:
+    resolution: {integrity: sha512-CW97acb8ty4EcxJGsCTrgxh1iiqLKbcuaIAte4DjPdoytK2ps1cRN1HpBJjIzqaL5cn1m/Dqc4AqA6NlKPPKKA==}
 
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
@@ -21448,7 +21457,7 @@ snapshots:
       commander: 9.4.1
       expect-playwright: 0.8.0
       glob: 10.4.5
-      jest: 29.7.0(@types/node@18.18.4)(ts-node@10.9.1(@swc/core@1.10.14(@swc/helpers@0.5.15))(@types/node@18.18.4)(typescript@4.9.5))
+      jest: 29.7.0(@types/node@18.18.4)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@18.18.4)(typescript@4.9.5))
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-junit: 16.0.0
@@ -25787,17 +25796,6 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-jest@28.6.0(@typescript-eslint/eslint-plugin@7.1.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(jest@29.7.0)(typescript@4.9.5):
-    dependencies:
-      '@typescript-eslint/utils': 7.1.1(eslint@8.57.0)(typescript@4.9.5)
-      eslint: 8.57.0
-    optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 7.1.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5)
-      jest: 29.7.0(@types/node@18.18.4)(ts-node@10.9.1(@swc/core@1.10.14(@swc/helpers@0.5.15))(@types/node@18.18.4)(typescript@4.9.5))
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   eslint-plugin-no-only-tests@3.3.0: {}
 
   eslint-plugin-node@11.1.0(eslint@8.57.0):
@@ -27999,7 +27997,7 @@ snapshots:
   jest-playwright-preset@4.0.0(jest-circus@29.7.0)(jest-environment-node@29.7.0)(jest-runner@29.7.0)(jest@29.7.0):
     dependencies:
       expect-playwright: 0.8.0
-      jest: 29.7.0(@types/node@18.18.4)(ts-node@10.9.1(@swc/core@1.10.14(@swc/helpers@0.5.15))(@types/node@18.18.4)(typescript@4.9.5))
+      jest: 29.7.0(@types/node@18.18.4)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@18.18.4)(typescript@4.9.5))
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-process-manager: 0.4.0
@@ -28157,7 +28155,7 @@ snapshots:
     dependencies:
       ansi-escapes: 6.0.0
       chalk: 5.4.1
-      jest: 29.7.0(@types/node@18.18.4)(ts-node@10.9.1(@swc/core@1.10.14(@swc/helpers@0.5.15))(@types/node@18.18.4)(typescript@4.9.5))
+      jest: 29.7.0(@types/node@18.18.4)(ts-node@10.9.1(@swc/core@1.11.4(@swc/helpers@0.5.15))(@types/node@18.18.4)(typescript@4.9.5))
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -29380,6 +29378,8 @@ snapshots:
       semver: 7.7.0
 
   node-abort-controller@3.1.1: {}
+
+  node-addon-api@2.0.2: {}
 
   node-addon-api@6.1.0: {}
 
@@ -32226,6 +32226,10 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
+
+  simdjson@0.9.2:
+    dependencies:
+      node-addon-api: 2.0.2
 
   simple-concat@1.0.1: {}
 


### PR DESCRIPTION
## Problem
We want to reduce CPU utilization in the `property-defs-node` service.

## Changes
* Adds [simdjson_nodejs](https://github.com/luizperes/simdjson_nodejs) package to the `plugin-server` project
* Wire up `simdjson_nodejs` parsing in the event loop
* Conditionally wire it up in shared package converting `RawClickHouseEvent`s into `ClickHouseEvent`s so as not to mess with existing services during eval period

Could add more metrics, but looks like we can measure before/after processing timings using `parseKafkaMessages` via `runInstrumented` wrapper, at least in the `property-defs-node` service 👍 

**TODO**: matching deployment PR to enable `PROPERY_DEFS_USE_SIMDJSON` once this is landed 🎗️ 

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally and in CI, so far
