### PR TITLE
fix(propdefs-v2): normalize handling of group_type_index resolution for v2 batch writes

### DIFF
--- a/rust/property-defs-rs/.sqlx/query-3a3aa6426262c39e793869c353a1fe91b98d1652d9054aac5fecd3d8aed3d3c9.json
+++ b/rust/property-defs-rs/.sqlx/query-3a3aa6426262c39e793869c353a1fe91b98d1652d9054aac5fecd3d8aed3d3c9.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO posthog_grouptypemapping (id, group_type, group_type_index, team_id, project_id)\n            VALUES(1, 'Organization', 1, 111, 111)\n    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "3a3aa6426262c39e793869c353a1fe91b98d1652d9054aac5fecd3d8aed3d3c9"
+}

--- a/rust/property-defs-rs/.sqlx/query-7fa314878d358c78204cdc1b6282897bcdd5f798d153e263dae6385be787afe4.json
+++ b/rust/property-defs-rs/.sqlx/query-7fa314878d358c78204cdc1b6282897bcdd5f798d153e263dae6385be787afe4.json
@@ -6,7 +6,7 @@
     "parameters": {
       "Left": [
         "Uuid",
-        "Varchar",
+        "Text",
         "Int4",
         "Int8",
         "Timestamptz"

--- a/rust/property-defs-rs/.sqlx/query-fdcd2297f6041a5fe6bc7499a6826db50bd3facc0e40cee8a20c5a070b5723a6.json
+++ b/rust/property-defs-rs/.sqlx/query-fdcd2297f6041a5fe6bc7499a6826db50bd3facc0e40cee8a20c5a070b5723a6.json
@@ -6,7 +6,7 @@
       {
         "ordinal": 0,
         "name": "name",
-        "type_info": "Varchar"
+        "type_info": "Text"
       }
     ],
     "parameters": {

--- a/rust/property-defs-rs/src/app_context.rs
+++ b/rust/property-defs-rs/src/app_context.rs
@@ -130,7 +130,10 @@ impl AppContext {
         }
     }
 
-    async fn resolve_group_types_indexes(&self, updates: &mut [Update]) -> Result<(), sqlx::Error> {
+    pub async fn resolve_group_types_indexes(
+        &self,
+        updates: &mut [Update],
+    ) -> Result<(), sqlx::Error> {
         if self.skip_reads {
             return Ok(());
         }

--- a/rust/property-defs-rs/src/lib.rs
+++ b/rust/property-defs-rs/src/lib.rs
@@ -83,6 +83,18 @@ pub async fn update_consumer_loop(
 
         // conditionall enable new write path
         if config.enable_v2 {
+            // enrich batch group events with resolved group_type_indices
+            // before passing along to process_batch_v2. We can refactor this
+            // to make it less awkward soon.
+            let _unused = context
+                .resolve_group_types_indexes(&mut batch)
+                .await
+                .map_err(|e| {
+                    warn!(
+                        "Failed resolving group type indices for batch, got: {:?}",
+                        e
+                    )
+                });
             process_batch_v2(&config, cache.clone(), &context.pool, batch).await;
         } else {
             process_batch_v1(&config, cache.clone(), context.clone(), batch).await;

--- a/rust/property-defs-rs/src/v2_batch_ingestion.rs
+++ b/rust/property-defs-rs/src/v2_batch_ingestion.rs
@@ -17,7 +17,9 @@ use crate::{
         V2_PROP_DEFS_BATCH_ATTEMPT, V2_PROP_DEFS_BATCH_CACHE_TIME,
         V2_PROP_DEFS_BATCH_ROWS_AFFECTED, V2_PROP_DEFS_BATCH_WRITE_TIME,
     },
-    types::{EventDefinition, EventProperty, GroupType, PropertyDefinition, Update},
+    types::{
+        EventDefinition, EventProperty, GroupType, PropertyDefinition, PropertyParentType, Update,
+    },
 };
 
 const V2_BATCH_MAX_RETRY_ATTEMPTS: u64 = 3;
@@ -156,13 +158,29 @@ impl PropertyDefinitionsBatch {
     }
 
     pub fn append(&mut self, pd: PropertyDefinition) {
-        let group_type_index: Option<i16> = match &pd.group_type_index {
-            Some(gt) => match gt {
-                GroupType::Resolved(_, gti) => Some(*gti as i16),
-                GroupType::Unresolved(_) => Some(-1_i16),
-            },
-            _ => Some(-1_i16),
+        let group_type_index = match &pd.group_type_index {
+            Some(GroupType::Resolved(_, i)) => Some(*i as i16),
+            Some(GroupType::Unresolved(group_name)) => {
+                warn!(
+                    "Group type {} not resolved for property definition {} for team {}, skipping update",
+                    group_name, pd.name, pd.team_id
+                );
+                None
+            }
+            _ => {
+                // We don't have a group type, so we don't have a group type index
+                None
+            }
         };
+
+        if group_type_index.is_none() && matches!(pd.event_type, PropertyParentType::Group) {
+            // Some teams/users wildly misuse group-types, and if we fail to issue an update
+            // during the transaction (which we do if we don't have a group-type index for a
+            // group property), the entire transaction is aborted, so instead we just warn
+            // loudly about this (above, and at resolve time), and drop the update.
+            return;
+        }
+
         let property_type: Option<i16> = pd.property_type.clone().map(|pt| pt as i16);
 
         self.ids.push(Uuid::now_v7());

--- a/rust/property-defs-rs/tests/test_migrations/20240830124836_setup_propdefs_tables.sql
+++ b/rust/property-defs-rs/tests/test_migrations/20240830124836_setup_propdefs_tables.sql
@@ -42,7 +42,7 @@ CREATE TABLE IF NOT EXISTS posthog_eventproperty (
 CREATE UNIQUE INDEX IF NOT EXISTS posthog_event_property_unique_proj_event_property ON posthog_eventproperty (coalesce(project_id, team_id), event, property);
 
 CREATE TABLE IF NOT EXISTS posthog_grouptypemapping (
-    id UUID PRIMARY KEY,
+    id integer PRIMARY KEY,
     group_type VARCHAR(400) NOT NULL,
     group_type_index INTEGER NOT NULL,
     team_id INTEGER NOT NULL,

--- a/rust/property-defs-rs/tests/v2_batch_ingestion.rs
+++ b/rust/property-defs-rs/tests/v2_batch_ingestion.rs
@@ -47,6 +47,15 @@ async fn test_simple_batch_write(db: PgPool) {
 
 #[sqlx::test(migrations = "./tests/test_migrations")]
 async fn test_group_batch_write(db: PgPool) {
+    let _unused = sqlx::query!(
+        r#"
+        INSERT INTO posthog_grouptypemapping (id, group_type, group_type_index, team_id, project_id)
+            VALUES(1, 'Organization', 1, 111, 111)
+    "#
+    )
+    .execute(&db)
+    .await;
+
     let config = Config::init_with_defaults().unwrap();
     let cache: Arc<Cache<Update, ()>> = Arc::new(Cache::new(config.cache_capacity));
     let updates = gen_test_event_updates("$groupidentify", 100, Some(PropertyParentType::Group));


### PR DESCRIPTION
## Problem
`property-defs-rs` processing pipeline resolves group type indices very late in the write path in `process_batch_v1`. We need to ensure this happens in the `process_batch_v2` write path, and that the new v2 test suite can exercise this.

The *right* fix requires a larger refactor that I'd like to spare for _after_ the new v2 batch writes is tested in prod, and we know we want to run with it 👍

If testing goes as planned, that PR will be a fast follow to this one.

## Changes
* Replicate "v1" behavior (resolve group types on `Vec<Update>` batches prior to chunking and persistence
* Drop group props from the batch with a warning if group type index can't be resolved
* Ensure the SQLX test schema for `grouptypemapping` table is in parity with `posthog` (and prod) DBs

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally, in CI, and soon in `dev` with the rest of the `enable_v2` batch write codepath 👍 