### PR TITLE
fix: getSurveyResponse also working for multiple choice

### DIFF
--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -1259,7 +1259,7 @@ HOGQL_CLICKHOUSE_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
         using_positional_arguments=True,
     ),
     # survey functions
-    "getSurveyResponse": HogQLFunctionMeta("getSurveyResponse", 1, 2),
+    "getSurveyResponse": HogQLFunctionMeta("getSurveyResponse", 1, 3),
 }
 
 # Permitted HogQL aggregations

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -1136,8 +1136,12 @@ class _Printer(Visitor):
                         ):
                             raise QueryError("getSurveyResponse first argument must be a valid integer")
                         second_arg = node_args[1] if len(node_args) > 1 else None
+                        third_arg = node_args[2] if len(node_args) > 2 else None
                         question_id = str(second_arg.value) if isinstance(second_arg, ast.Constant) else None
-                        return get_survey_response_clickhouse_query(int(question_index_obj.value), question_id)
+                        is_multiple_choice = bool(third_arg.value) if isinstance(third_arg, ast.Constant) else False
+                        return get_survey_response_clickhouse_query(
+                            int(question_index_obj.value), question_id, is_multiple_choice
+                        )
 
                 if node.name in FIRST_ARG_DATETIME_FUNCTIONS:
                     args: list[str] = []

--- a/posthog/models/surveys/test_survey_util.py
+++ b/posthog/models/surveys/test_survey_util.py
@@ -58,3 +58,13 @@ class TestSurveyResponseFunctions(TestCase):
         NULLIF(JSONExtractString(properties, '$survey_response'), '')
     )"""
         self.assertEqual(query, expected)
+
+    def test_get_survey_response_clickhouse_query_multiple_choice(self):
+        """Test the full query generation with a multiple choice question"""
+        query = get_survey_response_clickhouse_query(1, "abc123", True)
+        expected = """if(
+        JSONHas(properties, '$survey_response_abc123') AND length(JSONExtractArrayRaw(properties, '$survey_response_abc123')) > 0,
+        JSONExtractArrayRaw(properties, '$survey_response_abc123'),
+        JSONExtractArrayRaw(properties, '$survey_response_1')
+    )"""
+        self.assertEqual(query, expected)

--- a/posthog/models/surveys/util.py
+++ b/posthog/models/surveys/util.py
@@ -1,7 +1,9 @@
 survey_response = "$survey_response"
 
 
-def get_survey_response_clickhouse_query(question_index: int, question_id: str | None = None) -> str:
+def get_survey_response_clickhouse_query(
+    question_index: int, question_id: str | None = None, is_multiple_choice: bool = False
+) -> str:
     """
     Generate a ClickHouse query to extract survey response based on question index or ID
 
@@ -14,6 +16,10 @@ def get_survey_response_clickhouse_query(question_index: int, question_id: str |
     """
     id_based_key = _build_id_based_key(question_index, question_id)
     index_based_key = _build_index_based_key(question_index)
+
+    if is_multiple_choice is True:
+        query = _build_multiple_choice_query(id_based_key, index_based_key)
+        return query
 
     return _build_coalesce_query(id_based_key, index_based_key)
 
@@ -36,4 +42,12 @@ def _build_coalesce_query(id_based_key: str, index_based_key: str) -> str:
     return f"""COALESCE(
         NULLIF(JSONExtractString(properties, {id_based_key}), ''),
         NULLIF(JSONExtractString(properties, '{index_based_key}'), '')
+    )"""
+
+
+def _build_multiple_choice_query(id_based_key: str, index_based_key: str) -> str:
+    return f"""if(
+        JSONHas(properties, {id_based_key}) AND length(JSONExtractArrayRaw(properties, {id_based_key})) > 0,
+        JSONExtractArrayRaw(properties, {id_based_key}),
+        JSONExtractArrayRaw(properties, '{index_based_key}')
     )"""

--- a/posthog/models/surveys/util.py
+++ b/posthog/models/surveys/util.py
@@ -18,8 +18,7 @@ def get_survey_response_clickhouse_query(
     index_based_key = _build_index_based_key(question_index)
 
     if is_multiple_choice is True:
-        query = _build_multiple_choice_query(id_based_key, index_based_key)
-        return query
+        return _build_multiple_choice_query(id_based_key, index_based_key)
 
     return _build_coalesce_query(id_based_key, index_based_key)
 


### PR DESCRIPTION
## Problem

`getSurveyResponse` right now doesn't work for multiple choice questions, due to them being stored as an array

## Changes

updates the query printer to make it work for multiple choice as well

### Limitations

right now, we have to explicit say if the question type is multiple_choice or not.

in the future, maybe there's a way to remove this requirement and make it automatic based on the event properties 

## Does this work well for both Cloud and self-hosted?

yes

## How did you test this code?

unit tests