### PR TITLE
chore(experiments): generate experiment name automatically.

### DIFF
--- a/cypress/e2e/experiments.cy.ts
+++ b/cypress/e2e/experiments.cy.ts
@@ -17,13 +17,16 @@ describe('Experiments', () => {
         cy.visit('/experiments')
         cy.get('[data-attr=top-bar-name]').should('contain', 'Experiments')
 
-        // Name, flag key, description
+        // click on the create experiment button
         cy.get('[data-attr=create-experiment]').first().click()
+
+        // type experiment name
         cy.get('[data-attr=experiment-name]').click().type(`${experimentName}`).should('have.value', experimentName)
-        cy.get('[data-attr=experiment-feature-flag-key]')
-            .click()
-            .type(`${featureFlagKey}`)
-            .should('have.value', featureFlagKey)
+
+        // the flag key should be set automatically when name looses focus
+        cy.get('[data-attr=experiment-feature-flag-key]').click().should('have.value', featureFlagKey)
+
+        // type description
         cy.get('[data-attr=experiment-description]')
             .click()
             .type('This is the description of the experiment')

--- a/frontend/src/scenes/experiments/ExperimentForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm.tsx
@@ -1,6 +1,14 @@
-import { IconPlusSmall, IconSparkles, IconToggle, IconTrash } from '@posthog/icons'
-import { LemonBanner, LemonDivider, LemonInput, LemonModal, LemonTextArea, Link, Tooltip } from '@posthog/lemon-ui'
-import { LemonTable } from '@posthog/lemon-ui'
+import { IconPlusSmall, IconToggle, IconTrash } from '@posthog/icons'
+import {
+    LemonBanner,
+    LemonDivider,
+    LemonInput,
+    LemonModal,
+    LemonTable,
+    LemonTextArea,
+    Link,
+    Tooltip,
+} from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { Form, Group } from 'kea-forms'
 import { ExperimentVariantNumber } from 'lib/components/SeriesGlyph'
@@ -50,17 +58,25 @@ const ExperimentFormFields = (): JSX.Element => {
             <div className="deprecated-space-y-8">
                 <div className="deprecated-space-y-6 max-w-120">
                     <LemonField name="name" label="Name">
-                        <LemonInput placeholder="Pricing page conversion" data-attr="experiment-name" />
+                        <LemonInput
+                            placeholder="Pricing page conversion"
+                            data-attr="experiment-name"
+                            onBlur={() => {
+                                setExperiment({
+                                    feature_flag_key: generateFeatureFlagKey(
+                                        experiment.name,
+                                        unavailableFeatureFlagKeys
+                                    ),
+                                })
+                            }}
+                        />
                     </LemonField>
                     <LemonField
                         name="feature_flag_key"
                         label="Feature flag key"
                         help={
-                            <div className="flex items-center deprecated-space-x-2">
-                                <span>
-                                    Each experiment is backed by a feature flag. Create a new one by entering a key, or
-                                    choose an existing feature flag with multiple variants.
-                                </span>
+                            <div className="flex items-center justify-between">
+                                <span>Each experiment is backed by a feature flag.</span>
                                 <LemonButton
                                     type="secondary"
                                     size="xsmall"
@@ -69,27 +85,8 @@ const ExperimentFormFields = (): JSX.Element => {
                                         setShowFeatureFlagSelector(true)
                                     }}
                                 >
-                                    <IconToggle className="mr-1" /> Choose
-                                </LemonButton>
-                                <LemonButton
-                                    type="secondary"
-                                    size="xsmall"
-                                    disabledReason={
-                                        experiment.name
-                                            ? undefined
-                                            : 'Fill out the experiment name first to generate a key from it.'
-                                    }
-                                    tooltip={experiment.name ? 'Generate a key from the experiment name' : undefined}
-                                    onClick={() => {
-                                        setExperiment({
-                                            feature_flag_key: generateFeatureFlagKey(
-                                                experiment.name,
-                                                unavailableFeatureFlagKeys
-                                            ),
-                                        })
-                                    }}
-                                >
-                                    <IconSparkles className="mr-1" /> Generate
+                                    <IconToggle className="mr-1" />
+                                    Link to existing feature flag
                                 </LemonButton>
                             </div>
                         }


### PR DESCRIPTION
## Problem

Small _Quality Of Life_ improvement on the _New Experiment_ page to create the feature flag key automatically when the user leaves the `name` field. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

| Before | After |
| - | - |
|  <img width="515" alt="image" src="https://github.com/user-attachments/assets/8a077394-b1c3-4a18-b289-90e795b3414a" /> | <img width="515" alt="image" src="https://github.com/user-attachments/assets/4ca8a86a-087c-47f4-aed6-7440f592c81e" /> |

| Recording |
| - |
|  ![Mar-17-2025 19-31-28](https://github.com/user-attachments/assets/0efff7ab-08b9-4f23-942e-9dfff023caf8) |




<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
