### PR TITLE
feat(experiments): first iteration of multi-step funnel support

### DIFF
--- a/frontend/src/lib/monaco/languages/hogQL.ts
+++ b/frontend/src/lib/monaco/languages/hogQL.ts
@@ -782,6 +782,7 @@ export const language: () => languages.IMonarchLanguage = () => ({
         'maxIntersectionsPosition',
         'maxIntersectionsPositionIf',
         'getSurveyResponse',
+        'windowFunnel',
     ],
     builtinVariables: [],
     tokenizer: {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -8089,7 +8089,7 @@
                     "type": "array"
                 }
             },
-            "required": ["kind", "event", "order", "properties"],
+            "required": ["kind", "event", "order"],
             "type": "object"
         },
         "ExperimentFunnelsQuery": {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -8040,6 +8040,52 @@
             "required": ["variant", "days", "exposure_counts"],
             "type": "object"
         },
+        "ExperimentFunnelMetricConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "funnel": {
+                    "items": {
+                        "$ref": "#/definitions/ExperimentFunnelStepConfig"
+                    },
+                    "type": "array"
+                },
+                "kind": {
+                    "const": "ExperimentFunnelMetricConfig",
+                    "type": "string"
+                },
+                "math": {
+                    "$ref": "#/definitions/ExperimentMetricMathType"
+                }
+            },
+            "required": ["kind", "funnel"],
+            "type": "object"
+        },
+        "ExperimentFunnelStepConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "event": {
+                    "type": "string"
+                },
+                "kind": {
+                    "const": "ExperimentFunnelStepConfig",
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "order": {
+                    "type": "number"
+                },
+                "properties": {
+                    "items": {
+                        "$ref": "#/definitions/AnyPropertyFilter"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["kind", "event", "order", "properties"],
+            "type": "object"
+        },
         "ExperimentFunnelsQuery": {
             "additionalProperties": false,
             "properties": {
@@ -8154,6 +8200,9 @@
                         },
                         {
                             "$ref": "#/definitions/ExperimentDataWarehouseMetricConfig"
+                        },
+                        {
+                            "$ref": "#/definitions/ExperimentFunnelMetricConfig"
                         }
                     ]
                 },
@@ -11190,6 +11239,8 @@
                 "ExperimentExposureQuery",
                 "ExperimentEventExposureConfig",
                 "ExperimentEventMetricConfig",
+                "ExperimentFunnelMetricConfig",
+                "ExperimentFunnelStepConfig",
                 "ExperimentActionMetricConfig",
                 "ExperimentDataWarehouseMetricConfig",
                 "ExperimentTrendsQuery",

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -8080,7 +8080,7 @@
                     "type": "string"
                 },
                 "order": {
-                    "type": "number"
+                    "$ref": "#/definitions/integer"
                 },
                 "properties": {
                     "items": {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -8055,6 +8055,12 @@
                 },
                 "math": {
                     "$ref": "#/definitions/ExperimentMetricMathType"
+                },
+                "math_hogql": {
+                    "type": "string"
+                },
+                "math_property": {
+                    "type": "string"
                 }
             },
             "required": ["kind", "funnel"],

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -110,6 +110,8 @@ export enum NodeKind {
     ExperimentExposureQuery = 'ExperimentExposureQuery',
     ExperimentEventExposureConfig = 'ExperimentEventExposureConfig',
     ExperimentEventMetricConfig = 'ExperimentEventMetricConfig',
+    ExperimentFunnelMetricConfig = 'ExperimentFunnelMetricConfig',
+    ExperimentFunnelStepConfig = 'ExperimentFunnelStepConfig',
     ExperimentActionMetricConfig = 'ExperimentActionMetricConfig',
     ExperimentDataWarehouseMetricConfig = 'ExperimentDataWarehouseMetricConfig',
     ExperimentTrendsQuery = 'ExperimentTrendsQuery',
@@ -1967,8 +1969,23 @@ export interface ExperimentMetric {
     name?: string
     metric_type: ExperimentMetricType
     inverse?: boolean
-    metric_config: ExperimentEventMetricConfig | ExperimentActionMetricConfig | ExperimentDataWarehouseMetricConfig
+    metric_config: ExperimentEventMetricConfig | ExperimentActionMetricConfig | ExperimentDataWarehouseMetricConfig | ExperimentFunnelMetricConfig
     time_window_hours?: number
+}
+
+export interface ExperimentFunnelStepConfig {
+    kind: NodeKind.ExperimentFunnelStepConfig
+    event: string
+    name?: string
+    order: number
+    properties: AnyPropertyFilter[]
+}
+
+export interface ExperimentFunnelMetricConfig {
+    kind: NodeKind.ExperimentFunnelMetricConfig
+    funnel: ExperimentFunnelStepConfig[]
+    // NOTE: Just to make the type system happy
+    math?: ExperimentMetricMathType
 }
 
 export interface ExperimentEventMetricConfig {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1982,7 +1982,7 @@ export interface ExperimentFunnelStepConfig {
     event: string
     name?: string
     order: number
-    properties: AnyPropertyFilter[]
+    properties?: AnyPropertyFilter[]
 }
 
 export interface ExperimentFunnelMetricConfig {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1969,7 +1969,11 @@ export interface ExperimentMetric {
     name?: string
     metric_type: ExperimentMetricType
     inverse?: boolean
-    metric_config: ExperimentEventMetricConfig | ExperimentActionMetricConfig | ExperimentDataWarehouseMetricConfig | ExperimentFunnelMetricConfig
+    metric_config:
+        | ExperimentEventMetricConfig
+        | ExperimentActionMetricConfig
+        | ExperimentDataWarehouseMetricConfig
+        | ExperimentFunnelMetricConfig
     time_window_hours?: number
 }
 
@@ -1986,6 +1990,8 @@ export interface ExperimentFunnelMetricConfig {
     funnel: ExperimentFunnelStepConfig[]
     // NOTE: Just to make the type system happy
     math?: ExperimentMetricMathType
+    math_hogql?: string
+    math_property?: string
 }
 
 export interface ExperimentEventMetricConfig {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1981,7 +1981,7 @@ export interface ExperimentFunnelStepConfig {
     kind: NodeKind.ExperimentFunnelStepConfig
     event: string
     name?: string
-    order: number
+    order: integer
     properties?: AnyPropertyFilter[]
 }
 

--- a/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
@@ -50,7 +50,6 @@ export function ExperimentMetricForm({
     const allowedMathTypes = getAllowedMathTypes(metric.metric_type)
 
     const isDataWarehouseMetric = metric.metric_config.kind === NodeKind.ExperimentDataWarehouseMetricConfig
-    console.log('metric', metric)
 
     return (
         <div className="deprecated-space-y-4">

--- a/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
@@ -9,13 +9,7 @@ import { ExperimentMetric, ExperimentMetricType, NodeKind } from '~/queries/sche
 import { FilterType } from '~/types'
 
 import { commonActionFilterProps } from './Metrics/Selectors'
-import {
-    filterToMetricConfig,
-    getAllowedMathTypes,
-    getMathAvailability,
-    metricConfigToFilter,
-    metricToQuery,
-} from './utils'
+import { filterToMetricConfig, getAllowedMathTypes, getMathAvailability, metricToFilter, metricToQuery } from './utils'
 
 const dataWarehousePopoverFields: DataWarehousePopoverField[] = [
     {
@@ -88,33 +82,63 @@ export function ExperimentMetricForm({
             </div>
             <div>
                 <LemonLabel className="mb-1">Metric</LemonLabel>
-                <ActionFilter
-                    bordered
-                    filters={metricConfigToFilter(metric.metric_config)}
-                    setFilters={({ actions, events, data_warehouse }: Partial<FilterType>): void => {
-                        // We only support one event/action for experiment metrics
-                        const entity = events?.[0] || actions?.[0] || data_warehouse?.[0]
-                        const metricConfig = filterToMetricConfig(entity)
-                        if (metricConfig) {
-                            handleSetMetric({
-                                newMetric: {
-                                    ...metric,
-                                    metric_config: metricConfig,
-                                },
-                            })
-                        }
-                    }}
-                    typeKey="experiment-metric"
-                    buttonCopy="Add graph series"
-                    showSeriesIndicator={false}
-                    hideRename={true}
-                    entitiesLimit={1}
-                    showNumericalPropsOnly={true}
-                    mathAvailability={mathAvailability}
-                    allowedMathTypes={allowedMathTypes}
-                    dataWarehousePopoverFields={dataWarehousePopoverFields}
-                    {...commonActionFilterProps}
-                />
+
+                {metric.metric_type === ExperimentMetricType.MEAN && (
+                    <ActionFilter
+                        bordered
+                        filters={metricToFilter(metric)}
+                        setFilters={({ actions, events, data_warehouse }: Partial<FilterType>): void => {
+                            const metricConfig = filterToMetricConfig(
+                                metric.metric_type,
+                                actions,
+                                events,
+                                data_warehouse
+                            )
+                            if (metricConfig) {
+                                handleSetMetric({
+                                    newMetric: {
+                                        ...metric,
+                                        metric_config: metricConfig,
+                                    },
+                                })
+                            }
+                        }}
+                        typeKey="experiment-metric"
+                        buttonCopy="Add graph series"
+                        showSeriesIndicator={false}
+                        hideRename={true}
+                        entitiesLimit={1}
+                        showNumericalPropsOnly={true}
+                        mathAvailability={mathAvailability}
+                        allowedMathTypes={allowedMathTypes}
+                        dataWarehousePopoverFields={dataWarehousePopoverFields}
+                        {...commonActionFilterProps}
+                    />
+                )}
+
+                {metric.metric_type === ExperimentMetricType.FUNNEL && (
+                    <ActionFilter
+                        bordered
+                        filters={metricToFilter(metric)}
+                        setFilters={({ actions, events, data_warehouse }: Partial<FilterType>): void => {
+                            console.log('metric', metric)
+                            console.log('actions', actions)
+                            console.log('events', events)
+                            console.log('data_warehouse', data_warehouse)
+                        }}
+                        typeKey="experiment-metric"
+                        buttonCopy="Add step"
+                        showSeriesIndicator={false}
+                        hideRename={true}
+                        sortable={true}
+                        showNestedArrow={true}
+                        // showNumericalPropsOnly={true}
+                        mathAvailability={mathAvailability}
+                        allowedMathTypes={allowedMathTypes}
+                        dataWarehousePopoverFields={dataWarehousePopoverFields}
+                        {...commonActionFilterProps}
+                    />
+                )}
             </div>
             {/* :KLUDGE: Query chart type is inferred from the initial state, so need to render Trends and Funnels separately */}
             {metric.metric_type === ExperimentMetricType.MEAN && !isDataWarehouseMetric && (

--- a/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
@@ -9,7 +9,14 @@ import { ExperimentMetric, ExperimentMetricType, NodeKind } from '~/queries/sche
 import { FilterType } from '~/types'
 
 import { commonActionFilterProps } from './Metrics/Selectors'
-import { filterToMetricConfig, getAllowedMathTypes, getMathAvailability, metricToFilter, metricToQuery } from './utils'
+import {
+    filterToMetricConfig,
+    getAllowedMathTypes,
+    getDefaultExperimentMetric,
+    getMathAvailability,
+    metricToFilter,
+    metricToQuery,
+} from './utils'
 
 const dataWarehousePopoverFields: DataWarehousePopoverField[] = [
     {
@@ -43,6 +50,7 @@ export function ExperimentMetricForm({
     const allowedMathTypes = getAllowedMathTypes(metric.metric_type)
 
     const isDataWarehouseMetric = metric.metric_config.kind === NodeKind.ExperimentDataWarehouseMetricConfig
+    console.log('metric', metric)
 
     return (
         <div className="deprecated-space-y-4">
@@ -52,16 +60,8 @@ export function ExperimentMetricForm({
                     data-attr="metrics-selector"
                     value={metric.metric_type}
                     onChange={(newMetricType: ExperimentMetricType) => {
-                        const newAllowedMathTypes = getAllowedMathTypes(newMetricType)
                         handleSetMetric({
-                            newMetric: {
-                                ...metric,
-                                metric_type: newMetricType,
-                                metric_config: {
-                                    ...metric.metric_config,
-                                    math: newAllowedMathTypes[0],
-                                },
-                            },
+                            newMetric: getDefaultExperimentMetric(newMetricType),
                         })
                     }}
                     options={[
@@ -127,7 +127,6 @@ export function ExperimentMetricForm({
                                 events,
                                 data_warehouse
                             )
-                            console.log('metricConfig', metricConfig)
                             if (metricConfig) {
                                 handleSetMetric({
                                     newMetric: {
@@ -136,7 +135,6 @@ export function ExperimentMetricForm({
                                     },
                                 })
                             }
-                            console.log('new metric', metric)
                         }}
                         typeKey="experiment-metric"
                         buttonCopy="Add step"

--- a/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
@@ -51,6 +51,18 @@ export function ExperimentMetricForm({
 
     const isDataWarehouseMetric = metric.metric_config.kind === NodeKind.ExperimentDataWarehouseMetricConfig
 
+    const handleSetFilters = ({ actions, events, data_warehouse }: Partial<FilterType>): void => {
+        const metricConfig = filterToMetricConfig(metric.metric_type, actions, events, data_warehouse)
+        if (metricConfig) {
+            handleSetMetric({
+                newMetric: {
+                    ...metric,
+                    metric_config: metricConfig,
+                },
+            })
+        }
+    }
+
     return (
         <div className="deprecated-space-y-4">
             <div>
@@ -86,22 +98,7 @@ export function ExperimentMetricForm({
                     <ActionFilter
                         bordered
                         filters={metricToFilter(metric)}
-                        setFilters={({ actions, events, data_warehouse }: Partial<FilterType>): void => {
-                            const metricConfig = filterToMetricConfig(
-                                metric.metric_type,
-                                actions,
-                                events,
-                                data_warehouse
-                            )
-                            if (metricConfig) {
-                                handleSetMetric({
-                                    newMetric: {
-                                        ...metric,
-                                        metric_config: metricConfig,
-                                    },
-                                })
-                            }
-                        }}
+                        setFilters={handleSetFilters}
                         typeKey="experiment-metric"
                         buttonCopy="Add graph series"
                         showSeriesIndicator={false}
@@ -119,22 +116,7 @@ export function ExperimentMetricForm({
                     <ActionFilter
                         bordered
                         filters={metricToFilter(metric)}
-                        setFilters={({ actions, events, data_warehouse }: Partial<FilterType>): void => {
-                            const metricConfig = filterToMetricConfig(
-                                metric.metric_type,
-                                actions,
-                                events,
-                                data_warehouse
-                            )
-                            if (metricConfig) {
-                                handleSetMetric({
-                                    newMetric: {
-                                        ...metric,
-                                        metric_config: metricConfig,
-                                    },
-                                })
-                            }
-                        }}
+                        setFilters={handleSetFilters}
                         typeKey="experiment-metric"
                         buttonCopy="Add step"
                         showSeriesIndicator={false}

--- a/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
@@ -121,10 +121,22 @@ export function ExperimentMetricForm({
                         bordered
                         filters={metricToFilter(metric)}
                         setFilters={({ actions, events, data_warehouse }: Partial<FilterType>): void => {
-                            console.log('metric', metric)
-                            console.log('actions', actions)
-                            console.log('events', events)
-                            console.log('data_warehouse', data_warehouse)
+                            const metricConfig = filterToMetricConfig(
+                                metric.metric_type,
+                                actions,
+                                events,
+                                data_warehouse
+                            )
+                            console.log('metricConfig', metricConfig)
+                            if (metricConfig) {
+                                handleSetMetric({
+                                    newMetric: {
+                                        ...metric,
+                                        metric_config: metricConfig,
+                                    },
+                                })
+                            }
+                            console.log('new metric', metric)
                         }}
                         typeKey="experiment-metric"
                         buttonCopy="Add step"

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeCalculatorLogic.tsx
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeCalculatorLogic.tsx
@@ -39,6 +39,8 @@ const getKindField = (metric: ExperimentMetric): NodeKind => {
         ? NodeKind.EventsNode
         : metric.metric_config.kind === NodeKind.ExperimentActionMetricConfig
         ? NodeKind.ActionsNode
+        : metric.metric_config.kind === NodeKind.ExperimentFunnelMetricConfig
+        ? NodeKind.FunnelsQuery
         : NodeKind.DataWarehouseNode
 }
 
@@ -47,6 +49,8 @@ const getEventField = (metric: ExperimentMetric): string | number => {
         ? metric.metric_config.event
         : metric.metric_config.kind === NodeKind.ExperimentActionMetricConfig
         ? metric.metric_config.action
+        : metric.metric_config.kind === NodeKind.ExperimentFunnelMetricConfig
+        ? metric.metric_config.funnel[0].event
         : metric.metric_config.table_name
 }
 

--- a/frontend/src/scenes/experiments/utils.test.ts
+++ b/frontend/src/scenes/experiments/utils.test.ts
@@ -644,7 +644,7 @@ describe('metricToFilter', () => {
                 math_property: undefined,
                 math_hogql: undefined,
                 properties: [{ key: '$browser', value: ['Chrome'], operator: 'exact', type: 'event' }],
-            } as ExperimentEventMetricConfig
+            } as ExperimentEventMetricConfig,
         }
         const filter = metricToFilter(metric)
         expect(filter).toEqual({
@@ -676,7 +676,7 @@ describe('metricToFilter', () => {
                 math_property: undefined,
                 math_hogql: undefined,
                 properties: [{ key: '$lib', type: 'event', value: ['python'], operator: 'exact' }],
-            } as ExperimentActionMetricConfig
+            } as ExperimentActionMetricConfig,
         }
         const filter = metricToFilter(metric)
         expect(filter).toEqual({
@@ -710,7 +710,7 @@ describe('metricToFilter', () => {
                 math: ExperimentMetricMathType.TotalCount,
                 math_property: undefined,
                 math_hogql: undefined,
-            } as ExperimentDataWarehouseMetricConfig
+            } as ExperimentDataWarehouseMetricConfig,
         }
         const filter = metricToFilter(metric)
         expect(filter).toEqual({
@@ -752,12 +752,7 @@ describe('filterToMetricConfig', () => {
                 },
             ],
         } as Record<string, any>
-        const metricConfig = filterToMetricConfig(
-            ExperimentMetricType.MEAN,
-            undefined,
-            [event],
-            undefined
-        )
+        const metricConfig = filterToMetricConfig(ExperimentMetricType.MEAN, undefined, [event], undefined)
         expect(metricConfig).toEqual({
             kind: NodeKind.ExperimentEventMetricConfig,
             event: '$pageview',
@@ -793,12 +788,7 @@ describe('filterToMetricConfig', () => {
             order: 0,
             uuid: '29c01ac4-ebc3-4cb8-9d82-287c0487056e',
         } as Record<string, any>
-        const metricConfig = filterToMetricConfig(
-            ExperimentMetricType.MEAN,
-            [action],
-            undefined,
-            undefined
-        )
+        const metricConfig = filterToMetricConfig(ExperimentMetricType.MEAN, [action], undefined, undefined)
         expect(metricConfig).toEqual({
             kind: NodeKind.ExperimentActionMetricConfig,
             action: '8',
@@ -819,12 +809,7 @@ describe('filterToMetricConfig', () => {
             events_join_key: 'person.properties.email',
             data_warehouse_join_key: 'customer.email',
         } as Record<string, any>
-        const metricConfig = filterToMetricConfig(
-            ExperimentMetricType.MEAN,
-            undefined,
-            undefined,
-            [dataWarehouse]
-        )
+        const metricConfig = filterToMetricConfig(ExperimentMetricType.MEAN, undefined, undefined, [dataWarehouse])
         expect(metricConfig).toEqual({
             kind: NodeKind.ExperimentDataWarehouseMetricConfig,
             table_name: 'mysql_payments',

--- a/frontend/src/scenes/experiments/utils.test.ts
+++ b/frontend/src/scenes/experiments/utils.test.ts
@@ -37,7 +37,7 @@ import {
     filterToMetricConfig,
     getMinimumDetectableEffect,
     getViewRecordingFilters,
-    metricConfigToFilter,
+    metricToFilter,
     metricToQuery,
     percentageDistribution,
     transformFiltersForWinningVariant,
@@ -631,18 +631,22 @@ describe('filterToExposureConfig', () => {
     })
 })
 
-describe('metricConfigToFilter', () => {
+describe('metricToFilter', () => {
     it('returns the correct filter for an event', () => {
-        const metricConfig = {
-            kind: NodeKind.ExperimentEventMetricConfig,
-            event: '$pageview',
-            name: '$pageview',
-            math: 'total',
-            math_property: undefined,
-            math_hogql: undefined,
-            properties: [{ key: '$browser', value: ['Chrome'], operator: 'exact', type: 'event' }],
-        } as ExperimentEventMetricConfig
-        const filter = metricConfigToFilter(metricConfig)
+        const metric: ExperimentMetric = {
+            kind: NodeKind.ExperimentMetric,
+            metric_type: ExperimentMetricType.MEAN,
+            metric_config: {
+                kind: NodeKind.ExperimentEventMetricConfig,
+                event: '$pageview',
+                name: '$pageview',
+                math: 'total',
+                math_property: undefined,
+                math_hogql: undefined,
+                properties: [{ key: '$browser', value: ['Chrome'], operator: 'exact', type: 'event' }],
+            } as ExperimentEventMetricConfig
+        }
+        const filter = metricToFilter(metric)
         expect(filter).toEqual({
             events: [
                 {
@@ -661,16 +665,20 @@ describe('metricConfigToFilter', () => {
         })
     })
     it('returns the correct filter for an action', () => {
-        const metricConfig = {
-            kind: NodeKind.ExperimentActionMetricConfig,
-            action: 8,
-            name: 'jan-16-running payment action',
-            math: 'total',
-            math_property: undefined,
-            math_hogql: undefined,
-            properties: [{ key: '$lib', type: 'event', value: ['python'], operator: 'exact' }],
-        } as ExperimentActionMetricConfig
-        const filter = metricConfigToFilter(metricConfig)
+        const metric: ExperimentMetric = {
+            kind: NodeKind.ExperimentMetric,
+            metric_type: ExperimentMetricType.MEAN,
+            metric_config: {
+                kind: NodeKind.ExperimentActionMetricConfig,
+                action: 8,
+                name: 'jan-16-running payment action',
+                math: 'total',
+                math_property: undefined,
+                math_hogql: undefined,
+                properties: [{ key: '$lib', type: 'event', value: ['python'], operator: 'exact' }],
+            } as ExperimentActionMetricConfig
+        }
+        const filter = metricToFilter(metric)
         expect(filter).toEqual({
             events: [],
             actions: [
@@ -689,18 +697,22 @@ describe('metricConfigToFilter', () => {
         })
     })
     it('returns the correct filter for a data warehouse metric', () => {
-        const metricConfig = {
-            kind: NodeKind.ExperimentDataWarehouseMetricConfig,
-            table_name: 'mysql_payments',
-            name: 'mysql_payments',
-            timestamp_field: 'timestamp',
-            events_join_key: 'person.properties.email',
-            data_warehouse_join_key: 'customer.email',
-            math: ExperimentMetricMathType.TotalCount,
-            math_property: undefined,
-            math_hogql: undefined,
-        } as ExperimentDataWarehouseMetricConfig
-        const filter = metricConfigToFilter(metricConfig)
+        const metric: ExperimentMetric = {
+            kind: NodeKind.ExperimentMetric,
+            metric_type: ExperimentMetricType.MEAN,
+            metric_config: {
+                kind: NodeKind.ExperimentDataWarehouseMetricConfig,
+                table_name: 'mysql_payments',
+                name: 'mysql_payments',
+                timestamp_field: 'timestamp',
+                events_join_key: 'person.properties.email',
+                data_warehouse_join_key: 'customer.email',
+                math: ExperimentMetricMathType.TotalCount,
+                math_property: undefined,
+                math_hogql: undefined,
+            } as ExperimentDataWarehouseMetricConfig
+        }
+        const filter = metricToFilter(metric)
         expect(filter).toEqual({
             events: [],
             actions: [],
@@ -740,7 +752,12 @@ describe('filterToMetricConfig', () => {
                 },
             ],
         } as Record<string, any>
-        const metricConfig = filterToMetricConfig(event)
+        const metricConfig = filterToMetricConfig(
+            ExperimentMetricType.MEAN,
+            undefined,
+            [event],
+            undefined
+        )
         expect(metricConfig).toEqual({
             kind: NodeKind.ExperimentEventMetricConfig,
             event: '$pageview',
@@ -776,7 +793,12 @@ describe('filterToMetricConfig', () => {
             order: 0,
             uuid: '29c01ac4-ebc3-4cb8-9d82-287c0487056e',
         } as Record<string, any>
-        const metricConfig = filterToMetricConfig(action)
+        const metricConfig = filterToMetricConfig(
+            ExperimentMetricType.MEAN,
+            [action],
+            undefined,
+            undefined
+        )
         expect(metricConfig).toEqual({
             kind: NodeKind.ExperimentActionMetricConfig,
             action: '8',
@@ -797,7 +819,12 @@ describe('filterToMetricConfig', () => {
             events_join_key: 'person.properties.email',
             data_warehouse_join_key: 'customer.email',
         } as Record<string, any>
-        const metricConfig = filterToMetricConfig(dataWarehouse)
+        const metricConfig = filterToMetricConfig(
+            ExperimentMetricType.MEAN,
+            undefined,
+            undefined,
+            [dataWarehouse]
+        )
         expect(metricConfig).toEqual({
             kind: NodeKind.ExperimentDataWarehouseMetricConfig,
             table_name: 'mysql_payments',

--- a/frontend/src/scenes/experiments/utils.test.ts
+++ b/frontend/src/scenes/experiments/utils.test.ts
@@ -830,8 +830,14 @@ describe('metricToQuery', () => {
             kind: NodeKind.ExperimentMetric,
             metric_type: ExperimentMetricType.FUNNEL,
             metric_config: {
-                kind: NodeKind.ExperimentEventMetricConfig,
-                event: 'purchase',
+                kind: NodeKind.ExperimentFunnelMetricConfig,
+                funnel: [
+                    {
+                        event: 'purchase',
+                        order: 0,
+                        kind: NodeKind.ExperimentFunnelStepConfig,
+                    },
+                ],
             },
         }
 
@@ -850,11 +856,13 @@ describe('metricToQuery', () => {
             series: [
                 {
                     kind: NodeKind.EventsNode,
-                    event: '$feature_flag_called',
+                    event: '$pageview',
+                    name: '$pageview',
                 },
                 {
                     kind: NodeKind.EventsNode,
                     event: 'purchase',
+                    name: 'purchase',
                 },
             ],
         })

--- a/frontend/src/scenes/experiments/utils.test.ts
+++ b/frontend/src/scenes/experiments/utils.test.ts
@@ -858,6 +858,7 @@ describe('metricToQuery', () => {
                     kind: NodeKind.EventsNode,
                     event: '$pageview',
                     name: '$pageview',
+                    custom_name: 'Placeholder for experiment exposure',
                 },
                 {
                     kind: NodeKind.EventsNode,

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -3,8 +3,8 @@ import { EXPERIMENT_DEFAULT_DURATION, FunnelLayout } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import merge from 'lodash.merge'
 import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
-import { actionsAndEventsToSeries } from '~/queries/nodes/InsightQuery/utils/filtersToQueryNode'
 
+import { actionsAndEventsToSeries } from '~/queries/nodes/InsightQuery/utils/filtersToQueryNode'
 import {
     AnyEntityNode,
     EventsNode,
@@ -451,24 +451,11 @@ export function filterToExposureConfig(
     return undefined
 }
 
-export function metricToFilter(
-    metric: ExperimentMetric
-): FilterType {
-
+export function metricToFilter(metric: ExperimentMetric): FilterType {
     switch (metric.metric_type) {
         case ExperimentMetricType.FUNNEL:
-            const events = (metric.metric_config as ExperimentFunnelMetricConfig).funnel.map((step, index) => ({
-                id: step.event,
-                name: step.event,
-                event: step.event,
-                order: index,
-                type: 'events',
-                kind: NodeKind.EventsNode,
-                properties: step.properties,
-            })) || []
-            console.log('metricToFilter funnel events', events)
             return {
-                events: 
+                events:
                     (metric.metric_config as ExperimentFunnelMetricConfig).funnel.map((step, index) => ({
                         id: step.event,
                         name: step.event,
@@ -478,15 +465,6 @@ export function metricToFilter(
                         kind: NodeKind.EventsNode,
                         properties: step.properties,
                     })) || [],
-                // events: [
-                //     {
-                //         kind: NodeKind.EventsNode,
-                //         id: 'experiment created',
-                //         name: 'experiment created',
-                //         order: 1,
-                //         properties: [],
-                //     },
-                // ],
                 actions: [],
                 data_warehouse: [],
             }
@@ -496,14 +474,14 @@ export function metricToFilter(
                     return {
                         events: [
                             {
-                            id: metric.metric_config.event,
-                            name: metric.metric_config.event,
-                            kind: NodeKind.EventsNode,
-                            type: 'events',
-                            math: metric.metric_config.math,
-                            math_property: metric.metric_config.math_property,
-                            math_hogql: metric.metric_config.math_hogql,
-                            properties: metric.metric_config.properties,
+                                id: metric.metric_config.event,
+                                name: metric.metric_config.event,
+                                kind: NodeKind.EventsNode,
+                                type: 'events',
+                                math: metric.metric_config.math,
+                                math_property: metric.metric_config.math_property,
+                                math_hogql: metric.metric_config.math_hogql,
+                                properties: metric.metric_config.properties,
                             } as EventsNode,
                         ],
                         actions: [],
@@ -514,14 +492,14 @@ export function metricToFilter(
                         events: [],
                         actions: [
                             {
-                            id: metric.metric_config.action,
-                            name: metric.metric_config.name,
-                            kind: NodeKind.EventsNode,
-                            type: 'actions',
-                            math: metric.metric_config.math,
-                            math_property: metric.metric_config.math_property,
-                            math_hogql: metric.metric_config.math_hogql,
-                            properties: metric.metric_config.properties,
+                                id: metric.metric_config.action,
+                                name: metric.metric_config.name,
+                                kind: NodeKind.EventsNode,
+                                type: 'actions',
+                                math: metric.metric_config.math,
+                                math_property: metric.metric_config.math_property,
+                                math_hogql: metric.metric_config.math_hogql,
+                                properties: metric.metric_config.properties,
                             } as EventsNode,
                         ],
                         data_warehouse: [],
@@ -558,20 +536,26 @@ export function filterToMetricConfig(
     actions: Record<string, any>[] | undefined,
     events: Record<string, any>[] | undefined,
     data_warehouse: Record<string, any>[] | undefined
-): ExperimentEventMetricConfig | ExperimentActionMetricConfig | ExperimentDataWarehouseMetricConfig | ExperimentFunnelMetricConfig | undefined {
-
-
+):
+    | ExperimentEventMetricConfig
+    | ExperimentActionMetricConfig
+    | ExperimentDataWarehouseMetricConfig
+    | ExperimentFunnelMetricConfig
+    | undefined {
     switch (metricType) {
         case ExperimentMetricType.FUNNEL:
             return {
                 kind: NodeKind.ExperimentFunnelMetricConfig,
-                funnel: 
-                    events?.map((event) => ({
-                        kind: NodeKind.ExperimentFunnelStepConfig,
-                        event: event.id,
-                        order: event.order,
-                        properties: event.properties,
-                    } as ExperimentFunnelStepConfig)) || [],
+                funnel:
+                    events?.map(
+                        (event) =>
+                            ({
+                                kind: NodeKind.ExperimentFunnelStepConfig,
+                                event: event.id,
+                                order: event.order,
+                                properties: event.properties,
+                            } as ExperimentFunnelStepConfig)
+                    ) || [],
             }
         case ExperimentMetricType.MEAN:
             if (events?.[0]) {
@@ -606,9 +590,9 @@ export function filterToMetricConfig(
                     math_property: data_warehouse[0].math_property,
                     math_hogql: data_warehouse[0].math_hogql,
                 }
-            } else {
-                return undefined
             }
+            return undefined
+
         default:
             return undefined
     }
@@ -660,18 +644,17 @@ export function metricToQuery(
                         ],
                     } as TrendsQuery
             }
-        case ExperimentMetricType.FUNNEL:
+        case ExperimentMetricType.FUNNEL: {
             const filter = metricToFilter(metric)
             const { events } = filter
             // NOTE: hack for now
             // insert a pageview event at the beginning of the funnel to simulate the exposure criteria
-            console.log('events in funnel query', events)
             events?.unshift({
                 kind: NodeKind.EventsNode,
                 id: '$pageview',
                 event: '$pageview',
                 properties: [],
-                order: 0
+                order: 0,
             })
             return {
                 kind: NodeKind.FunnelsQuery,
@@ -685,11 +668,12 @@ export function metricToQuery(
                     layout: FunnelLayout.horizontal,
                 },
                 series: actionsAndEventsToSeries(
-                        { actions: [], events, data_warehouse: [] } as any,
-                        true,
-                        MathAvailability.None
-                    )
+                    { actions: [], events, data_warehouse: [] } as any,
+                    true,
+                    MathAvailability.None
+                ),
             } as FunnelsQuery
+        }
         default:
             return undefined
     }

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -654,6 +654,7 @@ export function metricToQuery(
                 id: '$pageview',
                 event: '$pageview',
                 name: '$pageview',
+                custom_name: 'Placeholder for experiment exposure',
                 properties: [],
                 order: 0,
             })

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -556,60 +556,80 @@ export function filterToMetricConfig(
     | ExperimentDataWarehouseMetricConfig
     | ExperimentFunnelMetricConfig
     | undefined {
-    switch (metricType) {
-        case ExperimentMetricType.FUNNEL:
-            return {
-                kind: NodeKind.ExperimentFunnelMetricConfig,
-                funnel:
-                    events?.map(
-                        (event) =>
-                            ({
-                                kind: NodeKind.ExperimentFunnelStepConfig,
-                                event: event.id,
-                                order: event.order,
-                                properties: event.properties,
-                            } as ExperimentFunnelStepConfig)
-                    ) || [],
-            }
-        case ExperimentMetricType.MEAN:
-            if (events?.[0]) {
-                return {
-                    kind: NodeKind.ExperimentEventMetricConfig,
-                    event: events[0].id as string,
-                    name: events[0].name,
-                    math: events[0].math || ExperimentMetricMathType.TotalCount,
-                    math_property: events[0].math_property,
-                    math_hogql: events[0].math_hogql,
-                    properties: events[0].properties,
-                }
-            } else if (actions?.[0]) {
-                return {
-                    kind: NodeKind.ExperimentActionMetricConfig,
-                    action: actions[0].id,
-                    name: actions[0].name,
-                    math: actions[0].math || ExperimentMetricMathType.TotalCount,
-                    math_property: actions[0].math_property,
-                    math_hogql: actions[0].math_hogql,
-                    properties: actions[0].properties,
-                }
-            } else if (data_warehouse?.[0]) {
-                return {
-                    kind: NodeKind.ExperimentDataWarehouseMetricConfig,
-                    name: data_warehouse[0].name,
-                    table_name: data_warehouse[0].id,
-                    timestamp_field: data_warehouse[0].timestamp_field,
-                    events_join_key: data_warehouse[0].events_join_key,
-                    data_warehouse_join_key: data_warehouse[0].data_warehouse_join_key,
-                    math: data_warehouse[0].math || ExperimentMetricMathType.TotalCount,
-                    math_property: data_warehouse[0].math_property,
-                    math_hogql: data_warehouse[0].math_hogql,
-                }
-            }
+    const getFunnelMetricConfig = (): ExperimentFunnelMetricConfig | undefined => {
+        if (metricType !== ExperimentMetricType.FUNNEL) {
             return undefined
+        }
 
-        default:
-            return undefined
+        return {
+            kind: NodeKind.ExperimentFunnelMetricConfig,
+            funnel:
+                events?.map(
+                    (event) =>
+                        ({
+                            kind: NodeKind.ExperimentFunnelStepConfig,
+                            event: event.id,
+                            order: event.order,
+                            properties: event.properties,
+                        } as ExperimentFunnelStepConfig)
+                ) || [],
+        }
     }
+
+    const getEventMetricConfig = (): ExperimentEventMetricConfig | undefined => {
+        if (metricType !== ExperimentMetricType.MEAN || !events?.[0]) {
+            return undefined
+        }
+
+        return {
+            kind: NodeKind.ExperimentEventMetricConfig,
+            event: events[0].id as string,
+            name: events[0].name,
+            math: events[0].math || ExperimentMetricMathType.TotalCount,
+            math_property: events[0].math_property,
+            math_hogql: events[0].math_hogql,
+            properties: events[0].properties,
+        }
+    }
+
+    const getActionMetricConfig = (): ExperimentActionMetricConfig | undefined => {
+        if (metricType !== ExperimentMetricType.MEAN || !actions?.[0]) {
+            return undefined
+        }
+
+        return {
+            kind: NodeKind.ExperimentActionMetricConfig,
+            action: actions[0].id,
+            name: actions[0].name,
+            math: actions[0].math || ExperimentMetricMathType.TotalCount,
+            math_property: actions[0].math_property,
+            math_hogql: actions[0].math_hogql,
+            properties: actions[0].properties,
+        }
+    }
+
+    const getDataWarehouseMetricConfig = (): ExperimentDataWarehouseMetricConfig | undefined => {
+        if (metricType !== ExperimentMetricType.MEAN || !data_warehouse?.[0]) {
+            return undefined
+        }
+
+        return {
+            kind: NodeKind.ExperimentDataWarehouseMetricConfig,
+            name: data_warehouse[0].name,
+            table_name: data_warehouse[0].id,
+            timestamp_field: data_warehouse[0].timestamp_field,
+            events_join_key: data_warehouse[0].events_join_key,
+            data_warehouse_join_key: data_warehouse[0].data_warehouse_join_key,
+            math: data_warehouse[0].math || ExperimentMetricMathType.TotalCount,
+            math_property: data_warehouse[0].math_property,
+            math_hogql: data_warehouse[0].math_hogql,
+        }
+    }
+
+    // Return the first non-undefined configuration
+    return (
+        getFunnelMetricConfig() || getEventMetricConfig() || getActionMetricConfig() || getDataWarehouseMetricConfig()
+    )
 }
 
 export function metricToQuery(

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -653,6 +653,7 @@ export function metricToQuery(
                 kind: NodeKind.EventsNode,
                 id: '$pageview',
                 event: '$pageview',
+                name: '$pageview',
                 properties: [],
                 order: 0,
             })

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -352,6 +352,15 @@ export function getDefaultContinuousMetric(): ExperimentMetric {
     }
 }
 
+export function getDefaultExperimentMetric(metricType: ExperimentMetricType): ExperimentMetric {
+    switch (metricType) {
+        case ExperimentMetricType.FUNNEL:
+            return getDefaultFunnelMetric()
+        default:
+            return getDefaultCountMetric()
+    }
+}
+
 export function getExperimentMetricFromInsight(
     insight: QueryBasedInsightModel | null
 ): ExperimentTrendsQuery | ExperimentFunnelsQuery | undefined {
@@ -448,26 +457,36 @@ export function metricToFilter(
 
     switch (metric.metric_type) {
         case ExperimentMetricType.FUNNEL:
+            const events = (metric.metric_config as ExperimentFunnelMetricConfig).funnel.map((step, index) => ({
+                id: step.event,
+                name: step.event,
+                event: step.event,
+                order: index,
+                type: 'events',
+                kind: NodeKind.EventsNode,
+                properties: step.properties,
+            })) || []
+            console.log('metricToFilter funnel events', events)
             return {
-                // events: [
-                //     (metric.metric_config as ExperimentFunnelMetricConfig).funnel.map((step, index) => ({
-                //         id: step.event,
-                //         name: step.event,
-                //         order: index,
-                //         kind: NodeKind.EventsNode,
-                //         type: 'events',
-                //         properties: step.properties,
-                //     })) || [],
-                // ],
-                events: [
-                    {
+                events: 
+                    (metric.metric_config as ExperimentFunnelMetricConfig).funnel.map((step, index) => ({
+                        id: step.event,
+                        name: step.event,
+                        event: step.event,
+                        order: index,
+                        type: 'events',
                         kind: NodeKind.EventsNode,
-                        id: 'experiment created',
-                        name: 'experiment created',
-                        order: 1,
-                        properties: [],
-                    },
-                ],
+                        properties: step.properties,
+                    })) || [],
+                // events: [
+                //     {
+                //         kind: NodeKind.EventsNode,
+                //         id: 'experiment created',
+                //         name: 'experiment created',
+                //         order: 1,
+                //         properties: [],
+                //     },
+                // ],
                 actions: [],
                 data_warehouse: [],
             }
@@ -654,22 +673,6 @@ export function metricToQuery(
                 properties: [],
                 order: 0
             })
-            // const events = [
-            //     {
-            //         kind: NodeKind.EventsNode,
-            //         id: '$pageview',
-            //         name: '$pageview',
-            //         order: 0,
-            //         properties: [],
-            //     },
-            //     {
-            //         kind: NodeKind.EventsNode,
-            //         id: 'experiment created',
-            //         name: 'experiment created',
-            //         order: 1,
-            //         properties: [],
-            //     },
-            // ]
             return {
                 kind: NodeKind.FunnelsQuery,
                 filterTestAccounts,

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -379,6 +379,18 @@ export const QUERY_TYPES_METADATA: Record<NodeKind, InsightTypeMetadata> = {
         icon: IconFlask,
         inMenu: false,
     },
+    [NodeKind.ExperimentFunnelMetricConfig]: {
+        name: 'Experiment Funnel Metric Config',
+        description: 'Configuration for experiment funnel metrics.',
+        icon: IconFlask,
+        inMenu: false,
+    },
+    [NodeKind.ExperimentFunnelStepConfig]: {
+        name: 'Experiment Funnel Step Config',
+        description: 'Configuration for experiment funnel steps.',
+        icon: IconFlask,
+        inMenu: false,
+    },
     [NodeKind.TeamTaxonomyQuery]: {
         name: 'Team Taxonomy',
         icon: IconHogQL,

--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -1477,6 +1477,7 @@ HOGQL_AGGREGATIONS: dict[str, HogQLFunctionMeta] = {
     "maxIntersectionsIf": HogQLFunctionMeta("maxIntersectionsIf", 3, 3, aggregate=True),
     "maxIntersectionsPosition": HogQLFunctionMeta("maxIntersectionsPosition", 2, 2, aggregate=True),
     "maxIntersectionsPositionIf": HogQLFunctionMeta("maxIntersectionsPositionIf", 3, 3, aggregate=True),
+    "windowFunnel": HogQLFunctionMeta("windowFunnel", 1, 5, aggregate=True),
 }
 HOGQL_POSTHOG_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
     "matchesAction": HogQLFunctionMeta("matchesAction", 1, 1),

--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -35,6 +35,7 @@ from posthog.schema import (
     ExperimentActionMetricConfig,
     ExperimentDataWarehouseMetricConfig,
     ExperimentEventMetricConfig,
+    ExperimentFunnelMetricConfig,
     ExperimentMetricMathType,
     ExperimentMetricType,
     ExperimentQueryResponse,
@@ -44,6 +45,7 @@ from posthog.schema import (
     ExperimentVariantTrendsBaseStats,
     DateRange,
     IntervalType,
+    ExperimentFunnelStepConfig,
 )
 from typing import Optional, cast
 from datetime import datetime, timedelta, UTC
@@ -287,6 +289,31 @@ class ExperimentQueryRunner(QueryRunner):
             group_by=cast(list[ast.Expr], exposure_query_group_by),
         )
 
+    def _funnel_step_to_filter(self, funnel_step: ExperimentFunnelStepConfig) -> ast.Expr:
+        """
+        Returns the filter for a single funnel step.
+        """
+
+        event_filter = ast.CompareOperation(
+            op=ast.CompareOperationOp.Eq,
+            left=ast.Field(chain=["event"]),
+            right=ast.Constant(value=funnel_step.event),
+        )
+
+        if funnel_step.properties:
+            event_properties = ast.And(
+                exprs=[property_to_expr(property, self.team) for property in funnel_step.properties]
+            )
+            event_filter = ast.And(exprs=[event_filter, event_properties])
+
+        return event_filter
+
+    def _funnel_steps_to_filter(self, funnel_steps: list[ExperimentFunnelStepConfig]) -> ast.Expr:
+        """
+        Returns the OR expression for a list of funnel steps. Will match if any of the funnel steps are true.
+        """
+        return ast.Or(exprs=[self._funnel_step_to_filter(funnel_step) for funnel_step in funnel_steps])
+
     def _get_metric_events_query(self, exposure_query: ast.SelectQuery) -> ast.SelectQuery:
         """
         Returns the query to get the relevant metric events. One row per event, so multiple rows per entity.
@@ -388,13 +415,63 @@ class ExperimentQueryRunner(QueryRunner):
                             *self._get_metric_time_window(left=ast.Field(chain=["events", "timestamp"])),
                             event_filter,
                             *self._get_test_accounts_filter(),
-                            *self._get_metric_property_filters(),
+                        ],
+                    ),
+                )
+
+            case ExperimentFunnelMetricConfig() as metric_config:
+                return ast.SelectQuery(
+                    select=[
+                        ast.Field(chain=["events", "timestamp"]),
+                        ast.Alias(alias="entity_id", expr=ast.Field(chain=["events", "person_id"])),
+                        ast.Field(chain=["exposure_data", "variant"]),
+                        ast.Field(chain=["events", "event"]),
+                    ],
+                    select_from=ast.JoinExpr(
+                        table=ast.Field(chain=["events"]),
+                        next_join=ast.JoinExpr(
+                            table=exposure_query,
+                            join_type="INNER JOIN",
+                            alias="exposure_data",
+                            constraint=ast.JoinConstraint(
+                                expr=ast.CompareOperation(
+                                    left=ast.Field(chain=["events", "person_id"]),
+                                    right=ast.Field(chain=["exposure_data", "entity_id"]),
+                                    op=ast.CompareOperationOp.Eq,
+                                ),
+                                constraint_type="ON",
+                            ),
+                        ),
+                    ),
+                    where=ast.And(
+                        exprs=[
+                            *self._get_metric_time_window(left=ast.Field(chain=["events", "timestamp"])),
+                            *self._get_test_accounts_filter(),
+                            self._funnel_steps_to_filter(metric_config.funnel),
                         ],
                     ),
                 )
 
             case _:
                 raise ValueError(f"Unsupported metric config: {self.metric.metric_config}")
+
+    def _funnel_steps_to_window_funnel_expr(self, funnel_config: ExperimentFunnelMetricConfig) -> ast.Expr:
+        """
+        Returns the expression for the window funnel. The expression returns 1 if the user completed the whole funnel, 0 if they didn't.
+        """
+        # TODO: get conversion time window from funnel config
+        num_steps = len(funnel_config.funnel)
+        conversion_time_window = 6048000000000000
+        funnel_steps_str = ", ".join(
+            [f"event = '{step.event}'" for step in sorted(funnel_config.funnel, key=lambda x: x.order)]
+        )
+        return parse_expr(
+            f"windowFunnel({conversion_time_window})(toDateTime(timestamp), {funnel_steps_str}) = {num_steps}",
+            placeholders={
+                "conversion_time_window": ast.Constant(value=conversion_time_window),
+                "num_steps": ast.Constant(value=num_steps),
+            },
+        )
 
     def _get_metrics_aggregated_per_entity_query(
         self, exposure_query: ast.SelectQuery, metric_events_query: ast.SelectQuery
@@ -409,10 +486,10 @@ class ExperimentQueryRunner(QueryRunner):
                 ast.Field(chain=["exposures", "variant"]),
                 ast.Field(chain=["exposures", "entity_id"]),
                 ast.Alias(
-                    expr=parse_expr("if(any(metric_events.value), 1, 0)"),
+                    expr=self._funnel_steps_to_window_funnel_expr(self.metric.metric_config),
                     alias="value",
                 )
-                if self.metric.metric_type == ExperimentMetricType.FUNNEL
+                if self.metric.metric_config.kind == "ExperimentFunnelMetricConfig"
                 else parse_expr("sum(coalesce(toFloat(metric_events.value), 0)) as value"),
             ],
             select_from=ast.JoinExpr(

--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -463,7 +463,10 @@ class ExperimentQueryRunner(QueryRunner):
         num_steps = len(funnel_config.funnel)
         conversion_time_window = 6048000000000000
         funnel_steps_str = ", ".join(
-            [f"event = '{step.event}'" for step in sorted(funnel_config.funnel, key=lambda x: x.order)]
+            [
+                f"event = {ast.Constant(value=step.event).to_hogql()}"
+                for step in sorted(funnel_config.funnel, key=lambda x: x.order)
+            ]
         )
         return parse_expr(
             f"windowFunnel({conversion_time_window})(toDateTime(timestamp), {funnel_steps_str}) = {num_steps}",

--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -393,6 +393,9 @@ class ExperimentQueryRunner(QueryRunner):
                     ),
                 )
 
+            case _:
+                raise ValueError(f"Unsupported metric config: {self.metric.metric_config}")
+
     def _get_metrics_aggregated_per_entity_query(
         self, exposure_query: ast.SelectQuery, metric_events_query: ast.SelectQuery
     ) -> ast.SelectQuery:

--- a/posthog/hogql_queries/experiments/experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_query_runner.py
@@ -294,7 +294,7 @@ class ExperimentQueryRunner(QueryRunner):
         Returns the filter for a single funnel step.
         """
 
-        event_filter = ast.CompareOperation(
+        event_filter: ast.Expr = ast.CompareOperation(
             op=ast.CompareOperationOp.Eq,
             left=ast.Field(chain=["event"]),
             right=ast.Constant(value=funnel_step.event),

--- a/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_query_runner.ambr
+++ b/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_query_runner.ambr
@@ -262,7 +262,7 @@
   FROM
     (SELECT exposures.variant AS variant,
             exposures.entity_id AS entity_id,
-            if(any(metric_events.value), 1, 0) AS value
+            ifNull(equals(windowFunnel(6048000000000000)(toDateTime(metric_events.timestamp, 'UTC'), ifNull(equals(metric_events.event, 'purchase'), 0)), 1), 0) AS value
      FROM
        (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
                if(ifNull(greater(count(DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
@@ -281,8 +281,7 @@
        (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp,
                if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
                exposure_data.variant AS variant,
-               events.event AS event,
-               1 AS value
+               events.event AS event
         FROM events
         LEFT OUTER JOIN
           (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -499,7 +498,7 @@
               HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
            WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), equals(events.event, '$feature_flag_called'), ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']), 0), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0))
            GROUP BY entity_id) AS exposure_data ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposure_data.entity_id)
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), exposure_data.first_exposure_time), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), equals(events.event, 'purchase'), ifNull(notEquals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'plan'), ''), 'null'), '^"|"$', ''), 'pro'), 1))) AS metric_events ON equals(toString(exposures.entity_id), toString(metric_events.entity_id))
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), exposure_data.first_exposure_time), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), equals(events.event, 'purchase'))) AS metric_events ON equals(toString(exposures.entity_id), toString(metric_events.entity_id))
      GROUP BY exposures.variant,
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
@@ -3107,7 +3106,7 @@
   FROM
     (SELECT exposures.variant AS variant,
             exposures.entity_id AS entity_id,
-            if(any(metric_events.value), 1, 0) AS value
+            ifNull(equals(windowFunnel(6048000000000000)(toDateTime(metric_events.timestamp, 'UTC'), ifNull(equals(metric_events.event, 'purchase'), 0)), 1), 0) AS value
      FROM
        (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
                if(ifNull(greater(count(DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
@@ -3126,8 +3125,7 @@
        (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp,
                if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
                exposure_data.variant AS variant,
-               events.event AS event,
-               1 AS value
+               events.event AS event
         FROM events
         LEFT OUTER JOIN
           (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -3150,7 +3148,7 @@
               HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
            WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), equals(events.event, '$feature_flag_called'), ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']), 0), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@posthog.com%'), 1), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0))
            GROUP BY entity_id) AS exposure_data ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposure_data.entity_id)
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), exposure_data.first_exposure_time), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), equals(events.event, 'purchase'), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@posthog.com%'), 1))) AS metric_events ON equals(toString(exposures.entity_id), toString(metric_events.entity_id))
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), exposure_data.first_exposure_time), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@posthog.com%'), 1), equals(events.event, 'purchase'))) AS metric_events ON equals(toString(exposures.entity_id), toString(metric_events.entity_id))
      GROUP BY exposures.variant,
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
@@ -3181,7 +3179,7 @@
   FROM
     (SELECT exposures.variant AS variant,
             exposures.entity_id AS entity_id,
-            if(any(metric_events.value), 1, 0) AS value
+            ifNull(equals(windowFunnel(6048000000000000)(toDateTime(metric_events.timestamp, 'UTC'), ifNull(equals(metric_events.event, 'purchase'), 0)), 1), 0) AS value
      FROM
        (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
                if(ifNull(greater(count(DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
@@ -3200,8 +3198,7 @@
        (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp,
                if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
                exposure_data.variant AS variant,
-               events.event AS event,
-               1 AS value
+               events.event AS event
         FROM events
         LEFT OUTER JOIN
           (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -3224,7 +3221,7 @@
               HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
            WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), equals(events.event, '$feature_flag_called'), ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']), 0), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@earlierevent.com%'), 1), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0))
            GROUP BY entity_id) AS exposure_data ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposure_data.entity_id)
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), exposure_data.first_exposure_time), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), equals(events.event, 'purchase'), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@earlierevent.com%'), 1))) AS metric_events ON equals(toString(exposures.entity_id), toString(metric_events.entity_id))
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), exposure_data.first_exposure_time), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@earlierevent.com%'), 1), equals(events.event, 'purchase'))) AS metric_events ON equals(toString(exposures.entity_id), toString(metric_events.entity_id))
      GROUP BY exposures.variant,
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
@@ -3255,7 +3252,7 @@
   FROM
     (SELECT exposures.variant AS variant,
             exposures.entity_id AS entity_id,
-            if(any(metric_events.value), 1, 0) AS value
+            ifNull(equals(windowFunnel(6048000000000000)(toDateTime(metric_events.timestamp, 'UTC'), ifNull(equals(metric_events.event, 'purchase'), 0)), 1), 0) AS value
      FROM
        (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
                if(ifNull(greater(count(DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
@@ -3274,8 +3271,7 @@
        (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp,
                if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
                exposure_data.variant AS variant,
-               events.event AS event,
-               1 AS value
+               events.event AS event
         FROM events
         LEFT OUTER JOIN
           (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -3298,7 +3294,7 @@
               HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
            WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), equals(events.event, '$feature_flag_called'), ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']), 0), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@laterevent.com%'), 1), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0))
            GROUP BY entity_id) AS exposure_data ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposure_data.entity_id)
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), exposure_data.first_exposure_time), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), equals(events.event, 'purchase'), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@laterevent.com%'), 1))) AS metric_events ON equals(toString(exposures.entity_id), toString(metric_events.entity_id))
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), exposure_data.first_exposure_time), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@laterevent.com%'), 1), equals(events.event, 'purchase'))) AS metric_events ON equals(toString(exposures.entity_id), toString(metric_events.entity_id))
      GROUP BY exposures.variant,
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
@@ -3329,7 +3325,7 @@
   FROM
     (SELECT exposures.variant AS variant,
             exposures.entity_id AS entity_id,
-            if(any(metric_events.value), 1, 0) AS value
+            ifNull(equals(windowFunnel(6048000000000000)(toDateTime(metric_events.timestamp, 'UTC'), ifNull(equals(metric_events.event, 'purchase'), 0)), 1), 0) AS value
      FROM
        (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
                if(ifNull(greater(count(DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
@@ -3358,8 +3354,7 @@
        (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp,
                if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
                exposure_data.variant AS variant,
-               events.event AS event,
-               1 AS value
+               events.event AS event
         FROM events
         LEFT OUTER JOIN
           (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -3402,7 +3397,7 @@
                                                                     HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
            WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), equals(events.event, '$feature_flag_called'), ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']), 0), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0))
            GROUP BY entity_id) AS exposure_data ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposure_data.entity_id)
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), exposure_data.first_exposure_time), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), equals(events.event, 'purchase'), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1))) AS metric_events ON equals(toString(exposures.entity_id), toString(metric_events.entity_id))
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), exposure_data.first_exposure_time), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), ifNull(notILike(toString(events__person.properties___email), '%@posthog.com%'), 1), equals(events.event, 'purchase'))) AS metric_events ON equals(toString(exposures.entity_id), toString(metric_events.entity_id))
      GROUP BY exposures.variant,
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
@@ -3433,7 +3428,7 @@
   FROM
     (SELECT exposures.variant AS variant,
             exposures.entity_id AS entity_id,
-            if(any(metric_events.value), 1, 0) AS value
+            ifNull(equals(windowFunnel(6048000000000000)(toDateTime(metric_events.timestamp, 'UTC'), ifNull(equals(metric_events.event, 'purchase'), 0)), 1), 0) AS value
      FROM
        (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
                if(ifNull(greater(count(DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
@@ -3462,8 +3457,7 @@
        (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp,
                if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
                exposure_data.variant AS variant,
-               events.event AS event,
-               1 AS value
+               events.event AS event
         FROM events
         LEFT OUTER JOIN
           (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -3506,7 +3500,7 @@
                                                                     HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
            WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), equals(events.event, '$feature_flag_called'), ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']), 0), ifNull(notILike(toString(events__person.properties___email), '%@earlierevent.com%'), 1), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0))
            GROUP BY entity_id) AS exposure_data ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposure_data.entity_id)
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), exposure_data.first_exposure_time), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), equals(events.event, 'purchase'), ifNull(notILike(toString(events__person.properties___email), '%@earlierevent.com%'), 1))) AS metric_events ON equals(toString(exposures.entity_id), toString(metric_events.entity_id))
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), exposure_data.first_exposure_time), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), ifNull(notILike(toString(events__person.properties___email), '%@earlierevent.com%'), 1), equals(events.event, 'purchase'))) AS metric_events ON equals(toString(exposures.entity_id), toString(metric_events.entity_id))
      GROUP BY exposures.variant,
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
@@ -3537,7 +3531,7 @@
   FROM
     (SELECT exposures.variant AS variant,
             exposures.entity_id AS entity_id,
-            if(any(metric_events.value), 1, 0) AS value
+            ifNull(equals(windowFunnel(6048000000000000)(toDateTime(metric_events.timestamp, 'UTC'), ifNull(equals(metric_events.event, 'purchase'), 0)), 1), 0) AS value
      FROM
        (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
                if(ifNull(greater(count(DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
@@ -3566,8 +3560,7 @@
        (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp,
                if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
                exposure_data.variant AS variant,
-               events.event AS event,
-               1 AS value
+               events.event AS event
         FROM events
         LEFT OUTER JOIN
           (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -3610,7 +3603,7 @@
                                                                     HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
            WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), equals(events.event, '$feature_flag_called'), ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']), 0), ifNull(notILike(toString(events__person.properties___email), '%@laterevent.com%'), 1), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0))
            GROUP BY entity_id) AS exposure_data ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposure_data.entity_id)
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), exposure_data.first_exposure_time), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), equals(events.event, 'purchase'), ifNull(notILike(toString(events__person.properties___email), '%@laterevent.com%'), 1))) AS metric_events ON equals(toString(exposures.entity_id), toString(metric_events.entity_id))
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), exposure_data.first_exposure_time), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), ifNull(notILike(toString(events__person.properties___email), '%@laterevent.com%'), 1), equals(events.event, 'purchase'))) AS metric_events ON equals(toString(exposures.entity_id), toString(metric_events.entity_id))
      GROUP BY exposures.variant,
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
@@ -3641,7 +3634,7 @@
   FROM
     (SELECT exposures.variant AS variant,
             exposures.entity_id AS entity_id,
-            if(any(metric_events.value), 1, 0) AS value
+            ifNull(equals(windowFunnel(6048000000000000)(toDateTime(metric_events.timestamp, 'UTC'), ifNull(equals(metric_events.event, 'purchase'), 0)), 1), 0) AS value
      FROM
        (SELECT events.person_id AS entity_id,
                if(ifNull(greater(count(DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
@@ -3653,8 +3646,7 @@
        (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp,
                events.person_id AS entity_id,
                exposure_data.variant AS variant,
-               events.event AS event,
-               1 AS value
+               events.event AS event
         FROM events
         INNER JOIN
           (SELECT events.person_id AS entity_id,
@@ -3663,7 +3655,7 @@
            FROM events
            WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-31 00:00:00.000000', 6, 'UTC')), equals(events.event, '$feature_flag_called'), ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']), 0), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@posthog.com%'), 1), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0))
            GROUP BY entity_id) AS exposure_data ON equals(events.person_id, exposure_data.entity_id)
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), exposure_data.first_exposure_time), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-31 00:00:00.000000', 6, 'UTC')), equals(events.event, 'purchase'), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@posthog.com%'), 1))) AS metric_events ON equals(toString(exposures.entity_id), toString(metric_events.entity_id))
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), exposure_data.first_exposure_time), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-31 00:00:00.000000', 6, 'UTC')), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@posthog.com%'), 1), equals(events.event, 'purchase'))) AS metric_events ON equals(toString(exposures.entity_id), toString(metric_events.entity_id))
      GROUP BY exposures.variant,
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
@@ -3694,7 +3686,7 @@
   FROM
     (SELECT exposures.variant AS variant,
             exposures.entity_id AS entity_id,
-            if(any(metric_events.value), 1, 0) AS value
+            ifNull(equals(windowFunnel(6048000000000000)(toDateTime(metric_events.timestamp, 'UTC'), ifNull(equals(metric_events.event, 'purchase'), 0)), 1), 0) AS value
      FROM
        (SELECT events.person_id AS entity_id,
                if(ifNull(greater(count(DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
@@ -3706,8 +3698,7 @@
        (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp,
                events.person_id AS entity_id,
                exposure_data.variant AS variant,
-               events.event AS event,
-               1 AS value
+               events.event AS event
         FROM events
         INNER JOIN
           (SELECT events.person_id AS entity_id,
@@ -3716,7 +3707,7 @@
            FROM events
            WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-31 00:00:00.000000', 6, 'UTC')), equals(events.event, '$feature_flag_called'), ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']), 0), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@earlierevent.com%'), 1), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0))
            GROUP BY entity_id) AS exposure_data ON equals(events.person_id, exposure_data.entity_id)
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), exposure_data.first_exposure_time), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-31 00:00:00.000000', 6, 'UTC')), equals(events.event, 'purchase'), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@earlierevent.com%'), 1))) AS metric_events ON equals(toString(exposures.entity_id), toString(metric_events.entity_id))
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), exposure_data.first_exposure_time), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-31 00:00:00.000000', 6, 'UTC')), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@earlierevent.com%'), 1), equals(events.event, 'purchase'))) AS metric_events ON equals(toString(exposures.entity_id), toString(metric_events.entity_id))
      GROUP BY exposures.variant,
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant
@@ -3747,7 +3738,7 @@
   FROM
     (SELECT exposures.variant AS variant,
             exposures.entity_id AS entity_id,
-            if(any(metric_events.value), 1, 0) AS value
+            ifNull(equals(windowFunnel(6048000000000000)(toDateTime(metric_events.timestamp, 'UTC'), ifNull(equals(metric_events.event, 'purchase'), 0)), 1), 0) AS value
      FROM
        (SELECT events.person_id AS entity_id,
                if(ifNull(greater(count(DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
@@ -3759,8 +3750,7 @@
        (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp,
                events.person_id AS entity_id,
                exposure_data.variant AS variant,
-               events.event AS event,
-               1 AS value
+               events.event AS event
         FROM events
         INNER JOIN
           (SELECT events.person_id AS entity_id,
@@ -3769,7 +3759,7 @@
            FROM events
            WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-31 00:00:00.000000', 6, 'UTC')), equals(events.event, '$feature_flag_called'), ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']), 0), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@laterevent.com%'), 1), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0))
            GROUP BY entity_id) AS exposure_data ON equals(events.person_id, exposure_data.entity_id)
-        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), exposure_data.first_exposure_time), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-31 00:00:00.000000', 6, 'UTC')), equals(events.event, 'purchase'), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@laterevent.com%'), 1))) AS metric_events ON equals(toString(exposures.entity_id), toString(metric_events.entity_id))
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), exposure_data.first_exposure_time), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-31 00:00:00.000000', 6, 'UTC')), ifNull(notILike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.person_properties, 'email'), ''), 'null'), '^"|"$', '')), '%@laterevent.com%'), 1), equals(events.event, 'purchase'))) AS metric_events ON equals(toString(exposures.entity_id), toString(metric_events.entity_id))
      GROUP BY exposures.variant,
               exposures.entity_id) AS metric_events
   GROUP BY metric_events.variant

--- a/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_query_runner.ambr
+++ b/posthog/hogql_queries/experiments/test/__snapshots__/test_experiment_query_runner.ambr
@@ -318,6 +318,70 @@
                      max_bytes_before_external_group_by=0
   '''
 # ---
+# name: TestExperimentQueryRunner.test_query_runner_funnel_metric_config
+  '''
+  SELECT metric_events.variant AS variant,
+         count(metric_events.entity_id) AS num_users,
+         sum(metric_events.value) AS total_sum,
+         sum(power(metric_events.value, 2)) AS total_sum_of_squares
+  FROM
+    (SELECT exposures.variant AS variant,
+            exposures.entity_id AS entity_id,
+            ifNull(equals(windowFunnel(6048000000000000)(toDateTime(metric_events.timestamp, 'UTC'), ifNull(equals(metric_events.event, '$pageview'), 0), ifNull(equals(metric_events.event, 'purchase'), 0)), 2), 0) AS value
+     FROM
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+               if(ifNull(greater(count(DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+               min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), equals(events.event, '$feature_flag_called'), ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']), 0), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0))
+        GROUP BY entity_id) AS exposures
+     LEFT JOIN
+       (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp,
+               if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+               exposure_data.variant AS variant,
+               events.event AS event
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        INNER JOIN
+          (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS entity_id,
+                  if(ifNull(greater(count(DISTINCT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', '')), 1), 0), '$multiple', any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''))) AS variant,
+                  min(toTimeZone(events.timestamp, 'UTC')) AS first_exposure_time
+           FROM events
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+           WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), equals(events.event, '$feature_flag_called'), ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag_response'), ''), 'null'), '^"|"$', ''), ['control', 'test']), 0), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature_flag'), ''), 'null'), '^"|"$', ''), 'test-experiment'), 0))
+           GROUP BY entity_id) AS exposure_data ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), exposure_data.entity_id)
+        WHERE and(equals(events.team_id, 99999), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('today', 6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), exposure_data.first_exposure_time), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), or(equals(events.event, '$pageview'), equals(events.event, 'purchase')))) AS metric_events ON equals(toString(exposures.entity_id), toString(metric_events.entity_id))
+     GROUP BY exposures.variant,
+              exposures.entity_id) AS metric_events
+  GROUP BY metric_events.variant
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0
+  '''
+# ---
 # name: TestExperimentQueryRunner.test_query_runner_includes_date_range
   '''
   SELECT metric_events.variant AS variant,

--- a/posthog/hogql_queries/experiments/test/test_experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_query_runner.py
@@ -1,6 +1,7 @@
 import json
 from typing import cast
 from django.test import override_settings
+from pytest import mark
 from posthog.constants import ExperimentNoResultsErrorKeys
 from posthog.hogql_queries.experiments.experiment_query_runner import ExperimentQueryRunner
 from posthog.hogql_queries.experiments.test.utils import create_data_warehouse_table
@@ -280,7 +281,11 @@ class TestExperimentQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         metric = ExperimentMetric(
             metric_type=ExperimentMetricType.FUNNEL,
-            metric_config=ExperimentEventMetricConfig(event="purchase"),
+            metric_config=ExperimentFunnelMetricConfig(
+                funnel=[
+                    ExperimentFunnelStepConfig(event="purchase", order=1),
+                ],
+            ),
         )
 
         experiment_query = ExperimentQuery(
@@ -788,7 +793,11 @@ class TestExperimentQueryRunner(ClickhouseTestMixin, APIBaseTest):
             kind="ExperimentQuery",
             metric=ExperimentMetric(
                 metric_type=ExperimentMetricType.FUNNEL,
-                metric_config=ExperimentEventMetricConfig(event="purchase"),
+                metric_config=ExperimentFunnelMetricConfig(
+                    funnel=[
+                        ExperimentFunnelStepConfig(event="purchase", order=1),
+                    ],
+                ),
             ),
         )
         experiment.exposure_criteria = {"filterTestAccounts": True}
@@ -1022,6 +1031,7 @@ class TestExperimentQueryRunner(ClickhouseTestMixin, APIBaseTest):
         # In the new query runner, the exposure value is the same as the absolute exposure value
         self.assertEqual(test_variant.exposure, 2.0)
 
+    @mark.skip("Funnel metrics on data warehouse tables are not supported yet")
     @snapshot_clickhouse_queries
     def test_query_runner_data_warehouse_funnel_metric(self):
         table_name = self.create_data_warehouse_table_with_usage()

--- a/posthog/hogql_queries/experiments/test/test_experiment_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_query_runner.py
@@ -31,6 +31,8 @@ from posthog.schema import (
     ExperimentVariantFunnelsBaseStats,
     ExperimentVariantTrendsBaseStats,
     PersonsOnEventsMode,
+    ExperimentFunnelMetricConfig,
+    ExperimentFunnelStepConfig,
 )
 from posthog.test.base import (
     APIBaseTest,
@@ -2494,3 +2496,198 @@ class TestExperimentQueryRunner(ClickhouseTestMixin, APIBaseTest):
         # Verify the exposure counts (users who have been exposed to the variant)
         self.assertEqual(control_variant.absolute_exposure, 1)  # Only user_control
         self.assertEqual(test_variant.absolute_exposure, 1)  # Only user_test
+
+    @freeze_time("2024-01-01T12:00:00Z")
+    @snapshot_clickhouse_queries
+    def test_query_runner_funnel_metric_config(self):
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        experiment.stats_config = {"version": 2}
+        experiment.save()
+
+        ff_property = f"$feature/{feature_flag.key}"
+
+        # Create test data using journeys
+        journeys_for(
+            {
+                # User with first step only
+                "user_control_1": [
+                    {
+                        "event": "$feature_flag_called",
+                        "timestamp": "2024-01-02T12:00:00",
+                        "properties": {
+                            "$feature_flag_response": "control",
+                            ff_property: "control",
+                            "$feature_flag": feature_flag.key,
+                        },
+                    },
+                    {
+                        "event": "$pageview",
+                        "timestamp": "2024-01-02T12:01:00",
+                        "properties": {
+                            ff_property: "control",
+                        },
+                    },
+                ],
+                # User with first and second step completed
+                "user_control_2": [
+                    {
+                        "event": "$feature_flag_called",
+                        "timestamp": "2024-01-02T12:00:00",
+                        "properties": {
+                            "$feature_flag_response": "control",
+                            ff_property: "control",
+                            "$feature_flag": feature_flag.key,
+                        },
+                    },
+                    {
+                        "event": "$pageview",
+                        "timestamp": "2024-01-02T12:01:00",
+                        "properties": {
+                            ff_property: "control",
+                        },
+                    },
+                    {
+                        "event": "purchase",
+                        "timestamp": "2024-01-03T12:02:00",
+                        "properties": {
+                            ff_property: "control",
+                        },
+                    },
+                ],
+                # User with second step only
+                "user_control_3": [
+                    {
+                        "event": "$feature_flag_called",
+                        "timestamp": "2024-01-03T12:00:00",
+                        "properties": {
+                            "$feature_flag_response": "control",
+                            ff_property: "control",
+                            "$feature_flag": feature_flag.key,
+                        },
+                    },
+                    {
+                        "event": "purchase",
+                        "timestamp": "2024-01-03T12:02:00",
+                        "properties": {
+                            ff_property: "control",
+                        },
+                    },
+                ],
+                # User with only first step completed
+                "user_test_1": [
+                    {
+                        "event": "$feature_flag_called",
+                        "timestamp": "2024-01-02T12:00:00",
+                        "properties": {
+                            "$feature_flag_response": "test",
+                            ff_property: "test",
+                            "$feature_flag": feature_flag.key,
+                        },
+                    },
+                    {
+                        "event": "$pageview",
+                        "timestamp": "2024-01-02T12:01:00",
+                        "properties": {
+                            ff_property: "test",
+                        },
+                    },
+                ],
+                # User with whole funnel completed
+                "user_test_2": [
+                    {
+                        "event": "$feature_flag_called",
+                        "timestamp": "2024-01-02T12:00:00",
+                        "properties": {
+                            "$feature_flag_response": "test",
+                            ff_property: "test",
+                            "$feature_flag": feature_flag.key,
+                        },
+                    },
+                    {
+                        "event": "$pageview",
+                        "timestamp": "2024-01-03T12:01:00",
+                        "properties": {
+                            ff_property: "test",
+                        },
+                    },
+                    {
+                        "event": "purchase",
+                        "timestamp": "2024-01-03T12:02:00",
+                        "properties": {
+                            ff_property: "test",
+                        },
+                    },
+                ],
+                # User with only feature flag and purchase, no pageview. Should be excluded.
+                "user_test_3": [
+                    {
+                        "event": "$feature_flag_called",
+                        "timestamp": "2024-01-02T12:00:00",
+                        "properties": {
+                            "$feature_flag_response": "test",
+                            ff_property: "test",
+                            "$feature_flag": feature_flag.key,
+                        },
+                    },
+                    {
+                        "event": "purchase",
+                        "timestamp": "2024-01-03T12:02:00",
+                        "properties": {
+                            ff_property: "test",
+                        },
+                    },
+                ],
+            },
+            self.team,
+        )
+
+        flush_persons_and_events()
+
+        metric = ExperimentMetric(
+            metric_type=ExperimentMetricType.FUNNEL,
+            metric_config=ExperimentFunnelMetricConfig(
+                funnel=[
+                    ExperimentFunnelStepConfig(
+                        event="$pageview",
+                        name="$pageview",
+                        order=0,
+                        properties=[],
+                    ),
+                    ExperimentFunnelStepConfig(
+                        event="purchase",
+                        name="purchase",
+                        order=1,
+                        properties=[],
+                    ),
+                ]
+            ),
+        )
+
+        experiment_query = ExperimentQuery(
+            experiment_id=experiment.id,
+            kind="ExperimentQuery",
+            metric=metric,
+        )
+
+        experiment.metrics = [metric.model_dump(mode="json")]
+        experiment.save()
+
+        flush_persons_and_events()
+
+        query_runner = ExperimentQueryRunner(query=experiment_query, team=self.team)
+        result = query_runner.calculate()
+
+        self.assertEqual(len(result.variants), 2)
+
+        control_variant = cast(
+            ExperimentVariantFunnelsBaseStats, next(variant for variant in result.variants if variant.key == "control")
+        )
+        test_variant = cast(
+            ExperimentVariantFunnelsBaseStats, next(variant for variant in result.variants if variant.key == "test")
+        )
+
+        self.assertEqual(control_variant.success_count, 1)
+        self.assertEqual(control_variant.failure_count, 2)
+        self.assertEqual(test_variant.success_count, 1)
+        self.assertEqual(test_variant.failure_count, 2)

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5562,24 +5562,26 @@ class ExperimentFunnelStepConfig(BaseModel):
     kind: Literal["ExperimentFunnelStepConfig"] = "ExperimentFunnelStepConfig"
     name: Optional[str] = None
     order: float
-    properties: list[
-        Union[
-            EventPropertyFilter,
-            PersonPropertyFilter,
-            ElementPropertyFilter,
-            EventMetadataPropertyFilter,
-            SessionPropertyFilter,
-            CohortPropertyFilter,
-            RecordingPropertyFilter,
-            LogEntryPropertyFilter,
-            GroupPropertyFilter,
-            FeaturePropertyFilter,
-            HogQLPropertyFilter,
-            EmptyPropertyFilter,
-            DataWarehousePropertyFilter,
-            DataWarehousePersonPropertyFilter,
+    properties: Optional[
+        list[
+            Union[
+                EventPropertyFilter,
+                PersonPropertyFilter,
+                ElementPropertyFilter,
+                EventMetadataPropertyFilter,
+                SessionPropertyFilter,
+                CohortPropertyFilter,
+                RecordingPropertyFilter,
+                LogEntryPropertyFilter,
+                GroupPropertyFilter,
+                FeaturePropertyFilter,
+                HogQLPropertyFilter,
+                EmptyPropertyFilter,
+                DataWarehousePropertyFilter,
+                DataWarehousePersonPropertyFilter,
+            ]
         ]
-    ]
+    ] = None
 
 
 class FunnelCorrelationResponse(BaseModel):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5561,7 +5561,7 @@ class ExperimentFunnelStepConfig(BaseModel):
     event: str
     kind: Literal["ExperimentFunnelStepConfig"] = "ExperimentFunnelStepConfig"
     name: Optional[str] = None
-    order: float
+    order: int
     properties: Optional[
         list[
             Union[

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -7517,6 +7517,8 @@ class ExperimentFunnelMetricConfig(BaseModel):
     funnel: list[ExperimentFunnelStepConfig]
     kind: Literal["ExperimentFunnelMetricConfig"] = "ExperimentFunnelMetricConfig"
     math: Optional[ExperimentMetricMathType] = None
+    math_hogql: Optional[str] = None
+    math_property: Optional[str] = None
 
 
 class ExperimentMetric(BaseModel):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1396,6 +1396,8 @@ class NodeKind(StrEnum):
     EXPERIMENT_EXPOSURE_QUERY = "ExperimentExposureQuery"
     EXPERIMENT_EVENT_EXPOSURE_CONFIG = "ExperimentEventExposureConfig"
     EXPERIMENT_EVENT_METRIC_CONFIG = "ExperimentEventMetricConfig"
+    EXPERIMENT_FUNNEL_METRIC_CONFIG = "ExperimentFunnelMetricConfig"
+    EXPERIMENT_FUNNEL_STEP_CONFIG = "ExperimentFunnelStepConfig"
     EXPERIMENT_ACTION_METRIC_CONFIG = "ExperimentActionMetricConfig"
     EXPERIMENT_DATA_WAREHOUSE_METRIC_CONFIG = "ExperimentDataWarehouseMetricConfig"
     EXPERIMENT_TRENDS_QUERY = "ExperimentTrendsQuery"
@@ -5552,32 +5554,32 @@ class ExperimentExposureQuery(BaseModel):
     response: Optional[ExperimentExposureQueryResponse] = None
 
 
-class ExperimentMetric(BaseModel):
+class ExperimentFunnelStepConfig(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    inverse: Optional[bool] = None
-    kind: Literal["ExperimentMetric"] = "ExperimentMetric"
-    metric_config: Union[ExperimentEventMetricConfig, ExperimentActionMetricConfig, ExperimentDataWarehouseMetricConfig]
-    metric_type: ExperimentMetricType
+    event: str
+    kind: Literal["ExperimentFunnelStepConfig"] = "ExperimentFunnelStepConfig"
     name: Optional[str] = None
-    time_window_hours: Optional[float] = None
-
-
-class ExperimentQueryResponse(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    credible_intervals: dict[str, list[float]]
-    insight: list[dict[str, Any]]
-    kind: Literal["ExperimentQuery"] = "ExperimentQuery"
-    metric: ExperimentMetric
-    p_value: float
-    probability: dict[str, float]
-    significance_code: ExperimentSignificanceCode
-    significant: bool
-    stats_version: Optional[int] = None
-    variants: Union[list[ExperimentVariantTrendsBaseStats], list[ExperimentVariantFunnelsBaseStats]]
+    order: float
+    properties: list[
+        Union[
+            EventPropertyFilter,
+            PersonPropertyFilter,
+            ElementPropertyFilter,
+            EventMetadataPropertyFilter,
+            SessionPropertyFilter,
+            CohortPropertyFilter,
+            RecordingPropertyFilter,
+            LogEntryPropertyFilter,
+            GroupPropertyFilter,
+            FeaturePropertyFilter,
+            HogQLPropertyFilter,
+            EmptyPropertyFilter,
+            DataWarehousePropertyFilter,
+            DataWarehousePersonPropertyFilter,
+        ]
+    ]
 
 
 class FunnelCorrelationResponse(BaseModel):
@@ -6230,22 +6232,6 @@ class QueryResponseAlternative13(BaseModel):
     timings: Optional[list[QueryTiming]] = Field(
         default=None, description="Measured timings for different parts of the query generation process"
     )
-
-
-class QueryResponseAlternative16(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    credible_intervals: dict[str, list[float]]
-    insight: list[dict[str, Any]]
-    kind: Literal["ExperimentQuery"] = "ExperimentQuery"
-    metric: ExperimentMetric
-    p_value: float
-    probability: dict[str, float]
-    significance_code: ExperimentSignificanceCode
-    significant: bool
-    stats_version: Optional[int] = None
-    variants: Union[list[ExperimentVariantTrendsBaseStats], list[ExperimentVariantFunnelsBaseStats]]
 
 
 class QueryResponseAlternative18(BaseModel):
@@ -7330,34 +7316,6 @@ class CachedErrorTrackingQueryResponse(BaseModel):
     )
 
 
-class CachedExperimentQueryResponse(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    cache_key: str
-    cache_target_age: Optional[datetime] = None
-    calculation_trigger: Optional[str] = Field(
-        default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
-    )
-    credible_intervals: dict[str, list[float]]
-    insight: list[dict[str, Any]]
-    is_cached: bool
-    kind: Literal["ExperimentQuery"] = "ExperimentQuery"
-    last_refresh: datetime
-    metric: ExperimentMetric
-    next_allowed_client_refresh: datetime
-    p_value: float
-    probability: dict[str, float]
-    query_status: Optional[QueryStatus] = Field(
-        default=None, description="Query status indicates whether next to the provided data, a query is still running."
-    )
-    significance_code: ExperimentSignificanceCode
-    significant: bool
-    stats_version: Optional[int] = None
-    timezone: str
-    variants: Union[list[ExperimentVariantTrendsBaseStats], list[ExperimentVariantFunnelsBaseStats]]
-
-
 class CachedHogQLQueryResponse(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -7552,18 +7510,46 @@ class EventTaxonomyQuery(BaseModel):
     response: Optional[EventTaxonomyQueryResponse] = None
 
 
-class ExperimentQuery(BaseModel):
+class ExperimentFunnelMetricConfig(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    experiment_id: Optional[int] = None
+    funnel: list[ExperimentFunnelStepConfig]
+    kind: Literal["ExperimentFunnelMetricConfig"] = "ExperimentFunnelMetricConfig"
+    math: Optional[ExperimentMetricMathType] = None
+
+
+class ExperimentMetric(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    inverse: Optional[bool] = None
+    kind: Literal["ExperimentMetric"] = "ExperimentMetric"
+    metric_config: Union[
+        ExperimentEventMetricConfig,
+        ExperimentActionMetricConfig,
+        ExperimentDataWarehouseMetricConfig,
+        ExperimentFunnelMetricConfig,
+    ]
+    metric_type: ExperimentMetricType
+    name: Optional[str] = None
+    time_window_hours: Optional[float] = None
+
+
+class ExperimentQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    credible_intervals: dict[str, list[float]]
+    insight: list[dict[str, Any]]
     kind: Literal["ExperimentQuery"] = "ExperimentQuery"
     metric: ExperimentMetric
-    modifiers: Optional[HogQLQueryModifiers] = Field(
-        default=None, description="Modifiers used when performing the query"
-    )
-    name: Optional[str] = None
-    response: Optional[ExperimentQueryResponse] = None
+    p_value: float
+    probability: dict[str, float]
+    significance_code: ExperimentSignificanceCode
+    significant: bool
+    stats_version: Optional[int] = None
+    variants: Union[list[ExperimentVariantTrendsBaseStats], list[ExperimentVariantFunnelsBaseStats]]
 
 
 class FunnelsFilter(BaseModel):
@@ -7703,6 +7689,22 @@ class PropertyGroupFilter(BaseModel):
     )
     type: FilterLogicalOperator
     values: list[PropertyGroupFilterValue]
+
+
+class QueryResponseAlternative16(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    credible_intervals: dict[str, list[float]]
+    insight: list[dict[str, Any]]
+    kind: Literal["ExperimentQuery"] = "ExperimentQuery"
+    metric: ExperimentMetric
+    p_value: float
+    probability: dict[str, float]
+    significance_code: ExperimentSignificanceCode
+    significant: bool
+    stats_version: Optional[int] = None
+    variants: Union[list[ExperimentVariantTrendsBaseStats], list[ExperimentVariantFunnelsBaseStats]]
 
 
 class QueryResponseAlternative41(BaseModel):
@@ -7983,6 +7985,34 @@ class WebVitalsPathBreakdownQuery(BaseModel):
     useSessionsTable: Optional[bool] = None
 
 
+class CachedExperimentQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    cache_key: str
+    cache_target_age: Optional[datetime] = None
+    calculation_trigger: Optional[str] = Field(
+        default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
+    )
+    credible_intervals: dict[str, list[float]]
+    insight: list[dict[str, Any]]
+    is_cached: bool
+    kind: Literal["ExperimentQuery"] = "ExperimentQuery"
+    last_refresh: datetime
+    metric: ExperimentMetric
+    next_allowed_client_refresh: datetime
+    p_value: float
+    probability: dict[str, float]
+    query_status: Optional[QueryStatus] = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    significance_code: ExperimentSignificanceCode
+    significant: bool
+    stats_version: Optional[int] = None
+    timezone: str
+    variants: Union[list[ExperimentVariantTrendsBaseStats], list[ExperimentVariantFunnelsBaseStats]]
+
+
 class CachedExperimentTrendsQueryResponse(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -8085,6 +8115,20 @@ class ErrorTrackingQuery(BaseModel):
     response: Optional[ErrorTrackingQueryResponse] = None
     searchQuery: Optional[str] = None
     status: Optional[Status1] = None
+
+
+class ExperimentQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    experiment_id: Optional[int] = None
+    kind: Literal["ExperimentQuery"] = "ExperimentQuery"
+    metric: ExperimentMetric
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    name: Optional[str] = None
+    response: Optional[ExperimentQueryResponse] = None
 
 
 class ExperimentTrendsQueryResponse(BaseModel):


### PR DESCRIPTION
## Problem
We currently only support a single conversion event in funnel metrics. I.e, experiment exposure -> event conversion. Our first round of feedback revealed that users really want to have multi-step funnel support.

## Changes
This is a first pass on implementing multi-step funnel support. Currently, the built-in Clickhouse function `windowFunnel` is used to figure out which level a given user reached. It works! As we don't support showing stats for intermediate steps in the UI, we return 1 (success) if a user completed the whole funnel, and 0 (dropped-off) otherwise. 

For now, I have dropped support for funnel metrics on data warehouse tables, at it requires additional logic, and I'd like to keep PR's small for easier review and faster time to merge (less merge conflicts). Also, I'd like to take a stab at improving the metric types first. After adding more metrics, it's clear that the abstractions can be improved.

![Screenshot 2025-03-25 at 21 20 05](https://github.com/user-attachments/assets/fe92d0cf-e4c0-4f09-9276-e964baacc608)

## How did you test this code?
* added new tests to test multi-step funnels
* fixed existing tests to use new config format
* tests passes
