### PR TITLE
fix(hogql): Fix date trunc

### DIFF
--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -997,7 +997,6 @@ HOGQL_CLICKHOUSE_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
             "dateTrunc",
             2,
             3,  # Allow optional timezone parameter
-            tz_aware=True,
             signatures=[
                 ((StringType(), DateTimeType()), DateTimeType()),
                 ((StringType(), DateTimeType(), StringType()), DateTimeType()),


### PR DESCRIPTION
## Problem
- When using date trunc, if the second argument is a date and not datetime, then adding a timezone throws an error - we do this automatically due to the `tz_aware` param
- https://posthog.slack.com/archives/C019RAX2XBN/p1742910223992549
- introduced by me in https://github.com/PostHog/posthog/pull/28472

## Changes
- Remove `tz_aware` for date trunc in hogql
