### PR TITLE
fix(project-tree): preserve state on close

### DIFF
--- a/frontend/src/layout/panel-layout/PanelLayout.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayout.tsx
@@ -1,5 +1,5 @@
 import { cva } from 'class-variance-authority'
-import { useActions, useValues } from 'kea'
+import { useActions, useMountedLogic, useValues } from 'kea'
 import { cn } from 'lib/utils/css-classes'
 import { useEffect } from 'react'
 
@@ -7,6 +7,7 @@ import { navigation3000Logic } from '../navigation-3000/navigationLogic'
 import { panelLayoutLogic } from './panelLayoutLogic'
 import { PanelLayoutNavBar } from './PanelLayoutNavBar'
 import { ProjectTree } from './ProjectTree/ProjectTree'
+import { projectTreeLogic } from './ProjectTree/projectTreeLogic'
 
 const panelLayoutStyles = cva('gap-0 w-fit relative h-screen z-[var(--z-project-panel-layout)]', {
     variants: {
@@ -68,6 +69,7 @@ export function PanelLayout({ mainRef }: { mainRef: React.RefObject<HTMLElement>
         useActions(panelLayoutLogic)
     const showMobileNavbarOverlay = isLayoutNavbarVisibleForMobile
     const showDesktopNavbarOverlay = isLayoutNavbarVisibleForDesktop && !isLayoutPanelPinned && isLayoutPanelVisible
+    useMountedLogic(projectTreeLogic)
 
     useEffect(() => {
         if (mainRef.current) {


### PR DESCRIPTION
## Problem

When the project tree would collapse, it would load from a blank state next time you opened it:

![2025-03-21 12 22 15](https://github.com/user-attachments/assets/cc0ef046-e45b-4d19-b530-4615540a7ccb)

## Changes

Keeps the logic mounted higher up in the tree

![2025-03-21 12 22 56](https://github.com/user-attachments/assets/700d76df-9a3b-4415-813b-88aaa12e0041)

## How did you test this code?

Locally