### PR TITLE
fix: make ci try multiple docker ups 

### DIFF
--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -38,8 +38,33 @@ runs:
               export CLICKHOUSE_SERVER_IMAGE=${{ inputs.clickhouse-server-image }}
               export DOCKER_REGISTRY_PREFIX="us-east1-docker.pkg.dev/posthog-301601/mirror/"
               cp posthog/user_scripts/latest_user_defined_function.xml docker/clickhouse/user_defined_function.xml
-              docker compose -f docker-compose.dev.yml down
-              docker compose -f docker-compose.dev.yml up -d
+
+              max_attempts=3
+              attempt=1
+              delay=5
+
+              while [ $attempt -le $max_attempts ]; do
+                  echo "Attempt $attempt of $max_attempts to start stack..."
+                  
+                  if docker compose -f docker-compose.dev.yml down && \
+                     docker compose -f docker-compose.dev.yml up -d; then
+                      echo "Stack started successfully"
+                      exit 0
+                  fi
+                  
+                  echo "Failed to start stack on attempt $attempt"
+                  
+                  if [ $attempt -lt $max_attempts ]; then
+                      sleep_time=$((delay * 2 ** (attempt - 1)))
+                      echo "Waiting ${sleep_time} seconds before retry..."
+                      sleep $sleep_time
+                  fi
+                  
+                  attempt=$((attempt + 1))
+              done
+
+              echo "Failed to start stack after $max_attempts attempts"
+              exit 1
 
         - name: Add Kafka and ClickHouse to /etc/hosts
           shell: bash

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -2,6 +2,7 @@ from unittest import mock
 from uuid import UUID
 
 from freezegun.api import freeze_time
+from orjson import orjson
 
 from posthog.helpers.dashboard_templates import create_group_type_mapping_detail_dashboard
 from posthog.hogql.parser import parse_select
@@ -285,7 +286,10 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
             ),
             self.team,
         )
-        self.assertEqual(response.results, [('{"name": "Mr. Krabs", "industry": "technology"}',)])
+        # Check properties regardless of JSON key order
+        self.assertEqual(len(response.results), 1)
+        self.assertEqual(len(response.results[0]), 1)
+        self.assertEqual(orjson.loads(response.results[0][0]), {"name": "Mr. Krabs", "industry": "technology"})
 
         mock_capture.assert_called_once_with(
             distinct_id=str(self.team.uuid),


### PR DESCRIPTION
CI Often fails with errors like this:
![image](https://github.com/user-attachments/assets/bf873909-d2b9-48ad-a6a5-0925ed52c2a0)

Try to retry in that case until we get a successful up