### PR TITLE
perf(queries): Default to using blocking loading for queries

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -171,7 +171,6 @@ export interface ActivityLogPaginatedResponse<T> extends PaginatedResponse<T> {
 export interface ApiMethodOptions {
     signal?: AbortSignal
     headers?: Record<string, any>
-    async?: boolean
 }
 
 export class ApiError extends Error {

--- a/frontend/src/lib/components/Metalytics/metalyticsLogic.ts
+++ b/frontend/src/lib/components/Metalytics/metalyticsLogic.ts
@@ -31,7 +31,7 @@ export const metalyticsLogic = kea<metalyticsLogicType>([
                     }
 
                     // NOTE: I think this gets cached heavily - how to correctly invalidate?
-                    const response = await api.query(query, undefined, undefined, true)
+                    const response = await api.query(query, undefined, undefined, 'force_blocking')
                     const result = response.results as number[][]
                     return {
                         views: result[0][0],
@@ -54,7 +54,7 @@ export const metalyticsLogic = kea<metalyticsLogicType>([
                             ORDER BY timestamp DESC`,
                     }
 
-                    const response = await api.query(query, undefined, undefined, true)
+                    const response = await api.query(query, undefined, undefined, 'force_blocking')
                     return response.results.map((result) => result[0]) as string[]
                 },
             },

--- a/frontend/src/lib/components/VersionChecker/versionCheckerLogic.ts
+++ b/frontend/src/lib/components/VersionChecker/versionCheckerLogic.ts
@@ -100,7 +100,7 @@ export const versionCheckerLogic = kea<versionCheckerLogicType>([
                                 limit 10`,
                     }
 
-                    const res = await api.query(query, undefined, undefined, true)
+                    const res = await api.query(query, undefined, undefined, 'force_blocking')
 
                     return (
                         res.results

--- a/frontend/src/queries/nodes/DataNode/Reload.tsx
+++ b/frontend/src/queries/nodes/DataNode/Reload.tsx
@@ -5,9 +5,10 @@ import { Spinner } from 'lib/lemon-ui/Spinner'
 
 import { dataNodeCollectionLogic } from '~/queries/nodes/DataNode/dataNodeCollectionLogic'
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
+import { shouldQueryBeAsync } from '~/queries/utils'
 
 export function Reload(): JSX.Element {
-    const { responseLoading } = useValues(dataNodeLogic)
+    const { responseLoading, query } = useValues(dataNodeLogic)
     const { loadData, cancelQuery } = useActions(dataNodeLogic)
 
     return (
@@ -17,7 +18,7 @@ export function Reload(): JSX.Element {
                 if (responseLoading) {
                     cancelQuery()
                 } else {
-                    loadData(true)
+                    loadData(shouldQueryBeAsync(query) ? 'force_async' : 'force_blocking')
                 }
             }}
             // Setting the loading icon manually to capture clicks while spinning.

--- a/frontend/src/queries/nodes/DataNode/dataNodeCollectionLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeCollectionLogic.ts
@@ -1,10 +1,12 @@
 import { actions, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 
+import { RefreshType } from '~/queries/schema/schema-general'
+
 import type { dataNodeCollectionLogicType } from './dataNodeCollectionLogicType'
 
 export interface DataNodeRegisteredProps {
     id: string
-    loadData: (refresh: boolean) => void
+    loadData: (refresh?: RefreshType) => void
     cancelQuery: () => void
 }
 
@@ -79,7 +81,10 @@ export const dataNodeCollectionLogic = kea<dataNodeCollectionLogicType>([
     }),
     listeners(({ values }) => ({
         reloadAll: () => {
-            values.mountedDataNodes.forEach((node) => node.loadData(true))
+            // We want to force refresh all nodes, so we use 'force_async' to bypass cache
+            // The loadData function in each node will handle converting this to the appropriate type
+            // based on whether the node is an insight or not
+            values.mountedDataNodes.forEach((node) => node.loadData('force_async'))
         },
         cancelAllLoading: () => {
             values.mountedDataNodes.forEach((node) => {

--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.test.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.test.ts
@@ -469,10 +469,10 @@ describe('dataNodeLogic', () => {
         expect(performQuery).toHaveBeenCalledWith(
             query,
             expect.anything(),
-            false,
+            'blocking',
             expect.any(String),
             expect.any(Function),
-            filtersOverride,
+            { date_from: '2022-12-24T17:00:41.165000Z' },
             undefined,
             false
         )
@@ -502,11 +502,11 @@ describe('dataNodeLogic', () => {
         expect(performQuery).toHaveBeenCalledWith(
             query,
             expect.anything(),
-            false,
+            'blocking',
             expect.any(String),
             expect.any(Function),
             undefined,
-            variablesOverride,
+            { test_1: { code_name: 'some_name', value: 'hello world', variableId: 'some_id' } },
             false
         )
     })
@@ -527,7 +527,7 @@ describe('dataNodeLogic', () => {
         expect(performQuery).toHaveBeenCalledWith(
             query,
             expect.anything(),
-            false,
+            'blocking',
             expect.any(String),
             expect.any(Function),
             undefined,
@@ -552,7 +552,7 @@ describe('dataNodeLogic', () => {
         expect(performQuery).toHaveBeenCalledWith(
             query,
             expect.anything(),
-            false,
+            'blocking',
             expect.any(String),
             expect.any(Function),
             undefined,

--- a/frontend/src/queries/nodes/DataTable/dataTableLogic.test.ts
+++ b/frontend/src/queries/nodes/DataTable/dataTableLogic.test.ts
@@ -61,10 +61,10 @@ describe('dataTableLogic', () => {
         })
 
         expect(performQuery).toHaveBeenCalledWith(
-            dataTableQuery.source,
-            expect.anything(),
-            false,
-            expect.any(String),
+            { kind: 'EventsQuery', select: ['*', 'event', 'timestamp'] },
+            { signal: {} },
+            'blocking',
+            'bc5142b8-0f5d-49ad-b2a5-0159af8cec24',
             expect.any(Function),
             undefined,
             undefined,

--- a/frontend/src/queries/nodes/DataTable/dataTableLogic.test.ts
+++ b/frontend/src/queries/nodes/DataTable/dataTableLogic.test.ts
@@ -62,9 +62,9 @@ describe('dataTableLogic', () => {
 
         expect(performQuery).toHaveBeenCalledWith(
             { kind: 'EventsQuery', select: ['*', 'event', 'timestamp'] },
-            { signal: {} },
+            { signal: expect.any(Object) },
             'blocking',
-            'bc5142b8-0f5d-49ad-b2a5-0159af8cec24',
+            expect.any(String),
             expect.any(Function),
             undefined,
             undefined,

--- a/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
@@ -26,6 +26,7 @@ import {
     NodeKind,
 } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
+import { shouldQueryBeAsync } from '~/queries/utils'
 import { ChartDisplayType, ExportContext, ExporterFormat, InsightLogicProps } from '~/types'
 
 import { dataNodeLogic, DataNodeLogicProps } from '../DataNode/dataNodeLogic'
@@ -120,7 +121,11 @@ export function DataTableVisualization({
                             sourceQuery: query,
                             setQuery: setQuery,
                             onUpdate: (query: DataVisualizationNode) => {
-                                loadData(true, undefined, query.source)
+                                loadData(
+                                    shouldQueryBeAsync(query.source) ? 'force_async' : 'force_blocking',
+                                    undefined,
+                                    query.source
+                                )
                             },
                         }}
                     >

--- a/frontend/src/queries/nodes/InsightViz/ComputationTimeWithRefresh.tsx
+++ b/frontend/src/queries/nodes/InsightViz/ComputationTimeWithRefresh.tsx
@@ -7,10 +7,12 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { userLogic } from 'scenes/userLogic'
 
+import { shouldQueryBeAsync } from '~/queries/utils'
+
 import { dataNodeLogic } from '../DataNode/dataNodeLogic'
 
 export function ComputationTimeWithRefresh({ disableRefresh }: { disableRefresh?: boolean }): JSX.Element | null {
-    const { lastRefresh, response } = useValues(dataNodeLogic)
+    const { lastRefresh, response, query } = useValues(dataNodeLogic)
 
     const { insightProps } = useValues(insightLogic)
     const { getInsightRefreshButtonDisabledReason } = useValues(insightDataLogic(insightProps))
@@ -41,7 +43,7 @@ export function ComputationTimeWithRefresh({ disableRefresh }: { disableRefresh?
                         }
                     >
                         <Link
-                            onClick={() => loadData(true)}
+                            onClick={() => loadData(shouldQueryBeAsync(query) ? 'force_async' : 'force_blocking')}
                             className={disabledReason ? 'opacity-50' : ''}
                             disabledReason={canBypassRefreshDisabled ? '' : disabledReason}
                         >

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -21,8 +21,9 @@ import {
     isDataTableNode,
     isDataVisualizationNode,
     isHogQLQuery,
-    isInsightVizNode,
+    isInsightQueryNode,
     isPersonsNode,
+    shouldQueryBeAsync,
 } from './utils'
 
 const QUERY_ASYNC_MAX_INTERVAL_SECONDS = 3
@@ -35,20 +36,15 @@ export function queryExportContext<N extends DataNode>(
     methodOptions?: ApiMethodOptions,
     refresh?: boolean
 ): OnlineExportContext | QueryExportContext {
-    if (isInsightVizNode(query) || isDataTableNode(query) || isDataVisualizationNode(query)) {
+    if (isDataTableNode(query) || isDataVisualizationNode(query)) {
         return queryExportContext(query.source, methodOptions, refresh)
+    } else if (isInsightQueryNode(query)) {
+        return { source: query }
     } else if (isPersonsNode(query)) {
         return { path: getPersonsEndpoint(query) }
     }
     return { source: query }
 }
-
-const SYNC_ONLY_QUERY_KINDS = [
-    'HogQuery',
-    'HogQLMetadata',
-    'HogQLAutocomplete',
-    'DatabaseSchemaQuery',
-] satisfies NodeKind[keyof NodeKind][]
 
 export async function pollForResults(
     queryId: string,
@@ -95,17 +91,21 @@ async function executeQuery<N extends DataNode>(
      */
     pollOnly = false
 ): Promise<NonNullable<N['response']>> {
-    const isAsyncQuery = methodOptions?.async !== false && !SYNC_ONLY_QUERY_KINDS.includes(queryNode.kind)
-
     const useOptimizedPolling = posthog.isFeatureEnabled('query-optimized-polling')
     const currentTeamId = teamLogic.findMounted()?.values.currentTeamId
 
     if (!pollOnly) {
-        const refreshParam: RefreshType | undefined = isAsyncQuery
-            ? refresh === true
-                ? 'force_async'
-                : 'async'
-            : refresh
+        // Determine the refresh type based on the query node type and refresh parameter
+        let refreshParam: RefreshType
+
+        // Handle insight-related queries - they should always be async
+        if (shouldQueryBeAsync(queryNode)) {
+            // For insight queries, use async variants but preserve explicit force requests
+            refreshParam = refresh || 'async'
+        } else {
+            // For other queries, use blocking unless explicitly set to a different RefreshType
+            refreshParam = refresh || 'blocking'
+        }
 
         if (useOptimizedPolling) {
             return new Promise((resolve, reject) => {
@@ -178,7 +178,7 @@ async function executeQuery<N extends DataNode>(
 
         queryId = response.query_status.id
     } else {
-        if (!isAsyncQuery) {
+        if (refresh !== 'async' && refresh !== 'force_async') {
             throw new Error('pollOnly is only supported for async queries')
         }
         if (!queryId) {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -14552,39 +14552,16 @@
             "type": "object"
         },
         "RefreshType": {
-            "anyOf": [
-                {
-                    "type": "boolean"
-                },
-                {
-                    "const": "async",
-                    "type": "string"
-                },
-                {
-                    "const": "async_except_on_cache_miss",
-                    "type": "string"
-                },
-                {
-                    "const": "blocking",
-                    "type": "string"
-                },
-                {
-                    "const": "force_async",
-                    "type": "string"
-                },
-                {
-                    "const": "force_blocking",
-                    "type": "string"
-                },
-                {
-                    "const": "force_cache",
-                    "type": "string"
-                },
-                {
-                    "const": "lazy_async",
-                    "type": "string"
-                }
-            ]
+            "enum": [
+                "async",
+                "async_except_on_cache_miss",
+                "blocking",
+                "force_async",
+                "force_blocking",
+                "force_cache",
+                "lazy_async"
+            ],
+            "type": "string"
         },
         "ResultCustomization": {
             "anyOf": [

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1289,7 +1289,6 @@ export type LifecycleFilter = {
 }
 
 export type RefreshType =
-    | boolean
     | 'async'
     | 'async_except_on_cache_miss'
     | 'blocking'

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -254,6 +254,15 @@ export function isAsyncResponse(response: NonNullable<QuerySchema['response']>):
     return 'query_status' in response && response.query_status
 }
 
+export function shouldQueryBeAsync(query: Node): boolean {
+    return (
+        isInsightQueryNode(query) ||
+        isHogQLQuery(query) ||
+        (isDataTableNode(query) && isInsightQueryNode(query.source)) ||
+        (isDataVisualizationNode(query) && isInsightQueryNode(query.source))
+    )
+}
+
 export function isInsightQueryWithSeries(
     node?: Node
 ): node is TrendsQuery | FunnelsQuery | StickinessQuery | LifecycleQuery {

--- a/frontend/src/scenes/cohorts/CohortEdit.tsx
+++ b/frontend/src/scenes/cohorts/CohortEdit.tsx
@@ -295,7 +295,7 @@ export function CohortEdit({ id }: CohortLogicProps): JSX.Element {
                                     minutes.
                                 </div>
                             ) : (
-                                <Query query={query} setQuery={setQuery} context={{ refresh: true }} />
+                                <Query query={query} setQuery={setQuery} context={{ refresh: 'force_blocking' }} />
                             )}
                         </div>
                     </>

--- a/frontend/src/scenes/data-warehouse/editor/EditorScene.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/EditorScene.tsx
@@ -100,7 +100,7 @@ export function EditorScene(): JSX.Element {
         sourceQuery,
         setQuery: setSourceQuery,
         onUpdate: (query) => {
-            loadData(true, undefined, query.source)
+            loadData('force_async', undefined, query.source)
         },
     }
 

--- a/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
@@ -520,7 +520,7 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
             dataNodeLogic({
                 key: values.currentDataLogicKey,
                 query: newSource,
-            }).actions.loadData(!switchTab)
+            }).actions.loadData(!switchTab ? 'force_async' : 'async')
         },
         saveAsView: async () => {
             LemonDialog.openForm({

--- a/frontend/src/scenes/error-tracking/errorTrackingIssueSceneLogic.ts
+++ b/frontend/src/scenes/error-tracking/errorTrackingIssueSceneLogic.ts
@@ -80,7 +80,7 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
                         }),
                         {},
                         undefined,
-                        true
+                        'force_blocking'
                     )
 
                     // ErrorTrackingQuery returns a list of issues

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeCalculatorLogic.tsx
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeCalculatorLogic.tsx
@@ -191,7 +191,7 @@ export const runningTimeCalculatorLogic = kea<runningTimeCalculatorLogicType>([
                         ? getSumQuery(metric, values.experiment)
                         : getFunnelQuery(metric, values.experiment)
 
-                const result = (await performQuery(query, undefined, true)) as Partial<TrendsQueryResponse>
+                const result = (await performQuery(query, undefined, 'force_blocking')) as Partial<TrendsQueryResponse>
 
                 return {
                     uniqueUsers: result?.results?.[0]?.count ?? null,

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -154,7 +154,7 @@ const loadMetrics = async ({
                         experiment_id: experimentId,
                     }
                 }
-                const response = await performQuery(queryWithExperimentId, undefined, refresh)
+                const response = await performQuery(queryWithExperimentId, undefined, refresh ? 'force_async' : 'async')
 
                 results[index] = {
                     ...response,
@@ -1405,7 +1405,7 @@ export const experimentLogic = kea<experimentLogicType>([
                         kind: NodeKind.ExperimentExposureQuery,
                         experiment_id: props.experimentId,
                     }
-                    return await performQuery(query, undefined, refresh)
+                    return await performQuery(query, undefined, refresh ? 'force_async' : 'async')
                 },
             },
         ],

--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -140,7 +140,7 @@ export function Group(): JSX.Element {
                             <Query
                                 query={groupEventsQuery}
                                 setQuery={setGroupEventsQuery}
-                                context={{ refresh: true }}
+                                context={{ refresh: 'force_blocking' }}
                             />
                         ) : (
                             <Spinner />

--- a/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
@@ -186,7 +186,7 @@ export const entityFilterLogic = kea<entityFilterLogicType>([
             const dataLogic = insightDataLogic.findMounted({
                 dashboardItemId: props.typeKey,
             })
-            dataLogic?.actions?.loadData(true)
+            dataLogic?.actions?.loadData('force_async')
         },
         hideModal: () => {
             actions.selectFilter(null)

--- a/frontend/src/scenes/pipeline/hogfunctions/logs/hogFunctionLogsLogic.ts
+++ b/frontend/src/scenes/pipeline/hogfunctions/logs/hogFunctionLogsLogic.ts
@@ -55,7 +55,7 @@ const loadClickhouseEvents = async (
         `,
     }
 
-    const response = await api.query(query, undefined, undefined, true, {
+    const response = await api.query(query, undefined, undefined, 'force_blocking', {
         date_from: date_from,
         date_to: date_to,
     })

--- a/frontend/src/scenes/pipeline/hogfunctions/logs/logsViewerLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/logs/logsViewerLogic.tsx
@@ -78,7 +78,7 @@ const loadGroupedLogs = async (request: GroupedLogEntryRequest): Promise<Grouped
         ORDER BY latest_timestamp DESC`,
     }
 
-    const response = await api.query(query, undefined, undefined, true, {
+    const response = await api.query(query, undefined, undefined, 'force_blocking', {
         date_from: request.date_from ?? '-7d',
         date_to: request.date_to,
     })

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
@@ -175,7 +175,7 @@ export const personsModalLogic = kea<personsModalLogicType>([
                         kind: NodeKind.InsightActorsQueryOptions,
                         source: query,
                     }
-                    const response = await performQuery(optionsQuery, { async: false })
+                    const response = await performQuery(optionsQuery, {}, 'blocking')
 
                     return Object.fromEntries(
                         Object.entries(response).filter(([key, _]) =>

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1560,6 +1560,16 @@ class RecordingPropertyFilter(BaseModel):
     value: Optional[Union[str, float, list[Union[str, float]]]] = None
 
 
+class RefreshType(StrEnum):
+    ASYNC_ = "async"
+    ASYNC_EXCEPT_ON_CACHE_MISS = "async_except_on_cache_miss"
+    BLOCKING = "blocking"
+    FORCE_ASYNC = "force_async"
+    FORCE_BLOCKING = "force_blocking"
+    FORCE_CACHE = "force_cache"
+    LAZY_ASYNC = "lazy_async"
+
+
 class ResultCustomizationBase(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -9182,8 +9192,8 @@ class QueryRequest(BaseModel):
         ),
         discriminator="kind",
     )
-    refresh: Optional[Union[bool, str]] = Field(
-        default="blocking",
+    refresh: Optional[RefreshType] = Field(
+        default=RefreshType.BLOCKING,
         description=(
             "Whether results should be calculated sync or async, and how much to rely on the cache:\n- `'blocking'` -"
             " calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in"

--- a/products/llm_observability/frontend/llmObservabilityLogic.tsx
+++ b/products/llm_observability/frontend/llmObservabilityLogic.tsx
@@ -697,7 +697,7 @@ export const llmObservabilityLogic = kea<llmObservabilityLogicType>([
                     }
                     const mountedInsightDataLogic = insightDataLogic.findMounted(insightProps)
                     if (mountedInsightDataLogic) {
-                        mountedInsightDataLogic.actions.loadData(true)
+                        mountedInsightDataLogic.actions.loadData('force_blocking')
                     }
                     actions.setRefreshStatus(`tile-${index}`, false)
                 })

--- a/products/llm_observability/frontend/llmObservabilityTraceDataLogic.ts
+++ b/products/llm_observability/frontend/llmObservabilityTraceDataLogic.ts
@@ -30,7 +30,6 @@ function getDataNodeLogicProps({ traceId, query, cachedResults }: TraceDataLogic
         query: query.source,
         key: vizKey,
         dataNodeCollectionId: traceId,
-        refresh: false,
         cachedResults: cachedResults || undefined,
     }
     return dataNodeLogicProps

--- a/products/llm_observability/frontend/llmObservabilityTraceLogic.ts
+++ b/products/llm_observability/frontend/llmObservabilityTraceLogic.ts
@@ -30,7 +30,6 @@ export function getDataNodeLogicProps({
         query: query.source,
         key: vizKey,
         dataNodeCollectionId: traceId,
-        refresh: false,
         cachedResults: cachedResults || undefined,
     }
     return dataNodeLogicProps


### PR DESCRIPTION
## Problem

For _most_ type of queries outside of insisghts a 60 second timeout should be fine. Also, the frontend logic around refreshing was kind of complicated, with multiple places where something could be refreshed. This just aligns it to what the backend expects, and will force devs to make a decision on whether they want blocking or async.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
