### PR TITLE
feat(crm): Use singular name for the `group_name` column

### DIFF
--- a/frontend/src/scenes/groups/Groups.tsx
+++ b/frontend/src/scenes/groups/Groups.tsx
@@ -7,7 +7,7 @@ import { Query } from '~/queries/Query/Query'
 import { groupsListLogic } from './groupsListLogic'
 
 export function Groups({ groupTypeIndex }: { groupTypeIndex: number }): JSX.Element {
-    const { query } = useValues(groupsListLogic({ groupTypeIndex }))
+    const { query, groupTypeName } = useValues(groupsListLogic({ groupTypeIndex }))
     const { setQuery } = useActions(groupsListLogic({ groupTypeIndex }))
     const { groupsAccessStatus } = useValues(groupsAccessLogic)
 
@@ -34,6 +34,11 @@ export function Groups({ groupTypeIndex }: { groupTypeIndex: number }): JSX.Elem
             context={{
                 refresh: 'blocking',
                 emptyStateHeading: 'No groups found',
+                columns: {
+                    group_name: {
+                        title: groupTypeName,
+                    },
+                },
             }}
             dataAttr="groups-table"
         />

--- a/frontend/src/scenes/groups/groupsListLogic.ts
+++ b/frontend/src/scenes/groups/groupsListLogic.ts
@@ -1,4 +1,4 @@
-import { actions, connect, kea, key, path, props, reducers } from 'kea'
+import { actions, connect, kea, key, path, props, reducers, selectors } from 'kea'
 import { groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -45,6 +45,12 @@ export const groupsListLogic = kea<groupsListLogicType>([
                     propertiesViaUrl: true,
                 } as DataTableNode),
             { setQuery: (_, { query }) => query },
+        ],
+    }),
+    selectors({
+        groupTypeName: [
+            (s, p) => [s.aggregationLabel, p.groupTypeIndex],
+            (aggregationLabel, index): string => aggregationLabel(index).singular,
         ],
     }),
 ])


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/29881

## Changes

| Before | After |
|--------|--------|
| ![CleanShot 2025-03-26 at 05 39 46@2x](https://github.com/user-attachments/assets/9e8acb95-4e9a-41d7-8666-05b61ca3695f) | ![CleanShot 2025-03-26 at 05 38 01@2x](https://github.com/user-attachments/assets/3387dd41-0c5a-4df7-99a8-22bacdbca774) | 

## How did you test this code?

Visual review