### PR TITLE
chore(propdefs/CI): configure property-defs-rs-v2 for CI and ArgoCD/charts state.yaml 

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -39,6 +39,9 @@ jobs:
                     - image: property-defs-rs
                       dockerfile: ./rust/Dockerfile
                       project: vznmbshh6q
+                    - image: property-defs-rs-v2
+                      dockerfile: ./rust/Dockerfile
+                      project: vznmbshh6q
                     - image: cymbal
                       dockerfile: ./rust/Dockerfile
                       project: 8dq0xkk0ck
@@ -59,6 +62,7 @@ jobs:
             cyclotron-fetch_digest: ${{ steps.digest.outputs.cyclotron-fetch_digest }}
             cyclotron-janitor_digest: ${{ steps.digest.outputs.cyclotron-janitor_digest }}
             property-defs-rs_digest: ${{ steps.digest.outputs.property-defs-rs_digest }}
+            property-defs-rs-v2_digest: ${{ steps.digest.outputs.property-defs-rs_digest }}
             batch-import-worker_digest: ${{ steps.digest.outputs.batch-import-worker_digest }}
             hook-api_digest: ${{ steps.digest.outputs.hook-api_digest }}
             hook-janitor_digest: ${{ steps.digest.outputs.hook-janitor_digest }}
@@ -169,6 +173,10 @@ jobs:
                       values:
                           image:
                               sha: '${{ needs.build.outputs.property-defs-rs_digest }}'
+                    - release: property-defs-rs-v2
+                      values:
+                          image:
+                              sha: '${{ needs.build.outputs.property-defs-rs-v2_digest }}'
                     - release: feature-flags
                       values:
                           image:


### PR DESCRIPTION
## Problem
We need to add a deploy trigger the new `property-defs-rs-v2` mirror deployment. cc @bciaraldi @pl 

## Changes
Update the rust-docker-build Action for the mirror deployment.

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally and CI