### PR TITLE
feat(propdefs): Isolate and vectorize batch writes in property-defs-rs

### DIFF
--- a/rust/property-defs-rs/.sqlx/query-7fa314878d358c78204cdc1b6282897bcdd5f798d153e263dae6385be787afe4.json
+++ b/rust/property-defs-rs/.sqlx/query-7fa314878d358c78204cdc1b6282897bcdd5f798d153e263dae6385be787afe4.json
@@ -6,7 +6,7 @@
     "parameters": {
       "Left": [
         "Uuid",
-        "Text",
+        "Varchar",
         "Int4",
         "Int8",
         "Timestamptz"

--- a/rust/property-defs-rs/.sqlx/query-8c0e2802cd5af5299b4b59860613dd69e107d61cee1a295ca6128d37b74a390f.json
+++ b/rust/property-defs-rs/.sqlx/query-8c0e2802cd5af5299b4b59860613dd69e107d61cee1a295ca6128d37b74a390f.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT count(*) from posthog_propertydefinition WHERE type = 3",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "8c0e2802cd5af5299b4b59860613dd69e107d61cee1a295ca6128d37b74a390f"
+}

--- a/rust/property-defs-rs/.sqlx/query-af8e999f7d3f77d225953b7e2e7f8c04cc43f014039ea2d05ef42abfc0daa4b8.json
+++ b/rust/property-defs-rs/.sqlx/query-af8e999f7d3f77d225953b7e2e7f8c04cc43f014039ea2d05ef42abfc0daa4b8.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT count(*) from posthog_propertydefinition WHERE type = 2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "af8e999f7d3f77d225953b7e2e7f8c04cc43f014039ea2d05ef42abfc0daa4b8"
+}

--- a/rust/property-defs-rs/.sqlx/query-d48ae61a9a754e56c908e98a4e78b5b59ebcfef3c2c2c43d6c54229b312d4dde.json
+++ b/rust/property-defs-rs/.sqlx/query-d48ae61a9a754e56c908e98a4e78b5b59ebcfef3c2c2c43d6c54229b312d4dde.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT count(*) from posthog_propertydefinition",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "d48ae61a9a754e56c908e98a4e78b5b59ebcfef3c2c2c43d6c54229b312d4dde"
+}

--- a/rust/property-defs-rs/.sqlx/query-f7595122b345c487667fb8414e82bc2c251aa5a58eb11fc153e3dac5bb11afc6.json
+++ b/rust/property-defs-rs/.sqlx/query-f7595122b345c487667fb8414e82bc2c251aa5a58eb11fc153e3dac5bb11afc6.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT count(*) from posthog_eventproperty",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "f7595122b345c487667fb8414e82bc2c251aa5a58eb11fc153e3dac5bb11afc6"
+}

--- a/rust/property-defs-rs/.sqlx/query-fdcd2297f6041a5fe6bc7499a6826db50bd3facc0e40cee8a20c5a070b5723a6.json
+++ b/rust/property-defs-rs/.sqlx/query-fdcd2297f6041a5fe6bc7499a6826db50bd3facc0e40cee8a20c5a070b5723a6.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT name from posthog_eventdefinition",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "fdcd2297f6041a5fe6bc7499a6826db50bd3facc0e40cee8a20c5a070b5723a6"
+}

--- a/rust/property-defs-rs/src/config.rs
+++ b/rust/property-defs-rs/src/config.rs
@@ -115,6 +115,9 @@ pub struct Config {
     // bundled ingest pipeline refactors
     #[envconfig(default = "false")]
     pub enable_v2: bool,
+
+    #[envconfig(default = "100")]
+    pub v2_ingest_batch_size: usize,
 }
 
 #[derive(Clone)]

--- a/rust/property-defs-rs/src/lib.rs
+++ b/rust/property-defs-rs/src/lib.rs
@@ -217,7 +217,7 @@ async fn write_event_properties_batch(
                 metrics::counter!(V2_EVENT_PROPS_BATCH_ATTEMPT, &[("result", "retry")]);
                 let jitter = rand::random::<u64>() % 50;
                 let delay: u64 = tries * UPDATE_RETRY_DELAY_MS + jitter;
-                let _unused = tokio::time::sleep(Duration::from_millis(delay));
+                tokio::time::sleep(Duration::from_millis(delay)).await;
                 tries += 1;
             }
 
@@ -279,7 +279,7 @@ async fn write_property_definitions_batch(
                 metrics::counter!(V2_PROP_DEFS_BATCH_ATTEMPT, &[("result", "retry")]);
                 let jitter = rand::random::<u64>() % 50;
                 let delay: u64 = tries * UPDATE_RETRY_DELAY_MS + jitter;
-                let _unused = tokio::time::sleep(Duration::from_millis(delay));
+                tokio::time::sleep(Duration::from_millis(delay)).await;
                 tries += 1;
             }
 
@@ -336,7 +336,7 @@ async fn write_event_definitions_batch(
                 metrics::counter!(V2_EVENT_DEFS_BATCH_ATTEMPT, &[("result", "retry")]);
                 let jitter = rand::random::<u64>() % 50;
                 let delay: u64 = tries * UPDATE_RETRY_DELAY_MS + jitter;
-                let _unused = tokio::time::sleep(Duration::from_millis(delay));
+                tokio::time::sleep(Duration::from_millis(delay)).await;
                 tries += 1;
             }
             Ok(pgq_result) => {

--- a/rust/property-defs-rs/src/lib.rs
+++ b/rust/property-defs-rs/src/lib.rs
@@ -22,12 +22,6 @@ use tokio::sync::mpsc::{self, error::TrySendError};
 use tokio::task::JoinHandle;
 use tracing::{error, warn};
 
-// allows us to import private functions from lib.rs to test
-// module under "../tests/" directory
-#[cfg(test)]
-#[path = "../tests/v2_batch_ingestion.rs"]
-mod v2_batch_ingestion_test;
-
 pub mod api;
 pub mod app_context;
 pub mod config;
@@ -99,7 +93,8 @@ pub async fn update_consumer_loop(
     }
 }
 
-async fn process_batch_v2(
+// HACK: making this public so the test suite file can live under "../tests/" dir
+pub async fn process_batch_v2(
     config: &Config,
     cache: Arc<Cache<Update, ()>>,
     pool: &PgPool,

--- a/rust/property-defs-rs/src/lib.rs
+++ b/rust/property-defs-rs/src/lib.rs
@@ -79,7 +79,8 @@ pub async fn update_consumer_loop(
         let cache_utilization = cache.len() as f64 / config.cache_capacity as f64;
         metrics::gauge!(CACHE_CONSUMED).set(cache_utilization);
 
-        if config.v2_enabled {
+        // conditionall enable new write path
+        if config.enable_v2 {
             process_batch_v2(&config, cache.clone(), context.clone(), batch).await;
         } else {
             process_batch_v1(&config, cache.clone(), context.clone(), batch).await;

--- a/rust/property-defs-rs/src/metrics_consts.rs
+++ b/rust/property-defs-rs/src/metrics_consts.rs
@@ -27,3 +27,19 @@ pub const ISSUE_FAILED: &str = "prop_defs_issue_failed";
 pub const CHUNK_SIZE: &str = "prop_defs_chunk_size";
 pub const DUPLICATES_IN_BATCH: &str = "prop_defs_duplicates_in_batch";
 pub const SINGLE_UPDATE_ISSUE_TIME: &str = "prop_defs_single_update_issue_time_ms";
+
+//
+// property-defs-rs "v2" (mirror deploy) metric keys below
+//
+
+pub const V2_EVENT_DEFS_BATCH_TIME: &str = "propdefs_v2_eventdefs_batch_ms";
+pub const V2_EVENT_DEFS_BATCH_ATTEMPT: &str = "propdefs_v2_eventdefs_batch_attempt";
+pub const V2_EVENT_DEFS_BATCH_ROWS_AFFECTED: &str = "propdefs_v2_eventdefs_batch_rows";
+
+pub const V2_EVENT_PROPS_BATCH_TIME: &str = "propdefs_v2_eventprops_batch_ms";
+pub const V2_EVENT_PROPS_BATCH_ATTEMPT: &str = "propdefs_v2_eventprops_batch_attempt";
+pub const V2_EVENT_PROPS_BATCH_ROWS_AFFECTED: &str = "propdefs_v2_eventprops_batch_rows";
+
+pub const V2_PROP_DEFS_BATCH_TIME: &str = "propdefs_v2_propdefs_batch_ms";
+pub const V2_PROP_DEFS_BATCH_ATTEMPT: &str = "propdefs_v2_propdefs_batch_attempt";
+pub const V2_PROP_DEFS_BATCH_ROWS_AFFECTED: &str = "propdefs_v2_propdefs_batch_rows";

--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -135,8 +135,8 @@ pub struct PropertyDefinitionsBatch {
     // note: I left off deprecated fields we null out on writes
 }
 
-impl PropertyDefinitionsBatch {
-    pub fn new() -> Self {
+impl Default for PropertyDefinitionsBatch {
+    fn default() -> Self {
         Self {
             ids: Vec::with_capacity(WRITE_BATCH_SIZE),
             team_ids: Vec::with_capacity(WRITE_BATCH_SIZE),
@@ -147,6 +147,12 @@ impl PropertyDefinitionsBatch {
             event_types: Vec::with_capacity(WRITE_BATCH_SIZE),
             group_type_indices: Vec::with_capacity(WRITE_BATCH_SIZE),
         }
+    }
+}
+
+impl PropertyDefinitionsBatch {
+    pub fn new() -> Self {
+        Default::default()
     }
 
     pub fn append(&mut self, pd: PropertyDefinition) -> bool {
@@ -168,7 +174,7 @@ impl PropertyDefinitionsBatch {
         self.event_types.push(pd.event_type as i16);
         self.group_type_indices.push(group_type_index);
 
-        return self.ids.len() >= WRITE_BATCH_SIZE;
+        self.ids.len() >= WRITE_BATCH_SIZE
     }
 
     pub fn is_empty(&self) -> bool {
@@ -193,8 +199,8 @@ pub struct EventDefinitionsBatch {
     pub last_seen_ats: Vec<DateTime<Utc>>,
 }
 
-impl EventDefinitionsBatch {
-    pub fn new() -> Self {
+impl Default for EventDefinitionsBatch {
+    fn default() -> Self {
         Self {
             ids: Vec::with_capacity(WRITE_BATCH_SIZE),
             names: Vec::with_capacity(WRITE_BATCH_SIZE),
@@ -202,6 +208,12 @@ impl EventDefinitionsBatch {
             project_ids: Vec::with_capacity(WRITE_BATCH_SIZE),
             last_seen_ats: Vec::with_capacity(WRITE_BATCH_SIZE),
         }
+    }
+}
+
+impl EventDefinitionsBatch {
+    pub fn new() -> Self {
+        Default::default()
     }
 
     pub fn append(&mut self, ed: EventDefinition) -> bool {
@@ -211,7 +223,7 @@ impl EventDefinitionsBatch {
         self.project_ids.push(ed.project_id);
         self.last_seen_ats.push(ed.last_seen_at);
 
-        return self.ids.len() >= WRITE_BATCH_SIZE;
+        self.ids.len() >= WRITE_BATCH_SIZE
     }
 
     pub fn is_empty(&self) -> bool {
@@ -237,14 +249,20 @@ pub struct EventPropertiesBatch {
     pub property_names: Vec<String>,
 }
 
-impl EventPropertiesBatch {
-    pub fn new() -> Self {
+impl Default for EventPropertiesBatch {
+    fn default() -> Self {
         Self {
             team_ids: Vec::with_capacity(WRITE_BATCH_SIZE),
             project_ids: Vec::with_capacity(WRITE_BATCH_SIZE),
             event_names: Vec::with_capacity(WRITE_BATCH_SIZE),
             property_names: Vec::with_capacity(WRITE_BATCH_SIZE),
         }
+    }
+}
+
+impl EventPropertiesBatch {
+    pub fn new() -> Self {
+        Default::default()
     }
 
     pub fn append(&mut self, ep: EventProperty) -> bool {
@@ -253,7 +271,7 @@ impl EventPropertiesBatch {
         self.event_names.push(ep.event);
         self.property_names.push(ep.property);
 
-        return self.team_ids.len() >= WRITE_BATCH_SIZE;
+        self.team_ids.len() >= WRITE_BATCH_SIZE
     }
 
     pub fn is_empty(&self) -> bool {

--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -13,6 +13,8 @@ use crate::metrics_consts::{EVENTS_SKIPPED, UPDATES_ISSUED, UPDATES_SKIPPED};
 // We skip updates for events we generate
 pub const EVENTS_WITHOUT_PROPERTIES: [&str; 1] = ["$$plugin_metrics"];
 
+pub const WRITE_BATCH_SIZE: usize = 100;
+
 pub const SIX_MONTHS_AGO_SECS: u64 = 15768000;
 // These properties have special meaning, and are ignored
 pub const SKIP_PROPERTIES: [&str; 9] = [
@@ -120,12 +122,101 @@ pub struct PropertyDefinition {
     pub query_usage_30_day: Option<i64>,      // Deprecated
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PropertyDefinitionsBatch {
+    pub ids: Vec<Uuid>,
+    pub team_ids: Vec<i32>,
+    pub project_ids: Vec<i64>,
+    pub names: Vec<String>,
+    pub are_numerical: Vec<bool>,
+    pub event_types: Vec<i16>,
+    pub property_types: Vec<Option<i16>>,
+    pub group_type_indices: Vec<Option<i16>>,
+    // note: I left off deprecated fields we null out on writes
+}
+
+impl PropertyDefinitionsBatch {
+    pub fn new() -> Self {
+        Self {
+            ids: Vec::with_capacity(WRITE_BATCH_SIZE),
+            team_ids: Vec::with_capacity(WRITE_BATCH_SIZE),
+            project_ids: Vec::with_capacity(WRITE_BATCH_SIZE),
+            names: Vec::with_capacity(WRITE_BATCH_SIZE),
+            are_numerical: Vec::with_capacity(WRITE_BATCH_SIZE),
+            property_types: Vec::with_capacity(WRITE_BATCH_SIZE),
+            event_types: Vec::with_capacity(WRITE_BATCH_SIZE),
+            group_type_indices: Vec::with_capacity(WRITE_BATCH_SIZE),
+        }
+    }
+
+    pub fn append(&mut self, pd: PropertyDefinition) -> bool {
+        let group_type_index: Option<i16> = match &pd.group_type_index {
+            Some(gt) => match gt {
+                GroupType::Resolved(_, gti) => Some(*gti as i16),
+                GroupType::Unresolved(_) => Some(-1_i16),
+            },
+            _ => Some(-1_i16),
+        };
+        let property_type: Option<i16> = pd.property_type.map(|pt| pt as i16);
+
+        self.ids.push(Uuid::now_v7());
+        self.team_ids.push(pd.team_id);
+        self.project_ids.push(pd.project_id);
+        self.names.push(pd.name);
+        self.are_numerical.push(pd.is_numerical);
+        self.property_types.push(property_type);
+        self.event_types.push(pd.event_type as i16);
+        self.group_type_indices.push(group_type_index);
+
+        return self.ids.len() >= WRITE_BATCH_SIZE;
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.ids.len() == 0
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct EventDefinition {
     pub name: String,
     pub team_id: i32,
     pub project_id: i64,
     pub last_seen_at: DateTime<Utc>, // Always floored to our update rate for last_seen, so this Eq derive is safe for deduping
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EventDefinitionsBatch {
+    pub ids: Vec<Uuid>,
+    pub names: Vec<String>,
+    pub team_ids: Vec<i32>,
+    pub project_ids: Vec<i64>,
+    pub last_seen_ats: Vec<DateTime<Utc>>,
+}
+
+impl EventDefinitionsBatch {
+    pub fn new() -> Self {
+        Self {
+            ids: Vec::with_capacity(WRITE_BATCH_SIZE),
+            names: Vec::with_capacity(WRITE_BATCH_SIZE),
+            team_ids: Vec::with_capacity(WRITE_BATCH_SIZE),
+            project_ids: Vec::with_capacity(WRITE_BATCH_SIZE),
+            last_seen_ats: Vec::with_capacity(WRITE_BATCH_SIZE),
+        }
+    }
+
+    pub fn append(&mut self, ed: EventDefinition) -> bool {
+        self.ids.push(Uuid::now_v7());
+        self.names.push(ed.name);
+        self.team_ids.push(ed.team_id);
+        self.project_ids.push(ed.project_id);
+        self.last_seen_ats.push(ed.last_seen_at);
+
+        return self.ids.len() >= WRITE_BATCH_SIZE;
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.ids.len() == 0
+    }
 }
 
 // Derived hash since these are keyed on all fields in the DB
@@ -135,6 +226,39 @@ pub struct EventProperty {
     pub project_id: i64,
     pub event: String,
     pub property: String,
+}
+
+// Derived hash since these are keyed on all fields in the DB
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EventPropertiesBatch {
+    pub team_ids: Vec<i32>,
+    pub project_ids: Vec<i64>,
+    pub event_names: Vec<String>,
+    pub property_names: Vec<String>,
+}
+
+impl EventPropertiesBatch {
+    pub fn new() -> Self {
+        Self {
+            team_ids: Vec::with_capacity(WRITE_BATCH_SIZE),
+            project_ids: Vec::with_capacity(WRITE_BATCH_SIZE),
+            event_names: Vec::with_capacity(WRITE_BATCH_SIZE),
+            property_names: Vec::with_capacity(WRITE_BATCH_SIZE),
+        }
+    }
+
+    pub fn append(&mut self, ep: EventProperty) -> bool {
+        self.team_ids.push(ep.team_id);
+        self.project_ids.push(ep.project_id);
+        self.event_names.push(ep.event);
+        self.property_names.push(ep.property);
+
+        return self.team_ids.len() >= WRITE_BATCH_SIZE;
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.team_ids.len() == 0
+    }
 }
 
 // Represents a generic update, but comparable, allowing us to dedupe and cache updates

--- a/rust/property-defs-rs/src/v2_batch_ingestion.rs
+++ b/rust/property-defs-rs/src/v2_batch_ingestion.rs
@@ -1,0 +1,422 @@
+use std::{sync::Arc, time::Duration};
+
+use chrono::{DateTime, Utc};
+use quick_cache::sync::Cache;
+use sqlx::PgPool;
+use tokio::task::JoinHandle;
+use tracing::warn;
+use uuid::Uuid;
+
+use crate::{
+    config::Config,
+    metrics_consts::{
+        CACHE_CONSUMED, V2_EVENT_DEFS_BATCH_ATTEMPT, V2_EVENT_DEFS_BATCH_ROWS_AFFECTED,
+        V2_EVENT_DEFS_BATCH_TIME, V2_EVENT_PROPS_BATCH_ATTEMPT, V2_EVENT_PROPS_BATCH_ROWS_AFFECTED,
+        V2_EVENT_PROPS_BATCH_TIME, V2_PROP_DEFS_BATCH_ATTEMPT, V2_PROP_DEFS_BATCH_ROWS_AFFECTED,
+        V2_PROP_DEFS_BATCH_TIME,
+    },
+    types::{EventDefinition, EventProperty, GroupType, PropertyDefinition, Update},
+};
+
+pub const WRITE_BATCH_SIZE: usize = 100;
+const V2_BATCH_MAX_RETRY_ATTEMPTS: u64 = 3;
+const V2_BATCH_RETRY_DELAY_MS: u64 = 50;
+
+// Derived hash since these are keyed on all fields in the DB
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EventPropertiesBatch {
+    pub team_ids: Vec<i32>,
+    pub project_ids: Vec<i64>,
+    pub event_names: Vec<String>,
+    pub property_names: Vec<String>,
+}
+
+impl Default for EventPropertiesBatch {
+    fn default() -> Self {
+        Self {
+            team_ids: Vec::with_capacity(WRITE_BATCH_SIZE),
+            project_ids: Vec::with_capacity(WRITE_BATCH_SIZE),
+            event_names: Vec::with_capacity(WRITE_BATCH_SIZE),
+            property_names: Vec::with_capacity(WRITE_BATCH_SIZE),
+        }
+    }
+}
+
+impl EventPropertiesBatch {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn append(&mut self, ep: EventProperty) -> bool {
+        self.team_ids.push(ep.team_id);
+        self.project_ids.push(ep.project_id);
+        self.event_names.push(ep.event);
+        self.property_names.push(ep.property);
+
+        self.team_ids.len() >= WRITE_BATCH_SIZE
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.team_ids.len() == 0
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EventDefinitionsBatch {
+    pub ids: Vec<Uuid>,
+    pub names: Vec<String>,
+    pub team_ids: Vec<i32>,
+    pub project_ids: Vec<i64>,
+    pub last_seen_ats: Vec<DateTime<Utc>>,
+}
+
+impl Default for EventDefinitionsBatch {
+    fn default() -> Self {
+        Self {
+            ids: Vec::with_capacity(WRITE_BATCH_SIZE),
+            names: Vec::with_capacity(WRITE_BATCH_SIZE),
+            team_ids: Vec::with_capacity(WRITE_BATCH_SIZE),
+            project_ids: Vec::with_capacity(WRITE_BATCH_SIZE),
+            last_seen_ats: Vec::with_capacity(WRITE_BATCH_SIZE),
+        }
+    }
+}
+
+impl EventDefinitionsBatch {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn append(&mut self, ed: EventDefinition) -> bool {
+        self.ids.push(Uuid::now_v7());
+        self.names.push(ed.name);
+        self.team_ids.push(ed.team_id);
+        self.project_ids.push(ed.project_id);
+        self.last_seen_ats.push(ed.last_seen_at);
+
+        self.ids.len() >= WRITE_BATCH_SIZE
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.ids.len() == 0
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PropertyDefinitionsBatch {
+    pub ids: Vec<Uuid>,
+    pub team_ids: Vec<i32>,
+    pub project_ids: Vec<i64>,
+    pub names: Vec<String>,
+    pub are_numerical: Vec<bool>,
+    pub event_types: Vec<i16>,
+    pub property_types: Vec<Option<i16>>,
+    pub group_type_indices: Vec<Option<i16>>,
+    // note: I left off deprecated fields we null out on writes
+}
+
+impl Default for PropertyDefinitionsBatch {
+    fn default() -> Self {
+        Self {
+            ids: Vec::with_capacity(WRITE_BATCH_SIZE),
+            team_ids: Vec::with_capacity(WRITE_BATCH_SIZE),
+            project_ids: Vec::with_capacity(WRITE_BATCH_SIZE),
+            names: Vec::with_capacity(WRITE_BATCH_SIZE),
+            are_numerical: Vec::with_capacity(WRITE_BATCH_SIZE),
+            property_types: Vec::with_capacity(WRITE_BATCH_SIZE),
+            event_types: Vec::with_capacity(WRITE_BATCH_SIZE),
+            group_type_indices: Vec::with_capacity(WRITE_BATCH_SIZE),
+        }
+    }
+}
+
+impl PropertyDefinitionsBatch {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn append(&mut self, pd: PropertyDefinition) -> bool {
+        let group_type_index: Option<i16> = match &pd.group_type_index {
+            Some(gt) => match gt {
+                GroupType::Resolved(_, gti) => Some(*gti as i16),
+                GroupType::Unresolved(_) => Some(-1_i16),
+            },
+            _ => Some(-1_i16),
+        };
+        let property_type: Option<i16> = pd.property_type.map(|pt| pt as i16);
+
+        self.ids.push(Uuid::now_v7());
+        self.team_ids.push(pd.team_id);
+        self.project_ids.push(pd.project_id);
+        self.names.push(pd.name);
+        self.are_numerical.push(pd.is_numerical);
+        self.property_types.push(property_type);
+        self.event_types.push(pd.event_type as i16);
+        self.group_type_indices.push(group_type_index);
+
+        self.ids.len() >= WRITE_BATCH_SIZE
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.ids.len() == 0
+    }
+}
+
+// HACK: making this public so the test suite file can live under "../tests/" dir
+pub async fn process_batch_v2(
+    config: &Config,
+    cache: Arc<Cache<Update, ()>>,
+    pool: &PgPool,
+    batch: Vec<Update>,
+) {
+    let cache_utilization = cache.len() as f64 / config.cache_capacity as f64;
+    metrics::gauge!(CACHE_CONSUMED).set(cache_utilization);
+
+    // TODO(eli): implement v1-style delay while cache is warming?
+
+    // prep reshaped, isolated data batch bufffers and async join handles
+    let mut event_defs = EventDefinitionsBatch::new();
+    let mut event_props = EventPropertiesBatch::new();
+    let mut prop_defs = PropertyDefinitionsBatch::new();
+    let mut handles: Vec<JoinHandle<Result<(), sqlx::Error>>> = vec![];
+
+    // loop on the Update batch, splitting into smaller vectorized PG write batches
+    // and submitted async. note for testing and simplicity, we don't work with
+    // the AppContext in process_batch_v2, just it's PgPool. We clone that all over
+    // the place to pass into `tokio::spawn()` which is fine b/c it's designed for
+    // this and manages concurrent access internaly. Some details here:
+    // https://github.com/launchbadge/sqlx/blob/main/sqlx-core/src/pool/mod.rs#L109-L111
+    for update in batch {
+        match update {
+            Update::Event(ed) => {
+                if event_defs.append(ed) {
+                    let pool = pool.clone();
+                    handles.push(tokio::spawn(async move {
+                        write_event_definitions_batch(event_defs, &pool).await
+                    }));
+                    event_defs = EventDefinitionsBatch::new();
+                }
+            }
+            Update::EventProperty(ep) => {
+                if event_props.append(ep) {
+                    let pool = pool.clone();
+                    handles.push(tokio::spawn(async move {
+                        write_event_properties_batch(event_props, &pool).await
+                    }));
+                    event_props = EventPropertiesBatch::new();
+                }
+            }
+            Update::Property(pd) => {
+                if prop_defs.append(pd) {
+                    let pool = pool.clone();
+                    handles.push(tokio::spawn(async move {
+                        write_property_definitions_batch(prop_defs, &pool).await
+                    }));
+                    prop_defs = PropertyDefinitionsBatch::new();
+                }
+            }
+        }
+    }
+
+    // ensure partial batches are flushed to Postgres too
+    if !event_defs.is_empty() {
+        let pool = pool.clone();
+        handles.push(tokio::spawn(async move {
+            write_event_definitions_batch(event_defs, &pool).await
+        }));
+    }
+    if !prop_defs.is_empty() {
+        let pool = pool.clone();
+        handles.push(tokio::spawn(async move {
+            write_property_definitions_batch(prop_defs, &pool).await
+        }));
+    }
+    if !event_props.is_empty() {
+        let pool = pool.clone();
+        handles.push(tokio::spawn(async move {
+            write_event_properties_batch(event_props, &pool).await
+        }));
+    }
+
+    for handle in handles {
+        match handle.await {
+            Ok(result) => match result {
+                Ok(_) => continue,
+                Err(db_err) => {
+                    warn!("Batch write exhausted retries: {:?}", db_err);
+                }
+            },
+            Err(join_err) => {
+                warn!("Batch query JoinError: {:?}", join_err);
+            }
+        }
+    }
+}
+
+async fn write_event_properties_batch(
+    batch: EventPropertiesBatch,
+    pool: &PgPool,
+) -> Result<(), sqlx::Error> {
+    let total_time = common_metrics::timing_guard(V2_EVENT_PROPS_BATCH_TIME, &[]);
+    let mut tries = 1;
+
+    loop {
+        let result = sqlx::query(
+            r#"
+            INSERT INTO posthog_eventproperty (event, property, team_id, project_id)
+                (SELECT * FROM UNNEST(
+                    $1::text[],
+                    $2::text[],
+                    $3::int[],
+                    $4::bigint[])) ON CONFLICT DO NOTHING"#,
+        )
+        .bind(&batch.event_names)
+        .bind(&batch.property_names)
+        .bind(&batch.team_ids)
+        .bind(&batch.project_ids)
+        .execute(pool)
+        .await;
+
+        match result {
+            Err(e) => {
+                if tries == V2_BATCH_MAX_RETRY_ATTEMPTS {
+                    metrics::counter!(V2_EVENT_PROPS_BATCH_ATTEMPT, &[("result", "failed")]);
+                    total_time.fin();
+                    return Err(e);
+                }
+
+                metrics::counter!(V2_EVENT_PROPS_BATCH_ATTEMPT, &[("result", "retry")]);
+                let jitter = rand::random::<u64>() % 50;
+                let delay: u64 = tries * V2_BATCH_RETRY_DELAY_MS + jitter;
+                tokio::time::sleep(Duration::from_millis(delay)).await;
+                tries += 1;
+            }
+
+            Ok(pgq_result) => {
+                let count = pgq_result.rows_affected();
+                metrics::counter!(V2_EVENT_PROPS_BATCH_ATTEMPT, &[("result", "success")]);
+                common_metrics::inc(V2_EVENT_PROPS_BATCH_ROWS_AFFECTED, &[], count);
+                total_time.fin();
+                return Ok(());
+            }
+        }
+    }
+}
+
+async fn write_property_definitions_batch(
+    batch: PropertyDefinitionsBatch,
+    pool: &PgPool,
+) -> Result<(), sqlx::Error> {
+    let total_time = common_metrics::timing_guard(V2_PROP_DEFS_BATCH_TIME, &[]);
+    let mut tries: u64 = 1;
+
+    loop {
+        // what if we just ditch properties without a property_type set? why update on conflict at all?
+        let result = sqlx::query(r#"
+            INSERT INTO posthog_propertydefinition (id, name, type, group_type_index, is_numerical, team_id, project_id, property_type)
+                (SELECT * FROM UNNEST(
+                    $1::uuid[],
+                    $2::varchar[],
+                    $3::smallint[],
+                    $4::smallint[],
+                    $5::boolean[],
+                    $6::int[],
+                    $7::bigint[],
+                    $8::varchar[]))
+                ON CONFLICT (
+                    COALESCE(project_id, team_id::bigint), name, type,
+                    COALESCE(group_type_index, -1))
+                DO UPDATE SET property_type=EXCLUDED.property_type
+                WHERE posthog_propertydefinition.property_type IS NULL"#,
+            )
+            .bind(&batch.ids)
+            .bind(&batch.names)
+            .bind(&batch.event_types)
+            .bind(&batch.group_type_indices)
+            .bind(&batch.are_numerical)
+            .bind(&batch.team_ids)
+            .bind(&batch.project_ids)
+            .bind(&batch.property_types)
+            .execute(pool).await;
+
+        match result {
+            Err(e) => {
+                if tries == V2_BATCH_MAX_RETRY_ATTEMPTS {
+                    metrics::counter!(V2_PROP_DEFS_BATCH_ATTEMPT, &[("result", "failed")]);
+                    total_time.fin();
+                    return Err(e);
+                }
+
+                metrics::counter!(V2_PROP_DEFS_BATCH_ATTEMPT, &[("result", "retry")]);
+                let jitter = rand::random::<u64>() % 50;
+                let delay: u64 = tries * V2_BATCH_RETRY_DELAY_MS + jitter;
+                tokio::time::sleep(Duration::from_millis(delay)).await;
+                tries += 1;
+            }
+
+            Ok(pgq_result) => {
+                let count = pgq_result.rows_affected();
+                metrics::counter!(V2_PROP_DEFS_BATCH_ATTEMPT, &[("result", "success")]);
+                common_metrics::inc(V2_PROP_DEFS_BATCH_ROWS_AFFECTED, &[], count);
+                total_time.fin();
+                return Ok(());
+            }
+        }
+    }
+}
+
+async fn write_event_definitions_batch(
+    batch: EventDefinitionsBatch,
+    pool: &PgPool,
+) -> Result<(), sqlx::Error> {
+    let total_time = common_metrics::timing_guard(V2_EVENT_DEFS_BATCH_TIME, &[]);
+    let mut tries: u64 = 1;
+
+    loop {
+        // TODO: is last_seen_at critical to the product UX? "ON CONFLICT DO NOTHING" may be much cheaper...
+        let result = sqlx::query(
+            r#"
+            INSERT INTO posthog_eventdefinition (id, name, team_id, project_id, last_seen_at, created_at)
+                (SELECT * FROM UNNEST (
+                    $1::uuid[],
+                    $2::varchar[],
+                    $3::int[],
+                    $4::bigint[],
+                    $5::timestamptz[],
+                    $5::timestamptz[]))
+                ON CONFLICT (coalesce(project_id, team_id::bigint), name) DO UPDATE
+                    SET last_seen_at=EXCLUDED.last_seen_at
+                    WHERE posthog_eventdefinition.last_seen_at < EXCLUDED.last_seen_at"#,
+        )
+        .bind(&batch.ids)
+        .bind(&batch.names)
+        .bind(&batch.team_ids)
+        .bind(&batch.project_ids)
+        .bind(&batch.last_seen_ats)
+        .execute(pool)
+        .await;
+
+        match result {
+            Err(e) => {
+                if tries == V2_BATCH_MAX_RETRY_ATTEMPTS {
+                    metrics::counter!(V2_EVENT_DEFS_BATCH_ATTEMPT, &[("result", "failed")]);
+                    total_time.fin();
+                    return Err(e);
+                }
+
+                metrics::counter!(V2_EVENT_DEFS_BATCH_ATTEMPT, &[("result", "retry")]);
+                let jitter = rand::random::<u64>() % 50;
+                let delay: u64 = tries * V2_BATCH_RETRY_DELAY_MS + jitter;
+                tokio::time::sleep(Duration::from_millis(delay)).await;
+                tries += 1;
+            }
+            Ok(pgq_result) => {
+                let count = pgq_result.rows_affected();
+                metrics::counter!(V2_EVENT_DEFS_BATCH_ATTEMPT, &[("result", "success")]);
+                common_metrics::inc(V2_EVENT_DEFS_BATCH_ROWS_AFFECTED, &[], count);
+                total_time.fin();
+                return Ok(());
+            }
+        }
+    }
+}

--- a/rust/property-defs-rs/src/v2_batch_ingestion.rs
+++ b/rust/property-defs-rs/src/v2_batch_ingestion.rs
@@ -18,7 +18,7 @@ use crate::{
     types::{EventDefinition, EventProperty, GroupType, PropertyDefinition, Update},
 };
 
-pub const WRITE_BATCH_SIZE: usize = 100;
+pub const V2_WRITE_BATCH_SIZE: usize = 100;
 const V2_BATCH_MAX_RETRY_ATTEMPTS: u64 = 3;
 const V2_BATCH_RETRY_DELAY_MS: u64 = 50;
 
@@ -34,10 +34,10 @@ pub struct EventPropertiesBatch {
 impl Default for EventPropertiesBatch {
     fn default() -> Self {
         Self {
-            team_ids: Vec::with_capacity(WRITE_BATCH_SIZE),
-            project_ids: Vec::with_capacity(WRITE_BATCH_SIZE),
-            event_names: Vec::with_capacity(WRITE_BATCH_SIZE),
-            property_names: Vec::with_capacity(WRITE_BATCH_SIZE),
+            team_ids: Vec::with_capacity(V2_WRITE_BATCH_SIZE),
+            project_ids: Vec::with_capacity(V2_WRITE_BATCH_SIZE),
+            event_names: Vec::with_capacity(V2_WRITE_BATCH_SIZE),
+            property_names: Vec::with_capacity(V2_WRITE_BATCH_SIZE),
         }
     }
 }
@@ -53,7 +53,7 @@ impl EventPropertiesBatch {
         self.event_names.push(ep.event);
         self.property_names.push(ep.property);
 
-        self.team_ids.len() >= WRITE_BATCH_SIZE
+        self.team_ids.len() >= V2_WRITE_BATCH_SIZE
     }
 
     pub fn is_empty(&self) -> bool {
@@ -73,11 +73,11 @@ pub struct EventDefinitionsBatch {
 impl Default for EventDefinitionsBatch {
     fn default() -> Self {
         Self {
-            ids: Vec::with_capacity(WRITE_BATCH_SIZE),
-            names: Vec::with_capacity(WRITE_BATCH_SIZE),
-            team_ids: Vec::with_capacity(WRITE_BATCH_SIZE),
-            project_ids: Vec::with_capacity(WRITE_BATCH_SIZE),
-            last_seen_ats: Vec::with_capacity(WRITE_BATCH_SIZE),
+            ids: Vec::with_capacity(V2_WRITE_BATCH_SIZE),
+            names: Vec::with_capacity(V2_WRITE_BATCH_SIZE),
+            team_ids: Vec::with_capacity(V2_WRITE_BATCH_SIZE),
+            project_ids: Vec::with_capacity(V2_WRITE_BATCH_SIZE),
+            last_seen_ats: Vec::with_capacity(V2_WRITE_BATCH_SIZE),
         }
     }
 }
@@ -94,7 +94,7 @@ impl EventDefinitionsBatch {
         self.project_ids.push(ed.project_id);
         self.last_seen_ats.push(ed.last_seen_at);
 
-        self.ids.len() >= WRITE_BATCH_SIZE
+        self.ids.len() >= V2_WRITE_BATCH_SIZE
     }
 
     pub fn is_empty(&self) -> bool {
@@ -118,14 +118,14 @@ pub struct PropertyDefinitionsBatch {
 impl Default for PropertyDefinitionsBatch {
     fn default() -> Self {
         Self {
-            ids: Vec::with_capacity(WRITE_BATCH_SIZE),
-            team_ids: Vec::with_capacity(WRITE_BATCH_SIZE),
-            project_ids: Vec::with_capacity(WRITE_BATCH_SIZE),
-            names: Vec::with_capacity(WRITE_BATCH_SIZE),
-            are_numerical: Vec::with_capacity(WRITE_BATCH_SIZE),
-            property_types: Vec::with_capacity(WRITE_BATCH_SIZE),
-            event_types: Vec::with_capacity(WRITE_BATCH_SIZE),
-            group_type_indices: Vec::with_capacity(WRITE_BATCH_SIZE),
+            ids: Vec::with_capacity(V2_WRITE_BATCH_SIZE),
+            team_ids: Vec::with_capacity(V2_WRITE_BATCH_SIZE),
+            project_ids: Vec::with_capacity(V2_WRITE_BATCH_SIZE),
+            names: Vec::with_capacity(V2_WRITE_BATCH_SIZE),
+            are_numerical: Vec::with_capacity(V2_WRITE_BATCH_SIZE),
+            property_types: Vec::with_capacity(V2_WRITE_BATCH_SIZE),
+            event_types: Vec::with_capacity(V2_WRITE_BATCH_SIZE),
+            group_type_indices: Vec::with_capacity(V2_WRITE_BATCH_SIZE),
         }
     }
 }
@@ -154,7 +154,7 @@ impl PropertyDefinitionsBatch {
         self.event_types.push(pd.event_type as i16);
         self.group_type_indices.push(group_type_index);
 
-        self.ids.len() >= WRITE_BATCH_SIZE
+        self.ids.len() >= V2_WRITE_BATCH_SIZE
     }
 
     pub fn is_empty(&self) -> bool {

--- a/rust/property-defs-rs/tests/v2_batch_ingestion.rs
+++ b/rust/property-defs-rs/tests/v2_batch_ingestion.rs
@@ -10,14 +10,15 @@ use sqlx::PgPool;
 use property_defs_rs::{
     config::Config,
     process_batch_v2,
-    types::{Event, Update},
+    types::{Event, PropertyParentType, Update},
 };
 
 #[sqlx::test(migrations = "./tests/test_migrations")]
 async fn test_simple_batch_write(db: PgPool) {
     let config = Config::init_with_defaults().unwrap();
     let cache: Arc<Cache<Update, ()>> = Arc::new(Cache::new(config.cache_capacity));
-    let updates = gen_test_event_updates("$pageview", 100);
+    let updates = gen_test_event_updates("$pageview", 100, None);
+    // should decompose into 1 event def, 100 event props, 100 prop defs (of event type)
     assert_eq!(updates.len(), 201);
 
     process_batch_v2(&config, cache, &db, updates).await;
@@ -45,15 +46,123 @@ async fn test_simple_batch_write(db: PgPool) {
     assert_eq!(Some(100), event_props_count);
 }
 
-fn gen_test_event_updates(event_name: &'static str, num_props: usize) -> Vec<Update> {
+#[sqlx::test(migrations = "./tests/test_migrations")]
+async fn test_group_batch_write(db: PgPool) {
+    let config = Config::init_with_defaults().unwrap();
+    let cache: Arc<Cache<Update, ()>> = Arc::new(Cache::new(config.cache_capacity));
+    let updates = gen_test_event_updates("$groupidentify", 100, Some(PropertyParentType::Group));
+    // should decompose into 1 group event def, 100 prop defs (of group type), 100 event props
+    assert_eq!(updates.len(), 201);
+
+    process_batch_v2(&config, cache, &db, updates).await;
+
+    // fetch results and ensure they landed correctly
+    let event_defs_count: Option<i64> = sqlx::query_scalar!(
+        r#"SELECT count(*) from posthog_eventdefinition WHERE name = '$groupidentify'"#
+    )
+    .fetch_one(&db)
+    .await
+    .unwrap();
+    assert_eq!(Some(1), event_defs_count);
+
+    let prop_defs_count: Option<i64> =
+        sqlx::query_scalar!(r#"SELECT count(*) from posthog_propertydefinition WHERE type = 3"#)
+            .fetch_one(&db)
+            .await
+            .unwrap();
+    assert_eq!(Some(100), prop_defs_count);
+
+    let event_props_count: Option<i64> =
+        sqlx::query_scalar!(r#"SELECT count(*) from posthog_eventproperty"#)
+            .fetch_one(&db)
+            .await
+            .unwrap();
+    assert_eq!(Some(100), event_props_count);
+}
+
+#[sqlx::test(migrations = "./tests/test_migrations")]
+async fn test_person_batch_write(db: PgPool) {
+    let config = Config::init_with_defaults().unwrap();
+    let cache: Arc<Cache<Update, ()>> = Arc::new(Cache::new(config.cache_capacity));
+    let updates =
+        gen_test_event_updates("event_with_person", 100, Some(PropertyParentType::Person));
+    // should decompose into 1 event def, 100 event props, 100 prop defs (50 $set, 50 $set_once props)
+    assert_eq!(updates.len(), 201);
+
+    process_batch_v2(&config, cache, &db, updates).await;
+
+    // fetch results and ensure they landed correctly
+    let event_defs_count: Option<i64> = sqlx::query_scalar!(
+        r#"SELECT count(*) from posthog_eventdefinition WHERE name = 'event_with_person'"#
+    )
+    .fetch_one(&db)
+    .await
+    .unwrap();
+    assert_eq!(Some(1), event_defs_count);
+
+    let prop_defs_count: Option<i64> =
+        sqlx::query_scalar!(r#"SELECT count(*) from posthog_propertydefinition WHERE type = 2"#)
+            .fetch_one(&db)
+            .await
+            .unwrap();
+    assert_eq!(Some(100), prop_defs_count);
+
+    let event_props_count: Option<i64> =
+        sqlx::query_scalar!(r#"SELECT count(*) from posthog_eventproperty"#)
+            .fetch_one(&db)
+            .await
+            .unwrap();
+    assert_eq!(Some(100), event_props_count);
+}
+
+fn gen_test_event_updates(
+    event_name: &'static str,
+    num_props: usize,
+    prop_type: Option<PropertyParentType>,
+) -> Vec<Update> {
     let prop_kvs = (0..num_props)
         .map(gen_test_prop_key_value)
         .collect::<Vec<(String, Value)>>();
 
+    // let's be *just* realistic enough to exercise we're decomposing the Event properly in unit tests
     let mut properties = HashMap::<String, Value>::new();
-    for kv in prop_kvs {
-        properties.insert(kv.0, kv.1);
+    match prop_type {
+        Some(PropertyParentType::Person) => {
+            let mut set_props = HashMap::<String, Value>::new();
+            let mut set_once_props = HashMap::<String, Value>::new();
+
+            // split the total props between $set and $set_once buckets.
+            // these will be flattened back into a single unique group of props
+            // during parsing into Update records
+            for kv in prop_kvs.iter().enumerate() {
+                if kv.0 % 2 == 0 {
+                    set_props.insert(kv.1 .0.clone(), kv.1 .1.clone());
+                } else {
+                    set_once_props.insert(kv.1 .0.clone(), kv.1 .1.clone());
+                }
+            }
+            properties.insert(String::from("$set"), json!(set_props));
+            properties.insert(String::from("$set_once"), json!(set_once_props));
+        }
+        Some(PropertyParentType::Group) => {
+            let mut group_props = HashMap::<String, Value>::new();
+            for kv in prop_kvs {
+                group_props.insert(kv.0, kv.1);
+            }
+            properties.insert(
+                String::from("$group_type"),
+                Value::String(String::from("Organization")),
+            );
+            properties.insert(String::from("$group_set"), json!(group_props));
+        }
+        _ => {
+            // generate flat list of "vanilla" event props
+            for kv in prop_kvs {
+                properties.insert(kv.0, kv.1);
+            }
+        }
     }
+
     let properties = json!(properties).to_string();
 
     let event = json!({
@@ -63,13 +172,9 @@ fn gen_test_event_updates(event_name: &'static str, num_props: usize) -> Vec<Upd
         "properties": properties,
     });
 
-    // each non-person property will generate 1 event_property and 1 property_definition
-    // Update, and we add one more for the event_definition Update from the parent
-    let limit = (2 * num_props) + 1;
-
     serde_json::from_value::<Event>(event)
         .unwrap()
-        .into_updates(limit)
+        .into_updates(10000)
 }
 
 fn gen_test_prop_key_value(ndx: usize) -> (String, Value) {

--- a/rust/property-defs-rs/tests/v2_batch_ingestion.rs
+++ b/rust/property-defs-rs/tests/v2_batch_ingestion.rs
@@ -24,12 +24,11 @@ async fn test_simple_batch_write(db: PgPool) {
     process_batch_v2(&config, cache, &db, updates).await;
 
     // fetch results and ensure they landed correctly
-    let event_defs_count: Option<i64> =
-        sqlx::query_scalar!(r#"SELECT count(*) from posthog_eventdefinition"#)
-            .fetch_one(&db)
-            .await
-            .unwrap();
-    assert_eq!(Some(1), event_defs_count);
+    let event_def_name: String = sqlx::query_scalar!(r#"SELECT name from posthog_eventdefinition"#)
+        .fetch_one(&db)
+        .await
+        .unwrap();
+    assert_eq!(String::from("$pageview"), event_def_name);
 
     let prop_defs_count: Option<i64> =
         sqlx::query_scalar!(r#"SELECT count(*) from posthog_propertydefinition"#)
@@ -57,13 +56,11 @@ async fn test_group_batch_write(db: PgPool) {
     process_batch_v2(&config, cache, &db, updates).await;
 
     // fetch results and ensure they landed correctly
-    let event_defs_count: Option<i64> = sqlx::query_scalar!(
-        r#"SELECT count(*) from posthog_eventdefinition WHERE name = '$groupidentify'"#
-    )
-    .fetch_one(&db)
-    .await
-    .unwrap();
-    assert_eq!(Some(1), event_defs_count);
+    let event_def_name: String = sqlx::query_scalar!(r#"SELECT name from posthog_eventdefinition"#)
+        .fetch_one(&db)
+        .await
+        .unwrap();
+    assert_eq!(String::from("$groupidentify"), event_def_name);
 
     let prop_defs_count: Option<i64> =
         sqlx::query_scalar!(r#"SELECT count(*) from posthog_propertydefinition WHERE type = 3"#)
@@ -92,13 +89,11 @@ async fn test_person_batch_write(db: PgPool) {
     process_batch_v2(&config, cache, &db, updates).await;
 
     // fetch results and ensure they landed correctly
-    let event_defs_count: Option<i64> = sqlx::query_scalar!(
-        r#"SELECT count(*) from posthog_eventdefinition WHERE name = 'event_with_person'"#
-    )
-    .fetch_one(&db)
-    .await
-    .unwrap();
-    assert_eq!(Some(1), event_defs_count);
+    let event_def_name: String = sqlx::query_scalar!(r#"SELECT name from posthog_eventdefinition"#)
+        .fetch_one(&db)
+        .await
+        .unwrap();
+    assert_eq!(String::from("event_with_person"), event_def_name);
 
     let prop_defs_count: Option<i64> =
         sqlx::query_scalar!(r#"SELECT count(*) from posthog_propertydefinition WHERE type = 2"#)

--- a/rust/property-defs-rs/tests/v2_batch_ingestion.rs
+++ b/rust/property-defs-rs/tests/v2_batch_ingestion.rs
@@ -9,8 +9,8 @@ use sqlx::PgPool;
 
 use property_defs_rs::{
     config::Config,
-    process_batch_v2,
     types::{Event, PropertyParentType, Update},
+    v2_batch_ingestion::process_batch_v2,
 };
 
 #[sqlx::test(migrations = "./tests/test_migrations")]

--- a/rust/property-defs-rs/tests/v2_batch_ingestion.rs
+++ b/rust/property-defs-rs/tests/v2_batch_ingestion.rs
@@ -1,0 +1,92 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use chrono::Utc;
+use quick_cache::sync::Cache;
+use rand::Rng;
+use serde_json::{json, Value};
+use sqlx::PgPool;
+
+use property_defs_rs::{
+    config::Config,
+    process_batch_v2,
+    types::{Event, Update},
+};
+#[sqlx::test(migrations = "./tests/test_migrations")]
+async fn test_simple_batch_write(db: PgPool) {
+    let config = Config::init_with_defaults().unwrap();
+    let cache: Arc<Cache<Update, ()>> = Arc::new(Cache::new(config.cache_capacity));
+    let updates = gen_test_event_updates("$pageview", 100);
+    assert_eq!(updates.len(), 201);
+
+    process_batch_v2(&config, cache, &db, updates).await;
+
+    // fetch results and ensure they landed correctly
+    let event_defs_count: u64 =
+        sqlx::query_scalar!(r#"SELECT count(*) from posthog_eventdefinition"#);
+    assert_eq!(1, event_defs_count);
+
+    let prop_defs_count: u64 =
+        sqlx::query_scalar!(r#"SELECT count(*) from posthog_propertydefinition"#);
+    assert_eq!(100, prop_defs_count);
+
+    let event_props_count: u64 =
+        sqlx::query_scalar!(r#"SELECT count(*) from posthog_eventproperty"#);
+    assert_eq!(100, event_props_count);
+}
+
+fn gen_test_event_updates(event_name: &'static str, num_props: usize) -> Vec<Update> {
+    let prop_kvs = (0..num_props)
+        .map(|ndx| gen_test_prop_key_value(ndx))
+        .collect::<Vec<(String, Value)>>();
+
+    let mut properties = HashMap::<String, Value>::new();
+    for kv in prop_kvs {
+        properties.insert(kv.0, kv.1);
+    }
+
+    let event = json!({
+        "team_id": 111,
+        "project_id": 111,
+        "event": event_name,
+        "properties": properties,
+    });
+
+    // each non-person property will generate 1 event_property and 1 property_definition
+    // Update, and we add one more for the event_definition Update from the parent
+    let limit = (2 * num_props) + 1;
+
+    serde_json::from_value::<Event>(event)
+        .unwrap()
+        .into_updates(limit)
+}
+
+fn gen_test_prop_key_value(ndx: usize) -> (String, Value) {
+    use rand::seq::SliceRandom;
+
+    match [0, 1, 2, 3].choose(&mut rand::thread_rng()) {
+        // String
+        Some(&0) => (
+            format!("str_prop_{}", ndx),
+            Value::String(format!("value_{}", ndx)),
+        ),
+
+        // Boolean
+        Some(&1) => (format!("bool_prop_{}", ndx), Value::Bool(true)),
+
+        // Numeric
+        Some(&2) => (
+            format!("numeric_prop_{}", ndx),
+            json!(rand::thread_rng().gen_range(0..1000)),
+        ),
+
+        // DateTime
+        Some(&3) => (
+            format!("datetime_prop_{}", ndx),
+            Value::String(Utc::now().to_rfc3339()),
+        ),
+
+        // skipping Duration as it's unused for now
+        _ => panic!("not reachable"),
+    }
+}


### PR DESCRIPTION
## Problem
Batch writes mix heterogenous data types and spread writes across multiple tables. 

## Changes
* Vectorize batch writes - [the internet](https://www.timescale.com/blog/boosting-postgres-insert-performance) thinks this will be a 2x query latency improvement 🤞 
* Refactor batching (behind `enable_v2` feature flag!) to isolate batch writes by data type and sink table

I suspect this will be a quick win prior to isolating the DB or more comprehensive "V2" refactors, so I'm borrowing the new `enable_v2` config flag to condition this for testing in `dev` (then `prod-{us,eu}`) to get it shipped quick.

I propmise I'll return the flag to it's intended use case for the mirror deployment afterwards 👍 

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally and in CI. Soon in `dev` (with or without mirror deploy)
