### PR TITLE
feat(dashboards): improve ux of adding insights to dashboard

### DIFF
--- a/frontend/src/scenes/saved-insights/AddSavedInsightsToDashboard.tsx
+++ b/frontend/src/scenes/saved-insights/AddSavedInsightsToDashboard.tsx
@@ -8,7 +8,7 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { LemonTable, LemonTableColumn, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { createdAtColumn, createdByColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
-import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
+import { Link } from 'lib/lemon-ui/Link'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { SavedInsightsEmptyState } from 'scenes/insights/EmptyStates'
@@ -40,6 +40,38 @@ export function AddSavedInsightsToDashboard(): JSX.Element {
 
     const columns: LemonTableColumns<QueryBasedInsightModel> = [
         {
+            width: 0,
+            render: function Render(_, insight) {
+                const isInDashboard = dashboard?.tiles.some((tile) => tile.insight?.id === insight.id)
+                return (
+                    <LemonButton
+                        type="secondary"
+                        status={isInDashboard ? 'danger' : 'default'}
+                        size="small"
+                        fullWidth
+                        disabled={dashboardUpdatesInProgress[insight.id]}
+                        onClick={(e) => {
+                            e.preventDefault()
+                            if (dashboardUpdatesInProgress[insight.id]) {
+                                return
+                            }
+                            isInDashboard
+                                ? removeInsightFromDashboard(insight, dashboard?.id || 0)
+                                : addInsightToDashboard(insight, dashboard?.id || 0)
+                        }}
+                    >
+                        {dashboardUpdatesInProgress[insight.id] ? (
+                            <Spinner textColored />
+                        ) : isInDashboard ? (
+                            <IconMinusSmall />
+                        ) : (
+                            <IconPlusSmall />
+                        )}
+                    </LemonButton>
+                )
+            },
+        },
+        {
             key: 'id',
             width: 32,
             render: function renderType(_, insight) {
@@ -53,11 +85,14 @@ export function AddSavedInsightsToDashboard(): JSX.Element {
             render: function renderName(name: string, insight) {
                 return (
                     <>
-                        <LemonTableLink
-                            to={urls.insightView(insight.short_id)}
-                            title={<>{name || <i>{summarizeInsight(insight.query)}</i>}</>}
-                            description={insight.description}
-                        />
+                        <div className="flex flex-col gap-1">
+                            <div className="inline-flex">
+                                <Link to={urls.insightView(insight.short_id)} target="_blank">
+                                    {name || <i>{summarizeInsight(insight.query)}</i>}
+                                </Link>
+                            </div>
+                            <div className="text-xs text-tertiary">{insight.description}</div>
+                        </div>
                     </>
                 )
             },
@@ -90,38 +125,6 @@ export function AddSavedInsightsToDashboard(): JSX.Element {
             render: function renderLastModified(last_modified_at: string) {
                 return (
                     <div className="whitespace-nowrap">{last_modified_at && <TZLabel time={last_modified_at} />}</div>
-                )
-            },
-        },
-        {
-            width: 0,
-            render: function Render(_, insight) {
-                const isInDashboard = dashboard?.tiles.some((tile) => tile.insight?.id === insight.id)
-                return (
-                    <LemonButton
-                        type="secondary"
-                        status={isInDashboard ? 'danger' : 'default'}
-                        size="small"
-                        fullWidth
-                        disabled={dashboardUpdatesInProgress[insight.id]}
-                        onClick={(e) => {
-                            e.preventDefault()
-                            if (dashboardUpdatesInProgress[insight.id]) {
-                                return
-                            }
-                            isInDashboard
-                                ? removeInsightFromDashboard(insight, dashboard?.id || 0)
-                                : addInsightToDashboard(insight, dashboard?.id || 0)
-                        }}
-                    >
-                        {dashboardUpdatesInProgress[insight.id] ? (
-                            <Spinner textColored />
-                        ) : isInDashboard ? (
-                            <IconMinusSmall />
-                        ) : (
-                            <IconPlusSmall />
-                        )}
-                    </LemonButton>
                 )
             },
         },


### PR DESCRIPTION
## Problem
a different iteration on the same problem as #30413 and this [slack thread](https://posthog.slack.com/archives/C045L1VEG87/p1742681394616439)



<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- links to actually open the insight in a **new tab**
- removed lemon table link, so the whole row is not clickable. 
- if i'm not clicking on the exact link text, it should +/-, but if i'm clicking exactly on the link, it should open the insight the action buttons are aligned with how i scan the page 


<img width="1139" alt="image" src="https://github.com/user-attachments/assets/65b48bb8-eaa4-4e2e-9c3b-d307157d27d4" />

![Clipboard-20250325-235717-069](https://github.com/user-attachments/assets/a461ee1f-a06b-4ad3-a3f4-bea879b35f9f)


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
