### PR TITLE
fix: end date on survey results

### DIFF
--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -201,8 +201,8 @@ const DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ss'
 
 function getSurveyStartDateForQuery(survey: Survey): string {
     return survey.start_date
-        ? dayjs(survey.start_date).startOf('day').format(DATE_FORMAT)
-        : dayjs(survey.created_at).startOf('day').format(DATE_FORMAT)
+        ? dayjs(survey.start_date).utc().startOf('day').format(DATE_FORMAT)
+        : dayjs(survey.created_at).utc().startOf('day').format(DATE_FORMAT)
 }
 
 function getSurveyEndDateForQuery(survey: Survey): string {

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -207,8 +207,8 @@ function getSurveyStartDateForQuery(survey: Survey): string {
 
 function getSurveyEndDateForQuery(survey: Survey): string {
     return survey.end_date
-        ? dayjs(survey.end_date).endOf('day').format(DATE_FORMAT)
-        : dayjs().endOf('day').format(DATE_FORMAT)
+        ? dayjs(survey.end_date).utc().endOf('day').format(DATE_FORMAT)
+        : dayjs().utc().endOf('day').format(DATE_FORMAT)
 }
 
 export const surveyLogic = kea<surveyLogicType>([


### PR DESCRIPTION
## Problem

some survey responses will not show up because of potential timezone differences when computng start/end date for queries

## Changes

uses UTC values instead

## How did you test this code?

recent survey responses now show up