### PR TITLE
fix(flags): Remote config payload cannot be empty if flag is edited

### DIFF
--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -139,8 +139,10 @@ function validatePayloadRequired(is_remote_configuration: boolean, payload?: Jso
     if (!is_remote_configuration) {
         return undefined
     }
-
-    return payload === undefined ? 'Payload is required for remote configuration flags.' : undefined
+    if (payload === undefined || payload === '') {
+        return 'Payload is required for remote configuration flags.'
+    }
+    return undefined
 }
 
 export interface FeatureFlagLogicProps {


### PR DESCRIPTION
## Problem

After editing a remote config payload feature flag, the payload can be cleared and the feature flag can be successfully saved. This is not correct. Trying to save an empty payload should trigger an error message.

Note: This should not affect the behaviour for other scenarios.

Closes #30607

## Changes

Error message now appears when you try to save an existing remote config feature flag with an empty payload. This validation only affects remote config flags because `validatePayloadRequired` first checks if the flag is a remote config type before performing any payload validation. 

![image](https://github.com/user-attachments/assets/026a9ba0-b7da-4107-bb00-e67fbfabac3d)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes - this is a purely frontend change that works the same way regardless of deployment type.

## How did you test this code?

Manually tested it. 
