### PR TITLE
refactor: remove processPerson arg default value

### DIFF
--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -70,7 +70,7 @@ export class EventsProcessor {
         teamId: number,
         timestamp: DateTime,
         eventUuid: string,
-        processPerson: boolean = false
+        processPerson: boolean
     ): Promise<PreIngestionEvent> {
         const singleSaveTimer = new Date()
         const timeout = timeoutGuard(

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -537,7 +537,8 @@ test('capture bad team', async () => {
             } as any as PluginEvent,
             1337,
             now,
-            new UUIDT().toString()
+            new UUIDT().toString(),
+            false
         )
     ).rejects.toThrowError("No team found with ID 1337. Can't ingest event.")
 })


### PR DESCRIPTION
## Problem

There's no actual impact, but having a default false value somewhere for person processing is asking for trouble.

## Changes

Removes the `processEvent` default value for the `processPerson` argument, fixes the broken test.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Covered by tests.