### PR TITLE
feat: interpolate env vars in the KAFKA_CLIENT_ID variables

### DIFF
--- a/bin/plugin-server
+++ b/bin/plugin-server
@@ -30,6 +30,9 @@ if [[ -n $INJECT_EC2_CLIENT_RACK ]]; then
   # TODO: switch to the downwards API when https://github.com/kubernetes/kubernetes/issues/40610 is released
   TOKEN=$(curl --max-time 0.1 -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
   export KAFKA_CLIENT_RACK=$(curl --max-time 0.1 -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/placement/availability-zone-id)
+  # interpolate the KAFKA_CLIENT_RACK value in KAFKA_CLIENT_ID env vars
+  export KAFKA_CLIENT_ID=$(echo $KAFKA_CLIENT_ID | envsubst)
+  export KAFKA_PRODUCER_CLIENT_ID=$(echo $KAFKA_PRODUCER_CLIENT_ID | envsubst)
 fi
 
 ./bin/migrate-check


### PR DESCRIPTION

## Problem

this allows us to reference $KAFKA_CLIENT_RACK, which we need for efficient usage of warpstream for ingestion

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

MSK doesn't use kafka client id, so no change there. Will test it on warpstream-replay in dev