### PR TITLE
fix: remove capitalization in flags values

### DIFF
--- a/frontend/src/scenes/persons/RelatedFeatureFlags.tsx
+++ b/frontend/src/scenes/persons/RelatedFeatureFlags.tsx
@@ -3,7 +3,6 @@ import { LemonInput, LemonSelect, LemonSnack, LemonTable, LemonTag, Link, Toolti
 import { useActions, useValues } from 'kea'
 import { LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
-import { capitalizeFirstLetter } from 'lib/utils'
 import stringWithWBR from 'lib/utils/stringWithWBR'
 import { urls } from 'scenes/urls'
 
@@ -83,9 +82,7 @@ export function RelatedFeatureFlags({ distinctId, groupTypeIndex, groups }: Prop
             render: function Render(_, featureFlag: RelatedFeatureFlag) {
                 return (
                     <div className="break-words">
-                        {featureFlag.active && featureFlag.value
-                            ? capitalizeFirstLetter(featureFlag.value.toString())
-                            : 'False'}
+                        {featureFlag.active && featureFlag.value ? featureFlag.value.toString() : 'false'}
                     </div>
                 )
             },


### PR DESCRIPTION
## Problem

When we create an experiment (or feature flags separately) and set string values for the options, the values shown in the profile can be confusing.

For example, if the options are set as 'control' and 'test', the profile displays them as 'Control' and 'Test'. This differs from what is shown in the experiment or feature flag setup.

This inconsistency can be misleading—especially if events aren’t received as expected. It may appear to be an error on your end, leading you to change the value in the code to the wrong one.

### Example:
<img width="395" alt="Screenshot 2025-03-28 at 17 47 47" src="https://github.com/user-attachments/assets/d31309d8-98a3-4323-b58a-99322d244a5d" />

#### Before:
<img width="449" alt="Screenshot 2025-03-28 at 17 47 33" src="https://github.com/user-attachments/assets/92b17a20-75af-4c69-a5cd-daa9b0955cf6" />

#### After:
<img width="502" alt="Screenshot 2025-03-28 at 17 47 17" src="https://github.com/user-attachments/assets/bdeef8e6-e55b-45d4-be7d-7aa13ea35804" />


