### PR TITLE
fix(max): Handle async query and recursion limit errors

### DIFF
--- a/ee/hogai/query_executor/nodes.py
+++ b/ee/hogai/query_executor/nodes.py
@@ -50,7 +50,7 @@ class QueryExecutorNode(AssistantNode):
     def run(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState | None:
         viz_message = state.messages[-1]
         if not isinstance(viz_message, VisualizationMessage):
-            raise ValueError("Can only run summarization with a visualization message as the last one in the state")
+            raise ValueError(f"Expected a visualization message, found {type(viz_message)}")
         if viz_message.answer is None:
             raise ValueError("Did not find query in the visualization message")
 
@@ -70,19 +70,27 @@ class QueryExecutorNode(AssistantNode):
                     else ExecutionMode.CALCULATE_BLOCKING_ALWAYS
                 ),
             ).model_dump(mode="json")
-            if results_response.get("query_status") and not results_response["query_status"]["complete"]:
-                query_id = results_response["query_status"]["id"]
-                for i in range(0, 999):
-                    sleep(i / 2)  # We start at 0.5s and every iteration we wait 0.5s more
-                    query_status = get_query_status(team_id=self._team.pk, query_id=query_id)
-                    if query_status.error:
-                        if query_status.error_message:
-                            raise APIException(query_status.error_message)
-                        else:
-                            raise ValueError("Query failed")
-                    if query_status.complete:
-                        results_response = query_status.results
-                        break
+            # If response has an async query_status, that's always the thing to use
+            if query_status := results_response.get("query_status"):
+                if not query_status["complete"]:
+                    # If it's an in-progress (likely just kicked off) status, let's poll until complete
+                    for wait_ms in range(100, 12000, 100):  # 726 s in total, if my math is correct
+                        sleep(wait_ms / 1000)
+                        query_status = get_query_status(team_id=self._team.pk, query_id=query_status["id"]).model_dump(
+                            mode="json"
+                        )
+                        if query_status["complete"]:
+                            break
+                    else:
+                        raise APIException(
+                            "Query hasn't completed in time. It's worth trying again, maybe with a shorter time range."
+                        )
+                # With results ready, let's first check for errors - then actually use the results
+                if query_status.get("error"):
+                    if error_message := query_status.get("error_message"):
+                        raise APIException(error_message)
+                    raise Exception("Query failed")
+                results_response = query_status["results"]
         except (APIException, ExposedHogQLError, ExposedCHQueryError) as err:
             err_message = str(err)
             if isinstance(err, APIException):
@@ -95,8 +103,8 @@ class QueryExecutorNode(AssistantNode):
                     FailureMessage(content=f"There was an error running this query: {err_message}", id=str(uuid4()))
                 ]
             )
-        except Exception as err:
-            capture_exception(err)
+        except:
+            capture_exception()
             return PartialAssistantState(
                 messages=[FailureMessage(content="There was an unknown error running this query.", id=str(uuid4()))]
             )

--- a/ee/hogai/query_executor/nodes.py
+++ b/ee/hogai/query_executor/nodes.py
@@ -103,8 +103,8 @@ class QueryExecutorNode(AssistantNode):
                     FailureMessage(content=f"There was an error running this query: {err_message}", id=str(uuid4()))
                 ]
             )
-        except:
-            capture_exception()
+        except Exception as err:
+            capture_exception(err)
             return PartialAssistantState(
                 messages=[FailureMessage(content="There was an unknown error running this query.", id=str(uuid4()))]
             )

--- a/ee/hogai/query_executor/test/test_nodes.py
+++ b/ee/hogai/query_executor/test/test_nodes.py
@@ -147,7 +147,7 @@ class TestQueryExecutorNode(ClickhouseTestMixin, BaseTest):
         node = QueryExecutorNode(self.team)
 
         with self.assertRaisesMessage(
-            ValueError, "Can only run summarization with a visualization message as the last one in the state"
+            ValueError, "Expected a visualization message, found <class 'posthog.schema.HumanMessage'>"
         ):
             node.run(
                 AssistantState(

--- a/ee/hogai/root/nodes.py
+++ b/ee/hogai/root/nodes.py
@@ -30,7 +30,8 @@ from posthog.schema import (
     AssistantMessage,
     AssistantToolCall,
     AssistantToolCallMessage,
-    HumanMessage,FailureMessage
+    HumanMessage,
+    FailureMessage,
 )
 
 RouteName = Literal["insights", "root", "end", "search_documentation", "session_recordings_filters"]

--- a/ee/hogai/root/nodes.py
+++ b/ee/hogai/root/nodes.py
@@ -30,7 +30,7 @@ from posthog.schema import (
     AssistantMessage,
     AssistantToolCall,
     AssistantToolCallMessage,
-    HumanMessage,
+    HumanMessage,FailureMessage
 )
 
 RouteName = Literal["insights", "root", "end", "search_documentation", "session_recordings_filters"]
@@ -81,7 +81,7 @@ CONTEXTUAL_TOOL_MODELS = tuple(CONTEXTUAL_TOOL_NAME_TO_TOOL_MODEL.values())
 RootToolCall = create_and_query_insight | search_documentation | search_session_recordings
 root_tools_parser = PydanticToolsParser(tools=[create_and_query_insight, search_documentation, *CONTEXTUAL_TOOL_MODELS])
 
-RootMessageUnion = HumanMessage | AssistantMessage | AssistantToolCallMessage
+RootMessageUnion = HumanMessage | AssistantMessage | FailureMessage | AssistantToolCallMessage
 
 T = TypeVar("T", RootMessageUnion, BaseMessage)
 
@@ -197,7 +197,7 @@ class RootNode(AssistantNode):
             elif isinstance(message, AssistantMessage):
                 # Filter out tool calls without a tool response, so the completion doesn't fail.
                 tool_calls = [
-                    tool for tool in message.model_dump()["tool_calls"] or [] if tool["id"] in tool_result_messages
+                    tool for tool in (message.model_dump()["tool_calls"] or []) if tool["id"] in tool_result_messages
                 ]
 
                 history.append(LangchainAIMessage(content=message.content, tool_calls=tool_calls, id=message.id))
@@ -211,6 +211,10 @@ class RootNode(AssistantNode):
                             content=result_message.content, tool_call_id=tool_call_id, id=result_message.id
                         )
                     )
+            elif isinstance(message, FailureMessage):
+                history.append(
+                    LangchainAIMessage(content=message.content or "An unknown failure occurred.", id=message.id)
+                )
 
         return history
 

--- a/ee/hogai/test/test_assistant.py
+++ b/ee/hogai/test/test_assistant.py
@@ -10,7 +10,7 @@ from langchain_core import messages
 from langchain_core.agents import AgentAction
 from langchain_core.prompts.chat import ChatPromptValue
 from langchain_core.runnables import RunnableConfig, RunnableLambda
-from langgraph.errors import NodeInterrupt
+from langgraph.errors import NodeInterrupt, GraphRecursionError
 from langgraph.graph.state import CompiledStateGraph
 from langgraph.types import StateSnapshot
 from pydantic import BaseModel
@@ -406,6 +406,24 @@ class TestAssistant(ClickhouseTestMixin, NonAtomicBaseTest):
 
             mock.return_value = RunnableLambda(interrupt_graph)
             self._run_assistant_graph(graph, conversation=self.conversation)
+
+    def test_recursion_error_is_handled(self):
+        class FakeStream:
+            def __init__(*args, **kwargs):
+                pass
+
+            def __iter__(self):
+                raise GraphRecursionError()
+
+        with patch("langgraph.pregel.Pregel.stream", side_effect=FakeStream):
+            output = self._run_assistant_graph(conversation=self.conversation)
+            self.assertEqual(output[0][0], "message")
+            self.assertEqual(output[0][1]["content"], "Hello")
+            self.assertEqual(output[1][0], "message")
+            self.assertEqual(
+                output[1][1]["content"],
+                "The assistant has reached the maximum number of steps. You can explicitly ask to continue.",
+            )
 
     def test_new_conversation_handles_serialized_conversation(self):
         graph = (

--- a/ee/hogai/test/test_assistant.py
+++ b/ee/hogai/test/test_assistant.py
@@ -409,7 +409,7 @@ class TestAssistant(ClickhouseTestMixin, NonAtomicBaseTest):
 
     def test_recursion_error_is_handled(self):
         class FakeStream:
-            def __init__(*args, **kwargs):
+            def __init__(self, *args, **kwargs):
                 pass
 
             def __iter__(self):


### PR DESCRIPTION
## Problem

Async query errors were handled correctly in tests, but not in prod. I've unified the logic, so that it applies the same now regardless of the query executing sync or async (prod is async, tests not).
We also didn't have a human-friendly error on the recursion limit being hit.

## Changes

Both classes of errors are now fixed.

## How did you test this code?

Recursion limit got a test. The query execution errors _were_ actually tested already, but the difference is that tests can't use async query execution – so I've ensured those tests continue to pass, and the fix is actually focused on unifying the logic of async vs sync running.