### PR TITLE
feat(propdefs): conditionally shift cache strategy in v2 ingest

### DIFF
--- a/rust/property-defs-rs/src/lib.rs
+++ b/rust/property-defs-rs/src/lib.rs
@@ -2,7 +2,7 @@ use std::{sync::Arc, time::Duration};
 
 use app_context::AppContext;
 use common_kafka::kafka_consumer::{RecvErr, SingleTopicConsumer};
-use config::{Config, TeamFilterMode, TeamList};
+use config::Config;
 use metrics_consts::{
     BATCH_ACQUIRE_TIME, CACHE_CONSUMED, CHUNK_SIZE, COMPACTED_UPDATES, DUPLICATES_IN_BATCH,
     EMPTY_EVENTS, EVENTS_RECEIVED, EVENT_PARSE_ERROR, FORCED_SMALL_BATCH, ISSUE_FAILED,
@@ -96,6 +96,7 @@ async fn process_batch_v1(
     context: Arc<AppContext>,
     mut batch: Vec<Update>,
 ) {
+    // unused in v2 as a throttling mechanism, but still useful to measure
     let cache_utilization = cache.len() as f64 / config.cache_capacity as f64;
     metrics::gauge!(CACHE_CONSUMED).set(cache_utilization);
 
@@ -162,15 +163,12 @@ async fn process_batch_v1(
 }
 
 pub async fn update_producer_loop(
+    config: Config,
     consumer: SingleTopicConsumer,
     channel: mpsc::Sender<Update>,
     shared_cache: Arc<Cache<Update, ()>>,
-    skip_threshold: usize,
-    compaction_batch_size: usize,
-    team_filter_mode: TeamFilterMode,
-    team_list: TeamList,
 ) {
-    let mut batch = AHashSet::with_capacity(compaction_batch_size);
+    let mut batch = AHashSet::with_capacity(config.compaction_batch_size);
     let mut last_send = tokio::time::Instant::now();
     loop {
         let (event, offset): (Event, _) = match consumer.json_recv().await {
@@ -206,12 +204,15 @@ pub async fn update_producer_loop(
             }
         }
 
-        if !team_filter_mode.should_process(&team_list.teams, event.team_id) {
+        if !config
+            .filter_mode
+            .should_process(&config.filtered_teams.teams, event.team_id)
+        {
             metrics::counter!(SKIPPED_DUE_TO_TEAM_FILTER).increment(1);
             continue;
         }
 
-        let updates = event.into_updates(skip_threshold);
+        let updates = event.into_updates(config.update_count_skip_threshold);
 
         metrics::counter!(EVENTS_RECEIVED).increment(1);
         metrics::counter!(UPDATES_SEEN).increment(updates.len() as u64);
@@ -231,7 +232,9 @@ pub async fn update_producer_loop(
         // wait on the next event, which might come an arbitrary amount of time later. This bit me
         // in testing, and while it's not a correctness problem and under normal load we'd never
         // see it, we may as well just do the full batch insert first.
-        if batch.len() >= compaction_batch_size || last_send.elapsed() > Duration::from_secs(10) {
+        if batch.len() >= config.compaction_batch_size
+            || last_send.elapsed() > Duration::from_secs(10)
+        {
             last_send = tokio::time::Instant::now();
             for update in batch.drain() {
                 if shared_cache.get(&update).is_some() {
@@ -240,8 +243,16 @@ pub async fn update_producer_loop(
                     metrics::counter!(UPDATES_FILTERED_BY_CACHE).increment(1);
                     continue;
                 }
-                metrics::counter!(UPDATES_CACHE, &[("action", "miss")]).increment(1);
-                shared_cache.insert(update.clone(), ());
+
+                // for v1 processing pipeline, we cache before we know the batch is
+                // persisted safely. for v2, we do this downstream. The bonus: this
+                // avoids the internal queue backups that can occur when batch writes
+                // fail and the entire contents must be manually removed from the cache
+                if !config.enable_v2 {
+                    metrics::counter!(UPDATES_CACHE, &[("action", "miss")]).increment(1);
+                    shared_cache.insert(update.clone(), ());
+                }
+
                 match channel.try_send(update) {
                     Ok(_) => {}
                     Err(TrySendError::Full(update)) => {

--- a/rust/property-defs-rs/src/main.rs
+++ b/rust/property-defs-rs/src/main.rs
@@ -89,20 +89,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for _ in 0..config.worker_loop_count {
         let handle = tokio::spawn(update_producer_loop(
+            config.clone(),
             consumer.clone(),
             tx.clone(),
             cache.clone(),
-            config.update_count_skip_threshold,
-            config.compaction_batch_size,
-            config.filter_mode.clone(),
-            config.filtered_teams.clone(),
         ));
 
         handles.push(handle);
     }
 
     handles.push(tokio::spawn(update_consumer_loop(
-        config, cache, context, rx,
+        config.clone(),
+        cache,
+        context,
+        rx,
     )));
 
     // if any handle returns, abort the other ones, and then return an error

--- a/rust/property-defs-rs/src/metrics_consts.rs
+++ b/rust/property-defs-rs/src/metrics_consts.rs
@@ -32,14 +32,17 @@ pub const SINGLE_UPDATE_ISSUE_TIME: &str = "prop_defs_single_update_issue_time_m
 // property-defs-rs "v2" (mirror deploy) metric keys below
 //
 
-pub const V2_EVENT_DEFS_BATCH_TIME: &str = "propdefs_v2_eventdefs_batch_ms";
+pub const V2_EVENT_DEFS_BATCH_WRITE_TIME: &str = "propdefs_v2_eventdefs_batch_ms";
 pub const V2_EVENT_DEFS_BATCH_ATTEMPT: &str = "propdefs_v2_eventdefs_batch_attempt";
 pub const V2_EVENT_DEFS_BATCH_ROWS_AFFECTED: &str = "propdefs_v2_eventdefs_batch_rows";
+pub const V2_EVENT_DEFS_BATCH_CACHE_TIME: &str = "propdefs_v2_eventdefs_batch_cache_time_ms";
 
-pub const V2_EVENT_PROPS_BATCH_TIME: &str = "propdefs_v2_eventprops_batch_ms";
+pub const V2_EVENT_PROPS_BATCH_WRITE_TIME: &str = "propdefs_v2_eventprops_batch_ms";
 pub const V2_EVENT_PROPS_BATCH_ATTEMPT: &str = "propdefs_v2_eventprops_batch_attempt";
 pub const V2_EVENT_PROPS_BATCH_ROWS_AFFECTED: &str = "propdefs_v2_eventprops_batch_rows";
+pub const V2_EVENT_PROPS_BATCH_CACHE_TIME: &str = "propdefs_v2_eventprops_batch_cache_time_ms";
 
-pub const V2_PROP_DEFS_BATCH_TIME: &str = "propdefs_v2_propdefs_batch_ms";
+pub const V2_PROP_DEFS_BATCH_WRITE_TIME: &str = "propdefs_v2_propdefs_batch_ms";
 pub const V2_PROP_DEFS_BATCH_ATTEMPT: &str = "propdefs_v2_propdefs_batch_attempt";
 pub const V2_PROP_DEFS_BATCH_ROWS_AFFECTED: &str = "propdefs_v2_propdefs_batch_rows";
+pub const V2_PROP_DEFS_BATCH_CACHE_TIME: &str = "propdefs_v2_propdefs_batch_cache_time_ms";

--- a/rust/property-defs-rs/src/v2_batch_ingestion.rs
+++ b/rust/property-defs-rs/src/v2_batch_ingestion.rs
@@ -10,10 +10,12 @@ use uuid::Uuid;
 use crate::{
     config::Config,
     metrics_consts::{
-        CACHE_CONSUMED, V2_EVENT_DEFS_BATCH_ATTEMPT, V2_EVENT_DEFS_BATCH_ROWS_AFFECTED,
-        V2_EVENT_DEFS_BATCH_TIME, V2_EVENT_PROPS_BATCH_ATTEMPT, V2_EVENT_PROPS_BATCH_ROWS_AFFECTED,
-        V2_EVENT_PROPS_BATCH_TIME, V2_PROP_DEFS_BATCH_ATTEMPT, V2_PROP_DEFS_BATCH_ROWS_AFFECTED,
-        V2_PROP_DEFS_BATCH_TIME,
+        CACHE_CONSUMED, V2_EVENT_DEFS_BATCH_ATTEMPT, V2_EVENT_DEFS_BATCH_CACHE_TIME,
+        V2_EVENT_DEFS_BATCH_ROWS_AFFECTED, V2_EVENT_DEFS_BATCH_WRITE_TIME,
+        V2_EVENT_PROPS_BATCH_ATTEMPT, V2_EVENT_PROPS_BATCH_CACHE_TIME,
+        V2_EVENT_PROPS_BATCH_ROWS_AFFECTED, V2_EVENT_PROPS_BATCH_WRITE_TIME,
+        V2_PROP_DEFS_BATCH_ATTEMPT, V2_PROP_DEFS_BATCH_CACHE_TIME,
+        V2_PROP_DEFS_BATCH_ROWS_AFFECTED, V2_PROP_DEFS_BATCH_WRITE_TIME,
     },
     types::{EventDefinition, EventProperty, GroupType, PropertyDefinition, Update},
 };
@@ -29,6 +31,8 @@ pub struct EventPropertiesBatch {
     pub project_ids: Vec<i64>,
     pub event_names: Vec<String>,
     pub property_names: Vec<String>,
+
+    pub to_cache: Vec<Update>,
 }
 
 impl EventPropertiesBatch {
@@ -39,22 +43,35 @@ impl EventPropertiesBatch {
             project_ids: Vec::with_capacity(batch_size),
             event_names: Vec::with_capacity(batch_size),
             property_names: Vec::with_capacity(batch_size),
+            to_cache: Vec::with_capacity(batch_size),
         }
     }
 
     pub fn append(&mut self, ep: EventProperty) {
         self.team_ids.push(ep.team_id);
         self.project_ids.push(ep.project_id);
-        self.event_names.push(ep.event);
-        self.property_names.push(ep.property);
+        self.event_names.push(ep.event.clone());
+        self.property_names.push(ep.property.clone());
+
+        self.to_cache.push(Update::EventProperty(ep));
     }
 
     pub fn should_flush_batch(&self) -> bool {
-        self.team_ids.len() >= self.batch_size
+        self.to_cache.len() >= self.batch_size
     }
 
     pub fn is_empty(&self) -> bool {
-        self.team_ids.len() == 0
+        self.to_cache.len() == 0
+    }
+
+    pub fn cache_batch(&mut self, cache: &mut Arc<Cache<Update, ()>>) {
+        let timer = common_metrics::timing_guard(V2_EVENT_PROPS_BATCH_CACHE_TIME, &[]);
+        let to_cache_size = self.to_cache.len();
+        for _ in 0..to_cache_size {
+            let update = self.to_cache.swap_remove(0);
+            cache.insert(update, ());
+        }
+        timer.fin();
     }
 }
 
@@ -66,6 +83,7 @@ pub struct EventDefinitionsBatch {
     pub team_ids: Vec<i32>,
     pub project_ids: Vec<i64>,
     pub last_seen_ats: Vec<DateTime<Utc>>,
+    pub to_cache: Vec<Update>,
 }
 
 impl EventDefinitionsBatch {
@@ -77,23 +95,36 @@ impl EventDefinitionsBatch {
             team_ids: Vec::with_capacity(batch_size),
             project_ids: Vec::with_capacity(batch_size),
             last_seen_ats: Vec::with_capacity(batch_size),
+            to_cache: Vec::with_capacity(batch_size),
         }
     }
 
     pub fn append(&mut self, ed: EventDefinition) {
         self.ids.push(Uuid::now_v7());
-        self.names.push(ed.name);
+        self.names.push(ed.name.clone());
         self.team_ids.push(ed.team_id);
         self.project_ids.push(ed.project_id);
         self.last_seen_ats.push(ed.last_seen_at);
+
+        self.to_cache.push(Update::Event(ed));
     }
 
     pub fn should_flush_batch(&self) -> bool {
-        self.ids.len() >= self.batch_size
+        self.to_cache.len() >= self.batch_size
     }
 
     pub fn is_empty(&self) -> bool {
-        self.ids.len() == 0
+        self.to_cache.len() == 0
+    }
+
+    pub fn cache_batch(mut self, cache: &mut Arc<Cache<Update, ()>>) {
+        let timer = common_metrics::timing_guard(V2_EVENT_DEFS_BATCH_CACHE_TIME, &[]);
+        let to_cache_size = self.to_cache.len();
+        for _ in 0..to_cache_size {
+            let update = self.to_cache.swap_remove(0);
+            cache.insert(update, ());
+        }
+        timer.fin();
     }
 }
 
@@ -109,6 +140,7 @@ pub struct PropertyDefinitionsBatch {
     pub property_types: Vec<Option<i16>>,
     pub group_type_indices: Vec<Option<i16>>,
     // note: I left off deprecated fields we null out on writes
+    pub to_cache: Vec<Update>,
 }
 
 impl PropertyDefinitionsBatch {
@@ -123,6 +155,7 @@ impl PropertyDefinitionsBatch {
             property_types: Vec::with_capacity(batch_size),
             event_types: Vec::with_capacity(batch_size),
             group_type_indices: Vec::with_capacity(batch_size),
+            to_cache: Vec::with_capacity(batch_size),
         }
     }
 
@@ -134,24 +167,36 @@ impl PropertyDefinitionsBatch {
             },
             _ => Some(-1_i16),
         };
-        let property_type: Option<i16> = pd.property_type.map(|pt| pt as i16);
+        let property_type: Option<i16> = pd.property_type.clone().map(|pt| pt as i16);
 
         self.ids.push(Uuid::now_v7());
         self.team_ids.push(pd.team_id);
         self.project_ids.push(pd.project_id);
-        self.names.push(pd.name);
+        self.names.push(pd.name.clone());
         self.are_numerical.push(pd.is_numerical);
         self.property_types.push(property_type);
         self.event_types.push(pd.event_type as i16);
         self.group_type_indices.push(group_type_index);
+
+        self.to_cache.push(Update::Property(pd));
     }
 
     pub fn should_flush_batch(&self) -> bool {
-        self.ids.len() >= self.batch_size
+        self.to_cache.len() >= self.batch_size
     }
 
     pub fn is_empty(&self) -> bool {
-        self.ids.len() == 0
+        self.to_cache.len() == 0
+    }
+
+    pub fn cache_batch(&mut self, cache: &mut Arc<Cache<Update, ()>>) {
+        let timer = common_metrics::timing_guard(V2_PROP_DEFS_BATCH_CACHE_TIME, &[]);
+        let to_cache_size = self.to_cache.len();
+        for _ in 0..to_cache_size {
+            let update = self.to_cache.swap_remove(0);
+            cache.insert(update, ());
+        }
+        timer.fin();
     }
 }
 
@@ -185,8 +230,9 @@ pub async fn process_batch_v2(
                 event_defs.append(ed);
                 if event_defs.should_flush_batch() {
                     let pool = pool.clone();
+                    let cache = cache.clone();
                     handles.push(tokio::spawn(async move {
-                        write_event_definitions_batch(event_defs, &pool).await
+                        write_event_definitions_batch(cache, event_defs, &pool).await
                     }));
                     event_defs = EventDefinitionsBatch::new(config.v2_ingest_batch_size);
                 }
@@ -195,8 +241,9 @@ pub async fn process_batch_v2(
                 event_props.append(ep);
                 if event_props.should_flush_batch() {
                     let pool = pool.clone();
+                    let cache = cache.clone();
                     handles.push(tokio::spawn(async move {
-                        write_event_properties_batch(event_props, &pool).await
+                        write_event_properties_batch(cache, event_props, &pool).await
                     }));
                     event_props = EventPropertiesBatch::new(config.v2_ingest_batch_size);
                 }
@@ -205,8 +252,9 @@ pub async fn process_batch_v2(
                 prop_defs.append(pd);
                 if prop_defs.should_flush_batch() {
                     let pool = pool.clone();
+                    let cache = cache.clone();
                     handles.push(tokio::spawn(async move {
-                        write_property_definitions_batch(prop_defs, &pool).await
+                        write_property_definitions_batch(cache, prop_defs, &pool).await
                     }));
                     prop_defs = PropertyDefinitionsBatch::new(config.v2_ingest_batch_size);
                 }
@@ -217,20 +265,23 @@ pub async fn process_batch_v2(
     // ensure partial batches are flushed to Postgres too
     if !event_defs.is_empty() {
         let pool = pool.clone();
+        let cache = cache.clone();
         handles.push(tokio::spawn(async move {
-            write_event_definitions_batch(event_defs, &pool).await
+            write_event_definitions_batch(cache, event_defs, &pool).await
         }));
     }
     if !prop_defs.is_empty() {
         let pool = pool.clone();
+        let cache = cache.clone();
         handles.push(tokio::spawn(async move {
-            write_property_definitions_batch(prop_defs, &pool).await
+            write_property_definitions_batch(cache, prop_defs, &pool).await
         }));
     }
     if !event_props.is_empty() {
         let pool = pool.clone();
+        let cache = cache.clone();
         handles.push(tokio::spawn(async move {
-            write_event_properties_batch(event_props, &pool).await
+            write_event_properties_batch(cache, event_props, &pool).await
         }));
     }
 
@@ -250,10 +301,11 @@ pub async fn process_batch_v2(
 }
 
 async fn write_event_properties_batch(
-    batch: EventPropertiesBatch,
+    mut cache: Arc<Cache<Update, ()>>,
+    mut batch: EventPropertiesBatch,
     pool: &PgPool,
 ) -> Result<(), sqlx::Error> {
-    let total_time = common_metrics::timing_guard(V2_EVENT_PROPS_BATCH_TIME, &[]);
+    let total_time = common_metrics::timing_guard(V2_EVENT_PROPS_BATCH_WRITE_TIME, &[]);
     let mut tries = 1;
 
     loop {
@@ -293,6 +345,10 @@ async fn write_event_properties_batch(
                 metrics::counter!(V2_EVENT_PROPS_BATCH_ATTEMPT, &[("result", "success")]);
                 common_metrics::inc(V2_EVENT_PROPS_BATCH_ROWS_AFFECTED, &[], count);
                 total_time.fin();
+
+                // now it's safe to cache the original updates
+                batch.cache_batch(&mut cache);
+
                 return Ok(());
             }
         }
@@ -300,10 +356,11 @@ async fn write_event_properties_batch(
 }
 
 async fn write_property_definitions_batch(
-    batch: PropertyDefinitionsBatch,
+    mut cache: Arc<Cache<Update, ()>>,
+    mut batch: PropertyDefinitionsBatch,
     pool: &PgPool,
 ) -> Result<(), sqlx::Error> {
-    let total_time = common_metrics::timing_guard(V2_PROP_DEFS_BATCH_TIME, &[]);
+    let total_time = common_metrics::timing_guard(V2_PROP_DEFS_BATCH_WRITE_TIME, &[]);
     let mut tries: u64 = 1;
 
     loop {
@@ -355,6 +412,10 @@ async fn write_property_definitions_batch(
                 metrics::counter!(V2_PROP_DEFS_BATCH_ATTEMPT, &[("result", "success")]);
                 common_metrics::inc(V2_PROP_DEFS_BATCH_ROWS_AFFECTED, &[], count);
                 total_time.fin();
+
+                // now it's safe to cache the original updates
+                batch.cache_batch(&mut cache);
+
                 return Ok(());
             }
         }
@@ -362,10 +423,11 @@ async fn write_property_definitions_batch(
 }
 
 async fn write_event_definitions_batch(
+    mut cache: Arc<Cache<Update, ()>>,
     batch: EventDefinitionsBatch,
     pool: &PgPool,
 ) -> Result<(), sqlx::Error> {
-    let total_time = common_metrics::timing_guard(V2_EVENT_DEFS_BATCH_TIME, &[]);
+    let total_time = common_metrics::timing_guard(V2_EVENT_DEFS_BATCH_WRITE_TIME, &[]);
     let mut tries: u64 = 1;
 
     loop {
@@ -411,6 +473,10 @@ async fn write_event_definitions_batch(
                 metrics::counter!(V2_EVENT_DEFS_BATCH_ATTEMPT, &[("result", "success")]);
                 common_metrics::inc(V2_EVENT_DEFS_BATCH_ROWS_AFFECTED, &[], count);
                 total_time.fin();
+
+                // now it's safe to cache the original updates
+                batch.cache_batch(&mut cache);
+
                 return Ok(());
             }
         }


### PR DESCRIPTION
## Problem
In v1 ingest, `property-defs-rs` caches data before it is safely persisted to the database, and must perform an expensive batch removal on batch write fails. This can cause backups in the internal produce/consume queue that can cause more batches to fail.

## Changes
With this change, v2 ingest (when the flag is enabled!) will only cache batches _after_ they are successfully persisted. This avoids the need for cache removals on batch write fail.

The change trades space for time, temporarily, b/c the individual `Update` records already exist. Once the v2 ingest is fully refactored, and we've observed the v2 batch writes in production and want to run with them, we can iterate on minimizing the memory utilization for cache key mgmt. 

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally and in CI
