### PR TITLE
chore: fix layout of billing summary and badge if no sub

### DIFF
--- a/frontend/src/scenes/billing/Billing.tsx
+++ b/frontend/src/scenes/billing/Billing.tsx
@@ -165,12 +165,16 @@ export function Billing(): JSX.Element {
 
             {(showBillingSummary || showCreditCTAHero || showBillingHero) && (
                 <div
-                    className={clsx('flex gap-6 max-w-300', {
+                    className={clsx(
+                        'flex gap-6 max-w-300',
                         // If there's no active subscription, BillingSummary is small so we stack it and invert order with CreditCTAHero or BillingHero
-                        'flex-col': size === 'small' && billing?.has_active_subscription,
-                        'flex-row': size !== 'small' && billing?.has_active_subscription,
-                        'flex-col-reverse': !billing?.has_active_subscription,
-                    })}
+                        billing?.has_active_subscription
+                            ? {
+                                  'flex-col': size === 'small',
+                                  'flex-row': size !== 'small',
+                              }
+                            : 'flex-col-reverse'
+                    )}
                 >
                     {showBillingSummary && (
                         <div className={clsx('flex-1', { 'flex-grow-0': showCreditCTAHero })}>

--- a/frontend/src/scenes/billing/Billing.tsx
+++ b/frontend/src/scenes/billing/Billing.tsx
@@ -166,8 +166,10 @@ export function Billing(): JSX.Element {
             {(showBillingSummary || showCreditCTAHero || showBillingHero) && (
                 <div
                     className={clsx('flex gap-6 max-w-300', {
-                        'flex-col': size === 'small',
-                        'flex-row': size !== 'small',
+                        // If there's no active subscription, BillingSummary is small so we stack it and invert order with CreditCTAHero or BillingHero
+                        'flex-col': size === 'small' && billing?.has_active_subscription,
+                        'flex-row': size !== 'small' && billing?.has_active_subscription,
+                        'flex-col-reverse': !billing?.has_active_subscription,
                     })}
                 >
                     {showBillingSummary && (


### PR DESCRIPTION
## Problem

When on free plan, the `BillingSummary` info is small as we don't show current and projected bill.

## Changes

Stack the `CreditCTAHero` or `BillingHero` on top of `BillingSummary` even on desktop, if the user is on a free plan.

## Does this work well for both Cloud and self-hosted?

Cloud only

## How did you test this code?

Tested manually multiple scenarios (sub/no sub, free/paid plan, desktop/mobile)

![SCR-20250326-psym](https://github.com/user-attachments/assets/adea9977-82e1-4330-a1ec-fe72e2a89b21)