### PR TITLE
fix: hogql printer dialect for aggregate functions

### DIFF
--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -1074,7 +1074,8 @@ class _Printer(Visitor):
 
             params_part = f"({', '.join(params)})" if params is not None else ""
             args_part = f"({f'DISTINCT ' if node.distinct else ''}{', '.join(args)})"
-            return f"{func_meta.clickhouse_name}{params_part}{args_part}"
+
+            return f"{node.name if self.dialect == 'hogql' else func_meta.clickhouse_name}{params_part}{args_part}"
 
         elif func_meta := find_hogql_function(node.name):
             validate_function_args(

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -2212,13 +2212,7 @@ class TestPrinter(BaseTest):
         )
         assert f"AS id FROM person WHERE and(equals(person.team_id, {self.team.pk}), in(id, tuple(4, 5, 6)))" in printed
 
-    def test_print_hogql_uses_hogql_function_names(self):
-        # Test that avgArray doesn't get printed as avgArrayOrNull in hogql dialect
+    def test_print_hogql_aggregation_function_uses_hogql_function_names(self):
         query = parse_expr("avgArray([1, 2, 3])")
-        printed = print_ast(
-            query,
-            HogQLContext(team_id=self.team.pk, enable_select_queries=True),
-            dialect="hogql",
-            settings=HogQLGlobalSettings(max_execution_time=10),
-        )
+        printed = print_ast(query, HogQLContext(team_id=self.team.pk), dialect="hogql")
         assert printed == "avgArray([1, 2, 3])"

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -2211,3 +2211,14 @@ class TestPrinter(BaseTest):
             in printed
         )
         assert f"AS id FROM person WHERE and(equals(person.team_id, {self.team.pk}), in(id, tuple(4, 5, 6)))" in printed
+
+    def test_print_hogql_uses_hogql_function_names(self):
+        # Test that avgArray doesn't get printed as avgArrayOrNull in hogql dialect
+        query = parse_expr("avgArray([1, 2, 3])")
+        printed = print_ast(
+            query,
+            HogQLContext(team_id=self.team.pk, enable_select_queries=True),
+            dialect="hogql",
+            settings=HogQLGlobalSettings(max_execution_time=10),
+        )
+        assert printed == "avgArray([1, 2, 3])"


### PR DESCRIPTION
## Problem

hogql aggregation functions are printing out clickhouse function names. this is causes the "edit as sql" functionality to break in insights

## Changes

make them not print out clickhouse

## Does this work well for both Cloud and self-hosted?

Yes
