### PR TITLE
chore(temporal): Flush heartbeats more frequently

### DIFF
--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -56,6 +56,9 @@ async def start_worker(
         activity_executor=ThreadPoolExecutor(max_workers=max_concurrent_activities or 50),
         max_concurrent_activities=max_concurrent_activities or 50,
         max_concurrent_workflow_tasks=max_concurrent_workflow_tasks,
+        # Worker will flush heartbeats every
+        # min(heartbeat_timeout * 0.8, max_heartbeat_throttle_interval).
+        max_heartbeat_throttle_interval=timedelta(seconds=5),
     )
 
     # catch the TERM signal, and stop the worker gracefully


### PR DESCRIPTION
## Problem

We are hitting heartbeat timeouts fairly consistently. We are looking into what could be blocking batch exports, but in the meantime, we are trying to heartbeat more frequently to avoid running into timeouts.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Flush heartbeats at most every 5 seconds.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
