### PR TITLE
fix: remote cfg is not dict, but a string

### DIFF
--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -93,7 +93,7 @@ def validated_client_query_id() -> Optional[str]:
 @cached(cache=TTLCache(maxsize=1, ttl=600))
 def get_api_queries_online_allow_list() -> set[int]:
     with suppress(Exception):
-        cfg = posthoganalytics.get_remote_config_payload("api-queries-on-online-cluster")
+        cfg = json.loads(posthoganalytics.get_remote_config_payload("api-queries-on-online-cluster"))
         return set(cfg.get("allowed_team_id", [])) if cfg else set[int]()
     return set[int]()
 


### PR DESCRIPTION
## Problem

get_remote_config_payload return value is string

## Changes

Run json.loads on the result

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Hand verify