### PR TITLE
chore: increase shards and workers for storybook test runner

### DIFF
--- a/.github/workflows/storybook-chromatic.yml
+++ b/.github/workflows/storybook-chromatic.yml
@@ -67,9 +67,9 @@ jobs:
             fail-fast: false
             matrix:
                 browser: ['chromium', 'webkit']
-                shard: [1, 2, 3, 4]
+                shard: [1, 2, 3, 4, 5, 6]
         env:
-            SHARD_COUNT: '4'
+            SHARD_COUNT: '6'
             CYPRESS_INSTALL_BINARY: '0'
             NODE_OPTIONS: --max-old-space-size=16384
             OPT_OUT_CAPTURE: 1
@@ -95,9 +95,14 @@ jobs:
             chromium-4-deleted: ${{ steps.diff.outputs.chromium-4-deleted }}
             chromium-4-total: ${{ steps.diff.outputs.chromium-4-total }}
             chromium-4-commitHash: ${{ steps.commit-hash.outputs.chromium-4-commitHash }}
-            webkit-1-added: ${{ steps.diff.outputs.webkit-1-added }}
-            webkit-1-modified: ${{ steps.diff.outputs.webkit-1-modified }}
-            webkit-1-deleted: ${{ steps.diff.outputs.webkit-1-deleted }}
+            chromium-5-added: ${{ steps.diff.outputs.chromium-5-added }}
+            chromium-5-modified: ${{ steps.diff.outputs.chromium-5-modified }}
+            chromium-5-deleted: ${{ steps.diff.outputs.chromium-5-deleted }}
+            chromium-5-total: ${{ steps.diff.outputs.chromium-5-total }}
+            chromium-5-commitHash: ${{ steps.commit-hash.outputs.chromium-5-commitHash }}
+            chromium-6-added: ${{ steps.diff.outputs.chromium-6-added }}
+            chromium-6-modified: ${{ steps.diff.outputs.chromium-6-modified }}
+            chromium-6-deleted: ${{ steps.diff.outputs.chromium-6-deleted }}
             webkit-1-total: ${{ steps.diff.outputs.webkit-1-total }}
             webkit-1-commitHash: ${{ steps.commit-hash.outputs.webkit-1-commitHash }}
             webkit-2-added: ${{ steps.diff.outputs.webkit-2-added }}
@@ -115,26 +120,15 @@ jobs:
             webkit-4-deleted: ${{ steps.diff.outputs.webkit-4-deleted }}
             webkit-4-total: ${{ steps.diff.outputs.webkit-4-total }}
             webkit-4-commitHash: ${{ steps.commit-hash.outputs.webkit-4-commitHash }}
-            firefox-1-added: ${{ steps.diff.outputs.firefox-1-added }}
-            firefox-1-modified: ${{ steps.diff.outputs.firefox-1-modified }}
-            firefox-1-deleted: ${{ steps.diff.outputs.firefox-1-deleted }}
-            firefox-1-total: ${{ steps.diff.outputs.firefox-1-total }}
-            firefox-1-commitHash: ${{ steps.commit-hash.outputs.firefox-1-commitHash }}
-            firefox-2-added: ${{ steps.diff.outputs.firefox-2-added }}
-            firefox-2-modified: ${{ steps.diff.outputs.firefox-2-modified }}
-            firefox-2-deleted: ${{ steps.diff.outputs.firefox-2-deleted }}
-            firefox-2-total: ${{ steps.diff.outputs.firefox-2-total }}
-            firefox-2-commitHash: ${{ steps.commit-hash.outputs.firefox-2-commitHash }}
-            firefox-3-added: ${{ steps.diff.outputs.firefox-3-added }}
-            firefox-3-modified: ${{ steps.diff.outputs.firefox-3-modified }}
-            firefox-3-deleted: ${{ steps.diff.outputs.firefox-3-deleted }}
-            firefox-3-total: ${{ steps.diff.outputs.firefox-3-total }}
-            firefox-3-commitHash: ${{ steps.commit-hash.outputs.firefox-3-commitHash }}
-            firefox-4-added: ${{ steps.diff.outputs.firefox-4-added }}
-            firefox-4-modified: ${{ steps.diff.outputs.firefox-4-modified }}
-            firefox-4-deleted: ${{ steps.diff.outputs.firefox-4-deleted }}
-            firefox-4-total: ${{ steps.diff.outputs.firefox-4-total }}
-            firefox-4-commitHash: ${{ steps.commit-hash.outputs.firefox-4-commitHash }}
+            webkit-5-added: ${{ steps.diff.outputs.webkit-5-added }}
+            webkit-5-modified: ${{ steps.diff.outputs.webkit-5-modified }}
+            webkit-5-deleted: ${{ steps.diff.outputs.webkit-5-deleted }}
+            webkit-5-total: ${{ steps.diff.outputs.webkit-5-total }}
+            webkit-5-commitHash: ${{ steps.commit-hash.outputs.webkit-5-commitHash }}
+            webkit-6-added: ${{ steps.diff.outputs.webkit-6-added }}
+            webkit-6-modified: ${{ steps.diff.outputs.webkit-6-modified }}
+            webkit-6-deleted: ${{ steps.diff.outputs.webkit-6-deleted }}
+            webkit-6-total: ${{ steps.diff.outputs.webkit-6-total }}
         steps:
             - uses: actions/checkout@v3
               with:

--- a/.github/workflows/storybook-chromatic.yml
+++ b/.github/workflows/storybook-chromatic.yml
@@ -67,9 +67,9 @@ jobs:
             fail-fast: false
             matrix:
                 browser: ['chromium', 'webkit']
-                shard: [1, 2, 3]
+                shard: [1, 2, 3, 4]
         env:
-            SHARD_COUNT: '3'
+            SHARD_COUNT: '4'
             CYPRESS_INSTALL_BINARY: '0'
             NODE_OPTIONS: --max-old-space-size=16384
             OPT_OUT_CAPTURE: 1
@@ -90,6 +90,11 @@ jobs:
             chromium-3-deleted: ${{ steps.diff.outputs.chromium-3-deleted }}
             chromium-3-total: ${{ steps.diff.outputs.chromium-3-total }}
             chromium-3-commitHash: ${{ steps.commit-hash.outputs.chromium-3-commitHash }}
+            chromium-4-added: ${{ steps.diff.outputs.chromium-4-added }}
+            chromium-4-modified: ${{ steps.diff.outputs.chromium-4-modified }}
+            chromium-4-deleted: ${{ steps.diff.outputs.chromium-4-deleted }}
+            chromium-4-total: ${{ steps.diff.outputs.chromium-4-total }}
+            chromium-4-commitHash: ${{ steps.commit-hash.outputs.chromium-4-commitHash }}
             webkit-1-added: ${{ steps.diff.outputs.webkit-1-added }}
             webkit-1-modified: ${{ steps.diff.outputs.webkit-1-modified }}
             webkit-1-deleted: ${{ steps.diff.outputs.webkit-1-deleted }}
@@ -105,6 +110,11 @@ jobs:
             webkit-3-deleted: ${{ steps.diff.outputs.webkit-3-deleted }}
             webkit-3-total: ${{ steps.diff.outputs.webkit-3-total }}
             webkit-3-commitHash: ${{ steps.commit-hash.outputs.webkit-3-commitHash }}
+            webkit-4-added: ${{ steps.diff.outputs.webkit-4-added }}
+            webkit-4-modified: ${{ steps.diff.outputs.webkit-4-modified }}
+            webkit-4-deleted: ${{ steps.diff.outputs.webkit-4-deleted }}
+            webkit-4-total: ${{ steps.diff.outputs.webkit-4-total }}
+            webkit-4-commitHash: ${{ steps.commit-hash.outputs.webkit-4-commitHash }}
             firefox-1-added: ${{ steps.diff.outputs.firefox-1-added }}
             firefox-1-modified: ${{ steps.diff.outputs.firefox-1-modified }}
             firefox-1-deleted: ${{ steps.diff.outputs.firefox-1-deleted }}
@@ -120,6 +130,11 @@ jobs:
             firefox-3-deleted: ${{ steps.diff.outputs.firefox-3-deleted }}
             firefox-3-total: ${{ steps.diff.outputs.firefox-3-total }}
             firefox-3-commitHash: ${{ steps.commit-hash.outputs.firefox-3-commitHash }}
+            firefox-4-added: ${{ steps.diff.outputs.firefox-4-added }}
+            firefox-4-modified: ${{ steps.diff.outputs.firefox-4-modified }}
+            firefox-4-deleted: ${{ steps.diff.outputs.firefox-4-deleted }}
+            firefox-4-total: ${{ steps.diff.outputs.firefox-4-total }}
+            firefox-4-commitHash: ${{ steps.commit-hash.outputs.firefox-4-commitHash }}
         steps:
             - uses: actions/checkout@v3
               with:

--- a/.github/workflows/storybook-chromatic.yml
+++ b/.github/workflows/storybook-chromatic.yml
@@ -103,6 +103,11 @@ jobs:
             chromium-6-added: ${{ steps.diff.outputs.chromium-6-added }}
             chromium-6-modified: ${{ steps.diff.outputs.chromium-6-modified }}
             chromium-6-deleted: ${{ steps.diff.outputs.chromium-6-deleted }}
+            chromium-6-total: ${{ steps.diff.outputs.chromium-6-total }}
+            chromium-6-commitHash: ${{ steps.commit-hash.outputs.chromium-6-commitHash }}
+            webkit-1-added: ${{ steps.diff.outputs.webkit-1-added }}
+            webkit-1-modified: ${{ steps.diff.outputs.webkit-1-modified }}
+            webkit-1-deleted: ${{ steps.diff.outputs.webkit-1-deleted }}
             webkit-1-total: ${{ steps.diff.outputs.webkit-1-total }}
             webkit-1-commitHash: ${{ steps.commit-hash.outputs.webkit-1-commitHash }}
             webkit-2-added: ${{ steps.diff.outputs.webkit-2-added }}
@@ -129,6 +134,7 @@ jobs:
             webkit-6-modified: ${{ steps.diff.outputs.webkit-6-modified }}
             webkit-6-deleted: ${{ steps.diff.outputs.webkit-6-deleted }}
             webkit-6-total: ${{ steps.diff.outputs.webkit-6-total }}
+            webkit-6-commitHash: ${{ steps.commit-hash.outputs.webkit-6-commitHash }}
         steps:
             - uses: actions/checkout@v3
               with:

--- a/common/storybook/package.json
+++ b/common/storybook/package.json
@@ -6,8 +6,8 @@
         "test:visual:update": "cd ../.. && rm -rf frontend/__snapshots__/__failures__/ && docker compose -f docker-compose.playwright.yml run --rm -it --build playwright pnpm test:visual:update:docker --url http://host.docker.internal:6006",
         "test:visual:update:docker": "NODE_OPTIONS=--max-old-space-size=16384 test-storybook -u --browsers chromium webkit --no-index-json",
         "test:visual:debug": "PWDEBUG=1 NODE_OPTIONS=--max-old-space-size=16384 test-storybook --browsers chromium webkit --no-index-json",
-        "test:visual:ci:update": "test-storybook -u --no-index-json --maxWorkers=2",
-        "test:visual:ci:verify": "test-storybook --ci --no-index-json --maxWorkers=2"
+        "test:visual:ci:update": "test-storybook -u --no-index-json --maxWorkers=$(( $(nproc 2>/dev/null || echo 3) - 1 ))",
+        "test:visual:ci:verify": "test-storybook --ci --no-index-json --maxWorkers=$(( $(nproc 2>/dev/null || echo 3) - 1 ))"
     },
     "dependencies": {
         "@babel/core": "^7.22.10",


### PR DESCRIPTION
## Problem

The storybook test runner tests are holding up the CI on my latest PRs, this splits them across 4 runners and increases the worker count.

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
