### PR TITLE
fix(sql-editor-overflow-handling): Fixing small overflow issues

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryInfo.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryInfo.tsx
@@ -68,7 +68,7 @@ export function QueryInfo({ codeEditorKey }: QueryInfoProps): JSX.Element {
     const savedQuery = editingView ? dataWarehouseSavedQueryMapById[editingView.id] : null
 
     return (
-        <div className="overflow-scroll">
+        <div className="overflow-auto">
             <div className="flex flex-col flex-1 p-4 gap-4 ">
                 <div>
                     <div className="flex flex-row items-center gap-2">

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryVariables.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryVariables.tsx
@@ -28,7 +28,7 @@ export function QueryVariables(): JSX.Element {
     }
 
     return (
-        <div className="flex flex-col gap-2 py-2 h-full">
+        <div className="flex flex-col gap-2 py-2 h-full overflow-auto">
             <div className="flex flex-row items-center justify-between px-2">
                 <h3 className="text-sm font-semibold mb-0">Query variables</h3>
                 <AddVariableButton buttonProps={{ type: 'primary', size: 'xsmall' }} title="" />


### PR DESCRIPTION
## Problem
Some minor scroll issues on the closed SQL Editor and materialized view scroll behavior.

### Before
<img width="481" alt="image" src="https://github.com/user-attachments/assets/9f7eea4c-83bb-4a05-ab0f-543971f2fd6e" />
<img width="113" alt="image" src="https://github.com/user-attachments/assets/f685e07e-8c83-4d47-819d-3564baa2eb48" />

## After
<img width="89" alt="image" src="https://github.com/user-attachments/assets/b56bcc44-3eab-4dbd-8fbb-42ac9ca0775b" />



## Changes

- [x] Scroll to auto to avoid always present scrollbars
- [x] Handling overflow of variables pane to prevent text overflow.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
