### PR TITLE
fix: cannot save feature flag when a payload is cleared

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -1231,7 +1231,9 @@ function FeatureFlagRollout({ readOnly }: { readOnly?: boolean }): JSX.Element {
                                             {({ value, onChange }) => {
                                                 return (
                                                     <JSONEditorInput
-                                                        onChange={onChange}
+                                                        onChange={(newValue) => {
+                                                            onChange(newValue === '' ? undefined : newValue)
+                                                        }}
                                                         value={value}
                                                         placeholder='{"key": "value"}'
                                                     />

--- a/frontend/src/toolbar/flags/flagsToolbarLogic.ts
+++ b/frontend/src/toolbar/flags/flagsToolbarLogic.ts
@@ -222,8 +222,7 @@ export const flagsToolbarLogic = kea<flagsToolbarLogicType>([
                 const draftPayload = values.draftPayloads[flagKey]
                 if (!draftPayload || draftPayload.trim() === '') {
                     actions.setPayloadError(flagKey, null)
-                    actions.setPayloadOverride(flagKey, null)
-                    actions.setOverriddenUserFlag(flagKey, true)
+                    actions.deleteOverriddenUserFlag(flagKey)
                     actions.setPayloadEditorOpen(flagKey, false)
                     return
                 }

--- a/frontend/src/toolbar/flags/flagsToolbarLogic.ts
+++ b/frontend/src/toolbar/flags/flagsToolbarLogic.ts
@@ -222,7 +222,8 @@ export const flagsToolbarLogic = kea<flagsToolbarLogicType>([
                 const draftPayload = values.draftPayloads[flagKey]
                 if (!draftPayload || draftPayload.trim() === '') {
                     actions.setPayloadError(flagKey, null)
-                    actions.deleteOverriddenUserFlag(flagKey)
+                    actions.setPayloadOverride(flagKey, null)
+                    actions.setOverriddenUserFlag(flagKey, true)
                     actions.setPayloadEditorOpen(flagKey, false)
                     return
                 }


### PR DESCRIPTION
## Problem

When editing a feature flag with multiple variants, clearing a payload and hitting save causes an error: "Payload value is not valid JSON". The expected output is that it should save with an empty payload. 

Closes #ISSUE_ID #30555

## Changes
Updated the frontend logic to prevent an empty payload to become an empty string. Now you can save a feature flag even if a payload is empty. It won’t show a JSON error and the UI reflects the cleared payload correctly.
![image](https://github.com/user-attachments/assets/ba35efec-a9c2-4e2b-bd6c-6259ef992d05)

A look at the network call shows that the empty payload is no longer sent to the backend. 
![image](https://github.com/user-attachments/assets/f71f6b46-13f7-44ae-8165-f98f23b36010)


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes - this is a purely frontend change that works the same way regardless of deployment type.

## How did you test this code?

Manually tested by:
- Creating a multivariate feature flag
- Setting and clearing payload values
- Confirmed backend payload and UI behave correctly post-change
