### PR TITLE
fix(err): default for cookieless

### DIFF
--- a/rust/common/types/src/event.rs
+++ b/rust/common/types/src/event.rs
@@ -47,7 +47,7 @@ pub struct CapturedEvent {
     )]
     pub sent_at: Option<OffsetDateTime>,
     pub token: String,
-    #[serde(skip_serializing_if = "<&bool>::not")] // only store if true
+    #[serde(skip_serializing_if = "<&bool>::not", default)]
     pub is_cookieless_mode: bool,
 }
 


### PR DESCRIPTION
We're failing to parse `CapturedEvent`s because there's no default and it's non-option