### PR TITLE
chore(crm): Use more descriptive 404 messages

### DIFF
--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -67,7 +67,7 @@ class GroupsTypesViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, viewsets
                 team=self.team, project_id=self.team.project_id, group_type_index=request.data["group_type_index"]
             )
         except GroupTypeMapping.DoesNotExist:
-            raise NotFound()
+            raise NotFound(detail="Group type not found")
 
         if group_type_mapping.detail_dashboard:
             return response.Response(
@@ -87,7 +87,7 @@ class GroupsTypesViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, viewsets
                 team=self.team, project_id=self.team.project_id, group_type_index=request.data["group_type_index"]
             )
         except GroupTypeMapping.DoesNotExist:
-            raise NotFound()
+            raise NotFound(detail="Group type not found")
 
         group_type_mapping.default_columns = request.data["default_columns"]
         group_type_mapping.save()

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -1053,6 +1053,7 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
             {"group_type_index": 1},
         )
         self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json().get("detail"), "Group type not found")
 
     def test_set_default_columns_success(self):
         group_type_mapping = GroupTypeMapping.objects.create(
@@ -1074,6 +1075,7 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
             {"group_type_index": 1, "default_columns": ["$group_0", "$group_1"]},
         )
         self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json().get("detail"), "Group type not found")
 
     def _create_related_groups_data(self):
         GroupTypeMapping.objects.create(


### PR DESCRIPTION
See https://posthog.slack.com/archives/C08GGECGJF4/p1743538867653389

## Changes

I'd like to know whether the endpoints aren't being registered, or the group types aren't being found.

## How did you test this code?

Tests should pass.