### PR TITLE
fix(crm): Prevent dupe groups from appearing in query runner

### DIFF
--- a/posthog/hogql/transforms/property_types.py
+++ b/posthog/hogql/transforms/property_types.py
@@ -125,15 +125,14 @@ class PropertyFinder(TraversingVisitor):
                             if self.group_properties.get(group_id) is None:
                                 self.group_properties[group_id] = set()
                             self.group_properties[group_id].add(property_name)
-                if table_name == "raw_groups":
-                    global_group_id: Optional[int] = (
-                        self.context.globals.get("group_id") if self.context.globals else None
-                    )
-                    if not isinstance(global_group_id, int):
-                        return
-                    if self.group_properties.get(global_group_id) is None:
-                        self.group_properties[global_group_id] = set()
-                    self.group_properties[global_group_id].add(property_name)
+                    elif isinstance(table_type, ast.LazyTableType):
+                        global_group_id: Optional[int] = (
+                            self.context.globals.get("group_id") if self.context.globals else None
+                        )
+                        if isinstance(global_group_id, int):
+                            if self.group_properties.get(global_group_id) is None:
+                                self.group_properties[global_group_id] = set()
+                            self.group_properties[global_group_id].add(property_name)
                 if table_name == "events":
                     if (
                         isinstance(node.field_type.table_type, ast.VirtualTableType)
@@ -219,15 +218,15 @@ class PropertySwapper(CloningVisitor):
                                 return self._convert_string_property_to_type(
                                     node, "group", f"{group_id}_{property_name}"
                                 )
-                if table_name == "raw_groups":
-                    global_group_id = self.context.globals.get("group_id") if self.context.globals else None
-                    if (
-                        isinstance(global_group_id, int)
-                        and f"{global_group_id}_{property_name}" in self.group_properties
-                    ):
-                        return self._convert_string_property_to_type(
-                            node, "group", f"{global_group_id}_{property_name}"
+                    elif isinstance(table_type, ast.LazyTableType):
+                        global_group_id: Optional[int] = (
+                            self.context.globals.get("group_id") if self.context.globals else None
                         )
+                        if isinstance(global_group_id, int):
+                            if f"{global_group_id}_{property_name}" in self.group_properties:
+                                return self._convert_string_property_to_type(
+                                    node, "group", f"{global_group_id}_{property_name}"
+                                )
                 if table_name == "events":
                     if property_name in self.event_properties:
                         return self._convert_string_property_to_type(node, "event", property_name)

--- a/posthog/hogql_queries/groups/groups_query_runner.py
+++ b/posthog/hogql_queries/groups/groups_query_runner.py
@@ -84,7 +84,7 @@ class GroupsQueryRunner(QueryRunner):
                 ast.Call(name="coalesce", args=[ast.Field(chain=["properties", "name"]), ast.Field(chain=["key"])]),
                 *[ast.Field(chain=list(col.split("."))) for col in self.columns[1:]],
             ],
-            select_from=ast.JoinExpr(table=ast.Field(chain=["raw_groups"])),
+            select_from=ast.JoinExpr(table=ast.Field(chain=["groups"])),
             where=where,
             order_by=order_by,
         )

--- a/posthog/hogql_queries/groups/test/__snapshots__/test_groups_query_runner.ambr
+++ b/posthog/hogql_queries/groups/test/__snapshots__/test_groups_query_runner.ambr
@@ -1,11 +1,46 @@
 # serializer version: 1
 # name: TestGroupsQueryRunner.test_groups_query_runner
   '''
-  SELECT coalesce(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), groups.group_key),
-         groups.group_key AS key
-  FROM groups
-  WHERE and(equals(groups.team_id, 99999), equals(groups.group_type_index, 0))
-  ORDER BY toTimeZone(groups.created_at, 'UTC') DESC
+  SELECT coalesce(groups.properties___name, groups.key),
+         groups.key AS key
+  FROM
+    (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
+            argMax(toTimeZone(groups.created_at, 'UTC'), toTimeZone(groups._timestamp, 'UTC')) AS created_at,
+            groups.group_type_index AS index,
+            groups.group_key AS key
+     FROM groups
+     WHERE equals(groups.team_id, 99999)
+     GROUP BY groups.group_type_index,
+              groups.group_key) AS groups
+  WHERE ifNull(equals(groups.index, 0), 0)
+  ORDER BY groups.created_at DESC
+  LIMIT 11
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestGroupsQueryRunner.test_groups_query_runner_normalize_multiple_groups
+  '''
+  SELECT coalesce(groups.properties___name, groups.key),
+         groups.key AS key,
+         accurateCastOrNull(groups.properties___arr, 'Float64') AS arr
+  FROM
+    (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
+            argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'arr'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___arr,
+            argMax(toTimeZone(groups.created_at, 'UTC'), toTimeZone(groups._timestamp, 'UTC')) AS created_at,
+            groups.group_type_index AS index,
+            groups.group_key AS key
+     FROM groups
+     WHERE equals(groups.team_id, 99999)
+     GROUP BY groups.group_type_index,
+              groups.group_key) AS groups
+  WHERE and(ifNull(equals(groups.index, 0), 0), 1)
+  ORDER BY groups.created_at DESC
   LIMIT 11
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -18,12 +53,21 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_numeric_property
   '''
-  SELECT coalesce(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), groups.group_key),
-         groups.group_key AS key,
-         accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'arr'), ''), 'null'), '^"|"$', ''), 'Float64') AS arr
-  FROM groups
-  WHERE and(equals(groups.team_id, 99999), equals(groups.group_type_index, 0), ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'arr'), ''), 'null'), '^"|"$', ''), 'Float64'), 100.0), 0))
-  ORDER BY toTimeZone(groups.created_at, 'UTC') DESC
+  SELECT coalesce(groups.properties___name, groups.key),
+         groups.key AS key,
+         accurateCastOrNull(groups.properties___arr, 'Float64') AS arr
+  FROM
+    (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
+            argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'arr'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___arr,
+            argMax(toTimeZone(groups.created_at, 'UTC'), toTimeZone(groups._timestamp, 'UTC')) AS created_at,
+            groups.group_type_index AS index,
+            groups.group_key AS key
+     FROM groups
+     WHERE equals(groups.team_id, 99999)
+     GROUP BY groups.group_type_index,
+              groups.group_key) AS groups
+  WHERE and(ifNull(equals(groups.index, 0), 0), ifNull(greater(accurateCastOrNull(groups.properties___arr, 'Float64'), 100.0), 0))
+  ORDER BY groups.created_at DESC
   LIMIT 11
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -36,11 +80,19 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_offset
   '''
-  SELECT coalesce(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), groups.group_key),
-         groups.group_key AS key
-  FROM groups
-  WHERE and(equals(groups.team_id, 99999), equals(groups.group_type_index, 0))
-  ORDER BY toTimeZone(groups.created_at, 'UTC') DESC
+  SELECT coalesce(groups.properties___name, groups.key),
+         groups.key AS key
+  FROM
+    (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
+            argMax(toTimeZone(groups.created_at, 'UTC'), toTimeZone(groups._timestamp, 'UTC')) AS created_at,
+            groups.group_type_index AS index,
+            groups.group_key AS key
+     FROM groups
+     WHERE equals(groups.team_id, 99999)
+     GROUP BY groups.group_type_index,
+              groups.group_key) AS groups
+  WHERE ifNull(equals(groups.index, 0), 0)
+  ORDER BY groups.created_at DESC
   LIMIT 11
   OFFSET 2 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -53,12 +105,20 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_order_by
   '''
-  SELECT coalesce(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), groups.group_key),
-         groups.group_key AS key,
-         accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'arr'), ''), 'null'), '^"|"$', ''), 'Float64') AS arr
-  FROM groups
-  WHERE and(equals(groups.team_id, 99999), equals(groups.group_type_index, 0))
-  ORDER BY accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'arr'), ''), 'null'), '^"|"$', ''), 'Float64') DESC
+  SELECT coalesce(groups.properties___name, groups.key),
+         groups.key AS key,
+         accurateCastOrNull(groups.properties___arr, 'Float64') AS arr
+  FROM
+    (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
+            argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'arr'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___arr,
+            groups.group_type_index AS index,
+            groups.group_key AS key
+     FROM groups
+     WHERE equals(groups.team_id, 99999)
+     GROUP BY groups.group_type_index,
+              groups.group_key) AS groups
+  WHERE ifNull(equals(groups.index, 0), 0)
+  ORDER BY accurateCastOrNull(groups.properties___arr, 'Float64') DESC
   LIMIT 11
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -71,12 +131,20 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_order_by.1
   '''
-  SELECT coalesce(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), groups.group_key),
-         groups.group_key AS key,
-         accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'arr'), ''), 'null'), '^"|"$', ''), 'Float64') AS arr
-  FROM groups
-  WHERE and(equals(groups.team_id, 99999), equals(groups.group_type_index, 0))
-  ORDER BY accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'arr'), ''), 'null'), '^"|"$', ''), 'Float64') ASC
+  SELECT coalesce(groups.properties___name, groups.key),
+         groups.key AS key,
+         accurateCastOrNull(groups.properties___arr, 'Float64') AS arr
+  FROM
+    (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
+            argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'arr'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___arr,
+            groups.group_type_index AS index,
+            groups.group_key AS key
+     FROM groups
+     WHERE equals(groups.team_id, 99999)
+     GROUP BY groups.group_type_index,
+              groups.group_key) AS groups
+  WHERE ifNull(equals(groups.index, 0), 0)
+  ORDER BY accurateCastOrNull(groups.properties___arr, 'Float64') ASC
   LIMIT 11
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -89,11 +157,18 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_order_by.2
   '''
-  SELECT coalesce(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), groups.group_key),
-         groups.group_key AS key
-  FROM groups
-  WHERE and(equals(groups.team_id, 99999), equals(groups.group_type_index, 0))
-  ORDER BY coalesce(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), groups.group_key) DESC
+  SELECT coalesce(groups.properties___name, groups.key),
+         groups.key AS key
+  FROM
+    (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
+            groups.group_type_index AS index,
+            groups.group_key AS key
+     FROM groups
+     WHERE equals(groups.team_id, 99999)
+     GROUP BY groups.group_type_index,
+              groups.group_key) AS groups
+  WHERE ifNull(equals(groups.index, 0), 0)
+  ORDER BY coalesce(groups.properties___name, groups.key) DESC
   LIMIT 11
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -106,12 +181,21 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_property_columns
   '''
-  SELECT coalesce(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), groups.group_key),
-         groups.group_key AS key,
-         accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'arr'), ''), 'null'), '^"|"$', ''), 'Float64') AS arr
-  FROM groups
-  WHERE and(equals(groups.team_id, 99999), equals(groups.group_type_index, 0))
-  ORDER BY toTimeZone(groups.created_at, 'UTC') DESC
+  SELECT coalesce(groups.properties___name, groups.key),
+         groups.key AS key,
+         accurateCastOrNull(groups.properties___arr, 'Float64') AS arr
+  FROM
+    (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
+            argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'arr'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___arr,
+            argMax(toTimeZone(groups.created_at, 'UTC'), toTimeZone(groups._timestamp, 'UTC')) AS created_at,
+            groups.group_type_index AS index,
+            groups.group_key AS key
+     FROM groups
+     WHERE equals(groups.team_id, 99999)
+     GROUP BY groups.group_type_index,
+              groups.group_key) AS groups
+  WHERE ifNull(equals(groups.index, 0), 0)
+  ORDER BY groups.created_at DESC
   LIMIT 11
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -124,11 +208,19 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_search
   '''
-  SELECT coalesce(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), groups.group_key),
-         groups.group_key AS key
-  FROM groups
-  WHERE and(equals(groups.team_id, 99999), equals(groups.group_type_index, 0), or(ifNull(ilike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), '%org2%'), 0), ilike(toString(groups.group_key), '%org2%')))
-  ORDER BY toTimeZone(groups.created_at, 'UTC') DESC
+  SELECT coalesce(groups.properties___name, groups.key),
+         groups.key AS key
+  FROM
+    (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
+            argMax(toTimeZone(groups.created_at, 'UTC'), toTimeZone(groups._timestamp, 'UTC')) AS created_at,
+            groups.group_type_index AS index,
+            groups.group_key AS key
+     FROM groups
+     WHERE equals(groups.team_id, 99999)
+     GROUP BY groups.group_type_index,
+              groups.group_key) AS groups
+  WHERE and(ifNull(equals(groups.index, 0), 0), or(ifNull(ilike(groups.properties___name, '%org2%'), 0), ilike(toString(groups.key), '%org2%')))
+  ORDER BY groups.created_at DESC
   LIMIT 11
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -141,11 +233,19 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_string_property
   '''
-  SELECT coalesce(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), groups.group_key),
-         groups.group_key AS key
-  FROM groups
-  WHERE and(equals(groups.team_id, 99999), equals(groups.group_type_index, 0), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), 'org0.inc'), 0))
-  ORDER BY toTimeZone(groups.created_at, 'UTC') DESC
+  SELECT coalesce(groups.properties___name, groups.key),
+         groups.key AS key
+  FROM
+    (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
+            argMax(toTimeZone(groups.created_at, 'UTC'), toTimeZone(groups._timestamp, 'UTC')) AS created_at,
+            groups.group_type_index AS index,
+            groups.group_key AS key
+     FROM groups
+     WHERE equals(groups.team_id, 99999)
+     GROUP BY groups.group_type_index,
+              groups.group_key) AS groups
+  WHERE and(ifNull(equals(groups.index, 0), 0), ifNull(equals(groups.properties___name, 'org0.inc'), 0))
+  ORDER BY groups.created_at DESC
   LIMIT 11
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,

--- a/posthog/hogql_queries/groups/test/test_groups_query_runner.py
+++ b/posthog/hogql_queries/groups/test/test_groups_query_runner.py
@@ -1,7 +1,9 @@
+from django.utils import timezone
+from datetime import timedelta
 from django.test import override_settings
 from freezegun import freeze_time
 from posthog.hogql_queries.groups.groups_query_runner import GroupsQueryRunner
-from posthog.models.group.util import create_group
+from posthog.models.group.util import create_group, raw_create_group_ch
 from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.models.property_definition import PropertyDefinition, PropertyType
 from posthog.schema import GroupsQuery, PropertyOperator, GroupPropertyFilter
@@ -235,3 +237,60 @@ class TestGroupsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(result.columns, ["group_name", "key", "properties.arr"])
         self.assertEqual(result.results[0][2], 150)
         self.assertEqual(result.results[1][2], 300)
+
+    @freeze_time("2025-01-01")
+    @snapshot_clickhouse_queries
+    def test_groups_query_runner_normalize_multiple_groups(self):
+        GroupTypeMapping.objects.create(
+            team=self.team, project_id=self.team.project_id, group_type="organization", group_type_index=0
+        )
+
+        PropertyDefinition.objects.create(
+            team=self.team,
+            name="arr",
+            property_type=PropertyType.Numeric,
+            is_numerical=True,
+            type=PropertyDefinition.Type.GROUP,
+            group_type_index=0,
+        )
+
+        group = create_group(
+            team_id=self.team.pk,
+            group_type_index=0,
+            group_key="org0",
+            properties={"name": "org0.inc", "arr": 100},
+        )
+        # Saving in Postgres won't update ClickHouse
+        group.group_properties["arr"] = 200
+        group.save()
+        # ... so we need to update ClickHouse too.
+        raw_create_group_ch(
+            team_id=self.team.pk,
+            group_type_index=0,
+            group_key="org0",
+            properties={"name": "org0.inc", "arr": 200},
+            created_at=timezone.now() + timedelta(days=1),
+            timestamp=timezone.now() + timedelta(days=1),
+        )
+
+        query = GroupsQuery(
+            group_type_index=0,
+            limit=10,
+            offset=0,
+            properties=[
+                GroupPropertyFilter(
+                    key="name",
+                    type="group",
+                    operator=PropertyOperator.EXACT,
+                    value="org0.inc",
+                )
+            ],
+            select=["properties.arr"],
+        )
+        query_runner = GroupsQueryRunner(query=query, team=self.team)
+        result = query_runner.calculate()
+
+        self.assertEqual(len(result.results), 1)
+        self.assertEqual(result.columns, ["group_name", "key", "properties.arr"])
+        self.assertEqual(result.results[0][0], "org0.inc")
+        self.assertEqual(result.results[0][2], 200)


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/29881
See https://posthog.slack.com/archives/C08GGECGJF4/p1742332096285729

## Changes

Switches `GroupsQueryRunner` to query against the `groups` lazy table instead of the `raw_groups` original table. Doing so applies some argMax fanciness that prevents the same group from appearing for each update.

Worth noting: `self.context.globals.get("group_id")`is hacky but I don't have a cleaner solution right now. The properties need to be transformed to their types but we don't know their type without access to the group id.

## How did you test this code?

Wrote a test that failed and then fixed it.