### PR TITLE
feat: API Queries move selected teams to online cluster

### DIFF
--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -7,7 +7,9 @@ from functools import lru_cache
 from time import perf_counter
 from typing import Any, Optional, Union
 
+import posthoganalytics
 import sqlparse
+from cachetools import cached, TTLCache
 from clickhouse_driver import Client as SyncClient
 from django.conf import settings as app_settings
 from prometheus_client import Counter, Gauge
@@ -16,6 +18,7 @@ from sentry_sdk import set_tag
 from posthog.clickhouse.client.connection import Workload, get_client_from_pool
 from posthog.clickhouse.client.escape import substitute_params
 from posthog.clickhouse.query_tagging import get_query_tag_value, get_query_tags
+from posthog.cloud_utils import is_cloud
 from posthog.errors import wrap_query_error
 from posthog.settings import TEST
 from posthog.utils import generate_short_id, patchable
@@ -87,6 +90,16 @@ def validated_client_query_id() -> Optional[str]:
     return f"{client_query_team_id}_{client_query_id}_{random_id}"
 
 
+@cached(cache=TTLCache(maxsize=1, ttl=600))
+def get_api_queries_online_allow_list() -> set[int]:
+    try:
+        cfg = posthoganalytics.get_remote_config_payload("api-queries-on-online-cluster")
+        return set(cfg.get("allowed_team_id", [])) if cfg else set()
+    finally:
+        pass
+    return set()
+
+
 @patchable
 def sync_execute(
     query,
@@ -119,6 +132,16 @@ def sync_execute(
 
     # Make sure we always have process_query_task on the online cluster
     if get_query_tag_value("id") == "posthog.tasks.tasks.process_query_task":
+        workload = Workload.ONLINE
+
+    # Customer is paying for API
+    if (
+        team_id
+        and workload == Workload.OFFLINE
+        and get_query_tag_value("chargeable")
+        and is_cloud()
+        and team_id in get_api_queries_online_allow_list()
+    ):
         workload = Workload.ONLINE
 
     start_time = perf_counter()

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -2,7 +2,7 @@ import json
 import threading
 import types
 from collections.abc import Sequence
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from functools import lru_cache
 from time import perf_counter
 from typing import Any, Optional, Union
@@ -92,12 +92,11 @@ def validated_client_query_id() -> Optional[str]:
 
 @cached(cache=TTLCache(maxsize=1, ttl=600))
 def get_api_queries_online_allow_list() -> set[int]:
-    try:
+    cfg = None
+    with suppress(Exception):
         cfg = posthoganalytics.get_remote_config_payload("api-queries-on-online-cluster")
-        return set(cfg.get("allowed_team_id", [])) if cfg else set()
-    finally:
-        pass
-    return set()
+        return set(cfg.get("allowed_team_id", [])) if cfg else set[int]()
+    return set[int]()
 
 
 @patchable

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -92,7 +92,6 @@ def validated_client_query_id() -> Optional[str]:
 
 @cached(cache=TTLCache(maxsize=1, ttl=600))
 def get_api_queries_online_allow_list() -> set[int]:
-    cfg = None
     with suppress(Exception):
         cfg = posthoganalytics.get_remote_config_payload("api-queries-on-online-cluster")
         return set(cfg.get("allowed_team_id", [])) if cfg else set[int]()


### PR DESCRIPTION
## Problem

Offline nodes are doing heavy lifting and API Queries are having a hard time executing.

## Changes

Add a feature flag: api-queries-on-online-cluster with a dict describing teams allowed to run their queries
on our online replica.
The config is cached (only) for 10 minutes, to allow us to disable this feature entirely.
The feature is only evaluated for API queries made to offline cluster.

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Manually with mock setting.