### PR TITLE
chore(web-analytics): Page Reports's filters UI improvements

### DIFF
--- a/frontend/src/scenes/web-analytics/PageReports.tsx
+++ b/frontend/src/scenes/web-analytics/PageReports.tsx
@@ -1,3 +1,5 @@
+import { IconAsterisk } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { XRayHog2 } from 'lib/components/hedgehogs'
@@ -62,15 +64,9 @@ export function PageReportsFilters(): JSX.Element {
                     />
                 </div>
                 <Tooltip title="Strip query parameters from URLs (e.g. '?utm_source=...'). This will match the base URL regardless of query parameters.">
-                    <div className="inline-block">
-                        <LemonSwitch
-                            checked={stripQueryParams}
-                            onChange={toggleStripQueryParams}
-                            label="Strip query params"
-                            size="small"
-                            bordered
-                        />
-                    </div>
+                    <LemonButton icon={<IconAsterisk />} onClick={toggleStripQueryParams} type="secondary" size="small">
+                        Strip query parameters: <LemonSwitch checked={stripQueryParams} className="ml-1" />
+                    </LemonButton>
                 </Tooltip>
                 <DateFilter dateFrom={dateFilter.dateFrom} dateTo={dateFilter.dateTo} onChange={setDates} />
                 <WebAnalyticsCompareFilter />

--- a/frontend/src/scenes/web-analytics/PageReports.tsx
+++ b/frontend/src/scenes/web-analytics/PageReports.tsx
@@ -1,4 +1,4 @@
-import { IconAsterisk } from '@posthog/icons'
+import { IconAsterisk, IconGlobe } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
@@ -48,20 +48,23 @@ export function PageReportsFilters(): JSX.Element {
         <div className="flex flex-col gap-2">
             <div className="flex items-center gap-2">
                 <div className="flex-1">
-                    <LemonInputSelect
-                        allowCustomValues={false}
-                        placeholder="Click or type to see top pages"
-                        loading={isLoading}
-                        size="small"
-                        mode="single"
-                        value={pageUrl ? [pageUrl] : null}
-                        onChange={(val: string[]) => setPageUrl(val.length > 0 ? val[0] : null)}
-                        options={options}
-                        onInputChange={(val: string) => setPageUrlSearchTerm(val)}
-                        data-attr="page-reports-url-search"
-                        onFocus={() => loadPages('')}
-                        className="max-w-full"
-                    />
+                    <div className="relative">
+                        <IconGlobe className="absolute left-2 top-1/2 -translate-y-1/2 text-muted" />
+                        <LemonInputSelect
+                            allowCustomValues={false}
+                            placeholder="Click or type to see top pages"
+                            loading={isLoading}
+                            size="small"
+                            mode="single"
+                            value={pageUrl ? [pageUrl] : null}
+                            onChange={(val: string[]) => setPageUrl(val.length > 0 ? val[0] : null)}
+                            options={options}
+                            onInputChange={(val: string) => setPageUrlSearchTerm(val)}
+                            data-attr="page-reports-url-search"
+                            onFocus={() => loadPages('')}
+                            className="max-w-full pl-8"
+                        />
+                    </div>
                 </div>
                 <Tooltip title="Strip query parameters from URLs (e.g. '?utm_source=...'). This will match the base URL regardless of query parameters.">
                     <LemonButton icon={<IconAsterisk />} onClick={toggleStripQueryParams} type="secondary" size="small">

--- a/frontend/src/scenes/web-analytics/pageReportsLogic.ts
+++ b/frontend/src/scenes/web-analytics/pageReportsLogic.ts
@@ -520,14 +520,14 @@ export const pageReportsLogic = kea<pageReportsLogicType>({
                 actions.setPageUrl(searchParams.pageURL)
             }
 
-            if (!!searchParams.stripQueryParams !== values.stripQueryParams) {
+            // Only toggle stripQueryParams if it's explicitly present in the URL
+            if ('stripQueryParams' in searchParams && !!searchParams.stripQueryParams !== values.stripQueryParams) {
                 actions.toggleStripQueryParams()
             }
         },
     }),
 
     actionToUrl: ({ values }) => ({
-        // So far we don't need to do anything for dateFilters because webAnalyticsLogic handles it.
         setPageUrl: () => {
             const searchParams = { ...router.values.searchParams }
 
@@ -537,14 +537,16 @@ export const pageReportsLogic = kea<pageReportsLogicType>({
                 delete searchParams.pageURL
             }
 
-            searchParams.stripQueryParams = Boolean(values.stripQueryParams)
+            // Only include stripQueryParams if it's different from the URL
+            if (!!router.values.searchParams.stripQueryParams !== values.stripQueryParams) {
+                searchParams.stripQueryParams = values.stripQueryParams
+            }
 
             return ['/web/page-reports', searchParams, router.values.hashParams, { replace: true }]
         },
         toggleStripQueryParams: () => {
             const searchParams = { ...router.values.searchParams }
-
-            searchParams.stripQueryParams = Boolean(values.stripQueryParams)
+            searchParams.stripQueryParams = values.stripQueryParams
 
             return ['/web/page-reports', searchParams, router.values.hashParams, { replace: true }]
         },


### PR DESCRIPTION
General improvements on the Page Reports filter's row based on a few of @robbie-c feedback. A small fix for the `stripQueryParams` filter was also included.

<img width="1426" alt="image" src="https://github.com/user-attachments/assets/5543912c-dcfa-486f-b387-7eae5e2dcfd7" />


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manually