### PR TITLE
fix(node): Failing tests due to bigint migration 

### DIFF
--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -821,7 +821,9 @@ export type PropertiesLastOperation = Record<string, PropertyUpdateOperation>
 
 /** Properties shared by RawPerson and Person. */
 export interface BasePerson {
-    id: string // NOTE: bigint comes back from the DB as a string
+    // NOTE: id is a bigint in the DB, which pg lib returns as a string
+    // We leave it as a string as dealing with the bigint type is tricky and we don't need any of its features
+    id: string
     team_id: number
     properties: Properties
     is_user_id: number

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -821,7 +821,7 @@ export type PropertiesLastOperation = Record<string, PropertyUpdateOperation>
 
 /** Properties shared by RawPerson and Person. */
 export interface BasePerson {
-    id: number
+    id: bigint
     team_id: number
     properties: Properties
     is_user_id: number

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -821,7 +821,7 @@ export type PropertiesLastOperation = Record<string, PropertyUpdateOperation>
 
 /** Properties shared by RawPerson and Person. */
 export interface BasePerson {
-    id: bigint
+    id: string // NOTE: bigint comes back from the DB as a string
     team_id: number
     properties: Properties
     is_user_id: number

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -460,7 +460,7 @@ export class DB {
     private toPerson(row: RawPerson): InternalPerson {
         return {
             ...row,
-            id: row.id,
+            id: String(row.id),
             created_at: DateTime.fromISO(row.created_at).toUTC(),
             version: Number(row.version || 0),
         }

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -460,7 +460,7 @@ export class DB {
     private toPerson(row: RawPerson): InternalPerson {
         return {
             ...row,
-            id: BigInt(row.id),
+            id: row.id,
             created_at: DateTime.fromISO(row.created_at).toUTC(),
             version: Number(row.version || 0),
         }

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -460,6 +460,7 @@ export class DB {
     private toPerson(row: RawPerson): InternalPerson {
         return {
             ...row,
+            id: BigInt(row.id),
             created_at: DateTime.fromISO(row.created_at).toUTC(),
             version: Number(row.version || 0),
         }

--- a/plugin-server/tests/helpers/sql.ts
+++ b/plugin-server/tests/helpers/sql.ts
@@ -40,8 +40,8 @@ DECLARE
     r RECORD;
 BEGIN
     -- Delete from tables in order of dependencies
-    TRUNCATE TABLE posthog_persondistinctid CASCADE;
-    TRUNCATE TABLE posthog_person CASCADE;
+    DELETE FROM posthog_persondistinctid;
+    DELETE FROM posthog_person;
     
     -- Then handle remaining tables
     FOR r IN (
@@ -50,7 +50,7 @@ BEGIN
         WHERE schemaname = current_schema()
         AND tablename NOT IN ('posthog_persondistinctid', 'posthog_person')
     ) LOOP
-        EXECUTE 'TRUNCATE TABLE ' || quote_ident(r.tablename) || ' CASCADE';
+        EXECUTE 'DELETE FROM ' || quote_ident(r.tablename);
     END LOOP;
 END $$;
 `

--- a/plugin-server/tests/helpers/sql.ts
+++ b/plugin-server/tests/helpers/sql.ts
@@ -35,12 +35,21 @@ export interface ExtraDatabaseRows {
 
 // TEST
 export const POSTGRES_DELETE_TABLES_QUERY = `
-DO $$ DECLARE
-  r RECORD;
+DO $$ 
+DECLARE
+    r RECORD;
 BEGIN
-  FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = current_schema()) LOOP
-    EXECUTE 'DELETE FROM ' || quote_ident(r.tablename);
-  END LOOP;
+    -- Disable foreign key constraints temporarily
+    SET CONSTRAINTS ALL DEFERRED;
+    
+    -- Delete from all tables in the current schema
+    FOR r IN (
+        SELECT tablename 
+        FROM pg_tables 
+        WHERE schemaname = current_schema()
+    ) LOOP
+        EXECUTE 'TRUNCATE TABLE ' || quote_ident(r.tablename) || ' CASCADE';
+    END LOOP;
 END $$;
 `
 

--- a/plugin-server/tests/helpers/sql.ts
+++ b/plugin-server/tests/helpers/sql.ts
@@ -33,6 +33,7 @@ export interface ExtraDatabaseRows {
     pluginAttachments?: Omit<PluginAttachmentDB, 'id'>[]
 }
 
+// TEST
 export const POSTGRES_DELETE_TABLES_QUERY = `
 DO $$ DECLARE
   r RECORD;

--- a/plugin-server/tests/helpers/sql.ts
+++ b/plugin-server/tests/helpers/sql.ts
@@ -40,8 +40,9 @@ DECLARE
     r RECORD;
 BEGIN
     -- Delete from tables in order of dependencies
-    DELETE FROM posthog_persondistinctid;
-    DELETE FROM posthog_person;
+    DELETE FROM posthog_featureflaghashkeyoverride CASCADE;
+    DELETE FROM posthog_persondistinctid CASCADE;
+    DELETE FROM posthog_person CASCADE;
     
     -- Then handle remaining tables
     FOR r IN (
@@ -50,7 +51,7 @@ BEGIN
         WHERE schemaname = current_schema()
         AND tablename NOT IN ('posthog_persondistinctid', 'posthog_person')
     ) LOOP
-        EXECUTE 'DELETE FROM ' || quote_ident(r.tablename);
+        EXECUTE 'DELETE FROM ' || quote_ident(r.tablename) || ' CASCADE';
     END LOOP;
 END $$;
 `

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -2,7 +2,16 @@ import { DateTime } from 'luxon'
 import { Pool } from 'pg'
 
 import { defaultConfig } from '../../src/config/config'
-import { BasePerson, Hub, Person, PropertyOperator, PropertyUpdateOperation, RawAction, Team } from '../../src/types'
+import {
+    BasePerson,
+    Hub,
+    InternalPerson,
+    Person,
+    PropertyOperator,
+    PropertyUpdateOperation,
+    RawAction,
+    Team,
+} from '../../src/types'
 import { DB } from '../../src/utils/db/db'
 import { DependencyUnavailableError, RedisOperationError } from '../../src/utils/db/error'
 import { closeHub, createHub } from '../../src/utils/db/hub'
@@ -256,7 +265,7 @@ describe('DB', () => {
         })
     })
 
-    async function fetchPersonByPersonId(teamId: number, personId: bigint): Promise<Person | undefined> {
+    async function fetchPersonByPersonId(teamId: number, personId: InternalPerson['id']): Promise<Person | undefined> {
         const selectResult = await db.postgres.query(
             PostgresUse.COMMON_WRITE,
             `SELECT * FROM posthog_person WHERE team_id = $1 AND id = $2`,

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -256,7 +256,7 @@ describe('DB', () => {
         })
     })
 
-    async function fetchPersonByPersonId(teamId: number, personId: number): Promise<Person | undefined> {
+    async function fetchPersonByPersonId(teamId: number, personId: bigint): Promise<Person | undefined> {
         const selectResult = await db.postgres.query(
             PostgresUse.COMMON_WRITE,
             `SELECT * FROM posthog_person WHERE team_id = $1 AND id = $2`,

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -499,7 +499,7 @@ describe('DB', () => {
             expect(person).toEqual(createdPerson)
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: uuid.toString(),
                     properties: { foo: 'bar' },
                     is_identified: true,

--- a/plugin-server/tests/worker/ingestion/action-matcher.test.ts
+++ b/plugin-server/tests/worker/ingestion/action-matcher.test.ts
@@ -6,6 +6,7 @@ import {
     Cohort,
     Element,
     Hub,
+    InternalPerson,
     ISOTimestamp,
     Person,
     PostIngestionEvent,
@@ -1279,8 +1280,8 @@ describe('ActionMatcher', () => {
     describe('doesPersonBelongToCohort()', () => {
         let team: Team
         let cohort: Cohort
-        let person: Person
-        let personId: number
+        let person: InternalPerson
+        let personId: bigint
         const TIMESTAMP = DateTime.fromISO('2000-10-14T11:42:06.502Z').toUTC()
 
         beforeEach(async () => {
@@ -1294,7 +1295,6 @@ describe('ActionMatcher', () => {
 
             person = await hub.db.createPerson(TIMESTAMP, {}, {}, {}, team.id, null, false, new UUIDT().toString(), [])
 
-            // @ts-expect-error TODO: Update underlying person type
             personId = person.id
         })
 

--- a/plugin-server/tests/worker/ingestion/action-matcher.test.ts
+++ b/plugin-server/tests/worker/ingestion/action-matcher.test.ts
@@ -1280,7 +1280,7 @@ describe('ActionMatcher', () => {
         let team: Team
         let cohort: Cohort
         let person: InternalPerson
-        let personId: bigint
+        let personId: InternalPerson['id']
         const TIMESTAMP = DateTime.fromISO('2000-10-14T11:42:06.502Z').toUTC()
 
         beforeEach(async () => {

--- a/plugin-server/tests/worker/ingestion/action-matcher.test.ts
+++ b/plugin-server/tests/worker/ingestion/action-matcher.test.ts
@@ -8,7 +8,6 @@ import {
     Hub,
     InternalPerson,
     ISOTimestamp,
-    Person,
     PostIngestionEvent,
     PropertyOperator,
     RawAction,

--- a/plugin-server/tests/worker/ingestion/event-pipeline/processPersonsStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/processPersonsStep.test.ts
@@ -67,7 +67,7 @@ describe('processPersonsStep()', () => {
         expect(resEvent).toEqual(pluginEvent)
         expect(resPerson).toEqual(
             expect.objectContaining({
-                id: expect.any(Number),
+                id: expect.any(String),
                 uuid: expect.any(String),
                 properties: { a: 5, $creator_event_uuid: expect.any(String) },
                 version: 0,
@@ -117,7 +117,7 @@ describe('processPersonsStep()', () => {
         })
         expect(resPerson).toEqual(
             expect.objectContaining({
-                id: expect.any(Number),
+                id: expect.any(String),
                 uuid: expect.any(String),
                 properties: {
                     $initial_browser: 'Chrome',

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -534,7 +534,7 @@ describe('PersonState.update()', () => {
 
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(BigInt),
+                    id: expect.any(String),
                     uuid: newUserUuid,
                     properties: { a: 1, b: 3, c: 4 },
                     created_at: timestamp,

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -92,6 +92,8 @@ describe('PersonState.update()', () => {
         )
     }
 
+    const sortPersons = (persons: InternalPerson[]) => persons.sort((a, b) => Number(a.id) - Number(b.id))
+
     async function fetchPostgresPersonsH() {
         return await fetchPostgresPersons(hub.db, teamId)
     }
@@ -374,7 +376,7 @@ describe('PersonState.update()', () => {
             expect(hub.db.updatePersonDeprecated).not.toHaveBeenCalled()
 
             // verify Postgres persons
-            const persons = await fetchPostgresPersonsH()
+            const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons.length).toEqual(1)
             expect(persons[0]).toEqual(person)
 
@@ -406,7 +408,7 @@ describe('PersonState.update()', () => {
             )
 
             // verify Postgres persons
-            const persons = await fetchPostgresPersonsH()
+            const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons.length).toEqual(1)
             expect(persons[0]).toEqual(person)
 
@@ -467,7 +469,7 @@ describe('PersonState.update()', () => {
             )
             expect(hub.db.updatePersonDeprecated).not.toHaveBeenCalled()
             // verify Postgres persons
-            const persons = await fetchPostgresPersonsH()
+            const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons.length).toEqual(1)
             expect(persons[0]).toEqual(person)
 
@@ -509,7 +511,7 @@ describe('PersonState.update()', () => {
             )
             expect(hub.db.updatePersonDeprecated).toHaveBeenCalledTimes(1)
             // verify Postgres persons
-            const persons = await fetchPostgresPersonsH()
+            const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons.length).toEqual(1)
             expect(persons[0]).toEqual(person)
 
@@ -545,7 +547,7 @@ describe('PersonState.update()', () => {
             expect(hub.db.updatePersonDeprecated).not.toHaveBeenCalled()
 
             // verify Postgres persons
-            const persons = await fetchPostgresPersonsH()
+            const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons.length).toEqual(1)
             expect(persons[0]).toEqual(person)
 
@@ -595,7 +597,7 @@ describe('PersonState.update()', () => {
             expect(hub.db.fetchPerson).toHaveBeenCalledTimes(1)
 
             // verify Postgres persons
-            const persons = await fetchPostgresPersonsH()
+            const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons.length).toEqual(1)
             expect(persons[0]).toEqual(person)
         })
@@ -632,7 +634,7 @@ describe('PersonState.update()', () => {
             expect(hub.db.fetchPerson).toHaveBeenCalledTimes(1)
 
             // verify Postgres persons
-            const persons = await fetchPostgresPersonsH()
+            const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons.length).toEqual(1)
             expect(persons[0]).toEqual(person)
         })
@@ -666,7 +668,7 @@ describe('PersonState.update()', () => {
             expect(hub.db.fetchPerson).toHaveBeenCalledTimes(1)
 
             // verify Postgres persons
-            const persons = await fetchPostgresPersonsH()
+            const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons).toEqual([
                 expect.objectContaining({
                     id: expect.any(Number),
@@ -708,7 +710,7 @@ describe('PersonState.update()', () => {
             expect(hub.db.fetchPerson).toHaveBeenCalledTimes(1)
 
             // verify Postgres persons
-            const persons = await fetchPostgresPersonsH()
+            const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons.length).toEqual(1)
             expect(persons[0]).toEqual(person) // We updated PG as it's a person event
         })
@@ -742,7 +744,7 @@ describe('PersonState.update()', () => {
             expect(hub.db.fetchPerson).toHaveBeenCalledTimes(1)
 
             // verify Postgres persons
-            const persons = await fetchPostgresPersonsH()
+            const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons.length).toEqual(1)
             expect(persons[0]).toEqual(person) // We updated PG as it was undefined before
         })
@@ -784,7 +786,7 @@ describe('PersonState.update()', () => {
             expect(hub.db.fetchPerson).toHaveBeenCalledTimes(1)
 
             // verify Postgres persons
-            const persons = await fetchPostgresPersonsH()
+            const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons.length).toEqual(1)
             expect(persons[0]).toEqual(person) // We updated PG as it's an initial property
         })
@@ -831,7 +833,7 @@ describe('PersonState.update()', () => {
             expect(hub.db.fetchPerson).toHaveBeenCalledTimes(0)
 
             // verify Postgres persons
-            const persons = await fetchPostgresPersonsH()
+            const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons.length).toEqual(1)
             expect(persons[0]).toEqual(person)
         })
@@ -867,7 +869,7 @@ describe('PersonState.update()', () => {
             expect(hub.db.updatePersonDeprecated).not.toHaveBeenCalled()
 
             // verify Postgres persons
-            const persons = await fetchPostgresPersonsH()
+            const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons.length).toEqual(1)
             expect(persons[0]).toEqual(person)
         })
@@ -901,7 +903,7 @@ describe('PersonState.update()', () => {
             expect(hub.db.updatePersonDeprecated).toHaveBeenCalledTimes(1)
 
             // verify Postgres persons
-            const persons = await fetchPostgresPersonsH()
+            const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons.length).toEqual(1)
             expect(persons[0]).toEqual(person)
 
@@ -917,7 +919,7 @@ describe('PersonState.update()', () => {
             const mergeDeletedPerson: InternalPerson = {
                 created_at: timestamp,
                 version: 0,
-                id: 0,
+                id: BigInt(0),
                 team_id: teamId,
                 properties: { a: 5, b: 7 },
                 is_user_id: 0,
@@ -959,7 +961,7 @@ describe('PersonState.update()', () => {
             expect(hub.db.updatePersonDeprecated).toHaveBeenCalledTimes(2)
 
             // verify Postgres persons
-            const persons = await fetchPostgresPersonsH()
+            const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons.length).toEqual(1)
             expect(persons[0]).toEqual(person)
         })
@@ -1159,7 +1161,7 @@ describe('PersonState.update()', () => {
             )
 
             // verify Postgres persons
-            const persons = await fetchPostgresPersonsH()
+            const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons.length).toEqual(1)
             expect(persons[0]).toEqual(person)
             expect([newUserUuid, oldUserUuid]).toContain(persons[0].uuid)
@@ -1226,7 +1228,7 @@ describe('PersonState.update()', () => {
             )
 
             // verify Postgres persons
-            const persons = await fetchPostgresPersonsH()
+            const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons.length).toEqual(1)
             expect(persons[0]).toEqual(person)
             expect([newUserUuid, oldUserUuid]).toContain(persons[0].uuid)
@@ -1295,7 +1297,7 @@ describe('PersonState.update()', () => {
             )
 
             // verify Postgres persons
-            const persons = (await fetchPostgresPersonsH()).sort((a, b) => a.id - b.id)
+            const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons.length).toEqual(2)
             expect(persons[0]).toEqual(
                 expect.objectContaining({
@@ -1346,7 +1348,7 @@ describe('PersonState.update()', () => {
             )
 
             // verify Postgres persons
-            const persons = (await fetchPostgresPersonsH()).sort((a, b) => a.id - b.id)
+            const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons.length).toEqual(2)
             expect(persons[0]).toEqual(
                 expect.objectContaining({
@@ -1399,7 +1401,7 @@ describe('PersonState.update()', () => {
             )
 
             // verify Postgres persons
-            const persons = await fetchPostgresPersonsH()
+            const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons.length).toEqual(1)
             expect(persons[0]).toEqual(person)
             expect([newUserUuid, oldUserUuid]).toContain(persons[0].uuid)
@@ -1481,7 +1483,7 @@ describe('PersonState.update()', () => {
             )
             // expect(hub.db.updatePersonDeprecated).not.toHaveBeenCalled()
             // verify Postgres persons
-            const persons = await fetchPostgresPersonsH()
+            const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons.length).toEqual(1)
             expect(persons[0]).toEqual(person)
 
@@ -1579,7 +1581,7 @@ describe('PersonState.update()', () => {
             )
 
             // verify Postgres persons
-            const persons = await fetchPostgresPersonsH()
+            const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons.length).toEqual(1)
             expect(persons[0]).toEqual(person)
             expect([newUserUuid, oldUserUuid]).toContain(persons[0].uuid)
@@ -2002,7 +2004,7 @@ describe('PersonState.update()', () => {
             expect(hub.db.updatePersonDeprecated).toHaveBeenCalledTimes(1)
             expect(hub.db.kafkaProducer.queueMessages).toHaveBeenCalledTimes(1)
             // verify Postgres persons
-            const persons = await fetchPostgresPersonsH()
+            const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons.length).toEqual(1)
             expect(persons[0]).toEqual(person)
 
@@ -2081,7 +2083,7 @@ describe('PersonState.update()', () => {
             jest.spyOn(hub.db.postgres, 'transaction').mockRestore()
             expect(hub.db.kafkaProducer.queueMessages).not.toBeCalled()
             // verify Postgres persons
-            const persons = await fetchPostgresPersonsH()
+            const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons).toEqual(
                 expect.arrayContaining([
                     expect.objectContaining({
@@ -2129,7 +2131,7 @@ describe('PersonState.update()', () => {
             jest.spyOn(state, 'mergePeople').mockRestore()
             expect(hub.db.kafkaProducer.queueMessages).not.toBeCalled()
             // verify Postgres persons
-            const persons = await fetchPostgresPersonsH()
+            const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons).toEqual(
                 expect.arrayContaining([
                     expect.objectContaining({
@@ -2182,7 +2184,7 @@ describe('PersonState.update()', () => {
             jest.spyOn(state, 'mergePeople').mockRestore()
             expect(hub.db.kafkaProducer.queueMessages).not.toBeCalled()
             // verify Postgres persons
-            const persons = await fetchPostgresPersonsH()
+            const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons).toEqual(
                 expect.arrayContaining([
                     expect.objectContaining({

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -363,7 +363,7 @@ describe('PersonState.update()', () => {
 
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: newUserUuid,
                     properties: { $creator_event_uuid: event_uuid, null_byte: '\uFFFD' },
                     created_at: timestamp,
@@ -398,7 +398,7 @@ describe('PersonState.update()', () => {
 
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: newUserUuid,
                     properties: { $creator_event_uuid: originalEventUuid, c: 420 },
                     created_at: timestamp,
@@ -459,7 +459,7 @@ describe('PersonState.update()', () => {
             // if creation fails we should return the person that another thread already created
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: newUserUuid,
                     properties: {},
                     created_at: timestamp,
@@ -501,7 +501,7 @@ describe('PersonState.update()', () => {
             // if creation fails we should return the person that another thread already created
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: newUserUuid,
                     properties: { b: 4, c: 4, e: 4 },
                     created_at: timestamp,
@@ -584,7 +584,7 @@ describe('PersonState.update()', () => {
 
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: newUserUuid,
                     // `null_byte` validates that `sanitizeJsonbValue` is working as expected
                     properties: { b: 4, c: 4, e: 4, toString: 1, null_byte: '\uFFFD' },
@@ -622,7 +622,7 @@ describe('PersonState.update()', () => {
 
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: newUserUuid,
                     properties: originalPersonProperties,
                     created_at: timestamp,
@@ -656,7 +656,7 @@ describe('PersonState.update()', () => {
 
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: newUserUuid,
                     properties: { $current_url: 4 }, // Here we keep 4 for passing forward to PoE
                     created_at: timestamp,
@@ -671,7 +671,7 @@ describe('PersonState.update()', () => {
             const persons = sortPersons(await fetchPostgresPersonsH())
             expect(persons).toEqual([
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: newUserUuid,
                     properties: { $current_url: 123 }, // We didn 't update this as it's auto added and it's not a person event
                     created_at: timestamp,
@@ -698,7 +698,7 @@ describe('PersonState.update()', () => {
 
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: newUserUuid,
                     properties: { $current_url: 4 }, // Here we keep 4 for passing forward to PoE
                     created_at: timestamp,
@@ -732,7 +732,7 @@ describe('PersonState.update()', () => {
 
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: newUserUuid,
                     properties: { $initial_current_url: 4 }, // Here we keep 4 for passing forward to PoE
                     created_at: timestamp,
@@ -774,7 +774,7 @@ describe('PersonState.update()', () => {
 
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: newUserUuid,
                     properties: { $initial_current_url: 4 }, // Here we keep 4 for passing forward to PoE
                     created_at: timestamp,
@@ -821,7 +821,7 @@ describe('PersonState.update()', () => {
 
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: newUserUuid,
                     properties: { b: 4, c: 4, e: 4 },
                     created_at: timestamp,
@@ -856,7 +856,7 @@ describe('PersonState.update()', () => {
 
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: newUserUuid,
                     properties: { b: 3, c: 4 },
                     created_at: timestamp,
@@ -890,7 +890,7 @@ describe('PersonState.update()', () => {
             await kafkaAcks
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: newUserUuid,
                     properties: {},
                     created_at: timestamp,
@@ -919,7 +919,7 @@ describe('PersonState.update()', () => {
             const mergeDeletedPerson: InternalPerson = {
                 created_at: timestamp,
                 version: 0,
-                id: BigInt(0),
+                id: '0',
                 team_id: teamId,
                 properties: { a: 5, b: 7 },
                 is_user_id: 0,
@@ -948,7 +948,7 @@ describe('PersonState.update()', () => {
 
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: newUserUuid,
                     properties: { a: 7, c: 8, d: 9 },
                     created_at: timestamp,
@@ -998,7 +998,7 @@ describe('PersonState.update()', () => {
 
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: newUserUuid,
                     properties: { foo: 'bar' },
                     created_at: timestamp,
@@ -1038,7 +1038,7 @@ describe('PersonState.update()', () => {
 
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: newUserUuid,
                     properties: {},
                     created_at: timestamp,
@@ -1073,7 +1073,7 @@ describe('PersonState.update()', () => {
             const persons = await fetchPostgresPersonsH()
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: newUserUuid,
                     properties: {},
                     created_at: timestamp,
@@ -1112,7 +1112,7 @@ describe('PersonState.update()', () => {
 
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: oldUserUuid,
                     properties: {},
                     created_at: timestamp,
@@ -1151,7 +1151,7 @@ describe('PersonState.update()', () => {
 
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: expect.any(String),
                     properties: {},
                     created_at: timestamp,
@@ -1218,7 +1218,7 @@ describe('PersonState.update()', () => {
 
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: expect.any(String),
                     properties: {},
                     created_at: timestamp,
@@ -1287,7 +1287,7 @@ describe('PersonState.update()', () => {
             expect(personS.updateIsIdentified).toBeTruthy()
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: newUserUuid,
                     properties: {},
                     created_at: timestamp2,
@@ -1301,7 +1301,7 @@ describe('PersonState.update()', () => {
             expect(persons.length).toEqual(2)
             expect(persons[0]).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: oldUserUuid,
                     properties: {},
                     created_at: timestamp,
@@ -1338,7 +1338,7 @@ describe('PersonState.update()', () => {
 
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: newUserUuid,
                     properties: {},
                     created_at: timestamp2,
@@ -1352,7 +1352,7 @@ describe('PersonState.update()', () => {
             expect(persons.length).toEqual(2)
             expect(persons[0]).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: oldUserUuid,
                     properties: {},
                     created_at: timestamp,
@@ -1391,7 +1391,7 @@ describe('PersonState.update()', () => {
 
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: expect.any(String),
                     properties: { a: 1, b: 3, c: 4, d: 6, e: 7, f: 9 },
                     created_at: timestamp,
@@ -1473,7 +1473,7 @@ describe('PersonState.update()', () => {
             // if creation fails we should return the person that another thread already created
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: oldUserUuid,
                     properties: {},
                     created_at: timestamp,
@@ -1571,7 +1571,7 @@ describe('PersonState.update()', () => {
 
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: expect.any(String),
                     properties: {},
                     created_at: timestamp,
@@ -1943,7 +1943,7 @@ describe('PersonState.update()', () => {
 
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: firstUserUuid,
                     properties: {},
                     created_at: timestamp,
@@ -1992,7 +1992,7 @@ describe('PersonState.update()', () => {
 
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     uuid: firstUserUuid,
                     properties: {},
                     created_at: timestamp,
@@ -2087,7 +2087,7 @@ describe('PersonState.update()', () => {
             expect(persons).toEqual(
                 expect.arrayContaining([
                     expect.objectContaining({
-                        id: expect.any(Number),
+                        id: expect.any(String),
                         uuid: firstUserUuid,
                         properties: {},
                         created_at: timestamp,
@@ -2095,7 +2095,7 @@ describe('PersonState.update()', () => {
                         is_identified: false,
                     }),
                     expect.objectContaining({
-                        id: expect.any(Number),
+                        id: expect.any(String),
                         uuid: secondUserUuid,
                         properties: {},
                         created_at: timestamp,
@@ -2135,7 +2135,7 @@ describe('PersonState.update()', () => {
             expect(persons).toEqual(
                 expect.arrayContaining([
                     expect.objectContaining({
-                        id: expect.any(Number),
+                        id: expect.any(String),
                         uuid: firstUserUuid,
                         properties: {},
                         created_at: timestamp,
@@ -2143,7 +2143,7 @@ describe('PersonState.update()', () => {
                         is_identified: false,
                     }),
                     expect.objectContaining({
-                        id: expect.any(Number),
+                        id: expect.any(String),
                         uuid: secondUserUuid,
                         properties: {},
                         created_at: timestamp,
@@ -2188,7 +2188,7 @@ describe('PersonState.update()', () => {
             expect(persons).toEqual(
                 expect.arrayContaining([
                     expect.objectContaining({
-                        id: expect.any(Number),
+                        id: expect.any(String),
                         uuid: firstUserUuid,
                         properties: {},
                         created_at: timestamp,
@@ -2196,7 +2196,7 @@ describe('PersonState.update()', () => {
                         is_identified: false,
                     }),
                     expect.objectContaining({
-                        id: expect.any(Number),
+                        id: expect.any(String),
                         uuid: secondUserUuid,
                         properties: {},
                         created_at: timestamp,

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -534,7 +534,7 @@ describe('PersonState.update()', () => {
 
             expect(person).toEqual(
                 expect.objectContaining({
-                    id: expect.any(Number),
+                    id: expect.any(BigInt),
                     uuid: newUserUuid,
                     properties: { a: 1, b: 3, c: 4 },
                     created_at: timestamp,

--- a/plugin-server/tests/worker/ingestion/postgres-parity.test.ts
+++ b/plugin-server/tests/worker/ingestion/postgres-parity.test.ts
@@ -110,7 +110,7 @@ describe('postgres parity', () => {
         const postgresPersons = await hub.db.fetchPersons(Database.Postgres)
         expect(postgresPersons).toEqual([
             {
-                id: expect.any(Number),
+                id: expect.any(String),
                 created_at: expect.any(DateTime),
                 properties: {
                     userProp: 'propValue',


### PR DESCRIPTION
## Problem

The schema was updated to match prod which then had unexpected test issues as BigInts are returned as strings.


## Changes

* Updates the type to be correct
* Leaves it as a string as that is what the prod code was doing and fortunately all works as expected
* Moving to `bigint` type was tried but it has a bunch of other complications - we don't actually need it

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
