### PR TITLE
feat(insight-variables): Show which insights are using a variable on a dashboard

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
@@ -42,11 +42,12 @@ export const VariablesForDashboard = (): JSX.Element => {
             <div className="flex gap-4 flex-wrap px-px mt-4">
                 {dashboardVariables.map((n) => (
                     <VariableComponent
-                        key={n.id}
-                        variable={n}
+                        key={n.variable.id}
+                        variable={n.variable}
                         showEditingUI={false}
                         onChange={overrideVariableValue}
                         variableOverridesAreSet={false}
+                        insightsUsingVariable={n.insights}
                     />
                 ))}
             </div>
@@ -296,6 +297,7 @@ interface VariableComponentProps {
     variableOverridesAreSet: boolean
     onRemove?: (variableId: string) => void
     variableSettingsOnClick?: () => void
+    insightsUsingVariable?: string[]
 }
 
 export const VariableComponent = ({
@@ -305,17 +307,20 @@ export const VariableComponent = ({
     variableOverridesAreSet,
     onRemove,
     variableSettingsOnClick,
+    insightsUsingVariable,
 }: VariableComponentProps): JSX.Element => {
     const [isPopoverOpen, setPopoverOpen] = useState(false)
+
+    let tooltip = `Use this variable in your HogQL by referencing {variables.${variable.code_name}}`
+
+    if (insightsUsingVariable && insightsUsingVariable.length) {
+        tooltip += `. Insights using this variable: ${insightsUsingVariable.join(', ')}`
+    }
 
     // Dont show the popover overlay for list variables not in edit mode
     if (!showEditingUI && variable.type === 'List') {
         return (
-            <LemonField.Pure
-                label={variable.name}
-                className="gap-0"
-                info={`Use this variable in your HogQL by referencing {variables.${variable.code_name}}`}
-            >
+            <LemonField.Pure label={variable.name} className="gap-0" info={tooltip}>
                 <LemonSelect
                     value={variable.value ?? variable.default_value}
                     onChange={(value) => onChange(variable.id, value, variable.isNull ?? false)}
@@ -349,11 +354,7 @@ export const VariableComponent = ({
             className="DataVizVariable_Popover"
         >
             <div>
-                <LemonField.Pure
-                    label={variable.name}
-                    className="gap-0"
-                    info={`Use this variable in your HogQL by referencing {variables.${variable.code_name}}`}
-                >
+                <LemonField.Pure label={variable.name} className="gap-0" info={tooltip}>
                     <LemonButton
                         type="secondary"
                         className="min-w-32 DataVizVariable_Button"


### PR DESCRIPTION
## Problem
- On our DWH dashboard, we have a `Customer ID` variable showing, meaning one of our insights is using this variable, but I have no idea which and I don't wanna have to go check 20+ insights to see

<img width="388" alt="image" src="https://github.com/user-attachments/assets/c2ffc712-1780-43b6-bcb7-7d86eeb8f196" />


## Changes
- On the variable tooltip, list the insights that the variable is being used in

<img width="480" alt="image" src="https://github.com/user-attachments/assets/277adf50-09db-49b3-9836-550e7928b3ae" />


## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
See screenshot