### PR TITLE
fix: replay menu positioning

### DIFF
--- a/frontend/src/scenes/session-recordings/components/PanelSettings.tsx
+++ b/frontend/src/scenes/session-recordings/components/PanelSettings.tsx
@@ -1,7 +1,6 @@
 import './PanelSettings.scss'
 
 import clsx from 'clsx'
-import { FloatingContainerContext } from 'lib/hooks/useFloatingContainerContext'
 import {
     LemonButton,
     LemonButtonWithoutSideActionProps,
@@ -9,7 +8,7 @@ import {
 } from 'lib/lemon-ui/LemonButton'
 import { LemonMenu, LemonMenuItem, LemonMenuProps } from 'lib/lemon-ui/LemonMenu/LemonMenu'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
-import { PropsWithChildren, useRef } from 'react'
+import { PropsWithChildren } from 'react'
 
 /**
  * TODO the lemon button font only has 700 and 800 weights available.
@@ -40,23 +39,19 @@ export function SettingsBar({
     border: 'bottom' | 'top' | 'all' | 'none'
     className?: string
 }>): JSX.Element {
-    const containerRef = useRef<HTMLDivElement>(null)
     return (
-        <FloatingContainerContext.Provider value={containerRef}>
-            <div
-                ref={containerRef}
-                className={clsx(
-                    'flex flex-row w-full overflow-hidden font-light text-xs bg-primary items-center',
-                    className,
-                    {
-                        'border-b': ['bottom', 'all'].includes(border),
-                        'border-t': ['top', 'all'].includes(border),
-                    }
-                )}
-            >
-                {children}
-            </div>
-        </FloatingContainerContext.Provider>
+        <div
+            className={clsx(
+                'flex flex-row w-full overflow-hidden font-light text-xs bg-primary items-center',
+                className,
+                {
+                    'border-b': ['bottom', 'all'].includes(border),
+                    'border-t': ['top', 'all'].includes(border),
+                }
+            )}
+        >
+            {children}
+        </div>
     )
 }
 

--- a/frontend/src/scenes/session-recordings/player/player-meta/PlayerMetaBottomSettings.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/PlayerMetaBottomSettings.tsx
@@ -1,4 +1,4 @@
-import { IconClock, IconEllipsis, IconHourglass, IconMouse, IconRabbit, IconSearch, IconTortoise } from '@posthog/icons'
+import { IconClock, IconEllipsis, IconHourglass, IconRabbit, IconSearch, IconTortoise } from '@posthog/icons'
 import { useActions, useValues } from 'kea'
 import { LemonMenuItem } from 'lib/lemon-ui/LemonMenu'
 import { humanFriendlyDuration } from 'lib/utils'
@@ -115,8 +115,8 @@ export function PlayerMetaBottomSettings({ size }: { size: PlayerMetaBreakpoints
     const {
         logicProps: { noInspector },
     } = useValues(sessionRecordingPlayerLogic)
-    const { showMouseTail, skipInactivitySetting, timestampFormat } = useValues(playerSettingsLogic)
-    const { setShowMouseTail, setSkipInactivitySetting, setTimestampFormat } = useActions(playerSettingsLogic)
+    const { skipInactivitySetting, timestampFormat } = useValues(playerSettingsLogic)
+    const { setSkipInactivitySetting, setTimestampFormat } = useActions(playerSettingsLogic)
     const isSmall = size === 'small'
 
     const menuItems: LemonMenuItem[] = [
@@ -158,14 +158,6 @@ export function PlayerMetaBottomSettings({ size }: { size: PlayerMetaBreakpoints
                   icon: <IconHourglass />,
               }
             : undefined,
-        {
-            // title: "Show a tail following the cursor to make it easier to see",
-            label: 'Show mouse tail',
-            active: showMouseTail,
-            'data-attr': 'show-mouse-tail-in-menu',
-            onClick: () => setShowMouseTail(!showMouseTail),
-            icon: <IconMouse className="text-lg" />,
-        },
     ].filter(Boolean) as LemonMenuItem[]
 
     return (
@@ -175,13 +167,14 @@ export function PlayerMetaBottomSettings({ size }: { size: PlayerMetaBreakpoints
                     <SetPlaybackSpeed />
                     {!isSmall && <SetTimeFormat />}
                     {!isSmall && <SkipInactivity />}
-
-                    <SettingsMenu
-                        icon={<IconEllipsis />}
-                        items={menuItems}
-                        highlightWhenActive={false}
-                        closeOnClickInside={false}
-                    />
+                    {isSmall && (
+                        <SettingsMenu
+                            icon={<IconEllipsis />}
+                            items={menuItems}
+                            highlightWhenActive={false}
+                            closeOnClickInside={false}
+                        />
+                    )}
                 </div>
                 <div className="flex flex-row gap-0.5">
                     {noInspector ? null : <InspectDOM />}

--- a/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
@@ -34,7 +34,6 @@ export const playerSettingsLogic = kea<playerSettingsLogicType>([
         setPreferredSidebarStacking: (stacking: SessionRecordingSidebarStacking) => ({ stacking }),
         setSidebarOpen: (open: boolean) => ({ open }),
         setPlaylistOpen: (open: boolean) => ({ open }),
-        setShowMouseTail: (showMouseTail: boolean) => ({ showMouseTail }),
     }),
     connect({
         values: [teamLogic, ['currentTeam']],
@@ -99,13 +98,6 @@ export const playerSettingsLogic = kea<playerSettingsLogicType>([
             { persist: true },
             {
                 setHideViewedRecordings: (_, { hideViewedRecordings }) => hideViewedRecordings,
-            },
-        ],
-        showMouseTail: [
-            true,
-            { persist: true },
-            {
-                setShowMouseTail: (_, { showMouseTail }) => showMouseTail,
             },
         ],
     })),

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -169,7 +169,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 'trackedWindow',
             ],
             playerSettingsLogic,
-            ['speed', 'skipInactivitySetting', 'showMouseTail'],
+            ['speed', 'skipInactivitySetting'],
             userLogic,
             ['user', 'hasAvailableFeature'],
             preflightLogic,
@@ -778,7 +778,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 ...COMMON_REPLAYER_CONFIG,
                 // these two settings are attempts to improve performance of running two Replayers at once
                 // the main player and a preview player
-                mouseTail: values.showMouseTail && props.mode !== SessionRecordingPlayerMode.Preview,
+                mouseTail: props.mode !== SessionRecordingPlayerMode.Preview,
                 useVirtualDom: false,
                 plugins,
                 onError: (error) => {


### PR DESCRIPTION
We added `FloatingContext` to replay `SettingsBar`s to try and use container queries 

That didn't work and we didn't bother removing the context provider because "what harm can it do"

Well, the harm is that it can make the `More` buttons move when you open them. I couldn't figure out what incantation CSS wanted and we're not using the `FloatingContext` so... yeet

Also flyby-removes the `show mouse tail` button because it takes up space and nobody (practically) was using it and it's not _for_ anything

|before | after|
|-|-|
|![2025-03-31 00 25 57](https://github.com/user-attachments/assets/5a4918cb-6922-4de2-9717-6b58e2d415ed)|![2025-03-31 00 25 23](https://github.com/user-attachments/assets/a92703cb-9f93-425e-87a9-6b8116003924)|


