### PR TITLE
feat: add ingestion token overflow

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -79,6 +79,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         INGESTION_CONCURRENCY: 10,
         INGESTION_BATCH_SIZE: 500,
         INGESTION_OVERFLOW_ENABLED: false,
+        INGESTION_FORCE_OVERFLOW_TOKENS: '',
         INGESTION_OVERFLOW_PRESERVE_PARTITION_LOCALITY: false,
         PLUGINS_DEFAULT_LOG_LEVEL: isTestEnv() ? PluginLogLevel.Full : PluginLogLevel.Log,
         LOG_LEVEL: isTestEnv() ? LogLevel.Warn : LogLevel.Info,

--- a/plugin-server/src/ingestion/__snapshots__/ingestion-consumer.test.ts.snap
+++ b/plugin-server/src/ingestion/__snapshots__/ingestion-consumer.test.ts.snap
@@ -17,6 +17,47 @@ exports[`IngestionConsumer error handling should handle explicitly non retriable
 ]
 `;
 
+exports[`IngestionConsumer general overflow force overflow should force events with matching token to overflow: force overflow messages 1`] = `
+[
+  {
+    "key": null,
+    "topic": "events_plugin_ingestion_overflow_test",
+    "value": {
+      "data": "{"distinct_id":"team1-user","uuid":"<REPLACED-UUID-0>","token":"THIS IS NOT A TOKEN FOR TEAM 2","ip":"127.0.0.1","site_url":"us.posthog.com","now":"2025-01-01T00:00:00.000Z","event":"$pageview","properties":{"$current_url":"http://localhost:8000"}}",
+      "distinct_id": "team1-user",
+      "ip": "127.0.0.1",
+      "now": "2025-01-01T00:00:00.000Z",
+      "token": "THIS IS NOT A TOKEN FOR TEAM 2",
+      "uuid": "<REPLACED-UUID-0>",
+    },
+  },
+]
+`;
+
+exports[`IngestionConsumer general overflow force overflow should force events with matching token to overflow: normal messages with force overflow enabled 1`] = `
+[
+  {
+    "key": "<REPLACED-UUID-0>",
+    "topic": "clickhouse_events_json_test",
+    "value": {
+      "created_at": "2025-01-01 00:00:00.000",
+      "distinct_id": "team2-user",
+      "elements_chain": "",
+      "event": "$pageview",
+      "person_created_at": "2025-01-01 00:00:00",
+      "person_id": "<REPLACED-UUID-1>",
+      "person_mode": "full",
+      "person_properties": "{"$current_url":"http://localhost:8000","$creator_event_uuid":"<REPLACED-UUID-0>","$initial_current_url":"http://localhost:8000"}",
+      "project_id": 662137301,
+      "properties": "{"$current_url":"http://localhost:8000","$ip":"127.0.0.1","$set":{"$current_url":"http://localhost:8000"},"$set_once":{"$initial_current_url":"http://localhost:8000"}}",
+      "team_id": 662137301,
+      "timestamp": "2025-01-01 00:00:00.000",
+      "uuid": "<REPLACED-UUID-0>",
+    },
+  },
+]
+`;
+
 exports[`IngestionConsumer general overflow should allow some events to pass 1`] = `
 [
   {

--- a/plugin-server/src/ingestion/__snapshots__/ingestion-consumer.test.ts.snap
+++ b/plugin-server/src/ingestion/__snapshots__/ingestion-consumer.test.ts.snap
@@ -34,30 +34,6 @@ exports[`IngestionConsumer general overflow force overflow should force events w
 ]
 `;
 
-exports[`IngestionConsumer general overflow force overflow should force events with matching token to overflow: normal messages with force overflow enabled 1`] = `
-[
-  {
-    "key": "<REPLACED-UUID-0>",
-    "topic": "clickhouse_events_json_test",
-    "value": {
-      "created_at": "2025-01-01 00:00:00.000",
-      "distinct_id": "team2-user",
-      "elements_chain": "",
-      "event": "$pageview",
-      "person_created_at": "2025-01-01 00:00:00",
-      "person_id": "<REPLACED-UUID-1>",
-      "person_mode": "full",
-      "person_properties": "{"$current_url":"http://localhost:8000","$creator_event_uuid":"<REPLACED-UUID-0>","$initial_current_url":"http://localhost:8000"}",
-      "project_id": 662137301,
-      "properties": "{"$current_url":"http://localhost:8000","$ip":"127.0.0.1","$set":{"$current_url":"http://localhost:8000"},"$set_once":{"$initial_current_url":"http://localhost:8000"}}",
-      "team_id": 662137301,
-      "timestamp": "2025-01-01 00:00:00.000",
-      "uuid": "<REPLACED-UUID-0>",
-    },
-  },
-]
-`;
-
 exports[`IngestionConsumer general overflow should allow some events to pass 1`] = `
 [
   {

--- a/plugin-server/src/ingestion/ingestion-consumer.test.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.test.ts
@@ -182,6 +182,73 @@ describe('IngestionConsumer', () => {
                 expect(getProducedKafkaMessagesForTopic('events_plugin_ingestion_overflow_test')).toHaveLength(0)
                 expect(getProducedKafkaMessagesForTopic('clickhouse_events_json_test')).toHaveLength(1)
             })
+
+            describe('force overflow', () => {
+                beforeEach(async () => {
+                    // Reset ingester with force overflow tokens
+                    await ingester.stop()
+                    hub.INGESTION_FORCE_OVERFLOW_TOKENS = team.api_token
+                    ingester = new IngestionConsumer(hub)
+                    await ingester.start()
+                })
+
+                it('should force events with matching token to overflow', async () => {
+                    const events = [
+                        createEvent({ token: team.api_token, distinct_id: 'team1-user' }),
+                        createEvent({ token: team2.api_token, distinct_id: 'team2-user' }),
+                    ]
+                    const messages = createKafkaMessages(events)
+
+                    await ingester.handleKafkaBatch(messages)
+
+                    // The team1 event should be routed to overflow
+                    expect(getProducedKafkaMessagesForTopic('events_plugin_ingestion_overflow_test')).toHaveLength(1)
+                    expect(getProducedKafkaMessagesForTopic('clickhouse_events_json_test')).toHaveLength(1)
+
+                    // Verify the right event went to overflow (team1) and the right event was processed normally (team2)
+                    const overflowMessages = getProducedKafkaMessagesForTopic('events_plugin_ingestion_overflow_test')
+                    const normalMessages = getProducedKafkaMessagesForTopic('clickhouse_events_json_test')
+
+                    expect(overflowMessages[0].value.distinct_id).toEqual('team1-user')
+                    expect(normalMessages[0].value.distinct_id).toEqual('team2-user')
+
+                    // Add snapshot for the overflow messages
+                    expect(forSnapshot(overflowMessages)).toMatchSnapshot('force overflow messages')
+                    expect(forSnapshot(normalMessages)).toMatchSnapshot('normal messages with force overflow enabled')
+                })
+
+                it('should handle multiple tokens in the force overflow setting', async () => {
+                    // Reset ingester with multiple force overflow tokens
+                    await ingester.stop()
+                    hub.INGESTION_FORCE_OVERFLOW_TOKENS = `${team.api_token},${team2.api_token}`
+                    ingester = new IngestionConsumer(hub)
+                    await ingester.start()
+
+                    // Create events for both teams
+                    const events = [
+                        createEvent({ token: team.api_token, distinct_id: 'distinct-id-team1' }),
+                        createEvent({ token: team2.api_token, distinct_id: 'distinct-id-team2' }),
+                    ]
+                    const messages = createKafkaMessages(events)
+
+                    await ingester.handleKafkaBatch(messages)
+
+                    // Both events should be routed to overflow
+                    expect(getProducedKafkaMessagesForTopic('events_plugin_ingestion_overflow_test')).toHaveLength(2)
+                    expect(getProducedKafkaMessagesForTopic('clickhouse_events_json_test')).toHaveLength(0)
+
+                    // Verify both team events went to overflow
+                    const overflowMessages = getProducedKafkaMessagesForTopic('events_plugin_ingestion_overflow_test')
+
+                    // Sort messages by distinct_id to make the test deterministic
+                    const sortedOverflowMessages = [...overflowMessages].sort((a, b) =>
+                        String(a.value.distinct_id).localeCompare(String(b.value.distinct_id))
+                    )
+
+                    expect(sortedOverflowMessages[0].value.distinct_id).toEqual('distinct-id-team1')
+                    expect(sortedOverflowMessages[1].value.distinct_id).toEqual('distinct-id-team2')
+                })
+            })
         })
     })
 

--- a/plugin-server/src/ingestion/ingestion-consumer.test.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.test.ts
@@ -214,7 +214,6 @@ describe('IngestionConsumer', () => {
 
                     // Add snapshot for the overflow messages
                     expect(forSnapshot(overflowMessages)).toMatchSnapshot('force overflow messages')
-                    expect(forSnapshot(normalMessages)).toMatchSnapshot('normal messages with force overflow enabled')
                 })
 
                 it('should handle multiple tokens in the force overflow setting', async () => {

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -135,6 +135,7 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
     INGESTION_CONCURRENCY: number // number of parallel event ingestion queues per batch
     INGESTION_BATCH_SIZE: number // kafka consumer batch size
     INGESTION_OVERFLOW_ENABLED: boolean // whether or not overflow rerouting is enabled (only used by analytics-ingestion)
+    INGESTION_FORCE_OVERFLOW_TOKENS: string // comma-separated list of tokens to always route to overflow
     INGESTION_OVERFLOW_PRESERVE_PARTITION_LOCALITY: boolean // whether or not Kafka message keys should be preserved or discarded when messages are rerouted to overflow
     TASK_TIMEOUT: number // how many seconds until tasks are timed out
     DATABASE_URL: string // Postgres database URL

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -229,9 +229,7 @@ impl KafkaSink {
                 // TODO: deprecate capture-led overflow or move logic in handler
                 let is_limited = match &self.partition {
                     None => false,
-                    Some(partition) => {
-                        partition.is_limited(&event_key) || partition.is_limited(&token)
-                    },
+                    Some(partition) => partition.is_limited(&event_key) || partition.is_limited(&token),
                 };
                 if is_limited {
                     (&self.main_topic, None) // Analytics overflow goes to the main topic without locality

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -231,7 +231,7 @@ impl KafkaSink {
                     None => false,
                     Some(partition) => {
                         partition.is_limited(&event_key) || partition.is_limited(&token)
-                    },
+                    }
                 };
                 if is_limited {
                     (&self.main_topic, None) // Analytics overflow goes to the main topic without locality

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -229,7 +229,7 @@ impl KafkaSink {
                 // TODO: deprecate capture-led overflow or move logic in handler
                 let is_limited = match &self.partition {
                     None => false,
-                    Some(partition) => partition.is_limited(&event_key),
+                    Some(partition) => partition.is_limited(&event_key) || partition.is_limited(&token),
                 };
                 if is_limited {
                     (&self.main_topic, None) // Analytics overflow goes to the main topic without locality

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -231,7 +231,7 @@ impl KafkaSink {
                     None => false,
                     Some(partition) => {
                         partition.is_limited(&event_key) || partition.is_limited(&token)
-                    }
+                    },
                 };
                 if is_limited {
                     (&self.main_topic, None) // Analytics overflow goes to the main topic without locality

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -229,7 +229,7 @@ impl KafkaSink {
                 // TODO: deprecate capture-led overflow or move logic in handler
                 let is_limited = match &self.partition {
                     None => false,
-                    Some(partition) => partition.is_limited(&event_key) || partition.is_limited(&token),
+                    Some(partition) => partition.is_limited(&event_key),
                 };
                 if is_limited {
                     (&self.main_topic, None) // Analytics overflow goes to the main topic without locality

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -229,7 +229,9 @@ impl KafkaSink {
                 // TODO: deprecate capture-led overflow or move logic in handler
                 let is_limited = match &self.partition {
                     None => false,
-                    Some(partition) => partition.is_limited(&event_key) || partition.is_limited(&token),
+                    Some(partition) => {
+                        partition.is_limited(&event_key) || partition.is_limited(&token)
+                    },
                 };
                 if is_limited {
                     (&self.main_topic, None) // Analytics overflow goes to the main topic without locality


### PR DESCRIPTION
## Problem

We can move individual clients (distinct ids or ips for anonymous ones) to overflow, but we can't move a whole team, which doesn't let us deal with some team-level traffic spikes.

## Changes

Checks the token against the limiter in ingestion.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added some tests