### PR TITLE
fix(temporal): Only capture SIGTERM and SIGINT

### DIFF
--- a/bin/temporal-django-worker
+++ b/bin/temporal-django-worker
@@ -17,11 +17,22 @@ python3 manage.py start_temporal_worker "$@" &
 
 worker_pid=$!
 
-# Run wait in a loop in case we trap SIGTERM as that will cause wait to exit
-# potentially not waiting for graceful shutdown. When a SIGTERM is issued,
-# wait will exit with a status equal to signal number + 128.
-while wait $worker_pid; test $? -ge 128
-      do echo "Received signal, waiting for worker to finish"
+# Run wait in a loop in case we trap SIGTERM or SIGINT.
+# In both cases, wait will terminate early, potentially not waiting for graceful shutdown.
+while wait $worker_pid
+do
+    status=$?
+    # If we exit with SIGTERM, status will be 128 + 15.
+    # If we exit with SIGINT, status will be 128 + 2.
+    if [ $status -eq 143 ] || [ $status -eq 130 ]; then
+        echo "Received signal $(($status - 128)), waiting for worker to finish"
+    elif [ $status -eq 0 ]; then
+        echo "Worker exited normally, terminating wait"
+        break
+    else
+        echo "Worker exited with unexpected exit status $status, terminating wait"
+        break
+    fi
 done
 
 cleanup


### PR DESCRIPTION
## Problem

Occasionally, workers will exit with undefined exit codes. We will look into why that is the case, but in the meantime, don't keep the loop spinning on anything that is not SIGTERM or SIGINT.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
