### PR TITLE
chore(err): allow filtering events by team id

### DIFF
--- a/rust/cymbal/src/app_context.rs
+++ b/rust/cymbal/src/app_context.rs
@@ -30,6 +30,11 @@ use crate::{
     teams::TeamManager,
 };
 
+pub enum FilterMode {
+    In,
+    Out,
+}
+
 pub struct AppContext {
     pub health_registry: HealthRegistry,
     pub worker_liveness: HealthHandle,
@@ -44,6 +49,9 @@ pub struct AppContext {
 
     pub team_manager: TeamManager,
     pub billing_limiter: RedisLimiter,
+
+    pub filtered_teams: Vec<i32>,
+    pub filter_mode: FilterMode,
 }
 
 impl AppContext {
@@ -147,6 +155,17 @@ impl AppContext {
         )
         .expect("Redis billing limiter construction succeeds");
 
+        let filtered_teams = config
+            .filtered_teams
+            .split(",")
+            .map(|tid| tid.parse().expect("Filtered team id's must be i32s"))
+            .collect();
+        let filter_mode = match config.filter_mode.as_str() {
+            "in" => FilterMode::In,
+            "out" => FilterMode::Out,
+            _ => panic!("Invalid filter mode"),
+        };
+
         Ok(Self {
             health_registry,
             worker_liveness,
@@ -160,6 +179,8 @@ impl AppContext {
             team_manager,
             geoip_client,
             billing_limiter,
+            filtered_teams,
+            filter_mode,
         })
     }
 }

--- a/rust/cymbal/src/app_context.rs
+++ b/rust/cymbal/src/app_context.rs
@@ -160,7 +160,7 @@ impl AppContext {
             .split(",")
             .map(|tid| tid.parse().expect("Filtered team id's must be i32s"))
             .collect();
-        let filter_mode = match config.filter_mode.as_str() {
+        let filter_mode = match config.filter_mode.to_lowercase().as_str() {
             "in" => FilterMode::In,
             "out" => FilterMode::Out,
             _ => panic!("Invalid filter mode"),

--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -110,6 +110,12 @@ pub struct Config {
 
     #[envconfig(default = "redis://localhost:6379/")]
     pub redis_url: String,
+
+    #[envconfig(default = "")]
+    pub filtered_teams: String, // Comma seperated list of teams to either filter in (process) or filter out (ignore)
+
+    #[envconfig(default = "out")]
+    pub filter_mode: String, // in/out - in means drop all teams not in the list, out means drop all teams in the list
 }
 
 impl Config {

--- a/rust/cymbal/src/error.rs
+++ b/rust/cymbal/src/error.rs
@@ -141,6 +141,8 @@ pub enum EventError {
     Suppressed(Uuid),
     #[error("Could not deserialize event data: {1}")]
     FailedToDeserialize(Box<CapturedEvent>, String),
+    #[error("Filtered by team id")]
+    FilteredByTeamId,
 }
 
 impl From<JsResolveErr> for Error {

--- a/rust/cymbal/src/error.rs
+++ b/rust/cymbal/src/error.rs
@@ -123,7 +123,7 @@ pub enum JsResolveErr {
     NoSourcemapUploaded(String),
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone)]
 pub enum EventError {
     #[error("Wrong event type: {0} for event {1}")]
     WrongEventType(String, Uuid),

--- a/rust/cymbal/src/pipeline/errors.rs
+++ b/rust/cymbal/src/pipeline/errors.rs
@@ -78,5 +78,9 @@ pub async fn report_error(_context: Arc<AppContext>, error: EventError) {
             error!("{}", error);
             counter!(DROPPED_EVENTS, "reason" => "failed_to_deserialize").increment(1);
         }
+        EventError::FilteredByTeamId => {
+            // Totally mundane
+            counter!(DROPPED_EVENTS, "reason" => "filtered_by_team_id").increment(1);
+        }
     }
 }

--- a/rust/cymbal/src/pipeline/mod.rs
+++ b/rust/cymbal/src/pipeline/mod.rs
@@ -109,14 +109,12 @@ fn filter_by_team_id(
         .map(|e| {
             let Ok(e) = e else { return e };
 
-            let res = match (mode, team_ids.contains(&e.team_id)) {
+            match (mode, team_ids.contains(&e.team_id)) {
                 (FilterMode::In, true) | (FilterMode::Out, false) => Ok(e),
                 (FilterMode::In, false) | (FilterMode::Out, true) => {
                     Err(EventError::FilteredByTeamId)
                 }
-            };
-
-            res
+            }
         })
         .collect()
 }


### PR DESCRIPTION
Part of the switch from old to new ingestion pipeline layout. This will let us configure just team 2 first, and make sure everything still looks right