### PR TITLE
fix(cdp): nested popover broken

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
@@ -7,7 +7,7 @@ import {
     TaxonomicFilterGroupType,
     TaxonomicFilterProps,
 } from 'lib/components/TaxonomicFilter/types'
-import React, { useEffect, useState } from 'react'
+import React, { forwardRef, useEffect, useState } from 'react'
 import { LogicalRowDivider } from 'scenes/cohorts/CohortFilters/CohortCriteriaRowBuilder'
 
 import { AnyDataNode, DatabaseSchemaField } from '~/queries/schema/schema-general'
@@ -45,9 +45,10 @@ interface PropertyFiltersProps {
     disabledReason?: string
     exactMatchFeatureFlagCohortOperators?: boolean
     hideBehavioralCohorts?: boolean
+    ref?: React.RefCallback<HTMLDivElement>
 }
 
-export function PropertyFilters({
+export const PropertyFilters = forwardRef<HTMLButtonElement, PropertyFiltersProps>(({
     propertyFilters = null,
     onChange,
     pageKey,
@@ -75,7 +76,7 @@ export function PropertyFilters({
     disabledReason = undefined,
     exactMatchFeatureFlagCohortOperators = false,
     hideBehavioralCohorts,
-}: PropertyFiltersProps): JSX.Element {
+}, ref): JSX.Element => {
     const logicProps = { propertyFilters, onChange, pageKey, sendAllKeyUpdates }
     const { filters, filtersWithNew } = useValues(propertyFilterLogic(logicProps))
     const { remove, setFilters, setFilter } = useActions(propertyFilterLogic(logicProps))
@@ -141,6 +142,7 @@ export function PropertyFilters({
                                             allowRelativeDateOptions={allowRelativeDateOptions}
                                             exactMatchFeatureFlagCohortOperators={exactMatchFeatureFlagCohortOperators}
                                             hideBehavioralCohorts={hideBehavioralCohorts}
+                                            ref={ref}
                                         />
                                     )}
                                     errorMessage={errorMessages && errorMessages[index]}
@@ -154,4 +156,4 @@ export function PropertyFilters({
             </div>
         </div>
     )
-}
+})

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -20,7 +20,7 @@ import {
     TaxonomicFilterValue,
 } from 'lib/components/TaxonomicFilter/types'
 import { isOperatorMulti, isOperatorRegex } from 'lib/utils'
-import { useMemo } from 'react'
+import { forwardRef, useMemo } from 'react'
 
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import {
@@ -36,7 +36,7 @@ import { taxonomicPropertyFilterLogic } from './taxonomicPropertyFilterLogic'
 
 let uniqueMemoizedIndex = 0
 
-export function TaxonomicPropertyFilter({
+export const TaxonomicPropertyFilter = forwardRef<HTMLButtonElement, PropertyFilterInternalProps>(({
     pageKey: pageKeyInput,
     index,
     filters,
@@ -57,7 +57,7 @@ export function TaxonomicPropertyFilter({
     allowRelativeDateOptions,
     exactMatchFeatureFlagCohortOperators,
     hideBehavioralCohorts,
-}: PropertyFilterInternalProps): JSX.Element {
+}, ref): JSX.Element => {
     const pageKey = useMemo(() => pageKeyInput || `filter-${uniqueMemoizedIndex++}`, [pageKeyInput])
     const groupTypes = taxonomicGroupTypes || [
         TaxonomicFilterGroupType.EventProperties,
@@ -219,6 +219,7 @@ export function TaxonomicPropertyFilter({
                                 data-attr={'property-select-toggle-' + index}
                                 sideIcon={null} // The null sideIcon is here on purpose - it prevents the dropdown caret
                                 onClick={() => (dropdownOpen ? closeDropdown() : openDropdown())}
+                                ref={ref}
                             >
                                 {filter?.type === 'cohort' ? (
                                     filter.cohort_name || `Cohort #${filter?.value}`
@@ -243,4 +244,4 @@ export function TaxonomicPropertyFilter({
             )}
         </div>
     )
-}
+})

--- a/frontend/src/lib/components/PropertyFilters/types.ts
+++ b/frontend/src/lib/components/PropertyFilters/types.ts
@@ -55,4 +55,5 @@ export interface PropertyFilterInternalProps {
     allowRelativeDateOptions?: boolean
     exactMatchFeatureFlagCohortOperators?: boolean
     hideBehavioralCohorts?: boolean
+    ref?: React.RefCallback<HTMLDivElement>
 }

--- a/frontend/src/lib/lemon-ui/LemonDropdown/LemonDropdown.tsx
+++ b/frontend/src/lib/lemon-ui/LemonDropdown/LemonDropdown.tsx
@@ -19,6 +19,8 @@ export interface LemonDropdownProps extends Omit<PopoverProps, 'children' | 'vis
             'aria-haspopup': Required<React.AriaAttributes>['aria-haspopup']
         }
     >
+    /** Any other refs that needs to be taken into account for handling outside clicks e.g. other nested popovers. */
+    additionalRefs?: React.MutableRefObject<HTMLDivElement | null>[]
 }
 
 /** A wrapper that provides a dropdown for any element supporting `onClick`. Built on top of Popover. */
@@ -34,6 +36,7 @@ export const LemonDropdown: React.FunctionComponent<LemonDropdownProps & React.R
                 closeOnClickInside = true,
                 trigger = 'click',
                 children,
+                additionalRefs = [],
                 ...popoverProps
             },
             ref
@@ -58,15 +61,18 @@ export const LemonDropdown: React.FunctionComponent<LemonDropdownProps & React.R
             return (
                 <Popover
                     ref={ref}
+                    additionalRefs={additionalRefs}
                     floatingRef={floatingRef}
                     referenceRef={referenceRef}
                     onClickOutside={(e) => {
+                        console.log('abcde onClickOutside detected', e)
                         if (trigger === 'click') {
                             setVisible(false)
                         }
                         onClickOutside?.(e)
                     }}
                     onClickInside={(e) => {
+                        console.log('abcde onClickInside detected', e)
                         e.stopPropagation()
                         closeOnClickInside && setVisible(false)
                         onClickInside?.(e)

--- a/frontend/src/lib/lemon-ui/Popover/Popover.tsx
+++ b/frontend/src/lib/lemon-ui/Popover/Popover.tsx
@@ -56,7 +56,7 @@ export interface PopoverProps {
     padded?: boolean
     middleware?: Middleware[]
     /** Any other refs that needs to be taken into account for handling outside clicks e.g. other nested popovers. */
-    additionalRefs?: React.MutableRefObject<HTMLDivElement | null>[]
+    additionalRefs?: React.MutableRefObject<HTMLDivElement | HTMLButtonElement | null>[]
     referenceRef?: UseFloatingReturn['refs']['reference']
     floatingRef?: UseFloatingReturn['refs']['floating']
     style?: React.CSSProperties

--- a/frontend/src/scenes/pipeline/hogFunctionTestingLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogFunctionTestingLogic.tsx
@@ -53,6 +53,7 @@ export const hogFunctionTestingLogic = kea<hogFunctionTestingLogicType>([
         deselectForRetry: (eventIds: string[]) => ({ eventIds }),
         resetSelectedForRetry: true,
         setSelectingMany: (selectingMany: boolean) => ({ selectingMany }),
+        setDisplayFilters: (displayFilters: boolean) => ({ displayFilters }),
     }),
     reducers({
         dateRange: [
@@ -104,6 +105,12 @@ export const hogFunctionTestingLogic = kea<hogFunctionTestingLogicType>([
                     ...state.filter((id: string) => !eventIds.includes(id)),
                 ],
                 resetSelectedForRetry: () => [],
+            },
+        ],
+        displayFilters: [
+            false as boolean,
+            {
+                setDisplayFilters: (_, { displayFilters }: { displayFilters: boolean }) => displayFilters,
             },
         ],
     }),

--- a/frontend/src/scenes/pipeline/hogfunctions/filters/HogFunctionFilters.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/filters/HogFunctionFilters.tsx
@@ -15,6 +15,7 @@ import { AnyPropertyFilter, EntityTypes, FilterType, HogFunctionFiltersType } fr
 
 import { hogFunctionConfigurationLogic } from '../hogFunctionConfigurationLogic'
 import { HogFunctionFiltersInternal } from './HogFunctionFiltersInternal'
+import { forwardRef } from 'react'
 
 function sanitizeActionFilters(filters?: FilterType): Partial<HogFunctionFiltersType> {
     if (!filters) {
@@ -45,7 +46,7 @@ function sanitizeActionFilters(filters?: FilterType): Partial<HogFunctionFilters
     return sanitized
 }
 
-export function HogFunctionFilters({ embedded = false }: { embedded?: boolean }): JSX.Element {
+export const HogFunctionFilters = forwardRef<HTMLButtonElement, { embedded?: boolean }>(({ embedded = false }, ref) => {
     const { groupsTaxonomicTypes } = useValues(groupsModel)
     const { configuration, type, useMapping, filtersContainPersonProperties } = useValues(hogFunctionConfigurationLogic)
 
@@ -142,6 +143,7 @@ export function HogFunctionFilters({ embedded = false }: { embedded?: boolean })
                                             })
                                         }}
                                         pageKey={`HogFunctionPropertyFilters.${id}`}
+                                        ref={ref}
                                     />
                                 </>
                             )}
@@ -352,4 +354,4 @@ export function HogFunctionFilters({ embedded = false }: { embedded?: boolean })
             ) : null}
         </div>
     )
-}
+})


### PR DESCRIPTION
## Problem

When clicking on a LemonDropdown, nested in a Popover, the click will close the entire popover.
![2025-03-26 at 14 05 26](https://github.com/user-attachments/assets/aec5dd75-9dcc-48e1-a512-72d124a0fe3b)

The issue is that LemonDropdown is using another Popover that is using a Portal, so the click will be detected as "being outside".

We can resolve this issue by providing the top Popover the ref of each nested LemonDropdown:
![2025-03-26 at 14 30 39](https://github.com/user-attachments/assets/460ae5d8-d603-43b2-860e-0630becb5bc4) 

BUUUT getting all of the refs is easier said than done. Especially since they'll prop drill through >10 components.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
