### PR TITLE
fix: anthropic negative costs with caching

### DIFF
--- a/plugin-server/src/ingestion/ai-costs/__snapshots__/process-ai-event.test.ts.snap
+++ b/plugin-server/src/ingestion/ai-costs/__snapshots__/process-ai-event.test.ts.snap
@@ -256,7 +256,7 @@ exports[`processAiEvent() smoke test every model processes command 1`] = `
 }
 `;
 
-exports[`processAiEvent() smoke test every model processes command-a-03-2025 1`] = `
+exports[`processAiEvent() smoke test every model processes command-a 1`] = `
 {
   "$ai_input_cost_usd": 0.00025,
   "$ai_output_cost_usd": 0.0005,
@@ -338,9 +338,9 @@ exports[`processAiEvent() smoke test every model processes deepseek-chat:free 1`
 
 exports[`processAiEvent() smoke test every model processes deepseek-r1 1`] = `
 {
-  "$ai_input_cost_usd": 0.00007,
-  "$ai_output_cost_usd": 0.000125,
-  "$ai_total_cost_usd": 0.000195,
+  "$ai_input_cost_usd": 0.000055,
+  "$ai_output_cost_usd": 0.0001095,
+  "$ai_total_cost_usd": 0.0001645,
 }
 `;
 
@@ -573,6 +573,14 @@ exports[`processAiEvent() smoke test every model processes gemma-2-27b-it 1`] = 
   "$ai_input_cost_usd": 0.000027,
   "$ai_output_cost_usd": 0.0000135,
   "$ai_total_cost_usd": 0.0000405,
+}
+`;
+
+exports[`processAiEvent() smoke test every model processes gemma-3-1b-it:free 1`] = `
+{
+  "$ai_input_cost_usd": 0,
+  "$ai_output_cost_usd": 0,
+  "$ai_total_cost_usd": 0,
 }
 `;
 
@@ -872,27 +880,11 @@ exports[`processAiEvent() smoke test every model processes llama-3.1-405b-instru
 }
 `;
 
-exports[`processAiEvent() smoke test every model processes llama-3.1-sonar-large-128k-chat 1`] = `
-{
-  "$ai_input_cost_usd": 0.0001,
-  "$ai_output_cost_usd": 0.00005,
-  "$ai_total_cost_usd": 0.00015,
-}
-`;
-
 exports[`processAiEvent() smoke test every model processes llama-3.1-sonar-large-128k-online 1`] = `
 {
   "$ai_input_cost_usd": 0.0001,
   "$ai_output_cost_usd": 0.00005,
   "$ai_total_cost_usd": 0.00015,
-}
-`;
-
-exports[`processAiEvent() smoke test every model processes llama-3.1-sonar-small-128k-chat 1`] = `
-{
-  "$ai_input_cost_usd": 0.00002,
-  "$ai_output_cost_usd": 0.00001,
-  "$ai_total_cost_usd": 0.00003,
 }
 `;
 
@@ -1011,8 +1003,8 @@ exports[`processAiEvent() smoke test every model processes llama-guard-2-8b 1`] 
 exports[`processAiEvent() smoke test every model processes llama-guard-3-8b 1`] = `
 {
   "$ai_input_cost_usd": 0.00002,
-  "$ai_output_cost_usd": 0.00000999,
-  "$ai_total_cost_usd": 0.00002999,
+  "$ai_output_cost_usd": 0.00001,
+  "$ai_total_cost_usd": 0.00003,
 }
 `;
 
@@ -1136,6 +1128,22 @@ exports[`processAiEvent() smoke test every model processes mistral-small 1`] = `
 }
 `;
 
+exports[`processAiEvent() smoke test every model processes mistral-small-3.1-24b-instruct 1`] = `
+{
+  "$ai_input_cost_usd": 0.00001,
+  "$ai_output_cost_usd": 0.000015,
+  "$ai_total_cost_usd": 0.000025,
+}
+`;
+
+exports[`processAiEvent() smoke test every model processes mistral-small-3.1-24b-instruct:free 1`] = `
+{
+  "$ai_input_cost_usd": 0,
+  "$ai_output_cost_usd": 0,
+  "$ai_total_cost_usd": 0,
+}
+`;
+
 exports[`processAiEvent() smoke test every model processes mistral-small-24b-instruct-2501 1`] = `
 {
   "$ai_input_cost_usd": 0.000007,
@@ -1221,6 +1229,14 @@ exports[`processAiEvent() smoke test every model processes o1-preview-2024-09-12
   "$ai_input_cost_usd": 0.0015,
   "$ai_output_cost_usd": 0.003,
   "$ai_total_cost_usd": 0.0045,
+}
+`;
+
+exports[`processAiEvent() smoke test every model processes o1-pro 1`] = `
+{
+  "$ai_input_cost_usd": 0.015,
+  "$ai_output_cost_usd": 0.03,
+  "$ai_total_cost_usd": 0.045,
 }
 `;
 

--- a/plugin-server/src/ingestion/ai-costs/process-ai-event.test.ts
+++ b/plugin-server/src/ingestion/ai-costs/process-ai-event.test.ts
@@ -210,14 +210,14 @@ describe('processAiEvent()', () => {
 
             // For testing_model: prompt_token = 0.1, completion_token = 0.1
             // Write cost: 20 * 0.1 * 1.25 = 2.5
-            // Read cost: 30 * 0.1 * 0.1 = 0.3
-            // Uncached cost: 1000 * 0.1 = 100
-            // Input cost: 2.5 + 0.3 + 100 = 102.8
+            // Read cost: 1000 * 0.1 * 0.1 = 10
+            // Uncached cost: 100 * 0.1 = 10
+            // Input cost: 2.5 + 10 + 10 = 22.5
             // Output cost: 50 * 0.1 = 5
-            // Total cost: 102.8 + 5 = 107.8
-            expect(result.properties!.$ai_input_cost_usd).toBeCloseTo(102.8, 2)
+            // Total cost: 22.5 + 5 = 27.5
+            expect(result.properties!.$ai_input_cost_usd).toBeCloseTo(22.5, 2)
             expect(result.properties!.$ai_output_cost_usd).toBeCloseTo(5, 2)
-            expect(result.properties!.$ai_total_cost_usd).toBeCloseTo(107.8, 2)
+            expect(result.properties!.$ai_total_cost_usd).toBeCloseTo(27.5, 2)
         })
 
         it('handles zero cache tokens correctly', () => {

--- a/plugin-server/src/ingestion/ai-costs/process-ai-event.test.ts
+++ b/plugin-server/src/ingestion/ai-costs/process-ai-event.test.ts
@@ -203,7 +203,7 @@ describe('processAiEvent()', () => {
             event.properties!.$ai_model = 'testing_model'
             event.properties!.$ai_input_tokens = 100
             event.properties!.$ai_output_tokens = 50
-            event.properties!.$ai_cache_read_input_tokens = 30
+            event.properties!.$ai_cache_read_input_tokens = 1000
             event.properties!.$ai_cache_creation_input_tokens = 20
 
             const result = processAiEvent(event)
@@ -211,13 +211,13 @@ describe('processAiEvent()', () => {
             // For testing_model: prompt_token = 0.1, completion_token = 0.1
             // Write cost: 20 * 0.1 * 1.25 = 2.5
             // Read cost: 30 * 0.1 * 0.1 = 0.3
-            // Uncached cost: (100 - 30) * 0.1 = 7
-            // Input cost: 2.5 + 0.3 + 7 = 9.8
+            // Uncached cost: 1000 * 0.1 = 100
+            // Input cost: 2.5 + 0.3 + 100 = 102.8
             // Output cost: 50 * 0.1 = 5
-            // Total cost: 9.8 + 5 = 14.8
-            expect(result.properties!.$ai_input_cost_usd).toBeCloseTo(9.8, 2)
+            // Total cost: 102.8 + 5 = 107.8
+            expect(result.properties!.$ai_input_cost_usd).toBeCloseTo(102.8, 2)
             expect(result.properties!.$ai_output_cost_usd).toBeCloseTo(5, 2)
-            expect(result.properties!.$ai_total_cost_usd).toBeCloseTo(14.8, 2)
+            expect(result.properties!.$ai_total_cost_usd).toBeCloseTo(107.8, 2)
         })
 
         it('handles zero cache tokens correctly', () => {

--- a/plugin-server/src/ingestion/ai-costs/process-ai-event.ts
+++ b/plugin-server/src/ingestion/ai-costs/process-ai-event.ts
@@ -13,8 +13,6 @@ export const processAiEvent = (event: PluginEvent): PluginEvent => {
     return event
 }
 
-//ai_cache_read_input_tokens
-
 const calculateInputCost = (event: PluginEvent, cost: ModelRow) => {
     if (!event.properties) {
         return '0'
@@ -32,15 +30,13 @@ const calculateInputCost = (event: PluginEvent, cost: ModelRow) => {
         const inputTokens = event.properties['$ai_input_tokens'] || 0
         const writeCost = bigDecimal.multiply(bigDecimal.multiply(cost.cost.prompt_token, 1.25), cacheWriteTokens)
         const cacheReadCost = bigDecimal.multiply(bigDecimal.multiply(cost.cost.prompt_token, 0.1), cacheReadTokens)
-        const difference = bigDecimal.subtract(inputTokens, cacheReadTokens)
         const totalCacheCost = bigDecimal.add(writeCost, cacheReadCost)
-        const uncachedCost = bigDecimal.multiply(cost.cost.prompt_token, difference)
+        const uncachedCost = bigDecimal.multiply(cost.cost.prompt_token, inputTokens)
         return bigDecimal.add(totalCacheCost, uncachedCost)
     }
     return bigDecimal.multiply(cost.cost.prompt_token, event.properties['$ai_input_tokens'] || 0)
 }
 
-// ai_reasoning_tokens
 const calculateOutputCost = (event: PluginEvent, cost: ModelRow) => {
     if (!event.properties) {
         return '0'

--- a/plugin-server/src/ingestion/ai-costs/providers/generated-providers.json
+++ b/plugin-server/src/ingestion/ai-costs/providers/generated-providers.json
@@ -1,254 +1,9 @@
 [
     {
-        "model": "gemma-3-4b-it:free",
+        "model": "o1-pro",
         "cost": {
-            "prompt_token": 0,
-            "completion_token": 0
-        }
-    },
-    {
-        "model": "gemma-3-12b-it:free",
-        "cost": {
-            "prompt_token": 0,
-            "completion_token": 0
-        }
-    },
-    {
-        "model": "gemma-3-27b-it:free",
-        "cost": {
-            "prompt_token": 0,
-            "completion_token": 0
-        }
-    },
-    {
-        "model": "gemma-3-27b-it",
-        "cost": {
-            "prompt_token": 3e-7,
-            "completion_token": 5e-7
-        }
-    },
-    {
-        "model": "gemini-2.0-flash-lite-001",
-        "cost": {
-            "prompt_token": 7.5e-8,
-            "completion_token": 3e-7
-        }
-    },
-    {
-        "model": "gemini-2.0-flash-001",
-        "cost": {
-            "prompt_token": 1e-7,
-            "completion_token": 4e-7
-        }
-    },
-    {
-        "model": "gemini-2.0-flash-lite-preview-02-05:free",
-        "cost": {
-            "prompt_token": 0,
-            "completion_token": 0
-        }
-    },
-    {
-        "model": "gemini-2.0-pro-exp-02-05:free",
-        "cost": {
-            "prompt_token": 0,
-            "completion_token": 0
-        }
-    },
-    {
-        "model": "gemini-2.0-flash-thinking-exp:free",
-        "cost": {
-            "prompt_token": 0,
-            "completion_token": 0
-        }
-    },
-    {
-        "model": "gemini-2.0-flash-thinking-exp-1219:free",
-        "cost": {
-            "prompt_token": 0,
-            "completion_token": 0
-        }
-    },
-    {
-        "model": "gemini-2.0-flash-exp:free",
-        "cost": {
-            "prompt_token": 0,
-            "completion_token": 0
-        }
-    },
-    {
-        "model": "gemini-exp-1206:free",
-        "cost": {
-            "prompt_token": 0,
-            "completion_token": 0
-        }
-    },
-    {
-        "model": "learnlm-1.5-pro-experimental:free",
-        "cost": {
-            "prompt_token": 0,
-            "completion_token": 0
-        }
-    },
-    {
-        "model": "gemini-flash-1.5-8b",
-        "cost": {
-            "prompt_token": 3.75e-8,
-            "completion_token": 1.5e-7
-        }
-    },
-    {
-        "model": "gemini-flash-1.5-8b-exp",
-        "cost": {
-            "prompt_token": 0,
-            "completion_token": 0
-        }
-    },
-    {
-        "model": "gemma-2-27b-it",
-        "cost": {
-            "prompt_token": 2.7e-7,
-            "completion_token": 2.7e-7
-        }
-    },
-    {
-        "model": "gemma-2-9b-it:free",
-        "cost": {
-            "prompt_token": 0,
-            "completion_token": 0
-        }
-    },
-    {
-        "model": "gemma-2-9b-it",
-        "cost": {
-            "prompt_token": 3e-8,
-            "completion_token": 6e-8
-        }
-    },
-    {
-        "model": "gemini-flash-1.5",
-        "cost": {
-            "prompt_token": 7.5e-8,
-            "completion_token": 3e-7
-        }
-    },
-    {
-        "model": "gemini-pro-1.5",
-        "cost": {
-            "prompt_token": 0.00000125,
-            "completion_token": 0.000005
-        }
-    },
-    {
-        "model": "gemma-7b-it",
-        "cost": {
-            "prompt_token": 1.5e-7,
-            "completion_token": 1.5e-7
-        }
-    },
-    {
-        "model": "gemini-pro-vision",
-        "cost": {
-            "prompt_token": 5e-7,
-            "completion_token": 0.0000015
-        }
-    },
-    {
-        "model": "gemini-pro",
-        "cost": {
-            "prompt_token": 5e-7,
-            "completion_token": 0.0000015
-        }
-    },
-    {
-        "model": "palm-2-chat-bison-32k",
-        "cost": {
-            "prompt_token": 0.000001,
-            "completion_token": 0.000002
-        }
-    },
-    {
-        "model": "palm-2-codechat-bison-32k",
-        "cost": {
-            "prompt_token": 0.000001,
-            "completion_token": 0.000002
-        }
-    },
-    {
-        "model": "palm-2-chat-bison",
-        "cost": {
-            "prompt_token": 0.000001,
-            "completion_token": 0.000002
-        }
-    },
-    {
-        "model": "palm-2-codechat-bison",
-        "cost": {
-            "prompt_token": 0.000001,
-            "completion_token": 0.000002
-        }
-    },
-    {
-        "model": "command-a-03-2025",
-        "cost": {
-            "prompt_token": 0.0000025,
-            "completion_token": 0.00001
-        }
-    },
-    {
-        "model": "command-r7b-12-2024",
-        "cost": {
-            "prompt_token": 3.75e-8,
-            "completion_token": 1.5e-7
-        }
-    },
-    {
-        "model": "command-r-08-2024",
-        "cost": {
-            "prompt_token": 1.425e-7,
-            "completion_token": 5.7e-7
-        }
-    },
-    {
-        "model": "command-r-plus-08-2024",
-        "cost": {
-            "prompt_token": 0.000002375,
-            "completion_token": 0.0000095
-        }
-    },
-    {
-        "model": "command-r-plus",
-        "cost": {
-            "prompt_token": 0.00000285,
-            "completion_token": 0.00001425
-        }
-    },
-    {
-        "model": "command-r-plus-04-2024",
-        "cost": {
-            "prompt_token": 0.00000285,
-            "completion_token": 0.00001425
-        }
-    },
-    {
-        "model": "command",
-        "cost": {
-            "prompt_token": 9.5e-7,
-            "completion_token": 0.0000019
-        }
-    },
-    {
-        "model": "command-r",
-        "cost": {
-            "prompt_token": 4.75e-7,
-            "completion_token": 0.000001425
-        }
-    },
-    {
-        "model": "command-r-03-2024",
-        "cost": {
-            "prompt_token": 4.75e-7,
-            "completion_token": 0.000001425
+            "prompt_token": 0.00015,
+            "completion_token": 0.0006
         }
     },
     {
@@ -469,325 +224,17 @@
         }
     },
     {
-        "model": "sonar-reasoning-pro",
-        "cost": {
-            "prompt_token": 0.000002,
-            "completion_token": 0.000008
-        }
-    },
-    {
-        "model": "sonar-pro",
-        "cost": {
-            "prompt_token": 0.000003,
-            "completion_token": 0.000015
-        }
-    },
-    {
-        "model": "sonar-deep-research",
-        "cost": {
-            "prompt_token": 0.000002,
-            "completion_token": 0.000008
-        }
-    },
-    {
-        "model": "r1-1776",
-        "cost": {
-            "prompt_token": 0.000002,
-            "completion_token": 0.000008
-        }
-    },
-    {
-        "model": "sonar-reasoning",
-        "cost": {
-            "prompt_token": 0.000001,
-            "completion_token": 0.000005
-        }
-    },
-    {
-        "model": "sonar",
-        "cost": {
-            "prompt_token": 0.000001,
-            "completion_token": 0.000001
-        }
-    },
-    {
-        "model": "llama-3.1-sonar-small-128k-chat",
-        "cost": {
-            "prompt_token": 2e-7,
-            "completion_token": 2e-7
-        }
-    },
-    {
-        "model": "llama-3.1-sonar-large-128k-chat",
-        "cost": {
-            "prompt_token": 0.000001,
-            "completion_token": 0.000001
-        }
-    },
-    {
-        "model": "llama-3.1-sonar-large-128k-online",
-        "cost": {
-            "prompt_token": 0.000001,
-            "completion_token": 0.000001
-        }
-    },
-    {
-        "model": "llama-3.1-sonar-small-128k-online",
-        "cost": {
-            "prompt_token": 2e-7,
-            "completion_token": 2e-7
-        }
-    },
-    {
-        "model": "deepseek-r1-zero:free",
+        "model": "mistral-small-3.1-24b-instruct:free",
         "cost": {
             "prompt_token": 0,
             "completion_token": 0
         }
     },
     {
-        "model": "deepseek-r1-distill-llama-8b",
+        "model": "mistral-small-3.1-24b-instruct",
         "cost": {
-            "prompt_token": 4e-8,
-            "completion_token": 4e-8
-        }
-    },
-    {
-        "model": "deepseek-r1-distill-qwen-1.5b",
-        "cost": {
-            "prompt_token": 1.8e-7,
-            "completion_token": 1.8e-7
-        }
-    },
-    {
-        "model": "deepseek-r1-distill-qwen-32b:free",
-        "cost": {
-            "prompt_token": 0,
-            "completion_token": 0
-        }
-    },
-    {
-        "model": "deepseek-r1-distill-qwen-32b",
-        "cost": {
-            "prompt_token": 1.2e-7,
-            "completion_token": 1.8e-7
-        }
-    },
-    {
-        "model": "deepseek-r1-distill-qwen-14b:free",
-        "cost": {
-            "prompt_token": 0,
-            "completion_token": 0
-        }
-    },
-    {
-        "model": "deepseek-r1-distill-qwen-14b",
-        "cost": {
-            "prompt_token": 1.5e-7,
-            "completion_token": 1.5e-7
-        }
-    },
-    {
-        "model": "deepseek-r1-distill-llama-70b:free",
-        "cost": {
-            "prompt_token": 0,
-            "completion_token": 0
-        }
-    },
-    {
-        "model": "deepseek-r1-distill-llama-70b",
-        "cost": {
-            "prompt_token": 2.3e-7,
-            "completion_token": 6.9e-7
-        }
-    },
-    {
-        "model": "deepseek-r1:free",
-        "cost": {
-            "prompt_token": 0,
-            "completion_token": 0
-        }
-    },
-    {
-        "model": "deepseek-r1",
-        "cost": {
-            "prompt_token": 7e-7,
-            "completion_token": 0.0000025
-        }
-    },
-    {
-        "model": "deepseek-chat:free",
-        "cost": {
-            "prompt_token": 0,
-            "completion_token": 0
-        }
-    },
-    {
-        "model": "deepseek-chat",
-        "cost": {
-            "prompt_token": 4e-7,
-            "completion_token": 0.0000013
-        }
-    },
-    {
-        "model": "claude-3.7-sonnet:beta",
-        "cost": {
-            "prompt_token": 0.000003,
-            "completion_token": 0.000015
-        }
-    },
-    {
-        "model": "claude-3.7-sonnet",
-        "cost": {
-            "prompt_token": 0.000003,
-            "completion_token": 0.000015
-        }
-    },
-    {
-        "model": "claude-3.7-sonnet:thinking",
-        "cost": {
-            "prompt_token": 0.000003,
-            "completion_token": 0.000015
-        }
-    },
-    {
-        "model": "claude-3.5-haiku-20241022:beta",
-        "cost": {
-            "prompt_token": 8e-7,
-            "completion_token": 0.000004
-        }
-    },
-    {
-        "model": "claude-3.5-haiku-20241022",
-        "cost": {
-            "prompt_token": 8e-7,
-            "completion_token": 0.000004
-        }
-    },
-    {
-        "model": "claude-3.5-haiku:beta",
-        "cost": {
-            "prompt_token": 8e-7,
-            "completion_token": 0.000004
-        }
-    },
-    {
-        "model": "claude-3.5-haiku",
-        "cost": {
-            "prompt_token": 8e-7,
-            "completion_token": 0.000004
-        }
-    },
-    {
-        "model": "claude-3.5-sonnet:beta",
-        "cost": {
-            "prompt_token": 0.000003,
-            "completion_token": 0.000015
-        }
-    },
-    {
-        "model": "claude-3.5-sonnet",
-        "cost": {
-            "prompt_token": 0.000003,
-            "completion_token": 0.000015
-        }
-    },
-    {
-        "model": "claude-3.5-sonnet-20240620:beta",
-        "cost": {
-            "prompt_token": 0.000003,
-            "completion_token": 0.000015
-        }
-    },
-    {
-        "model": "claude-3.5-sonnet-20240620",
-        "cost": {
-            "prompt_token": 0.000003,
-            "completion_token": 0.000015
-        }
-    },
-    {
-        "model": "claude-3-haiku:beta",
-        "cost": {
-            "prompt_token": 2.5e-7,
-            "completion_token": 0.00000125
-        }
-    },
-    {
-        "model": "claude-3-haiku",
-        "cost": {
-            "prompt_token": 2.5e-7,
-            "completion_token": 0.00000125
-        }
-    },
-    {
-        "model": "claude-3-opus:beta",
-        "cost": {
-            "prompt_token": 0.000015,
-            "completion_token": 0.000075
-        }
-    },
-    {
-        "model": "claude-3-opus",
-        "cost": {
-            "prompt_token": 0.000015,
-            "completion_token": 0.000075
-        }
-    },
-    {
-        "model": "claude-3-sonnet:beta",
-        "cost": {
-            "prompt_token": 0.000003,
-            "completion_token": 0.000015
-        }
-    },
-    {
-        "model": "claude-3-sonnet",
-        "cost": {
-            "prompt_token": 0.000003,
-            "completion_token": 0.000015
-        }
-    },
-    {
-        "model": "claude-2:beta",
-        "cost": {
-            "prompt_token": 0.000008,
-            "completion_token": 0.000024
-        }
-    },
-    {
-        "model": "claude-2",
-        "cost": {
-            "prompt_token": 0.000008,
-            "completion_token": 0.000024
-        }
-    },
-    {
-        "model": "claude-2.1:beta",
-        "cost": {
-            "prompt_token": 0.000008,
-            "completion_token": 0.000024
-        }
-    },
-    {
-        "model": "claude-2.1",
-        "cost": {
-            "prompt_token": 0.000008,
-            "completion_token": 0.000024
-        }
-    },
-    {
-        "model": "claude-2.0:beta",
-        "cost": {
-            "prompt_token": 0.000008,
-            "completion_token": 0.000024
-        }
-    },
-    {
-        "model": "claude-2.0",
-        "cost": {
-            "prompt_token": 0.000008,
-            "completion_token": 0.000024
+            "prompt_token": 1e-7,
+            "completion_token": 3e-7
         }
     },
     {
@@ -966,10 +413,577 @@
         }
     },
     {
+        "model": "gemma-3-1b-it:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "gemma-3-4b-it:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "gemma-3-12b-it:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "gemma-3-27b-it:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "gemma-3-27b-it",
+        "cost": {
+            "prompt_token": 3e-7,
+            "completion_token": 5e-7
+        }
+    },
+    {
+        "model": "gemini-2.0-flash-lite-001",
+        "cost": {
+            "prompt_token": 7.5e-8,
+            "completion_token": 3e-7
+        }
+    },
+    {
+        "model": "gemini-2.0-flash-001",
+        "cost": {
+            "prompt_token": 1e-7,
+            "completion_token": 4e-7
+        }
+    },
+    {
+        "model": "gemini-2.0-flash-lite-preview-02-05:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "gemini-2.0-pro-exp-02-05:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "gemini-2.0-flash-thinking-exp:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "gemini-2.0-flash-thinking-exp-1219:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "gemini-2.0-flash-exp:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "gemini-exp-1206:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "learnlm-1.5-pro-experimental:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "gemini-flash-1.5-8b",
+        "cost": {
+            "prompt_token": 3.75e-8,
+            "completion_token": 1.5e-7
+        }
+    },
+    {
+        "model": "gemini-flash-1.5-8b-exp",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "gemma-2-27b-it",
+        "cost": {
+            "prompt_token": 2.7e-7,
+            "completion_token": 2.7e-7
+        }
+    },
+    {
+        "model": "gemma-2-9b-it:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "gemma-2-9b-it",
+        "cost": {
+            "prompt_token": 3e-8,
+            "completion_token": 6e-8
+        }
+    },
+    {
+        "model": "gemini-flash-1.5",
+        "cost": {
+            "prompt_token": 7.5e-8,
+            "completion_token": 3e-7
+        }
+    },
+    {
+        "model": "gemini-pro-1.5",
+        "cost": {
+            "prompt_token": 0.00000125,
+            "completion_token": 0.000005
+        }
+    },
+    {
+        "model": "gemma-7b-it",
+        "cost": {
+            "prompt_token": 1.5e-7,
+            "completion_token": 1.5e-7
+        }
+    },
+    {
+        "model": "gemini-pro-vision",
+        "cost": {
+            "prompt_token": 5e-7,
+            "completion_token": 0.0000015
+        }
+    },
+    {
+        "model": "gemini-pro",
+        "cost": {
+            "prompt_token": 5e-7,
+            "completion_token": 0.0000015
+        }
+    },
+    {
+        "model": "palm-2-chat-bison-32k",
+        "cost": {
+            "prompt_token": 0.000001,
+            "completion_token": 0.000002
+        }
+    },
+    {
+        "model": "palm-2-codechat-bison-32k",
+        "cost": {
+            "prompt_token": 0.000001,
+            "completion_token": 0.000002
+        }
+    },
+    {
+        "model": "palm-2-chat-bison",
+        "cost": {
+            "prompt_token": 0.000001,
+            "completion_token": 0.000002
+        }
+    },
+    {
+        "model": "palm-2-codechat-bison",
+        "cost": {
+            "prompt_token": 0.000001,
+            "completion_token": 0.000002
+        }
+    },
+    {
+        "model": "command-a",
+        "cost": {
+            "prompt_token": 0.0000025,
+            "completion_token": 0.00001
+        }
+    },
+    {
+        "model": "command-r7b-12-2024",
+        "cost": {
+            "prompt_token": 3.75e-8,
+            "completion_token": 1.5e-7
+        }
+    },
+    {
+        "model": "command-r-08-2024",
+        "cost": {
+            "prompt_token": 1.425e-7,
+            "completion_token": 5.7e-7
+        }
+    },
+    {
+        "model": "command-r-plus-08-2024",
+        "cost": {
+            "prompt_token": 0.000002375,
+            "completion_token": 0.0000095
+        }
+    },
+    {
+        "model": "command-r-plus",
+        "cost": {
+            "prompt_token": 0.00000285,
+            "completion_token": 0.00001425
+        }
+    },
+    {
+        "model": "command-r-plus-04-2024",
+        "cost": {
+            "prompt_token": 0.00000285,
+            "completion_token": 0.00001425
+        }
+    },
+    {
+        "model": "command",
+        "cost": {
+            "prompt_token": 9.5e-7,
+            "completion_token": 0.0000019
+        }
+    },
+    {
+        "model": "command-r",
+        "cost": {
+            "prompt_token": 4.75e-7,
+            "completion_token": 0.000001425
+        }
+    },
+    {
+        "model": "command-r-03-2024",
+        "cost": {
+            "prompt_token": 4.75e-7,
+            "completion_token": 0.000001425
+        }
+    },
+    {
+        "model": "sonar-reasoning-pro",
+        "cost": {
+            "prompt_token": 0.000002,
+            "completion_token": 0.000008
+        }
+    },
+    {
+        "model": "sonar-pro",
+        "cost": {
+            "prompt_token": 0.000003,
+            "completion_token": 0.000015
+        }
+    },
+    {
+        "model": "sonar-deep-research",
+        "cost": {
+            "prompt_token": 0.000002,
+            "completion_token": 0.000008
+        }
+    },
+    {
+        "model": "r1-1776",
+        "cost": {
+            "prompt_token": 0.000002,
+            "completion_token": 0.000008
+        }
+    },
+    {
+        "model": "sonar-reasoning",
+        "cost": {
+            "prompt_token": 0.000001,
+            "completion_token": 0.000005
+        }
+    },
+    {
+        "model": "sonar",
+        "cost": {
+            "prompt_token": 0.000001,
+            "completion_token": 0.000001
+        }
+    },
+    {
+        "model": "llama-3.1-sonar-small-128k-online",
+        "cost": {
+            "prompt_token": 2e-7,
+            "completion_token": 2e-7
+        }
+    },
+    {
+        "model": "llama-3.1-sonar-large-128k-online",
+        "cost": {
+            "prompt_token": 0.000001,
+            "completion_token": 0.000001
+        }
+    },
+    {
+        "model": "deepseek-r1-zero:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "deepseek-r1-distill-llama-8b",
+        "cost": {
+            "prompt_token": 4e-8,
+            "completion_token": 4e-8
+        }
+    },
+    {
+        "model": "deepseek-r1-distill-qwen-1.5b",
+        "cost": {
+            "prompt_token": 1.8e-7,
+            "completion_token": 1.8e-7
+        }
+    },
+    {
+        "model": "deepseek-r1-distill-qwen-32b:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "deepseek-r1-distill-qwen-32b",
+        "cost": {
+            "prompt_token": 1.2e-7,
+            "completion_token": 1.8e-7
+        }
+    },
+    {
+        "model": "deepseek-r1-distill-qwen-14b:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "deepseek-r1-distill-qwen-14b",
+        "cost": {
+            "prompt_token": 1.5e-7,
+            "completion_token": 1.5e-7
+        }
+    },
+    {
+        "model": "deepseek-r1-distill-llama-70b:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "deepseek-r1-distill-llama-70b",
+        "cost": {
+            "prompt_token": 2.3e-7,
+            "completion_token": 6.9e-7
+        }
+    },
+    {
+        "model": "deepseek-r1:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "deepseek-r1",
+        "cost": {
+            "prompt_token": 5.5e-7,
+            "completion_token": 0.00000219
+        }
+    },
+    {
+        "model": "deepseek-chat:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "deepseek-chat",
+        "cost": {
+            "prompt_token": 4e-7,
+            "completion_token": 0.0000013
+        }
+    },
+    {
+        "model": "claude-3.7-sonnet:beta",
+        "cost": {
+            "prompt_token": 0.000003,
+            "completion_token": 0.000015
+        }
+    },
+    {
+        "model": "claude-3.7-sonnet",
+        "cost": {
+            "prompt_token": 0.000003,
+            "completion_token": 0.000015
+        }
+    },
+    {
+        "model": "claude-3.7-sonnet:thinking",
+        "cost": {
+            "prompt_token": 0.000003,
+            "completion_token": 0.000015
+        }
+    },
+    {
+        "model": "claude-3.5-haiku-20241022:beta",
+        "cost": {
+            "prompt_token": 8e-7,
+            "completion_token": 0.000004
+        }
+    },
+    {
+        "model": "claude-3.5-haiku-20241022",
+        "cost": {
+            "prompt_token": 8e-7,
+            "completion_token": 0.000004
+        }
+    },
+    {
+        "model": "claude-3.5-haiku:beta",
+        "cost": {
+            "prompt_token": 8e-7,
+            "completion_token": 0.000004
+        }
+    },
+    {
+        "model": "claude-3.5-haiku",
+        "cost": {
+            "prompt_token": 8e-7,
+            "completion_token": 0.000004
+        }
+    },
+    {
+        "model": "claude-3.5-sonnet:beta",
+        "cost": {
+            "prompt_token": 0.000003,
+            "completion_token": 0.000015
+        }
+    },
+    {
+        "model": "claude-3.5-sonnet",
+        "cost": {
+            "prompt_token": 0.000003,
+            "completion_token": 0.000015
+        }
+    },
+    {
+        "model": "claude-3.5-sonnet-20240620:beta",
+        "cost": {
+            "prompt_token": 0.000003,
+            "completion_token": 0.000015
+        }
+    },
+    {
+        "model": "claude-3.5-sonnet-20240620",
+        "cost": {
+            "prompt_token": 0.000003,
+            "completion_token": 0.000015
+        }
+    },
+    {
+        "model": "claude-3-haiku:beta",
+        "cost": {
+            "prompt_token": 2.5e-7,
+            "completion_token": 0.00000125
+        }
+    },
+    {
+        "model": "claude-3-haiku",
+        "cost": {
+            "prompt_token": 2.5e-7,
+            "completion_token": 0.00000125
+        }
+    },
+    {
+        "model": "claude-3-opus:beta",
+        "cost": {
+            "prompt_token": 0.000015,
+            "completion_token": 0.000075
+        }
+    },
+    {
+        "model": "claude-3-opus",
+        "cost": {
+            "prompt_token": 0.000015,
+            "completion_token": 0.000075
+        }
+    },
+    {
+        "model": "claude-3-sonnet:beta",
+        "cost": {
+            "prompt_token": 0.000003,
+            "completion_token": 0.000015
+        }
+    },
+    {
+        "model": "claude-3-sonnet",
+        "cost": {
+            "prompt_token": 0.000003,
+            "completion_token": 0.000015
+        }
+    },
+    {
+        "model": "claude-2:beta",
+        "cost": {
+            "prompt_token": 0.000008,
+            "completion_token": 0.000024
+        }
+    },
+    {
+        "model": "claude-2",
+        "cost": {
+            "prompt_token": 0.000008,
+            "completion_token": 0.000024
+        }
+    },
+    {
+        "model": "claude-2.1:beta",
+        "cost": {
+            "prompt_token": 0.000008,
+            "completion_token": 0.000024
+        }
+    },
+    {
+        "model": "claude-2.1",
+        "cost": {
+            "prompt_token": 0.000008,
+            "completion_token": 0.000024
+        }
+    },
+    {
+        "model": "claude-2.0:beta",
+        "cost": {
+            "prompt_token": 0.000008,
+            "completion_token": 0.000024
+        }
+    },
+    {
+        "model": "claude-2.0",
+        "cost": {
+            "prompt_token": 0.000008,
+            "completion_token": 0.000024
+        }
+    },
+    {
         "model": "llama-guard-3-8b",
         "cost": {
             "prompt_token": 2e-7,
-            "completion_token": 1.998e-7
+            "completion_token": 2e-7
         }
     },
     {


### PR DESCRIPTION
## Problem

uses who had token caching enabled and used anthropic were seeing negative costs.
This was due to a miscalculation on expecting input tokens to include cache read tokens (it did not)

## Changes

fix calculation to separate cache token calc from input tokens on anthropic