### PR TITLE
fix(cdp): throw if select in filters

### DIFF
--- a/posthog/cdp/filters.py
+++ b/posthog/cdp/filters.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from posthog.hogql.visitor import TraversingVisitor
 from posthog.models.action.action import Action
 from posthog.hogql.compiler.bytecode import create_bytecode
 from posthog.hogql.parser import parse_expr
@@ -87,10 +88,29 @@ def compile_filters_expr(filters: Optional[dict], team: Team, actions: Optional[
     return hog_function_filters_to_expr(filters, team, actions)
 
 
+class SelectFinder(TraversingVisitor):
+    found = False
+
+    def visit_select_query(self, node):
+        self.found = True
+        return
+
+    # class method
+    @classmethod
+    def has_select(cls, node):
+        visitor = cls()
+        visitor.visit(node)
+        return visitor.found
+
+
 def compile_filters_bytecode(filters: Optional[dict], team: Team, actions: Optional[dict[int, Action]] = None) -> dict:
     filters = filters or {}
     try:
-        filters["bytecode"] = create_bytecode(compile_filters_expr(filters, team, actions)).bytecode
+        expr = compile_filters_expr(filters, team, actions)
+        if SelectFinder.has_select(expr):
+            raise Exception("Select queries are not allowed in filters")
+
+        filters["bytecode"] = create_bytecode(expr).bytecode
         if "bytecode_error" in filters:
             del filters["bytecode_error"]
     except Exception as e:


### PR DESCRIPTION
## Problem

Turns out you can write subqueries in HogQL filters in data pipelines.

## Changes

Throws an error when saving the filter, not later during runtime.

![2025-03-20 21 00 22](https://github.com/user-attachments/assets/1f90c245-193c-40a0-a21f-cd02608e8fea)

## How did you test this code?

In the browser and added a test