### PR TITLE
fix: increase receive_timeout for system sync queries in dags

### DIFF
--- a/dags/common.py
+++ b/dags/common.py
@@ -25,7 +25,7 @@ class ClickhouseClusterResource(dagster.ConfigurableResource):
         "max_execution_time": "0",
         "max_memory_usage": "0",
         "mutations_sync": "0",
-        "receive_timeout": f"{10 * 60}",  # some synchronous queries like dictionary checksumming can be very slow to return
+        "receive_timeout": f"{15 * 60}",  # some synchronous queries like dictionary checksumming can be very slow to return
     }
 
     def create_resource(self, context: dagster.InitResourceContext) -> ClickhouseCluster:


### PR DESCRIPTION
## Problem

For the deletes job, the dictionary SYNC can take a bit more than the specified 10 minutes.

## Changes

Increase timeout to 15 minutes.

## Does this work well for both Cloud and self-hosted?

Yes.


