### PR TITLE
fix: Fix column names on revenue data warehouse examples table

### DIFF
--- a/posthog/hogql_queries/web_analytics/revenue_example_data_warehouse_tables_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/revenue_example_data_warehouse_tables_query_runner.py
@@ -95,7 +95,7 @@ class RevenueExampleDataWarehouseTablesQueryRunner(QueryRunner):
         )
 
         return RevenueExampleDataWarehouseTablesQueryResponse(
-            columns=["table_name", "original_revenue", "original_currency", "revenue", "currency"],
+            columns=["table_name", "distinct_id", "original_revenue", "original_currency", "revenue", "currency"],
             results=response.results,
             timings=response.timings,
             types=response.types,

--- a/posthog/hogql_queries/web_analytics/test/test_revenue_example_data_warehouse_tables_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/test/test_revenue_example_data_warehouse_tables_query_runner.py
@@ -194,11 +194,12 @@ class TestRevenueExampleDataWarehouseTablesQueryRunner(ClickhouseTestMixin, APIB
         "clickhouse_driver.result.QueryResult.get_result",
         return_value=(
             [
-                ("database_with_revenue_column", 42, "USD", 42, "USD"),
-                ("database_with_revenue_column", 43, "USD", 43, "USD"),
-                ("database_with_revenue_column", 44, "USD", 44, "USD"),
+                ("database_with_revenue_column", "distinct_id_1", 42, "USD", 42, "USD"),
+                ("database_with_revenue_column", "distinct_id_2", 43, "USD", 43, "USD"),
+                ("database_with_revenue_column", "distinct_id_3", 44, "USD", 44, "USD"),
             ],
             (
+                "String",
                 "String",
                 "Float64",
                 "String",
@@ -208,28 +209,32 @@ class TestRevenueExampleDataWarehouseTablesQueryRunner(ClickhouseTestMixin, APIB
         ),
     )
     def test_single_table_query(self, mock_get_result, feature_enabled_mock):
-        results = self._run_revenue_example_external_tables_query(SINGLE_TABLE_REVENUE_TRACKING_CONFIG).results
+        response = self._run_revenue_example_external_tables_query(SINGLE_TABLE_REVENUE_TRACKING_CONFIG)
+        results = response.results
 
+        # 3 rows, 6 columns
         assert len(results) == 3
+        assert len(results[0]) == 6
+        assert len(response.columns) == 6
 
-        # table_name, revenue
-        assert results[0] == ("database_with_revenue_column", 42, "USD", 42, "USD")
-        assert results[1] == ("database_with_revenue_column", 43, "USD", 43, "USD")
-        assert results[2] == ("database_with_revenue_column", 44, "USD", 44, "USD")
+        assert results[0] == ("database_with_revenue_column", "distinct_id_1", 42, "USD", 42, "USD")
+        assert results[1] == ("database_with_revenue_column", "distinct_id_2", 43, "USD", 43, "USD")
+        assert results[2] == ("database_with_revenue_column", "distinct_id_3", 44, "USD", 44, "USD")
 
     @patch("posthoganalytics.feature_enabled", return_value=False)
     @patch(
         "clickhouse_driver.result.QueryResult.get_result",
         return_value=(
             [
-                ("database_with_revenue_column_a", 42, "USD", 42, "USD"),
-                ("database_with_revenue_column_a", 43, "USD", 43, "USD"),
-                ("database_with_revenue_column_a", 44, "USD", 44, "USD"),
-                ("database_with_revenue_column_b", 43, "USD", 43, "USD"),
-                ("database_with_revenue_column_b", 44, "USD", 44, "USD"),
-                ("database_with_revenue_column_b", 45, "USD", 45, "USD"),
+                ("database_with_revenue_column_a", "distinct_id_1", 42, "USD", 42, "USD"),
+                ("database_with_revenue_column_a", "distinct_id_2", 43, "USD", 43, "USD"),
+                ("database_with_revenue_column_a", "distinct_id_3", 44, "USD", 44, "USD"),
+                ("database_with_revenue_column_b", "distinct_id_1", 43, "USD", 43, "USD"),
+                ("database_with_revenue_column_b", "distinct_id_2", 44, "USD", 44, "USD"),
+                ("database_with_revenue_column_b", "distinct_id_3", 45, "USD", 45, "USD"),
             ],
             (
+                "String",
                 "String",
                 "Float64",
                 "String",
@@ -239,29 +244,34 @@ class TestRevenueExampleDataWarehouseTablesQueryRunner(ClickhouseTestMixin, APIB
         ),
     )
     def test_multiple_tables_query(self, mock_get_result, feature_enabled_mock):
-        results = self._run_revenue_example_external_tables_query(MULTIPLE_TABLES_REVENUE_TRACKING_CONFIG).results
+        response = self._run_revenue_example_external_tables_query(MULTIPLE_TABLES_REVENUE_TRACKING_CONFIG)
+        results = response.results
 
+        # 6 rows, 6 columns
         assert len(results) == 6
+        assert len(results[0]) == 6
+        assert len(response.columns) == 6
 
         # Results are returned in the order defined by the SQL UNION ALL query
         # The first table from dataWarehouseTables should come first
-        assert results[0] == ("database_with_revenue_column_a", 42, "USD", 42, "USD")
-        assert results[1] == ("database_with_revenue_column_a", 43, "USD", 43, "USD")
-        assert results[2] == ("database_with_revenue_column_a", 44, "USD", 44, "USD")
-        assert results[3] == ("database_with_revenue_column_b", 43, "USD", 43, "USD")
-        assert results[4] == ("database_with_revenue_column_b", 44, "USD", 44, "USD")
-        assert results[5] == ("database_with_revenue_column_b", 45, "USD", 45, "USD")
+        assert results[0] == ("database_with_revenue_column_a", "distinct_id_1", 42, "USD", 42, "USD")
+        assert results[1] == ("database_with_revenue_column_a", "distinct_id_2", 43, "USD", 43, "USD")
+        assert results[2] == ("database_with_revenue_column_a", "distinct_id_3", 44, "USD", 44, "USD")
+        assert results[3] == ("database_with_revenue_column_b", "distinct_id_1", 43, "USD", 43, "USD")
+        assert results[4] == ("database_with_revenue_column_b", "distinct_id_2", 44, "USD", 44, "USD")
+        assert results[5] == ("database_with_revenue_column_b", "distinct_id_3", 45, "USD", 45, "USD")
 
     @patch("posthoganalytics.feature_enabled", return_value=True)
     @patch(
         "clickhouse_driver.result.QueryResult.get_result",
         return_value=(
             [
-                ("database_with_revenue_column", 42, "USD", 42, "USD"),
-                ("database_with_revenue_column", 43, "USD", 43, "USD"),
-                ("database_with_revenue_column", 44, "USD", 44, "USD"),
+                ("database_with_revenue_column", "distinct_id_1", 42, "USD", 42, "USD"),
+                ("database_with_revenue_column", "distinct_id_2", 43, "USD", 43, "USD"),
+                ("database_with_revenue_column", "distinct_id_3", 44, "USD", 44, "USD"),
             ],
             (
+                "String",
                 "String",
                 "Float64",
                 "String",
@@ -271,26 +281,29 @@ class TestRevenueExampleDataWarehouseTablesQueryRunner(ClickhouseTestMixin, APIB
         ),
     )
     def test_single_table_query_with_currency_conversion(self, mock_get_result, feature_enabled_mock):
-        results = self._run_revenue_example_external_tables_query(SINGLE_TABLE_REVENUE_TRACKING_CONFIG).results
+        response = self._run_revenue_example_external_tables_query(SINGLE_TABLE_REVENUE_TRACKING_CONFIG)
+        results = response.results
 
+        # 3 rows, 6 columns
         assert len(results) == 3
+        assert len(results[0]) == 6
+        assert len(response.columns) == 6
 
-        # table_name, revenue
-        assert results[0] == ("database_with_revenue_column", 42, "USD", 42, "USD")
-        assert results[1] == ("database_with_revenue_column", 43, "USD", 43, "USD")
-        assert results[2] == ("database_with_revenue_column", 44, "USD", 44, "USD")
+        assert results[0] == ("database_with_revenue_column", "distinct_id_1", 42, "USD", 42, "USD")
+        assert results[1] == ("database_with_revenue_column", "distinct_id_2", 43, "USD", 43, "USD")
+        assert results[2] == ("database_with_revenue_column", "distinct_id_3", 44, "USD", 44, "USD")
 
     @patch("posthoganalytics.feature_enabled", return_value=True)
     @patch(
         "clickhouse_driver.result.QueryResult.get_result",
         return_value=(
             [
-                ("database_with_revenue_column_a", 42, "USD", 42, "USD"),
-                ("database_with_revenue_column_a", 43, "USD", 43, "USD"),
-                ("database_with_revenue_column_a", 44, "USD", 44, "USD"),
-                ("database_with_revenue_column_b", 43, "USD", 43, "USD"),
-                ("database_with_revenue_column_b", 44, "USD", 44, "USD"),
-                ("database_with_revenue_column_b", 45, "USD", 45, "USD"),
+                ("database_with_revenue_column_a", "distinct_id_1", 42, "USD", 42, "USD"),
+                ("database_with_revenue_column_a", "distinct_id_2", 43, "USD", 43, "USD"),
+                ("database_with_revenue_column_a", "distinct_id_3", 44, "USD", 44, "USD"),
+                ("database_with_revenue_column_b", "distinct_id_1", 43, "USD", 43, "USD"),
+                ("database_with_revenue_column_b", "distinct_id_2", 44, "USD", 44, "USD"),
+                ("database_with_revenue_column_b", "distinct_id_3", 45, "USD", 45, "USD"),
             ],
             (
                 "String",
@@ -302,15 +315,19 @@ class TestRevenueExampleDataWarehouseTablesQueryRunner(ClickhouseTestMixin, APIB
         ),
     )
     def test_multiple_tables_query_with_currency_conversion(self, mock_get_result, feature_enabled_mock):
-        results = self._run_revenue_example_external_tables_query(MULTIPLE_TABLES_REVENUE_TRACKING_CONFIG).results
+        response = self._run_revenue_example_external_tables_query(MULTIPLE_TABLES_REVENUE_TRACKING_CONFIG)
+        results = response.results
 
+        # 6 rows, 6 columns
         assert len(results) == 6
+        assert len(results[0]) == 6
+        assert len(response.columns) == 6
 
         # Results are returned in the order defined by the SQL UNION ALL query
         # The first table from dataWarehouseTables should come first
-        assert results[0] == ("database_with_revenue_column_a", 42, "USD", 42, "USD")
-        assert results[1] == ("database_with_revenue_column_a", 43, "USD", 43, "USD")
-        assert results[2] == ("database_with_revenue_column_a", 44, "USD", 44, "USD")
-        assert results[3] == ("database_with_revenue_column_b", 43, "USD", 43, "USD")
-        assert results[4] == ("database_with_revenue_column_b", 44, "USD", 44, "USD")
-        assert results[5] == ("database_with_revenue_column_b", 45, "USD", 45, "USD")
+        assert results[0] == ("database_with_revenue_column_a", "distinct_id_1", 42, "USD", 42, "USD")
+        assert results[1] == ("database_with_revenue_column_a", "distinct_id_2", 43, "USD", 43, "USD")
+        assert results[2] == ("database_with_revenue_column_a", "distinct_id_3", 44, "USD", 44, "USD")
+        assert results[3] == ("database_with_revenue_column_b", "distinct_id_1", 43, "USD", 43, "USD")
+        assert results[4] == ("database_with_revenue_column_b", "distinct_id_2", 44, "USD", 44, "USD")
+        assert results[5] == ("database_with_revenue_column_b", "distinct_id_3", 45, "USD", 45, "USD")


### PR DESCRIPTION
Column names are incorrect and tests weren't asserting them