### PR TITLE
fix: more toolbar z-index discovery

### DIFF
--- a/frontend/src/toolbar/elements/Elements.tsx
+++ b/frontend/src/toolbar/elements/Elements.tsx
@@ -59,10 +59,7 @@ export function Elements(): JSX.Element {
                 <Heatmap />
                 {highlightElementMeta?.rect ? <FocusRect rect={highlightElementMeta.rect} /> : null}
 
-                {elementsToDisplay.map(({ rect, element }, index) => {
-                    // being able to hover over elements might rely on their original z-index
-                    // so we copy it over to the toolbar element
-                    const elementZIndex = getComputedStyle(element).zIndex
+                {elementsToDisplay.map(({ rect, element, apparentZIndex }, index) => {
                     return (
                         <AutocaptureElement
                             key={`inspect-${index}`}
@@ -70,7 +67,7 @@ export function Elements(): JSX.Element {
                             style={{
                                 pointerEvents: heatmapPointerEvents,
                                 cursor: 'pointer',
-                                zIndex: elementZIndex ? elementZIndex : hoverElement === element ? 2 : 1,
+                                zIndex: apparentZIndex ? apparentZIndex : hoverElement === element ? 2 : 1,
                                 opacity:
                                     (!hoverElement && !selectedElement) ||
                                     selectedElement === element ||

--- a/frontend/src/toolbar/elements/elementsLogic.ts
+++ b/frontend/src/toolbar/elements/elementsLogic.ts
@@ -18,6 +18,21 @@ import { heatmapLogic } from './heatmapLogic'
 export type ActionElementMap = Map<HTMLElement, ActionElementWithMetadata[]>
 export type ElementMap = Map<HTMLElement, ElementWithMetadata>
 
+const getMaxZIndex = (element: Element): number => {
+    let maxZIndex = 0
+    let currentElement: Element | null = element
+
+    while (currentElement) {
+        const zIndex = parseInt(getComputedStyle(currentElement).zIndex)
+        if (!isNaN(zIndex) && zIndex > maxZIndex) {
+            maxZIndex = zIndex
+        }
+        currentElement = currentElement.parentElement
+    }
+
+    return maxZIndex
+}
+
 export const elementsLogic = kea<elementsLogicType>([
     path(['toolbar', 'elements', 'elementsLogic']),
     connect(() => ({
@@ -294,7 +309,12 @@ export const elementsLogic = kea<elementsLogicType>([
         elementsToDisplay: [
             (s) => [s.elementsToDisplayRaw],
             (elementsToDisplayRaw) => {
-                return elementsToDisplayRaw.filter(({ rect }) => rect && (rect.width !== 0 || rect.height !== 0))
+                return elementsToDisplayRaw
+                    .filter(({ rect }) => rect && (rect.width !== 0 || rect.height !== 0))
+                    .map((element) => ({
+                        ...element,
+                        apparentZIndex: getMaxZIndex(element.element),
+                    }))
             },
         ],
 

--- a/frontend/src/toolbar/elements/elementsLogic.ts
+++ b/frontend/src/toolbar/elements/elementsLogic.ts
@@ -313,6 +313,8 @@ export const elementsLogic = kea<elementsLogicType>([
                     .filter(({ rect }) => rect && (rect.width !== 0 || rect.height !== 0))
                     .map((element) => ({
                         ...element,
+                        // being able to hover over elements might rely on their original z-index
+	                // so we copy it over to the toolbar element
                         apparentZIndex: getMaxZIndex(element.element),
                     }))
             },

--- a/frontend/src/toolbar/elements/elementsLogic.ts
+++ b/frontend/src/toolbar/elements/elementsLogic.ts
@@ -314,7 +314,7 @@ export const elementsLogic = kea<elementsLogicType>([
                     .map((element) => ({
                         ...element,
                         // being able to hover over elements might rely on their original z-index
-	                // so we copy it over to the toolbar element
+                        // so we copy it over to the toolbar element
                         apparentZIndex: getMaxZIndex(element.element),
                     }))
             },

--- a/frontend/src/toolbar/types.ts
+++ b/frontend/src/toolbar/types.ts
@@ -60,6 +60,7 @@ export interface ElementWithMetadata {
     clickCount?: number
     rageclickCount?: number
     position?: number
+    apparentZIndex?: number
 }
 
 export interface ActionElementWithMetadata extends ElementWithMetadata {


### PR DESCRIPTION
see https://posthoghelp.zendesk.com/agent/tickets/26867 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/29101)

we now read the comptued z-index off the element, but sometimes the element's z-index is determined by a parent, so we have to walk it's parents too