### PR TITLE
chore(sql-editor): Change suspended back to error

### DIFF
--- a/frontend/src/scenes/data-warehouse/settings/source/Schemas.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/Schemas.tsx
@@ -52,7 +52,6 @@ const StatusTagSetting: Record<string, LemonTagType> = {
     Completed: 'success',
     Error: 'danger',
     Failed: 'danger',
-    Suspended: 'warning',
     'Billing limits': 'danger',
 }
 
@@ -274,13 +273,8 @@ export const SchemaTable = ({ schemas, isLoading }: SchemaTableProps): JSX.Eleme
                             if (!schema.status) {
                                 return null
                             }
-                            const isSuspended = schema.status === 'Error' && !schema.should_sync
                             const tagContent = (
-                                <LemonTag
-                                    type={StatusTagSetting[isSuspended ? 'Suspended' : schema.status] || 'default'}
-                                >
-                                    {isSuspended ? 'Suspended' : schema.status}
-                                </LemonTag>
+                                <LemonTag type={StatusTagSetting[schema.status] || 'default'}>{schema.status}</LemonTag>
                             )
                             return schema.latest_error && schema.status === 'Error' ? (
                                 <Tooltip title={schema.latest_error}>{tagContent}</Tooltip>


### PR DESCRIPTION
## Problem
- We display "suspended" instead of "error" in the schema list when a sync has failed and is turned off in the source list
- I dont think "suspended" really means anything to a user and so I wanna revert it back to just "Error"

<img width="418" alt="image" src="https://github.com/user-attachments/assets/2876a6f3-4e51-4d17-a359-7f68323708df" />
