### PR TITLE
feat(stickiness) : Added breakdown filters to FE

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -223,7 +223,7 @@ export const productUrls = {
     replayPlaylist: (id: string): string => `/replay/playlists/${id}`,
     replaySingle: (id: string): string => `/replay/${id}`,
     replayFilePlayback: (): string => '/replay/file-playback',
-    replaySettings: (sectionId?: string): string => `/replay/settings${sectionId ? `?sectionId=${sectionId}` : ''}`,
+    replaySettings: (): string => '/replay/settings',
     webAnalytics: (): string => `/web`,
     webAnalyticsWebVitals: (): string => `/web/web-vitals`,
     webAnalyticsPageReports: (): string => `/web/page-reports`,

--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
@@ -77,7 +77,8 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
         (isTrends && !NON_BREAKDOWN_DISPLAY_TYPES.includes(display || ChartDisplayType.ActionsLineGraph)) ||
         isStepsFunnel ||
         isTrendsFunnel ||
-        isRetention
+        isRetention ||
+        isStickiness
     const hasPathsAdvanced = hasAvailableFeature(AvailableFeature.PATHS_ADVANCED)
     const hasAttribution = isStepsFunnel || isTrendsFunnel
     const hasPathsHogQL = isPaths && pathsFilter?.includeEventTypes?.includes(PathType.HogQL)

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -15775,6 +15775,10 @@
         "StickinessQuery": {
             "additionalProperties": false,
             "properties": {
+                "breakdownFilter": {
+                    "$ref": "#/definitions/BreakdownFilter",
+                    "description": "Breakdown properties"
+                },
                 "compareFilter": {
                     "$ref": "#/definitions/CompareFilter",
                     "description": "Compare to date range"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1282,6 +1282,8 @@ export interface StickinessQuery
     stickinessFilter?: StickinessFilter
     /** Compare to date range */
     compareFilter?: CompareFilter
+    /** Breakdown properties */
+    breakdownFilter?: BreakdownFilter
 }
 
 /** `LifecycleFilterType` minus everything inherited from `FilterType` */

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -230,8 +230,10 @@ export function isInsightQueryWithDisplay(node?: Record<string, any> | null): no
     return isTrendsQuery(node) || isStickinessQuery(node)
 }
 
-export function isInsightQueryWithBreakdown(node?: Record<string, any> | null): node is TrendsQuery | FunnelsQuery {
-    return isTrendsQuery(node) || isFunnelsQuery(node) || isRetentionQuery(node)
+export function isInsightQueryWithBreakdown(
+    node?: Record<string, any> | null
+): node is TrendsQuery | FunnelsQuery | RetentionQuery | StickinessQuery {
+    return isTrendsQuery(node) || isFunnelsQuery(node) || isRetentionQuery(node) || isStickinessQuery(node)
 }
 
 export function isInsightQueryWithCompare(node?: Record<string, any> | null): node is TrendsQuery | StickinessQuery {
@@ -437,7 +439,7 @@ export function filterKeyForQuery(node: InsightQueryNode): InsightFilterProperty
 
 export function filterForQuery(node: InsightQueryNode): InsightFilter | undefined {
     const filterProperty = nodeKindToFilterProperty[node.kind]
-    return node[filterProperty]
+    return node[filterProperty as keyof typeof node] as InsightFilter | undefined
 }
 
 export function isQuoted(identifier: string): boolean {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -7715,6 +7715,7 @@ class StickinessQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    breakdownFilter: Optional[BreakdownFilter] = Field(default=None, description="Breakdown properties")
     compareFilter: Optional[CompareFilter] = Field(default=None, description="Compare to date range")
     dataColorTheme: Optional[float] = Field(default=None, description="Colors used in the insight's visualization")
     dateRange: Optional[DateRange] = Field(default=None, description="Date range for the query")


### PR DESCRIPTION
## Problem

Users currently do not have the ability to breakdown their stickiness insight. This PR allows users to breakdown their stickiness by a property similar to the trends and retention insights.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
