### PR TITLE
fix(editor-3001): info tab overflow scroll

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryInfo.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryInfo.tsx
@@ -68,8 +68,8 @@ export function QueryInfo({ codeEditorKey }: QueryInfoProps): JSX.Element {
     const savedQuery = editingView ? dataWarehouseSavedQueryMapById[editingView.id] : null
 
     return (
-        <div>
-            <div className="flex flex-col flex-1 p-4 gap-4">
+        <div className="overflow-scroll">
+            <div className="flex flex-col flex-1 p-4 gap-4 overflow-y-auto">
                 <div>
                     <div className="flex flex-row items-center gap-2">
                         <h3 className="mb-0">Materialization</h3>

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryInfo.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryInfo.tsx
@@ -69,7 +69,7 @@ export function QueryInfo({ codeEditorKey }: QueryInfoProps): JSX.Element {
 
     return (
         <div className="overflow-scroll">
-            <div className="flex flex-col flex-1 p-4 gap-4 overflow-y-auto">
+            <div className="flex flex-col flex-1 p-4 gap-4 ">
                 <div>
                     <div className="flex flex-row items-center gap-2">
                         <h3 className="mb-0">Materialization</h3>


### PR DESCRIPTION
## Problem

- can't scroll when there's too many elements

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- add scroll styling

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
