### PR TITLE
fix: perform backups only on data nodes

### DIFF
--- a/dags/backups.py
+++ b/dags/backups.py
@@ -9,6 +9,7 @@ import dagster
 from django.conf import settings
 import pydantic
 from dags.common import JobOwners
+from posthog.clickhouse.client.connection import NodeRole
 from posthog.clickhouse.cluster import ClickhouseCluster
 
 from dagster_aws.s3 import S3Resource
@@ -315,7 +316,7 @@ def run_backup(
     if backup.shard:
         cluster.map_any_host_in_shards({backup.shard: backup.create}).result()
     else:
-        cluster.any_host(backup.create).result()
+        cluster.any_host_by_role(backup.create, NodeRole.DATA).result()
 
     return backup
 


### PR DESCRIPTION
## Problem

We are creating backups on query nodes. 😑 

## Changes

Do it only in data nodes.

Also, remove steps failures info as it only add noise. Add run tags instead.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes
