### PR TITLE
fix: move consent layer inside the popup

### DIFF
--- a/frontend/src/scenes/session-recordings/components/AiRegexHelper/AiRegexHelper.tsx
+++ b/frontend/src/scenes/session-recordings/components/AiRegexHelper/AiRegexHelper.tsx
@@ -110,26 +110,18 @@ export function AiRegexHelper({ onApply }: AiRegexHelperProps): JSX.Element {
 
 export function AiRegexHelperButton(): JSX.Element {
     const { setIsOpen } = useActions(aiRegexHelperLogic)
-    const { dataProcessingAccepted, dataProcessingApprovalDisabledReason } = useValues(maxGlobalLogic)
-
-    const disabledReason = !dataProcessingAccepted
-        ? dataProcessingApprovalDisabledReason || 'You must accept the data processing agreement to use AI features'
-        : null
 
     return (
-        <AIConsentPopoverWrapper>
-            <LemonButton
-                type="tertiary"
-                size="small"
-                icon={<IconAI />}
-                onClick={() => {
-                    setIsOpen(true)
-                    posthog.capture('ai_regex_helper_open')
-                }}
-                disabledReason={disabledReason}
-            >
-                Help me with Regex
-            </LemonButton>
-        </AIConsentPopoverWrapper>
+        <LemonButton
+            type="tertiary"
+            size="small"
+            icon={<IconAI />}
+            onClick={() => {
+                setIsOpen(true)
+                posthog.capture('ai_regex_helper_open')
+            }}
+        >
+            Help me with Regex
+        </LemonButton>
     )
 }


### PR DESCRIPTION
## Problem

The AI consent popup covers the triggers. Let's move them inside the popup.

![0195ca38-0011-0000-6c05-3ad469d5723b](https://github.com/user-attachments/assets/1470a1b8-382d-40ec-8577-f27f9e2bbf22)

