### PR TITLE
fix: Actually give mutations a bit of time to show up in mutation runner

### DIFF
--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -512,6 +512,7 @@ class MutationRunner(abc.ABC):
             mutations_running = self.find_existing_mutations(client, expected_commands)
             if mutations_running.keys() == expected_commands:
                 return MutationWaiter(self.table, set(mutations_running.values()))
+            time.sleep(1.0)
 
         raise Exception(
             f"unable to find mutation for {expected_commands - mutations_running.keys()!r} after {time.time() - start:0.2f}s!"


### PR DESCRIPTION
## Problem

We are not giving mutations a long enough grace period to arrive because I accidentally removed the retry delay when refactoring this code in #29510.

## Changes

Brings back the delay that was originally added in #28069.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

😑 