### PR TITLE
chore: Add taxonomy for some neglected fields

### DIFF
--- a/frontend/src/lib/taxonomy.tsx
+++ b/frontend/src/lib/taxonomy.tsx
@@ -1050,7 +1050,7 @@ export const CORE_FILTER_DEFINITIONS_BY_GROUP = {
             examples: ['{"flag": "value"}'],
         },
         $feature_flag_reason: {
-            label: 'Feature Flag Reason',
+            label: 'Feature Flag Evaluation Reason',
             description: 'The reason the feature flag was matched or not matched.',
             examples: ['Matched condition set 1'],
         },

--- a/frontend/src/lib/taxonomy.tsx
+++ b/frontend/src/lib/taxonomy.tsx
@@ -1049,6 +1049,28 @@ export const CORE_FILTER_DEFINITIONS_BY_GROUP = {
                 'Keys and multivariate values of the feature flags that were active while this event was sent.',
             examples: ['{"flag": "value"}'],
         },
+        $feature_flag_reason: {
+            label: 'Feature Flag Reason',
+            description: 'The reason the feature flag was matched or not matched.',
+            examples: ['Matched condition set 1'],
+        },
+        $feature_flag_request_id: {
+            label: 'Feature Flag Request ID',
+            description: (
+                <>
+                    The unique identifier for the request that retrieved this feature flag result.
+                    <br />
+                    <br />
+                    Note: Primarily used by PostHog support for debugging issues with feature flags.
+                </>
+            ),
+            examples: ['01234567-89ab-cdef-0123-456789abcdef'],
+        },
+        $feature_flag_version: {
+            label: 'Feature Flag Version',
+            description: 'The version of the feature flag that was called.',
+            examples: ['3'],
+        },
         $feature_flag_response: {
             label: 'Feature Flag Response',
             description: 'What the call to feature flag responded with.',

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -1023,6 +1023,21 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "description": 'The feature flag that was called.\n\nWarning! This only works in combination with the $feature_flag_called event. If you want to filter other events, try "Active Feature Flags".',
             "examples": ["beta-feature"],
         },
+        "$feature_flag_reason": {
+            "label": "Feature Flag Reason",
+            "description": "The reason the feature flag was matched or not matched.",
+            "examples": ["Matched condition set 1"],
+        },
+        "$feature_flag_request_id": {
+            "label": "Feature Flag Request ID",
+            "description": "The unique identifier for the request that retrieved this feature flag result. Primarily used by PostHog support for debugging issues with feature flags.",
+            "examples": ["1234567890"],
+        },
+        "$feature_flag_version": {
+            "label": "Feature Flag Version",
+            "description": "The version of the feature flag that was called.",
+            "examples": ["3"],
+        },
         "$survey_response": {
             "label": "Survey Response",
             "description": "The response value for the first question in the survey.",

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -1024,14 +1024,14 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "examples": ["beta-feature"],
         },
         "$feature_flag_reason": {
-            "label": "Feature Flag Reason",
+            "label": "Feature Flag Evaluation Reason",
             "description": "The reason the feature flag was matched or not matched.",
             "examples": ["Matched condition set 1"],
         },
         "$feature_flag_request_id": {
             "label": "Feature Flag Request ID",
             "description": "The unique identifier for the request that retrieved this feature flag result. Primarily used by PostHog support for debugging issues with feature flags.",
-            "examples": ["1234567890"],
+            "examples": ["01234567-89ab-cdef-0123-456789abcdef"],
         },
         "$feature_flag_version": {
             "label": "Feature Flag Version",


### PR DESCRIPTION
Adds some taxonomic descriptions to new properties of the `$feature_flag_called` event.

![Screenshot 2025-03-19 at 1 11 49 PM](https://github.com/user-attachments/assets/15b0d8ee-92a2-45fc-8a7f-84042f568ca6)

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manually testing