### PR TITLE
chore: Add minimum uv version

### DIFF
--- a/.github/actions/python-code-quality/action.yml
+++ b/.github/actions/python-code-quality/action.yml
@@ -26,6 +26,7 @@ runs:
           uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
           with:
               enable-cache: true
+              pyproject-file: 'pyproject.toml'
 
         - name: Install SAML (python3-saml) dependencies
           shell: bash

--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -82,6 +82,7 @@ runs:
           uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
           with:
               enable-cache: true
+              pyproject-file: 'pyproject.toml'
 
         - name: Determine if hogql-parser has changed compared to master
           shell: bash

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -61,6 +61,7 @@ jobs:
               uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
               with:
                   enable-cache: true
+                  pyproject-file: 'pyproject.toml'
 
             - name: Install SAML (python3-saml) dependencies
               shell: bash

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -139,6 +139,7 @@ jobs:
               uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
               with:
                   enable-cache: true
+                  pyproject-file: 'pyproject.toml'
 
             - name: Install SAML (python3-saml) dependencies
               run: |
@@ -316,6 +317,7 @@ jobs:
               uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
               with:
                   enable-cache: true
+                  pyproject-file: 'pyproject.toml'
 
             - name: Install SAML (python3-saml) dependencies
               run: |

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -106,6 +106,7 @@ jobs:
               uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
               with:
                   enable-cache: true
+                  pyproject-file: 'pyproject.toml'
 
             - name: Install SAML (python3-saml) dependencies
               run: |

--- a/.github/workflows/ci-hog.yml
+++ b/.github/workflows/ci-hog.yml
@@ -74,6 +74,7 @@ jobs:
               uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
               with:
                   enable-cache: true
+                  pyproject-file: 'pyproject.toml'
 
             - name: Install SAML (python3-saml) dependencies
               run: |
@@ -178,6 +179,7 @@ jobs:
               uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
               with:
                   enable-cache: true
+                  pyproject-file: 'pyproject.toml'
             - name: Install SAML (python3-saml) dependencies
               run: |
                   sudo apt-get update

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -120,6 +120,7 @@ jobs:
               uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
               with:
                   enable-cache: true
+                  pyproject-file: 'pyproject.toml'
 
             - name: Install rust
               if: needs.changes.outputs.plugin-server == 'true'
@@ -236,6 +237,7 @@ jobs:
               uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
               with:
                   enable-cache: true
+                  pyproject-file: 'pyproject.toml'
 
             - name: Install SAML (python3-saml) dependencies
               if: needs.changes.outputs.plugin-server == 'true'

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -136,6 +136,7 @@ jobs:
               uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
               with:
                   enable-cache: true
+                  pyproject-file: 'pyproject.toml'
 
             - name: Install SAML (python3-saml) dependencies
               if: needs.changes.outputs.rust == 'true' && matrix.package == 'feature-flags'

--- a/.github/workflows/ci-turbo.yml
+++ b/.github/workflows/ci-turbo.yml
@@ -47,6 +47,7 @@ jobs:
               uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
               with:
                   enable-cache: true
+                  pyproject-file: 'pyproject.toml'
 
             - name: Install pnpm
               uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -125,7 +125,7 @@ RUN apt-get update && \
     "pkg-config" \
     && \
     rm -rf /var/lib/apt/lists/* && \
-    pip install uv~=0.6 --no-cache-dir && \
+    pip install uv~=0.6.11 --no-cache-dir && \
     UV_PROJECT_ENVIRONMENT=/python-runtime uv sync --frozen --no-dev --no-cache --compile-bytecode --no-binary-package lxml --no-binary-package xmlsec
 
 ENV PATH=/python-runtime/bin:$PATH \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,6 +186,9 @@ dev = [
     "watchdog==5.0.3",
 ]
 
+[tool.uv]
+required-version = ">=0.6.0"
+
 [tool.uv.sources]
 infi-clickhouse-orm = { git = "https://github.com/PostHog/infi.clickhouse_orm", rev = "9578c79f29635ee2c1d01b7979e89adab8383de2" }
 


### PR DESCRIPTION
## Problem

I tried running uv sync with uv 0.2.x and the error message was very cryptic.

The problem was that I needed to update uv, so let's make this way clearer for the next person.

## Changes
Set a minimum uv version of 0.6.0

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Failed when I set the number to 0.7.0