### PR TITLE
feat(cdp): execute hogFn before saving

### DIFF
--- a/common/hogvm/python/test/test_execute.py
+++ b/common/hogvm/python/test/test_execute.py
@@ -181,7 +181,7 @@ class TestBytecodeExecute:
         try:
             execute_bytecode(bytecode, {})
         except Exception as e:
-            assert str(e) == "Memory limit of 67108864 bytes exceeded. Tried to allocate 75497504 bytes."
+            assert str(e) == "Memory limit of 67108864 bytes exceeded. Attempted to use 75497504 bytes"
         else:
             raise AssertionError("Expected Exception not raised")
 
@@ -268,7 +268,7 @@ class TestBytecodeExecute:
         try:
             execute_bytecode(bytecode, {})
         except Exception as e:
-            assert str(e) == "Memory limit of 67108864 bytes exceeded. Tried to allocate 67155164 bytes."
+            assert str(e) == "Memory limit of 67108864 bytes exceeded. Attempted to use 67155164 bytes"
         else:
             raise AssertionError("Expected Exception not raised")
 

--- a/common/hogvm/python/utils.py
+++ b/common/hogvm/python/utils.py
@@ -25,6 +25,24 @@ class UncaughtHogVMException(HogVMException):
         return f"{self.type}('{msg}')"
 
 
+class HogVMRuntimeExceededException(HogVMException):
+    """Exception thrown when HogVM code exceeds its runtime limit"""
+
+    def __init__(self, timeout_seconds: float, ops_performed: int):
+        self.timeout_seconds = timeout_seconds
+        self.ops_performed = ops_performed
+        super().__init__(f"Runtime exceeded {timeout_seconds} seconds after {ops_performed} operations")
+
+
+class HogVMMemoryExceededException(HogVMException):
+    """Exception thrown when HogVM code exceeds its memory limit"""
+
+    def __init__(self, memory_limit: int, attempted_memory: int):
+        self.memory_limit = memory_limit
+        self.attempted_memory = attempted_memory
+        super().__init__(f"Memory limit of {memory_limit} bytes exceeded. Attempted to use {attempted_memory} bytes")
+
+
 def like(string, pattern, flags=0):
     pattern = re.escape(pattern).replace("%", ".*").replace("_", ".")
     re_pattern = re.compile(pattern, flags)

--- a/posthog/api/hog_function.py
+++ b/posthog/api/hog_function.py
@@ -292,10 +292,11 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
                 attrs["bytecode"] = compile_hog(attrs["hog"], hog_type)
                 attrs["transpiled"] = None
 
-                # Test execution to catch memory/execution exceptions
-                is_valid, error_message = validate_bytecode(attrs["bytecode"], attrs.get("inputs", {}))
-                if not is_valid:
-                    raise serializers.ValidationError({"hog": error_message})
+                # Test execution to catch memory/execution exceptions only for transformations
+                if hog_type == "transformation":
+                    is_valid, error_message = validate_bytecode(attrs["bytecode"], attrs.get("inputs", {}))
+                    if not is_valid:
+                        raise serializers.ValidationError({"hog": error_message})
 
         if is_create:
             if not attrs.get("hog"):

--- a/posthog/api/hog_function.py
+++ b/posthog/api/hog_function.py
@@ -1,5 +1,6 @@
 import json
 from typing import Optional, cast
+from common.hogvm.python.execute import validate_bytecode
 import structlog
 from django_filters.rest_framework import DjangoFilterBackend
 from django_filters import BaseInFilter, CharFilter, FilterSet
@@ -290,6 +291,11 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
             else:
                 attrs["bytecode"] = compile_hog(attrs["hog"], hog_type)
                 attrs["transpiled"] = None
+
+                # Test execution to catch memory/execution exceptions
+                is_valid, error_message = validate_bytecode(attrs["bytecode"], attrs.get("inputs", {}))
+                if not is_valid:
+                    raise serializers.ValidationError({"hog": error_message})
 
         if is_create:
             if not attrs.get("hog"):

--- a/posthog/api/test/test_hog_function.py
+++ b/posthog/api/test/test_hog_function.py
@@ -1958,3 +1958,65 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
 
             assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
             assert "Your function needs too much memory" in response.json()["detail"]
+
+    def test_validation_catches_runtime_exceeded_in_python_vm_for_transformations(self):
+        with override_settings(HOG_TRANSFORMATIONS_CUSTOM_ENABLED_TEAMS=[self.team.id]):
+            """Test that runtime exceeded errors during validation in our Python VM are properly handled for transformations"""
+            # Create a function with an infinite loop that will exceed the 100ms validation timeout
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/hog_functions/",
+                data={
+                    "name": "Slow Function",
+                    "type": "transformation",
+                    "hog": """
+                    while (true) { print('hello'); } return event;
+                    """,
+                },
+            )
+
+            assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+            assert "Your function is taking too long to run (over 0.1 seconds)" in response.json()["detail"]
+
+            # Test that the same code is allowed for destinations
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/hog_functions/",
+                data={
+                    "name": "Slow Function",
+                    "type": "destination",
+                    "hog": """
+                    while (true) { print('hello'); } return event;
+                    """,
+                },
+            )
+            assert response.status_code == status.HTTP_201_CREATED, response.json()
+
+    def test_validation_catches_memory_exceeded_in_python_vm_for_transformations(self):
+        with override_settings(HOG_TRANSFORMATIONS_CUSTOM_ENABLED_TEAMS=[self.team.id]):
+            """Test that memory exceeded errors during validation in our Python VM are properly handled for transformations"""
+            memory_hungry_code = """
+                let arr := arrayMap(x -> toString(x), range(10000000));  // Create array with 10M strings
+                return event;
+                """
+
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/hog_functions/",
+                data={
+                    "name": "Memory Hungry Function",
+                    "type": "transformation",
+                    "hog": memory_hungry_code,
+                },
+            )
+
+            assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+            assert "Your function needs too much memory" in response.json()["detail"]
+
+            # Test that the same code is allowed for destinations
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/hog_functions/",
+                data={
+                    "name": "Memory Hungry Function",
+                    "type": "destination",
+                    "hog": memory_hungry_code,
+                },
+            )
+            assert response.status_code == status.HTTP_201_CREATED, response.json()


### PR DESCRIPTION
## Problem

As we are allowing custom transformations we want to protect ourselves from bad actors. We are mainly concerned about infinite loops and functions that take up too much memory.. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- uses our VM (python one) to execute the hog-function before being able to save it 
- use VM rail-guards (execution time, memory limit) to protect against bad actors before hitting ingestion pipeline
- added more human readable errors


### slow hog

![2025-03-25 17 33 48](https://github.com/user-attachments/assets/51b1cc47-8d57-4761-8a0c-9b2c787fc9b4)

### memory hogger...

![2025-03-25 17 38 16](https://github.com/user-attachments/assets/4026a37f-cc43-4b65-9a63-388bdf2cfcb1)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- added tests
- tested manually

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
