### PR TITLE
fix(max-ai): do not run memory collector node during onboarding

### DIFF
--- a/ee/hogai/graph.py
+++ b/ee/hogai/graph.py
@@ -313,7 +313,7 @@ class AssistantGraph:
 
         builder.add_conditional_edges(
             AssistantNodeName.START,
-            memory_onboarding.memory_onboarding_should_run,
+            memory_onboarding.should_run,
             path_map={True: AssistantNodeName.MEMORY_ONBOARDING, False: next_node},
         )
         builder.add_conditional_edges(

--- a/ee/hogai/graph.py
+++ b/ee/hogai/graph.py
@@ -313,7 +313,7 @@ class AssistantGraph:
 
         builder.add_conditional_edges(
             AssistantNodeName.START,
-            memory_onboarding.should_run,
+            memory_onboarding.memory_onboarding_should_run,
             path_map={True: AssistantNodeName.MEMORY_ONBOARDING, False: next_node},
         )
         builder.add_conditional_edges(

--- a/ee/hogai/memory/nodes.py
+++ b/ee/hogai/memory/nodes.py
@@ -79,7 +79,7 @@ class MemoryInitializerContextMixin:
 
 
 class MemoryOnboardingShouldRunMixin(AssistantNode):
-    def memory_onboarding_should_run(self, _: AssistantState) -> bool:
+    def should_run(self, _: AssistantState) -> bool:
         """
         If another user has already started the onboarding process, or it has already been completed, do not trigger it again.
         """
@@ -290,13 +290,13 @@ class core_memory_replace(BaseModel):
 memory_collector_tools = [core_memory_append, core_memory_replace]
 
 
-class MemoryCollectorNode(MemoryOnboardingShouldRunMixin):
+class MemoryCollectorNode(MemoryOnboardingShouldRunMixin, AssistantNode):
     """
     The Memory Collector manages the core memory of the agent. Core memory is a text containing facts about a user's company and product. It helps the agent save and remember facts that could be useful for insight generation or other agentic functions requiring deeper context about the product.
     """
 
     def run(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState | None:
-        if self.memory_onboarding_should_run(state):
+        if self.should_run(state):
             return None
 
         node_messages = state.memory_collection_messages or []

--- a/ee/hogai/memory/nodes.py
+++ b/ee/hogai/memory/nodes.py
@@ -78,7 +78,7 @@ class MemoryInitializerContextMixin:
         return response.results
 
 
-class MemoryOnboardingShouldRunMixin:
+class MemoryOnboardingShouldRunMixin(AssistantNode):
     def memory_onboarding_should_run(self, _: AssistantState) -> bool:
         """
         If another user has already started the onboarding process, or it has already been completed, do not trigger it again.
@@ -87,7 +87,7 @@ class MemoryOnboardingShouldRunMixin:
         return not core_memory or (not core_memory.is_scraping_pending and not core_memory.is_scraping_finished)
 
 
-class MemoryOnboardingNode(MemoryInitializerContextMixin, MemoryOnboardingShouldRunMixin, AssistantNode):
+class MemoryOnboardingNode(MemoryInitializerContextMixin, MemoryOnboardingShouldRunMixin):
     def run(self, state: AssistantState, config: RunnableConfig) -> Optional[PartialAssistantState]:
         core_memory, _ = CoreMemory.objects.get_or_create(team=self._team)
 
@@ -290,12 +290,12 @@ class core_memory_replace(BaseModel):
 memory_collector_tools = [core_memory_append, core_memory_replace]
 
 
-class MemoryCollectorNode(MemoryOnboardingShouldRunMixin, AssistantNode):
+class MemoryCollectorNode(MemoryOnboardingShouldRunMixin):
     """
     The Memory Collector manages the core memory of the agent. Core memory is a text containing facts about a user's company and product. It helps the agent save and remember facts that could be useful for insight generation or other agentic functions requiring deeper context about the product.
     """
 
-    def run(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState:
+    def run(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState | None:
         if self.memory_onboarding_should_run(state):
             return None
 

--- a/ee/hogai/memory/nodes.py
+++ b/ee/hogai/memory/nodes.py
@@ -78,7 +78,16 @@ class MemoryInitializerContextMixin:
         return response.results
 
 
-class MemoryOnboardingNode(MemoryInitializerContextMixin, AssistantNode):
+class MemoryOnboardingShouldRunMixin:
+    def memory_onboarding_should_run(self, _: AssistantState) -> bool:
+        """
+        If another user has already started the onboarding process, or it has already been completed, do not trigger it again.
+        """
+        core_memory = self.core_memory
+        return not core_memory or (not core_memory.is_scraping_pending and not core_memory.is_scraping_finished)
+
+
+class MemoryOnboardingNode(MemoryInitializerContextMixin, MemoryOnboardingShouldRunMixin, AssistantNode):
     def run(self, state: AssistantState, config: RunnableConfig) -> Optional[PartialAssistantState]:
         core_memory, _ = CoreMemory.objects.get_or_create(team=self._team)
 
@@ -103,13 +112,6 @@ class MemoryOnboardingNode(MemoryInitializerContextMixin, AssistantNode):
                 )
             ]
         )
-
-    def should_run(self, _: AssistantState) -> bool:
-        """
-        If another user has already started the onboarding process, or it has already been completed, do not trigger it again.
-        """
-        core_memory = self.core_memory
-        return not core_memory or (not core_memory.is_scraping_pending and not core_memory.is_scraping_finished)
 
     def router(self, state: AssistantState) -> Literal["initialize_memory", "continue"]:
         last_message = state.messages[-1]
@@ -288,12 +290,15 @@ class core_memory_replace(BaseModel):
 memory_collector_tools = [core_memory_append, core_memory_replace]
 
 
-class MemoryCollectorNode(AssistantNode):
+class MemoryCollectorNode(MemoryOnboardingShouldRunMixin, AssistantNode):
     """
     The Memory Collector manages the core memory of the agent. Core memory is a text containing facts about a user's company and product. It helps the agent save and remember facts that could be useful for insight generation or other agentic functions requiring deeper context about the product.
     """
 
     def run(self, state: AssistantState, config: RunnableConfig) -> PartialAssistantState:
+        if self.memory_onboarding_should_run(state):
+            return None
+
         node_messages = state.memory_collection_messages or []
 
         prompt = ChatPromptTemplate.from_messages(


### PR DESCRIPTION
## Problem
In Max AI, we currently run the memory collector during the onboarding, adding a useless LLM call to the flow.

## Changes
Do not run the memory collector node during the onboarding.

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Checked LLM observability logs
