### PR TITLE
fix(crm): Support special characters in group links

### DIFF
--- a/frontend/src/queries/nodes/DataTable/renderColumn.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumn.tsx
@@ -293,7 +293,7 @@ export function renderColumn(
         )
     } else if (key === 'group_name' && isGroupsQuery(query.source)) {
         const key = (record as any[])[1] // 'key' is the second column in the groups query
-        return <Link to={urls.group(query.source.group_type_index, encodeURIComponent(key), false)}>{value}</Link>
+        return <Link to={urls.group(query.source.group_type_index, key, true)}>{value}</Link>
     }
     if (typeof value === 'object') {
         return <JSONViewer src={value} name={null} collapsed={Object.keys(value).length > 10 ? 0 : 1} />

--- a/frontend/src/queries/nodes/DataTable/renderColumn.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumn.tsx
@@ -293,7 +293,7 @@ export function renderColumn(
         )
     } else if (key === 'group_name' && isGroupsQuery(query.source)) {
         const key = (record as any[])[1] // 'key' is the second column in the groups query
-        return <Link to={urls.group(query.source.group_type_index, key, false)}>{value}</Link>
+        return <Link to={urls.group(query.source.group_type_index, encodeURIComponent(key), false)}>{value}</Link>
     }
     if (typeof value === 'object') {
         return <JSONViewer src={value} name={null} collapsed={Object.keys(value).length > 10 ? 0 : 1} />


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/29881
Reported in https://posthoghelp.zendesk.com/agent/tickets/27740 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/29998)

## Changes

Encodes the group key when creating a URL to ensure special characters don't break the URL.

**Before**

![CleanShot 2025-03-25 at 08 15 15](https://github.com/user-attachments/assets/20ec641e-2ce3-4ef6-a688-67dcfd7d1bff)

**After**

![CleanShot 2025-03-25 at 08 14 28](https://github.com/user-attachments/assets/938f5a77-43b9-4ea2-ad97-c33348131e73)

## How did you test this code?

I clicked on the link for a group with special characters and verified it loaded.