### PR TITLE
fix: remove hardcoded integration in react onboarding

### DIFF
--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/components/SetupWizardBanner.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/components/SetupWizardBanner.tsx
@@ -5,7 +5,7 @@ import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonTag } from 'lib/lemon-ui/LemonTag'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
-const SetupWizardBanner = (): JSX.Element => {
+const SetupWizardBanner = ({ integrationName }: { integrationName: string }): JSX.Element => {
     const { preflight } = useValues(preflightLogic)
 
     const region = preflight?.region || 'us'
@@ -18,7 +18,9 @@ const SetupWizardBanner = (): JSX.Element => {
             </h3>
             <div className="flex flex-col p-2">
                 <p className="font-normal pb-1">Try using the AI setup wizard to automatically install PostHog.</p>
-                <p className="font-normal pb-2">Run the following command from the root of your NextJS project.</p>
+                <p className="font-normal pb-2">
+                    Run the following command from the root of your {integrationName} project.
+                </p>
                 <CodeSnippet language={Language.Bash}>{wizardCommand}</CodeSnippet>
             </div>
         </LemonBanner>

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/next-js.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/next-js.tsx
@@ -176,7 +176,7 @@ export function SDKInstallNextJSInstructions({ hideWizard }: { hideWizard?: bool
             {showSetupWizard && (
                 <>
                     <h2>Automated Installation</h2>
-                    <SetupWizardBanner />
+                    <SetupWizardBanner integrationName="Next.js" />
                     <LemonDivider label="OR" />
                     <h2>Manual Installation</h2>
                 </>

--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/react.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/react.tsx
@@ -59,7 +59,7 @@ export function SDKInstallReactInstructions({ hideWizard }: { hideWizard?: boole
             {showSetupWizard && (
                 <>
                     <h2>Automated Installation</h2>
-                    <SetupWizardBanner />
+                    <SetupWizardBanner integrationName="React" />
                     <LemonDivider label="OR" />
                     <h2>Manual Installation</h2>
                 </>


### PR DESCRIPTION
## Problem

Next.js was hardcoded in the wizard banner - should be specific to the integration.

## Changes

Set the integration name based on the SDK docs.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Ran locally
