### PR TITLE
fix: we can stream large files for filebased playback

### DIFF
--- a/frontend/src/scenes/session-recordings/file-playback/sessionRecordingFilePlaybackSceneLogic.ts
+++ b/frontend/src/scenes/session-recordings/file-playback/sessionRecordingFilePlaybackSceneLogic.ts
@@ -95,16 +95,18 @@ export const sessionRecordingFilePlaybackSceneLogic = kea<sessionRecordingFilePl
             __default: null as ExportedSessionRecordingFileV2['data'] | null,
             loadFromFile: async (file: File) => {
                 try {
-                    const loadedFile: string = await new Promise((resolve, reject) => {
-                        const filereader = new FileReader()
-                        filereader.onload = (e) => {
-                            resolve(e.target?.result as string)
+                    const decoder = new TextDecoder('utf-8')
+                    let loadedFile = ''
+
+                    const stream = (file as Blob).stream().getReader()
+
+                    while (true) {
+                        const { done, value } = await stream.read()
+                        if (done) {
+                            break
                         }
-                        filereader.onerror = (e) => {
-                            reject(e)
-                        }
-                        filereader.readAsText(file)
-                    })
+                        loadedFile += decoder.decode(value, { stream: true })
+                    }
 
                     const data = parseExportedSessionRecording(loadedFile)
 


### PR DESCRIPTION
we were trying to load a very large extract file and just couldn't process it... this will be slightly better

(of course if the final string is very large this also won't work... browser starts to really struggle at ~500MB+)