### PR TITLE
feat(propdefs): reduce base batch write timeout in property-defs-rs

### DIFF
--- a/rust/property-defs-rs/src/lib.rs
+++ b/rust/property-defs-rs/src/lib.rs
@@ -23,7 +23,7 @@ pub mod metrics_consts;
 pub mod types;
 
 const BATCH_UPDATE_MAX_ATTEMPTS: u64 = 2;
-const UPDATE_RETRY_DELAY_MS: u64 = 150;
+const UPDATE_RETRY_DELAY_MS: u64 = 50;
 
 pub async fn update_consumer_loop(
     config: Config,


### PR DESCRIPTION
## Problem
Seeing some backlog today that a "safe" horizontal scaleup didn't entirely remediate, along with lots of timeouts on retries in the 200-300ms range. 

## Changes
This PR lowers the default base timeout from `150ms` to `50ms` here to ensure retry loops aren't clogging the batch write pipeline too much vs. giving the DB room to breath (in this case today, unlike previous incidents, the DB looks fine 👍 )

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally and CI
