### PR TITLE
fix(environments): Properly handle case restricted access

### DIFF
--- a/.cursor/rules/django-python.mdc
+++ b/.cursor/rules/django-python.mdc
@@ -89,6 +89,7 @@ Testing
   - All new packages and most new significant functionality should come with unit tests
   - Significant features should come with integration and/or end-to-end tests
   - Analytics-related queries should be covered by snapshot tests for ease of reviewing
+  - Run tests with `pytest`
 
 Unit tests
   - A good unit test should:

--- a/ee/api/test/test_insight.py
+++ b/ee/api/test/test_insight.py
@@ -34,7 +34,7 @@ class TestInsightEnterpriseAPI(APILicensedTest):
             f"/api/projects/{self.team.id}/insights/trend/?events={json.dumps([{'id': '$pageview'}])}"
         )
         self.assertDictEqual(
-            self.permission_denied_response("You don't have access to the project."),
+            self.permission_denied_response("You don't have access to the environment."),
             response.json(),
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -150,7 +150,7 @@ class ActionViewSet(
             queryset = queryset.filter(deleted=False)
 
         queryset = queryset.annotate(count=Count(TREND_FILTER_TYPE_EVENTS))
-        return queryset.filter(team_id=self.team_id).order_by(*self.ordering)
+        return queryset.order_by(*self.ordering)
 
     def list(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
         # :HACKY: we need to override this viewset method until actions support

--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -1,5 +1,4 @@
 from datetime import UTC, datetime, timedelta
-from functools import cached_property
 from typing import Any, Optional, cast
 from django.db import transaction
 
@@ -805,12 +804,6 @@ class ProjectViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets
         return response.Response(
             ProjectBackwardCompatSerializer(project, context=self.get_serializer_context()).data, status=200
         )
-
-    @cached_property
-    def user_permissions(self):
-        project = self.get_object() if self.action == "reset_token" else None
-        team = project.get_passthrough_team(self.user_permissions.team_ids_visible_for_user) if project else None
-        return UserPermissions(cast(User, self.request.user), team)
 
 
 class RootProjectViewSet(ProjectViewSet):

--- a/posthog/models/project.py
+++ b/posthog/models/project.py
@@ -62,4 +62,7 @@ class Project(models.Model):
 
     @cached_property
     def passthrough_team(self) -> "Team":
-        return self.teams.get(pk=self.pk)
+        passthrough_team = self.teams.first()
+        if passthrough_team is None:
+            raise ValueError(f"Project {self.pk} has no environments, which should not be possible")
+        return passthrough_team

--- a/posthog/models/project.py
+++ b/posthog/models/project.py
@@ -1,4 +1,4 @@
-from functools import cached_property
+from functools import lru_cache
 from typing import TYPE_CHECKING, Optional, cast
 
 from django.core.validators import MinLengthValidator
@@ -60,9 +60,9 @@ class Project(models.Model):
 
     __repr__ = sane_repr("id", "name")
 
-    @cached_property
-    def passthrough_team(self) -> "Team":
-        passthrough_team = self.teams.first()
+    @lru_cache(maxsize=1)
+    def get_passthrough_team(self, visible_team_ids: tuple[int, ...]) -> "Team":
+        passthrough_team = self.teams.filter(id__in=visible_team_ids).first()
         if passthrough_team is None:
             raise ValueError(f"Project {self.pk} has no environments, which should not be possible")
         return passthrough_team

--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -162,7 +162,7 @@ class OrganizationAdminWritePermissions(BasePermission):
 class TeamMemberAccessPermission(BasePermission):
     """Require effective membership in the environment for any access at all."""
 
-    message = "You don't have access to this environment."
+    message = "You don't have access to the environment."
 
     def has_permission(self, request, view) -> bool:
         try:
@@ -179,7 +179,7 @@ class TeamMemberAccessPermission(BasePermission):
 class AnyTeamInProjectMemberAccessPermission(BasePermission):
     """Require effective membership in any environment of the project for any access at all."""
 
-    message = "You don't have access to this project."
+    message = "You don't have access to the project."
 
     def has_permission(self, request, view) -> bool:
         try:
@@ -536,7 +536,7 @@ class AccessControlPermission(ScopeBasePermission):
         is_member = uac.check_access_level_for_object(team, required_level="member")
 
         if not is_member:
-            self.message = f"You don't have access to the project."
+            self.message = "You don't have access to the project."
             return False
 
         # If the API doesn't have a scope object or a required level for accessing then we can simply allow access

--- a/posthog/test/test_user_permissions.py
+++ b/posthog/test/test_user_permissions.py
@@ -99,13 +99,13 @@ class TestUserTeamPermissions(BaseTest, WithPermissionsBase):
             assert self.permissions().current_team.effective_membership_level == OrganizationMembership.Level.ADMIN
 
     def test_team_ids_visible_for_user(self):
-        assert self.permissions().team_ids_visible_for_user == [self.team.pk]
+        assert self.permissions().team_ids_visible_for_user == (self.team.pk,)
 
     def test_team_ids_visible_for_user_no_explicit_permissions(self):
         self.team.access_control = True
         self.team.save()
 
-        assert self.permissions().team_ids_visible_for_user == []
+        assert self.permissions().team_ids_visible_for_user == ()
 
     def test_team_ids_visible_for_user_explicit_permission(self):
         self.team.access_control = True
@@ -117,10 +117,10 @@ class TestUserTeamPermissions(BaseTest, WithPermissionsBase):
             level=ExplicitTeamMembership.Level.ADMIN,
         )
 
-        assert self.permissions().team_ids_visible_for_user == [self.team.pk]
+        assert self.permissions().team_ids_visible_for_user == (self.team.pk,)
 
     def test_project_ids_visible_for_user(self):
-        assert self.permissions().project_ids_visible_for_user == [self.team.project_id]
+        assert self.permissions().project_ids_visible_for_user == (self.team.project_id,)
 
     def test_project_ids_visible_for_user_multiple_teams(self):
         # Create a second team with the same project_id
@@ -143,7 +143,7 @@ class TestUserTeamPermissions(BaseTest, WithPermissionsBase):
         self.team.save()
 
         # User shouldn't see any project IDs
-        assert self.permissions().project_ids_visible_for_user == []
+        assert self.permissions().project_ids_visible_for_user == ()
 
     def test_project_ids_visible_for_user_explicit_permission(self):
         self.team.access_control = True
@@ -155,7 +155,7 @@ class TestUserTeamPermissions(BaseTest, WithPermissionsBase):
             level=ExplicitTeamMembership.Level.ADMIN,
         )
 
-        assert self.permissions().project_ids_visible_for_user == [self.team.project_id]
+        assert self.permissions().project_ids_visible_for_user == (self.team.project_id,)
 
 
 class TestUserDashboardPermissions(BaseTest, WithPermissionsBase):

--- a/posthog/user_permissions.py
+++ b/posthog/user_permissions.py
@@ -75,12 +75,12 @@ class UserPermissions:
         return [team for team in candidate_teams if self.team(team).effective_membership_level is not None]
 
     @cached_property
-    def team_ids_visible_for_user(self) -> list[int]:
-        return [team.pk for team in self.teams_visible_for_user]
+    def team_ids_visible_for_user(self) -> tuple[int, ...]:
+        return tuple(team.pk for team in self.teams_visible_for_user)
 
     @cached_property
-    def project_ids_visible_for_user(self) -> list[int]:
-        return list({team.project_id for team in self.teams_visible_for_user})
+    def project_ids_visible_for_user(self) -> tuple[int, ...]:
+        return tuple({team.project_id for team in self.teams_visible_for_user})
 
     # Cached properties/functions for efficient lookups in other classes
 


### PR DESCRIPTION
## Problem

When the initial environment of a project had restricted access, and the user did not in fact have access, errors appeared as this wasn't handled.

## Changes

Two key changes **in the `/projects/` endpoint, and all endpoints nested under it**:
1. Those endpoints are now guarded by the new `AnyTeamInProjectMemberAccessPermission`, rather than `TeamMemberAccessPermission`. This means the user has access to this endpoint (and ones nested under it) if they have access to _at least 1_ environment (since the "private project" setting has become the "private environment" setting).
2. `UserTeamPermissions` in those endpoints gets the first `team` of the project that the user has access to, rather than the first `team` overall. This means we don't say the user has no access to the project if they actually do.

## How did you test this code?

Added API tests, verify them.