### PR TITLE
fix(err): add confirm for merging

### DIFF
--- a/frontend/src/scenes/error-tracking/issue/BulkActions.tsx
+++ b/frontend/src/scenes/error-tracking/issue/BulkActions.tsx
@@ -1,4 +1,4 @@
-import { LemonButton } from '@posthog/lemon-ui'
+import { LemonButton, LemonDialog } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 
 import { ErrorTrackingIssue } from '~/queries/schema/schema-general'
@@ -45,10 +45,20 @@ export function BulkActions(): JSX.Element {
                         disabledReason={!hasAtLeastTwoIssues ? 'Select at least two issues to merge' : null}
                         type="secondary"
                         size="small"
-                        onClick={() => {
-                            mergeIssues(selectedIssueIds)
-                            setSelectedIssueIds([])
-                        }}
+                        onClick={() =>
+                            LemonDialog.open({
+                                title: 'Merge Issues',
+                                content: `Are you sure you want to merge these ${selectedIssueIds.length} issues?`,
+                                primaryButton: {
+                                    children: 'Merge',
+                                    status: 'danger',
+                                    onClick: () => {
+                                        mergeIssues(selectedIssueIds)
+                                        setSelectedIssueIds([])
+                                    },
+                                },
+                            })
+                        }
                     >
                         Merge
                     </LemonButton>


### PR DESCRIPTION
Merging is high consequence enough that, while we should support it as a bulk action, it should take a confirm. I watched a user accidentally merge all of their issues and it was grim, we want to inspire calm, not panic.

Open to only requiring a confirm if it's more than e.g. X issues, or letting users hit a "don't ask again", but did this as a first pass because it was simple.