### PR TITLE
fix: null on survey single question chart

### DIFF
--- a/frontend/src/scenes/surveys/surveyViewViz.tsx
+++ b/frontend/src/scenes/surveys/surveyViewViz.tsx
@@ -6,7 +6,7 @@ import {
     IconThumbsUp,
     IconThumbsUpFilled,
 } from '@posthog/icons'
-import { LemonButton, LemonTable } from '@posthog/lemon-ui'
+import { LemonButton, LemonCheckbox, LemonTable } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
 import { FlaggedFeature } from 'lib/components/FlaggedFeature'
@@ -381,7 +381,8 @@ export function SingleChoiceQuestionPieChart({
     surveySingleChoiceResultsReady: QuestionResultsReady
 }): JSX.Element {
     const { loadSurveySingleChoiceResults } = useActions(surveyLogic)
-    const { survey } = useValues(surveyLogic)
+    const { survey, showSkipped } = useValues(surveyLogic)
+    const { setShowSkipped } = useActions(surveyLogic)
 
     const question = survey.questions[questionIndex]
     if (question.type !== SurveyQuestionType.SingleChoice) {
@@ -419,9 +420,12 @@ export function SingleChoiceQuestionPieChart({
             ) : !surveySingleChoiceResults[questionIndex]?.data.length ? (
                 <></>
             ) : (
-                <div>
-                    <div className="font-semibold text-secondary">Single choice</div>
-                    <div className="text-xl font-bold mb-2">{question.question}</div>
+                <div className="flex flex-col gap-2">
+                    <div>
+                        <div className="font-semibold text-secondary">Single choice</div>
+                        <div className="text-xl font-bold">{question.question}</div>
+                    </div>
+                    <LemonCheckbox label="Show skipped responses" checked={showSkipped} onChange={setShowSkipped} />
                     <div className="h-80 overflow-y-auto border rounded pt-4 pb-2 flex">
                         <div className="relative h-full w-80">
                             <BindLogic logic={insightLogic} props={insightProps}>

--- a/frontend/src/scenes/surveys/surveyViewViz.tsx
+++ b/frontend/src/scenes/surveys/surveyViewViz.tsx
@@ -6,7 +6,7 @@ import {
     IconThumbsUp,
     IconThumbsUpFilled,
 } from '@posthog/icons'
-import { LemonButton, LemonCheckbox, LemonTable } from '@posthog/lemon-ui'
+import { LemonButton, LemonTable } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
 import { FlaggedFeature } from 'lib/components/FlaggedFeature'
@@ -381,8 +381,7 @@ export function SingleChoiceQuestionPieChart({
     surveySingleChoiceResultsReady: QuestionResultsReady
 }): JSX.Element {
     const { loadSurveySingleChoiceResults } = useActions(surveyLogic)
-    const { survey, showSkipped } = useValues(surveyLogic)
-    const { setShowSkipped } = useActions(surveyLogic)
+    const { survey } = useValues(surveyLogic)
 
     const question = survey.questions[questionIndex]
     if (question.type !== SurveyQuestionType.SingleChoice) {
@@ -425,7 +424,6 @@ export function SingleChoiceQuestionPieChart({
                         <div className="font-semibold text-secondary">Single choice</div>
                         <div className="text-xl font-bold">{question.question}</div>
                     </div>
-                    <LemonCheckbox label="Show skipped responses" checked={showSkipped} onChange={setShowSkipped} />
                     <div className="h-80 overflow-y-auto border rounded pt-4 pb-2 flex">
                         <div className="relative h-full w-80">
                             <BindLogic logic={insightLogic} props={insightProps}>


### PR DESCRIPTION
## Problem

when a single-choice question is skipped (due to conditional logic or making it optional), it shows a `null` in the chart which is not very useful.

## Changes

hides `null` responses from the pie chart

`null` is no longer shown

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

yes

## How did you test this code?

smoke tests locally