### PR TITLE
SUPPORT SUPERDAY added button to open bug report.

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
@@ -2,6 +2,7 @@ import {
     IconAI,
     IconBook,
     IconChevronDown,
+    IconConfetti,
     IconDatabase,
     IconFeatures,
     IconGraph,
@@ -365,6 +366,19 @@ export const SidePanelSupport = (): JSX.Element => {
                                             targetBlank
                                         >
                                             Request a feature
+                                        </LemonButton>
+                                    </li>
+                                    <li>
+                                        <LemonButton
+                                            type="secondary"
+                                            status="alt"
+                                            to={`https://github.com/PostHog/posthog/issues/new?template=bug_report.yml&debug-info=${encodeURIComponent(
+                                                getPublicSupportSnippet(region, currentOrganization, currentTeam)
+                                            )}`}
+                                            icon={<IconConfetti />}
+                                            targetBlank
+                                        >
+                                            Report a bug
                                         </LemonButton>
                                     </li>
                                 </ul>


### PR DESCRIPTION
## Problem
Bug reports are not always easy to get to. 

I took a look and did not find any issues about this, but I may have missed. 

## Changes
adds a report bug button to sidebar near feature requests. Uses Confetti icon because Bug reporting is a party! 
<!-- If there are frontend changes, please include screenshots. -->
![Screenshot 2025-03-17 at 12 13 53 PM](https://github.com/user-attachments/assets/fb429290-523f-4b5b-9153-606435195eb5)


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes, I believe this will work for both. I am not yet 100% familiar with the lines between self hosted and cloud.

## How did you test this code?

Made change with Local environment, confirmed 1) button appeared and 2) that it linked correctly to GitHub new issue page using bug template. 
