### PR TITLE
chore: add automatic react installation

### DIFF
--- a/frontend/src/scenes/onboarding/sdks/experiments/react.tsx
+++ b/frontend/src/scenes/onboarding/sdks/experiments/react.tsx
@@ -8,7 +8,7 @@ import { ExperimentsImplementationSnippet } from './ExperimentsImplementationSni
 export function ExperimentsReactInstructions(): JSX.Element {
     return (
         <>
-            <SDKInstallReactInstructions />
+            <SDKInstallReactInstructions hideWizard />
             <LemonDivider thick dashed className="my-4" />
             <ExperimentsImplementationSnippet sdkKey={SDKKey.REACT} />
         </>

--- a/frontend/src/scenes/onboarding/sdks/feature-flags/react.tsx
+++ b/frontend/src/scenes/onboarding/sdks/feature-flags/react.tsx
@@ -6,7 +6,7 @@ import { FlagImplementationSnippet } from './flagImplementationSnippet'
 export function FeatureFlagsReactInstructions(): JSX.Element {
     return (
         <>
-            <SDKInstallReactInstructions />
+            <SDKInstallReactInstructions hideWizard />
             <FlagImplementationSnippet sdkKey={SDKKey.REACT} />
         </>
     )

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/components/SetupWizardBanner.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/components/SetupWizardBanner.tsx
@@ -1,0 +1,28 @@
+import { useValues } from 'kea'
+import { Language } from 'lib/components/CodeSnippet'
+import { CodeSnippet } from 'lib/components/CodeSnippet'
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+
+const SetupWizardBanner = (): JSX.Element => {
+    const { preflight } = useValues(preflightLogic)
+
+    const region = preflight?.region || 'us'
+    const wizardCommand = `npx @posthog/wizard@latest${region ? ` --region ${region.toLowerCase()}` : ''}`
+
+    return (
+        <LemonBanner type="info" hideIcon={true}>
+            <h3 className="flex items-center gap-2 pb-1">
+                <LemonTag type="completion">ALPHA</LemonTag> AI setup wizard
+            </h3>
+            <div className="flex flex-col p-2">
+                <p className="font-normal pb-1">Try using the AI setup wizard to automatically install PostHog.</p>
+                <p className="font-normal pb-2">Run the following command from the root of your NextJS project.</p>
+                <CodeSnippet language={Language.Bash}>{wizardCommand}</CodeSnippet>
+            </div>
+        </LemonBanner>
+    )
+}
+
+export default SetupWizardBanner

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/next-js.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/next-js.tsx
@@ -1,4 +1,4 @@
-import { LemonBanner, LemonDivider, LemonTabs, LemonTag } from '@posthog/lemon-ui'
+import { LemonDivider, LemonTabs } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -9,6 +9,7 @@ import { apiHostOrigin } from 'lib/utils/apiHost'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
+import SetupWizardBanner from './components/SetupWizardBanner'
 import { JSInstallSnippet } from './js-web'
 import { nextJsInstructionsLogic, type NextJSRouter } from './nextJsInstructionsLogic'
 
@@ -167,31 +168,15 @@ function SuspendedPostHogPageView() {
 export function SDKInstallNextJSInstructions({ hideWizard }: { hideWizard?: boolean }): JSX.Element {
     const { nextJsRouter } = useValues(nextJsInstructionsLogic)
     const { setNextJsRouter } = useActions(nextJsInstructionsLogic)
-    const { preflight, isCloudOrDev } = useValues(preflightLogic)
+    const { isCloudOrDev } = useValues(preflightLogic)
     const showSetupWizard = useFeatureFlag('AI_SETUP_WIZARD') && !hideWizard && isCloudOrDev
 
-    const region = preflight?.region || 'us'
-
-    const wizardCommand = `npx @posthog/wizard@latest${region ? ` --region ${region.toLowerCase()}` : ''}`
     return (
         <>
             {showSetupWizard && (
                 <>
                     <h2>Automated Installation</h2>
-                    <LemonBanner type="info" hideIcon={true}>
-                        <h3 className="flex items-center gap-2 pb-1">
-                            <LemonTag type="completion">ALPHA</LemonTag> AI setup wizard
-                        </h3>
-                        <div className="flex flex-col p-2">
-                            <p className="font-normal pb-1">
-                                Try using the AI setup wizard to automatically install PostHog.
-                            </p>
-                            <p className="font-normal pb-2">
-                                Run the following command from the root of your NextJS project.
-                            </p>
-                            <CodeSnippet language={Language.Bash}>{wizardCommand}</CodeSnippet>
-                        </div>
-                    </LemonBanner>
+                    <SetupWizardBanner />
                     <LemonDivider label="OR" />
                     <h2>Manual Installation</h2>
                 </>

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/react.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/react.tsx
@@ -1,8 +1,12 @@
+import { LemonDivider } from '@posthog/lemon-ui'
 import { useValues } from 'kea'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { apiHostOrigin } from 'lib/utils/apiHost'
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
+import SetupWizardBanner from './components/SetupWizardBanner'
 import { JSInstallSnippet } from './js-web'
 
 function ReactEnvVarsSnippet(): JSX.Element {
@@ -47,9 +51,19 @@ root.render(
     )
 }
 
-export function SDKInstallReactInstructions(): JSX.Element {
+export function SDKInstallReactInstructions({ hideWizard }: { hideWizard?: boolean }): JSX.Element {
+    const { isCloudOrDev } = useValues(preflightLogic)
+    const showSetupWizard = useFeatureFlag('AI_SETUP_WIZARD') && !hideWizard && isCloudOrDev
     return (
         <>
+            {showSetupWizard && (
+                <>
+                    <h2>Automated Installation</h2>
+                    <SetupWizardBanner />
+                    <LemonDivider label="OR" />
+                    <h2>Manual Installation</h2>
+                </>
+            )}
             <h3>Install the package</h3>
             <JSInstallSnippet />
             <h3>Add environment variables</h3>


### PR DESCRIPTION
## Problem

React users should enjoy automatic installations

## Changes

Add setup wizard to react docs

## Does this work well for both Cloud and self-hosted?

Yes - it's hidden on self hosted instances

## How did you test this code?

Ran locally
