### PR TITLE
fix: f-string in slack alert

### DIFF
--- a/dags/slack_alerts.py
+++ b/dags/slack_alerts.py
@@ -53,7 +53,10 @@ def notify_slack_on_failure(context: dagster.RunFailureSensorContext, slack: dag
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"*Step failures*:\n{'- \n'.join([f'`{step_key}`: {step_failure[:1000]}' for step_key, step_failure in step_failures.items()])}",
+                "text": f"*Step failures*:\n"
+                + "\n".join(
+                    [f"- `{step_key}`: {step_failure[:1000]}" for step_key, step_failure in step_failures.items()]
+                ),
             },
         },
         {


### PR DESCRIPTION
## Problem

I broke the code location

## Changes

Fix f-string

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Ensure it starts locally
