### PR TITLE
chore(environments): Prevent accidental other env deletion

### DIFF
--- a/frontend/src/scenes/settings/project/ProjectDangerZone.tsx
+++ b/frontend/src/scenes/settings/project/ProjectDangerZone.tsx
@@ -4,6 +4,7 @@ import { useActions, useValues } from 'kea'
 import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
 import { OrganizationMembershipLevel } from 'lib/constants'
 import { Dispatch, SetStateAction, useState } from 'react'
+import { organizationLogic } from 'scenes/organizationLogic'
 import { projectLogic } from 'scenes/projectLogic'
 
 export function DeleteProjectModal({
@@ -14,10 +15,16 @@ export function DeleteProjectModal({
     setIsOpen: Dispatch<SetStateAction<boolean>>
 }): JSX.Element {
     const { currentProject, projectBeingDeleted } = useValues(projectLogic)
+    const { currentOrganization } = useValues(organizationLogic)
     const { deleteProject } = useActions(projectLogic)
 
     const [isDeletionConfirmed, setIsDeletionConfirmed] = useState(false)
     const isDeletionInProgress = !!currentProject && projectBeingDeleted?.id === currentProject.id
+
+    const allTeamsOfProject =
+        currentProject && currentOrganization
+            ? currentOrganization.teams.filter((team) => team.project_id === currentProject.id)
+            : []
 
     return (
         <LemonModal
@@ -45,8 +52,13 @@ export function DeleteProjectModal({
             isOpen={isOpen}
         >
             <p>
-                Project deletion <b>cannot be undone</b>. You will lose all environments and their data,{' '}
-                <b>including events</b>.
+                Project deletion <b>cannot be undone</b>. You will lose all environments and their data (
+                <b>including events</b>):
+                <ul className="list-disc list-inside ml-4 mt-1">
+                    {allTeamsOfProject.map((team) => (
+                        <li key={team.id}>{team.name}</li>
+                    ))}
+                </ul>
             </p>
             <p>
                 Please type <strong>{currentProject ? currentProject.name : "this project's name"}</strong> to confirm.

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -523,7 +523,7 @@ async def initialize_self_capture_api_token():
         )
         # Get the current user's team (or first team in the instance) to set self capture configs
         team = None
-        if user and getattr(user, "team", None):
+        if user and getattr(user, "current_team", None):
             team = user.current_team
         else:
             team = await Team.objects.only("api_token").aget()


### PR DESCRIPTION
## Problem

When deleting a project, we didn't show the list of environment that'll be deleted. Especially crucial after someone opts out of the Environments preview (ZEN-27328).

## Changes

We're now explicit:

<img width="707" alt="Screenshot 2025-03-19 at 13 33 37" src="https://github.com/user-attachments/assets/5af15070-b97c-4a3b-bf8b-6ecf76031c64" />