### PR TITLE
chore(temporal): Add exception logging in ClickHouse liveness check

### DIFF
--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -14,6 +14,7 @@ import structlog
 from django.conf import settings
 
 import posthog.temporal.common.asyncpa as asyncpa
+from posthog.temporal.common.logger import get_internal_logger
 
 logger = structlog.get_logger()
 
@@ -157,6 +158,9 @@ class ClickHouseClient:
         self.connector: None | aiohttp.TCPConnector = None
         self.session: None | aiohttp.ClientSession = None
 
+        logger = get_internal_logger()
+        self.logger = logger.bind(url=url, database=database, user=user)
+
         if user:
             self.headers["X-ClickHouse-User"] = user
         if password:
@@ -194,6 +198,7 @@ class ClickHouseClient:
                 raise_for_status=True,
             )
         except aiohttp.ClientResponseError:
+            await self.logger.aexception("Failed ClickHouse liveness check")
             return False
         return True
 

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -197,8 +197,8 @@ class ClickHouseClient:
                 headers=self.headers,
                 raise_for_status=True,
             )
-        except aiohttp.ClientResponseError:
-            await self.logger.aexception("Failed ClickHouse liveness check")
+        except aiohttp.ClientResponseError as exc:
+            await self.logger.aexception("Failed ClickHouse liveness check", exc_info=exc)
             return False
         return True
 


### PR DESCRIPTION
## Problem

When a ClickHouse liveness check fails, we assume it's safe to retry, but we could be masking connection problems that could require a more manual intervention to fix.

To address this, we simply add some logging on what exception failed the liveness check, including some relevant context variables.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
