### PR TITLE
fix(loading mat views): Avoid rendering early if we don't have the mat view

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/QueryTabs.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryTabs.tsx
@@ -28,7 +28,7 @@ export function QueryTabs({ models, onClear, onClick, onAdd, onRename, activeMod
                     onRename={onRename}
                 />
             ))}
-            <LemonButton onClick={() => onAdd()} icon={<IconPlus fontSize={14} />} />
+            <LemonButton className="rounded-none" onClick={() => onAdd()} icon={<IconPlus fontSize={14} />} />
         </div>
     )
 }

--- a/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
@@ -52,7 +52,7 @@ export function QueryWindow({ onSetMonacoAndEditor }: QueryWindowProps): JSX.Ele
                 {sidebarWidth === 0 && (
                     <LemonButton
                         onClick={() => resetDefaultSidebarWidth()}
-                        className="mt-1 mr-1"
+                        className="rounded-none"
                         icon={<IconSidebarClose />}
                         type="tertiary"
                         size="small"

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryInfo.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryInfo.tsx
@@ -1,4 +1,4 @@
-import { LemonTable } from '@posthog/lemon-ui'
+import { LemonTable, Spinner } from '@posthog/lemon-ui'
 import { useActions } from 'kea'
 import { useValues } from 'kea'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -61,15 +61,24 @@ export function QueryInfo({ codeEditorKey }: QueryInfoProps): JSX.Element {
     const { editingView } = useValues(multitabEditorLogic)
     const { runDataWarehouseSavedQuery } = useActions(multitabEditorLogic)
 
-    const { dataWarehouseSavedQueryMapById, updatingDataWarehouseSavedQuery } = useValues(dataWarehouseViewsLogic)
+    const { dataWarehouseSavedQueryMapById, updatingDataWarehouseSavedQuery, initialDataWarehouseSavedQueryLoading } =
+        useValues(dataWarehouseViewsLogic)
     const { updateDataWarehouseSavedQuery } = useActions(dataWarehouseViewsLogic)
 
     // note: editingView is stale, but dataWarehouseSavedQueryMapById gets updated
     const savedQuery = editingView ? dataWarehouseSavedQueryMapById[editingView.id] : null
 
+    if (initialDataWarehouseSavedQueryLoading) {
+        return (
+            <div className="w-full h-full flex items-center justify-center">
+                <Spinner className="text-lg" />
+            </div>
+        )
+    }
+
     return (
         <div className="overflow-auto">
-            <div className="flex flex-col flex-1 p-4 gap-4 ">
+            <div className="flex flex-col flex-1 p-4 gap-4">
                 <div>
                     <div className="flex flex-row items-center gap-2">
                         <h3 className="mb-0">Materialization</h3>


### PR DESCRIPTION
## Problem
We rendered a little too early in the case that we have a mat view, but haven't loaded it yet.



Also removed some rounded and style details in the top navigation:

### Before
<img width="382" alt="image" src="https://github.com/user-attachments/assets/c0083b36-4cdb-4b70-95d5-c6525aa8dc22" />


### After
<img width="507" alt="image" src="https://github.com/user-attachments/assets/f8150df1-7f49-404d-bb6a-47fb2f72db8f" />
<img width="498" alt="image" src="https://github.com/user-attachments/assets/a0734a3a-1a20-459e-b2df-9949adafb17f" />

## Changes

- [x] Loading indicator on saved query
- [x] Minor adjustments to remove rounding from top tabs which look out of place. 

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Loading works (More apparent when there is a slower API call) and rounding removed.
