### PR TITLE
fix(crm): Ensure group type property definitions are created

### DIFF
--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -215,6 +215,12 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, viewsets.Gene
                         },
                         status=400,
                     )
+            try:
+                group_type_mapping = GroupTypeMapping.objects.get(
+                    team=self.team, project_id=self.team.project_id, group_type_index=group.group_type_index
+                )
+            except GroupTypeMapping.DoesNotExist:
+                raise NotFound()
             original_value = group.group_properties.get(request.data["key"], None)
             group.group_properties[request.data["key"]] = request.data["value"]
             group.save()
@@ -237,7 +243,7 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, viewsets.Gene
                 event={
                     "event": "$groupidentify",
                     "properties": {
-                        "$group_type_index": group.group_type_index,
+                        "$group_type": group_type_mapping.group_type,
                         "$group_key": group.group_key,
                         "$group_set": {request.data["key"]: request.data["value"]},
                     },
@@ -300,6 +306,12 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, viewsets.Gene
                         },
                         status=400,
                     )
+            try:
+                group_type_mapping = GroupTypeMapping.objects.get(
+                    team=self.team, project_id=self.team.project_id, group_type_index=group.group_type_index
+                )
+            except GroupTypeMapping.DoesNotExist:
+                raise NotFound()
             original_value = group.group_properties[request.data["$unset"]]
             del group.group_properties[request.data["$unset"]]
             group.save()
@@ -322,7 +334,7 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, viewsets.Gene
                 event={
                     "event": "$delete_group_property",
                     "properties": {
-                        "$group_type_index": group.group_type_index,
+                        "$group_type": group_type_mapping.group_type,
                         "$group_key": group.group_key,
                         "$group_unset": [request.data["$unset"]],
                     },

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -511,9 +511,15 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
 
     @freeze_time("2021-05-02")
     def test_get_group_activities_success(self):
+        group_type_mapping = GroupTypeMapping.objects.create(
+            team=self.team,
+            project_id=self.team.project_id,
+            group_type_index=0,
+            group_type="organization",
+        )
         group = create_group(
             team_id=self.team.pk,
-            group_type_index=0,
+            group_type_index=group_type_mapping.group_type_index,
             group_key="org:5",
             properties={"industry": "finance", "name": "Mr. Krabs"},
         )
@@ -541,9 +547,15 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
 
     @freeze_time("2021-05-02")
     def test_get_group_activities_invalid_group(self):
+        group_type_mapping = GroupTypeMapping.objects.create(
+            team=self.team,
+            project_id=self.team.project_id,
+            group_type_index=0,
+            group_type="organization",
+        )
         create_group(
             team_id=self.team.pk,
-            group_type_index=0,
+            group_type_index=group_type_mapping.group_type_index,
             group_key="org:5",
             properties={"industry": "finance", "name": "Mr. Krabs"},
         )

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -4,6 +4,8 @@ from uuid import UUID
 from freezegun.api import freeze_time
 from orjson import orjson
 
+from flaky import flaky
+
 from posthog.helpers.dashboard_templates import create_group_type_mapping_detail_dashboard
 from posthog.hogql.parser import parse_select
 from posthog.hogql import ast
@@ -170,10 +172,17 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
 
     @freeze_time("2021-05-02")
     @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    @flaky(max_runs=3, min_passes=1)
     def test_group_property_crud_add_success(self, mock_capture):
+        group_type_mapping = GroupTypeMapping.objects.create(
+            team=self.team,
+            project_id=self.team.project_id,
+            group_type_index=0,
+            group_type="organization",
+        )
         group = create_group(
             team_id=self.team.pk,
-            group_type_index=0,
+            group_type_index=group_type_mapping.group_type_index,
             group_key="org:5",
             properties={"name": "Mr. Krabs"},
         )
@@ -221,7 +230,7 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
             event={
                 "event": "$groupidentify",
                 "properties": {
-                    "$group_type_index": group.group_type_index,
+                    "$group_type": group_type_mapping.group_type,
                     "$group_key": group.group_key,
                     "$group_set": {"industry": "technology"},
                 },
@@ -247,10 +256,17 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
 
     @freeze_time("2021-05-02")
     @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    @flaky(max_runs=3, min_passes=1)
     def test_group_property_crud_update_success(self, mock_capture):
+        group_type_mapping = GroupTypeMapping.objects.create(
+            team=self.team,
+            project_id=self.team.project_id,
+            group_type_index=0,
+            group_type="organization",
+        )
         group = create_group(
             team_id=self.team.pk,
-            group_type_index=0,
+            group_type_index=group_type_mapping.group_type_index,
             group_key="org:5",
             properties={"industry": "finance", "name": "Mr. Krabs"},
         )
@@ -301,7 +317,7 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
             event={
                 "event": "$groupidentify",
                 "properties": {
-                    "$group_type_index": group.group_type_index,
+                    "$group_type": group_type_mapping.group_type,
                     "$group_key": group.group_key,
                     "$group_set": {"industry": "technology"},
                 },
@@ -327,9 +343,15 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
 
     @freeze_time("2021-05-02")
     def test_group_property_crud_update_missing_key(self):
+        group_type_mapping = GroupTypeMapping.objects.create(
+            team=self.team,
+            project_id=self.team.project_id,
+            group_type_index=0,
+            group_type="organization",
+        )
         create_group(
             team_id=self.team.pk,
-            group_type_index=0,
+            group_type_index=group_type_mapping.group_type_index,
             group_key="org:5",
             properties={"industry": "finance", "name": "Mr. Krabs"},
         )
@@ -342,9 +364,15 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
 
     @freeze_time("2021-05-02")
     def test_group_property_crud_update_invalid_group_key(self):
+        group_type_mapping = GroupTypeMapping.objects.create(
+            team=self.team,
+            project_id=self.team.project_id,
+            group_type_index=0,
+            group_type="organization",
+        )
         create_group(
             team_id=self.team.pk,
-            group_type_index=0,
+            group_type_index=group_type_mapping.group_type_index,
             group_key="org:5",
             properties={"industry": "finance", "name": "Mr. Krabs"},
         )
@@ -357,10 +385,17 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
 
     @freeze_time("2021-05-02")
     @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    @flaky(max_runs=3, min_passes=1)
     def test_group_property_crud_delete_success(self, mock_capture):
+        group_type_mapping = GroupTypeMapping.objects.create(
+            team=self.team,
+            project_id=self.team.project_id,
+            group_type_index=0,
+            group_type="organization",
+        )
         group = create_group(
             team_id=self.team.pk,
-            group_type_index=0,
+            group_type_index=group_type_mapping.group_type_index,
             group_key="org:5",
             properties={"industry": "finance", "name": "Mr. Krabs"},
         )
@@ -408,7 +443,7 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
             event={
                 "event": "$delete_group_property",
                 "properties": {
-                    "$group_type_index": group.group_type_index,
+                    "$group_type": group_type_mapping.group_type,
                     "$group_key": group.group_key,
                     "$group_unset": ["industry"],
                 },
@@ -434,9 +469,15 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
 
     @freeze_time("2021-05-02")
     def test_group_property_crud_delete_missing_key(self):
+        group_type_mapping = GroupTypeMapping.objects.create(
+            team=self.team,
+            project_id=self.team.project_id,
+            group_type_index=0,
+            group_type="organization",
+        )
         create_group(
             team_id=self.team.pk,
-            group_type_index=0,
+            group_type_index=group_type_mapping.group_type_index,
             group_key="org:5",
             properties={"industry": "finance", "name": "Mr. Krabs"},
         )
@@ -449,9 +490,15 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
 
     @freeze_time("2021-05-02")
     def test_group_property_crud_delete_invalid_group_key(self):
+        group_type_mapping = GroupTypeMapping.objects.create(
+            team=self.team,
+            project_id=self.team.project_id,
+            group_type_index=0,
+            group_type="organization",
+        )
         create_group(
             team_id=self.team.pk,
-            group_type_index=0,
+            group_type_index=group_type_mapping.group_type_index,
             group_key="org:5",
             properties={"industry": "finance", "name": "Mr. Krabs"},
         )


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/29881

## Changes

Ensures group type property definitions are created in the `$groupidentify` call. `$group_type` is expected, and `$group_type_index` doesn't do anything.

Also adds `@flaky` decorator to the tests that read from ClickHouse because sometimes the data doesn't end up in ClickHouse quick enough.

## How did you test this code?

I added a new property to a group and verified the property definition was created.