### PR TITLE
feat(custom-columns): add guard popup for custom columns

### DIFF
--- a/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
+++ b/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
@@ -11,6 +11,7 @@ import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
 import { TaxonomicFilter } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { upgradeModalLogic } from 'lib/components/UpgradeModal/upgradeModalLogic'
 import { TeamMembershipLevel } from 'lib/constants'
 import { IconTuning, SortableDragIcon } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -23,7 +24,7 @@ import { AutoSizer } from 'react-virtualized/dist/es/AutoSizer'
 import { dataTableLogic } from '~/queries/nodes/DataTable/dataTableLogic'
 import { DataTableNode, NodeKind } from '~/queries/schema/schema-general'
 import { isEventsQuery, taxonomicEventFilterToHogQL, trimQuotes } from '~/queries/utils'
-import { PropertyFilterType } from '~/types'
+import { AvailableFeature, PropertyFilterType } from '~/types'
 
 import { defaultDataTableColumns, extractExpressionComment, removeExpressionComment } from '../utils'
 import { columnConfiguratorLogic, ColumnConfiguratorLogicProps } from './columnConfiguratorLogic'
@@ -95,6 +96,7 @@ function ColumnConfiguratorModal({ query }: ColumnConfiguratorProps): JSX.Elemen
     const { hideModal, moveColumn, setColumns, selectColumn, unselectColumn, save, toggleSaveAsDefault } =
         useActions(columnConfiguratorLogic)
     const { context } = useValues(columnConfiguratorLogic)
+    const { guardAvailableFeature } = useValues(upgradeModalLogic)
 
     const onEditColumn = (column: string, index: number): void => {
         const newColumn = window.prompt('Edit column', column)
@@ -199,7 +201,7 @@ function ColumnConfiguratorModal({ query }: ColumnConfiguratorProps): JSX.Elemen
                         data-attr="events-table-save-columns-as-default-toggle"
                         bordered
                         checked={saveAsDefault}
-                        onChange={toggleSaveAsDefault}
+                        onChange={() => guardAvailableFeature(AvailableFeature.CUSTOMIZE_COLUMNS, toggleSaveAsDefault)}
                         disabledReason={restrictionReason}
                     />
                 ) : null}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -171,6 +171,7 @@ export enum AvailableFeature {
     MANAGED_REVERSE_PROXY = 'managed_reverse_proxy',
     ALERTS = 'alerts',
     DATA_COLOR_THEMES = 'data_color_themes',
+    CUSTOMIZE_COLUMNS = 'customize_columns',
 }
 
 type AvailableFeatureUnion = `${AvailableFeature}`


### PR DESCRIPTION
## Problem

the column customization is ee only feature, causing this for non-ee (self-hosted) users. 
![image](https://github.com/user-attachments/assets/f6f5c356-0b79-4398-99a6-83d789f6749b)


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

add a popup guard similar to color customization (but currently doesn't work for my local customer)

how it will look in future (for color one as example):
![image](https://github.com/user-attachments/assets/4a5e1303-eae3-444c-aa99-1f37ee957b67)


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
