### PR TITLE
fix(err): find place we're expecting rows that might not be returned

### DIFF
--- a/rust/cymbal/src/issue_resolution.rs
+++ b/rust/cymbal/src/issue_resolution.rs
@@ -118,7 +118,7 @@ impl Issue {
             self.description
         )
         .fetch_one(executor)
-        .await?
+        .await.expect("Got at least one row back")
         // TODO - I'm fairly sure the Option here is a bug in sqlx, so the unwrap will
         // never be hit, but nonetheless I'm not 100% sure the "no rows" case actually
         // means the insert was not done.
@@ -214,7 +214,7 @@ impl IssueFingerprintOverride {
             issue.id,
             fingerprint,
             first_seen
-        ).fetch_one(executor).await?;
+        ).fetch_one(executor).await.expect("Got at least one row back");
 
         Ok(res)
     }

--- a/rust/cymbal/src/issue_resolution.rs
+++ b/rust/cymbal/src/issue_resolution.rs
@@ -118,7 +118,7 @@ impl Issue {
             self.description
         )
         .fetch_one(executor)
-        .await.expect("Got at least one row back")
+        .await.expect("Got at least one row back") // // NOTE - I think this is the bug, ON CONFLICT DO NOTHING doesn't guarantee a returned row
         // TODO - I'm fairly sure the Option here is a bug in sqlx, so the unwrap will
         // never be hit, but nonetheless I'm not 100% sure the "no rows" case actually
         // means the insert was not done.
@@ -214,7 +214,7 @@ impl IssueFingerprintOverride {
             issue.id,
             fingerprint,
             first_seen
-        ).fetch_one(executor).await.expect("Got at least one row back");
+        ).fetch_one(executor).await.expect("Got at least one row back"); // NOTE - I think this is the bug, ON CONFLICT DO NOTHING doesn't guarantee a returned row
 
         Ok(res)
     }

--- a/rust/cymbal/src/issue_resolution.rs
+++ b/rust/cymbal/src/issue_resolution.rs
@@ -118,7 +118,7 @@ impl Issue {
             self.description
         )
         .fetch_one(executor)
-        .await.expect("Got at least one row back") // // NOTE - I think this is the bug, ON CONFLICT DO NOTHING doesn't guarantee a returned row
+        .await.expect("Got at least one row back") // NOTE - I think this is the bug, ON CONFLICT DO NOTHING doesn't guarantee a returned row
         // TODO - I'm fairly sure the Option here is a bug in sqlx, so the unwrap will
         // never be hit, but nonetheless I'm not 100% sure the "no rows" case actually
         // means the insert was not done.

--- a/rust/cymbal/src/symbol_store/saving.rs
+++ b/rust/cymbal/src/symbol_store/saving.rs
@@ -103,7 +103,7 @@ impl<F> Saving<F> {
             record.id // The call to save() above ensures that this id is correct
         )
         .fetch_one(&self.pool)
-        .await?.map_or(0, |v| {
+        .await.expect("Got at least one row back").map_or(0, |v| {
             v.max(0) as u64
         });
 
@@ -300,7 +300,7 @@ impl SymbolSetRecord {
             self.content_hash
         )
         .fetch_one(e)
-        .await?;
+        .await.expect("Got at least one row back");
 
         metrics::counter!(SYMBOL_SET_SAVED).increment(1);
 


### PR DESCRIPTION
We're seeing occasional crashes in prod that look like:
```
2025-03-28T06:39:01.104479Z  INFO health: liveness health check ok
2025-03-28T06:39:03.278459Z ERROR cymbal: Error handling event: SqlxError(RowNotFound); offset: { partition: 57, offset: 3121774 }
thread 'main' panicked at cymbal/src/main.rs:127:17:
Unhandled error: SqlxError(RowNotFound); offset: { partition: 57, offset: 3121774 }
stack backtrace:
   0: rust_begin_unwind
   1: core::panicking::panic_fmt
   2: cymbal::main::{{closure}}
   3: tokio::runtime::park::CachedParkThread::block_on
   4: cymbal::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

This is due to some `fetch_one` being used somewhere a row isn't actually being returned, so the call returns an `Err(RowNotFound)`. I have a couple of guesses in there about which queries are written under the assumption they always return a row, but I figure given our CI takes like 10 minutes end-to-end, I can just push and check my thinking.

Using `expect` rather than the question mark operator means the pods will panic /at the line of the error/, rather than in main, but otherwise doesn't really change the behaviour of cymbal - it just makes the backtrace more informative.

Guess as to which query is incorrect is based on [these docs](https://www.postgresql.org/docs/current/sql-insert.html), which state:
```
If the INSERT command contains a RETURNING clause, the result will be similar to that of a SELECT statement containing the columns and values defined in the RETURNING list, computed over the row(s) inserted or updated by the command.
```

My interpretation of this line is "if your insert query didn't update or insert a row, **no row will be returned**", which is a little unintuitive, but easy to work around.