### PR TITLE
refactor: Support sync heartbeats in heartbeater module 

### DIFF
--- a/posthog/temporal/data_imports/deltalake_compaction_job.py
+++ b/posthog/temporal/data_imports/deltalake_compaction_job.py
@@ -14,7 +14,7 @@ from posthog.exceptions_capture import capture_exception
 from posthog.settings import DEBUG, TEST
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.client import sync_connect
-from posthog.temporal.common.heartbeat_sync import HeartbeaterSync
+from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import (
     FilteringBoundLogger,
     bind_temporal_worker_logger_sync,
@@ -74,7 +74,7 @@ class DeltalakeCompactionJobWorkflowInputs:
 @activity.defn
 def run_compaction(inputs: DeltalakeCompactionJobWorkflowInputs):
     logger = bind_temporal_worker_logger_sync(team_id=inputs.team_id)
-    with HeartbeaterSync(factor=30, logger=logger):
+    with Heartbeater(factor=30, logger=logger):
         close_old_connections()
 
         job = ExternalDataJob.objects.get(id=inputs.external_data_job_id, team_id=inputs.team_id)

--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -12,7 +12,7 @@ from structlog.typing import FilteringBoundLogger
 from temporalio import activity
 
 from posthog.models.integration import Integration
-from posthog.temporal.common.heartbeat_sync import HeartbeaterSync
+from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import bind_temporal_worker_logger_sync
 from posthog.temporal.common.shutdown import ShutdownMonitor
 from posthog.temporal.data_imports.pipelines.bigquery import (
@@ -80,7 +80,7 @@ def _trim_source_job_inputs(source: ExternalDataSource) -> None:
 def import_data_activity_sync(inputs: ImportDataActivityInputs):
     logger = bind_temporal_worker_logger_sync(team_id=inputs.team_id)
 
-    with HeartbeaterSync(factor=30, logger=logger), ShutdownMonitor() as shutdown_monitor:
+    with Heartbeater(factor=30, logger=logger), ShutdownMonitor() as shutdown_monitor:
         close_old_connections()
 
         model = ExternalDataJob.objects.prefetch_related(

--- a/posthog/temporal/tests/utils/workflow.py
+++ b/posthog/temporal/tests/utils/workflow.py
@@ -11,7 +11,6 @@ from temporalio.common import RetryPolicy
 
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat import Heartbeater
-from posthog.temporal.common.heartbeat_sync import HeartbeaterSync
 from posthog.temporal.common.shutdown import ShutdownMonitor
 
 
@@ -31,7 +30,6 @@ class Waiter:
         self.is_waiting = asyncio.Event()
         self.is_waiting_sync = threading.Event()
         self.heartbeater: Heartbeater | None = None
-        self.heartbeater_sync: HeartbeaterSync | None = None
         self.shutdown_monitor: ShutdownMonitor | None = None
 
     @activity.defn
@@ -62,11 +60,11 @@ class Waiter:
         elapsed = 0.0
         start = time.monotonic()
         self.shutdown_monitor = ShutdownMonitor()
-        self.heartbeater_sync = HeartbeaterSync()
+        self.heartbeater = Heartbeater()
 
         self.is_waiting_sync.set()
 
-        with self.heartbeater_sync, self.shutdown_monitor:
+        with self.heartbeater, self.shutdown_monitor:
             while True:
                 elapsed = time.monotonic() - start
 


### PR DESCRIPTION
## Problem

We have two modules for handling heartbeats, which do roughly the same thing, but for syncrhonous and asynchronous activities. Following the example of `ShutdownMonitor` and Temporal's own `_CompositeEvent`, I think we could handle these in the same module.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Support for sync heartbeatting in `Heartbeater` class when using a non-async context manager.
Change every instance of `HeartbeaterSync` to be just `Hearbeater`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
