### PR TITLE
fix(propdefs): Add config flag and random negative event prop ID gen to property-defs-rs

### DIFF
--- a/rust/property-defs-rs/src/config.rs
+++ b/rust/property-defs-rs/src/config.rs
@@ -109,6 +109,9 @@ pub struct Config {
     // once rollout is complete.
     #[envconfig(default = "opt_in")]
     pub filter_mode: TeamFilterMode,
+
+    #[envconfig(default = "false")]
+    pub deploy_env_is_prod_eu: bool,
 }
 
 #[derive(Clone)]

--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -131,7 +131,7 @@ pub struct EventDefinition {
 // Derived hash since these are keyed on all fields in the DB
 #[derive(Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
 pub struct EventProperty {
-    pub neg_id: i64, // TEMPORARY: only apply if set; use until posthog_eventproperty table is fixed in prod-eu
+    pub id: i32, // TEMPORARY, remove when ID space is widened on event props table
     pub team_id: i32,
     pub project_id: i64,
     pub event: String,
@@ -287,7 +287,7 @@ impl Event {
             }
 
             updates.push(Update::EventProperty(EventProperty {
-                neg_id: 0, // TODO(eli): temporary - will be replaced with negative ID in PROD-EU deployment only
+                id: 0, // TEMPORARY - will be replaced downstream with negative ID in PROD-EU deployment only
                 team_id: self.team_id,
                 project_id: self.project_id,
                 event: self.event.clone(),
@@ -570,10 +570,10 @@ impl EventProperty {
     {
         let mut res: Result<(), sqlx::Error> = Ok(());
 
-        if self.neg_id < 0 {
+        if self.id < 0 {
             res = sqlx::query!(
                 r#"INSERT INTO posthog_eventproperty (id, event, property, team_id, project_id) VALUES ($1, $2, $3, $4, $5) ON CONFLICT DO NOTHING"#,
-                self.neg_id,
+                self.id,
                 self.event,
                 self.property,
                 self.team_id,

--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -131,6 +131,7 @@ pub struct EventDefinition {
 // Derived hash since these are keyed on all fields in the DB
 #[derive(Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
 pub struct EventProperty {
+    pub neg_id: i64, // TEMPORARY: only apply if set; use until posthog_eventproperty table is fixed in prod-eu
     pub team_id: i32,
     pub project_id: i64,
     pub event: String,
@@ -286,6 +287,7 @@ impl Event {
             }
 
             updates.push(Update::EventProperty(EventProperty {
+                neg_id: 0, // TODO(eli): temporary - will be replaced with negative ID in PROD-EU deployment only
                 team_id: self.team_id,
                 project_id: self.project_id,
                 event: self.event.clone(),
@@ -566,16 +568,32 @@ impl EventProperty {
     where
         E: Executor<'c, Database = Postgres>,
     {
-        let res = sqlx::query!(
-            r#"INSERT INTO posthog_eventproperty (event, property, team_id, project_id) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING"#,
-            self.event,
-            self.property,
-            self.team_id,
-            self.project_id
-        )
-        .execute(executor)
-        .await
-        .map(|_| ());
+        let mut res: Result<(), sqlx::Error> = Ok(());
+
+        if self.neg_id < 0 {
+            res = sqlx::query!(
+                r#"INSERT INTO posthog_eventproperty (id, event, property, team_id, project_id) VALUES ($1, $2, $3, $4, $5) ON CONFLICT DO NOTHING"#,
+                self.neg_id,
+                self.event,
+                self.property,
+                self.team_id,
+                self.project_id
+            )
+            .execute(executor)
+            .await
+            .map(|_| ());
+        } else {
+            res = sqlx::query!(
+                r#"INSERT INTO posthog_eventproperty (event, property, team_id, project_id) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING"#,
+                self.event,
+                self.property,
+                self.team_id,
+                self.project_id
+            )
+            .execute(executor)
+            .await
+            .map(|_| ());
+        }
 
         metrics::counter!(UPDATES_ISSUED, &[("type", "event_property")]).increment(1);
 


### PR DESCRIPTION
## Problem
Temporary shim to address Postgres ID space issue in EU deploy env.

## Changes
* Add config flag to know if we're deployed to EU env
* Generate random negative seed ID and count down from there when writing `EventProperty` Updates to Postgres

This is a hacky temporary fix that's sure to fail sporadically, but better than losing data while we await the long-term fix 🤞 

Requires matching deployment PR to trigger negative ID generation for EU deploy only

## Does this work well for both Cloud and self-hosted?
I suppose...

## How did you test this code?
Not very thoroughly yet...
