### PR TITLE
fix(data-warehouse): Fix data imports for PlanetScale MySQL

### DIFF
--- a/posthog/models/filters/test/__snapshots__/test_filter.ambr
+++ b/posthog/models/filters/test/__snapshots__/test_filter.ambr
@@ -472,7 +472,7 @@
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '75'
+  WHERE ("posthog_filesystem"."ref" = '85'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'cohort')
   ORDER BY "posthog_filesystem"."id" ASC
@@ -579,7 +579,7 @@
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '76'
+  WHERE ("posthog_filesystem"."ref" = '86'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'cohort')
   ORDER BY "posthog_filesystem"."id" ASC
@@ -677,7 +677,7 @@
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '77'
+  WHERE ("posthog_filesystem"."ref" = '87'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'cohort')
   ORDER BY "posthog_filesystem"."id" ASC
@@ -842,7 +842,7 @@
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '78'
+  WHERE ("posthog_filesystem"."ref" = '88'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'cohort')
   ORDER BY "posthog_filesystem"."id" ASC
@@ -871,7 +871,7 @@
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '79'
+  WHERE ("posthog_filesystem"."ref" = '89'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'cohort')
   ORDER BY "posthog_filesystem"."id" ASC
@@ -900,7 +900,7 @@
          "posthog_filesystem"."created_at",
          "posthog_filesystem"."created_by_id"
   FROM "posthog_filesystem"
-  WHERE ("posthog_filesystem"."ref" = '80'
+  WHERE ("posthog_filesystem"."ref" = '90'
          AND "posthog_filesystem"."team_id" = 99999
          AND "posthog_filesystem"."type" = 'cohort')
   ORDER BY "posthog_filesystem"."id" ASC


### PR DESCRIPTION
## Problem

PlanetScale (MySQL) has a limit of 100k rows per query causing an error on the import.

## Changes

Copy over connection settings we were using with the old DLT-based MySQL source.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

I haven't
