### PR TITLE
feat: API queries quota limiting

### DIFF
--- a/ee/api/test/test_billing.py
+++ b/ee/api/test/test_billing.py
@@ -53,6 +53,7 @@ def create_missing_billing_customer(**kwargs) -> CustomerInfo:
             "recordings": {"limit": None, "usage": 0},
             "rows_synced": {"limit": None, "usage": 0},
             "feature_flag_requests": {"limit": None, "usage": 0},
+            "qaas_read_bytes": {"limit": None, "usage": 0},
         },
         free_trial_until=None,
         available_product_features=[],
@@ -149,6 +150,7 @@ def create_billing_customer(**kwargs) -> CustomerInfo:
             "recordings": {"limit": None, "usage": 0},
             "rows_synced": {"limit": None, "usage": 0},
             "feature_flag_requests": {"limit": None, "usage": 0},
+            "qaas_read_bytes": {"limit": None, "usage": 0},
         },
         free_trial_until=None,
     )
@@ -441,6 +443,7 @@ class TestBillingAPI(APILicensedTest):
                 "recordings": {"limit": None, "usage": 0},
                 "rows_synced": {"limit": None, "usage": 0},
                 "feature_flag_requests": {"limit": None, "usage": 0},
+                "qaas_read_bytes": {"limit": None, "usage": 0},
             },
             "free_trial_until": None,
         }
@@ -565,6 +568,7 @@ class TestBillingAPI(APILicensedTest):
                 "recordings": {"limit": None, "usage": 0},
                 "rows_synced": {"limit": None, "usage": 0},
                 "feature_flag_requests": {"limit": None, "usage": 0},
+                "qaas_read_bytes": {"limit": None, "usage": 0},
             },
             "free_trial_until": None,
             "current_total_amount_usd": "0.00",
@@ -745,6 +749,11 @@ class TestBillingAPI(APILicensedTest):
                     "todays_usage": 0,
                     "usage": 0,
                 },
+                "qaas_read_bytes": {
+                    "limit": None,
+                    "todays_usage": 0,
+                    "usage": 0,
+                },
                 "period": ["2022-10-07T11:12:48", "2022-11-07T11:12:48"],
             },
         )
@@ -822,6 +831,7 @@ class TestBillingAPI(APILicensedTest):
             "recordings": {"limit": None, "usage": 0, "todays_usage": 0},
             "rows_synced": {"limit": None, "usage": 0, "todays_usage": 0},
             "feature_flag_requests": {"limit": None, "usage": 0, "todays_usage": 0},
+            "qaas_read_bytes": {"limit": None, "usage": 0, "todays_usage": 0},
             "period": ["2022-10-07T11:12:48", "2022-11-07T11:12:48"],
         }
 
@@ -846,11 +856,13 @@ class TestBillingAPI(APILicensedTest):
         mock_request.side_effect = mock_implementation
 
         self.organization.customer_id = None
+        # For key values check: TRUST_SCORE_KEYS
         self.organization.customer_trust_scores = {
             "recordings": 0,
             "events": 0,
             "rows_synced": 0,
             "feature_flags": 0,
+            "qaas_read_bytes": 17,
         }
         self.organization.save()
 
@@ -863,6 +875,7 @@ class TestBillingAPI(APILicensedTest):
             "events": 15,
             "rows_synced": 0,
             "feature_flags": 0,
+            "qaas_read_bytes": 17,
         }
 
     @patch("ee.api.billing.requests.get")

--- a/ee/api/test/test_billing.py
+++ b/ee/api/test/test_billing.py
@@ -53,7 +53,7 @@ def create_missing_billing_customer(**kwargs) -> CustomerInfo:
             "recordings": {"limit": None, "usage": 0},
             "rows_synced": {"limit": None, "usage": 0},
             "feature_flag_requests": {"limit": None, "usage": 0},
-            "qaas_read_bytes": {"limit": None, "usage": 0},
+            "api_queries_read_bytes": {"limit": None, "usage": 0},
         },
         free_trial_until=None,
         available_product_features=[],
@@ -150,7 +150,7 @@ def create_billing_customer(**kwargs) -> CustomerInfo:
             "recordings": {"limit": None, "usage": 0},
             "rows_synced": {"limit": None, "usage": 0},
             "feature_flag_requests": {"limit": None, "usage": 0},
-            "qaas_read_bytes": {"limit": None, "usage": 0},
+            "api_queries_read_bytes": {"limit": None, "usage": 0},
         },
         free_trial_until=None,
     )
@@ -443,7 +443,7 @@ class TestBillingAPI(APILicensedTest):
                 "recordings": {"limit": None, "usage": 0},
                 "rows_synced": {"limit": None, "usage": 0},
                 "feature_flag_requests": {"limit": None, "usage": 0},
-                "qaas_read_bytes": {"limit": None, "usage": 0},
+                "api_queries_read_bytes": {"limit": None, "usage": 0},
             },
             "free_trial_until": None,
         }
@@ -568,7 +568,7 @@ class TestBillingAPI(APILicensedTest):
                 "recordings": {"limit": None, "usage": 0},
                 "rows_synced": {"limit": None, "usage": 0},
                 "feature_flag_requests": {"limit": None, "usage": 0},
-                "qaas_read_bytes": {"limit": None, "usage": 0},
+                "api_queries_read_bytes": {"limit": None, "usage": 0},
             },
             "free_trial_until": None,
             "current_total_amount_usd": "0.00",
@@ -749,7 +749,7 @@ class TestBillingAPI(APILicensedTest):
                     "todays_usage": 0,
                     "usage": 0,
                 },
-                "qaas_read_bytes": {
+                "api_queries_read_bytes": {
                     "limit": None,
                     "todays_usage": 0,
                     "usage": 0,
@@ -831,7 +831,7 @@ class TestBillingAPI(APILicensedTest):
             "recordings": {"limit": None, "usage": 0, "todays_usage": 0},
             "rows_synced": {"limit": None, "usage": 0, "todays_usage": 0},
             "feature_flag_requests": {"limit": None, "usage": 0, "todays_usage": 0},
-            "qaas_read_bytes": {"limit": None, "usage": 0, "todays_usage": 0},
+            "api_queries_read_bytes": {"limit": None, "usage": 0, "todays_usage": 0},
             "period": ["2022-10-07T11:12:48", "2022-11-07T11:12:48"],
         }
 
@@ -862,7 +862,7 @@ class TestBillingAPI(APILicensedTest):
             "events": 0,
             "rows_synced": 0,
             "feature_flags": 0,
-            "qaas_read_bytes": 17,
+            "api_queries_read_bytes": 17,
         }
         self.organization.save()
 
@@ -875,7 +875,7 @@ class TestBillingAPI(APILicensedTest):
             "events": 15,
             "rows_synced": 0,
             "feature_flags": 0,
-            "qaas_read_bytes": 17,
+            "api_queries_read_bytes": 17,
         }
 
     @patch("ee.api.billing.requests.get")

--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -316,6 +316,7 @@ class BillingManager:
                 recordings=usage_summary["recordings"],
                 rows_synced=usage_summary.get("rows_synced", {}),
                 feature_flag_requests=usage_summary.get("feature_flag_requests", {}),
+                qaas_read_bytes=usage_summary.get("qaas_read_bytes", {}),
                 period=[
                     data["billing_period"]["current_period_start"],
                     data["billing_period"]["current_period_end"],

--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -316,7 +316,7 @@ class BillingManager:
                 recordings=usage_summary["recordings"],
                 rows_synced=usage_summary.get("rows_synced", {}),
                 feature_flag_requests=usage_summary.get("feature_flag_requests", {}),
-                qaas_read_bytes=usage_summary.get("qaas_read_bytes", {}),
+                api_queries_read_bytes=usage_summary.get("api_queries_read_bytes", {}),
                 period=[
                     data["billing_period"]["current_period_start"],
                     data["billing_period"]["current_period_end"],

--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -48,6 +48,7 @@ class QuotaResource(Enum):
     RECORDINGS = "recordings"
     ROWS_SYNCED = "rows_synced"
     FEATURE_FLAG_REQUESTS = "feature_flag_requests"
+    QAAS_READ_BYTES = "qaas_read_bytes"
 
 
 class QuotaLimitingCaches(Enum):
@@ -60,6 +61,7 @@ OVERAGE_BUFFER = {
     QuotaResource.RECORDINGS: 1000,
     QuotaResource.ROWS_SYNCED: 0,
     QuotaResource.FEATURE_FLAG_REQUESTS: 0,
+    QuotaResource.QAAS_READ_BYTES: 0,
 }
 
 TRUST_SCORE_KEYS = {
@@ -67,6 +69,7 @@ TRUST_SCORE_KEYS = {
     QuotaResource.RECORDINGS: "recordings",
     QuotaResource.ROWS_SYNCED: "rows_synced",
     QuotaResource.FEATURE_FLAG_REQUESTS: "feature_flags",
+    QuotaResource.QAAS_READ_BYTES: "qaas_read_bytes",
 }
 
 
@@ -75,6 +78,7 @@ class UsageCounters(TypedDict):
     recordings: int
     rows_synced: int
     feature_flags: int
+    qaas_read_bytes: int
 
 
 # -------------------------------------------------------------------------------------------------

--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -22,6 +22,7 @@ from posthog.tasks.usage_report import (
     get_teams_with_recording_count_in_period,
     get_teams_with_rows_synced_in_period,
     get_teams_with_feature_flag_requests_count_in_period,
+    get_teams_with_qaas_metrics,
 )
 from posthog.utils import get_current_day
 
@@ -421,6 +422,7 @@ def update_org_billing_quotas(organization: Organization):
         QuotaResource.RECORDINGS,
         QuotaResource.ROWS_SYNCED,
         QuotaResource.FEATURE_FLAG_REQUESTS,
+        QuotaResource.QAAS_READ_BYTES,
     ]:
         previously_quota_limited_team_tokens = list_limited_team_attributes(
             resource,
@@ -476,7 +478,7 @@ def set_org_usage_summary(
 
     new_usage = copy.deepcopy(new_usage)
 
-    for field in ["events", "recordings", "rows_synced", "feature_flag_requests"]:
+    for field in ["events", "recordings", "rows_synced", "feature_flag_requests", "qaas_read_bytes"]:
         original_field_usage = original_usage.get(field, {}) if original_usage else {}
         resource_usage = cast(dict, new_usage.get(field, {"limit": None, "usage": 0, "todays_usage": 0}))
 
@@ -535,6 +537,8 @@ def update_all_orgs_billing_quotas(
         },
     )
 
+    qaas_usage = get_teams_with_qaas_metrics(period_start, period_end)
+
     # Clickhouse is good at counting things so we count across all teams rather than doing it one by one
     all_data = {
         "teams_with_event_count_in_period": convert_team_usage_rows_to_dict(
@@ -554,6 +558,7 @@ def update_all_orgs_billing_quotas(
                 period_start, period_end, FlagRequestType.LOCAL_EVALUATION
             )
         ),
+        "teams_with_qaas_read_bytes": convert_team_usage_rows_to_dict(qaas_usage["read_bytes"]),
     }
 
     teams: Sequence[Team] = list(
@@ -589,6 +594,7 @@ def update_all_orgs_billing_quotas(
             recordings=all_data["teams_with_recording_count_in_period"].get(team.id, 0),
             rows_synced=all_data["teams_with_rows_synced_in_period"].get(team.id, 0),
             feature_flags=decide_requests + (local_evaluation_requests * 10),  # Same weighting as in _get_team_report
+            qaas_read_bytes=all_data["teams_with_qaas_read_bytes"].get(team.id, 0),
         )
 
         org_id = str(team.organization.id)
@@ -603,7 +609,7 @@ def update_all_orgs_billing_quotas(
 
     # Now we have the usage for all orgs for the current day
     # orgs_by_id is a dict of orgs by id (e.g. {"018e9acf-b488-0000-259c-534bcef40359": <Organization: 018e9acf-b488-0000-259c-534bcef40359>})
-    # todays_usage_report is a dict of orgs by id with their usage for the current day (e.g. {"018e9acf-b488-0000-259c-534bcef40359": {"events": 100, "recordings": 100, "rows_synced": 100, "feature_flag_requests": 100}})
+    # todays_usage_report is a dict of orgs by id with their usage for the current day (e.g. {"018e9acf-b488-0000-259c-534bcef40359": {"events": 100, "recordings": 100, "rows_synced": 100, "feature_flag_requests": 100, "qaas_read_bytes": 100}})
     report_quota_limiting_event(
         "update_all_orgs_billing_quotas",
         {
@@ -626,7 +632,7 @@ def update_all_orgs_billing_quotas(
             QuotaResource(field), QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
         )
     # We have the teams that are currently under quota limits
-    # previously_quota_limited_team_tokens is a dict of resources to team tokens from redis (e.g. {"events": ["phc_123", "phc_456"], "recordings": ["phc_123", "phc_456"], "rows_synced": ["phc_123", "phc_456"], "feature_flag_requests": ["phc_123", "phc_456"]})
+    # previously_quota_limited_team_tokens is a dict of resources to team tokens from redis (e.g. {"events": ["phc_123", "phc_456"], "recordings": ["phc_123", "phc_456"], "rows_synced": ["phc_123", "phc_456"], "feature_flag_requests": ["phc_123", "phc_456"], "qaas_read_bytes": ["phc_123", "phc_456"]})
     report_quota_limiting_event(
         "update_all_orgs_billing_quotas",
         {
@@ -635,6 +641,7 @@ def update_all_orgs_billing_quotas(
             "recordings_count": len(previously_quota_limited_team_tokens["recordings"]),
             "rows_synced_count": len(previously_quota_limited_team_tokens["rows_synced"]),
             "feature_flags_count": len(previously_quota_limited_team_tokens["feature_flag_requests"]),
+            "qaas_read_bytes_count": len(previously_quota_limited_team_tokens["qaas_read_bytes"]),
         },
     )
 
@@ -647,7 +654,7 @@ def update_all_orgs_billing_quotas(
             if set_org_usage_summary(org, todays_usage=todays_report):
                 org.save(update_fields=["usage"])
 
-            for field in ["events", "recordings", "rows_synced", "feature_flag_requests"]:
+            for field in ["events", "recordings", "rows_synced", "feature_flag_requests", "qaas_read_bytes"]:
                 # for each organization, we check if the current usage + today's unreported usage is over the limit
                 result = org_quota_limited_until(org, QuotaResource(field), previously_quota_limited_team_tokens[field])
                 if result:
@@ -659,8 +666,8 @@ def update_all_orgs_billing_quotas(
                         quota_limited_orgs[field][org_id] = quota_limited_until
 
     # Now we have the teams that are currently under quota limits
-    # quota_limited_orgs is a dict of resources to org ids (e.g. {"events": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "recordings": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "rows_synced": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "feature_flag_requests": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}})
-    # quota_limiting_suspended_orgs is a dict of resources to org ids (e.g. {"events": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "recordings": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "rows_synced": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "feature_flag_requests": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}})
+    # quota_limited_orgs is a dict of resources to org ids (e.g. {"events": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "recordings": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "rows_synced": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "feature_flag_requests": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "qaas_read_bytes": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}})
+    # quota_limiting_suspended_orgs is a dict of resources to org ids (e.g. {"events": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "recordings": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "rows_synced": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "feature_flag_requests": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "qaas_read_bytes": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}})
     report_quota_limiting_event(
         "update_all_orgs_billing_quotas",
         {
@@ -691,8 +698,8 @@ def update_all_orgs_billing_quotas(
                     orgs_with_changes.add(org_id)
 
     # Now we have the teams that are currently under quota limits
-    # quota_limited_teams is a dict of resources to team tokens (e.g. {"events": {"phc_123": 1737867600}, "recordings": {"phc_123": 1737867600}, "rows_synced": {"phc_123": 1737867600}, "feature_flag_requests": {"phc_123": 1737867600}})
-    # quota_limiting_suspended_teams is a dict of resources to team tokens (e.g. {"events": {"phc_123": 1737867600}, "recordings": {"phc_123": 1737867600}, "rows_synced": {"phc_123": 1737867600}, "feature_flag_requests": {"phc_123": 1737867600}})
+    # quota_limited_teams is a dict of resources to team tokens (e.g. {"events": {"phc_123": 1737867600}, "recordings": {"phc_123": 1737867600}, "rows_synced": {"phc_123": 1737867600}, "feature_flag_requests": {"phc_123": 1737867600}, "qaas_read_bytes": {"phc_123": 1737867600}})
+    # quota_limiting_suspended_teams is a dict of resources to team tokens (e.g. {"events": {"phc_123": 1737867600}, "recordings": {"phc_123": 1737867600}, "rows_synced": {"phc_123": 1737867600}, "feature_flag_requests": {"phc_123": 1737867600}, "qaas_read_bytes": {"phc_123": 1737867600}})
     report_quota_limiting_event(
         "update_all_orgs_billing_quotas",
         {
@@ -709,6 +716,7 @@ def update_all_orgs_billing_quotas(
             "quota_limited_recordings": quota_limited_orgs["recordings"].get(org_id, None),
             "quota_limited_rows_synced": quota_limited_orgs["rows_synced"].get(org_id, None),
             "quota_limited_feature_flags": quota_limited_orgs["feature_flag_requests"].get(org_id, None),
+            "quota_limited_qaas": quota_limited_orgs["qaas_read_bytes"].get(org_id, None),
         }
 
         report_organization_action(

--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -22,7 +22,7 @@ from posthog.tasks.usage_report import (
     get_teams_with_recording_count_in_period,
     get_teams_with_rows_synced_in_period,
     get_teams_with_feature_flag_requests_count_in_period,
-    get_teams_with_qaas_metrics,
+    get_teams_with_api_queries_metrics,
 )
 from posthog.utils import get_current_day
 
@@ -49,7 +49,7 @@ class QuotaResource(Enum):
     RECORDINGS = "recordings"
     ROWS_SYNCED = "rows_synced"
     FEATURE_FLAG_REQUESTS = "feature_flag_requests"
-    QAAS_READ_BYTES = "qaas_read_bytes"
+    API_QUERIES = "api_queries_read_bytes"
 
 
 class QuotaLimitingCaches(Enum):
@@ -62,7 +62,7 @@ OVERAGE_BUFFER = {
     QuotaResource.RECORDINGS: 1000,
     QuotaResource.ROWS_SYNCED: 0,
     QuotaResource.FEATURE_FLAG_REQUESTS: 0,
-    QuotaResource.QAAS_READ_BYTES: 0,
+    QuotaResource.API_QUERIES: 0,
 }
 
 TRUST_SCORE_KEYS = {
@@ -70,7 +70,7 @@ TRUST_SCORE_KEYS = {
     QuotaResource.RECORDINGS: "recordings",
     QuotaResource.ROWS_SYNCED: "rows_synced",
     QuotaResource.FEATURE_FLAG_REQUESTS: "feature_flags",
-    QuotaResource.QAAS_READ_BYTES: "qaas_read_bytes",
+    QuotaResource.API_QUERIES: "api_queries",
 }
 
 
@@ -79,7 +79,7 @@ class UsageCounters(TypedDict):
     recordings: int
     rows_synced: int
     feature_flags: int
-    qaas_read_bytes: int
+    api_queries_read_bytes: int
 
 
 # -------------------------------------------------------------------------------------------------
@@ -194,7 +194,7 @@ def org_quota_limited_until(
         return None
 
     # 1b. never drop or high trust
-    if (organization.never_drop_data and resource != QuotaResource.QAAS_READ_BYTES) or trust_score == 15:
+    if (organization.never_drop_data and resource != QuotaResource.API_QUERIES) or trust_score == 15:
         report_organization_action(
             organization,
             "org_quota_limited_until",
@@ -422,7 +422,7 @@ def update_org_billing_quotas(organization: Organization):
         QuotaResource.RECORDINGS,
         QuotaResource.ROWS_SYNCED,
         QuotaResource.FEATURE_FLAG_REQUESTS,
-        QuotaResource.QAAS_READ_BYTES,
+        QuotaResource.API_QUERIES,
     ]:
         previously_quota_limited_team_tokens = list_limited_team_attributes(
             resource,
@@ -478,7 +478,7 @@ def set_org_usage_summary(
 
     new_usage = copy.deepcopy(new_usage)
 
-    for field in ["events", "recordings", "rows_synced", "feature_flag_requests", "qaas_read_bytes"]:
+    for field in ["events", "recordings", "rows_synced", "feature_flag_requests", "api_queries_read_bytes"]:
         original_field_usage = original_usage.get(field, {}) if original_usage else {}
         resource_usage = cast(dict, new_usage.get(field, {"limit": None, "usage": 0, "todays_usage": 0}))
 
@@ -537,7 +537,7 @@ def update_all_orgs_billing_quotas(
         },
     )
 
-    qaas_usage = get_teams_with_qaas_metrics(period_start, period_end)
+    api_queries_usage = get_teams_with_api_queries_metrics(period_start, period_end)
 
     # Clickhouse is good at counting things so we count across all teams rather than doing it one by one
     all_data = {
@@ -558,7 +558,7 @@ def update_all_orgs_billing_quotas(
                 period_start, period_end, FlagRequestType.LOCAL_EVALUATION
             )
         ),
-        "teams_with_qaas_read_bytes": convert_team_usage_rows_to_dict(qaas_usage["read_bytes"]),
+        "teams_with_api_queries_read_bytes": convert_team_usage_rows_to_dict(api_queries_usage["read_bytes"]),
     }
 
     teams: Sequence[Team] = list(
@@ -594,7 +594,7 @@ def update_all_orgs_billing_quotas(
             recordings=all_data["teams_with_recording_count_in_period"].get(team.id, 0),
             rows_synced=all_data["teams_with_rows_synced_in_period"].get(team.id, 0),
             feature_flags=decide_requests + (local_evaluation_requests * 10),  # Same weighting as in _get_team_report
-            qaas_read_bytes=all_data["teams_with_qaas_read_bytes"].get(team.id, 0),
+            api_queries_read_bytes=all_data["teams_with_api_queries_read_bytes"].get(team.id, 0),
         )
 
         org_id = str(team.organization.id)
@@ -609,7 +609,7 @@ def update_all_orgs_billing_quotas(
 
     # Now we have the usage for all orgs for the current day
     # orgs_by_id is a dict of orgs by id (e.g. {"018e9acf-b488-0000-259c-534bcef40359": <Organization: 018e9acf-b488-0000-259c-534bcef40359>})
-    # todays_usage_report is a dict of orgs by id with their usage for the current day (e.g. {"018e9acf-b488-0000-259c-534bcef40359": {"events": 100, "recordings": 100, "rows_synced": 100, "feature_flag_requests": 100, "qaas_read_bytes": 100}})
+    # todays_usage_report is a dict of orgs by id with their usage for the current day (e.g. {"018e9acf-b488-0000-259c-534bcef40359": {"events": 100, "recordings": 100, "rows_synced": 100, "feature_flag_requests": 100, "api_queries_read_bytes": 100}})
     report_quota_limiting_event(
         "update_all_orgs_billing_quotas",
         {
@@ -632,7 +632,7 @@ def update_all_orgs_billing_quotas(
             QuotaResource(field), QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
         )
     # We have the teams that are currently under quota limits
-    # previously_quota_limited_team_tokens is a dict of resources to team tokens from redis (e.g. {"events": ["phc_123", "phc_456"], "recordings": ["phc_123", "phc_456"], "rows_synced": ["phc_123", "phc_456"], "feature_flag_requests": ["phc_123", "phc_456"], "qaas_read_bytes": ["phc_123", "phc_456"]})
+    # previously_quota_limited_team_tokens is a dict of resources to team tokens from redis (e.g. {"events": ["phc_123", "phc_456"], "recordings": ["phc_123", "phc_456"], "rows_synced": ["phc_123", "phc_456"], "feature_flag_requests": ["phc_123", "phc_456"], "api_queries_read_bytes": ["phc_123", "phc_456"]})
     report_quota_limiting_event(
         "update_all_orgs_billing_quotas",
         {
@@ -641,7 +641,7 @@ def update_all_orgs_billing_quotas(
             "recordings_count": len(previously_quota_limited_team_tokens["recordings"]),
             "rows_synced_count": len(previously_quota_limited_team_tokens["rows_synced"]),
             "feature_flags_count": len(previously_quota_limited_team_tokens["feature_flag_requests"]),
-            "qaas_read_bytes_count": len(previously_quota_limited_team_tokens["qaas_read_bytes"]),
+            "api_queries_read_bytes_count": len(previously_quota_limited_team_tokens["api_queries_read_bytes"]),
         },
     )
 
@@ -654,7 +654,7 @@ def update_all_orgs_billing_quotas(
             if set_org_usage_summary(org, todays_usage=todays_report):
                 org.save(update_fields=["usage"])
 
-            for field in ["events", "recordings", "rows_synced", "feature_flag_requests", "qaas_read_bytes"]:
+            for field in ["events", "recordings", "rows_synced", "feature_flag_requests", "api_queries_read_bytes"]:
                 # for each organization, we check if the current usage + today's unreported usage is over the limit
                 result = org_quota_limited_until(org, QuotaResource(field), previously_quota_limited_team_tokens[field])
                 if result:
@@ -666,8 +666,8 @@ def update_all_orgs_billing_quotas(
                         quota_limited_orgs[field][org_id] = quota_limited_until
 
     # Now we have the teams that are currently under quota limits
-    # quota_limited_orgs is a dict of resources to org ids (e.g. {"events": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "recordings": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "rows_synced": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "feature_flag_requests": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "qaas_read_bytes": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}})
-    # quota_limiting_suspended_orgs is a dict of resources to org ids (e.g. {"events": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "recordings": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "rows_synced": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "feature_flag_requests": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "qaas_read_bytes": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}})
+    # quota_limited_orgs is a dict of resources to org ids (e.g. {"events": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "recordings": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "rows_synced": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "feature_flag_requests": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "api_queries_read_bytes": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}})
+    # quota_limiting_suspended_orgs is a dict of resources to org ids (e.g. {"events": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "recordings": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "rows_synced": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "feature_flag_requests": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}, "api_queries_read_bytes": {"018e9acf-b488-0000-259c-534bcef40359": 1737867600}})
     report_quota_limiting_event(
         "update_all_orgs_billing_quotas",
         {
@@ -698,8 +698,8 @@ def update_all_orgs_billing_quotas(
                     orgs_with_changes.add(org_id)
 
     # Now we have the teams that are currently under quota limits
-    # quota_limited_teams is a dict of resources to team tokens (e.g. {"events": {"phc_123": 1737867600}, "recordings": {"phc_123": 1737867600}, "rows_synced": {"phc_123": 1737867600}, "feature_flag_requests": {"phc_123": 1737867600}, "qaas_read_bytes": {"phc_123": 1737867600}})
-    # quota_limiting_suspended_teams is a dict of resources to team tokens (e.g. {"events": {"phc_123": 1737867600}, "recordings": {"phc_123": 1737867600}, "rows_synced": {"phc_123": 1737867600}, "feature_flag_requests": {"phc_123": 1737867600}, "qaas_read_bytes": {"phc_123": 1737867600}})
+    # quota_limited_teams is a dict of resources to team tokens (e.g. {"events": {"phc_123": 1737867600}, "recordings": {"phc_123": 1737867600}, "rows_synced": {"phc_123": 1737867600}, "feature_flag_requests": {"phc_123": 1737867600}, "api_queries_read_bytes": {"phc_123": 1737867600}})
+    # quota_limiting_suspended_teams is a dict of resources to team tokens (e.g. {"events": {"phc_123": 1737867600}, "recordings": {"phc_123": 1737867600}, "rows_synced": {"phc_123": 1737867600}, "feature_flag_requests": {"phc_123": 1737867600}, "api_queries_read_bytes": {"phc_123": 1737867600}})
     report_quota_limiting_event(
         "update_all_orgs_billing_quotas",
         {
@@ -716,7 +716,7 @@ def update_all_orgs_billing_quotas(
             "quota_limited_recordings": quota_limited_orgs["recordings"].get(org_id, None),
             "quota_limited_rows_synced": quota_limited_orgs["rows_synced"].get(org_id, None),
             "quota_limited_feature_flags": quota_limited_orgs["feature_flag_requests"].get(org_id, None),
-            "quota_limited_qaas": quota_limited_orgs["qaas_read_bytes"].get(org_id, None),
+            "quota_limited_api_queries": quota_limited_orgs["api_queries_read_bytes"].get(org_id, None),
         }
 
         report_organization_action(

--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -194,7 +194,7 @@ def org_quota_limited_until(
         return None
 
     # 1b. never drop or high trust
-    if organization.never_drop_data or trust_score == 15:
+    if (organization.never_drop_data and resource != QuotaResource.QAAS_READ_BYTES) or trust_score == 15:
         report_organization_action(
             organization,
             "org_quota_limited_until",

--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -194,7 +194,7 @@ def org_quota_limited_until(
         return None
 
     # 1b. never drop or high trust
-    if (organization.never_drop_data and resource != QuotaResource.API_QUERIES) or trust_score == 15:
+    if organization.never_drop_data or trust_score == 15:
         report_organization_action(
             organization,
             "org_quota_limited_until",

--- a/ee/billing/test/test_billing_manager.py
+++ b/ee/billing/test/test_billing_manager.py
@@ -144,6 +144,7 @@ class TestBillingManager(BaseTest):
             },
             "rows_synced": {"usage": 45, "limit": 500, "todays_usage": 5},
             "feature_flag_requests": {"usage": 25, "limit": 300, "todays_usage": 5},
+            "qaas_read_bytes": {"usage": 1000, "limit": 1000000, "todays_usage": 500},
             "period": ["2024-01-01T00:00:00Z", "2024-01-31T23:59:59Z"],
         }
         organization.save()
@@ -161,6 +162,7 @@ class TestBillingManager(BaseTest):
                     "recordings": {"usage": 15, "limit": 100},
                     "rows_synced": {"usage": 45, "limit": 500},
                     "feature_flag_requests": {"usage": 25, "limit": 300},
+                    "qaas_read_bytes": {"usage": 1000, "limit": 1000000},
                 },
                 "billing_period": {
                     "current_period_start": "2024-01-01T00:00:00Z",
@@ -188,4 +190,5 @@ class TestBillingManager(BaseTest):
             "rows_synced": {"usage": 45, "limit": 500, "todays_usage": 5},
             "feature_flag_requests": {"usage": 25, "limit": 300, "todays_usage": 5},
             "period": ["2024-01-01T00:00:00Z", "2024-01-31T23:59:59Z"],
+            "qaas_read_bytes": {"usage": 1000, "limit": 1000000, "todays_usage": 500},
         }

--- a/ee/billing/test/test_billing_manager.py
+++ b/ee/billing/test/test_billing_manager.py
@@ -144,7 +144,7 @@ class TestBillingManager(BaseTest):
             },
             "rows_synced": {"usage": 45, "limit": 500, "todays_usage": 5},
             "feature_flag_requests": {"usage": 25, "limit": 300, "todays_usage": 5},
-            "qaas_read_bytes": {"usage": 1000, "limit": 1000000, "todays_usage": 500},
+            "api_queries_read_bytes": {"usage": 1000, "limit": 1000000, "todays_usage": 500},
             "period": ["2024-01-01T00:00:00Z", "2024-01-31T23:59:59Z"],
         }
         organization.save()
@@ -162,7 +162,7 @@ class TestBillingManager(BaseTest):
                     "recordings": {"usage": 15, "limit": 100},
                     "rows_synced": {"usage": 45, "limit": 500},
                     "feature_flag_requests": {"usage": 25, "limit": 300},
-                    "qaas_read_bytes": {"usage": 1000, "limit": 1000000},
+                    "api_queries_read_bytes": {"usage": 1000, "limit": 1000000},
                 },
                 "billing_period": {
                     "current_period_start": "2024-01-01T00:00:00Z",
@@ -190,5 +190,5 @@ class TestBillingManager(BaseTest):
             "rows_synced": {"usage": 45, "limit": 500, "todays_usage": 5},
             "feature_flag_requests": {"usage": 25, "limit": 300, "todays_usage": 5},
             "period": ["2024-01-01T00:00:00Z", "2024-01-31T23:59:59Z"],
-            "qaas_read_bytes": {"usage": 1000, "limit": 1000000, "todays_usage": 500},
+            "api_queries_read_bytes": {"usage": 1000, "limit": 1000000, "todays_usage": 500},
         }

--- a/ee/billing/test/test_quota_limiting.py
+++ b/ee/billing/test/test_quota_limiting.py
@@ -1128,13 +1128,11 @@ class TestQuotaLimiting(BaseTest):
             assert quota_limiting_suspended_orgs["api_queries_read_bytes"] == {}
             assert self.redis_client.zrange(f"@posthog/quota-limits/api_queries_read_bytes", 0, -1) == []
 
-            # Test never_drop_data organization is limited
+            # Test never_drop_data organization is not limited
             self.organization.customer_trust_scores[trust_key] = 0
             self.organization.never_drop_data = True
             self.organization.save()
             quota_limited_orgs, quota_limiting_suspended_orgs = update_all_orgs_billing_quotas()
-            assert quota_limited_orgs["api_queries_read_bytes"] == {org_id: 1612137599}
+            assert quota_limited_orgs["api_queries_read_bytes"] == {}
             assert quota_limiting_suspended_orgs["api_queries_read_bytes"] == {}
-            assert self.team.api_token.encode("UTF-8") in self.redis_client.zrange(
-                f"@posthog/quota-limits/api_queries_read_bytes", 0, -1
-            )
+            assert self.redis_client.zrange(f"@posthog/quota-limits/api_queries_read_bytes", 0, -1) == []

--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -44,6 +44,7 @@ class OrganizationUsageInfo(TypedDict):
     recordings: Optional[OrganizationUsageResource]
     rows_synced: Optional[OrganizationUsageResource]
     feature_flag_requests: Optional[OrganizationUsageResource]
+    qaas_read_bytes: Optional[OrganizationUsageResource]
     period: Optional[list[str]]
 
 
@@ -145,6 +146,7 @@ class Organization(UUIDModel):
     #   'events': { 'usage': 10000, 'limit': 20000, 'todays_usage': 1000 },
     #   'recordings': { 'usage': 10000, 'limit': 20000, 'todays_usage': 1000 }
     #   'feature_flags_requests': { 'usage': 10000, 'limit': 20000, 'todays_usage': 1000 }
+    #   'qaas_read_bytes': { 'usage': 123456789, 'limit': 1000000000000, 'todays_usage': 1234 }
     #   'period': ['2021-01-01', '2021-01-31']
     # }
     # Also currently indicates if the organization is on billing V2 or not

--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -44,7 +44,7 @@ class OrganizationUsageInfo(TypedDict):
     recordings: Optional[OrganizationUsageResource]
     rows_synced: Optional[OrganizationUsageResource]
     feature_flag_requests: Optional[OrganizationUsageResource]
-    qaas_read_bytes: Optional[OrganizationUsageResource]
+    api_queries_read_bytes: Optional[OrganizationUsageResource]
     period: Optional[list[str]]
 
 
@@ -146,7 +146,7 @@ class Organization(UUIDModel):
     #   'events': { 'usage': 10000, 'limit': 20000, 'todays_usage': 1000 },
     #   'recordings': { 'usage': 10000, 'limit': 20000, 'todays_usage': 1000 }
     #   'feature_flags_requests': { 'usage': 10000, 'limit': 20000, 'todays_usage': 1000 }
-    #   'qaas_read_bytes': { 'usage': 123456789, 'limit': 1000000000000, 'todays_usage': 1234 }
+    #   'api_queries_read_bytes': { 'usage': 123456789, 'limit': 1000000000000, 'todays_usage': 1234 }
     #   'period': ['2021-01-01', '2021-01-31']
     # }
     # Also currently indicates if the organization is on billing V2 or not

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -1848,6 +1848,10 @@ class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
                         "usage": 1000,
                         "limit": None,
                     },
+                    "qaas_read_bytes": {
+                        "usage": 1024,
+                        "limit": None,
+                    },
                 },
             }
         }

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -1088,8 +1088,8 @@ class HogQLUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTables
         # Queries were read via the API
         assert report.query_api_rows_read == 200
         assert report.event_explorer_api_rows_read == 100
-        assert report.qaas_query_count == 2
-        assert report.qaas_bytes_read > 16000  # locally it's about 16753
+        assert report.api_queries_query_count == 2
+        assert report.api_queries_bytes_read > 16000  # locally it's about 16753
 
 
 @freeze_time("2022-01-10T00:01:00Z")
@@ -1848,7 +1848,7 @@ class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
                         "usage": 1000,
                         "limit": None,
                     },
-                    "qaas_read_bytes": {
+                    "api_queries_read_bytes": {
                         "usage": 1024,
                         "limit": None,
                     },

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -118,9 +118,9 @@ class UsageReportCounters:
     query_api_rows_read: int
     query_api_duration_ms: int
 
-    # QaaS usage
-    qaas_query_count: int
-    qaas_bytes_read: int
+    # API Queries usage
+    api_queries_query_count: int
+    api_queries_bytes_read: int
 
     # Event Explorer
     event_explorer_app_bytes_read: int
@@ -577,7 +577,7 @@ def get_teams_with_mobile_billable_recording_count_in_period(begin: datetime, en
 
 @timed_log()
 @retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
-def get_teams_with_qaas_metrics(
+def get_teams_with_api_queries_metrics(
     begin: datetime,
     end: datetime,
 ) -> dict[str, list[tuple[int, int]]]:
@@ -593,7 +593,7 @@ def get_teams_with_qaas_metrics(
         AND JSONExtractBool(log_comment, 'qaas')
         GROUP BY team_id
     """
-    with tags_context(usage_report="get_teams_with_qaas_metrics"):
+    with tags_context(usage_report="get_teams_with_api_queries_metrics"):
         results = sync_execute(
             query,
             {
@@ -905,7 +905,7 @@ def _get_all_usage_data(period_start: datetime, period_end: datetime) -> dict[st
     """
 
     all_metrics = get_all_event_metrics_in_period(period_start, period_end)
-    qaas_usage = get_teams_with_qaas_metrics(period_start, period_end)
+    api_queries_usage = get_teams_with_api_queries_metrics(period_start, period_end)
 
     return {
         "teams_with_event_count_in_period": get_teams_with_billable_event_count_in_period(
@@ -1033,8 +1033,8 @@ def _get_all_usage_data(period_start: datetime, period_end: datetime) -> dict[st
             metric="query_duration_ms",
             access_method="personal_api_key",
         ),
-        "teams_with_qaas_count": qaas_usage["count"],
-        "teams_with_qaas_read_bytes": qaas_usage["read_bytes"],
+        "teams_with_api_queries_count": api_queries_usage["count"],
+        "teams_with_api_queries_read_bytes": api_queries_usage["read_bytes"],
         "teams_with_event_explorer_app_bytes_read": get_teams_with_query_metric(
             period_start,
             period_end,
@@ -1157,8 +1157,8 @@ def _get_team_report(all_data: dict[str, Any], team: Team) -> UsageReportCounter
         query_api_bytes_read=all_data["teams_with_query_api_bytes_read"].get(team.id, 0),
         query_api_rows_read=all_data["teams_with_query_api_rows_read"].get(team.id, 0),
         query_api_duration_ms=all_data["teams_with_query_api_duration_ms"].get(team.id, 0),
-        qaas_query_count=all_data["teams_with_qaas_count"].get(team.id, 0),
-        qaas_bytes_read=all_data["teams_with_qaas_read_bytes"].get(team.id, 0),
+        api_queries_query_count=all_data["teams_with_api_queries_count"].get(team.id, 0),
+        api_queries_bytes_read=all_data["teams_with_api_queries_read_bytes"].get(team.id, 0),
         event_explorer_app_bytes_read=all_data["teams_with_event_explorer_app_bytes_read"].get(team.id, 0),
         event_explorer_app_rows_read=all_data["teams_with_event_explorer_app_rows_read"].get(team.id, 0),
         event_explorer_app_duration_ms=all_data["teams_with_event_explorer_app_duration_ms"].get(team.id, 0),


### PR DESCRIPTION
## Problem

Want quota limiting for QaaS (Query-as-a-Service) product.
The purpose of this is to limit a usage of /query endpoint to 1 concurrent request for free users and 3 concurrent requests for paying users.

## Changes

Introduces a necessary logic in billing.

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Tests