### PR TITLE
fix(uploads): run the upload files callback only once

### DIFF
--- a/frontend/src/lib/hooks/useUploadFiles.ts
+++ b/frontend/src/lib/hooks/useUploadFiles.ts
@@ -72,7 +72,7 @@ export function useUploadFiles({
             }
         }
         uploadFiles().catch(console.error)
-    }, [filesToUpload, onUpload, onError])
+    }, [filesToUpload])
 
     return { setFilesToUpload, filesToUpload, uploading }
 }


### PR DESCRIPTION
## Problem

> When uploading an image to a text card on a dashboard, the image is uploaded twice.

See https://posthoghelp.zendesk.com/agent/tickets/23238. (moved to PostHog: https://us.posthog.com/project/2/support/tickets/28850)

## Changes

This is because `onUpload` is added as a `useEffect` dependency but is defined inline in `LemonTextAreaMarkdown`. This causes the hook to run twice and as such call the callback twice.

## How did you test this code?

Tried myself