### PR TITLE
fix(err): improve `was_minified` guess

### DIFF
--- a/rust/cymbal/src/langs/js.rs
+++ b/rust/cymbal/src/langs/js.rs
@@ -214,7 +214,8 @@ impl From<(&RawJSFrame, JsResolveErr, &FrameLocation)> for Frame {
         // TODO - extremely rough
         let was_minified = match err {
             JsResolveErr::NoSourceUrl | JsResolveErr::NoUrlOrChunkId => false, // This frame's `source` didn't exist
-            JsResolveErr::NoSourcemap(_) => false,                             // A total guess
+            // A total guess - intuition is people tend not to write lines longer than about 300 chars
+            JsResolveErr::NoSourcemap(_) => location.column > 300,
             _ => true,
         };
 


### PR DESCRIPTION
We're seeing customers where there is no sourcemap reference in the chunk, but it's still obviously minified. This is a small step towards getting better at differentiating those cases from actually unminified function names.

Note this is a fingerprint-impacting change, but I think a necessary one.