### PR TITLE
feat: add capture 200 endpoint

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -21,8 +21,7 @@ services:
                     @capture {
                         path /e
                         path /e/*
-                        path /i/v0/e
-                        path /i/v0/e*
+                        path /i/v0/*
                         path /batch
                         path /batch*
                         path /capture

--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -128,14 +128,8 @@ pub fn router<
                 .get(v0_endpoint::event)
                 .options(v0_endpoint::options),
         )
-        .route(
-            "/i/v0",
-            get(index)
-        )
-        .route(
-            "/i/v0/",
-            get(index)
-        )
+        .route("/i/v0", get(index))
+        .route("/i/v0/", get(index))
         .layer(DefaultBodyLimit::max(EVENT_BODY_SIZE));
 
     let status_router = Router::new()

--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -128,6 +128,14 @@ pub fn router<
                 .get(v0_endpoint::event)
                 .options(v0_endpoint::options),
         )
+        .route(
+            "/i/v0",
+            get(index)
+        )
+        .route(
+            "/i/v0/",
+            get(index)
+        )
         .layer(DefaultBodyLimit::max(EVENT_BODY_SIZE));
 
     let status_router = Router::new()


### PR DESCRIPTION
## Problem

We were asked for a capture endpoint that responds with a 200.

## Changes

Adds /i/v0 endpoint that responds with 200.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Locally, will check after deployment too.