### PR TITLE
fix: bump release runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ on:
 jobs:
     # Run 'dist plan' (or host) to determine what tasks we need to do
     plan:
-        runs-on: 'ubuntu-20.04'
+        runs-on: 'ubuntu-22.04'
         outputs:
             val: ${{ steps.plan.outputs.manifest }}
             tag: ${{ !github.event.pull_request && github.ref_name || '' }}
@@ -168,7 +168,7 @@ jobs:
         needs:
             - plan
             - build-local-artifacts
-        runs-on: 'ubuntu-20.04'
+        runs-on: 'ubuntu-22.04'
         env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
@@ -218,7 +218,7 @@ jobs:
         if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
         env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        runs-on: 'ubuntu-20.04'
+        runs-on: 'ubuntu-22.04'
         outputs:
             val: ${{ steps.host.outputs.manifest }}
         steps:
@@ -282,7 +282,7 @@ jobs:
         # still allowing individual publish jobs to skip themselves (for prereleases).
         # "host" however must run to completion, no skipping allowed!
         if: ${{ always() && needs.host.result == 'success' }}
-        runs-on: 'ubuntu-20.04'
+        runs-on: 'ubuntu-22.04'
         env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         steps:

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -24,3 +24,10 @@ targets = [
 install-path = "~/.posthog"
 # Whether to install an updater program
 install-updater = true
+
+[dist.github-custom-runners]
+# ubuntu-20.04 (the dist default) is now deprecated by github
+aarch64-unknown-linux-gnu = "ubuntu-22.04"
+x86_64-unknown-linux-gnu = "ubuntu-22.04"
+x86_64-unknown-linux-musl = "ubuntu-22.04"
+global = "ubuntu-22.04"


### PR DESCRIPTION
Github are deprecating the 20.04 runner.