### PR TITLE
fix: replay text color in playlist

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/Playlist.scss
+++ b/frontend/src/scenes/session-recordings/playlist/Playlist.scss
@@ -13,10 +13,6 @@
             // width: 25%;
             min-width: 285px;
         }
-
-        .text-link {
-            color: var(--text-primary) !important;
-        }
     }
 
     .Playlist__main {

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingPreview.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingPreview.tsx
@@ -209,7 +209,7 @@ export function SessionRecordingPreview({
             >
                 <div className="grow overflow-hidden deprecated-space-y-1">
                     <div className="flex items-center justify-between gap-x-0.5">
-                        <div className="flex overflow-hidden font-medium text-link ph-no-capture">
+                        <div className="flex overflow-hidden font-medium ph-no-capture">
                             <span className="truncate">{asDisplay(recording.person)}</span>
                         </div>
 


### PR DESCRIPTION
text-link styling has changed
and made all the person display orange in a playlist
we don't need it at all
so we 🪓 

|before | after|
|-|-|
|<img width="395" alt="Screenshot 2025-03-17 at 19 53 56" src="https://github.com/user-attachments/assets/517f1b17-fb90-4581-9db8-bf65383f3666" />| <img width="367" alt="Screenshot 2025-03-17 at 20 08 37" src="https://github.com/user-attachments/assets/b1b9dfd7-dd29-4941-86ba-97964ee68ad5" />|

