### PR TITLE
fix(bigquery): Tolerate missing permissions to get schemas

### DIFF
--- a/posthog/temporal/data_imports/workflow_activities/sync_new_schemas.py
+++ b/posthog/temporal/data_imports/workflow_activities/sync_new_schemas.py
@@ -5,6 +5,7 @@ from django.db import close_old_connections
 from temporalio import activity
 
 from posthog.temporal.common.logger import bind_temporal_worker_logger_sync
+from posthog.temporal.data_imports.pipelines.bigquery import get_schemas as get_bigquery_schemas
 from posthog.temporal.data_imports.pipelines.schemas import (
     PIPELINE_TYPE_SCHEMA_DEFAULT_MAPPING,
 )
@@ -17,7 +18,6 @@ from posthog.warehouse.models.external_data_schema import (
     get_sql_schemas_for_source_type,
 )
 from posthog.warehouse.models.ssh_tunnel import SSHTunnel
-from posthog.temporal.data_imports.pipelines.bigquery import get_schemas as get_bigquery_schemas
 
 
 @dataclasses.dataclass
@@ -142,6 +142,7 @@ def sync_new_schemas_activity(inputs: SyncNewSchemasActivityInputs) -> None:
             private_key_id=private_key_id,
             client_email=client_email,
             token_uri=token_uri,
+            logger=logger,
         )
 
         schemas_to_sync = list(bq_schemas.keys())

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -989,6 +989,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 private_key_id=private_key_id,
                 client_email=client_email,
                 token_uri=token_uri,
+                logger=logger,
             )
 
             filtered_results = [


### PR DESCRIPTION
## Problem

Permissions can be granted and later revoked, so in Data Warehouse we should tolerate not being able to query for new schemas to sync. In this case, we'll just report back an empty list (`dict`, actually) of schemas, which means we'll keep the current list of schemas to sync as it is.

The `Forbidden` error is logged as a warning to not pass silently.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
