### PR TITLE
chore(migrations): Only allow UUID as primary key for new models

### DIFF
--- a/posthog/management/commands/test/test_migrations_are_safe.py
+++ b/posthog/management/commands/test/test_migrations_are_safe.py
@@ -20,7 +20,7 @@ COMMIT;
     assert should_fail is True
 
 
-def test_new_tables_can_have_int64_ids() -> None:
+def test_new_tables_must_not_have_int64_ids() -> None:
     sql_for_model_with_int64 = """
 BEGIN;
 --
@@ -36,4 +36,23 @@ CREATE TABLE "posthog_strawman" ("id" bigserial NOT NULL PRIMARY KEY, "name" var
 COMMIT;
     """
     should_fail = validate_migration_sql(sql_for_model_with_int64)
+    assert should_fail is True
+
+
+def test_new_tables_can_have_uuid_ids() -> None:
+    sql_for_model_with_uuid = """
+BEGIN;
+--
+-- Create model StrawMan
+--
+CREATE TABLE "posthog_strawman" ("id" uuid NOT NULL PRIMARY KEY, "name" varchar(400) NULL);
+COMMIT;
+BEGIN;
+--
+-- Create model StrawMan
+--
+CREATE TABLE "posthog_strawman" ("id" uuid NOT NULL PRIMARY KEY, "name" varchar(400) NULL);
+COMMIT;
+    """
+    should_fail = validate_migration_sql(sql_for_model_with_uuid)
     assert should_fail is False

--- a/posthog/management/commands/test_migrations_are_safe.py
+++ b/posthog/management/commands/test_migrations_are_safe.py
@@ -31,9 +31,9 @@ def validate_migration_sql(sql) -> bool:
             table_name = re.findall(r"CREATE TABLE \"([a-z_]+)\"", operation_sql)[0]
             tables_created_so_far.append(table_name)
 
-            if '"id" serial' in operation_sql:
+            if '"id" serial' in operation_sql or '"id" bigserial' in operation_sql:
                 print(
-                    f"\n\n\033[91mFound a new table with an int32 id. Please use an int64 id or use UUIDModel instead.\nSource: `{operation_sql}`"
+                    f"\n\n\033[91mFound a new table with an integer id. Please use UUIDModel instead.\nSource: `{operation_sql}`"
                 )
                 return True
 


### PR DESCRIPTION
## Problem

Bigints are not ideal for other reasons (leaks usage information for example, and makes it harder to shard if we ever need to)
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
