### PR TITLE
fix(trends): stricter check for stringified numbers

### DIFF
--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -333,10 +333,10 @@ export function formatBreakdownLabel(
     }
 
     // stringified numbers
-    if (!Number.isNaN(Number(breakdown_value))) {
+    if (breakdown_value && /^\d+$/.test(breakdown_value)) {
         const numericValue =
             Number.isInteger(Number(breakdown_value)) && !Number.isSafeInteger(Number(breakdown_value))
-                ? BigInt(breakdown_value!)
+                ? BigInt(breakdown_value)
                 : Number(breakdown_value)
         return formatNumericBreakdownLabel(
             numericValue,


### PR DESCRIPTION
## Problem

We need to handle numbers that are represented as string in breakdown values for historic reasons e.g. breaking down by session duration. Our current number detection will consider strings like "0123456e78" as number and that actually results in a crash, as `BigInt` doesn't support e-notation.

See https://posthoghelp.zendesk.com/agent/tickets/27930 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/29625) for a customer issue.

## Changes

Changes the number detection to accept only digit numbers.

## How did you test this code?

```
posthog.capture('abc', {someprop: '0123456e78'})
```
and checked a session duration breakdown