### PR TITLE
feat: Add screen dimensions and UA as person property

### DIFF
--- a/frontend/src/lib/taxonomy.tsx
+++ b/frontend/src/lib/taxonomy.tsx
@@ -46,6 +46,11 @@ const PERSON_PROPERTIES_ADAPTED_FROM_EVENT = new Set([
     '$os_version',
     '$referring_domain',
     '$referrer',
+    '$screen_height',
+    '$screen_width',
+    '$viewport_height',
+    '$viewport_width',
+    '$raw_user_agent',
     ...CAMPAIGN_PROPERTIES,
 ])
 

--- a/plugin-server/src/utils/db/utils.ts
+++ b/plugin-server/src/utils/db/utils.ts
@@ -103,6 +103,11 @@ export const eventToPersonProperties = new Set([
     '$os_version',
     '$referring_domain',
     '$referrer',
+    '$screen_height',
+    '$screen_width',
+    '$viewport_height',
+    '$viewport_width',
+    '$raw_user_agent',
 
     ...campaignParams,
 ])

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -50,6 +50,11 @@ PERSON_PROPERTIES_ADAPTED_FROM_EVENT: set[str] = {
     "$os_version",
     "$referring_domain",
     "$referrer",
+    "$screen_height",
+    "$screen_width",
+    "$viewport_height",
+    "$viewport_width",
+    "$raw_user_agent",
     *CAMPAIGN_PROPERTIES,
 }
 


### PR DESCRIPTION
## Problem
These are needed for some conversion destinations

See also https://github.com/PostHog/posthog-js/pull/1840

## Changes

Add screen / viewport dimensions and user agent as person properties

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
n/a
