### PR TITLE
chore: use online nodes for backups

### DIFF
--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -23,7 +23,7 @@ from clickhouse_driver import Client
 from clickhouse_pool import ChPool
 
 from posthog import settings
-from posthog.clickhouse.client.connection import NodeRole, _make_ch_pool, default_client
+from posthog.clickhouse.client.connection import NodeRole, Workload, _make_ch_pool, default_client
 from posthog.settings import CLICKHOUSE_PER_TEAM_SETTINGS
 from posthog.settings.data_stores import CLICKHOUSE_CLUSTER
 
@@ -185,6 +185,16 @@ class ClickhouseCluster:
 
         return task
 
+    def __hosts_by_role(
+        self, hosts: set[HostInfo], node_role: NodeRole, workload: Workload = Workload.DEFAULT
+    ) -> set[HostInfo]:
+        return {
+            host
+            for host in hosts
+            if (host.host_cluster_role == node_role.value.lower() or node_role == NodeRole.ALL)
+            and (host.host_cluster_type == workload.value.lower() or workload == Workload.DEFAULT)
+        }
+
     @property
     def __hosts(self) -> set[HostInfo]:
         """Set containing all hosts in the cluster."""
@@ -202,13 +212,15 @@ class ClickhouseCluster:
             host = next(iter(self.__hosts))
             return executor.submit(self.__get_task_function(host, fn))
 
-    def any_host_by_role(self, fn: Callable[[Client], T], node_role: NodeRole) -> Future[T]:
+    def any_host_by_role(
+        self, fn: Callable[[Client], T], node_role: NodeRole, workload: Workload = Workload.DEFAULT
+    ) -> Future[T]:
         """
         Execute the callable once for any host with the given node role.
         """
         with ThreadPoolExecutor() as executor:
             try:
-                host = next(host for host in self.__hosts if host.host_cluster_role == node_role.value.lower())
+                host = next(iter(self.__hosts_by_role(self.__hosts, node_role, workload)))
             except StopIteration:
                 raise ValueError(f"No hosts found with role {node_role.value}")
             return executor.submit(self.__get_task_function(host, fn))
@@ -227,6 +239,7 @@ class ClickhouseCluster:
         fn: Callable[[Client], T],
         node_role: NodeRole,
         concurrency: int | None = None,
+        workload: Workload = Workload.DEFAULT,
     ) -> FuturesMap[HostInfo, T]:
         """
         Execute the callable once for each host in the cluster with the given node role.
@@ -238,8 +251,7 @@ class ClickhouseCluster:
             return FuturesMap(
                 {
                     host: executor.submit(self.__get_task_function(host, fn))
-                    for host in self.__hosts
-                    if host.host_cluster_role == node_role.value.lower() or node_role == NodeRole.ALL
+                    for host in self.__hosts_by_role(self.__hosts, node_role, workload)
                 }
             )
 
@@ -258,7 +270,9 @@ class ClickhouseCluster:
             )
 
     def map_all_hosts_in_shards(
-        self, shard_fns: dict[int, Callable[[Client], T]], concurrency: int | None = None
+        self,
+        shard_fns: dict[int, Callable[[Client], T]],
+        concurrency: int | None = None,
     ) -> FuturesMap[HostInfo, T]:
         """
         Execute the callable once for each host in the specified shards.
@@ -287,9 +301,29 @@ class ClickhouseCluster:
         The number of concurrent queries can limited with the ``concurrency`` parameter, or set to ``None`` to use the
         default limit of the executor.
         """
+        return self.map_any_host_in_shards_by_role(
+            shard_fns,
+            concurrency=concurrency,
+            node_role=NodeRole.ALL,
+            workload=Workload.DEFAULT,
+        )
+
+    def map_any_host_in_shards_by_role(
+        self,
+        shard_fns: dict[int, Callable[[Client], T]],
+        concurrency: int | None = None,
+        node_role: NodeRole = NodeRole.ALL,
+        workload: Workload = Workload.DEFAULT,
+    ) -> FuturesMap[HostInfo, T]:
+        """
+        Execute the callable on one host for each of the specified shards and role.
+
+        The number of concurrent queries can limited with the ``concurrency`` parameter, or set to ``None`` to use the
+        default limit of the executor.
+        """
         shard_host_fns = {}
         for shard, fn in shard_fns.items():
-            host = next(iter(self.__shards[shard]))
+            host = next(iter(self.__hosts_by_role(self.__shards[shard], node_role, workload)))
             shard_host_fns[host] = fn
 
         with ThreadPoolExecutor(max_workers=concurrency) as executor:

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -405,16 +405,12 @@ class Retryable(Generic[T]):  # note: this class exists primarily to allow a rea
 
     def __call__(self, client: Client) -> T:
         if isinstance(self.policy.exceptions, tuple):
-
-            def is_retryable_exception(e):
-                return isinstance(e, self.policy.exceptions)
+            is_retryable_exception = lambda e: isinstance(e, self.policy.exceptions)
         else:
             is_retryable_exception = self.policy.exceptions
 
         if not callable(self.policy.delay):
-
-            def delay_fn(_):
-                return self.policy.delay
+            delay_fn = lambda _: self.policy.delay
         else:
             delay_fn = self.policy.delay
 

--- a/posthog/clickhouse/test/test_cluster.py
+++ b/posthog/clickhouse/test/test_cluster.py
@@ -289,14 +289,17 @@ def test_map_hosts_by_role() -> None:
         cluster.map_hosts_by_role(lambda _: (), node_role=NodeRole.ALL).result()
         assert times_called[NodeRole.DATA] == 3
         assert times_called[NodeRole.COORDINATOR] == 1
+        times_called.clear()
 
         cluster.map_hosts_by_role(lambda _: (), node_role=NodeRole.ALL, workload=Workload.OFFLINE).result()
         assert times_called[NodeRole.DATA] == 1
         assert times_called[NodeRole.COORDINATOR] == 0
+        times_called.clear()
 
         cluster.map_hosts_by_role(lambda _: (), node_role=NodeRole.DATA, workload=Workload.ONLINE).result()
         assert times_called[NodeRole.DATA] == 3
         assert times_called[NodeRole.COORDINATOR] == 0
+        times_called.clear()
 
 
 def test_lightweight_delete(cluster: ClickhouseCluster) -> None:

--- a/posthog/clickhouse/test/test_cluster.py
+++ b/posthog/clickhouse/test/test_cluster.py
@@ -297,7 +297,7 @@ def test_map_hosts_by_role() -> None:
         times_called.clear()
 
         cluster.map_hosts_by_role(lambda _: (), node_role=NodeRole.DATA, workload=Workload.ONLINE).result()
-        assert times_called[NodeRole.DATA] == 3
+        assert times_called[NodeRole.DATA] == 2
         assert times_called[NodeRole.COORDINATOR] == 0
         times_called.clear()
 

--- a/posthog/clickhouse/test/test_cluster.py
+++ b/posthog/clickhouse/test/test_cluster.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock, patch, sentinel
 import pytest
 from clickhouse_driver import Client
 
-from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.connection import NodeRole, Workload
 from posthog.clickhouse.cluster import (
     AlterTableMutationRunner,
     ClickhouseCluster,
@@ -260,7 +260,7 @@ def test_map_hosts_by_role() -> None:
     bootstrap_client_mock.execute.return_value = [
         ("host1", "9000", "1", "1", "online", "data"),
         ("host2", "9000", "1", "2", "online", "data"),
-        ("host3", "9000", "1", "3", "online", "data"),
+        ("host3", "9000", "1", "3", "offline", "data"),
         ("host4", "9000", "1", "4", "online", "coordinator"),
     ]
 
@@ -289,6 +289,14 @@ def test_map_hosts_by_role() -> None:
         cluster.map_hosts_by_role(lambda _: (), node_role=NodeRole.ALL).result()
         assert times_called[NodeRole.DATA] == 3
         assert times_called[NodeRole.COORDINATOR] == 1
+
+        cluster.map_hosts_by_role(lambda _: (), node_role=NodeRole.ALL, workload=Workload.OFFLINE).result()
+        assert times_called[NodeRole.DATA] == 1
+        assert times_called[NodeRole.COORDINATOR] == 0
+
+        cluster.map_hosts_by_role(lambda _: (), node_role=NodeRole.DATA, workload=Workload.ONLINE).result()
+        assert times_called[NodeRole.DATA] == 3
+        assert times_called[NodeRole.COORDINATOR] == 0
 
 
 def test_lightweight_delete(cluster: ClickhouseCluster) -> None:


### PR DESCRIPTION
## Problem

Offline nodes are already under heavy load, and backups can lead to them being restarted at some point.

On the other hand, online nodes are not that loaded at the time we perform the backups and they can finish correctly.

## Changes

Update dagster jobs to specify the workload to run backups on.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Unit testing + end 2 end backup jobs
