### PR TITLE
fix(devex): fix URL matching in project tree, fix side action in project tree

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -116,7 +116,7 @@ export function ProjectTree(): JSX.Element {
                     if (!item.record?.href) {
                         return false
                     }
-                    return window.location.href.includes(item.record?.href) ? true : false
+                    return window.location.href.endsWith(item.record?.href)
                 }}
                 onNodeClick={(node) => {
                     if (!isLayoutPanelPinned) {

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -1,7 +1,6 @@
-import { IconFolderPlus } from '@posthog/icons'
-import { LemonButton } from '@posthog/lemon-ui'
+import { IconEllipsis, IconFolderPlus } from '@posthog/icons'
+import { LemonButton, LemonMenu, LemonMenuItems } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
-import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonTree, LemonTreeRef } from 'lib/lemon-ui/LemonTree/LemonTree'
 import { ContextMenuGroup, ContextMenuItem } from 'lib/ui/ContextMenu/ContextMenu'
 import { IconWrapper } from 'lib/ui/IconWrapper/IconWrapper'
@@ -239,61 +238,50 @@ export function ProjectTree(): JSX.Element {
                     }
                     return {
                         icon: (
-                            <More
-                                size="xsmall"
-                                onClick={(e) => e.stopPropagation()}
-                                overlay={
-                                    <>
-                                        {item.record?.type === 'folder' || item.record?.type === 'project' ? (
-                                            <LemonButton
-                                                onClick={(e) => {
-                                                    e.stopPropagation()
-                                                    item.record?.path && createFolder(item.record.path)
-                                                }}
-                                                fullWidth
-                                                size="small"
-                                            >
-                                                New Folder
-                                            </LemonButton>
-                                        ) : null}
-                                        {item.record?.path ? (
-                                            <LemonButton
-                                                onClick={() => item.record?.path && rename(item.record.path)}
-                                                fullWidth
-                                                size="small"
-                                            >
-                                                Rename
-                                            </LemonButton>
-                                        ) : null}
-                                        {item.record?.path ? (
-                                            <LemonButton
-                                                onClick={(e) => {
-                                                    e.stopPropagation()
-                                                    handleCopyPath(item.record?.path)
-                                                }}
-                                                fullWidth
-                                                size="small"
-                                            >
-                                                Copy Path
-                                            </LemonButton>
-                                        ) : null}
-                                        {item.record?.created_at ? (
-                                            <LemonButton
-                                                onClick={(e) => {
-                                                    e.stopPropagation()
-                                                    deleteItem(item.record as unknown as FileSystemEntry)
-                                                }}
-                                                fullWidth
-                                                size="small"
-                                            >
-                                                Delete
-                                            </LemonButton>
-                                        ) : null}
-                                    </>
+                            <LemonMenu
+                                placement="top-end"
+                                fallbackPlacements={['bottom-end']}
+                                items={
+                                    [
+                                        item.record?.type === 'folder' || item.record?.type === 'project'
+                                            ? {
+                                                  label: 'New Folder',
+                                                  onClick: () => {
+                                                      item.record?.path && createFolder(item.record.path)
+                                                  },
+                                              }
+                                            : undefined,
+                                        item.record?.path
+                                            ? {
+                                                  label: 'Rename',
+                                                  onClick: () => {
+                                                      item.record?.path && rename(item.record.path)
+                                                  },
+                                              }
+                                            : undefined,
+                                        item.record?.path
+                                            ? {
+                                                  label: 'Copy Path',
+                                                  onClick: () => {
+                                                      handleCopyPath(item.record?.path)
+                                                  },
+                                              }
+                                            : undefined,
+                                        item.record?.path
+                                            ? {
+                                                  label: 'Delete',
+                                                  onClick: () => {
+                                                      deleteItem(item.record as unknown as FileSystemEntry)
+                                                  },
+                                              }
+                                            : undefined,
+                                    ].filter(Boolean) as LemonMenuItems
                                 }
-                            />
+                                maxContentWidth={true}
+                            >
+                                <IconEllipsis className="size-4 text-tertiary" />
+                            </LemonMenu>
                         ),
-                        identifier: item.record?.path || 'more',
                     }
                 }}
             />

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -217,7 +217,7 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                                         <ContextMenuTrigger asChild>
                                             <LemonButton
                                                 className={cn(
-                                                    'group/lemon-tree-button flex-1 flex items-center gap-2 font-normal cursor-pointer z-10',
+                                                    'group/lemon-tree-button flex-1 flex items-center gap-2 font-normal cursor-pointer z-1',
                                                     {
                                                         'ring-2 ring-inset ring-offset-[-1px] ring-accent-primary':
                                                             focusedId === item.id ||


### PR DESCRIPTION
## Problem
* Project tree was suggesting both URLS: `example/1` and `example/11` were current with `includes()`
* Recent changes to z-indexes in the lemon tree removed `sideAction` from being interacted with

<img width="710" alt="image" src="https://github.com/user-attachments/assets/aaa9a455-948a-466d-b3f1-1daed9c9222a" />

## Changes
* Project tree matches URLs with `endsWith` 
* Lemon tree z-indexes toned down, 
* Move Project tree sideAction to a better API using  `<LemonMenu>` instead of `<More>`
* 
![2025-03-26 12 20 09](https://github.com/user-attachments/assets/b9033ab3-b7c6-413b-a927-187df7c6ef2a)

## How did you test this code?
Locally