### PR TITLE
fix: proper tracking async queries

### DIFF
--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -289,6 +289,7 @@ async def query_awaited(request: Request, *args, **kwargs) -> StreamingHttpRespo
                 execution_mode=execution_mode,
                 query_id=client_query_id,
                 user=request.user if not isinstance(request.user, AnonymousUser) else None,
+                is_query_service=(get_query_tag_value("access_method") == "personal_api_key"),
             )
         )
 

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -30,7 +30,7 @@ from posthog.clickhouse.client.execute_async import (
     get_query_status,
     QueryStatusManager,
 )
-from posthog.clickhouse.query_tagging import tag_queries
+from posthog.clickhouse.query_tagging import tag_queries, get_query_tag_value
 from posthog.errors import ExposedCHQueryError
 from posthog.hogql.ai import PromptUnclear, write_sql_from_prompt
 from posthog.hogql.errors import ExposedHogQLError
@@ -129,7 +129,7 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
                 execution_mode=execution_mode,
                 query_id=client_query_id,
                 user=request.user,
-                is_query_service=True,
+                is_query_service=(get_query_tag_value("access_method") == "personal_api_key"),
             )
             if isinstance(result, BaseModel):
                 result = result.model_dump(by_alias=True)

--- a/posthog/api/services/query.py
+++ b/posthog/api/services/query.py
@@ -43,6 +43,7 @@ def process_query_dict(
     query_id: Optional[str] = None,
     insight_id: Optional[int] = None,
     dashboard_id: Optional[int] = None,
+    is_query_service: bool = False,
 ) -> dict | BaseModel:
     model = QuerySchemaRoot.model_validate(query_json)
     tag_queries(query=query_json)
@@ -63,6 +64,7 @@ def process_query_dict(
         query_id=query_id,
         insight_id=insight_id,
         dashboard_id=dashboard_id,
+        is_query_service=is_query_service,
     )
 
 
@@ -97,6 +99,7 @@ def process_query_model(
                 query_id=query_id,
                 insight_id=insight_id,
                 dashboard_id=dashboard_id,
+                is_query_service=is_query_service,
             )
         elif execution_mode == ExecutionMode.CACHE_ONLY_NEVER_CALCULATE:
             # Caching is handled by query runners, so in this case we can only return a cache miss

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -139,6 +139,7 @@ def execute_process_query(
     query_id: str,
     query_json: dict,
     limit_context: Optional[LimitContext],
+    is_query_service: bool = False,
 ):
     manager = QueryStatusManager(query_id, team_id)
 
@@ -186,6 +187,7 @@ def execute_process_query(
             insight_id=query_status.insight_id,
             dashboard_id=query_status.dashboard_id,
             user=user,
+            is_query_service=is_query_service,
         )
         if isinstance(results, BaseModel):
             results = results.model_dump(by_alias=True)
@@ -223,7 +225,7 @@ def enqueue_process_query_task(
     refresh_requested: bool = False,
     force: bool = False,
     _test_only_bypass_celery: bool = False,
-    api_query_personal_key: bool = False,
+    is_query_service: bool = False,
 ) -> QueryStatus:
     if not query_id:
         query_id = uuid.uuid4().hex
@@ -248,7 +250,7 @@ def enqueue_process_query_task(
     manager.store_query_status(query_status)
 
     task_signature = process_query_task.si(
-        team.id, user_id, query_id, query_json, api_query_personal_key, LimitContext.QUERY_ASYNC
+        team.id, user_id, query_id, query_json, is_query_service, LimitContext.QUERY_ASYNC
     )
 
     if _test_only_bypass_celery:

--- a/posthog/clickhouse/test/test_query_tagging.py
+++ b/posthog/clickhouse/test/test_query_tagging.py
@@ -5,11 +5,11 @@ def test_clear_tag():
     clear_tag("some")
     reset_query_tags()
     assert get_query_tags() == {}
-    tag_queries(qaas=True)
-    assert get_query_tags() == {"qaas": True}
+    tag_queries(another=True)
+    assert get_query_tags() == {"another": True}
     clear_tag("some")
-    assert get_query_tags() == {"qaas": True}
-    clear_tag("qaas")
+    assert get_query_tags() == {"another": True}
+    clear_tag("another")
     assert get_query_tags() == {}
 
 

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -782,9 +782,9 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             is_api=self.query_endpoint_with_personal_key(), team_id=self.team.pk, task_id=self.query_id
         ):
             if self.query_endpoint_with_personal_key():
-                tag_queries(qaas=True)
+                tag_queries(chargeable=True)
             else:
-                clear_tag("qaas")
+                clear_tag("chargeable")
 
             fresh_response_dict = {
                 **self.calculate().model_dump(),

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -12,7 +12,7 @@ from sentry_sdk import get_traceparent, push_scope, set_tag
 from posthog.caching.utils import ThresholdMode, cache_target_age, is_stale, last_refresh_from_cached_result
 from posthog.clickhouse.client.execute_async import QueryNotFoundError, enqueue_process_query_task, get_query_status
 from posthog.clickhouse.client.limit import get_api_personal_rate_limiter
-from posthog.clickhouse.query_tagging import get_query_tag_value, tag_queries, clear_tag
+from posthog.clickhouse.query_tagging import get_query_tag_value, tag_queries
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql import ast
 from posthog.hogql.constants import LimitContext
@@ -630,7 +630,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             query_json=self.query.model_dump(),
             query_id=self.query_id or cache_manager.cache_key,  # Use cache key as query ID to avoid duplicates
             refresh_requested=refresh_requested,
-            api_query_personal_key=self.query_endpoint_with_personal_key(),
+            is_query_service=self.is_query_service,
         )
 
     def get_async_query_status(self, *, cache_key: str) -> Optional[QueryStatus]:
@@ -721,9 +721,6 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         # Nothing useful out of cache, nor async query status
         return None
 
-    def query_endpoint_with_personal_key(self):
-        return self.is_query_service and get_query_tag_value("access_method") == "personal_api_key"
-
     def run(
         self,
         execution_mode: ExecutionMode = ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
@@ -779,12 +776,10 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             self.modifiers.useMaterializedViews = True
 
         with get_api_personal_rate_limiter().run(
-            is_api=self.query_endpoint_with_personal_key(), team_id=self.team.pk, task_id=self.query_id
+            is_api=self.is_query_service, team_id=self.team.pk, task_id=self.query_id
         ):
-            if self.query_endpoint_with_personal_key():
-                tag_queries(chargeable=True)
-            else:
-                clear_tag("chargeable")
+            if self.is_query_service:
+                tag_queries(chargeable=1)
 
             fresh_response_dict = {
                 **self.calculate().model_dump(),

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -77,9 +77,9 @@ def process_query_task(
         from posthog.clickhouse.client import execute_process_query
 
         if api_query_personal_key:
-            tag_queries(qaas=True)
+            tag_queries(chargeable=True)
         else:
-            clear_tag("qaas")
+            clear_tag("chargeable")
 
         execute_process_query(
             team_id=team_id,

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -14,7 +14,7 @@ from redis import Redis
 from structlog import get_logger
 
 from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded, limit_concurrency, get_api_personal_rate_limiter
-from posthog.clickhouse.query_tagging import tag_queries, clear_tag
+from posthog.clickhouse.query_tagging import tag_queries
 from posthog.cloud_utils import is_cloud
 from posthog.errors import CHQueryErrorTooManySimultaneousQueries
 from posthog.hogql.constants import LimitContext
@@ -66,20 +66,18 @@ def process_query_task(
     user_id: Optional[int],
     query_id: str,
     query_json: dict,
-    api_query_personal_key: bool,
+    is_query_service: bool,
     limit_context: Optional[LimitContext] = None,
 ) -> None:
     """
     Kick off query
     Once complete save results to redis
     """
-    with get_api_personal_rate_limiter().run(is_api=api_query_personal_key, team_id=team_id, task_id=query_id):
+    with get_api_personal_rate_limiter().run(is_api=is_query_service, team_id=team_id, task_id=query_id):
         from posthog.clickhouse.client import execute_process_query
 
-        if api_query_personal_key:
-            tag_queries(chargeable=True)
-        else:
-            clear_tag("chargeable")
+        if is_query_service:
+            tag_queries(chargeable=1)
 
         execute_process_query(
             team_id=team_id,
@@ -87,6 +85,7 @@ def process_query_task(
             query_id=query_id,
             query_json=query_json,
             limit_context=limit_context,
+            is_query_service=is_query_service,
         )
 
 

--- a/posthog/tasks/test/__snapshots__/test_usage_report.ambr
+++ b/posthog/tasks/test/__snapshots__/test_usage_report.ambr
@@ -23,7 +23,7 @@
     AND is_initial_query
     AND event_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
     AND team_id > 0
-    AND JSONExtractBool(log_comment, 'qaas')
+    AND JSONExtractBool(log_comment, 'chargeable')
   GROUP BY team_id
   '''
 # ---

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -1063,7 +1063,7 @@ class HogQLUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTables
         flush_persons_and_events()
         sync_execute("SYSTEM FLUSH LOGS")
         sync_execute("TRUNCATE TABLE system.query_log")
-        tag_queries(kind="request", id="1", access_method="personal_api_key", chargeable=True)
+        tag_queries(kind="request", id="1", access_method="personal_api_key", chargeable=1)
 
         execute_hogql_query(
             query="select * from events limit 400",

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -1063,7 +1063,7 @@ class HogQLUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTables
         flush_persons_and_events()
         sync_execute("SYSTEM FLUSH LOGS")
         sync_execute("TRUNCATE TABLE system.query_log")
-        tag_queries(kind="request", id="1", access_method="personal_api_key", qaas=True)
+        tag_queries(kind="request", id="1", access_method="personal_api_key", chargeable=True)
 
         execute_hogql_query(
             query="select * from events limit 400",

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -590,7 +590,7 @@ def get_teams_with_api_queries_metrics(
         AND is_initial_query
         AND event_time between %(begin)s AND %(end)s
         AND team_id > 0
-        AND JSONExtractBool(log_comment, 'qaas')
+        AND JSONExtractBool(log_comment, 'chargeable')
         GROUP BY team_id
     """
     with tags_context(usage_report="get_teams_with_api_queries_metrics"):


### PR DESCRIPTION
## Problem

Async queries made by API were not marked with either `qaas` or `chargeable`.

## Changes

Ensure that information about the query being issued through `/query` endpoint will be passed.

## Rootcause

The code responsible for clearing a `chargeable` tag was invoked, because the query processing did not now it's being called with a API Queries context.

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Tests  + manual verification
