### PR TITLE
chore: add utility to copy survey response key

### DIFF
--- a/frontend/src/scenes/surveys/SurveyResponseFilters.tsx
+++ b/frontend/src/scenes/surveys/SurveyResponseFilters.tsx
@@ -1,4 +1,4 @@
-import { IconCode } from '@posthog/icons'
+import { IconCode, IconCopy } from '@posthog/icons'
 import { LemonButton, LemonSelect, LemonSelectOptions } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { PropertyValue } from 'lib/components/PropertyFilters/components/PropertyValue'
@@ -7,8 +7,9 @@ import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { getPropertyKey } from 'lib/taxonomy'
 import { allOperatorsMapping } from 'lib/utils'
+import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import React, { useState } from 'react'
-import { SurveyQuestionLabel } from 'scenes/surveys/constants'
+import { QUESTION_TYPE_ICON_MAP, SURVEY_RESPONSE_PROPERTY, SurveyQuestionLabel } from 'scenes/surveys/constants'
 import { getSurveyResponseKey } from 'scenes/surveys/utils'
 
 import {
@@ -53,6 +54,18 @@ const OPERATOR_OPTIONS: Record<SurveyQuestionType, OperatorOption[]> = {
         { label: allOperatorsMapping[PropertyOperator.NotRegex], value: PropertyOperator.NotRegex },
     ],
     [SurveyQuestionType.Link]: [],
+}
+
+function CopyResponseKeyButton({ questionId }: { questionId: string }): JSX.Element {
+    return (
+        <button
+            onClick={() => void copyToClipboard(`${SURVEY_RESPONSE_PROPERTY}_${questionId}`, 'survey response key')}
+            className="flex items-center cursor-pointer gap-1"
+        >
+            <IconCopy />
+            Copy survey response key
+        </button>
+    )
 }
 
 function _SurveyResponseFilters(): JSX.Element {
@@ -128,8 +141,12 @@ function _SurveyResponseFilters(): JSX.Element {
                                     <div className="grid grid-cols-6 gap-2 p-2 items-center hover:bg-bg-light transition-all">
                                         <div className="col-span-3">
                                             <span className="font-medium">{question.question}</span>
-                                            <div className="text-muted text-xs">
-                                                {SurveyQuestionLabel[question.type]}
+                                            <div className="text-muted text-xs flex gap-4">
+                                                <span className="flex items-center gap-1">
+                                                    {QUESTION_TYPE_ICON_MAP[question.type]}
+                                                    {SurveyQuestionLabel[question.type]}
+                                                </span>
+                                                {question.id && <CopyResponseKeyButton questionId={question.id} />}
                                             </div>
                                         </div>
                                         <div>

--- a/frontend/src/scenes/surveys/constants.tsx
+++ b/frontend/src/scenes/surveys/constants.tsx
@@ -1,3 +1,4 @@
+import { IconAreaChart, IconComment, IconGridView, IconLink, IconListView } from 'lib/lemon-ui/icons'
 import { allOperatorsMapping } from 'lib/utils'
 
 import {
@@ -359,3 +360,11 @@ export const WEB_SAFE_FONTS = [
 export const NPS_DETRACTOR_LABEL = 'Detractors'
 export const NPS_PASSIVE_LABEL = 'Passives'
 export const NPS_PROMOTER_LABEL = 'Promoters'
+
+export const QUESTION_TYPE_ICON_MAP = {
+    [SurveyQuestionType.Open]: <IconComment className="text-muted" />,
+    [SurveyQuestionType.Link]: <IconLink className="text-muted" />,
+    [SurveyQuestionType.Rating]: <IconAreaChart className="text-muted" />,
+    [SurveyQuestionType.SingleChoice]: <IconListView className="text-muted" />,
+    [SurveyQuestionType.MultipleChoice]: <IconGridView className="text-muted" />,
+}


### PR DESCRIPTION
## Problem

adds a new button to copy survey response key. will be used in the docs for webhook responses

## Changes

![CleanShot 2025-04-02 at 02 51 27@2x](https://github.com/user-attachments/assets/1c5f24f2-fe82-4abf-a22e-7d0b5a4fd4e4)

also adds the icon for the question type that we're already using on the Overview tab

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

yes

## How did you test this code?

tested locally
