### PR TITLE
fix(drop-ff-modifiers): Drop ff guard for modifiers

### DIFF
--- a/posthog/hogql/modifiers.py
+++ b/posthog/hogql/modifiers.py
@@ -100,18 +100,7 @@ def set_default_modifier_values(modifiers: HogQLQueryModifiers, team: "Team"):
     if modifiers.useMaterializedViews is None:
         modifiers.useMaterializedViews = True
 
-    if (
-        modifiers.propertyGroupsMode is None
-        and is_cloud()
-        and posthoganalytics.feature_enabled(
-            "hogql-optimized-property-groups-mode-enabled",
-            str(team.uuid),
-            groups={"project": str(team.id)},
-            group_properties={"project": {"id": str(team.id), "created_at": team.created_at, "uuid": team.uuid}},
-            only_evaluate_locally=True,
-            send_feature_flag_events=False,
-        )
-    ):
+    if modifiers.propertyGroupsMode is None and is_cloud():
         modifiers.propertyGroupsMode = PropertyGroupsMode.OPTIMIZED
 
 


### PR DESCRIPTION
## Problem
Dropping ff guard that is now set to 100% and seems to be null and stopping the application in our temporal workers.

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?