### PR TITLE
chore(temporal): Move shutdown logging

### DIFF
--- a/posthog/temporal/common/shutdown.py
+++ b/posthog/temporal/common/shutdown.py
@@ -184,4 +184,4 @@ class ShutdownMonitor:
             self.logger.debug("Worker is shutting down.")
             raise WorkerShuttingDownError.from_activity_context()
 
-        self.logger.debug("Worker not is shutting down.")
+        self.logger.debug("Worker is not shutting down.")

--- a/posthog/temporal/common/shutdown.py
+++ b/posthog/temporal/common/shutdown.py
@@ -115,8 +115,6 @@ class ShutdownMonitor:
             self.logger.info("Starting shutdown monitoring thread.")
 
             while not self._stop_event_sync.is_set():
-                self.logger.debug("Checking for worker shutdown.")
-
                 try:
                     activity.wait_for_worker_shutdown_sync(timeout=0.1)
                 except RuntimeError:
@@ -183,4 +181,7 @@ class ShutdownMonitor:
     def raise_if_is_worker_shutdown(self):
         """Raise an exception if worker is shutting down."""
         if self.is_worker_shutdown():
+            self.logger.debug("Worker is shutting down.")
             raise WorkerShuttingDownError.from_activity_context()
+
+        self.logger.debug("Worker not is shutting down.")

--- a/posthog/temporal/data_imports/external_data_job.py
+++ b/posthog/temporal/data_imports/external_data_job.py
@@ -258,7 +258,7 @@ class ExternalDataJobWorkflow(PostHogWorkflow):
             await workflow.execute_activity(
                 import_data_activity_sync,
                 job_inputs,
-                heartbeat_timeout=dt.timedelta(minutes=5),
+                heartbeat_timeout=dt.timedelta(minutes=2),
                 **timeout_params,
             )  # type: ignore
 


### PR DESCRIPTION
## Problem

Shutdown logging is noisy, but I still would like it around to identify how are things working. So, let's move it to a less noisy call instead of the main running loop.

Moreover, I noticed heartbeat timeout was set to 5 minutes for the `import_data_sync_activity`. Graceful shutdown period is also 5 minutes (see `posthog/temporal/common/worker.py`). There could be problems if we don't deliver a heartbeat in time before the graceful shutdown, and since heartbeats are buffered until timeout, we need a timeout smaller than graceful shutdown period. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

* Move shutdown monitor logging from main loop to `raise_if_worker_is_shutting_down`.
* Make heartbeat timeout for import data sync activity 2 minutes instead of 5.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
