### PR TITLE
fix(cdp): dont show dropping warning on return event

### DIFF
--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
@@ -225,16 +225,22 @@ export type SparklineData = {
 
 // Helper function to check if code might return null/undefined
 export function mightDropEvents(code: string): boolean {
-    if (!code) {
+    const sanitizedCode = code
+        .replace(/\/\*[\s\S]*?\*\/|\/\/.*/g, '') // Remove comments
+        .replace(/\s+/g, ' ') // Collapse whitespace
+        .trim()
+
+    if (!sanitizedCode) {
         return false
     }
+
     // Direct null/undefined returns
     if (
-        code.includes('return null') ||
-        code.includes('return undefined') ||
-        /\breturn\b\s*;/.test(code) ||
-        /\breturn\b\s*$/.test(code) ||
-        /\bif\s*\([^)]*\)\s*\{\s*\breturn\s+(null|undefined)\b/.test(code)
+        sanitizedCode.includes('return null') ||
+        sanitizedCode.includes('return undefined') ||
+        /\breturn\b\s*;/.test(sanitizedCode) ||
+        /\breturn\b\s*$/.test(sanitizedCode) ||
+        /\bif\s*\([^)]*\)\s*\{\s*\breturn\s+(null|undefined)\b/.test(sanitizedCode)
     ) {
         return true
     }


### PR DESCRIPTION
## Problem

we show the warning although we should not

<img width="635" alt="Screenshot 2025-03-27 at 15 10 54" src="https://github.com/user-attachments/assets/5555e5ea-2672-4e0e-9c01-8cc5961cb584" />


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- fixes that 

<img width="624" alt="Screenshot 2025-03-27 at 15 11 10" src="https://github.com/user-attachments/assets/f497b7b5-9d55-4656-b0b8-cde4d4044f0c" />


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- local dev

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
