### PR TITLE
chore(data-warehouse): Added cross sell intent to add data source

### DIFF
--- a/frontend/src/lib/utils/product-intents.ts
+++ b/frontend/src/lib/utils/product-intents.ts
@@ -10,6 +10,7 @@ export enum ProductIntentContext {
 
     // Data Warehouse
     SELECTED_CONNECTOR = 'selected connector',
+    SQL_EDITOR = 'sql editor',
 
     // Experiments
     EXPERIMENT_CREATED = 'experiment created',

--- a/frontend/src/lib/utils/product-intents.ts
+++ b/frontend/src/lib/utils/product-intents.ts
@@ -10,7 +10,7 @@ export enum ProductIntentContext {
 
     // Data Warehouse
     SELECTED_CONNECTOR = 'selected connector',
-    SQL_EDITOR = 'sql editor',
+    SQL_EDITOR_EMPTY_STATE = 'sql editor empty state',
 
     // Experiments
     EXPERIMENT_CREATED = 'experiment created',

--- a/frontend/src/scenes/data-warehouse/editor/editorSidebarLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/editorSidebarLogic.tsx
@@ -5,16 +5,18 @@ import { connect, kea, path, selectors } from 'kea'
 import { router } from 'kea-router'
 import { subscriptions } from 'kea-subscriptions'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { ProductIntentContext } from 'lib/utils/product-intents'
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { Scene } from 'scenes/sceneTypes'
+import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { navigation3000Logic } from '~/layout/navigation-3000/navigationLogic'
 import { FuseSearchMatch } from '~/layout/navigation-3000/sidebars/utils'
 import { BasicListItem, ExtendedListItem, ListItemAccordion, SidebarCategory } from '~/layout/navigation-3000/types'
 import { DatabaseSchemaDataWarehouseTable, DatabaseSchemaTable } from '~/queries/schema/schema-general'
-import { DataWarehouseSavedQuery, PipelineStage } from '~/types'
+import { DataWarehouseSavedQuery, PipelineStage, ProductKey } from '~/types'
 
 import { dataWarehouseViewsLogic } from '../saved_queries/dataWarehouseViewsLogic'
 import { DataWarehouseSourceIcon } from '../settings/DataWarehouseSourceIcon'
@@ -62,6 +64,8 @@ export const editorSidebarLogic = kea<editorSidebarLogicType>([
             ['deleteDataWarehouseSavedQuery', 'runDataWarehouseSavedQuery'],
             viewLinkLogic,
             ['selectSourceTable', 'toggleJoinTableModal'],
+            teamLogic,
+            ['addProductIntentForCrossSell'],
         ],
     }),
     selectors(({ actions }) => ({
@@ -130,9 +134,17 @@ export const editorSidebarLogic = kea<editorSidebarLogicType>([
                             </p>
                             <LemonButton
                                 type="primary"
-                                onClick={() => router.actions.push(urls.pipelineNodeNew(PipelineStage.Source))}
+                                onClick={() => {
+                                    actions.addProductIntentForCrossSell({
+                                        from: ProductKey.DATA_WAREHOUSE,
+                                        to: ProductKey.DATA_WAREHOUSE,
+                                        intent_context: ProductIntentContext.SQL_EDITOR,
+                                    })
+                                    router.actions.push(urls.pipelineNodeNew(PipelineStage.Source))
+                                }}
                                 center
                                 size="small"
+                                id="data-warehouse-sql-editor-add-data-source"
                             >
                                 Add data source
                             </LemonButton>

--- a/frontend/src/scenes/data-warehouse/editor/editorSidebarLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/editorSidebarLogic.tsx
@@ -65,7 +65,7 @@ export const editorSidebarLogic = kea<editorSidebarLogicType>([
             viewLinkLogic,
             ['selectSourceTable', 'toggleJoinTableModal'],
             teamLogic,
-            ['addProductIntentForCrossSell'],
+            ['addProductIntent'],
         ],
     }),
     selectors(({ actions }) => ({
@@ -135,10 +135,9 @@ export const editorSidebarLogic = kea<editorSidebarLogicType>([
                             <LemonButton
                                 type="primary"
                                 onClick={() => {
-                                    actions.addProductIntentForCrossSell({
-                                        from: ProductKey.DATA_WAREHOUSE,
-                                        to: ProductKey.DATA_WAREHOUSE,
-                                        intent_context: ProductIntentContext.SQL_EDITOR,
+                                    actions.addProductIntent({
+                                        product_type: ProductKey.DATA_WAREHOUSE,
+                                        intent_context: ProductIntentContext.SQL_EDITOR_EMPTY_STATE,
                                     })
                                     router.actions.push(urls.pipelineNodeNew(PipelineStage.Source))
                                 }}

--- a/frontend/src/scenes/pipeline/Overview.tsx
+++ b/frontend/src/scenes/pipeline/Overview.tsx
@@ -2,7 +2,7 @@ import { IconPlusSmall } from '@posthog/icons'
 import { Link } from '@posthog/lemon-ui'
 import { PageHeader } from 'lib/components/PageHeader'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
-import { LemonMenu } from 'lib/lemon-ui/LemonMenu'
+import { LemonMenu, LemonMenuItems } from 'lib/lemon-ui/LemonMenu'
 import { DataWarehouseManagedSourcesTable } from 'scenes/data-warehouse/settings/DataWarehouseManagedSourcesTable'
 import { DataWarehouseSelfManagedSourcesTable } from 'scenes/data-warehouse/settings/DataWarehouseSelfManagedSourcesTable'
 import { urls } from 'scenes/urls'
@@ -13,8 +13,12 @@ import { DESTINATION_TYPES, TRANSFORMATION_TYPES } from './destinations/constant
 import { DestinationsTable } from './destinations/Destinations'
 
 export function Overview(): JSX.Element {
-    const menuItems = [
-        { label: 'Source', to: urls.pipelineNodeNew(PipelineStage.Source) },
+    const menuItems: LemonMenuItems = [
+        {
+            label: 'Source',
+            to: urls.pipelineNodeNew(PipelineStage.Source),
+            'data-attr': 'data-warehouse-data-pipelines-overview-new-source',
+        },
         { label: 'Transformation', to: urls.pipelineNodeNew(PipelineStage.Transformation) },
         { label: 'Destination', to: urls.pipelineNodeNew(PipelineStage.Destination) },
     ]


### PR DESCRIPTION
## Problem
- We're adding more places where users can add data sources, but attributing people clicking these buttons is hard

## Changes
- Add product intent action to the new "add data source" to the SQL editor
- Adds `id` to some buttons around the app to track clicks from them better

## Does this work well for both Cloud and self-hosted?
Yep

## How did you test this code?
Tested locally