### PR TITLE
feat(cdp): accept power platform webhook urls for ms teams destination

### DIFF
--- a/posthog/cdp/templates/microsoft_teams/template_microsoft_teams.py
+++ b/posthog/cdp/templates/microsoft_teams/template_microsoft_teams.py
@@ -12,8 +12,10 @@ template: HogFunctionTemplate = HogFunctionTemplate(
     category=["Customer Success"],
     hog="""
 if (not match(inputs.webhookUrl, '^https://[^/]+.logic.azure.com:443/workflows/[^/]+/triggers/manual/paths/invoke?.*') and
-    not match(inputs.webhookUrl, '^https://[^/]+.webhook.office.com/webhookb2/[^/]+/IncomingWebhook/[^/]+/[^/]+')) {
-    throw Error('Invalid URL. The URL should match either Azure Logic Apps format (https://<region>.logic.azure.com:443/workflows/...) or Power Platform format (https://<tenant>.webhook.office.com/webhookb2/...)')
+    not match(inputs.webhookUrl, '^https://[^/]+.webhook.office.com/webhookb2/[^/]+/IncomingWebhook/[^/]+/[^/]+') and
+    not match(inputs.webhookUrl, '^https://[^/]+.powerautomate.com/[^/]+') and
+    not match(inputs.webhookUrl, '^https://[^/]+.flow.microsoft.com/[^/]+')) {
+    throw Error('Invalid URL. The URL should match either Azure Logic Apps format (https://<region>.logic.azure.com:443/workflows/...), Power Platform format (https://<tenant>.webhook.office.com/webhookb2/...), or Power Automate format (https://<region>.powerautomate.com/... or https://<region>.flow.microsoft.com/...)')
 }
 
 let res := fetch(inputs.webhookUrl, {
@@ -53,7 +55,7 @@ if (res.status >= 400) {
             "key": "webhookUrl",
             "type": "string",
             "label": "Webhook URL",
-            "description": "You can use either Azure Logic Apps (see: https://support.microsoft.com/en-us/office/create-incoming-webhooks-with-workflows-for-microsoft-teams-8ae491c7-0394-4861-ba59-055e33f75498) or a Power Platform webhook (create through Microsoft Teams by adding an incoming webhook connector to your channel)",
+            "description": "You can use any of these options: Azure Logic Apps (logic.azure.com), Power Platform webhooks (create through Microsoft Teams by adding an incoming webhook connector to your channel), or Power Automate (powerautomate.com or flow.microsoft.com)",
             "secret": False,
             "required": True,
         },

--- a/posthog/cdp/templates/microsoft_teams/template_microsoft_teams.py
+++ b/posthog/cdp/templates/microsoft_teams/template_microsoft_teams.py
@@ -11,8 +11,9 @@ template: HogFunctionTemplate = HogFunctionTemplate(
     icon_url="/static/services/microsoft-teams.png",
     category=["Customer Success"],
     hog="""
-if (not match(inputs.webhookUrl, '^https://[^/]+.logic.azure.com:443/workflows/[^/]+/triggers/manual/paths/invoke?.*')) {
-    throw Error('Invalid URL. The URL should match the format: https://<region>.logic.azure.com:443/workflows/<workflowId>/triggers/manual/paths/invoke?...')
+if (not match(inputs.webhookUrl, '^https://[^/]+.logic.azure.com:443/workflows/[^/]+/triggers/manual/paths/invoke?.*') and
+    not match(inputs.webhookUrl, '^https://[^/]+.webhook.office.com/webhookb2/[^/]+/IncomingWebhook/[^/]+/[^/]+')) {
+    throw Error('Invalid URL. The URL should match either Azure Logic Apps format (https://<region>.logic.azure.com:443/workflows/...) or Power Platform format (https://<tenant>.webhook.office.com/webhookb2/...)')
 }
 
 let res := fetch(inputs.webhookUrl, {
@@ -52,7 +53,7 @@ if (res.status >= 400) {
             "key": "webhookUrl",
             "type": "string",
             "label": "Webhook URL",
-            "description": "See this page on how to generate a Webhook URL: https://support.microsoft.com/en-us/office/create-incoming-webhooks-with-workflows-for-microsoft-teams-8ae491c7-0394-4861-ba59-055e33f75498",
+            "description": "You can use either Azure Logic Apps (see: https://support.microsoft.com/en-us/office/create-incoming-webhooks-with-workflows-for-microsoft-teams-8ae491c7-0394-4861-ba59-055e33f75498) or a Power Platform webhook (create through Microsoft Teams by adding an incoming webhook connector to your channel)",
             "secret": False,
             "required": True,
         },

--- a/posthog/cdp/templates/microsoft_teams/test_template_microsoft_teams.py
+++ b/posthog/cdp/templates/microsoft_teams/test_template_microsoft_teams.py
@@ -57,6 +57,18 @@ class TestTemplateMicrosoftTeams(BaseHogFunctionTemplateTest):
                 "https://prod-180.westus.logic.azure.com:443/workflows/abc/triggers/manual/paths/invoke?api-version=2016-06-01",
                 True,
             ],
+            [
+                "https://tenant.webhook.office.com/webhookb2/guid1/IncomingWebhook/guid2/guid3",
+                True,
+            ],
+            [
+                "https://region.powerautomate.com/workflows/guid1/triggers/manual/guid2",
+                True,
+            ],
+            [
+                "https://region.flow.microsoft.com/workflows/guid1/triggers/manual/guid2",
+                True,
+            ],
             ["https://webhook.site/def", False],
             [
                 "https://webhook.site/def#https://prod-180.westus.logic.azure.com:443/workflows/abc/triggers/manual/paths/invoke?api-version=2016-06-01",
@@ -66,10 +78,11 @@ class TestTemplateMicrosoftTeams(BaseHogFunctionTemplateTest):
             if allowed:
                 self.run_function(inputs=self._inputs(webhookUrl=url))
                 assert len(self.get_mock_fetch_calls()) == 1
+                self.mock_fetch.reset_mock()  # Reset mock between tests
             else:
                 with pytest.raises(Exception) as e:
                     self.run_function(inputs=self._inputs(webhookUrl=url))
                 assert (
                     e.value.message  # type: ignore[attr-defined]
-                    == "Invalid URL. The URL should match the format: https://<region>.logic.azure.com:443/workflows/<workflowId>/triggers/manual/paths/invoke?..."
+                    == "Invalid URL. The URL should match either Azure Logic Apps format (https://<region>.logic.azure.com:443/workflows/...), Power Platform format (https://<tenant>.webhook.office.com/webhookb2/...), or Power Automate format (https://<region>.powerautomate.com/... or https://<region>.flow.microsoft.com/...)"
                 )


### PR DESCRIPTION
## Problem

Currently, the Microsoft Teams destination enforces a strict regex pattern that only accepts Azure Logic Apps (logic.azure.com) webhook URLs. However, some users prefer to use Power Automate, which generates webhook URLs under powerautomate.com or flow.microsoft.com.

## Changes

Now the template accepts all three webhook URL formats:
- Azure Logic Apps: https://<region>.logic.azure.com:443/workflows/...
- Power Platform: https://<tenant>.webhook.office.com/webhookb2/...
- Power Automate: Both https://<region>.powerautomate.com/... and https://<region>.flow.microsoft.com/...

## How did you test this code?

- added tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
