### PR TITLE
chore: combine usage report activities

### DIFF
--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -3,7 +3,7 @@ import os
 from posthog.settings.utils import get_from_env, get_list
 
 TEMPORAL_NAMESPACE: str = os.getenv("TEMPORAL_NAMESPACE", "default")
-TEMPORAL_TASK_QUEUE: str = os.getenv("TEMPORAL_TASK_QUEUE", "no-sandbox-python-django")
+TEMPORAL_TASK_QUEUE: str = os.getenv("TEMPORAL_TASK_QUEUE", "general-purpose-task-queue")
 TEMPORAL_HOST: str = os.getenv("TEMPORAL_HOST", "127.0.0.1")
 TEMPORAL_PORT: str = os.getenv("TEMPORAL_PORT", "7233")
 TEMPORAL_CLIENT_ROOT_CA: str | None = os.getenv("TEMPORAL_CLIENT_ROOT_CA", None)

--- a/posthog/temporal/usage_reports/__init__.py
+++ b/posthog/temporal/usage_reports/__init__.py
@@ -1,7 +1,6 @@
 from posthog.temporal.usage_reports.run_usage_reports import (
     RunUsageReportsWorkflow,
     query_usage_reports,
-    send_usage_reports,
 )
 
 WORKFLOWS = [
@@ -10,5 +9,4 @@ WORKFLOWS = [
 
 ACTIVITIES = [
     query_usage_reports,
-    send_usage_reports,
 ]

--- a/posthog/temporal/usage_reports/run_usage_reports.py
+++ b/posthog/temporal/usage_reports/run_usage_reports.py
@@ -50,15 +50,10 @@ class QueryUsageReportsInputs:
     skip_capture_event: Optional[bool] = False
 
 
-@dataclasses.dataclass
-class QueryUsageReportsResult:
-    pass
-
-
 @activity.defn(name="query-usage-reports")
 async def query_usage_reports(
     inputs: QueryUsageReportsInputs,
-) -> QueryUsageReportsResult:
+) -> None:
     async with Heartbeater():
         import posthoganalytics
         from sentry_sdk import capture_message
@@ -68,7 +63,7 @@ async def query_usage_reports(
         )
         if are_usage_reports_disabled:
             capture_message(f"Usage reports are disabled for {inputs.at}")
-            return QueryUsageReportsResult()
+            return None
 
         at_date = parser.parse(inputs.at) if inputs.at else None
         period = get_previous_day(at=at_date)
@@ -211,7 +206,7 @@ async def query_usage_reports(
         )
         pha_client.flush()  # Flush and close the client
 
-        return QueryUsageReportsResult()
+        return None
 
 
 @workflow.defn(name="run-usage-reports")

--- a/posthog/temporal/usage_reports/run_usage_reports.py
+++ b/posthog/temporal/usage_reports/run_usage_reports.py
@@ -68,7 +68,7 @@ async def query_usage_reports(
         )
         if are_usage_reports_disabled:
             capture_message(f"Usage reports are disabled for {inputs.at}")
-            return
+            return QueryUsageReportsResult()
 
         at_date = parser.parse(inputs.at) if inputs.at else None
         period = get_previous_day(at=at_date)
@@ -210,6 +210,8 @@ async def query_usage_reports(
             groups={"instance": settings.SITE_URL},
         )
         pha_client.flush()  # Flush and close the client
+
+        return QueryUsageReportsResult()
 
 
 @workflow.defn(name="run-usage-reports")

--- a/posthog/temporal/usage_reports/run_usage_reports.py
+++ b/posthog/temporal/usage_reports/run_usage_reports.py
@@ -47,18 +47,12 @@ class RunUsageReportsInputs:
 @dataclasses.dataclass
 class QueryUsageReportsInputs:
     at: Optional[str] = None
+    skip_capture_event: Optional[bool] = False
 
 
 @dataclasses.dataclass
 class QueryUsageReportsResult:
-    org_reports: dict[str, OrgReport]
-
-
-@dataclasses.dataclass
-class SendUsageReportsInputs:
-    org_reports: dict[str, OrgReport]
-    skip_capture_event: Optional[bool] = False
-    at: Optional[str] = None
+    pass
 
 
 @activity.defn(name="query-usage-reports")
@@ -74,9 +68,7 @@ async def query_usage_reports(
         )
         if are_usage_reports_disabled:
             capture_message(f"Usage reports are disabled for {inputs.at}")
-            return QueryUsageReportsResult(
-                org_reports={},
-            )
+            return
 
         at_date = parser.parse(inputs.at) if inputs.at else None
         period = get_previous_day(at=at_date)
@@ -95,8 +87,6 @@ async def query_usage_reports(
             return result
 
         raw_data = await async_get_all_usage_data(period_start, period_end)
-
-        activity.heartbeat()
 
         all_data = convert_to_team_rows(raw_data)
 
@@ -124,20 +114,6 @@ async def query_usage_reports(
 
         print(f"Generating org reports complete {len(org_reports)} orgs")  # noqa: T201
 
-        return QueryUsageReportsResult(
-            org_reports=org_reports,
-        )
-
-
-@activity.defn(name="send-usage-reports")
-async def send_usage_reports(
-    inputs: SendUsageReportsInputs,
-) -> None:
-    async with Heartbeater():
-        at_date = parser.parse(inputs.at) if inputs.at else None
-        period = get_previous_day(at=at_date)
-        period_start, period_end = period
-
         @sync_to_async
         def async_get_instance_metadata(p):
             return get_instance_metadata(p)
@@ -155,7 +131,7 @@ async def send_usage_reports(
 
         pha_client = get_ph_client(sync_mode=True)
 
-        total_orgs = len(inputs.org_reports)
+        total_orgs = len(org_reports)
         total_orgs_sent = 0
 
         pha_client.capture(
@@ -172,8 +148,13 @@ async def send_usage_reports(
 
         print(f"Sending usage reports {total_orgs} orgs")  # noqa: T201
 
-        for org_report in inputs.org_reports.values():
+        org_count = 0
+        for org_report in org_reports.values():
             try:
+                org_count += 1
+                if org_count % 500 == 0:
+                    print(f"Processed {org_count}/{total_orgs} organizations...")  # noqa: T201
+
                 organization_id = org_report.organization_id
 
                 full_report = _get_full_org_usage_report(org_report, instance_metadata)
@@ -213,6 +194,9 @@ async def send_usage_reports(
             except Exception as loop_err:
                 logger.exception(f"Error processing organization report: {loop_err}")
 
+        print(f"Total orgs: {total_orgs}")  # noqa: T201
+        print(f"Total orgs sent: {total_orgs_sent}")  # noqa: T201
+
         pha_client.capture(
             "internal_billing_events",
             "usage reports - sending complete",
@@ -241,36 +225,17 @@ class RunUsageReportsWorkflow(PostHogWorkflow):
         try:
             query_usage_reports_inputs = QueryUsageReportsInputs(
                 at=inputs.at,
-            )
-            query_usage_reports_result = await workflow.execute_activity(
-                query_usage_reports,
-                query_usage_reports_inputs,
-                start_to_close_timeout=timedelta(minutes=20),
-                retry_policy=common.RetryPolicy(
-                    maximum_attempts=3,
-                    initial_interval=timedelta(minutes=1),
-                ),
-                heartbeat_timeout=timedelta(minutes=2),
-            )
-
-            if not query_usage_reports_result.org_reports:
-                logger.info("No org reports found - skipping send")
-                return
-
-            send_usage_reports_inputs = SendUsageReportsInputs(
-                org_reports=query_usage_reports_result.org_reports,
                 skip_capture_event=inputs.skip_capture_event,
-                at=inputs.at,
             )
             await workflow.execute_activity(
-                send_usage_reports,
-                send_usage_reports_inputs,
-                start_to_close_timeout=timedelta(minutes=30),
+                query_usage_reports,
+                query_usage_reports_inputs,
+                start_to_close_timeout=timedelta(minutes=40),
                 retry_policy=common.RetryPolicy(
                     maximum_attempts=3,
                     initial_interval=timedelta(minutes=1),
                 ),
-                heartbeat_timeout=timedelta(minutes=2),
+                heartbeat_timeout=timedelta(minutes=4),
             )
 
         except Exception as e:


### PR DESCRIPTION
## Changes

We're seeing some issues with the query activity OOMing on the return because the org report object is so big. So combining the two activities so it doesn't need to serializer the large object.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

I doesn't have an impact.

## How did you test this code?

Tested manually
