### PR TITLE
feat: store exception context

### DIFF
--- a/rust/cymbal/src/frames/mod.rs
+++ b/rust/cymbal/src/frames/mod.rs
@@ -80,15 +80,20 @@ impl RawFrame {
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Frame {
     // Properties used in processing
-    pub raw_id: String,                  // The raw frame id this was resolved from
-    pub mangled_name: String,            // Mangled name of the function
-    pub line: Option<u32>,               // Line the function is define on, if known
-    pub column: Option<u32>,             // Column the function is defined on, if known
-    pub source: Option<String>,          // Generally, the file the function is defined in
-    pub in_app: bool,                    // We hard-require clients to tell us this?
-    pub resolved_name: Option<String>,   // The name of the function, after symbolification
-    pub lang: String,                    // The language of the frame. Always known (I guess?)
-    pub resolved: bool,                  // Did we manage to resolve the frame?
+    pub raw_id: String,       // The raw frame id this was resolved from
+    pub mangled_name: String, // Mangled name of the function
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line: Option<u32>, // Line the function is define on, if known
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub column: Option<u32>, // Column the function is defined on, if known
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>, // Generally, the file the function is defined in
+    pub in_app: bool,         // We hard-require clients to tell us this?
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolved_name: Option<String>, // The name of the function, after symbolification
+    pub lang: String,         // The language of the frame. Always known (I guess?)
+    pub resolved: bool,       // Did we manage to resolve the frame?
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub resolve_failure: Option<String>, // If we failed to resolve the frame, why?
 
     // Random extra/internal data we want to tag onto frames, e.g. the raw input. For debugging

--- a/rust/cymbal/src/types/mod.rs
+++ b/rust/cymbal/src/types/mod.rs
@@ -151,8 +151,7 @@ impl FingerprintedErrProps {
             .exception_list
             .iter()
             .filter_map(|e| e.stack.as_ref())
-            .map(Stacktrace::get_frames)
-            .flatten();
+            .flat_map(Stacktrace::get_frames);
 
         let sources = unique_by(frames.clone(), |f| f.source.clone());
         let functions = unique_by(frames, |f| f.resolved_name.clone());
@@ -186,7 +185,7 @@ where
     K: Eq + Hash + Clone,
 {
     items
-        .filter_map(|item| key_extractor(item))
+        .filter_map(key_extractor)
         .collect::<HashSet<_>>()
         .into_iter()
         .collect()

--- a/rust/cymbal/src/types/mod.rs
+++ b/rust/cymbal/src/types/mod.rs
@@ -33,6 +33,7 @@ pub struct Exception {
     pub exception_type: String,
     #[serde(rename = "value")]
     pub exception_message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mechanism: Option<Mechanism>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub module: Option<String>,


### PR DESCRIPTION
## Problem

We want to be able to search over the properties of an Exception much quicker. We could materialize the `$exception_stacktrace` column but @tkaemming suggested that if we could get a >50% reduction in size from materialising only the components of the stacktrace that we need we should do that instead.

Made the decision to store (& materialise) many properties in case we want to add filters like "function name is..." or "description contains ..."

## Changes

- [ ] Add properties for each of the relevant fields in the stacktrace (this PR). We unique to save space
- [ ] Materialize those new columns
- [ ] Update the query runner to use the new materialised columns rather than the stacktrace
