### PR TITLE
fix(flags): Selecting edit in the feature flag list view takes you to edit

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -38,6 +38,7 @@ import {
     FeatureFlagType,
 } from '~/types'
 
+import { featureFlagLogic } from './featureFlagLogic'
 import { featureFlagsLogic, FeatureFlagsTab, FLAGS_PER_PAGE } from './featureFlagsLogic'
 
 export const scene: SceneExport = {
@@ -252,9 +253,13 @@ export function OverViewTab({
                                         resourceType={AccessControlResourceType.FeatureFlag}
                                         fullWidth
                                         disabled={!featureFlag.can_edit}
-                                        onClick={() =>
-                                            featureFlag.id && router.actions.push(urls.featureFlag(featureFlag.id))
-                                        }
+                                        onClick={() => {
+                                            if (featureFlag.id) {
+                                                featureFlagLogic({ id: featureFlag.id }).mount()
+                                                featureFlagLogic({ id: featureFlag.id }).actions.editFeatureFlag(true)
+                                                router.actions.push(urls.featureFlag(featureFlag.id))
+                                            }
+                                        }}
                                     >
                                         Edit
                                     </AccessControlledLemonButton>


### PR DESCRIPTION
## Problem

When trying to edit a feature flag by clicking on the hamburger menu on the left, it takes you to the details page and you have to click edit again to actually edit it. This PR fixes it.

Closes #ISSUE_ID #30574

## Changes

Please view screen recording to see changes

https://github.com/user-attachments/assets/dd9652b4-7d8d-4325-848f-32f8d7f5a97b

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes - this is a purely frontend change that works the same way regardless of deployment type.

## How did you test this code?

Manually tested it
