### PR TITLE
fix(property-definitions): client-side filtering to avoid 431

### DIFF
--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
@@ -235,7 +235,7 @@ export const eventDefinitionsTableLogic = kea<eventDefinitionsTableLogicType>([
                     cache.apiCache = {
                         ...(cache.apiCache ?? {}),
                         [currentUrl]: {
-                            count: response.count,
+                            count: response.results.length,
                             previous: normalizePropertyDefinitionEndpointUrl(response.previous),
                             next: normalizePropertyDefinitionEndpointUrl(response.next),
                             current: currentUrl,


### PR DESCRIPTION
## Problem
![image](https://github.com/user-attachments/assets/eb82d6bb-63fa-4976-b28a-0683e7182bc8)

[slack thread](https://posthog.slack.com/archives/C0368RPHLQH/p1742558417377739)
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
<img width="812" alt="image" src="https://github.com/user-attachments/assets/cf4876f5-1c7c-49c4-9e33-dde8ce2b79ae" />

1. remove exclude key from api call (too large)
2. remove limit to get all props client side (1000 for now, don't like it at all)
3. filter the returned response in a similar way that `PropertiesTable.tsx` doing

more ideas on how to fix it longterm has been shared in the thread, pushing this to fix prod asap. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
localy 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
