### PR TITLE
feat(propdefs): Add config flag for v2 ingest (isolated DB per env) 

### DIFF
--- a/rust/property-defs-rs/src/app_context.rs
+++ b/rust/property-defs-rs/src/app_context.rs
@@ -32,6 +32,7 @@ pub struct AppContext {
     pub skip_writes: bool,
     pub skip_reads: bool,
     pub group_type_cache: Cache<String, i32>, // Keyed on group-type name, and team id
+    pub enable_v2: bool,
 }
 
 impl AppContext {
@@ -56,6 +57,7 @@ impl AppContext {
             skip_writes: config.skip_writes,
             skip_reads: config.skip_reads,
             group_type_cache,
+            enable_v2: config.enable_v2,
         })
     }
 

--- a/rust/property-defs-rs/src/config.rs
+++ b/rust/property-defs-rs/src/config.rs
@@ -111,7 +111,7 @@ pub struct Config {
     pub filter_mode: TeamFilterMode,
 
     // flag for "v2" deployment that will initially point to an
-    // isolated Postgres instance per delploy env, and will include
+    // isolated Postgres instance per deploy env, and will include
     // bundled ingest pipeline refactors
     #[envconfig(default = "false")]
     pub enable_v2: bool,

--- a/rust/property-defs-rs/src/config.rs
+++ b/rust/property-defs-rs/src/config.rs
@@ -109,6 +109,12 @@ pub struct Config {
     // once rollout is complete.
     #[envconfig(default = "opt_in")]
     pub filter_mode: TeamFilterMode,
+
+    // flag for "v2" deployment that will initially point to an
+    // isolated Postgres instance per delploy env, and will include
+    // bundled ingest pipeline refactors
+    #[envconfig(default = "false")]
+    pub enable_v2: bool,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
## Problem
As `#team-ingestion` iterates to isolate the Postgres database for all `property-defs-rs` deploy envs, we plan to ship a mirror deployment (first `dev`, then `prod-eu`, then `prod-us` last) of the current service where we can test writes to the new DB, and make related ingest pipe changes.

To do this safely, we need a new config flag so the mirror deployment knows where to route it's writes and when to use new ingest features.

## Changes
* Adds the `enable_v2` flag to the `property-defs-rs` service to begin to scaffold this out

Alternatively (cc @pl)  we could split this into a more granular set of flags or something more like a map of flags?

If not, this should be gtg. Once we have some code written (PRs on the way) for alternate ingest path, we can enable in `dev` 👍 

## Does this work well for both Cloud and self-hosted?
Yes