### PR TITLE
fix(crm): Ensure group property updates propagate to CH

### DIFF
--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -3,6 +3,9 @@ from uuid import UUID
 
 from freezegun.api import freeze_time
 
+from posthog.hogql.parser import parse_select
+from posthog.hogql import ast
+from posthog.hogql.query import execute_hogql_query
 from posthog.models import GroupTypeMapping, Person
 from posthog.models.group.util import create_group
 from posthog.models.organization import Organization
@@ -188,6 +191,23 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
             },
         )
 
+        response = execute_hogql_query(
+            parse_select(
+                """
+                select properties
+                from groups
+                where index = {index}
+                and key = {key}
+                """,
+                placeholders={
+                    "index": ast.Constant(value=group.group_type_index),
+                    "key": ast.Constant(value=group.group_key),
+                },
+            ),
+            self.team,
+        )
+        self.assertEqual(response.results, [('{"name": "Mr. Krabs", "industry": "technology"}',)])
+
         response = self.client.get(
             f"/api/projects/{self.team.id}/groups/activity?group_key=org:5&group_type_index=0",
         )
@@ -227,6 +247,23 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
                 "group_type_index": 0,
             },
         )
+
+        response = execute_hogql_query(
+            parse_select(
+                """
+                select properties
+                from groups
+                where index = {index}
+                and key = {key}
+                """,
+                placeholders={
+                    "index": ast.Constant(value=group.group_type_index),
+                    "key": ast.Constant(value=group.group_key),
+                },
+            ),
+            self.team,
+        )
+        self.assertEqual(response.results, [('{"name": "Mr. Krabs", "industry": "technology"}',)])
 
         response = self.client.get(
             f"/api/projects/{self.team.id}/groups/activity?group_key=org:5&group_type_index=0",
@@ -297,6 +334,23 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
                 "group_type_index": 0,
             },
         )
+
+        response = execute_hogql_query(
+            parse_select(
+                """
+                select properties
+                from groups
+                where index = {index}
+                and key = {key}
+                """,
+                placeholders={
+                    "index": ast.Constant(value=group.group_type_index),
+                    "key": ast.Constant(value=group.group_key),
+                },
+            ),
+            self.team,
+        )
+        self.assertEqual(response.results, [('{"name": "Mr. Krabs"}',)])
 
         response = self.client.get(
             f"/api/projects/{self.team.id}/groups/activity?group_key=org:5&group_type_index=0",


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/29881
Related https://github.com/PostHog/posthog/pull/30120

## Changes

Ensures group properties are propagated appropriately to ClickHouse when updated by writing them with `raw_create_group_ch()`.

Person property updates are implemented a little bit differently by sending a `$set` event:

https://github.com/PostHog/posthog/blob/a389858969adf2bfe6b2e0779d25f6ce1899731e/posthog/api/person.py#L688-L701

However, 1) I'm not convinced that's a great way to do it even if it does centralize the logic to the events path, 2) I'd prefer to not have the associated latency, and 3) I'd prefer to have tests that actually work.

## How did you test this code?

Wrote some tests that failed and then fixed them.
