### PR TITLE
fix: Issues with parsing group properties

### DIFF
--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -264,7 +264,10 @@ export class CdpApi {
                 compoundConfiguration.id = new UUIDT().toString()
                 const pluginEvent: PluginEvent = {
                     ...triggerGlobals.event,
-                    ip: triggerGlobals.event.properties.$ip,
+                    ip:
+                        typeof triggerGlobals.event.properties.$ip === 'string'
+                            ? triggerGlobals.event.properties.$ip
+                            : null,
                     site_url: triggerGlobals.project.url,
                     team_id: triggerGlobals.project.id,
                     now: '',

--- a/plugin-server/src/cdp/consumers/cdp-events-consumer.test.ts
+++ b/plugin-server/src/cdp/consumers/cdp-events-consumer.test.ts
@@ -9,9 +9,15 @@ import { HogWatcherState } from '../services/hog-watcher.service'
 import { HogFunctionInvocationGlobals, HogFunctionType } from '../types'
 import { Hub, Team } from '../../types'
 import { closeHub, createHub } from '../../utils/db/hub'
-import { getFirstTeam, resetTestDatabase } from '../../../tests/helpers/sql'
+import { createTeam, getFirstTeam, resetTestDatabase } from '../../../tests/helpers/sql'
 import { HOG_EXAMPLES, HOG_FILTERS_EXAMPLES, HOG_INPUTS_EXAMPLES } from '../_tests/examples'
-import { createHogExecutionGlobals, insertHogFunction as _insertHogFunction } from '../_tests/fixtures'
+import {
+    createHogExecutionGlobals,
+    insertHogFunction as _insertHogFunction,
+    createKafkaMessage,
+    createIncomingEvent,
+    createInternalEvent,
+} from '../_tests/fixtures'
 import { CdpProcessedEventsConsumer } from './cdp-processed-events.consumer'
 import { CdpInternalEventsConsumer } from './cdp-internal-event.consumer'
 
@@ -75,22 +81,25 @@ describe.each([
     let processor: CdpProcessedEventsConsumer | CdpInternalEventsConsumer
     let hub: Hub
     let team: Team
+    let team2: Team
 
     const insertHogFunction = async (hogFunction: Partial<HogFunctionType>) => {
-        const item = await _insertHogFunction(hub.postgres, team.id, {
+        const teamId = hogFunction.team_id ?? team.id
+        const item = await _insertHogFunction(hub.postgres, teamId, {
             ...hogFunction,
             type: hogType,
         })
         // Trigger the reload that django would do
-        processor['hogFunctionManager']['onHogFunctionsReloaded'](team.id, [item.id])
+        processor['hogFunctionManager']['onHogFunctionsReloaded'](teamId, [item.id])
         return item
     }
 
     beforeEach(async () => {
         await resetTestDatabase()
         hub = await createHub()
-
         team = await getFirstTeam(hub)
+        const team2Id = await createTeam(hub.postgres, team.organization_id)
+        team2 = (await hub.teamManager.fetchTeam(team2Id))!
 
         processor = new Consumer(hub)
         await processor.start()
@@ -107,6 +116,41 @@ describe.each([
 
     afterAll(() => {
         jest.useRealTimers()
+    })
+
+    describe('team filtering', () => {
+        it('should not parse events for teams without hog functions', async () => {
+            await insertHogFunction({
+                team_id: team.id,
+                ...HOG_EXAMPLES.simple_fetch,
+                ...HOG_INPUTS_EXAMPLES.simple_fetch,
+                ...HOG_FILTERS_EXAMPLES.no_filters,
+            })
+
+            const events =
+                processor instanceof CdpInternalEventsConsumer
+                    ? [
+                          createKafkaMessage(createInternalEvent(team.id, {})),
+                          createKafkaMessage(createInternalEvent(team2.id, {})),
+                      ]
+                    : [
+                          createKafkaMessage(createIncomingEvent(team.id, {})),
+                          createKafkaMessage(createIncomingEvent(team2.id, {})),
+                      ]
+            const invocations = await processor._parseKafkaBatch(events)
+            expect(invocations).toHaveLength(1)
+            expect(invocations[0].project.id).toBe(team.id)
+
+            await insertHogFunction({
+                team_id: team2.id,
+                ...HOG_EXAMPLES.simple_fetch,
+                ...HOG_INPUTS_EXAMPLES.simple_fetch,
+                ...HOG_FILTERS_EXAMPLES.no_filters,
+            })
+
+            const invocations2 = await processor._parseKafkaBatch(events)
+            expect(invocations2).toHaveLength(2)
+        })
     })
 
     describe('general event processing', () => {

--- a/plugin-server/src/cdp/consumers/cdp-internal-event.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-internal-event.consumer.ts
@@ -28,11 +28,11 @@ export class CdpInternalEventsConsumer extends CdpProcessedEventsConsumer {
                             const event = CdpInternalEventSchema.parse(kafkaEvent)
 
                             const [teamHogFunctions, team] = await Promise.all([
-                                this.hogFunctionManager.getHogFunctionsForTeam(event.team_id, ['destination']),
+                                this.hogFunctionManager.getHogFunctionsForTeam(event.team_id, ['internal_destination']),
                                 this.hub.teamManager.fetchTeam(event.team_id),
                             ])
 
-                            if (!teamHogFunctions || !team) {
+                            if (!teamHogFunctions.length || !team) {
                                 return
                             }
 

--- a/plugin-server/src/cdp/consumers/cdp-processed-events.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-processed-events.consumer.ts
@@ -182,7 +182,7 @@ export class CdpProcessedEventsConsumer extends CdpConsumerBase {
                                     this.hub.teamManager.fetchTeam(clickHouseEvent.team_id),
                                 ])
 
-                                if (!teamHogFunctions || !team) {
+                                if (!teamHogFunctions.length || !team) {
                                     return
                                 }
                                 events.push(

--- a/plugin-server/src/cdp/services/groups-manager.service.ts
+++ b/plugin-server/src/cdp/services/groups-manager.service.ts
@@ -133,11 +133,21 @@ export class GroupsManagerService {
         const groupsByTeamTypeId: Record<string, Group> = {}
 
         itemsNeedingGroups.forEach((item) => {
-            const groupsProperty: Record<string, string> = item.event.properties['$groups'] || {}
+            // TODO: In the future move this kind of validation to Zod
+            const validGroupsProperty: Record<string, string> = {}
+            const groupsProperty = item.event.properties['$groups']
+
+            if (typeof groupsProperty === 'object' && groupsProperty !== null) {
+                Object.entries(groupsProperty).forEach(([groupType, groupKey]) => {
+                    if (typeof groupType === 'string' && typeof groupKey === 'string') {
+                        validGroupsProperty[groupType] = groupKey
+                    }
+                })
+            }
             const groups: HogFunctionInvocationGlobals['groups'] = {}
 
             // Add the base group info without properties
-            Object.entries(groupsProperty).forEach(([groupType, groupKey]) => {
+            Object.entries(validGroupsProperty).forEach(([groupType, groupKey]) => {
                 const groupIndex = byTeamType[`${item.project.id}:${groupType}`]
 
                 if (typeof groupIndex === 'number') {

--- a/plugin-server/src/cdp/services/hog-executor.service.ts
+++ b/plugin-server/src/cdp/services/hog-executor.service.ts
@@ -498,7 +498,9 @@ export class HogExecutorService {
                                     'postHogCapture was called more than once. Only one call is allowed per function'
                                 )
                             }
-                            const executionCount = globals.event.properties?.$hog_function_execution_count ?? 0
+
+                            const givenCount = globals.event.properties?.$hog_function_execution_count
+                            const executionCount = typeof givenCount === 'number' ? givenCount : 0
 
                             if (executionCount > 0) {
                                 result.logs.push({

--- a/plugin-server/src/cdp/services/legacy-plugin-executor.service.ts
+++ b/plugin-server/src/cdp/services/legacy-plugin-executor.service.ts
@@ -1,4 +1,4 @@
-import { PluginEvent, ProcessedPluginEvent, Properties, RetryError, StorageExtension } from '@posthog/plugin-scaffold'
+import { PluginEvent, ProcessedPluginEvent, RetryError, StorageExtension } from '@posthog/plugin-scaffold'
 import { DateTime } from 'luxon'
 import { Histogram } from 'prom-client'
 

--- a/plugin-server/src/cdp/services/legacy-plugin-executor.service.ts
+++ b/plugin-server/src/cdp/services/legacy-plugin-executor.service.ts
@@ -1,4 +1,4 @@
-import { PluginEvent, ProcessedPluginEvent, RetryError, StorageExtension } from '@posthog/plugin-scaffold'
+import { PluginEvent, ProcessedPluginEvent, Properties, RetryError, StorageExtension } from '@posthog/plugin-scaffold'
 import { DateTime } from 'luxon'
 import { Histogram } from 'prom-client'
 
@@ -266,7 +266,10 @@ export class LegacyPluginExecutorService {
                 const processedEvent: ProcessedPluginEvent = {
                     ...event,
                     ip: null, // convertToOnEventPayload removes this so we should too
-                    properties: event.properties || {},
+                    // NOTE: We want to improve validation of these properties but for now for legacy plugins we just cast
+                    properties: event.properties as ProcessedPluginEvent['properties'],
+                    $set: event.$set as ProcessedPluginEvent['$set'],
+                    $set_once: event.$set_once as ProcessedPluginEvent['$set_once'],
                 }
 
                 const start = performance.now()

--- a/plugin-server/src/cdp/types.ts
+++ b/plugin-server/src/cdp/types.ts
@@ -70,7 +70,7 @@ export type HogFunctionInvocationGlobals = {
         uuid: string
         event: string
         distinct_id: string
-        properties: Record<string, any>
+        properties: Record<string, unknown>
         elements_chain: string
         timestamp: string
 

--- a/plugin-server/tests/helpers/sql.ts
+++ b/plugin-server/tests/helpers/sql.ts
@@ -41,6 +41,9 @@ DECLARE
 BEGIN
     -- Delete from tables in order of dependencies
     DELETE FROM posthog_featureflaghashkeyoverride CASCADE;
+    DELETE FROM posthog_cohortpeople CASCADE;
+    DELETE FROM posthog_cohort CASCADE;
+    DELETE FROM posthog_featureflag CASCADE;
     DELETE FROM posthog_persondistinctid CASCADE;
     DELETE FROM posthog_person CASCADE;
     


### PR DESCRIPTION
## Problem

Small PR to fix issues with the original loader

## Changes

- [x] Fixes filtering list to check the length of the team functions
- [x] Fixes the global properties to be "unknown" record values to force type level warnings to validate
- [x] Fixes areas where this is an issue particularly in the groups loader
- [x] Adds tests to cover these kinds of issues


## Follow up
- Follow up PR to ingestion to forbid groups shape at ingestion level

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
