### PR TITLE
fix(flags): sneaky new flags cohort dependency bug

### DIFF
--- a/rust/feature-flags/src/cohort/cohort_operations.rs
+++ b/rust/feature-flags/src/cohort/cohort_operations.rs
@@ -39,6 +39,7 @@ impl Cohort {
               FROM posthog_cohort AS c
               JOIN posthog_team AS t ON (c.team_id = t.id)
             WHERE t.project_id = $1
+            AND c.deleted = false
         "#;
         let cohorts = sqlx::query_as::<_, Cohort>(query)
             .bind(project_id)

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -21,6 +21,7 @@ use petgraph::graph::DiGraph;
 use serde_json::Value;
 use sha1::{Digest, Sha1};
 use sqlx::{postgres::PgQueryResult, Acquire, FromRow, Row};
+use std::collections::hash_map::Entry;
 use std::fmt::Write;
 use std::sync::Arc;
 use std::{
@@ -1022,11 +1023,10 @@ impl FeatureFlagMatcher {
                 .get_cohort_id()
                 .ok_or(FlagError::CohortFiltersParsingError)?;
 
-            // Only evaluate if we haven't already got a result from static evaluation
-            if !cohort_matches.contains_key(&cohort_id) {
+            if let Entry::Vacant(e) = cohort_matches.entry(cohort_id) {
                 let match_result =
                     evaluate_dynamic_cohorts(cohort_id, target_properties, &cohorts)?;
-                cohort_matches.insert(cohort_id, match_result);
+                e.insert(match_result);
             }
         }
 

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -801,7 +801,7 @@ impl FeatureFlagMatcher {
     /// It compares the current match reason with a new match reason and returns the higher priority one.
     /// The priority is determined by the ordering of FeatureFlagMatchReason variants.
     /// It's used to keep track of the most significant reason why a flag matched or didn't match,
-    /// which is especially useful when multiple conditions are evaluated.
+    /// especially useful when multiple conditions are evaluated.
     fn get_highest_priority_match_evaluation(
         &self,
         current_match: FeatureFlagMatchReason,
@@ -999,13 +999,13 @@ impl FeatureFlagMatcher {
         // Split the cohorts into static and dynamic, since the dynamic ones have property filters
         // and we need to evaluate them based on the target properties, whereas the static ones are
         // purely based on person properties and are membership-based.
-        let (static_cohorts, dynamic_cohorts): (Vec<_>, Vec<_>) =
-            cohorts.iter().partition(|c| c.is_static);
+        let (static_cohorts, _): (Vec<_>, Vec<_>) = cohorts.iter().partition(|c| c.is_static);
 
         // Store all cohort match results in a HashMap to avoid re-evaluating the same cohort multiple times,
         // since the same cohort could appear in multiple property filters.
         let mut cohort_matches = HashMap::new();
 
+        // Always evaluate static cohorts first
         if !static_cohorts.is_empty() {
             let results = evaluate_static_cohorts(
                 self.reader.clone(),
@@ -1016,11 +1016,14 @@ impl FeatureFlagMatcher {
             cohort_matches.extend(results);
         }
 
-        if !dynamic_cohorts.is_empty() {
-            for filter in cohort_property_filters {
-                let cohort_id = filter
-                    .get_cohort_id()
-                    .ok_or(FlagError::CohortFiltersParsingError)?;
+        // For any cohorts not yet evaluated (i.e., dynamic ones), evaluate them
+        for filter in cohort_property_filters {
+            let cohort_id = filter
+                .get_cohort_id()
+                .ok_or(FlagError::CohortFiltersParsingError)?;
+
+            // Only evaluate if we haven't already got a result from static evaluation
+            if !cohort_matches.contains_key(&cohort_id) {
                 let match_result =
                     evaluate_dynamic_cohorts(cohort_id, target_properties, &cohorts)?;
                 cohort_matches.insert(cohort_id, match_result);
@@ -1400,6 +1403,18 @@ fn evaluate_dynamic_cohorts(
     target_properties: &HashMap<String, Value>,
     cohorts: &[Cohort],
 ) -> Result<bool, FlagError> {
+    // First check if this is a static cohort
+    let initial_cohort = cohorts
+        .iter()
+        .find(|c| c.id == initial_cohort_id)
+        .ok_or(FlagError::CohortNotFound(initial_cohort_id.to_string()))?;
+
+    // If it's static, we don't need to evaluate dependencies - the membership was already
+    // checked in evaluate_static_cohorts and stored in cohort_matches
+    if initial_cohort.is_static {
+        return Ok(false); // Static cohorts are handled by evaluate_static_cohorts
+    }
+
     let cohort_dependency_graph = build_cohort_dependency_graph(initial_cohort_id, cohorts)?;
 
     // We need to sort cohorts topologically to ensure we evaluate dependencies before the cohorts that depend on them.
@@ -5106,5 +5121,90 @@ mod tests {
         // so it should fall back to hash-based variant computation
         assert!(result_invalid.matches);
         assert!(result_invalid.variant.is_some()); // Will be either "control" or "test" based on hash
+    }
+
+    #[tokio::test]
+    async fn test_static_cohort_evaluation_skips_dependency_graph() {
+        let reader = setup_pg_reader_client(None).await;
+        let writer = setup_pg_writer_client(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(reader.clone(), None, None));
+        let team = insert_new_team_in_pg(reader.clone(), None).await.unwrap();
+
+        // Insert a static cohort
+        let cohort = insert_cohort_for_team_in_pg(
+            reader.clone(),
+            team.id,
+            Some("Static Cohort".to_string()),
+            json!({}), // Static cohorts don't have property filters
+            true,      // is_static = true
+        )
+        .await
+        .unwrap();
+
+        // Insert a person
+        let distinct_id = "static_user".to_string();
+        insert_person_for_team_in_pg(
+            reader.clone(),
+            team.id,
+            distinct_id.clone(),
+            Some(json!({"email": "static@user.com"})),
+        )
+        .await
+        .unwrap();
+
+        // Get person ID and add to cohort
+        let person_id = get_person_id_by_distinct_id(reader.clone(), team.id, &distinct_id)
+            .await
+            .unwrap();
+        add_person_to_cohort(reader.clone(), person_id, cohort.id)
+            .await
+            .unwrap();
+
+        // Define a flag that references the static cohort
+        let flag = create_test_flag(
+            None,
+            Some(team.id),
+            None,
+            None,
+            Some(FlagFilters {
+                groups: vec![FlagGroupType {
+                    properties: Some(vec![PropertyFilter {
+                        key: "id".to_string(),
+                        value: json!(cohort.id),
+                        operator: Some(OperatorType::In),
+                        prop_type: "cohort".to_string(),
+                        group_type_index: None,
+                        negation: Some(false),
+                    }]),
+                    rollout_percentage: Some(100.0),
+                    variant: None,
+                }],
+                multivariate: None,
+                aggregation_group_type_index: None,
+                payloads: None,
+                super_groups: None,
+            }),
+            None,
+            None,
+            None,
+        );
+
+        let mut matcher = FeatureFlagMatcher::new(
+            distinct_id.clone(),
+            team.id,
+            team.project_id,
+            reader.clone(),
+            writer.clone(),
+            cohort_cache.clone(),
+            None,
+            None,
+        );
+
+        // This should not throw CohortNotFound because we skip dependency graph evaluation for static cohorts
+        let result = matcher.get_match(&flag, None, None).await;
+        assert!(result.is_ok(), "Should not throw CohortNotFound error");
+
+        let match_result = result.unwrap();
+        assert!(match_result.matches, "User should match the static cohort");
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes a critical bug in feature flag evaluation where static cohorts were being incorrectly processed through the dynamic cohort evaluation path, leading to `CohortNotFound` errors. Static cohorts should be evaluated purely based on membership in the `posthog_cohortpeople` table, not through property-based dependency graphs.

## The Bug
When evaluating feature flags that reference static cohorts, we were incorrectly:
1. Attempting to build a dependency graph (which is only relevant for dynamic cohorts)
2. Running the cohort through dynamic evaluation logic
3. Failing to properly check the actual cohort membership

This caused `CohortNotFound` errors even when:
- The cohort existed in the database
- The user was actually a member of the cohort
- The cohort was properly marked as static

## The Fix
Added early return logic in `evaluate_dynamic_cohorts` to properly handle static cohorts:
```rust
if initial_cohort.is_static {
    return Ok(false); // Static cohorts are handled by evaluate_static_cohorts
}
```

This ensures static cohorts are evaluated purely through membership checks in `evaluate_static_cohorts`, which queries the `posthog_cohortpeople` table directly.

## Testing
Added test `test_static_cohort_evaluation_skips_dependency_graph` that verifies:
- Static cohorts don't trigger dependency graph evaluation
- The evaluation completes without throwing `CohortNotFound` errors
- Membership-based matching works correctly for static cohorts

## Performance Impact
As a bonus, this fix also improves performance by eliminating unnecessary computation for static cohorts:
- Avoids graph construction
- Skips topological sort
- Eliminates unnecessary property evaluations
