### PR TITLE
chore(devex): add lemon tree folder lines

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -198,16 +198,26 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                             disabled={!!item.disabledReason}
                         >
                             <AccordionPrimitive.Item value={item.id} className="flex flex-col w-full gap-y-px">
+                                {/* Node */}
                                 <AccordionPrimitive.Trigger className="flex items-center gap-2 w-full h-8" asChild>
                                     <ContextMenu
                                         onOpenChange={(open) => {
                                             handleContextMenuOpen(open, item.id)
                                         }}
                                     >
+                                        {/* Folder lines */}
+                                        {depth !== 0 && (
+                                            // eslint-disable-next-line react/forbid-dom-props
+                                            <div
+                                                className="absolute border-l border-secondary h-[calc(100%+2px)] w-px -top-px pointer-events-none z-0"
+                                                style={{ left: `${DEPTH_OFFSET * 1.1}px` }}
+                                            />
+                                        )}
+
                                         <ContextMenuTrigger asChild>
                                             <LemonButton
                                                 className={cn(
-                                                    'group/lemon-tree-button flex-1 flex items-center gap-2 font-normal cursor-pointer',
+                                                    'group/lemon-tree-button flex-1 flex items-center gap-2 font-normal cursor-pointer z-10',
                                                     {
                                                         'ring-2 ring-inset ring-offset-[-1px] ring-accent-primary':
                                                             focusedId === item.id ||

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -147,7 +147,7 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
         },
         ref
     ): JSX.Element => {
-        const DEPTH_OFFSET = depth === 0 ? 0 : 6 * depth
+        const DEPTH_OFFSET = depth === 0 ? 0 : 16 * depth
 
         const [isContextMenuOpenForItem, setIsContextMenuOpenForItem] = useState<string | undefined>(undefined)
 
@@ -207,10 +207,10 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                                     >
                                         {/* Folder lines */}
                                         {depth !== 0 && (
-                                            // eslint-disable-next-line react/forbid-dom-props
                                             <div
                                                 className="absolute border-l border-secondary h-[calc(100%+2px)] w-px -top-px pointer-events-none z-0"
-                                                style={{ left: `${DEPTH_OFFSET * 1.1}px` }}
+                                                // eslint-disable-next-line react/forbid-dom-props
+                                                style={{ left: `${DEPTH_OFFSET}px` }}
                                             />
                                         )}
 


### PR DESCRIPTION
## Problem
Hard to see when a folder ends and begins
<img width="319" alt="image" src="https://github.com/user-attachments/assets/2aad37fb-aaeb-40ee-86a4-38125bbf50fc" />



## Changes
Add folder lines
![image](https://github.com/user-attachments/assets/549eee36-499c-44c9-ab71-9680acedf520)

## How did you test this code?

Locally