### PR TITLE
refactor(temporal): Use /ping to check if ClickHouse is alive

### DIFF
--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -6,6 +6,7 @@ import json
 import ssl
 import typing
 import uuid
+from urllib.parse import urljoin
 
 import aiohttp
 import pyarrow as pa
@@ -190,10 +191,11 @@ class ClickHouseClient:
         if self.session is None:
             raise ClickHouseClientNotConnected()
 
+        ping_url = urljoin(self.url, "ping")
+
         try:
             await self.session.get(
-                url=self.url,
-                params={**self.params, "query": "SELECT 1"},
+                url=ping_url,
                 headers=self.headers,
                 raise_for_status=True,
             )


### PR DESCRIPTION
## Problem

The /ping endpoint is the recommended way of checking if the ClickHouse cluster is alive, so let's use that instead.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
