### PR TITLE
chore: usage reports optimizations

### DIFF
--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -1111,6 +1111,7 @@ def _get_teams_for_usage_reports() -> Sequence[Team]:
         Team.objects.select_related("organization")
         .exclude(Q(organization__for_internal_metrics=True) | Q(is_demo=True))
         .only("id", "name", "organization__id", "organization__name", "organization__created_at")
+        .order_by("organization__id")
     )
 
 

--- a/posthog/temporal/usage_reports/run_usage_reports.py
+++ b/posthog/temporal/usage_reports/run_usage_reports.py
@@ -246,19 +246,20 @@ async def query_usage_reports(
         print(f"Total orgs counted: {org_count}")  # noqa: T201
         print(f"Total orgs sent: {total_orgs_sent}")  # noqa: T201
 
-        pha_client.capture(
-            "internal_billing_events",
-            "usage reports - sending complete",
-            {
-                "total_orgs": total_orgs,
-                "total_orgs_sent": total_orgs_sent,
-                "period_start": period_start.isoformat(),
-                "period_end": period_end.isoformat(),
-                "region": get_instance_region(),
-            },
-            groups={"instance": settings.SITE_URL},
-        )
-        pha_client.flush()  # Flush and close the client
+        if get_instance_region():
+            pha_client.capture(
+                "internal_billing_events",
+                "usage reports - sending complete",
+                {
+                    "total_orgs": total_orgs,
+                    "total_orgs_sent": total_orgs_sent,
+                    "period_start": period_start.isoformat(),
+                    "period_end": period_end.isoformat(),
+                    "region": get_instance_region(),
+                },
+                groups={"instance": settings.SITE_URL},
+            )
+            pha_client.flush()  # Flush and close the client
 
         return None
 

--- a/posthog/temporal/usage_reports/run_usage_reports.py
+++ b/posthog/temporal/usage_reports/run_usage_reports.py
@@ -204,6 +204,12 @@ async def query_usage_reports(
             else:
                 # Add this team to the current org report
                 team_report = await async_get_team_report(all_data, team)
+
+                # Safety check to ensure team belongs to the current organization (should never happen)
+                if str(team.organization.id) != current_org_id:
+                    capture_message(f"Usage report: team organization mismatch: {team.id} {current_org_id}")
+                    continue
+
                 current_org_report.teams[str(team.id)] = team_report
                 current_org_report.team_count += 1
 

--- a/posthog/temporal/usage_reports/run_usage_reports.py
+++ b/posthog/temporal/usage_reports/run_usage_reports.py
@@ -157,9 +157,12 @@ async def query_usage_reports(
             org_id = str(team.organization.id)
 
             # If we've moved to a new organization, process the previous one
-            if current_org_id is not None and current_org_id != org_id:
+            # The linter incorrectly thinks current_org_id is always None, but it's updated in the loop
+            if current_org_id is not None and current_org_id != org_id:  # type: ignore[unreachable]
+                # This is not unreachable because current_org_id is updated in the loop
                 org_count += 1
-                if org_count % 500 == 0:
+                # This line is flagged because it's inside the conditionals the linter thinks are unreachable
+                if org_count % 500 == 0:  # type: ignore[unreachable]
                     print(f"Processed {org_count} organizations...")  # noqa: T201
 
                 # Process the completed organization report
@@ -208,7 +211,8 @@ async def query_usage_reports(
                 # Safety check to ensure team belongs to the current organization (should never happen)
                 if str(team.organization.id) != current_org_id:
                     capture_message(f"Usage report: team organization mismatch: {team.id} {current_org_id}")
-                    continue
+                    # False positive: The linter doesn't understand the loop state changes
+                    continue  # type: ignore[unreachable]
 
                 current_org_report.teams[str(team.id)] = team_report
                 current_org_report.team_count += 1


### PR DESCRIPTION
## Changes

Follow up to: https://github.com/PostHog/posthog/pull/30604

We're still seeing OOMs so this should solve it by optimizing the memory usage. Only keeping one org report in memory at a time. What this does is essentially sort the teams by organization id so we can go through them sequentially and aggregate all the data for all teams in an org and send that to SQS. 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

It doesn't have an impact. 

## How did you test this code?

Manually. 
