### PR TITLE
chore: add more failure details in Dagster alert

### DIFF
--- a/dags/slack_alerts.py
+++ b/dags/slack_alerts.py
@@ -53,7 +53,7 @@ def notify_slack_on_failure(context: dagster.RunFailureSensorContext, slack: dag
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"*Step failures*:\n{'- \n'.join([f'`{step_key}`: {step_failure}' for step_key, step_failure in step_failures.items()])}",
+                "text": f"*Step failures*:\n{'- \n'.join([f'`{step_key}`: {step_failure[:1000]}' for step_key, step_failure in step_failures.items()])}",
             },
         },
         {

--- a/dags/slack_alerts.py
+++ b/dags/slack_alerts.py
@@ -20,6 +20,9 @@ def notify_slack_on_failure(context: dagster.RunFailureSensorContext, slack: dag
     run_id = failed_run.run_id
     job_owner = failed_run.tags.get("owner", "unknown")
     error = context.failure_event.message if context.failure_event.message else "Unknown error"
+    step_failures = {
+        event.step_key: event.event_specific_data.error.to_string() for event in context.get_step_failure_events()
+    }
 
     # Only send notifications in prod environment
     if not settings.CLOUD_DEPLOYMENT:
@@ -46,6 +49,13 @@ def notify_slack_on_failure(context: dagster.RunFailureSensorContext, slack: dag
             },
         },
         {"type": "section", "text": {"type": "mrkdwn", "text": f"*Error*:\n```{error}```"}},
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"*Step failures*:\n{'- \n'.join([f'`{step_key}`: {step_failure}' for step_key, step_failure in step_failures.items()])}",
+            },
+        },
         {
             "type": "context",
             "elements": [{"type": "mrkdwn", "text": f"Environment: {environment}"}],


### PR DESCRIPTION
## Problem

We barely know what happened when we receive an Slack alert about a failed run in Dagster.

## Changes

Add specific details about the failed steps.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes
