### PR TITLE
fix(max): Only throttle AI calls, not canceling

### DIFF
--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -52,7 +52,9 @@ class ConversationViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
         return queryset.filter(user=self.request.user)
 
     def get_throttles(self):
-        return [AIBurstRateThrottle(), AISustainedRateThrottle()]
+        if self.action == "create":
+            return [AIBurstRateThrottle(), AISustainedRateThrottle()]
+        return super().get_throttles()
 
     def get_renderers(self):
         if self.action == "create":


### PR DESCRIPTION
## Problem

Currently any operation on the /conversations/ endpoint is throttled as if it made LLM calls. Means you can't _stop_ a generation when you run into the LLM call rate limit!

## Changes

Tweaked the viewset so that only POST /conversations/ is rate-limited with the AI throttled.
