### PR TITLE
fix(propdefs): Reduce batch retry count

### DIFF
--- a/rust/property-defs-rs/src/lib.rs
+++ b/rust/property-defs-rs/src/lib.rs
@@ -22,7 +22,7 @@ pub mod config;
 pub mod metrics_consts;
 pub mod types;
 
-const BATCH_UPDATE_MAX_ATTEMPTS: u64 = 5;
+const BATCH_UPDATE_MAX_ATTEMPTS: u64 = 2;
 const UPDATE_RETRY_DELAY_MS: u64 = 150;
 
 pub async fn update_consumer_loop(


### PR DESCRIPTION
Just a few of these should be plenty even without filtering for constraint errors yet, given the new (wider) delay between attempts 👍

## Problem
Retries on non-retryable errors are slowing processing under high ingest volume.

## Changes
 Let's reduce those until we can sort out error classification better 👍 


## Does this work well for both Cloud and self-hosted?
Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Live 🚀 