### PR TITLE
fix(data-table): Don't show person deletion button by default

### DIFF
--- a/frontend/src/queries/nodes/DataTable/utils.ts
+++ b/frontend/src/queries/nodes/DataTable/utils.ts
@@ -10,7 +10,7 @@ export const defaultDataTableEventColumns: HogQLExpression[] = [
     'timestamp',
 ]
 
-export const defaultDataTablePersonColumns: HogQLExpression[] = ['person', 'id', 'created_at', 'person.$delete']
+export const defaultDataTablePersonColumns: HogQLExpression[] = ['person', 'id', 'created_at']
 
 export const defaultDataTableGroupColumns: HogQLExpression[] = ['group_name', 'key', 'created_at']
 

--- a/frontend/src/scenes/persons-management/tabs/personsSceneLogic.ts
+++ b/frontend/src/scenes/persons-management/tabs/personsSceneLogic.ts
@@ -13,7 +13,10 @@ export const personsSceneLogic = kea<personsSceneLogicType>([
         query: [
             {
                 kind: NodeKind.DataTableNode,
-                source: { kind: NodeKind.ActorsQuery, select: defaultDataTableColumns(NodeKind.ActorsQuery) },
+                source: {
+                    kind: NodeKind.ActorsQuery,
+                    select: [...defaultDataTableColumns(NodeKind.ActorsQuery), 'person.$delete'],
+                },
                 full: true,
                 propertiesViaUrl: true,
             } as DataTableNode,


### PR DESCRIPTION
## Problem

@zlwaterfield and I [noticed](https://posthog.slack.com/archives/C03B04XGLAZ/p1743172039225179?thread_ts=1743132249.595139&cid=C03B04XGLAZ) the "Delete" button on persons when viewing a static cohort. We both thought this button deletes the person from the cohort. Surprisingly, that button deletes the person altogether.

![screenshot_2025-03-28_at_10 25 31___am](https://github.com/user-attachments/assets/4054ce4b-e9fb-43ed-979b-d6e2f296cb03)

Turns out the person deletion column is included _by default_ when rendering an `ActorsQuery`.

## Changes

This PR makes it so that the deletion button is only shown in the persons scene, and not by default in other cases of `ActorsQuery`.
