### PR TITLE
chore: log when setting team in cache

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -109,10 +109,10 @@ export const productConfiguration: Record<string, any> = {
         layout: 'app-container',
         defaultDocsPath: '/docs/ai-engineering/observability',
     },
-    MessagingAutomations: { name: 'Messaging', projectBased: true },
+    MessagingAutomations: { name: 'Automations', projectBased: true },
     MessagingBroadcasts: { name: 'Messaging', projectBased: true },
     MessagingProviders: { name: 'Messaging', projectBased: true },
-    MessagingLibrary: { name: 'Messaging', projectBased: true },
+    MessagingLibrary: { name: 'Library', projectBased: true },
 }
 
 /** This const is auto-generated, as is the whole file */

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -109,10 +109,10 @@ export const productConfiguration: Record<string, any> = {
         layout: 'app-container',
         defaultDocsPath: '/docs/ai-engineering/observability',
     },
-    MessagingAutomations: { name: 'Automations', projectBased: true },
+    MessagingAutomations: { name: 'Messaging', projectBased: true },
     MessagingBroadcasts: { name: 'Messaging', projectBased: true },
     MessagingProviders: { name: 'Messaging', projectBased: true },
-    MessagingLibrary: { name: 'Library', projectBased: true },
+    MessagingLibrary: { name: 'Messaging', projectBased: true },
 }
 
 /** This const is auto-generated, as is the whole file */

--- a/posthog/models/team/team_caching.py
+++ b/posthog/models/team/team_caching.py
@@ -1,5 +1,8 @@
 import json
 from typing import TYPE_CHECKING, Optional
+from structlog import get_logger
+from prometheus_client import Counter
+
 
 from django.core.cache import cache
 from posthog.exceptions_capture import capture_exception
@@ -8,6 +11,15 @@ if TYPE_CHECKING:
     from posthog.models.team import Team
 
 FIVE_DAYS = 60 * 60 * 24 * 5  # 5 days in seconds
+
+logger = get_logger()
+
+
+SET_TEAM_IN_CACHE_COUNTER = Counter(
+    "set_team_in_cache_counter",
+    "The number of times we've set a team in cache",
+    labelnames=["success"],
+)
 
 
 def set_team_in_cache(token: str, team: Optional["Team"] = None) -> None:
@@ -18,12 +30,24 @@ def set_team_in_cache(token: str, team: Optional["Team"] = None) -> None:
         try:
             team = Team.objects.get(api_token=token)
         except (Team.DoesNotExist, Team.MultipleObjectsReturned):
+            SET_TEAM_IN_CACHE_COUNTER.labels(success=False).inc()
             cache.delete(f"team_token:{token}")
             return
 
     serialized_team = CachingTeamSerializer(team).data
 
+    # the serialized team should have many settings... if there are less than 6, something is wrong
+    if len(serialized_team.keys()) <= 6:
+        logger.error(
+            f"Team {team.id} has no session recording URL config. It might be using an incorrectly serialized team.",
+            team_id=team.id,
+            token=token,
+            serialized_team=serialized_team,
+            stack_info=True,
+        )
+
     cache.set(f"team_token:{token}", json.dumps(serialized_team), FIVE_DAYS)
+    SET_TEAM_IN_CACHE_COUNTER.labels(success=True).inc()
 
 
 def get_team_in_cache(token: str) -> Optional["Team"]:

--- a/posthog/models/team/team_caching.py
+++ b/posthog/models/team/team_caching.py
@@ -34,6 +34,10 @@ def set_team_in_cache(token: str, team: Optional["Team"] = None) -> None:
             cache.delete(f"team_token:{token}")
             return
 
+    if not team:
+        # this is for mypy which doesn't know that Team must be present at this point
+        raise Exception(f"Team not found with token: {token}")
+
     serialized_team = CachingTeamSerializer(team).data
 
     # the serialized team should have many settings... if there are less than 6, something is wrong

--- a/posthog/models/team/team_caching.py
+++ b/posthog/models/team/team_caching.py
@@ -30,6 +30,7 @@ def set_team_in_cache(token: str, team: Optional["Team"] = None) -> None:
         try:
             team = Team.objects.get(api_token=token)
         except (Team.DoesNotExist, Team.MultipleObjectsReturned):
+            cache.delete(f"team_token:{token}")
             SET_TEAM_IN_CACHE_COUNTER.labels(success=False).inc()
             cache.delete(f"team_token:{token}")
             return

--- a/posthog/models/team/team_caching.py
+++ b/posthog/models/team/team_caching.py
@@ -44,9 +44,10 @@ def set_team_in_cache(token: str, team: Optional["Team"] = None) -> None:
     # the serialized team should have many settings... if there are less than 6, something is wrong
     if len(serialized_team.keys()) <= 6:
         logger.error(
-            f"Team {team.id} has no session recording URL config. It might be using an incorrectly serialized team.",
+            f"Team {team.id} has suspiciously few keys. It might be using an incorrectly serialized team.",
             team_id=team.id,
             token=token,
+            number_of_keys=len(serialized_team.keys()),
             serialized_team=serialized_team,
             stack_info=True,
         )


### PR DESCRIPTION
let's try and get some log output from setting teams in cache to see if we can catch if we are adding a bad team value to the cache