### PR TITLE
chore(dev): Fix bin/ruff to detect correct venv

### DIFF
--- a/bin/ruff.sh
+++ b/bin/ruff.sh
@@ -1,3 +1,12 @@
 #!/bin/bash
-source env/bin/activate
+if [ -z "$VIRTUAL_ENV" ]; then
+    if [ -d ".flox/env" ]; then
+        source .flox/cache/venv/bin/activate
+    elif [ -d ".venv" ]; then
+        source .venv/bin/activate
+    elif [ -d "env" ]; then
+        source env/bin/activate
+    fi
+fi
+
 python -m ruff "$@" 


### PR DESCRIPTION
## Problem

bin/ruff doesn't work on my machine, as I don't have a venv under `venv`.

## Changes

Made bin/ruff more versatile.