### PR TITLE
refactor(experiments): extract Metric Header components.

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.test.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.test.tsx
@@ -1,6 +1,4 @@
-import { ExperimentMetric, ExperimentMetricType, NodeKind } from '~/queries/schema/schema-general'
-
-import { generateViolinPath, getDefaultMetricTitle } from './DeltaChart'
+import { generateViolinPath } from './DeltaChart'
 
 /**
  * Helper function to parse SVG path string into points, optionally skipping the initial move command
@@ -150,33 +148,5 @@ describe('generateViolinPath', () => {
         expect(typeof path).toBe('string')
         expect(path).toContain('M')
         expect(path).toContain('Z')
-    })
-})
-
-describe('getDefaultMetricTitle', () => {
-    it('handles ExperimentEventMetricConfig with math and math_property', () => {
-        const metric: ExperimentMetric = {
-            kind: NodeKind.ExperimentMetric,
-            metric_type: ExperimentMetricType.MEAN,
-            metric_config: {
-                kind: NodeKind.ExperimentEventMetricConfig,
-                event: 'purchase completed',
-            },
-        }
-        expect(getDefaultMetricTitle(metric)).toBe('purchase completed')
-    })
-
-    it('returns action name for ExperimentActionMetricConfig', () => {
-        const metric: ExperimentMetric = {
-            kind: NodeKind.ExperimentMetric,
-            metric_type: ExperimentMetricType.MEAN,
-            metric_config: {
-                kind: NodeKind.ExperimentActionMetricConfig,
-                action: 1,
-                name: 'purchase',
-            },
-        }
-
-        expect(getDefaultMetricTitle(metric)).toBe('purchase')
     })
 })

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -1,13 +1,4 @@
-import {
-    IconActivity,
-    IconArrowRight,
-    IconClock,
-    IconFunnels,
-    IconGraph,
-    IconMinus,
-    IconPencil,
-    IconTrending,
-} from '@posthog/icons'
+import { IconActivity, IconClock, IconGraph, IconMinus, IconTrending } from '@posthog/icons'
 import { LemonBanner, LemonButton, LemonModal, LemonTag, LemonTagType, Tooltip } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
@@ -17,7 +8,7 @@ import { humanFriendlyNumber } from 'lib/utils'
 import { useEffect, useRef, useState } from 'react'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
-import { ExperimentMetric, NodeKind } from '~/queries/schema/schema-general'
+import { NodeKind } from '~/queries/schema/schema-general'
 import { InsightType, TrendExperimentVariant } from '~/types'
 
 import { EXPERIMENT_MIN_EXPOSURES_FOR_RESULTS } from '../constants'
@@ -25,16 +16,8 @@ import { experimentLogic } from '../experimentLogic'
 import { ExploreButton, ResultsQuery, VariantTag } from '../ExperimentView/components'
 import { SignificanceText, WinningVariantText } from '../ExperimentView/Overview'
 import { SummaryTable } from '../ExperimentView/SummaryTable'
+import { MetricHeader } from './MetricHeader'
 import { NoResultEmptyState } from './NoResultEmptyState'
-import { getMetricTag } from './utils'
-export function getDefaultMetricTitle(metric: ExperimentMetric): string {
-    if (metric.metric_config.kind === NodeKind.ExperimentEventMetricConfig) {
-        return metric.metric_config.event
-    } else if (metric.metric_config.kind === NodeKind.ExperimentActionMetricConfig) {
-        return metric.metric_config.name || `Action ${metric.metric_config.action}`
-    }
-    return 'Untitled metric'
-}
 
 function formatTickValue(value: number): string {
     if (value === 0) {
@@ -56,42 +39,6 @@ function formatTickValue(value: number): string {
     }
 
     return `${(value * 100).toFixed(decimals)}%`
-}
-export const getMetricTitle = (metric: any, metricType?: InsightType): JSX.Element => {
-    if (metric.name) {
-        return <span className="truncate">{metric.name}</span>
-    }
-
-    if (metric.kind === NodeKind.ExperimentMetric) {
-        return <span className="truncate">{getDefaultMetricTitle(metric)}</span>
-    }
-
-    if (metricType === InsightType.TRENDS && metric.count_query?.series?.[0]?.name) {
-        return <span className="truncate">{metric.count_query.series[0].name}</span>
-    }
-
-    if (metricType === InsightType.FUNNELS && metric.funnels_query?.series) {
-        const series = metric.funnels_query.series
-        if (series.length > 0) {
-            const firstStep = series[0]?.name
-            const lastStep = series[series.length - 1]?.name
-
-            return (
-                <div className="inline-flex flex-wrap items-center gap-1 min-w-0">
-                    <div className="inline-flex items-center gap-1 min-w-0">
-                        <IconFunnels className="text-secondary flex-shrink-0" fontSize="14" />
-                        <span className="truncate">{firstStep}</span>
-                    </div>
-                    <div className="inline-flex items-center gap-1 min-w-0 @max-[200px]:ml-5">
-                        <IconArrowRight className="text-secondary flex-shrink-0" fontSize="14" />
-                        <span className="truncate">{lastStep}</span>
-                    </div>
-                </div>
-            )
-        }
-    }
-
-    return <span className="text-secondary truncate">Untitled metric</span>
 }
 
 export function generateViolinPath(x1: number, x2: number, y: number, height: number, deltaX: number): string {
@@ -182,12 +129,13 @@ export function DeltaChart({
     } = useValues(experimentLogic)
 
     const {
-        openPrimaryMetricModal,
-        openSecondaryMetricModal,
-        openPrimarySharedMetricModal,
-        openSecondarySharedMetricModal,
+        // openPrimaryMetricModal,
+        // openSecondaryMetricModal,
+        // openPrimarySharedMetricModal,
+        // openSecondarySharedMetricModal,
         openVariantDeltaTimeseriesModal,
     } = useActions(experimentLogic)
+
     const [tooltipData, setTooltipData] = useState<{ x: number; y: number; variant: string } | null>(null)
     const [emptyStateTooltipVisible, setEmptyStateTooltipVisible] = useState(true)
     const [tooltipPosition, setTooltipPosition] = useState({ x: 0, y: 0 })
@@ -294,45 +242,12 @@ export function DeltaChart({
                     style={{ height: `${chartSvgHeight}px`, borderRight: `1px solid ${COLORS.BOUNDARY_LINES}` }}
                     className="p-2 overflow-auto"
                 >
-                    <div className="text-xs font-semibold whitespace-nowrap overflow-hidden">
-                        <div className="deprecated-space-y-1">
-                            <div className="flex items-center gap-2">
-                                <div className="@container cursor-default text-xs font-semibold whitespace-nowrap overflow-hidden text-ellipsis flex-grow flex items-start">
-                                    <span className="mr-1">{metricIndex + 1}.</span>
-                                    {getMetricTitle(metric, metricType)}
-                                </div>
-                                <LemonButton
-                                    className="flex-shrink-0"
-                                    type="secondary"
-                                    size="xsmall"
-                                    icon={<IconPencil fontSize="12" />}
-                                    onClick={() => {
-                                        if (metric.isSharedMetric) {
-                                            if (isSecondary) {
-                                                openSecondarySharedMetricModal(metric.sharedMetricId)
-                                            } else {
-                                                openPrimarySharedMetricModal(metric.sharedMetricId)
-                                            }
-                                            return
-                                        }
-                                        isSecondary
-                                            ? openSecondaryMetricModal(metricIndex)
-                                            : openPrimaryMetricModal(metricIndex)
-                                    }}
-                                />
-                            </div>
-                            <div className="deprecated-space-x-1">
-                                <LemonTag type="muted" size="small">
-                                    {getMetricTag(metric)}
-                                </LemonTag>
-                                {metric.isSharedMetric && (
-                                    <LemonTag type="option" size="small">
-                                        Shared
-                                    </LemonTag>
-                                )}
-                            </div>
-                        </div>
-                    </div>
+                    <MetricHeader
+                        metricIndex={metricIndex}
+                        metric={metric}
+                        metricType={metricType}
+                        isPrimaryMetric={!isSecondary}
+                    />
                 </div>
             </div>
             {/* SVGs container */}

--- a/frontend/src/scenes/experiments/MetricsView/MetricHeader.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/MetricHeader.tsx
@@ -1,0 +1,76 @@
+import { IconPencil } from '@posthog/icons'
+import { useActions } from 'kea'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+
+import { experimentLogic } from '../experimentLogic'
+import { MetricTitle } from './MetricTitle'
+import { getMetricTag } from './utils'
+
+export const MetricHeader = ({
+    metricIndex,
+    metric,
+    metricType,
+    isPrimaryMetric,
+}: {
+    metricIndex: number
+    metric: any
+    metricType: any
+    isPrimaryMetric: boolean
+}): JSX.Element => {
+    /**
+     * This is a bit overkill, since primary and secondary metric dialogs are
+     * identical.
+     * Also, it's not the responsibility of this component to understand
+     * the difference between primary and secondary metrics.
+     * For this component, primary and secondary are identical,
+     * except for which modal to open.
+     * The openModal function has to be provided as a dependency.
+     */
+    const {
+        openPrimaryMetricModal,
+        openSecondaryMetricModal,
+        openPrimarySharedMetricModal,
+        openSecondarySharedMetricModal,
+    } = useActions(experimentLogic)
+
+    return (
+        <div className="text-xs font-semibold whitespace-nowrap overflow-hidden">
+            <div className="deprecated-space-y-1">
+                <div className="flex items-center gap-2">
+                    <div className="@container cursor-default text-xs font-semibold whitespace-nowrap overflow-hidden text-ellipsis flex-grow flex items-start">
+                        <span className="mr-1">{metricIndex + 1}.</span>
+                        <MetricTitle metric={metric} metricType={metricType} />
+                    </div>
+                    <LemonButton
+                        className="flex-shrink-0"
+                        type="secondary"
+                        size="xsmall"
+                        icon={<IconPencil fontSize="12" />}
+                        onClick={() => {
+                            const openModal = isPrimaryMetric
+                                ? metric.isSharedMetric
+                                    ? openPrimarySharedMetricModal
+                                    : openPrimaryMetricModal
+                                : metric.isSharedMetric
+                                ? openSecondarySharedMetricModal
+                                : openSecondaryMetricModal
+
+                            openModal(metric.isSharedMetric ? metric.sharedMetricId : metricIndex)
+                        }}
+                    />
+                </div>
+                <div className="deprecated-space-x-1">
+                    <LemonTag type="muted" size="small">
+                        {getMetricTag(metric)}
+                    </LemonTag>
+                    {metric.isSharedMetric && (
+                        <LemonTag type="option" size="small">
+                            Shared
+                        </LemonTag>
+                    )}
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/experiments/MetricsView/MetricTitle.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/MetricTitle.tsx
@@ -1,0 +1,43 @@
+import { IconArrowRight, IconFunnels } from '@posthog/icons'
+
+import { NodeKind } from '~/queries/schema/schema-general'
+import { InsightType } from '~/types'
+
+import { getDefaultMetricTitle } from './utils'
+
+export const MetricTitle = ({ metric, metricType }: { metric: any; metricType?: InsightType }): JSX.Element => {
+    if (metric.name) {
+        return <span className="truncate">{metric.name}</span>
+    }
+
+    if (metric.kind === NodeKind.ExperimentMetric) {
+        return <span className="truncate">{getDefaultMetricTitle(metric)}</span>
+    }
+
+    if (metricType === InsightType.TRENDS && metric.count_query?.series?.[0]?.name) {
+        return <span className="truncate">{metric.count_query.series[0].name}</span>
+    }
+
+    if (metricType === InsightType.FUNNELS && metric.funnels_query?.series) {
+        const series = metric.funnels_query.series
+        if (series.length > 0) {
+            const firstStep = series[0]?.name
+            const lastStep = series[series.length - 1]?.name
+
+            return (
+                <div className="inline-flex flex-wrap items-center gap-1 min-w-0">
+                    <div className="inline-flex items-center gap-1 min-w-0">
+                        <IconFunnels className="text-secondary flex-shrink-0" fontSize="14" />
+                        <span className="truncate">{firstStep}</span>
+                    </div>
+                    <div className="inline-flex items-center gap-1 min-w-0 @max-[200px]:ml-5">
+                        <IconArrowRight className="text-secondary flex-shrink-0" fontSize="14" />
+                        <span className="truncate">{lastStep}</span>
+                    </div>
+                </div>
+            )
+        }
+    }
+
+    return <span className="text-secondary truncate">Untitled metric</span>
+}

--- a/frontend/src/scenes/experiments/MetricsView/utils.test.ts
+++ b/frontend/src/scenes/experiments/MetricsView/utils.test.ts
@@ -2,7 +2,7 @@ import type { ExperimentFunnelsQuery, ExperimentMetric, ExperimentTrendsQuery } 
 import { ExperimentMetricType, NodeKind } from '~/queries/schema/schema-general'
 import { ExperimentMetricMathType } from '~/types'
 
-import { getMetricTag } from './utils'
+import { getDefaultMetricTitle, getMetricTag } from './utils'
 
 describe('getMetricTag', () => {
     it('handles different metric types correctly', () => {
@@ -35,5 +35,33 @@ describe('getMetricTag', () => {
         expect(getMetricTag(experimentMetric)).toBe('Mean')
         expect(getMetricTag(funnelMetric)).toBe('Funnel')
         expect(getMetricTag(trendMetric)).toBe('Trend')
+    })
+})
+
+describe('getDefaultMetricTitle', () => {
+    it('handles ExperimentEventMetricConfig with math and math_property', () => {
+        const metric: ExperimentMetric = {
+            kind: NodeKind.ExperimentMetric,
+            metric_type: ExperimentMetricType.MEAN,
+            metric_config: {
+                kind: NodeKind.ExperimentEventMetricConfig,
+                event: 'purchase completed',
+            },
+        }
+        expect(getDefaultMetricTitle(metric)).toBe('purchase completed')
+    })
+
+    it('returns action name for ExperimentActionMetricConfig', () => {
+        const metric: ExperimentMetric = {
+            kind: NodeKind.ExperimentMetric,
+            metric_type: ExperimentMetricType.MEAN,
+            metric_config: {
+                kind: NodeKind.ExperimentActionMetricConfig,
+                action: 1,
+                name: 'purchase',
+            },
+        }
+
+        expect(getDefaultMetricTitle(metric)).toBe('purchase')
     })
 })

--- a/frontend/src/scenes/experiments/MetricsView/utils.ts
+++ b/frontend/src/scenes/experiments/MetricsView/utils.ts
@@ -9,3 +9,12 @@ export const getMetricTag = (metric: ExperimentMetric | ExperimentTrendsQuery | 
     }
     return 'Trend'
 }
+
+export const getDefaultMetricTitle = (metric: ExperimentMetric): string => {
+    if (metric.metric_config.kind === NodeKind.ExperimentEventMetricConfig) {
+        return metric.metric_config.event
+    } else if (metric.metric_config.kind === NodeKind.ExperimentActionMetricConfig) {
+        return metric.metric_config.name || `Action ${metric.metric_config.action}`
+    }
+    return 'Untitled metric'
+}

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/RunningTimeCalculatorModal.tsx
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/RunningTimeCalculatorModal.tsx
@@ -1,13 +1,20 @@
 import { IconInfo } from '@posthog/icons'
-import { LemonButton, LemonInput, LemonModal, LemonSegmentedButton, LemonSelect, Tooltip } from '@posthog/lemon-ui'
-import { Spinner } from '@posthog/lemon-ui'
+import {
+    LemonButton,
+    LemonInput,
+    LemonModal,
+    LemonSegmentedButton,
+    LemonSelect,
+    Spinner,
+    Tooltip,
+} from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { humanFriendlyNumber } from 'lib/utils'
 
 import { ExperimentMetric, ExperimentMetricType } from '~/queries/schema/schema-general'
 
 import { experimentLogic } from '../experimentLogic'
-import { getMetricTitle } from '../MetricsView/DeltaChart'
+import { MetricTitle } from '../MetricsView/MetricTitle'
 import {
     AverageEventsPerUserPanel,
     AveragePropertyValuePerUserPanel,
@@ -184,7 +191,7 @@ export function RunningTimeCalculatorModal(): JSX.Element {
                                     label: (
                                         <div className="cursor-default text-xs font-semibold whitespace-nowrap overflow-hidden text-ellipsis flex-grow flex items-center">
                                             <span className="mr-1">{index + 1}.</span>
-                                            {getMetricTitle(metric)}
+                                            <MetricTitle metric={metric} />
                                         </div>
                                     ),
                                     value: index,


### PR DESCRIPTION
## Problem

Another PR in the long road of making `DeltaChart` fit in one page without scrolling (and not less importantly, reduce coupling and code duplication).

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

This PR extracts code from `DeltaChart` into two new components that have the only responsibility of rendering each metric header.

There are no visual changes or regressions. This code does not change any features of the app.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
