### PR TITLE
chore(data-warehouse): Disable syncs on tables with missing primary keys

### DIFF
--- a/posthog/temporal/data_imports/external_data_job.py
+++ b/posthog/temporal/data_imports/external_data_job.py
@@ -37,7 +37,10 @@ from posthog.warehouse.external_data_source.jobs import update_external_job_stat
 from posthog.warehouse.models import ExternalDataJob, ExternalDataSource
 from posthog.warehouse.models.external_data_schema import update_should_sync
 
-Any_Source_Errors: list[str] = ["Could not establish session to SSH gateway"]
+Any_Source_Errors: list[str] = [
+    "Could not establish session to SSH gateway",
+    "Primary key required for incremental syncs",
+]
 
 Non_Retryable_Schema_Errors: dict[ExternalDataSource.Type, list[str]] = {
     ExternalDataSource.Type.STRIPE: [


### PR DESCRIPTION
## Problem
- A handful of schemas source tables don't have primary keys and unfortunately we can't sync these tables without them

## Changes
- Add missing primary key as a non-recoverable error to disable schemas