### PR TITLE
feat(cyclotron): Add metrics to cyclotron-core vm_state compression functions

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1571,6 +1571,7 @@ name = "cyclotron-core"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "common-metrics",
  "flate2",
  "futures",
  "serde",

--- a/rust/cyclotron-core/Cargo.toml
+++ b/rust/cyclotron-core/Cargo.toml
@@ -18,3 +18,4 @@ uuid = { workspace = true }
 futures = { workspace = true }
 tracing = { workspace = true }
 flate2 = { workspace = true }
+common-metrics = { path = "../common/metrics" }


### PR DESCRIPTION
## Problem
Since we purposely no-op when decompressing uncompressed `vm_state` payloads in `cyclotron-core` it would be useful to have metrics to understand when and where compression is enabled during the cutover

## Changes
* Pull in `common-metrics` to `cyclotron-core` lib, which are already wired up to publish for `cyclotron-{fetch,janitor}` 
* Add metrics to compress/decompress `vm_state` code paths in `ops/compress.rs`

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally & CI but not much signal there. I'll be observing the deploy as well.
