### PR TITLE
fix(stop-bad-view-update): Prohibit unaliased view modification

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
@@ -89,7 +89,13 @@ export function QueryWindow({ onSetMonacoAndEditor }: QueryWindowProps): JSX.Ele
                                 types: response?.types ?? [],
                             })
                         }
-                        disabledReason={updatingDataWarehouseSavedQuery ? 'Saving...' : ''}
+                        disabledReason={
+                            !isValidView
+                                ? 'Some fields may need an alias'
+                                : updatingDataWarehouseSavedQuery
+                                ? 'Saving...'
+                                : ''
+                        }
                         icon={<IconDownload />}
                         type="tertiary"
                         size="xsmall"


### PR DESCRIPTION
## Problem
Users can break our aliasing standards for view resulting in confusing states in our subsequent dlt delta situation once an update like this occurs.

## Changes

- [x] Enforce the same standard for updates that we do for 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Prevents button clicking when the view should not be changed.
