### PR TITLE
chore: track taxonomic search queries

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -728,7 +728,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                 actions.tabRight()
             }
 
-            await breakpoint(100)
+            await breakpoint(500)
             if (searchQuery) {
                 posthog.capture('taxonomic_filter_search_query', {
                     searchQuery,

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -15,6 +15,7 @@ import {
 import { IconCohort } from 'lib/lemon-ui/icons'
 import { CORE_FILTER_DEFINITIONS_BY_GROUP } from 'lib/taxonomy'
 import { capitalizeFirstLetter, pluralize, toParams } from 'lib/utils'
+import posthog from 'posthog-js'
 import { getEventDefinitionIcon, getPropertyDefinitionIcon } from 'scenes/data-management/events/DefinitionHeader'
 import { dataWarehouseJoinsLogic } from 'scenes/data-warehouse/external/dataWarehouseJoinsLogic'
 import { dataWarehouseSceneLogic } from 'scenes/data-warehouse/settings/dataWarehouseSceneLogic'
@@ -714,7 +715,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
             }
         },
 
-        setSearchQuery: () => {
+        setSearchQuery: async ({ searchQuery }, breakpoint) => {
             const { activeTaxonomicGroup, infiniteListCounts } = values
 
             // Taxonomic group with a local data source, zero results after searching.
@@ -725,6 +726,14 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                 infiniteListCounts[activeTaxonomicGroup.type] === 0
             ) {
                 actions.tabRight()
+            }
+
+            await breakpoint(100)
+            if (searchQuery) {
+                posthog.capture('taxonomic_filter_search_query', {
+                    searchQuery,
+                    groupType: activeTaxonomicGroup?.type,
+                })
             }
         },
 


### PR DESCRIPTION
we have no visibility of how people are using this box
let's track search queries so that we can see what they're doing

validated locally

<img width="909" alt="Screenshot 2025-03-19 at 09 46 15" src="https://github.com/user-attachments/assets/3d59601d-2621-4885-8193-b2d91d524b4d" />

added a pretty long breakpoint delay to try and avoid capturing too many events per typing but it'll always be slightly noisy