### PR TITLE
fix(cdp): show warning for load estimation only for destinations

### DIFF
--- a/frontend/src/scenes/pipeline/hogfunctions/metrics/HogFunctionEventEstimates.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/metrics/HogFunctionEventEstimates.tsx
@@ -48,15 +48,13 @@ export function HogFunctionEventEstimates(): JSX.Element | null {
             <LemonLabel>Matching events</LemonLabel>
             {sparkline && !sparklineLoading ? (
                 <>
-                    {sparkline.count > EVENT_THRESHOLD_ALERT_LEVEL ? (
+                    {sparkline.count > EVENT_THRESHOLD_ALERT_LEVEL && type !== 'transformation' ? (
                         <LemonBanner type="warning">
-                            <b>Warning:</b> This {type === 'transformation' ? 'transformation' : 'destination'} would
-                            have triggered{' '}
+                            <b>Warning:</b> This destination would have triggered{' '}
                             <strong>
                                 {sparkline.count ?? 0} time{sparkline.count !== 1 ? 's' : ''}
                             </strong>{' '}
-                            in the last 7 days. Consider the impact of this function on your{' '}
-                            {type === 'transformation' ? 'data pipeline' : 'destination'}.
+                            in the last 7 days. Consider the impact of this function on your destination.
                         </LemonBanner>
                     ) : (
                         <p>


### PR DESCRIPTION
## Problem

load warning is shown for transformations instead but we do not want to show them for transformations

<img width="459" alt="Screenshot 2025-03-21 at 16 18 05" src="https://github.com/user-attachments/assets/4c43bc00-4ff1-4c3d-bf97-1cbf53c5d753" />


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- shows it for every other hogfunction type but transformations

<img width="439" alt="Screenshot 2025-03-21 at 16 57 56" src="https://github.com/user-attachments/assets/100b8f24-a871-4bd4-a3b0-4093feb0915c" />


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- locally

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
