### PR TITLE
chore(editor-3001): make expand button clear

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/DataGrid.scss
+++ b/frontend/src/scenes/data-warehouse/editor/DataGrid.scss
@@ -1,7 +1,6 @@
 .rdg-cell {
     font-size: 0.75rem;
     border-block-end: 1px solid var(--border);
-    border-inline-end: 1px solid var(--border);
     border-right: 0;
 }
 

--- a/frontend/src/scenes/data-warehouse/editor/DataGrid.scss
+++ b/frontend/src/scenes/data-warehouse/editor/DataGrid.scss
@@ -2,8 +2,20 @@
     font-size: 0.75rem;
     border-block-end: 1px solid var(--border);
     border-inline-end: 1px solid var(--border);
+    border-right: 0;
 }
 
-.rdg-row:hover {
-    cursor: pointer;
+.rdg-row {
+    .hover-actions-cell {
+        opacity: 0;
+        transition: opacity 0.2s ease;
+    }
+
+    &:hover {
+        cursor: pointer;
+
+        .hover-actions-cell {
+            opacity: 1;
+        }
+    }
 }

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -1,14 +1,14 @@
 import 'react-data-grid/lib/styles.css'
 import './DataGrid.scss'
 
-import { IconExpand, IconGear } from '@posthog/icons'
+import { IconExpand45, IconGear } from '@posthog/icons'
 import { LemonButton, LemonModal, LemonTable, LemonTabs } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { ExportButton } from 'lib/components/ExportButton/ExportButton'
 import { LoadingBar } from 'lib/lemon-ui/LoadingBar'
 import { useCallback, useMemo, useState } from 'react'
-import DataGrid, { CellClickArgs } from 'react-data-grid'
+import DataGrid from 'react-data-grid'
 import { InsightErrorState, StatelessInsightLoadingState } from 'scenes/insights/EmptyStates'
 import { HogQLBoldNumber } from 'scenes/insights/views/BoldNumber/BoldNumber'
 
@@ -29,48 +29,6 @@ import { ChartDisplayType, ExporterFormat } from '~/types'
 import { multitabEditorLogic } from './multitabEditorLogic'
 import { outputPaneLogic, OutputTab } from './outputPaneLogic'
 import TabScroller from './TabScroller'
-
-interface ExpandableCellProps {
-    value: any
-    columnName: string
-    isExpanded: boolean
-    onToggleExpand: () => void
-    hasManualWidth: boolean
-}
-
-export function ExpandableCell({
-    value,
-    columnName,
-    isExpanded,
-    onToggleExpand,
-    hasManualWidth,
-}: ExpandableCellProps): JSX.Element {
-    const [isHovered, setIsHovered] = useState(false)
-
-    return (
-        <div
-            className="relative w-full h-full flex items-center gap-1"
-            onMouseEnter={() => setIsHovered(true)}
-            onMouseLeave={() => setIsHovered(false)}
-        >
-            <div className={clsx('flex-1 overflow-hidden', !isExpanded && 'text-ellipsis whitespace-nowrap')}>
-                {value}
-            </div>
-            {isHovered && !isExpanded && !hasManualWidth && (
-                <LemonButton
-                    className="rotate-90 shrink-0"
-                    size="xsmall"
-                    icon={<IconExpand />}
-                    onClick={(e) => {
-                        e.stopPropagation()
-                        onToggleExpand()
-                    }}
-                    tooltip={`Expand ${columnName} column`}
-                />
-            )}
-        </div>
-    )
-}
 
 interface RowDetailsModalProps {
     isOpen: boolean
@@ -136,11 +94,34 @@ export function OutputPane(): JSX.Element {
 
     const vizKey = useMemo(() => `SQLEditorScene`, [])
 
+    const [selectedRow, setSelectedRow] = useState<Record<string, any> | null>(null)
+
+    const setProgress = useCallback((loadId: string, progress: number) => {
+        setProgressCache((prev) => ({ ...prev, [loadId]: progress }))
+    }, [])
+
     const columns = useMemo(() => {
         const types = response?.types
 
-        return (
-            response?.columns?.map((column: string, index: number) => {
+        const baseColumns = [
+            {
+                key: '__details',
+                name: '',
+                width: 15,
+                renderCell: ({ row }: { row: any }) => (
+                    <div className="hover-actions-cell flex justify-center items-center">
+                        <LemonButton
+                            size="xsmall"
+                            icon={<IconExpand45 />}
+                            onClick={(e) => {
+                                e.stopPropagation()
+                                setSelectedRow(row)
+                            }}
+                        />
+                    </div>
+                ),
+            },
+            ...(response?.columns?.map((column: string, index: number) => {
                 const type = types?.[index]?.[1]
 
                 const maxContentLength = Math.max(
@@ -184,9 +165,11 @@ export function OutputPane(): JSX.Element {
                     ...baseColumn,
                     renderCell: (props: any) => props.row[column],
                 }
-            }) ?? []
-        )
-    }, [response])
+            }) ?? []),
+        ]
+
+        return baseColumns
+    }, [response, setSelectedRow])
 
     const rows = useMemo(() => {
         if (!response?.results) {
@@ -205,16 +188,6 @@ export function OutputPane(): JSX.Element {
             return rowObject
         })
     }, [response])
-
-    const [selectedRow, setSelectedRow] = useState<Record<string, any> | null>(null)
-
-    const handleRowClick = useCallback((args: CellClickArgs<any, any>) => {
-        setSelectedRow(args.row)
-    }, [])
-
-    const setProgress = useCallback((loadId: string, progress: number) => {
-        setProgressCache((prev) => ({ ...prev, [loadId]: progress }))
-    }, [])
 
     return (
         <div className="OutputPane flex flex-col w-full flex-1 bg-primary">
@@ -292,7 +265,6 @@ export function OutputPane(): JSX.Element {
                     queryId={queryId}
                     pollResponse={pollResponse}
                     editorKey={editorKey}
-                    onRowClick={handleRowClick}
                     setProgress={setProgress}
                     progress={queryId ? progressCache[queryId] : undefined}
                 />
@@ -396,7 +368,6 @@ const Content = ({
     saveAsInsight,
     queryId,
     pollResponse,
-    onRowClick,
     setProgress,
     progress,
 }: any): JSX.Element | null => {
@@ -433,7 +404,6 @@ const Content = ({
                     className={isDarkModeOn ? 'rdg-dark h-full' : 'rdg-light h-full'}
                     columns={columns}
                     rows={rows}
-                    onCellClick={onRowClick}
                 />
             </TabScroller>
         )

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -107,7 +107,8 @@ export function OutputPane(): JSX.Element {
             {
                 key: '__details',
                 name: '',
-                width: 15,
+                minWidth: 30,
+                width: 30,
                 renderCell: ({ row }: { row: any }) => (
                     <div className="hover-actions-cell flex justify-center items-center">
                         <LemonButton


### PR DESCRIPTION
## Problem

- unclear and spammy when you click to expand

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- add explicit button and adjust styling

<!-- If there are frontend changes, please include screenshots. -->

![CleanShot 2025-03-25 at 15 28 09@2x](https://github.com/user-attachments/assets/f6ffcb6a-d292-4ef9-b4ff-769c9cfe42a5)

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
