### PR TITLE
chore(crm): Make property editing live for everyone

### DIFF
--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -127,12 +127,8 @@ export function Group(): JSX.Element {
                                 type={PropertyDefinitionType.Group}
                                 properties={groupData.group_properties || {}}
                                 embedded={false}
-                                onEdit={featureFlags[FEATURE_FLAGS.CRM_ITERATION_ONE] ? editProperty : undefined}
-                                onDelete={
-                                    featureFlags[FEATURE_FLAGS.CRM_ITERATION_ONE]
-                                        ? (key) => deleteProperty(key)
-                                        : undefined
-                                }
+                                onEdit={editProperty}
+                                onDelete={(key) => deleteProperty(key)}
                                 searchable
                             />
                         ),
@@ -243,24 +239,22 @@ export function Group(): JSX.Element {
                             />
                         ),
                     },
-                    featureFlags[FEATURE_FLAGS.CRM_ITERATION_ONE]
-                        ? {
-                              key: PersonsTabType.HISTORY,
-                              label: 'History',
-                              content: (
-                                  <ActivityLog
-                                      scope={ActivityScope.GROUP}
-                                      id={`${groupTypeIndex}-${groupKey}`}
-                                      caption={
-                                          <LemonBanner type="info">
-                                              This page only shows changes made by users in the PostHog site. Automatic
-                                              changes from the API aren't shown here.
-                                          </LemonBanner>
-                                      }
-                                  />
-                              ),
-                          }
-                        : null,
+                    {
+                        key: PersonsTabType.HISTORY,
+                        label: 'History',
+                        content: (
+                            <ActivityLog
+                                scope={ActivityScope.GROUP}
+                                id={`${groupTypeIndex}-${groupKey}`}
+                                caption={
+                                    <LemonBanner type="info">
+                                        This page only shows changes made by users in the PostHog site. Automatic
+                                        changes from the API aren't shown here.
+                                    </LemonBanner>
+                                }
+                            />
+                        ),
+                    },
                     showCustomerSuccessDashboards
                         ? {
                               key: PersonsTabType.DASHBOARD,

--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -128,7 +128,7 @@ export function Group(): JSX.Element {
                                 properties={groupData.group_properties || {}}
                                 embedded={false}
                                 onEdit={editProperty}
-                                onDelete={(key) => deleteProperty(key)}
+                                onDelete={deleteProperty}
                                 searchable
                             />
                         ),


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/29881
Needs https://github.com/PostHog/posthog/pull/30123 first

## Changes

Removes feature flag gate for property editing.

## How did you test this code?

Visual review.