### PR TITLE
fix(web-analytics): live users count interval is rerendering charts

### DIFF
--- a/frontend/src/scenes/web-analytics/WebAnalyticsLiveUserCount.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsLiveUserCount.tsx
@@ -51,3 +51,26 @@ export const WebAnalyticsLiveUserCount = (): JSX.Element | null => {
         </Tooltip>
     )
 }
+
+const SecondsAgoTooltipText = (): JSX.Element | null => {
+    const { currentTeam } = useValues(teamLogic)
+    const { liveUserUpdatedSecondsAgo, liveUserCount } = useValues(liveEventsTableLogic)
+
+    if (liveUserCount == null) {
+        return null
+    }
+
+    const updatedAgoString =
+        liveUserUpdatedSecondsAgo === 0
+            ? ' (updated just now)'
+            : liveUserUpdatedSecondsAgo == null
+            ? ''
+            : ` (updated ${liveUserUpdatedSecondsAgo} seconds ago)`
+
+    const usersOnlineString = `${humanFriendlyNumber(liveUserCount)} ${
+        liveUserCount === 1 ? 'user is' : 'users are'
+    } online`
+    const inTeamString = currentTeam ? ` in ${currentTeam.name}` : ''
+    const tooltip = `${usersOnlineString}${inTeamString}${updatedAgoString}`
+    return <>{tooltip}</>
+}

--- a/frontend/src/scenes/web-analytics/WebAnalyticsLiveUserCount.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsLiveUserCount.tsx
@@ -8,6 +8,8 @@ import { teamLogic } from 'scenes/teamLogic'
 import { liveEventsTableLogic } from 'scenes/web-analytics/liveWebAnalyticsLogic'
 
 const SecondsAgoTooltipText = (): JSX.Element | null => {
+    // We connect to liveUserUpdatedSecondsAgo only when the user is hovering over the indicator
+    // otherwise we were causing a lot of unnecessary re-renders. See: https://github.com/PostHog/posthog/pull/30477
     const { liveUserCount, liveUserUpdatedSecondsAgo } = useValues(liveEventsTableLogic)
     const { currentTeam } = useValues(teamLogic)
 

--- a/frontend/src/scenes/web-analytics/WebAnalyticsLiveUserCount.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsLiveUserCount.tsx
@@ -1,39 +1,46 @@
 import './WebAnalyticsLiveUserCount.scss'
 
 import clsx from 'clsx'
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { humanFriendlyLargeNumber, humanFriendlyNumber } from 'lib/utils'
+import { useEffect } from 'react'
 import { teamLogic } from 'scenes/teamLogic'
-import { liveEventsTableLogic } from 'scenes/web-analytics/liveWebAnalyticsLogic'
+import { liveWebAnalyticsLogic } from 'scenes/web-analytics/liveWebAnalyticsLogic'
 
-const SecondsAgoTooltipText = (): JSX.Element | null => {
-    // We connect to liveUserUpdatedSecondsAgo only when the user is hovering over the indicator
-    // otherwise we were causing a lot of unnecessary re-renders. See: https://github.com/PostHog/posthog/pull/30477
-    const { liveUserCount, liveUserUpdatedSecondsAgo } = useValues(liveEventsTableLogic)
+const TooltipContent = (): JSX.Element | null => {
     const { currentTeam } = useValues(teamLogic)
+    const { liveUserUpdatedSecondsAgo, liveUserCount } = useValues(liveWebAnalyticsLogic)
+    const { setIsHovering } = useActions(liveWebAnalyticsLogic)
+
+    // This is only rendered when the tooltip is open, so we will let the Kea interval knows
+    // when we're rendered and when we're not
+    useEffect(() => {
+        setIsHovering(true)
+        return () => setIsHovering(false)
+    }, [setIsHovering])
 
     if (liveUserCount == null) {
         return null
     }
 
-    const usersOnlineString = `${humanFriendlyNumber(liveUserCount)} ${
-        liveUserCount === 1 ? 'user is' : 'users are'
-    } online`
-    const inTeamString = currentTeam ? ` in ${currentTeam.name}` : ''
     const updatedAgoString =
         liveUserUpdatedSecondsAgo === 0
             ? ' (updated just now)'
             : liveUserUpdatedSecondsAgo == null
             ? ''
             : ` (updated ${liveUserUpdatedSecondsAgo} seconds ago)`
-    const tooltip = `${usersOnlineString}${inTeamString}${updatedAgoString}`
 
+    const usersOnlineString = `${humanFriendlyNumber(liveUserCount)} ${
+        liveUserCount === 1 ? 'user is' : 'users are'
+    } online`
+    const inTeamString = currentTeam ? ` in ${currentTeam.name}` : ''
+    const tooltip = `${usersOnlineString}${inTeamString}${updatedAgoString}`
     return <>{tooltip}</>
 }
 
 export const WebAnalyticsLiveUserCount = (): JSX.Element | null => {
-    const { liveUserCount } = useValues(liveEventsTableLogic)
+    const { liveUserCount } = useValues(liveWebAnalyticsLogic)
 
     // No data yet, or feature flag disabled
     if (liveUserCount == null) {
@@ -41,7 +48,7 @@ export const WebAnalyticsLiveUserCount = (): JSX.Element | null => {
     }
 
     return (
-        <Tooltip title={<SecondsAgoTooltipText />}>
+        <Tooltip title={<TooltipContent />} interactive={true} delayMs={0}>
             <div className="flex flex-row items-center justify-center">
                 <div className={clsx('live-user-indicator', liveUserCount > 0 ? 'online' : 'offline')} />
                 <span className="whitespace-nowrap" data-attr="web-analytics-live-user-count">
@@ -50,27 +57,4 @@ export const WebAnalyticsLiveUserCount = (): JSX.Element | null => {
             </div>
         </Tooltip>
     )
-}
-
-const SecondsAgoTooltipText = (): JSX.Element | null => {
-    const { currentTeam } = useValues(teamLogic)
-    const { liveUserUpdatedSecondsAgo, liveUserCount } = useValues(liveEventsTableLogic)
-
-    if (liveUserCount == null) {
-        return null
-    }
-
-    const updatedAgoString =
-        liveUserUpdatedSecondsAgo === 0
-            ? ' (updated just now)'
-            : liveUserUpdatedSecondsAgo == null
-            ? ''
-            : ` (updated ${liveUserUpdatedSecondsAgo} seconds ago)`
-
-    const usersOnlineString = `${humanFriendlyNumber(liveUserCount)} ${
-        liveUserCount === 1 ? 'user is' : 'users are'
-    } online`
-    const inTeamString = currentTeam ? ` in ${currentTeam.name}` : ''
-    const tooltip = `${usersOnlineString}${inTeamString}${updatedAgoString}`
-    return <>{tooltip}</>
 }

--- a/frontend/src/scenes/web-analytics/WebAnalyticsLiveUserCount.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsLiveUserCount.tsx
@@ -1,47 +1,16 @@
 import './WebAnalyticsLiveUserCount.scss'
 
 import clsx from 'clsx'
-import { useActions, useValues } from 'kea'
+import { useValues } from 'kea'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { humanFriendlyLargeNumber, humanFriendlyNumber } from 'lib/utils'
-import { useEffect, useRef, useState } from 'react'
 import { teamLogic } from 'scenes/teamLogic'
 import { liveEventsTableLogic } from 'scenes/web-analytics/liveWebAnalyticsLogic'
 
-export const WebAnalyticsLiveUserCount = (): JSX.Element | null => {
+const SecondsAgoTooltipText = (): JSX.Element | null => {
     const { liveUserCount, liveUserUpdatedSecondsAgo } = useValues(liveEventsTableLogic)
-    const { setNow } = useActions(liveEventsTableLogic)
     const { currentTeam } = useValues(teamLogic)
-    const [isHovering, setIsHovering] = useState(false)
-    const intervalRef = useRef<number | null>(null)
 
-    // Start/stop the interval when tooltip visibility changes
-    useEffect(() => {
-        if (isHovering) {
-            if (intervalRef.current !== null) {
-                window.clearInterval(intervalRef.current)
-            }
-
-            intervalRef.current = window.setInterval(() => {
-                setNow({ now: new Date() })
-            }, 500)
-        } else {
-            if (intervalRef.current !== null) {
-                window.clearInterval(intervalRef.current)
-                intervalRef.current = null
-            }
-        }
-
-        // Cleanup on component unmount
-        return () => {
-            if (intervalRef.current !== null) {
-                window.clearInterval(intervalRef.current)
-                intervalRef.current = null
-            }
-        }
-    }, [isHovering, setNow])
-
-    // No data yet, or feature flag disabled
     if (liveUserCount == null) {
         return null
     }
@@ -58,13 +27,20 @@ export const WebAnalyticsLiveUserCount = (): JSX.Element | null => {
             : ` (updated ${liveUserUpdatedSecondsAgo} seconds ago)`
     const tooltip = `${usersOnlineString}${inTeamString}${updatedAgoString}`
 
+    return <>{tooltip}</>
+}
+
+export const WebAnalyticsLiveUserCount = (): JSX.Element | null => {
+    const { liveUserCount } = useValues(liveEventsTableLogic)
+
+    // No data yet, or feature flag disabled
+    if (liveUserCount == null) {
+        return null
+    }
+
     return (
-        <Tooltip title={tooltip}>
-            <div
-                className="flex flex-row items-center justify-center"
-                onMouseEnter={() => setIsHovering(true)}
-                onMouseLeave={() => setIsHovering(false)}
-            >
+        <Tooltip title={<SecondsAgoTooltipText />}>
+            <div className="flex flex-row items-center justify-center">
                 <div className={clsx('live-user-indicator', liveUserCount > 0 ? 'online' : 'offline')} />
                 <span className="whitespace-nowrap" data-attr="web-analytics-live-user-count">
                     <strong>{humanFriendlyLargeNumber(liveUserCount)}</strong> online

--- a/frontend/src/scenes/web-analytics/WebAnalyticsLiveUserCount.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsLiveUserCount.tsx
@@ -1,15 +1,45 @@
 import './WebAnalyticsLiveUserCount.scss'
 
 import clsx from 'clsx'
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { humanFriendlyLargeNumber, humanFriendlyNumber } from 'lib/utils'
+import { useEffect, useRef, useState } from 'react'
 import { teamLogic } from 'scenes/teamLogic'
 import { liveEventsTableLogic } from 'scenes/web-analytics/liveWebAnalyticsLogic'
 
 export const WebAnalyticsLiveUserCount = (): JSX.Element | null => {
     const { liveUserCount, liveUserUpdatedSecondsAgo } = useValues(liveEventsTableLogic)
+    const { setNow } = useActions(liveEventsTableLogic)
     const { currentTeam } = useValues(teamLogic)
+    const [isHovering, setIsHovering] = useState(false)
+    const intervalRef = useRef<number | null>(null)
+
+    // Start/stop the interval when tooltip visibility changes
+    useEffect(() => {
+        if (isHovering) {
+            if (intervalRef.current !== null) {
+                window.clearInterval(intervalRef.current)
+            }
+
+            intervalRef.current = window.setInterval(() => {
+                setNow({ now: new Date() })
+            }, 500)
+        } else {
+            if (intervalRef.current !== null) {
+                window.clearInterval(intervalRef.current)
+                intervalRef.current = null
+            }
+        }
+
+        // Cleanup on component unmount
+        return () => {
+            if (intervalRef.current !== null) {
+                window.clearInterval(intervalRef.current)
+                intervalRef.current = null
+            }
+        }
+    }, [isHovering, setNow])
 
     // No data yet, or feature flag disabled
     if (liveUserCount == null) {
@@ -30,7 +60,11 @@ export const WebAnalyticsLiveUserCount = (): JSX.Element | null => {
 
     return (
         <Tooltip title={tooltip}>
-            <div className="flex flex-row items-center justify-center">
+            <div
+                className="flex flex-row items-center justify-center"
+                onMouseEnter={() => setIsHovering(true)}
+                onMouseLeave={() => setIsHovering(false)}
+            >
                 <div className={clsx('live-user-indicator', liveUserCount > 0 ? 'online' : 'offline')} />
                 <span className="whitespace-nowrap" data-attr="web-analytics-live-user-count">
                     <strong>{humanFriendlyLargeNumber(liveUserCount)}</strong> online

--- a/frontend/src/scenes/web-analytics/liveWebAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/liveWebAnalyticsLogic.tsx
@@ -85,10 +85,6 @@ export const liveEventsTableLogic = kea<liveEventsTableLogicType>([
             cache.statsInterval = setInterval(() => {
                 actions.pollStats()
             }, 30000)
-
-            cache.nowInterval = setInterval(() => {
-                actions.setNow({ now: new Date() })
-            }, 500)
         },
         beforeUnmount: () => {
             if (cache.statsInterval) {

--- a/frontend/src/scenes/web-analytics/liveWebAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/liveWebAnalyticsLogic.tsx
@@ -85,6 +85,10 @@ export const liveEventsTableLogic = kea<liveEventsTableLogicType>([
             cache.statsInterval = setInterval(() => {
                 actions.pollStats()
             }, 30000)
+
+            cache.nowInterval = setInterval(() => {
+                actions.setNow({ now: new Date() })
+            }, 500)
         },
         beforeUnmount: () => {
             if (cache.statsInterval) {

--- a/frontend/src/scenes/web-analytics/liveWebAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/liveWebAnalyticsLogic.tsx
@@ -1,16 +1,15 @@
 import { actions, connect, events, kea, listeners, path, reducers, selectors } from 'kea'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { liveEventsHostOrigin } from 'lib/utils/apiHost'
 import { teamLogic } from 'scenes/teamLogic'
 
-import type { liveEventsTableLogicType } from './liveWebAnalyticsLogicType'
+import type { liveWebAnalyticsLogicType } from './liveWebAnalyticsLogicType'
 export interface StatsResponse {
     users_on_product?: number
 }
-export const liveEventsTableLogic = kea<liveEventsTableLogicType>([
-    path(['scenes', 'activity', 'live-events', 'liveEventsTableLogic']),
+export const liveWebAnalyticsLogic = kea<liveWebAnalyticsLogicType>([
+    path(['scenes', 'webAnalytics', 'liveWebAnalyticsLogic']),
     connect({
-        values: [teamLogic, ['currentTeam'], featureFlagLogic, ['featureFlags']],
+        values: [teamLogic, ['currentTeam']],
     }),
     actions(() => ({
         pollStats: true,
@@ -19,6 +18,7 @@ export const liveEventsTableLogic = kea<liveEventsTableLogicType>([
             now,
         }),
         setNow: ({ now }: { now: Date }) => ({ now }),
+        setIsHovering: (isHovering: boolean) => ({ isHovering }),
     })),
     reducers({
         liveUserCount: [
@@ -40,6 +40,12 @@ export const liveEventsTableLogic = kea<liveEventsTableLogicType>([
                 setLiveUserCount: (_, { now }) => now,
             },
         ],
+        isHovering: [
+            false,
+            {
+                setIsHovering: (_, { isHovering }) => isHovering,
+            },
+        ],
     }),
     selectors({
         liveUserUpdatedSecondsAgo: [
@@ -57,7 +63,7 @@ export const liveEventsTableLogic = kea<liveEventsTableLogicType>([
             },
         ],
     }),
-    listeners(({ actions, values }) => ({
+    listeners(({ actions, values, cache }) => ({
         pollStats: async () => {
             try {
                 if (!values.currentTeam) {
@@ -76,6 +82,17 @@ export const liveEventsTableLogic = kea<liveEventsTableLogicType>([
                 console.error('Failed to poll stats:', error)
             }
         },
+        setIsHovering: ({ isHovering }) => {
+            if (isHovering) {
+                actions.setNow({ now: new Date() })
+                cache.nowInterval = setInterval(() => {
+                    actions.setNow({ now: new Date() })
+                }, 500)
+            } else if (cache.nowInterval) {
+                clearInterval(cache.nowInterval)
+                cache.nowInterval = null
+            }
+        },
     })),
     events(({ actions, cache }) => ({
         afterMount: () => {
@@ -85,15 +102,15 @@ export const liveEventsTableLogic = kea<liveEventsTableLogicType>([
             cache.statsInterval = setInterval(() => {
                 actions.pollStats()
             }, 30000)
-
-            cache.nowInterval = setInterval(() => {
-                actions.setNow({ now: new Date() })
-            }, 500)
         },
         beforeUnmount: () => {
             if (cache.statsInterval) {
                 clearInterval(cache.statsInterval)
                 cache.statsInterval = null
+            }
+            if (cache.nowInterval) {
+                clearInterval(cache.nowInterval)
+                cache.nowInterval = null
             }
         },
     })),

--- a/frontend/src/scenes/web-analytics/liveWebAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/liveWebAnalyticsLogic.tsx
@@ -84,6 +84,9 @@ export const liveWebAnalyticsLogic = kea<liveWebAnalyticsLogicType>([
         },
         setIsHovering: ({ isHovering }) => {
             if (isHovering) {
+                if (cache.nowInterval) {
+                    clearInterval(cache.nowInterval)
+                }
                 actions.setNow({ now: new Date() })
                 cache.nowInterval = setInterval(() => {
                     actions.setNow({ now: new Date() })


### PR DESCRIPTION
## Problem

This is another take on #30407 after @thmsobrmlr's comment.

Live Web Analytics was causing way too many re-renders. The culprit? A 500ms interval updating the `now` state in `liveWebAnalyticsLogic` kicked off a chain reaction that ultimately made `WebAnalyticsDashboard` refresh way more than it needed to.

Debugging this was a bit of a headache—tracking down all the dependencies involved took a long time. This fix should improve things, but I'm not 100% sure it’s the best fix—just a quick one to stop the excessive re-renders and the tooltip bug.

## Changes

The debugging steps/explanation that I found were something like this (I filled my notes to a GPT to improve it):

- This interval calls `setNow` every 500ms, creating a new Date object with the current time
- This updates the `now` state in liveWebAnalyticsLogic with a new object reference
- The `liveUserUpdatedSecondsAgo` selector recalculates because it has now changed:
- The `WebAnalyticsLiveUserCount` component rerenders because its values from `liveEventsTableLogic` changed
- Since `WebAnalyticsLiveUserCount` is rendered in `WebAnalyticsFilters`:
- The parent `WebAnalyticsFilters` also rerenders
- The `WebAnalyticsDashboard` component rerenders because its child `Filters` component changed
- This causes all children of `WebAnalyticsDashboard` to rerender, including `MainContent` and `Tiles.`
- When `Tiles` rerenders, it creates new props for `LineGraph` components, which all have a useEffect with many dependencies and will destroy/create another graph.


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manually, adding many console.logs;

A quick way to note that this is happening is to hover over any chart insights on web analytics and check that the small bubbles on the data points blink. If you open the chart as an insight and do the same, you'll see that they don't.a 

You could also add logs to the useEffect on `[LineGraph](https://github.com/PostHog/posthog/blob/0444568519265371d31739a0ef3d698b463fa6b5/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx#L546)` to see it is constantly rerendering in WebAnalytics or just comment the setInterval on the `webAnalyticsLiveCountLogic`.
