### PR TITLE
fix(devex): fixed org name truncate, fixed project dropown links 

### DIFF
--- a/frontend/src/layout/panel-layout/OrganizationDropdownMenu.tsx
+++ b/frontend/src/layout/panel-layout/OrganizationDropdownMenu.tsx
@@ -32,7 +32,7 @@ export function OrganizationDropdownMenu(): JSX.Element {
     return (
         <DropdownMenu>
             <DropdownMenuTrigger asChild>
-                <Button.Root>
+                <Button.Root className="max-w-[210px]">
                     <Button.Icon>
                         {currentOrganization ? (
                             <UploadedLogo
@@ -45,7 +45,7 @@ export function OrganizationDropdownMenu(): JSX.Element {
                             <IconPlusSmall />
                         )}
                     </Button.Icon>
-                    <Button.Label className="font-semibold">
+                    <Button.Label className="font-semibold truncate">
                         {currentOrganization ? currentOrganization.name : 'Select organization'}
                     </Button.Label>
                     <Button.Icon size="sm">
@@ -68,7 +68,9 @@ export function OrganizationDropdownMenu(): JSX.Element {
                                 />
                             </Button.Icon>
                             <Button.Label>{currentOrganization.name}</Button.Label>
-                            <AccessLevelIndicator organization={currentOrganization} />
+                            <div className="ml-auto">
+                                <AccessLevelIndicator organization={currentOrganization} />
+                            </div>
                         </Button.Root>
                     </DropdownMenuItem>
                 )}
@@ -77,15 +79,16 @@ export function OrganizationDropdownMenu(): JSX.Element {
                         <Button.Root menuItem onClick={() => updateCurrentOrganization(otherOrganization.id)}>
                             <Button.Icon>
                                 <UploadedLogo
+                                    size="xsmall"
                                     name={otherOrganization.name}
                                     entityId={otherOrganization.id}
                                     mediaId={otherOrganization.logo_media_id}
                                 />
                             </Button.Icon>
                             <Button.Label>{otherOrganization.name}</Button.Label>
-                            <Button.Icon>
+                            <div className="ml-auto">
                                 <AccessLevelIndicator organization={otherOrganization} />
-                            </Button.Icon>
+                            </div>
                         </Button.Root>
                     </DropdownMenuItem>
                 ))}

--- a/frontend/src/layout/panel-layout/ProjectDropdownMenu.tsx
+++ b/frontend/src/layout/panel-layout/ProjectDropdownMenu.tsx
@@ -88,7 +88,7 @@ export function ProjectDropdownMenu(): JSX.Element | null {
                 <DropdownMenuSeparator />
                 <div className="flex flex-col gap-px">
                     <DropdownMenuItem asChild>
-                        <Button.Root menuItem active className="hover:bg-transparent">
+                        <Button.Root menuItem active>
                             <Button.Label menuItem>
                                 <ProjectName team={currentTeam} />
                             </Button.Label>

--- a/frontend/src/layout/panel-layout/ProjectDropdownMenu.tsx
+++ b/frontend/src/layout/panel-layout/ProjectDropdownMenu.tsx
@@ -1,9 +1,9 @@
 import { IconChevronRight, IconFolderOpen, IconGear, IconPlusSmall } from '@posthog/icons'
-import { LemonSnack } from '@posthog/lemon-ui'
+import { LemonSnack, Link } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { upgradeModalLogic } from 'lib/components/UpgradeModal/upgradeModalLogic'
-import { Button } from 'lib/ui/Button/Button'
+import { Button, iconVariants } from 'lib/ui/Button/Button'
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -12,6 +12,7 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from 'lib/ui/DropdownMenu/DropdownMenu'
+import { cn } from 'lib/utils/css-classes'
 import { getProjectSwitchTargetUrl } from 'lib/utils/router-utils'
 import { useMemo } from 'react'
 import { organizationLogic } from 'scenes/organizationLogic'
@@ -42,22 +43,20 @@ function OtherProjectButton({ team }: { team: TeamBasicType }): JSX.Element {
 
     return (
         <DropdownMenuItem asChild>
-            <Button.Root menuItem to={relativeOtherProjectPath}>
-                <Button.Label>
-                    <ProjectName team={team} />
-                </Button.Label>
-                <Button.Icon
-                    isTrigger
-                    isTriggerRight
-                    onClick={(e) => {
-                        e.preventDefault()
-                        e.stopPropagation()
-                        e.nativeEvent.stopImmediatePropagation()
-                        router.actions.push(urls.project(team.id, urls.settings()))
-                    }}
+            <Button.Root menuItem>
+                <Link to={relativeOtherProjectPath}>
+                    <Button.Label className="text-primary">
+                        <ProjectName team={team} />
+                    </Button.Label>
+                </Link>
+                <Link
+                    to={urls.project(team.id, urls.settings())}
+                    className={cn(iconVariants({ isTrigger: true, isTriggerRight: true }), 'ml-auto')}
                 >
-                    <IconGear />
-                </Button.Icon>
+                    <Button.Icon>
+                        <IconGear className="text-tertiary" />
+                    </Button.Icon>
+                </Link>
             </Button.Root>
         </DropdownMenuItem>
     )
@@ -69,7 +68,6 @@ export function ProjectDropdownMenu(): JSX.Element | null {
     const { closeAccountPopover } = useActions(navigationLogic)
     const { showCreateProjectModal } = useActions(globalModalsLogic)
     const { currentTeam } = useValues(teamLogic)
-    const { push } = useActions(router)
     const { currentOrganization } = useValues(organizationLogic)
 
     return isAuthenticatedTeam(currentTeam) ? (
@@ -90,13 +88,18 @@ export function ProjectDropdownMenu(): JSX.Element | null {
                 <DropdownMenuSeparator />
                 <div className="flex flex-col gap-px">
                     <DropdownMenuItem asChild>
-                        <Button.Root menuItem active>
+                        <Button.Root menuItem active className="hover:bg-transparent">
                             <Button.Label menuItem>
                                 <ProjectName team={currentTeam} />
                             </Button.Label>
-                            <Button.Icon onClick={() => push(urls.settings('project'))} isTrigger isTriggerRight>
-                                <IconGear className="text-tertiary" />
-                            </Button.Icon>
+                            <Link
+                                to={urls.settings('project')}
+                                className={cn(iconVariants({ isTrigger: true, isTriggerRight: true }), 'ml-auto')}
+                            >
+                                <Button.Icon>
+                                    <IconGear className="text-tertiary" />
+                                </Button.Icon>
+                            </Link>
                         </Button.Root>
                     </DropdownMenuItem>
 

--- a/frontend/src/lib/ui/Button/Button.tsx
+++ b/frontend/src/lib/ui/Button/Button.tsx
@@ -238,7 +238,7 @@ ButtonRoot.displayName = 'Button.Root'
 /*                              Button.Icon                                   */
 /* -------------------------------------------------------------------------- */
 
-const iconVariants = cva({
+export const iconVariants = cva({
     base: `
         flex
         items-center

--- a/frontend/src/lib/ui/Button/Button.tsx
+++ b/frontend/src/lib/ui/Button/Button.tsx
@@ -97,8 +97,6 @@ const buttonVariants = cva({
         px-[5px] 
         py-[3px] 
         rounded-md 
-        transition-colors 
-        duration-100
         cursor-default
     `,
     variants: {

--- a/frontend/src/lib/ui/Label/Label.tsx
+++ b/frontend/src/lib/ui/Label/Label.tsx
@@ -6,7 +6,7 @@ const labelVariants = cva({
     base: 'font-semibold',
     variants: {
         intent: {
-            menu: 'text-tertiary uppercase font-semibold text-xs leading-6 tracking-[0.075em]',
+            menu: 'text-tertiary uppercase font-semibold text-[0.6875rem] leading-5 tracking-[0.075em] pt-1',
         },
     },
 })


### PR DESCRIPTION
## Problem
* in panel layout/ tree, when an org name was too long, it didn't truncate
* in panel layout/ tree, project links and their links to settings were not working correctly
* Org trigger wasn't bold
* Dropdown labels were a bit too big
* New button didn't feel snappy

<img width="401" alt="image" src="https://github.com/user-attachments/assets/739d09e3-2cb9-4539-b1b0-89c7bba8cd69" />

![2025-03-31 11 53 11](https://github.com/user-attachments/assets/ca6f3918-5f71-47ab-ba8c-d096399ba292)


## Changes
* Added max with to org dropdown, limiting it's space and truncating the text correctly.
* Use Link components for the project links
* Made org dropdown bold
* Dropdown labels text size change
* New button removed transitions

## How did you test this code?
Locally

