### PR TITLE
chore(sql-editor): Order warehouse tables by source and table name

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -617,6 +617,7 @@ def serialize_database(
             ),
         )
         .filter(Q(deleted=False) | Q(deleted__isnull=True), team_id=context.team_id, name__in=warehouse_table_names)
+        .order_by("external_data_source__prefix", "external_data_source__source_type", "name")
         .all()
         if warehouse_table_names
         else []


### PR DESCRIPTION
## Problem
- tables in the sql editor are in no particular order within each source group, making it hard to find certain tables

## Changes
- Order the warehouse tables by source prefix, then source type, and finally table name
