### PR TITLE
fix(temporal): SIGTERM handling

### DIFF
--- a/bin/temporal-django-worker
+++ b/bin/temporal-django-worker
@@ -6,6 +6,8 @@ cleanup() {
     echo "Stopping worker..."
     if kill -0 "$worker_pid" >/dev/null 2>&1; then
         kill -SIGTERM "$worker_pid"
+
+        wait "$worker_pid"
     else
         echo "Worker process is not running."
     fi
@@ -17,6 +19,11 @@ python3 manage.py start_temporal_worker "$@" &
 
 worker_pid=$!
 
-wait $worker_pid
+# Run wait in a loop in case we trap SIGTERM as that will cause wait to exit
+# potentially not waiting for graceful shutdown. When a SIGTERM is issued,
+# wait will exit with a status equal to signal number + 128.
+while wait $worker_pid; test $? -ge 128
+      do echo "Worker process finished"
+done
 
 cleanup

--- a/bin/temporal-django-worker
+++ b/bin/temporal-django-worker
@@ -6,8 +6,6 @@ cleanup() {
     echo "Stopping worker..."
     if kill -0 "$worker_pid" >/dev/null 2>&1; then
         kill -SIGTERM "$worker_pid"
-
-        wait "$worker_pid"
     else
         echo "Worker process is not running."
     fi
@@ -23,7 +21,7 @@ worker_pid=$!
 # potentially not waiting for graceful shutdown. When a SIGTERM is issued,
 # wait will exit with a status equal to signal number + 128.
 while wait $worker_pid; test $? -ge 128
-      do echo "Worker process finished"
+      do echo "Received signal, waiting for worker to finish"
 done
 
 cleanup

--- a/bin/temporal-django-worker
+++ b/bin/temporal-django-worker
@@ -5,7 +5,7 @@ set -e
 cleanup() {
     echo "Stopping worker..."
     if kill -0 "$worker_pid" >/dev/null 2>&1; then
-        kill "$worker_pid"
+        kill -SIGTERM "$worker_pid"
     else
         echo "Worker process is not running."
     fi

--- a/posthog/management/commands/execute_temporal_workflow.py
+++ b/posthog/management/commands/execute_temporal_workflow.py
@@ -11,6 +11,7 @@ from posthog.temporal.common.client import connect
 from posthog.temporal.data_imports.settings import WORKFLOWS as DATA_IMPORT_WORKFLOWS
 from posthog.temporal.delete_persons import WORKFLOWS as DELETE_PERSONS_WORKFLOWS
 from posthog.temporal.proxy_service import WORKFLOWS as PROXY_SERVICE_WORKFLOWS
+from posthog.temporal.tests.utils.workflow import WORKFLOWS as TEST_WORKFLOWS
 from posthog.temporal.usage_reports import WORKFLOWS as USAGE_REPORTS_WORKFLOWS
 
 
@@ -112,6 +113,7 @@ class Command(BaseCommand):
             + PROXY_SERVICE_WORKFLOWS
             + DELETE_PERSONS_WORKFLOWS
             + USAGE_REPORTS_WORKFLOWS
+            + TEST_WORKFLOWS
         )
         try:
             workflow = next(workflow for workflow in WORKFLOWS if workflow.is_named(workflow_name))

--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -75,7 +75,8 @@ async def start_worker(
         logger.info("Finished Temporal worker shutdown")
 
     loop = asyncio.get_event_loop()
-    loop.add_signal_handler(signal.SIGINT, lambda: asyncio.create_task(shutdown_worker("SIGINT")))
-    loop.add_signal_handler(signal.SIGTERM, lambda: asyncio.create_task(shutdown_worker("SIGTERM")))
+    shutdown_tasks = set()
+    loop.add_signal_handler(signal.SIGINT, lambda: shutdown_tasks.add(asyncio.create_task(shutdown_worker("SIGINT"))))
+    loop.add_signal_handler(signal.SIGTERM, lambda: shutdown_tasks.add(asyncio.create_task(shutdown_worker("SIGTERM"))))
 
     await worker.run()

--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -69,13 +69,13 @@ async def start_worker(
 
     # catch the TERM and INT signals, and stop the worker gracefully
     # https://github.com/temporalio/sdk-python#worker-shutdown
-    async def shutdown_worker(s: signal.Signals):
+    async def shutdown_worker(s: str):
         logger.info("%s received, initiating Temporal worker shutdown", s)
         await worker.shutdown()
         logger.info("Finished Temporal worker shutdown")
 
     loop = asyncio.get_event_loop()
-    for s in (signal.SIGTERM, signal.SIGINT):
-        loop.add_signal_handler(s, lambda s=s: asyncio.create_task(shutdown_worker(s)))
+    loop.add_signal_handler(signal.SIGINT, lambda: asyncio.create_task(shutdown_worker("SIGINT")))
+    loop.add_signal_handler(signal.SIGTERM, lambda: asyncio.create_task(shutdown_worker("SIGTERM")))
 
     await worker.run()

--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -4,6 +4,7 @@ import datetime as dt
 import signal
 from concurrent.futures import ThreadPoolExecutor
 
+import structlog
 from django.conf import settings
 from temporalio.runtime import PrometheusConfig, Runtime, TelemetryConfig
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
@@ -11,6 +12,8 @@ from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 from posthog.temporal.common.client import connect
 from posthog.temporal.common.posthog_client import PostHogClientInterceptor
 from posthog.temporal.common.sentry import SentryInterceptor
+
+logger = structlog.get_logger(__name__)
 
 
 def _debug_pyarrows():
@@ -64,12 +67,15 @@ async def start_worker(
         max_heartbeat_throttle_interval=dt.timedelta(seconds=5),
     )
 
-    # catch the TERM signal, and stop the worker gracefully
+    # catch the TERM and INT signals, and stop the worker gracefully
     # https://github.com/temporalio/sdk-python#worker-shutdown
-    async def shutdown_worker():
+    async def shutdown_worker(s: signal.Signals):
+        logger.info("%s received, initiating Temporal worker shutdown", s)
         await worker.shutdown()
+        logger.info("Finished Temporal worker shutdown")
 
     loop = asyncio.get_event_loop()
-    loop.add_signal_handler(signal.SIGTERM, lambda: asyncio.create_task(shutdown_worker()))
+    for s in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(s, lambda s=s: asyncio.create_task(shutdown_worker(s)))
 
     await worker.run()


### PR DESCRIPTION
## Problem

We send SIGTERM to temporal workers for multiple reasons. The problem is that our bash script `temporal-django-worker` is not properly waiting for the worker PID: When a signal is handled by `trap`, `wait` will immediately return after handling with a status code > 128. This means that we will not wait for graceful shutdown handling of the workers.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Wait in a loop. As long as the status code > 128, we continue waiting on worker PID.

This does mean that now temporal tasks may run a lot longer than before while shutting down. Overall, this should lead to less heartbeat timeouts. But it does mean that engineers at PostHog need to be more careful of any activities they execute: At any point during the activity, you could be running on a worker that is shutting down. `ShutdownMonitor` provides a way to collaboratively check for shutdown at points where engineers determine it is safe to exit and issue a retry.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Smoke tested in dev.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
