### PR TITLE
chore(data-warehouse): Add non-retryable error for chargebee

### DIFF
--- a/posthog/temporal/data_imports/external_data_job.py
+++ b/posthog/temporal/data_imports/external_data_job.py
@@ -79,7 +79,7 @@ Non_Retryable_Schema_Errors: dict[ExternalDataSource.Type, list[str]] = {
         "404 Not Found",
         "Your free trial has ended",
     ],
-    ExternalDataSource.Type.CHARGEBEE: ["403 Client Error: Forbidden for url"],
+    ExternalDataSource.Type.CHARGEBEE: ["403 Client Error: Forbidden for url", "Unauthorized for url"],
     ExternalDataSource.Type.HUBSPOT: ["missing or invalid refresh token"],
 }
 


### PR DESCRIPTION
## Changes
- Add a non-retryable error for chargebee sources for when they're not authed for the endpoint