### PR TITLE
feat(project-tree): more reliable moves

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -385,6 +385,9 @@ class ApiRequest {
     public fileSystemDetail(id: NonNullable<FileSystemEntry['id']>, projectId?: ProjectType['id']): ApiRequest {
         return this.fileSystem(projectId).addPathComponent(id)
     }
+    public fileSystemMove(id: NonNullable<FileSystemEntry['id']>, projectId?: ProjectType['id']): ApiRequest {
+        return this.fileSystem(projectId).addPathComponent(id).addPathComponent('move')
+    }
 
     // # Plugins
     public plugins(orgId?: OrganizationType['id']): ApiRequest {
@@ -1251,6 +1254,9 @@ const api = {
         },
         async delete(id: NonNullable<FileSystemEntry['id']>): Promise<FileSystemEntry> {
             return await new ApiRequest().fileSystemDetail(id).delete()
+        },
+        async move(id: NonNullable<FileSystemEntry['id']>, newPath: string): Promise<FileSystemEntry> {
+            return await new ApiRequest().fileSystemMove(id).create({ data: { new_path: newPath } })
         },
     },
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,6 @@
 [project]
+name = "posthog"
+version = "0.0.0"
 requires-python = ">=3.11"
 
 [tool.black]


### PR DESCRIPTION
## Problem

Until now you could not move folders, without loading into view and explicitly moving every folder item.

## Changes

Adds a backend move action that also moves the folder

![2025-03-27 13 08 18](https://github.com/user-attachments/assets/6904cb77-e1d5-40e5-95fc-5d4a80ca452a)


## How did you test this code?

Tested locally 