### PR TITLE
fix: update view mixin comment

### DIFF
--- a/ee/api/rbac/access_control.py
+++ b/ee/api/rbac/access_control.py
@@ -89,12 +89,9 @@ class AccessControlSerializer(serializers.ModelSerializer):
 
 
 class AccessControlViewSetMixin(_GenericViewSet):
-    """
-    Adds an "access_controls" action to the viewset that handles access control for the given resource
-
-    Why a mixin? We want to easily add this to any existing resource, including providing easy helpers for adding access control info such
-    as the current users access level to any response.
-    """
+    # Adds an "access_controls" action to the viewset that handles access control for the given resource
+    # Why a mixin? We want to easily add this to any existing resource, including providing easy helpers for adding access control info such
+    # as the current users access level to any response.
 
     # 1. Know that the project level access is covered by the Permission check
     # 2. Get the actual object which we can pass to the serializer to check if the user created it


### PR DESCRIPTION
## Problem

It looks like it the main view set doesn't have a description is falls down to a viewset it's inheriting from to render as the resource description in the API so I'm change this to be a normal comment so that can't happen. 

![Screenshot 2025-03-25 at 5 19 05 PM](https://github.com/user-attachments/assets/794cd125-a2f7-4cf4-8de3-fb8003438bbd)

reported here: https://posthog.slack.com/archives/C07UWTB25S9/p1740501393718189

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

It doesn't have an impact.

## How did you test this code?

Manually
