### PR TITLE
fix: Two small Web-analytics related fixes

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -315,17 +315,22 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
         items: [
             (s, p) => [s.remoteItems, s.localItems, p.showNumericalPropsOnly ?? (() => false)],
             (remoteItems, localItems, showNumericalPropsOnly) => {
-                const results = [...localItems.results, ...remoteItems.results].filter((n) => {
+                const results = [...localItems.results, ...remoteItems.results].filter((result) => {
                     if (!showNumericalPropsOnly) {
                         return true
                     }
 
-                    if ('is_numerical' in n) {
-                        return !!n.is_numerical
+                    // It's still loading, just display it while we figure it out
+                    if (!result) {
+                        return true
                     }
 
-                    if ('property_type' in n) {
-                        const property_type = n.property_type as string // Data warehouse props dont conform to PropertyType for some reason
+                    if ('is_numerical' in result) {
+                        return !!result.is_numerical
+                    }
+
+                    if ('property_type' in result) {
+                        const property_type = result.property_type as string // Data warehouse props dont conform to PropertyType for some reason
                         return property_type === 'Integer' || property_type === 'Float'
                     }
 

--- a/frontend/src/scenes/web-analytics/CrossSellButtons/HeatmapButton.tsx
+++ b/frontend/src/scenes/web-analytics/CrossSellButtons/HeatmapButton.tsx
@@ -40,9 +40,18 @@ export const HeatmapButton = ({ breakdownBy, value }: HeatmapButtonProps): JSX.E
         return <></>
     }
 
-    // When there's no domain filter selected, just don't show the button
+    // When there's no domain filter selected, display a disabled button with a tooltip
     if (!webAnalyticsSelectedDomain || webAnalyticsSelectedDomain === 'all') {
-        return <></>
+        return (
+            <LemonButton
+                disabledReason="Select a domain to view heatmaps"
+                icon={<IconHeatmap />}
+                type="tertiary"
+                size="xsmall"
+                tooltip="View heatmap for this page"
+                className="no-underline"
+            />
+        )
     }
 
     // Normalize domain and path then join with a slash


### PR DESCRIPTION
Currency selector was breaking after recent changes to the TaxonomyFilter. Because we now have loading items that don't exist yet, let's show them up while they're loading, and avoid crashing when calling `'is_numerical' in undefined`. CC @HamedMP 

We're also now displaying disabled heatmap button when no domain is selected