### PR TITLE
feat(cdp): add restrictions to hogtransformation creation

### DIFF
--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
@@ -65,6 +65,7 @@ export interface HogFunctionConfigurationLogicProps {
 
 export const EVENT_VOLUME_DAILY_WARNING_THRESHOLD = 1000
 const UNSAVED_CONFIGURATION_TTL = 1000 * 60 * 5
+export const HOG_CODE_SIZE_LIMIT = 100 * 1024 // 100KB to match backend limit
 
 const NEW_FUNCTION_TEMPLATE: HogFunctionTemplateType = {
     id: 'new',
@@ -480,6 +481,19 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                 }
             },
             submit: async (data) => {
+                // Check HOG code size immediately before submission
+                if (data.hog) {
+                    const hogSize = new Blob([data.hog]).size
+                    if (hogSize > HOG_CODE_SIZE_LIMIT) {
+                        lemonToast.error(
+                            `Hog code exceeds maximum size of ${
+                                HOG_CODE_SIZE_LIMIT / 1024
+                            }KB. Please simplify your code or contact support to increase the limit.`
+                        )
+                        return
+                    }
+                }
+
                 const payload: Record<string, any> = sanitizeConfiguration(data)
                 // Only sent on create
                 payload.template_id = props.templateId || values.hogFunction?.template?.id

--- a/posthog/api/hog_function.py
+++ b/posthog/api/hog_function.py
@@ -244,7 +244,7 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
         # We allow unlimited creation of disabled transformations as they don't run during ingestion
         if hog_type == "transformation" and attrs.get("enabled", False):
             # Don't apply the limit for updates where the function was already enabled
-            apply_limit = is_create or (self.instance and not self.instance.enabled)
+            apply_limit = is_create or (isinstance(self.instance, HogFunction) and not self.instance.enabled)
 
             if apply_limit:
                 # Count enabled and non-deleted transformations

--- a/posthog/api/test/test_hog_function.py
+++ b/posthog/api/test/test_hog_function.py
@@ -1851,6 +1851,7 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 team=self.team, type="transformation", deleted=False, enabled=True
             ).first()
 
+            assert enabled_transformation is not None, "No enabled transformation found to delete"
             self.client.patch(
                 f"/api/projects/{self.team.id}/hog_functions/{enabled_transformation.id}/",
                 data={"deleted": True},
@@ -1861,6 +1862,7 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 team=self.team, type="transformation", deleted=False, enabled=False
             ).first()
 
+            assert disabled_transformation is not None, "No disabled transformation found to enable"
             response = self.client.patch(
                 f"/api/projects/{self.team.id}/hog_functions/{disabled_transformation.id}/",
                 data={"enabled": True},


### PR DESCRIPTION
## Problem


As we are rolling out hog-transformations out soon (also with the ability to write custom code) we want to take a rather defensive approach to not get taken down. We need to be careful around how many hog transformations run during the ingestion step and we need to make sure to not run into OOM issues when loading all hogfunctions from teams into memory. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- API Level restrictions on hog code to not exceed a certain threshold (took our biggest function and multiplied its size by 10) --> this applies also to _**destinations**_
- API Level restrictions on how many hog transformations can be enabled (unlimited creation is possible as long as there is only 20 transformations enabled at a time)
- Added UI validation to prevent creation / updates of hog functions with same size limit as in backend (will also apply to destinations)



(test was done with 20KB which was easier to reach, real limit is 100KB)
![2025-03-21 14 33 17](https://github.com/user-attachments/assets/541bbdaa-fae2-4f08-b1de-094867c3b102)


(limit was done with 10.. real limit is 20)
![Screenshot 2025-03-24 at 10 16 01](https://github.com/user-attachments/assets/65571a69-ba9c-4ffa-b767-298c031a538c)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- added tests 
- Tested locally
- [x] test out locally via api / ui limit of transformation creation
- [x] Test out via api if exceeding hog function code throws error

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
