### PR TITLE
fix: broken link in toolbar

### DIFF
--- a/frontend/src/toolbar/web-vitals/WebVitalsToolbarMenu.tsx
+++ b/frontend/src/toolbar/web-vitals/WebVitalsToolbarMenu.tsx
@@ -20,7 +20,7 @@ const ALL_METRICS: WebVitalsMetric[] = ['INP', 'LCP', 'FCP', 'CLS']
 
 export const WebVitalsToolbarMenu = (): JSX.Element => {
     const { localWebVitals, remoteWebVitals } = useValues(webVitalsToolbarLogic)
-    const { posthog } = useValues(toolbarConfigLogic)
+    const { posthog, apiURL } = useValues(toolbarConfigLogic)
 
     return (
         <ToolbarMenu>
@@ -71,7 +71,7 @@ export const WebVitalsToolbarMenu = (): JSX.Element => {
 
             <ToolbarMenu.Footer>
                 <div className="flex flex-row justify-between w-full">
-                    <Link to={urls.webAnalyticsWebVitals()} target="_blank">
+                    <Link to={`${apiURL}${urls.webAnalyticsWebVitals()}`} target="_blank">
                         View all metrics
                     </Link>
                     <Link to="https://posthog.com/docs/web-analytics/web-vitals" target="_blank">


### PR DESCRIPTION
## Problem

A link is not working on the toolbar because its not include the apiURL as part of the URL

## Changes

Updated the link to use the apiURL same as actions tab: https://github.com/PostHog/posthog/blob/310de14c2d792c1e563789dc926764c64f18110c/frontend/src/toolbar/actions/ActionsToolbarMenu.tsx

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes 

## How did you test this code?

I didn't because I don't have Local set up yet. 
