### PR TITLE
fix: Ensure `$session_id_uuid` migration actually runs

### DIFF
--- a/posthog/clickhouse/migrations/0106_materialize_session_ids_uuid.py
+++ b/posthog/clickhouse/migrations/0106_materialize_session_ids_uuid.py
@@ -1,25 +1,2 @@
-from infi.clickhouse_orm import migrations
-
-from posthog.clickhouse.client.connection import NodeRole
-from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
-
-
-ADD_COLUMNS_SHARDED_EVENTS = """
-ALTER TABLE {table}
-ADD COLUMN IF NOT EXISTS $session_id_uuid Nullable(UInt128) MATERIALIZED toUInt128(JSONExtract(properties, '$session_id', 'Nullable(UUID)'))
-"""
-
-ADD_COLUMNS_EVENTS = """
-ALTER TABLE {table}
-ADD COLUMN IF NOT EXISTS $session_id_uuid Nullable(UInt128)
-"""
-
-
-def add_columns_to_required_tables(_):
-    run_sql_with_exceptions(ADD_COLUMNS_SHARDED_EVENTS.format(table="sharded_events"))
-    run_sql_with_exceptions(ADD_COLUMNS_EVENTS.format(table="events"), node_role=NodeRole.ALL)
-
-
-operations = [
-    migrations.RunPython(add_columns_to_required_tables),
-]
+# migration did not run, superceded by 0107_materialize_session_ids_uuid
+operations = []

--- a/posthog/clickhouse/migrations/0107_materialize_session_ids_uuid.py
+++ b/posthog/clickhouse/migrations/0107_materialize_session_ids_uuid.py
@@ -1,0 +1,19 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+
+
+ADD_COLUMNS_SHARDED_EVENTS = """
+ALTER TABLE {table}
+ADD COLUMN IF NOT EXISTS $session_id_uuid Nullable(UInt128) MATERIALIZED toUInt128(JSONExtract(properties, '$session_id', 'Nullable(UUID)'))
+"""
+
+ADD_COLUMNS_EVENTS = """
+ALTER TABLE {table}
+ADD COLUMN IF NOT EXISTS $session_id_uuid Nullable(UInt128)
+"""
+
+
+operations = [
+    run_sql_with_exceptions(ADD_COLUMNS_SHARDED_EVENTS.format(table="sharded_events")),
+    run_sql_with_exceptions(ADD_COLUMNS_EVENTS.format(table="events"), node_role=NodeRole.ALL),
+]


### PR DESCRIPTION
## Problem

Migration `0106_materialize_session_ids_uuid` was inadvertently a noop.

## Changes

Fixes migration structure so that the statements are run.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Ran locally, observed output.

Before (note lack of logged statements):

```
2025-03-18T01:00:38.234506Z [info     ] Applying migration 0106_materialize_session_ids_uuid... [migrations] pid=90111 tid=8635185856
2025-03-18T01:00:38.234556Z [info     ]     Executing python operation add_columns_to_required_tables [migrations] pid=90111 tid=8635185856
✅ Migration successful
```

After:

```
2025-03-18T01:03:01.321896Z [info     ] Applying migration 0107_materialize_session_ids_uuid... [migrations] pid=90876 tid=8635185856
2025-03-18T01:03:01.321984Z [info     ]     Executing python operation <lambda> [migrations] pid=90876 tid=8635185856
2025-03-18T01:03:01.322025Z [info     ]        Running migration on datas [migrations] pid=90876 tid=8635185856
2025-03-18T01:03:01.322351Z [info     ] Executing Query(query="\nALTER TABLE sharded_events\nADD COLUMN IF NOT EXISTS $session_id_uuid Nullable(UInt128) MATERIALIZED toUInt128(JSONExtract(properties, '$session_id', 'Nullable(UUID)'))\n", parameters=None, settings=None) on HostInfo(connection_info=ConnectionInfo(host='clickhouse', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data')... [posthog.clickhouse.cluster] pid=90876 tid=13515829248
2025-03-18T01:03:01.386694Z [info     ] Successfully executed Query(query="\nALTER TABLE sharded_events\nADD COLUMN IF NOT EXISTS $session_id_uuid Nullable(UInt128) MATERIALIZED toUInt128(JSONExtract(properties, '$session_id', 'Nullable(UUID)'))\n", parameters=None, settings=None) on HostInfo(connection_info=ConnectionInfo(host='clickhouse', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'). [posthog.clickhouse.cluster] pid=90876 tid=13515829248
2025-03-18T01:03:01.386916Z [info     ]     Executing python operation <lambda> [migrations] pid=90876 tid=8635185856
2025-03-18T01:03:01.386959Z [info     ]        Running migration on coordinators and data nodes [migrations] pid=90876 tid=8635185856
2025-03-18T01:03:01.387098Z [info     ] Executing Query(query='\nALTER TABLE events\nADD COLUMN IF NOT EXISTS $session_id_uuid Nullable(UInt128)\n', parameters=None, settings=None) on HostInfo(connection_info=ConnectionInfo(host='clickhouse', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data')... [posthog.clickhouse.cluster] pid=90876 tid=13515829248
2025-03-18T01:03:01.390465Z [info     ] Successfully executed Query(query='\nALTER TABLE events\nADD COLUMN IF NOT EXISTS $session_id_uuid Nullable(UInt128)\n', parameters=None, settings=None) on HostInfo(connection_info=ConnectionInfo(host='clickhouse', port=9000), shard_num=1, replica_num=1, host_cluster_type='online', host_cluster_role='data'). [posthog.clickhouse.cluster] pid=90876 tid=13515829248
✅ Migration successful
```