### PR TITLE
chore(temporal): Add PostHog error tracking back in Temporal

### DIFF
--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -8,6 +8,7 @@ from temporalio.runtime import PrometheusConfig, Runtime, TelemetryConfig
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
 from posthog.temporal.common.client import connect
+from posthog.temporal.common.posthog_client import PostHogClientInterceptor
 from posthog.temporal.common.sentry import SentryInterceptor
 
 
@@ -52,7 +53,7 @@ async def start_worker(
         activities=activities,
         workflow_runner=UnsandboxedWorkflowRunner(),
         graceful_shutdown_timeout=timedelta(minutes=5),
-        interceptors=[SentryInterceptor()],
+        interceptors=[SentryInterceptor(), PostHogClientInterceptor()],
         activity_executor=ThreadPoolExecutor(max_workers=max_concurrent_activities or 50),
         max_concurrent_activities=max_concurrent_activities or 50,
         max_concurrent_workflow_tasks=max_concurrent_workflow_tasks,

--- a/posthog/temporal/tests/common/test_error_tracking.py
+++ b/posthog/temporal/tests/common/test_error_tracking.py
@@ -79,7 +79,6 @@ async def failing_activity_with_properties_to_log(inputs: OptionallyFailingInput
         raise ValueError("Activity failed!")
 
 
-@pytest.mark.skip("Skipping test because we've disabled PostHog error tracking for now")
 @pytest.mark.parametrize("fail", [True, False])
 @pytest.mark.parametrize("capture_additional_properties", [True, False])
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Something is blocking our Temporal batch export workflows but it's not the PostHog client.

## Changes

Come back PostHog client, we were wrong to doubt you ;)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

