### PR TITLE
feat: respect teams' console log enabled setting

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.test.ts
@@ -438,7 +438,7 @@ describe('SessionBatchRecorder', () => {
                 mockConsoleLogStore
             )
             expect(jest.mocked(SessionConsoleLogRecorder).mock.results[0].value.recordMessage).toHaveBeenCalledWith(
-                message.message
+                message
             )
         })
 
@@ -474,8 +474,8 @@ describe('SessionBatchRecorder', () => {
             )
             const mockRecorder = jest.mocked(SessionConsoleLogRecorder).mock.results[0].value
             expect(mockRecorder.recordMessage).toHaveBeenCalledTimes(2)
-            expect(mockRecorder.recordMessage).toHaveBeenNthCalledWith(1, messages[0].message)
-            expect(mockRecorder.recordMessage).toHaveBeenNthCalledWith(2, messages[1].message)
+            expect(mockRecorder.recordMessage).toHaveBeenNthCalledWith(1, messages[0])
+            expect(mockRecorder.recordMessage).toHaveBeenNthCalledWith(2, messages[1])
         })
 
         it('should create separate console log recorders for different sessions', async () => {
@@ -514,10 +514,10 @@ describe('SessionBatchRecorder', () => {
                 mockConsoleLogStore
             )
             expect(jest.mocked(SessionConsoleLogRecorder).mock.results[0].value.recordMessage).toHaveBeenCalledWith(
-                messages[0].message
+                messages[0]
             )
             expect(jest.mocked(SessionConsoleLogRecorder).mock.results[1].value.recordMessage).toHaveBeenCalledWith(
-                messages[1].message
+                messages[1]
             )
         })
 
@@ -626,17 +626,17 @@ describe('SessionBatchRecorder', () => {
 
             // Verify session1 recorder calls
             expect(session1Recorder.recordMessage).toHaveBeenCalledTimes(2)
-            expect(session1Recorder.recordMessage).toHaveBeenNthCalledWith(1, messages[0].message)
-            expect(session1Recorder.recordMessage).toHaveBeenNthCalledWith(2, messages[2].message)
+            expect(session1Recorder.recordMessage).toHaveBeenNthCalledWith(1, messages[0])
+            expect(session1Recorder.recordMessage).toHaveBeenNthCalledWith(2, messages[2])
 
             // Verify session2 recorder calls
             expect(session2Recorder.recordMessage).toHaveBeenCalledTimes(2)
-            expect(session2Recorder.recordMessage).toHaveBeenNthCalledWith(1, messages[1].message)
-            expect(session2Recorder.recordMessage).toHaveBeenNthCalledWith(2, messages[4].message)
+            expect(session2Recorder.recordMessage).toHaveBeenNthCalledWith(1, messages[1])
+            expect(session2Recorder.recordMessage).toHaveBeenNthCalledWith(2, messages[4])
 
             // Verify session3 recorder calls
             expect(session3Recorder.recordMessage).toHaveBeenCalledTimes(1)
-            expect(session3Recorder.recordMessage).toHaveBeenCalledWith(messages[3].message)
+            expect(session3Recorder.recordMessage).toHaveBeenCalledWith(messages[3])
         })
 
         it('should handle messages with different team IDs', async () => {
@@ -674,12 +674,12 @@ describe('SessionBatchRecorder', () => {
 
             // Verify correct message recording for each team
             expect(session1Recorder.recordMessage).toHaveBeenCalledTimes(2)
-            expect(session1Recorder.recordMessage).toHaveBeenNthCalledWith(1, messages[0].message)
-            expect(session1Recorder.recordMessage).toHaveBeenNthCalledWith(2, messages[1].message)
+            expect(session1Recorder.recordMessage).toHaveBeenNthCalledWith(1, messages[0])
+            expect(session1Recorder.recordMessage).toHaveBeenNthCalledWith(2, messages[1])
 
             expect(session2Recorder.recordMessage).toHaveBeenCalledTimes(2)
-            expect(session2Recorder.recordMessage).toHaveBeenNthCalledWith(1, messages[2].message)
-            expect(session2Recorder.recordMessage).toHaveBeenNthCalledWith(2, messages[3].message)
+            expect(session2Recorder.recordMessage).toHaveBeenNthCalledWith(1, messages[2])
+            expect(session2Recorder.recordMessage).toHaveBeenNthCalledWith(2, messages[3])
         })
     })
 

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.ts
@@ -107,7 +107,7 @@ export class SessionBatchRecorder {
 
         const [sessionBlockRecorder, consoleLogRecorder] = sessions.get(sessionId)!
         const bytesWritten = sessionBlockRecorder.recordMessage(message.message)
-        await consoleLogRecorder.recordMessage(message.message)
+        await consoleLogRecorder.recordMessage(message)
 
         const currentPartitionSize = this.partitionSizes.get(partition)!
         this.partitionSizes.set(partition, currentPartitionSize + bytesWritten)

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-console-log-recorder.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-console-log-recorder.test.ts
@@ -1,7 +1,7 @@
 import { DateTime } from 'luxon'
 
-import { ParsedMessageData } from '../kafka/types'
 import { ConsoleLogLevel, RRWebEventType } from '../rrweb-types'
+import { MessageWithTeam } from '../teams/types'
 import { SessionConsoleLogRecorder } from './session-console-log-recorder'
 import { SessionConsoleLogStore } from './session-console-log-store'
 
@@ -41,25 +41,31 @@ describe('SessionConsoleLogRecorder', () => {
     const createMessage = (
         windowId: string,
         events: any[],
-        { sessionId = 'session_id', distinctId = 'distinct_id' } = {}
-    ): ParsedMessageData => ({
-        distinct_id: distinctId,
-        session_id: sessionId,
-        eventsByWindowId: {
-            [windowId]: events,
+        { sessionId = 'session_id', distinctId = 'distinct_id', teamId = 1, consoleLogIngestionEnabled = true } = {}
+    ): MessageWithTeam => ({
+        team: {
+            teamId,
+            consoleLogIngestionEnabled,
         },
-        eventsRange: {
-            start: DateTime.fromMillis(events[0]?.timestamp || 0),
-            end: DateTime.fromMillis(events[events.length - 1]?.timestamp || 0),
-        },
-        snapshot_source: null,
-        snapshot_library: null,
-        metadata: {
-            partition: 1,
-            topic: 'test',
-            offset: 0,
-            timestamp: 0,
-            rawSize: 0,
+        message: {
+            distinct_id: distinctId,
+            session_id: sessionId,
+            eventsByWindowId: {
+                [windowId]: events,
+            },
+            eventsRange: {
+                start: DateTime.fromMillis(events[0]?.timestamp || 0),
+                end: DateTime.fromMillis(events[events.length - 1]?.timestamp || 0),
+            },
+            snapshot_source: null,
+            snapshot_library: null,
+            metadata: {
+                partition: 1,
+                topic: 'test',
+                offset: 0,
+                timestamp: 0,
+                rawSize: 0,
+            },
         },
     })
 
@@ -294,23 +300,13 @@ describe('SessionConsoleLogRecorder', () => {
 
     describe('Error handling', () => {
         it('should throw error when recording after end', async () => {
-            const message = createMessage(
-                'window1',
-                [
-                    {
-                        type: RRWebEventType.Plugin,
-                        timestamp: 1000,
-                        data: {
-                            plugin: 'rrweb/console@1',
-                            payload: {
-                                level: ConsoleLogLevel.Log,
-                                content: ['Test message'],
-                            },
-                        },
-                    },
-                ],
-                { sessionId: 'session_error_handling_1', distinctId: 'user_7' }
-            )
+            const message = createMessage('window1', [
+                createConsoleLogEvent({
+                    level: 'info',
+                    payload: ['Test message'],
+                    timestamp: 1000,
+                }),
+            ])
 
             await recorder.recordMessage(message)
             recorder.end()
@@ -321,23 +317,13 @@ describe('SessionConsoleLogRecorder', () => {
         })
 
         it('should throw error when calling end multiple times', async () => {
-            const message = createMessage(
-                'window1',
-                [
-                    {
-                        type: RRWebEventType.Plugin,
-                        timestamp: 1000,
-                        data: {
-                            plugin: 'rrweb/console@1',
-                            payload: {
-                                level: ConsoleLogLevel.Log,
-                                content: ['Test message'],
-                            },
-                        },
-                    },
-                ],
-                { sessionId: 'session_error_handling_2', distinctId: 'user_8' }
-            )
+            const message = createMessage('window1', [
+                createConsoleLogEvent({
+                    level: 'info',
+                    payload: ['Test message'],
+                    timestamp: 1000,
+                }),
+            ])
 
             await recorder.recordMessage(message)
             recorder.end()
@@ -348,41 +334,21 @@ describe('SessionConsoleLogRecorder', () => {
 
     describe('Multiple windows', () => {
         it('should count console events from multiple windows', async () => {
-            const message1 = createMessage(
-                'window1',
-                [
-                    {
-                        type: RRWebEventType.Plugin,
-                        timestamp: 1000,
-                        data: {
-                            plugin: 'rrweb/console@1',
-                            payload: {
-                                level: ConsoleLogLevel.Log,
-                                content: ['Window 1 log'],
-                            },
-                        },
-                    },
-                ],
-                { sessionId: 'session_multi_window_1', distinctId: 'user_9' }
-            )
+            const message1 = createMessage('window1', [
+                createConsoleLogEvent({
+                    level: 'info',
+                    payload: ['Window 1 log'],
+                    timestamp: 1000,
+                }),
+            ])
 
-            const message2 = createMessage(
-                'window2',
-                [
-                    {
-                        type: RRWebEventType.Plugin,
-                        timestamp: 2000,
-                        data: {
-                            plugin: 'rrweb/console@1',
-                            payload: {
-                                level: ConsoleLogLevel.Error,
-                                content: ['Window 2 error'],
-                            },
-                        },
-                    },
-                ],
-                { sessionId: 'session_multi_window_1', distinctId: 'user_9' }
-            )
+            const message2 = createMessage('window2', [
+                createConsoleLogEvent({
+                    level: 'error',
+                    payload: ['Window 2 error'],
+                    timestamp: 2000,
+                }),
+            ])
 
             await recorder.recordMessage(message1)
             await recorder.recordMessage(message2)
@@ -553,7 +519,7 @@ describe('SessionConsoleLogRecorder', () => {
             )
 
             // Add events from window2 to the same message
-            message.eventsByWindowId['window2'] = [
+            message.message.eventsByWindowId['window2'] = [
                 createConsoleLogEvent({
                     level: 'info',
                     payload: ['Duplicate message'],

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-console-log-recorder.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-console-log-recorder.test.ts
@@ -636,6 +636,37 @@ describe('SessionConsoleLogRecorder', () => {
                     message: 'Third unique message',
                 }),
             ])
+
+            it('should not record logs when consoleLogIngestionEnabled is false', async () => {
+                const now = DateTime.now()
+                const message = createMessage(
+                    'window1',
+                    [
+                        {
+                            timestamp: now.toMillis(),
+                            type: RRWebEventType.Plugin,
+                            data: {
+                                plugin: 'rrweb/console@1',
+                                payload: {
+                                    level: 'log',
+                                    payload: ['test message'],
+                                },
+                            },
+                        },
+                    ],
+                    { consoleLogIngestionEnabled: false }
+                )
+
+                await recorder.recordMessage(message)
+                expect(mockConsoleLogStore.storeSessionConsoleLogs).not.toHaveBeenCalled()
+
+                const result = recorder.end()
+                expect(result).toEqual({
+                    consoleLogCount: 0,
+                    consoleWarnCount: 0,
+                    consoleErrorCount: 0,
+                })
+            })
         })
     })
 })

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-console-log-recorder.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-console-log-recorder.test.ts
@@ -636,36 +636,36 @@ describe('SessionConsoleLogRecorder', () => {
                     message: 'Third unique message',
                 }),
             ])
+        })
 
-            it('should not record logs when consoleLogIngestionEnabled is false', async () => {
-                const now = DateTime.now()
-                const message = createMessage(
-                    'window1',
-                    [
-                        {
-                            timestamp: now.toMillis(),
-                            type: RRWebEventType.Plugin,
-                            data: {
-                                plugin: 'rrweb/console@1',
-                                payload: {
-                                    level: 'log',
-                                    payload: ['test message'],
-                                },
+        it('should not record logs when consoleLogIngestionEnabled is false', async () => {
+            const now = DateTime.now()
+            const message = createMessage(
+                'window1',
+                [
+                    {
+                        timestamp: now.toMillis(),
+                        type: RRWebEventType.Plugin,
+                        data: {
+                            plugin: 'rrweb/console@1',
+                            payload: {
+                                level: 'log',
+                                payload: ['test message'],
                             },
                         },
-                    ],
-                    { consoleLogIngestionEnabled: false }
-                )
+                    },
+                ],
+                { consoleLogIngestionEnabled: false }
+            )
 
-                await recorder.recordMessage(message)
-                expect(mockConsoleLogStore.storeSessionConsoleLogs).not.toHaveBeenCalled()
+            await recorder.recordMessage(message)
+            expect(mockConsoleLogStore.storeSessionConsoleLogs).not.toHaveBeenCalled()
 
-                const result = recorder.end()
-                expect(result).toEqual({
-                    consoleLogCount: 0,
-                    consoleWarnCount: 0,
-                    consoleErrorCount: 0,
-                })
+            const result = recorder.end()
+            expect(result).toEqual({
+                consoleLogCount: 0,
+                consoleWarnCount: 0,
+                consoleErrorCount: 0,
             })
         })
     })

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-console-log-recorder.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-console-log-recorder.ts
@@ -102,6 +102,10 @@ export class SessionConsoleLogRecorder {
             throw new Error('Cannot record message after end() has been called')
         }
 
+        if (!message.team.consoleLogIngestionEnabled) {
+            return
+        }
+
         const logsToStore: ConsoleLogEntry[] = []
 
         for (const events of Object.values(message.message.eventsByWindowId)) {

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-console-log-recorder.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-console-log-recorder.ts
@@ -2,8 +2,8 @@ import { DateTime } from 'luxon'
 
 import { TimestampFormat } from '../../../../types'
 import { castTimestampOrNow } from '../../../../utils/utils'
-import { ParsedMessageData } from '../kafka/types'
 import { ConsoleLogLevel, RRWebEventType } from '../rrweb-types'
+import { MessageWithTeam } from '../teams/types'
 import { ConsoleLogEntry, SessionConsoleLogStore } from './session-console-log-store'
 
 const levelMapping: Record<string, ConsoleLogLevel> = {
@@ -97,14 +97,14 @@ export class SessionConsoleLogRecorder {
      * @param message - Message containing events for one or more windows
      * @throws If called after end()
      */
-    public async recordMessage(message: ParsedMessageData): Promise<void> {
+    public async recordMessage(message: MessageWithTeam): Promise<void> {
         if (this.ended) {
             throw new Error('Cannot record message after end() has been called')
         }
 
         const logsToStore: ConsoleLogEntry[] = []
 
-        for (const events of Object.values(message.eventsByWindowId)) {
+        for (const events of Object.values(message.message.eventsByWindowId)) {
             for (const event of events) {
                 const eventData = event.data as
                     | { plugin?: unknown; payload?: { payload?: unknown; level?: unknown } }


### PR DESCRIPTION
## Problem

In Blobby V2 we're ingesting logs for all messages, but there's team-level setting for console log ingestion.

## Changes

- Refactors the session console log recorder to take messages with team config
- Filters out messages for teams with disabled console log ingestion

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added unit tests