### PR TITLE
fix(experiments): limiting foreign key options in admin to team

### DIFF
--- a/posthog/admin/admins/experiment_admin.py
+++ b/posthog/admin/admins/experiment_admin.py
@@ -1,11 +1,32 @@
 from django.contrib import admin
 from django.utils.html import format_html
 from django.urls import reverse
+from django.forms import ModelForm
 
-from posthog.models import Experiment
+from posthog.models import Experiment, Cohort, ExperimentHoldout, FeatureFlag
+
+
+class ExperimentAdminForm(ModelForm):
+    class Meta:
+        model = Experiment
+        fields = "__all__"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Limit the queryset of the exposure_cohort and holdout fields to the team
+        # Otherwise, the queryset will fetch _all_ cohorts and holdouts for _all_ teams,
+        # which is a lot and quite slow.
+        if self.instance and self.instance.pk:
+            if "exposure_cohort" in self.fields:
+                self.fields["exposure_cohort"].queryset = Cohort.objects.filter(team=self.instance.team)
+            if "holdout" in self.fields:
+                self.fields["holdout"].queryset = ExperimentHoldout.objects.filter(team=self.instance.team)
+            if "feature_flag" in self.fields:
+                self.fields["feature_flag"].queryset = FeatureFlag.objects.filter(team=self.instance.team)
 
 
 class ExperimentAdmin(admin.ModelAdmin):
+    form = ExperimentAdminForm
     list_display = (
         "id",
         "name",

--- a/posthog/admin/admins/experiment_admin.py
+++ b/posthog/admin/admins/experiment_admin.py
@@ -18,11 +18,11 @@ class ExperimentAdminForm(ModelForm):
         # which is a lot and quite slow.
         if self.instance and self.instance.pk:
             if "exposure_cohort" in self.fields:
-                self.fields["exposure_cohort"].queryset = Cohort.objects.filter(team=self.instance.team)
+                self.fields["exposure_cohort"].queryset = Cohort.objects.filter(team=self.instance.team)  # type: ignore
             if "holdout" in self.fields:
-                self.fields["holdout"].queryset = ExperimentHoldout.objects.filter(team=self.instance.team)
+                self.fields["holdout"].queryset = ExperimentHoldout.objects.filter(team=self.instance.team)  # type: ignore
             if "feature_flag" in self.fields:
-                self.fields["feature_flag"].queryset = FeatureFlag.objects.filter(team=self.instance.team)
+                self.fields["feature_flag"].queryset = FeatureFlag.objects.filter(team=self.instance.team)  # type: ignore
 
 
 class ExperimentAdmin(admin.ModelAdmin):

--- a/posthog/models/__init__.py
+++ b/posthog/models/__init__.py
@@ -42,7 +42,7 @@ from .event.event import Event
 from .event_buffer import EventBuffer
 from .event_definition import EventDefinition
 from .event_property import EventProperty
-from .experiment import Experiment, ExperimentSavedMetric
+from .experiment import Experiment, ExperimentHoldout, ExperimentSavedMetric
 from .exported_asset import ExportedAsset
 from .feature_flag import FeatureFlag
 from .surveys.survey import Survey


### PR DESCRIPTION
## Problem
It takes ages to load the admin form due to a very large amount of foreign key objects being fetched. 

## Changes
Limit form options to the team.

## How did you test this code?
* tested locally