### PR TITLE
feat(experiments): add ExperimentSavedMetrics to django admin

### DIFF
--- a/posthog/admin/__init__.py
+++ b/posthog/admin/__init__.py
@@ -9,6 +9,7 @@ from posthog.admin.admins import (
     DataColorThemeAdmin,
     InsightAdmin,
     ExperimentAdmin,
+    ExperimentSavedMetricAdmin,
     FeatureFlagAdmin,
     AsyncDeletionAdmin,
     InstanceSettingAdmin,
@@ -32,6 +33,7 @@ from posthog.models import (
     DashboardTemplate,
     Insight,
     Experiment,
+    ExperimentSavedMetric,
     DataColorTheme,
     FeatureFlag,
     AsyncDeletion,
@@ -61,6 +63,7 @@ admin.site.register(GroupTypeMapping, GroupTypeMappingAdmin)
 admin.site.register(DataColorTheme, DataColorThemeAdmin)
 
 admin.site.register(Experiment, ExperimentAdmin)
+admin.site.register(ExperimentSavedMetric, ExperimentSavedMetricAdmin)
 admin.site.register(FeatureFlag, FeatureFlagAdmin)
 
 admin.site.register(AsyncDeletion, AsyncDeletionAdmin)

--- a/posthog/admin/admins/__init__.py
+++ b/posthog/admin/admins/__init__.py
@@ -5,6 +5,7 @@ from .dashboard_template_admin import DashboardTemplateAdmin
 from .data_color_theme_admin import DataColorThemeAdmin
 from .data_warehouse_table_admin import DataWarehouseTableAdmin
 from .experiment_admin import ExperimentAdmin
+from .experiment_saved_metric_admin import ExperimentSavedMetricAdmin
 from .feature_flag_admin import FeatureFlagAdmin
 from .group_type_mapping_admin import GroupTypeMappingAdmin
 from .insight_admin import InsightAdmin

--- a/posthog/admin/admins/cohort_admin.py
+++ b/posthog/admin/admins/cohort_admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.utils.html import format_html
+from django.urls import reverse
 
 from posthog.models import Cohort
 
@@ -21,7 +22,7 @@ class CohortAdmin(admin.ModelAdmin):
     @admin.display(description="Team")
     def team_link(self, cohort: Cohort):
         return format_html(
-            '<a href="/admin/posthog/team/{}/change/">{}</a>',
-            cohort.team.pk,
+            '<a href="{}">{}</a>',
+            reverse("admin:posthog_team_change", args=[cohort.team.pk]),
             cohort.team.name,
         )

--- a/posthog/admin/admins/dashboard_admin.py
+++ b/posthog/admin/admins/dashboard_admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.utils.html import format_html
+from django.urls import reverse
 
 from posthog.models import Dashboard, DashboardTile
 
@@ -36,15 +37,15 @@ class DashboardAdmin(admin.ModelAdmin):
     @admin.display(description="Team")
     def team_link(self, dashboard: Dashboard):
         return format_html(
-            '<a href="/admin/posthog/team/{}/change/">{}</a>',
-            dashboard.team.pk,
+            '<a href="{}">{}</a>',
+            reverse("admin:posthog_team_change", args=[dashboard.team.pk]),
             dashboard.team.name,
         )
 
     @admin.display(description="Organization")
     def organization_link(self, dashboard: Dashboard):
         return format_html(
-            '<a href="/admin/posthog/organization/{}/change/">{}</a>',
-            dashboard.team.organization.pk,
+            '<a href="{}">{}</a>',
+            reverse("admin:posthog_organization_change", args=[dashboard.team.organization.pk]),
             dashboard.team.organization.name,
         )

--- a/posthog/admin/admins/dashboard_template_admin.py
+++ b/posthog/admin/admins/dashboard_template_admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.utils.html import format_html
+from django.urls import reverse
 
 from posthog.models.dashboard_templates import DashboardTemplate
 
@@ -25,7 +26,7 @@ class DashboardTemplateAdmin(admin.ModelAdmin):
         if template.team is None:
             return None
         return format_html(
-            '<a href="/admin/posthog/team/{}/change/">{}</a>',
-            template.team.pk,
+            '<a href="{}">{}</a>',
+            reverse("admin:posthog_team_change", args=[template.team.pk]),
             template.team.name,
         )

--- a/posthog/admin/admins/data_color_theme_admin.py
+++ b/posthog/admin/admins/data_color_theme_admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.utils.html import format_html
+from django.urls import reverse
 
 from posthog.models import DataColorTheme
 
@@ -13,11 +14,9 @@ class DataColorThemeAdmin(admin.ModelAdmin):
     readonly_fields = ("team",)
 
     @admin.display(description="Team")
-    def team_link(self, theme: DataColorTheme):
-        if theme.team is None:
-            return None
+    def team_link(self, data_color_theme: DataColorTheme):
         return format_html(
-            '<a href="/admin/posthog/team/{}/change/">{}</a>',
-            theme.team.pk,
-            theme.team.name,
+            '<a href="{}">{}</a>',
+            reverse("admin:posthog_team_change", args=[data_color_theme.team.pk]),
+            data_color_theme.team.name,
         )

--- a/posthog/admin/admins/data_color_theme_admin.py
+++ b/posthog/admin/admins/data_color_theme_admin.py
@@ -15,6 +15,8 @@ class DataColorThemeAdmin(admin.ModelAdmin):
 
     @admin.display(description="Team")
     def team_link(self, data_color_theme: DataColorTheme):
+        if not data_color_theme.team:
+            return "-"
         return format_html(
             '<a href="{}">{}</a>',
             reverse("admin:posthog_team_change", args=[data_color_theme.team.pk]),

--- a/posthog/admin/admins/data_warehouse_table_admin.py
+++ b/posthog/admin/admins/data_warehouse_table_admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.utils.html import format_html
+from django.urls import reverse
 
 from posthog.models import Dashboard
 
@@ -24,15 +25,15 @@ class DataWarehouseTableAdmin(admin.ModelAdmin):
     @admin.display(description="Team")
     def team_link(self, dashboard: Dashboard):
         return format_html(
-            '<a href="/admin/posthog/team/{}/change/">{}</a>',
-            dashboard.team.pk,
+            '<a href="{}">{}</a>',
+            reverse("admin:posthog_team_change", args=[dashboard.team.pk]),
             dashboard.team.name,
         )
 
     @admin.display(description="Organization")
     def organization_link(self, dashboard: Dashboard):
         return format_html(
-            '<a href="/admin/posthog/organization/{}/change/">{}</a>',
-            dashboard.team.organization.pk,
+            '<a href="{}">{}</a>',
+            reverse("admin:posthog_organization_change", args=[dashboard.team.organization.pk]),
             dashboard.team.organization.name,
         )

--- a/posthog/admin/admins/experiment_admin.py
+++ b/posthog/admin/admins/experiment_admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.utils.html import format_html
+from django.urls import reverse
 
 from posthog.models import Experiment
 
@@ -21,7 +22,7 @@ class ExperimentAdmin(admin.ModelAdmin):
     @admin.display(description="Team")
     def team_link(self, experiment: Experiment):
         return format_html(
-            '<a href="/admin/posthog/team/{}/change/">{}</a>',
-            experiment.team.pk,
+            '<a href="{}">{}</a>',
+            reverse("admin:posthog_team_change", args=[experiment.team.pk]),
             experiment.team.name,
         )

--- a/posthog/admin/admins/experiment_saved_metric_admin.py
+++ b/posthog/admin/admins/experiment_saved_metric_admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django.utils.html import format_html
-
+from django.urls import reverse
 from posthog.models import ExperimentSavedMetric
 
 
@@ -21,7 +21,7 @@ class ExperimentSavedMetricAdmin(admin.ModelAdmin):
     @admin.display(description="Team")
     def team_link(self, saved_metric: ExperimentSavedMetric):
         return format_html(
-            '<a href="/admin/posthog/team/{}/change/">{}</a>',
-            saved_metric.team.pk,
+            '<a href="{}">{}</a>',
+            reverse("admin:posthog_team_change", args=[saved_metric.team.pk]),
             saved_metric.team.name,
         )

--- a/posthog/admin/admins/experiment_saved_metric_admin.py
+++ b/posthog/admin/admins/experiment_saved_metric_admin.py
@@ -1,0 +1,27 @@
+from django.contrib import admin
+from django.utils.html import format_html
+
+from posthog.models import ExperimentSavedMetric
+
+
+class ExperimentSavedMetricAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "name",
+        "team_link",
+        "created_at",
+        "created_by",
+    )
+    list_display_links = ("id", "name")
+    list_select_related = ("team", "team__organization")
+    search_fields = ("id", "name", "team__name", "team__organization__name")
+    autocomplete_fields = ("team", "created_by")
+    ordering = ("-created_at",)
+
+    @admin.display(description="Team")
+    def team_link(self, saved_metric: ExperimentSavedMetric):
+        return format_html(
+            '<a href="/admin/posthog/team/{}/change/">{}</a>',
+            saved_metric.team.pk,
+            saved_metric.team.name,
+        )

--- a/posthog/admin/admins/feature_flag_admin.py
+++ b/posthog/admin/admins/feature_flag_admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.utils.html import format_html
+from django.urls import reverse
 
 from posthog.models import FeatureFlag
 
@@ -21,7 +22,7 @@ class FeatureFlagAdmin(admin.ModelAdmin):
     @admin.display(description="Team")
     def team_link(self, flag: FeatureFlag):
         return format_html(
-            '<a href="/admin/posthog/team/{}/change/">{}</a>',
-            flag.team.pk,
+            '<a href="{}">{}</a>',
+            reverse("admin:posthog_team_change", args=[flag.team.pk]),
             flag.team.name,
         )

--- a/posthog/admin/admins/group_type_mapping_admin.py
+++ b/posthog/admin/admins/group_type_mapping_admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.utils.html import format_html
+from django.urls import reverse
 
 from posthog.models.group_type_mapping import GroupTypeMapping
 
@@ -19,7 +20,7 @@ class GroupTypeMappingAdmin(admin.ModelAdmin):
     @admin.display(description="Team")
     def team_link(self, group_type_mapping: GroupTypeMapping):
         return format_html(
-            '<a href="/admin/posthog/team/{}/change/">{}</a>',
-            group_type_mapping.team.pk,
+            '<a href="{}">{}</a>',
+            reverse("admin:posthog_team_change", args=[group_type_mapping.team.pk]),
             group_type_mapping.team.name,
         )

--- a/posthog/admin/admins/hog_function_admin.py
+++ b/posthog/admin/admins/hog_function_admin.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.contrib import admin
 from django.utils.html import format_html
+from django.urls import reverse
 
 from posthog.models.hog_functions.hog_function import HogFunction, HogFunctionState
 
@@ -58,11 +59,11 @@ class HogFunctionAdmin(admin.ModelAdmin):
     )
 
     @admin.display(description="Team")
-    def team_link(self, instance: HogFunction):
+    def team_link(self, hog_function):
         return format_html(
-            '<a href="/admin/posthog/team/{}/change/">{}</a>',
-            instance.team.pk,
-            instance.team.name,
+            '<a href="{}">{}</a>',
+            reverse("admin:posthog_team_change", args=[hog_function.team.pk]),
+            hog_function.team.name,
         )
 
     def save_model(self, request, obj: HogFunction, form, change):

--- a/posthog/admin/admins/insight_admin.py
+++ b/posthog/admin/admins/insight_admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.utils.html import format_html
+from django.urls import reverse
 
 from posthog.models import Insight
 
@@ -29,15 +30,15 @@ class InsightAdmin(admin.ModelAdmin):
     @admin.display(description="Team")
     def team_link(self, insight: Insight):
         return format_html(
-            '<a href="/admin/posthog/team/{}/change/">{}</a>',
-            insight.team.pk,
+            '<a href="{}">{}</a>',
+            reverse("admin:posthog_team_change", args=[insight.team.pk]),
             insight.team.name,
         )
 
     @admin.display(description="Organization")
     def organization_link(self, insight: Insight):
         return format_html(
-            '<a href="/admin/posthog/organization/{}/change/">{}</a>',
-            insight.team.organization.pk,
+            '<a href="{}">{}</a>',
+            reverse("admin:posthog_organization_change", args=[insight.team.organization.pk]),
             insight.team.organization.name,
         )

--- a/posthog/admin/admins/organization_admin.py
+++ b/posthog/admin/admins/organization_admin.py
@@ -76,7 +76,7 @@ class OrganizationAdmin(admin.ModelAdmin):
     def first_member(self, organization: Organization):
         user = organization.members.order_by("id").first()
         return (
-            format_html(f'<a href="/admin/posthog/user/{user.pk}/change/">{user.email}</a>')
+            format_html('<a href="{}">{}</a>', reverse("admin:posthog_user_change", args=[user.pk]), user.email)
             if user is not None
             else "None"
         )

--- a/posthog/admin/admins/project_admin.py
+++ b/posthog/admin/admins/project_admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.utils.html import format_html
+from django.urls import reverse
 
 from posthog.admin.inlines.team_inline import TeamInline
 from posthog.models import Project
@@ -27,7 +28,7 @@ class ProjectAdmin(admin.ModelAdmin):
 
     def organization_link(self, project: Project):
         return format_html(
-            '<a href="/admin/posthog/organization/{}/change/">{}</a>',
-            project.organization.pk,
+            '<a href="{}">{}</a>',
+            reverse("admin:posthog_organization_change", args=[project.organization.pk]),
             project.organization.name,
         )

--- a/posthog/admin/admins/survey_admin.py
+++ b/posthog/admin/admins/survey_admin.py
@@ -1,7 +1,8 @@
 from django.contrib import admin
 from django.utils.html import format_html
+from django.urls import reverse
 
-from posthog.models import Experiment
+from posthog.models import Survey
 
 
 class SurveyAdmin(admin.ModelAdmin):
@@ -35,9 +36,9 @@ class SurveyAdmin(admin.ModelAdmin):
         return form
 
     @admin.display(description="Team")
-    def team_link(self, experiment: Experiment):
+    def team_link(self, survey: Survey):
         return format_html(
-            '<a href="/admin/posthog/team/{}/change/">{}</a>',
-            experiment.team.pk,
-            experiment.team.name,
+            '<a href="{}">{}</a>',
+            reverse("admin:posthog_team_change", args=[survey.team.pk]),
+            survey.team.name,
         )

--- a/posthog/admin/admins/team_admin.py
+++ b/posthog/admin/admins/team_admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django.utils.html import format_html
 from posthog.admin.inlines.action_inline import ActionInline
 from posthog.admin.inlines.group_type_mapping_inline import GroupTypeMappingInline
+from django.urls import reverse
 
 from posthog.models import Team
 
@@ -113,14 +114,16 @@ class TeamAdmin(admin.ModelAdmin):
 
     def organization_link(self, team: Team):
         return format_html(
-            '<a href="/admin/posthog/organization/{}/change/">{}</a>',
-            team.organization.pk,
+            '<a href="{}">{}</a>',
+            reverse("admin:posthog_organization_change", args=[team.organization.pk]),
             team.organization.name,
         )
 
     def project_link(self, team: Team):
-        return format_html(
-            '<a href="/admin/posthog/project/{}/change/">{}</a>',
-            team.project.pk,
-            team.project.name,
-        )
+        if team.project:
+            return format_html(
+                '<a href="{}">{}</a>',
+                reverse("admin:posthog_project_change", args=[team.project.pk]),
+                team.project.name,
+            )
+        return "-"

--- a/posthog/admin/admins/team_admin.py
+++ b/posthog/admin/admins/team_admin.py
@@ -113,11 +113,13 @@ class TeamAdmin(admin.ModelAdmin):
     ]
 
     def organization_link(self, team: Team):
-        return format_html(
-            '<a href="{}">{}</a>',
-            reverse("admin:posthog_organization_change", args=[team.organization.pk]),
-            team.organization.name,
-        )
+        if team.organization:
+            return format_html(
+                '<a href="{}">{}</a>',
+                reverse("admin:posthog_organization_change", args=[team.organization.pk]),
+                team.organization.name,
+            )
+        return "-"
 
     def project_link(self, team: Team):
         if team.project:

--- a/posthog/admin/admins/user_admin.py
+++ b/posthog/admin/admins/user_admin.py
@@ -3,6 +3,7 @@ from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
 from django.contrib.auth.forms import UserChangeForm as DjangoUserChangeForm
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
+from django.urls import reverse
 
 from posthog.admin.inlines.organization_member_inline import OrganizationMemberInline
 from posthog.admin.inlines.totp_device_inline import TOTPDeviceInline
@@ -77,8 +78,8 @@ class UserAdmin(DjangoUserAdmin):
             return "–"
 
         return format_html(
-            '<a href="/admin/posthog/team/{}/change/">{}</a>',
-            user.team.pk,
+            '<a href="{}">{}</a>',
+            reverse("admin:posthog_team_change", args=[user.team.pk]),
             user.team.name,
         )
 
@@ -88,7 +89,7 @@ class UserAdmin(DjangoUserAdmin):
             return "–"
 
         return format_html(
-            '<a href="/admin/posthog/organization/{}/change/">{}</a>',
-            user.organization.pk,
+            '<a href="{}">{}</a>',
+            reverse("admin:posthog_organization_change", args=[user.organization.pk]),
             user.organization.name,
         )

--- a/posthog/models/__init__.py
+++ b/posthog/models/__init__.py
@@ -42,7 +42,7 @@ from .event.event import Event
 from .event_buffer import EventBuffer
 from .event_definition import EventDefinition
 from .event_property import EventProperty
-from .experiment import Experiment
+from .experiment import Experiment, ExperimentSavedMetric
 from .exported_asset import ExportedAsset
 from .feature_flag import FeatureFlag
 from .surveys.survey import Survey
@@ -125,6 +125,7 @@ __all__ = [
     "EventDefinition",
     "EventProperty",
     "Experiment",
+    "ExperimentSavedMetric",
     "ExportedAsset",
     "FeatureFlag",
     "FileSystem",

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -112,7 +112,7 @@ class Cohort(FileSystemSyncMixin, models.Model):
     objects = CohortManager()
 
     def __str__(self):
-        return self.name
+        return self.name or "Untitled cohort"
 
     @classmethod
     def get_file_system_unfiled(cls, team: "Team") -> QuerySet["Cohort"]:


### PR DESCRIPTION
## Problem
We are rolling out a new metric format, and it's not 100% stable yet. So for the few metrics we stored in the db in production, it's cumbersome to update those to the new format.

Also, django admin interface fails for experiments due to unnamed cohorts.

## Changes
* Make `ExperimentSavedMetric` available in Django admin for easy editing and issue fixing in production.
<img width="1640" alt="Screenshot 2025-03-26 at 12 36 38" src="https://github.com/user-attachments/assets/bc8bfd0d-557f-486f-81ba-d010bcd39d43" />

* Make sure we return a string in `__str__` function on the `Cohort` models. We allow empty values in the db, and django fails hard if this function returns `None`.

* use `django.url.reverse` in all admin views to get URL's instead of hard-coding them

## How did you test this code?
* tested locally