### PR TITLE
feat(hogql): Alias ast.Call nodes when used in a view

### DIFF
--- a/ee/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_query.ambr
+++ b/ee/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_query.ambr
@@ -2,8 +2,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_effect_of_poe_settings_on_query_generated_0_test_poe_v1_still_falls_back_to_person_subquery
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, %(hogql_val_0)s)) AS start_time,
          max(toTimeZone(s.max_last_timestamp, %(hogql_val_1)s)) AS end_time,
          dateDiff(%(hogql_val_2)s, start_time, end_time) AS duration,
@@ -34,8 +34,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_effect_of_poe_settings_on_query_generated_1_test_poe_being_unavailable_we_fall_back_to_person_id_overrides
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, %(hogql_val_0)s)) AS start_time,
          max(toTimeZone(s.max_last_timestamp, %(hogql_val_1)s)) AS end_time,
          dateDiff(%(hogql_val_2)s, start_time, end_time) AS duration,
@@ -78,8 +78,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_effect_of_poe_settings_on_query_generated_2_test_poe_being_unavailable_we_fall_back_to_person_subquery_but_still_use_mat_props
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, %(hogql_val_0)s)) AS start_time,
          max(toTimeZone(s.max_last_timestamp, %(hogql_val_1)s)) AS end_time,
          dateDiff(%(hogql_val_2)s, start_time, end_time) AS duration,
@@ -122,8 +122,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_effect_of_poe_settings_on_query_generated_3_test_allow_denormalised_props_fix_does_not_stop_all_poe_processing
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, %(hogql_val_0)s)) AS start_time,
          max(toTimeZone(s.max_last_timestamp, %(hogql_val_1)s)) AS end_time,
          dateDiff(%(hogql_val_2)s, start_time, end_time) AS duration,
@@ -154,8 +154,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_effect_of_poe_settings_on_query_generated_4_test_poe_v2_available_person_properties_are_used_in_replay_listing
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, %(hogql_val_0)s)) AS start_time,
          max(toTimeZone(s.max_last_timestamp, %(hogql_val_1)s)) AS end_time,
          dateDiff(%(hogql_val_2)s, start_time, end_time) AS duration,
@@ -186,8 +186,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_00_poe_v2_and_materialized_columns_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -222,8 +222,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_00_poe_v2_and_materialized_columns_allowed_with_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -263,8 +263,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_01_poe_v2_and_materialized_columns_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -299,8 +299,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_01_poe_v2_and_materialized_columns_allowed_without_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -340,8 +340,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_02_poe_v2_and_materialized_columns_off_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -376,8 +376,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_02_poe_v2_and_materialized_columns_off_with_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -417,8 +417,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_03_poe_v2_and_materialized_columns_off_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -453,8 +453,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_03_poe_v2_and_materialized_columns_off_without_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -494,8 +494,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_04_poe_off_and_materialized_columns_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -530,8 +530,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_04_poe_off_and_materialized_columns_allowed_with_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -586,8 +586,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_05_poe_off_and_materialized_columns_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -622,8 +622,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_05_poe_off_and_materialized_columns_allowed_without_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -678,8 +678,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_06_poe_off_and_materialized_columns_not_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -714,8 +714,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_06_poe_off_and_materialized_columns_not_allowed_with_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -770,8 +770,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_07_poe_off_and_materialized_columns_not_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -806,8 +806,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_07_poe_off_and_materialized_columns_not_allowed_without_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -862,8 +862,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_08_poe_v1_and_materialized_columns_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -898,8 +898,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_08_poe_v1_and_materialized_columns_allowed_with_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -939,8 +939,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_09_poe_v1_and_materialized_columns_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -975,8 +975,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_09_poe_v1_and_materialized_columns_allowed_without_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1016,8 +1016,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_10_poe_v1_and_not_materialized_columns_not_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1052,8 +1052,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_10_poe_v1_and_not_materialized_columns_not_allowed_with_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1093,8 +1093,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_11_poe_v1_and_not_materialized_columns_not_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1129,8 +1129,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_11_poe_v1_and_not_materialized_columns_not_allowed_without_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1170,8 +1170,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_00_poe_v2_and_materialized_columns_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1209,8 +1209,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_01_poe_v2_and_materialized_columns_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1248,8 +1248,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_02_poe_v2_and_materialized_columns_off_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1287,8 +1287,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_03_poe_v2_and_materialized_columns_off_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1326,8 +1326,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_04_poe_off_and_materialized_columns_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1371,8 +1371,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_05_poe_off_and_materialized_columns_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1416,8 +1416,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_06_poe_off_and_materialized_columns_not_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1461,8 +1461,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_07_poe_off_and_materialized_columns_not_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1506,8 +1506,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_08_poe_v1_and_materialized_columns_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1551,8 +1551,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_09_poe_v1_and_materialized_columns_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1596,8 +1596,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_10_poe_v1_and_not_materialized_columns_not_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1641,8 +1641,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_11_poe_v1_and_not_materialized_columns_not_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,

--- a/ee/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_query.ambr
+++ b/ee/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_query.ambr
@@ -2,8 +2,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_effect_of_poe_settings_on_query_generated_0_test_poe_v1_still_falls_back_to_person_subquery
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, %(hogql_val_0)s)) AS start_time,
          max(toTimeZone(s.max_last_timestamp, %(hogql_val_1)s)) AS end_time,
          dateDiff(%(hogql_val_2)s, start_time, end_time) AS duration,
@@ -34,8 +34,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_effect_of_poe_settings_on_query_generated_1_test_poe_being_unavailable_we_fall_back_to_person_id_overrides
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, %(hogql_val_0)s)) AS start_time,
          max(toTimeZone(s.max_last_timestamp, %(hogql_val_1)s)) AS end_time,
          dateDiff(%(hogql_val_2)s, start_time, end_time) AS duration,
@@ -78,8 +78,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_effect_of_poe_settings_on_query_generated_2_test_poe_being_unavailable_we_fall_back_to_person_subquery_but_still_use_mat_props
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, %(hogql_val_0)s)) AS start_time,
          max(toTimeZone(s.max_last_timestamp, %(hogql_val_1)s)) AS end_time,
          dateDiff(%(hogql_val_2)s, start_time, end_time) AS duration,
@@ -122,8 +122,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_effect_of_poe_settings_on_query_generated_3_test_allow_denormalised_props_fix_does_not_stop_all_poe_processing
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, %(hogql_val_0)s)) AS start_time,
          max(toTimeZone(s.max_last_timestamp, %(hogql_val_1)s)) AS end_time,
          dateDiff(%(hogql_val_2)s, start_time, end_time) AS duration,
@@ -154,8 +154,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_effect_of_poe_settings_on_query_generated_4_test_poe_v2_available_person_properties_are_used_in_replay_listing
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, %(hogql_val_0)s)) AS start_time,
          max(toTimeZone(s.max_last_timestamp, %(hogql_val_1)s)) AS end_time,
          dateDiff(%(hogql_val_2)s, start_time, end_time) AS duration,
@@ -186,8 +186,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_00_poe_v2_and_materialized_columns_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -222,8 +222,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_00_poe_v2_and_materialized_columns_allowed_with_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -263,8 +263,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_01_poe_v2_and_materialized_columns_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -299,8 +299,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_01_poe_v2_and_materialized_columns_allowed_without_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -340,8 +340,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_02_poe_v2_and_materialized_columns_off_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -376,8 +376,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_02_poe_v2_and_materialized_columns_off_with_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -417,8 +417,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_03_poe_v2_and_materialized_columns_off_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -453,8 +453,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_03_poe_v2_and_materialized_columns_off_without_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -494,8 +494,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_04_poe_off_and_materialized_columns_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -530,8 +530,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_04_poe_off_and_materialized_columns_allowed_with_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -586,8 +586,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_05_poe_off_and_materialized_columns_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -622,8 +622,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_05_poe_off_and_materialized_columns_allowed_without_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -678,8 +678,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_06_poe_off_and_materialized_columns_not_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -714,8 +714,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_06_poe_off_and_materialized_columns_not_allowed_with_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -770,8 +770,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_07_poe_off_and_materialized_columns_not_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -806,8 +806,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_07_poe_off_and_materialized_columns_not_allowed_without_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -862,8 +862,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_08_poe_v1_and_materialized_columns_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -898,8 +898,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_08_poe_v1_and_materialized_columns_allowed_with_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -939,8 +939,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_09_poe_v1_and_materialized_columns_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -975,8 +975,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_09_poe_v1_and_materialized_columns_allowed_without_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1016,8 +1016,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_10_poe_v1_and_not_materialized_columns_not_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1052,8 +1052,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_10_poe_v1_and_not_materialized_columns_not_allowed_with_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1093,8 +1093,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_11_poe_v1_and_not_materialized_columns_not_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1129,8 +1129,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_11_poe_v1_and_not_materialized_columns_not_allowed_without_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1170,8 +1170,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_00_poe_v2_and_materialized_columns_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1209,8 +1209,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_01_poe_v2_and_materialized_columns_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1248,8 +1248,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_02_poe_v2_and_materialized_columns_off_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1287,8 +1287,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_03_poe_v2_and_materialized_columns_off_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1326,8 +1326,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_04_poe_off_and_materialized_columns_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1371,8 +1371,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_05_poe_off_and_materialized_columns_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1416,8 +1416,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_06_poe_off_and_materialized_columns_not_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1461,8 +1461,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_07_poe_off_and_materialized_columns_not_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1506,8 +1506,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_08_poe_v1_and_materialized_columns_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1551,8 +1551,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_09_poe_v1_and_materialized_columns_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1596,8 +1596,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_10_poe_v1_and_not_materialized_columns_not_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1641,8 +1641,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_11_poe_v1_and_not_materialized_columns_not_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,

--- a/ee/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_query.ambr
+++ b/ee/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_query.ambr
@@ -2,8 +2,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_effect_of_poe_settings_on_query_generated_0_test_poe_v1_still_falls_back_to_person_subquery
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, %(hogql_val_0)s)) AS start_time,
          max(toTimeZone(s.max_last_timestamp, %(hogql_val_1)s)) AS end_time,
          dateDiff(%(hogql_val_2)s, start_time, end_time) AS duration,
@@ -34,8 +34,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_effect_of_poe_settings_on_query_generated_1_test_poe_being_unavailable_we_fall_back_to_person_id_overrides
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, %(hogql_val_0)s)) AS start_time,
          max(toTimeZone(s.max_last_timestamp, %(hogql_val_1)s)) AS end_time,
          dateDiff(%(hogql_val_2)s, start_time, end_time) AS duration,
@@ -78,8 +78,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_effect_of_poe_settings_on_query_generated_2_test_poe_being_unavailable_we_fall_back_to_person_subquery_but_still_use_mat_props
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, %(hogql_val_0)s)) AS start_time,
          max(toTimeZone(s.max_last_timestamp, %(hogql_val_1)s)) AS end_time,
          dateDiff(%(hogql_val_2)s, start_time, end_time) AS duration,
@@ -122,8 +122,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_effect_of_poe_settings_on_query_generated_3_test_allow_denormalised_props_fix_does_not_stop_all_poe_processing
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, %(hogql_val_0)s)) AS start_time,
          max(toTimeZone(s.max_last_timestamp, %(hogql_val_1)s)) AS end_time,
          dateDiff(%(hogql_val_2)s, start_time, end_time) AS duration,
@@ -154,8 +154,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_effect_of_poe_settings_on_query_generated_4_test_poe_v2_available_person_properties_are_used_in_replay_listing
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, %(hogql_val_0)s)) AS start_time,
          max(toTimeZone(s.max_last_timestamp, %(hogql_val_1)s)) AS end_time,
          dateDiff(%(hogql_val_2)s, start_time, end_time) AS duration,
@@ -186,8 +186,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_00_poe_v2_and_materialized_columns_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -222,8 +222,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_00_poe_v2_and_materialized_columns_allowed_with_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -263,8 +263,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_01_poe_v2_and_materialized_columns_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -299,8 +299,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_01_poe_v2_and_materialized_columns_allowed_without_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -340,8 +340,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_02_poe_v2_and_materialized_columns_off_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -376,8 +376,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_02_poe_v2_and_materialized_columns_off_with_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -417,8 +417,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_03_poe_v2_and_materialized_columns_off_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -453,8 +453,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_03_poe_v2_and_materialized_columns_off_without_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -494,8 +494,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_04_poe_off_and_materialized_columns_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -530,8 +530,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_04_poe_off_and_materialized_columns_allowed_with_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -586,8 +586,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_05_poe_off_and_materialized_columns_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -622,8 +622,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_05_poe_off_and_materialized_columns_allowed_without_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -678,8 +678,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_06_poe_off_and_materialized_columns_not_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -714,8 +714,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_06_poe_off_and_materialized_columns_not_allowed_with_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -770,8 +770,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_07_poe_off_and_materialized_columns_not_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -806,8 +806,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_07_poe_off_and_materialized_columns_not_allowed_without_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -862,8 +862,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_08_poe_v1_and_materialized_columns_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -898,8 +898,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_08_poe_v1_and_materialized_columns_allowed_with_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -939,8 +939,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_09_poe_v1_and_materialized_columns_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -975,8 +975,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_09_poe_v1_and_materialized_columns_allowed_without_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1016,8 +1016,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_10_poe_v1_and_not_materialized_columns_not_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1052,8 +1052,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_10_poe_v1_and_not_materialized_columns_not_allowed_with_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1093,8 +1093,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_11_poe_v1_and_not_materialized_columns_not_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1129,8 +1129,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_event_filter_with_person_properties_materialized_11_poe_v1_and_not_materialized_columns_not_allowed_without_materialization.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1170,8 +1170,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_00_poe_v2_and_materialized_columns_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1209,8 +1209,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_01_poe_v2_and_materialized_columns_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1248,8 +1248,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_02_poe_v2_and_materialized_columns_off_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1287,8 +1287,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_03_poe_v2_and_materialized_columns_off_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1326,8 +1326,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_04_poe_off_and_materialized_columns_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1371,8 +1371,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_05_poe_off_and_materialized_columns_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1416,8 +1416,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_06_poe_off_and_materialized_columns_not_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1461,8 +1461,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_07_poe_off_and_materialized_columns_not_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1506,8 +1506,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_08_poe_v1_and_materialized_columns_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1551,8 +1551,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_09_poe_v1_and_materialized_columns_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1596,8 +1596,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_10_poe_v1_and_not_materialized_columns_not_allowed_with_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1641,8 +1641,8 @@
 # name: TestClickhouseSessionRecordingsListFromQuery.test_person_id_filter_11_poe_v1_and_not_materialized_columns_not_allowed_without_materialization
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,

--- a/posthog/api/test/__snapshots__/test_query.ambr
+++ b/posthog/api/test/__snapshots__/test_query.ambr
@@ -6,7 +6,7 @@
          events.distinct_id AS distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -28,7 +28,7 @@
          events.distinct_id AS distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), 'test_val3'), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -50,7 +50,7 @@
          events.distinct_id AS distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), ifNull(ilike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'path'), ''), 'null'), '^"|"$', '')), '%/%'), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -72,7 +72,7 @@
          events.distinct_id AS distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -94,7 +94,7 @@
          events.distinct_id AS distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), ifNull(equals(nullIf(nullIf(events.mat_key, ''), 'null'), 'test_val3'), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -116,7 +116,7 @@
          events.distinct_id AS distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), ifNull(ilike(toString(nullIf(nullIf(events.mat_path, ''), 'null')), '%/%'), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -276,7 +276,7 @@
          events.distinct_id AS distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -298,7 +298,7 @@
          events.distinct_id AS distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), 0, less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -320,7 +320,7 @@
          events.distinct_id AS distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), 1, less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -342,7 +342,7 @@
          events.distinct_id AS distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), 'test_val2'), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -364,7 +364,7 @@
          events.distinct_id AS distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -386,7 +386,7 @@
          events.distinct_id AS distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), 0, less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -408,7 +408,7 @@
          events.distinct_id AS distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), 1, less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -430,7 +430,7 @@
          events.distinct_id AS distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), ifNull(equals(nullIf(nullIf(events.mat_key, ''), 'null'), 'test_val2'), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -452,7 +452,7 @@
          events.distinct_id AS distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   LEFT OUTER JOIN
     (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -491,7 +491,7 @@
          events.distinct_id AS distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), ''))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   LEFT OUTER JOIN
     (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -527,7 +527,7 @@
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
-         count()
+         count() AS `count()`
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   GROUP BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')
@@ -547,7 +547,7 @@
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
-         count()
+         count() AS `count()`
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   GROUP BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')
@@ -568,7 +568,7 @@
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT nullIf(nullIf(events.mat_key, ''), 'null') AS key,
-         count()
+         count() AS `count()`
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   GROUP BY nullIf(nullIf(events.mat_key, ''), 'null')
@@ -588,7 +588,7 @@
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT nullIf(nullIf(events.mat_key, ''), 'null') AS key,
-         count()
+         count() AS `count()`
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   GROUP BY nullIf(nullIf(events.mat_key, ''), 'null')
@@ -631,7 +631,7 @@
   SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
          events.event AS event,
          events.distinct_id AS distinct_id,
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), ''))
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') ASC
@@ -649,7 +649,7 @@
 # name: TestQuery.test_select_hogql_expressions.1
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC')),
+  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC')) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'UTC'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'UTC'))`,
          events.event AS event
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
@@ -668,7 +668,7 @@
 # name: TestQuery.test_select_hogql_expressions.2
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT count(),
+  SELECT count() AS `count()`,
          events.event AS event
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
@@ -688,7 +688,7 @@
 # name: TestQuery.test_select_hogql_expressions.3
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT count(),
+  SELECT count() AS `count()`,
          events.event AS event
   FROM events
   WHERE and(equals(events.team_id, 99999), or(equals(events.event, 'sign up'), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), '%val2'), 0)), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))

--- a/posthog/api/test/__snapshots__/test_query.ambr
+++ b/posthog/api/test/__snapshots__/test_query.ambr
@@ -6,7 +6,7 @@
          events.distinct_id AS distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS _concat_event_properties_key
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -28,7 +28,7 @@
          events.distinct_id AS distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS _concat_event_properties_key
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), 'test_val3'), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -50,7 +50,7 @@
          events.distinct_id AS distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS _concat_event_properties_key
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), ifNull(ilike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'path'), ''), 'null'), '^"|"$', '')), '%/%'), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -72,7 +72,7 @@
          events.distinct_id AS distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS _concat_event_properties_key
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -94,7 +94,7 @@
          events.distinct_id AS distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS _concat_event_properties_key
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), ifNull(equals(nullIf(nullIf(events.mat_key, ''), 'null'), 'test_val3'), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -116,7 +116,7 @@
          events.distinct_id AS distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS _concat_event_properties_key
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), ifNull(ilike(toString(nullIf(nullIf(events.mat_path, ''), 'null')), '%/%'), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -276,7 +276,7 @@
          events.distinct_id AS distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS _concat_event_properties_key
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -298,7 +298,7 @@
          events.distinct_id AS distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS _concat_event_properties_key
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), 0, less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -320,7 +320,7 @@
          events.distinct_id AS distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS _concat_event_properties_key
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), 1, less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -342,7 +342,7 @@
          events.distinct_id AS distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS _concat_event_properties_key
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), 'test_val2'), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -364,7 +364,7 @@
          events.distinct_id AS distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS _concat_event_properties_key
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -386,7 +386,7 @@
          events.distinct_id AS distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS _concat_event_properties_key
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), 0, less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -408,7 +408,7 @@
          events.distinct_id AS distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS _concat_event_properties_key
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), 1, less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -430,7 +430,7 @@
          events.distinct_id AS distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS _concat_event_properties_key
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), ifNull(equals(nullIf(nullIf(events.mat_key, ''), 'null'), 'test_val2'), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -452,7 +452,7 @@
          events.distinct_id AS distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS _concat_event_properties_key
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   LEFT OUTER JOIN
     (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -491,7 +491,7 @@
          events.distinct_id AS distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS _concat_event_properties_key
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   LEFT OUTER JOIN
     (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -527,7 +527,7 @@
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
-         count() AS _count
+         count() AS `count()`
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   GROUP BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')
@@ -547,7 +547,7 @@
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
-         count() AS _count
+         count() AS `count()`
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   GROUP BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')
@@ -568,7 +568,7 @@
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT nullIf(nullIf(events.mat_key, ''), 'null') AS key,
-         count() AS _count
+         count() AS `count()`
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   GROUP BY nullIf(nullIf(events.mat_key, ''), 'null')
@@ -588,7 +588,7 @@
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT nullIf(nullIf(events.mat_key, ''), 'null') AS key,
-         count() AS _count
+         count() AS `count()`
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   GROUP BY nullIf(nullIf(events.mat_key, ''), 'null')
@@ -631,7 +631,7 @@
   SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
          events.event AS event,
          events.distinct_id AS distinct_id,
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS _concat_event_properties_key
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') ASC
@@ -649,7 +649,7 @@
 # name: TestQuery.test_select_hogql_expressions.1
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC')) AS _tuple_uuid_event_properties_toTimeZone_timestamp_UTC_team_id_distinct_id_elements_chain_toTimeZone_created_at_UTC,
+  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC')) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'UTC'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'UTC'))`,
          events.event AS event
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
@@ -668,7 +668,7 @@
 # name: TestQuery.test_select_hogql_expressions.2
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT count() AS _count,
+  SELECT count() AS `count()`,
          events.event AS event
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
@@ -688,7 +688,7 @@
 # name: TestQuery.test_select_hogql_expressions.3
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT count() AS _count,
+  SELECT count() AS `count()`,
          events.event AS event
   FROM events
   WHERE and(equals(events.team_id, 99999), or(equals(events.event, 'sign up'), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), '%val2'), 0)), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))

--- a/posthog/api/test/__snapshots__/test_query.ambr
+++ b/posthog/api/test/__snapshots__/test_query.ambr
@@ -6,7 +6,7 @@
          events.distinct_id AS distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS _concat_event_properties_key
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -28,7 +28,7 @@
          events.distinct_id AS distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS _concat_event_properties_key
   FROM events
   WHERE and(equals(events.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), 'test_val3'), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -50,7 +50,7 @@
          events.distinct_id AS distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS _concat_event_properties_key
   FROM events
   WHERE and(equals(events.team_id, 99999), ifNull(ilike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'path'), ''), 'null'), '^"|"$', '')), '%/%'), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -72,7 +72,7 @@
          events.distinct_id AS distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS `concat(event, ' ', properties.key)`
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS _concat_event_properties_key
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -94,7 +94,7 @@
          events.distinct_id AS distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS `concat(event, ' ', properties.key)`
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS _concat_event_properties_key
   FROM events
   WHERE and(equals(events.team_id, 99999), ifNull(equals(nullIf(nullIf(events.mat_key, ''), 'null'), 'test_val3'), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -116,7 +116,7 @@
          events.distinct_id AS distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS `concat(event, ' ', properties.key)`
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS _concat_event_properties_key
   FROM events
   WHERE and(equals(events.team_id, 99999), ifNull(ilike(toString(nullIf(nullIf(events.mat_path, ''), 'null')), '%/%'), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -276,7 +276,7 @@
          events.distinct_id AS distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS _concat_event_properties_key
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -298,7 +298,7 @@
          events.distinct_id AS distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS _concat_event_properties_key
   FROM events
   WHERE and(equals(events.team_id, 99999), 0, less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -320,7 +320,7 @@
          events.distinct_id AS distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS _concat_event_properties_key
   FROM events
   WHERE and(equals(events.team_id, 99999), 1, less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -342,7 +342,7 @@
          events.distinct_id AS distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS _concat_event_properties_key
   FROM events
   WHERE and(equals(events.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), 'test_val2'), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -364,7 +364,7 @@
          events.distinct_id AS distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS `concat(event, ' ', properties.key)`
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS _concat_event_properties_key
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -386,7 +386,7 @@
          events.distinct_id AS distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS `concat(event, ' ', properties.key)`
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS _concat_event_properties_key
   FROM events
   WHERE and(equals(events.team_id, 99999), 0, less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -408,7 +408,7 @@
          events.distinct_id AS distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS `concat(event, ' ', properties.key)`
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS _concat_event_properties_key
   FROM events
   WHERE and(equals(events.team_id, 99999), 1, less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -430,7 +430,7 @@
          events.distinct_id AS distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS `concat(event, ' ', properties.key)`
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS _concat_event_properties_key
   FROM events
   WHERE and(equals(events.team_id, 99999), ifNull(equals(nullIf(nullIf(events.mat_key, ''), 'null'), 'test_val2'), 0), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY events.event ASC
@@ -452,7 +452,7 @@
          events.distinct_id AS distinct_id,
          replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS _concat_event_properties_key
   FROM events
   LEFT OUTER JOIN
     (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -491,7 +491,7 @@
          events.distinct_id AS distinct_id,
          nullIf(nullIf(events.mat_key, ''), 'null') AS key,
          'a%sd',
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS `concat(event, ' ', properties.key)`
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(nullIf(nullIf(events.mat_key, ''), 'null')), '')) AS _concat_event_properties_key
   FROM events
   LEFT OUTER JOIN
     (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -527,7 +527,7 @@
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
-         count() AS `count()`
+         count() AS _count
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   GROUP BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')
@@ -547,7 +547,7 @@
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
-         count() AS `count()`
+         count() AS _count
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   GROUP BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')
@@ -568,7 +568,7 @@
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT nullIf(nullIf(events.mat_key, ''), 'null') AS key,
-         count() AS `count()`
+         count() AS _count
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   GROUP BY nullIf(nullIf(events.mat_key, ''), 'null')
@@ -588,7 +588,7 @@
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT nullIf(nullIf(events.mat_key, ''), 'null') AS key,
-         count() AS `count()`
+         count() AS _count
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   GROUP BY nullIf(nullIf(events.mat_key, ''), 'null')
@@ -631,7 +631,7 @@
   SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') AS key,
          events.event AS event,
          events.distinct_id AS distinct_id,
-         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS `concat(event, ' ', properties.key)`
+         concat(ifNull(toString(events.event), ''), ' ', ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '')), '')) AS _concat_event_properties_key
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
   ORDER BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', '') ASC
@@ -649,7 +649,7 @@
 # name: TestQuery.test_select_hogql_expressions.1
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC')) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'UTC'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'UTC'))`,
+  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC')) AS _tuple_uuid_event_properties_toTimeZone_timestamp_UTC_team_id_distinct_id_elements_chain_toTimeZone_created_at_UTC,
          events.event AS event
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
@@ -668,7 +668,7 @@
 # name: TestQuery.test_select_hogql_expressions.2
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT count() AS `count()`,
+  SELECT count() AS _count,
          events.event AS event
   FROM events
   WHERE and(equals(events.team_id, 99999), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))
@@ -688,7 +688,7 @@
 # name: TestQuery.test_select_hogql_expressions.3
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT count() AS `count()`,
+  SELECT count() AS _count,
          events.event AS event
   FROM events
   WHERE and(equals(events.team_id, 99999), or(equals(events.event, 'sign up'), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'key'), ''), 'null'), '^"|"$', ''), '%val2'), 0)), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-10 12:14:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-09 12:14:00.000000', 6, 'UTC')))

--- a/posthog/hogql/database/schema/test/__snapshots__/test_session_replay_events.ambr
+++ b/posthog/hogql/database/schema/test/__snapshots__/test_session_replay_events.ambr
@@ -139,7 +139,7 @@
 # name: TestFilterSessionReplaysByEvents.test_select_event_property
   '''
   SELECT session_replay_events.session_id AS session_id,
-         any(raw_session_replay_events__events.`properties___$current_url`)
+         any(raw_session_replay_events__events.`properties___$current_url`) AS `any(events.properties.$current_url)`
   FROM session_replay_events
   JOIN
     (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', '') AS `properties___$current_url`,
@@ -253,7 +253,7 @@
 # name: TestFilterSessionReplaysByPerson.test_select_person_property
   '''
   SELECT session_replay_events.session_id AS session_id,
-         any(raw_session_replay_events__pdi__person.properties___person_property)
+         any(raw_session_replay_events__pdi__person.properties___person_property) AS `any(person.properties.person_property)`
   FROM session_replay_events
   INNER JOIN
     (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS raw_session_replay_events__pdi___person_id,
@@ -289,7 +289,7 @@
 # name: TestFilterSessionReplaysByPerson.test_select_where_person_property_with_join_optimization
   '''
   SELECT session_replay_events.session_id AS session_id,
-         any(raw_session_replay_events__pdi__person.properties___person_property)
+         any(raw_session_replay_events__pdi__person.properties___person_property) AS `any(person.properties.person_property)`
   FROM session_replay_events
   INNER JOIN
     (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS raw_session_replay_events__pdi___person_id,
@@ -325,7 +325,7 @@
 # name: TestFilterSessionReplaysByPerson.test_select_where_person_property_without_join_optimization
   '''
   SELECT session_replay_events.session_id AS session_id,
-         any(raw_session_replay_events__pdi__person.properties___person_property)
+         any(raw_session_replay_events__pdi__person.properties___person_property) AS `any(person.properties.person_property)`
   FROM session_replay_events
   INNER JOIN
     (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS raw_session_replay_events__pdi___person_id,

--- a/posthog/hogql/database/schema/test/__snapshots__/test_session_replay_events.ambr
+++ b/posthog/hogql/database/schema/test/__snapshots__/test_session_replay_events.ambr
@@ -139,7 +139,7 @@
 # name: TestFilterSessionReplaysByEvents.test_select_event_property
   '''
   SELECT session_replay_events.session_id AS session_id,
-         any(raw_session_replay_events__events.`properties___$current_url`) AS _any_events_properties_current_url
+         any(raw_session_replay_events__events.`properties___$current_url`) AS `any(events.properties.$current_url)`
   FROM session_replay_events
   JOIN
     (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', '') AS `properties___$current_url`,
@@ -253,7 +253,7 @@
 # name: TestFilterSessionReplaysByPerson.test_select_person_property
   '''
   SELECT session_replay_events.session_id AS session_id,
-         any(raw_session_replay_events__pdi__person.properties___person_property) AS _any_person_properties_person_property
+         any(raw_session_replay_events__pdi__person.properties___person_property) AS `any(person.properties.person_property)`
   FROM session_replay_events
   INNER JOIN
     (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS raw_session_replay_events__pdi___person_id,
@@ -289,7 +289,7 @@
 # name: TestFilterSessionReplaysByPerson.test_select_where_person_property_with_join_optimization
   '''
   SELECT session_replay_events.session_id AS session_id,
-         any(raw_session_replay_events__pdi__person.properties___person_property) AS _any_person_properties_person_property
+         any(raw_session_replay_events__pdi__person.properties___person_property) AS `any(person.properties.person_property)`
   FROM session_replay_events
   INNER JOIN
     (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS raw_session_replay_events__pdi___person_id,
@@ -325,7 +325,7 @@
 # name: TestFilterSessionReplaysByPerson.test_select_where_person_property_without_join_optimization
   '''
   SELECT session_replay_events.session_id AS session_id,
-         any(raw_session_replay_events__pdi__person.properties___person_property) AS _any_person_properties_person_property
+         any(raw_session_replay_events__pdi__person.properties___person_property) AS `any(person.properties.person_property)`
   FROM session_replay_events
   INNER JOIN
     (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS raw_session_replay_events__pdi___person_id,

--- a/posthog/hogql/database/schema/test/__snapshots__/test_session_replay_events.ambr
+++ b/posthog/hogql/database/schema/test/__snapshots__/test_session_replay_events.ambr
@@ -139,7 +139,7 @@
 # name: TestFilterSessionReplaysByEvents.test_select_event_property
   '''
   SELECT session_replay_events.session_id AS session_id,
-         any(raw_session_replay_events__events.`properties___$current_url`) AS `any(events.properties.$current_url)`
+         any(raw_session_replay_events__events.`properties___$current_url`) AS _any_events_properties_current_url
   FROM session_replay_events
   JOIN
     (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', '') AS `properties___$current_url`,
@@ -253,7 +253,7 @@
 # name: TestFilterSessionReplaysByPerson.test_select_person_property
   '''
   SELECT session_replay_events.session_id AS session_id,
-         any(raw_session_replay_events__pdi__person.properties___person_property) AS `any(person.properties.person_property)`
+         any(raw_session_replay_events__pdi__person.properties___person_property) AS _any_person_properties_person_property
   FROM session_replay_events
   INNER JOIN
     (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS raw_session_replay_events__pdi___person_id,
@@ -289,7 +289,7 @@
 # name: TestFilterSessionReplaysByPerson.test_select_where_person_property_with_join_optimization
   '''
   SELECT session_replay_events.session_id AS session_id,
-         any(raw_session_replay_events__pdi__person.properties___person_property) AS `any(person.properties.person_property)`
+         any(raw_session_replay_events__pdi__person.properties___person_property) AS _any_person_properties_person_property
   FROM session_replay_events
   INNER JOIN
     (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS raw_session_replay_events__pdi___person_id,
@@ -325,7 +325,7 @@
 # name: TestFilterSessionReplaysByPerson.test_select_where_person_property_without_join_optimization
   '''
   SELECT session_replay_events.session_id AS session_id,
-         any(raw_session_replay_events__pdi__person.properties___person_property) AS `any(person.properties.person_property)`
+         any(raw_session_replay_events__pdi__person.properties___person_property) AS _any_person_properties_person_property
   FROM session_replay_events
   INNER JOIN
     (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS raw_session_replay_events__pdi___person_id,

--- a/posthog/hogql/database/schema/util/test/test_session_v2_where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/test/test_session_v2_where_clause_extractor.py
@@ -390,7 +390,7 @@ LIMIT 50000\
             """
 SELECT
     sessions.session_id,
-    uniq(uuid)
+    uniq(uuid) as uniq_uuid
 FROM events
 JOIN sessions
 ON events.$session_id = sessions.session_id
@@ -402,7 +402,7 @@ GROUP BY sessions.session_id
             """\
 SELECT
     sessions.session_id AS session_id,
-    uniq(events.uuid)
+    uniq(events.uuid) AS uniq_uuid
 FROM
     events
     JOIN (SELECT

--- a/posthog/hogql/database/schema/util/test/test_session_where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/test/test_session_where_clause_extractor.py
@@ -359,7 +359,7 @@ LIMIT 50000\
             """
 SELECT
     sessions.session_id,
-    uniq(uuid)
+    uniq(uuid) as uniq_uuid
 FROM events
 JOIN sessions
 ON events.$session_id = sessions.session_id
@@ -371,7 +371,7 @@ GROUP BY sessions.session_id
             """\
 SELECT
     sessions.session_id AS session_id,
-    uniq(events.uuid)
+    uniq(events.uuid) AS uniq_uuid
 FROM
     events
     JOIN (SELECT

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -201,19 +201,6 @@ def print_prepared_ast(
         ).visit(node)
 
 
-_non_alnum_re = re.compile(r"[^a-zA-Z0-9]")
-_multi_underscore_re = re.compile(r"_+")
-
-
-def print_ast_call(call: ast.Call, context: HogQLContext) -> str:
-    printed_call = print_prepared_ast(call, context, dialect="hogql")
-
-    printed_call_underscored = re.sub(_non_alnum_re, "_", printed_call)
-    collapsed = re.sub(_multi_underscore_re, "_", printed_call_underscored)
-
-    return f"_{collapsed.strip('_')}"
-
-
 @dataclass
 class JoinExprResponse:
     printed_sql: str
@@ -394,7 +381,7 @@ class _Printer(Visitor):
                             # Non-unique hidden alias. Skip.
                             column = column.expr
                     elif isinstance(column, ast.Call):
-                        column_alias = print_ast_call(column, self.context)
+                        column_alias = print_prepared_ast(column, self.context, dialect="hogql")
                         column = ast.Alias(alias=column_alias, expr=column)
                     columns.append(self.visit(column))
             else:

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -380,6 +380,9 @@ class _Printer(Visitor):
                         else:
                             # Non-unique hidden alias. Skip.
                             column = column.expr
+                    elif isinstance(column, ast.Call):
+                        alias = print_prepared_ast(column, self.context, dialect="hogql")
+                        column = ast.Alias(alias=alias, expr=column)
                     columns.append(self.visit(column))
             else:
                 columns = [self.visit(column) for column in node.select]

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -381,8 +381,8 @@ class _Printer(Visitor):
                             # Non-unique hidden alias. Skip.
                             column = column.expr
                     elif isinstance(column, ast.Call):
-                        alias = print_prepared_ast(column, self.context, dialect="hogql")
-                        column = ast.Alias(alias=alias, expr=column)
+                        column_alias = print_prepared_ast(column, self.context, dialect="hogql")
+                        column = ast.Alias(alias=column_alias, expr=column)
                     columns.append(self.visit(column))
             else:
                 columns = [self.visit(column) for column in node.select]

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -201,6 +201,19 @@ def print_prepared_ast(
         ).visit(node)
 
 
+_non_alnum_re = re.compile(r"[^a-zA-Z0-9]")
+_multi_underscore_re = re.compile(r"_+")
+
+
+def print_ast_call(call: ast.Call, context: HogQLContext) -> str:
+    printed_call = print_prepared_ast(call, context, dialect="hogql")
+
+    printed_call_underscored = re.sub(_non_alnum_re, "_", printed_call)
+    collapsed = re.sub(_multi_underscore_re, "_", printed_call_underscored)
+
+    return f"_{collapsed.strip('_')}"
+
+
 @dataclass
 class JoinExprResponse:
     printed_sql: str
@@ -381,7 +394,7 @@ class _Printer(Visitor):
                             # Non-unique hidden alias. Skip.
                             column = column.expr
                     elif isinstance(column, ast.Call):
-                        column_alias = print_prepared_ast(column, self.context, dialect="hogql")
+                        column_alias = print_ast_call(column, self.context)
                         column = ast.Alias(alias=column_alias, expr=column)
                     columns.append(self.visit(column))
             else:

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -211,9 +211,9 @@ class Resolver(CloningVisitor):
             elif isinstance(new_expr, ast.Alias):
                 alias = new_expr.alias
             elif isinstance(new_expr.type, ast.CallType):
-                from posthog.hogql.printer import print_ast_call
+                from posthog.hogql.printer import print_prepared_ast
 
-                alias = print_ast_call(new_expr, self.context)
+                alias = print_prepared_ast(node=new_expr, context=self.context, dialect="hogql")
             else:
                 alias = None
 

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -210,6 +210,10 @@ class Resolver(CloningVisitor):
                 alias = new_expr.type.name
             elif isinstance(new_expr, ast.Alias):
                 alias = new_expr.alias
+            elif isinstance(new_expr.type, ast.CallType):
+                from posthog.hogql.printer import print_prepared_ast
+
+                alias = print_prepared_ast(node=new_expr, context=self.context, dialect="hogql")
             else:
                 alias = None
 

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -211,9 +211,9 @@ class Resolver(CloningVisitor):
             elif isinstance(new_expr, ast.Alias):
                 alias = new_expr.alias
             elif isinstance(new_expr.type, ast.CallType):
-                from posthog.hogql.printer import print_prepared_ast
+                from posthog.hogql.printer import print_ast_call
 
-                alias = print_prepared_ast(node=new_expr, context=self.context, dialect="hogql")
+                alias = print_ast_call(new_expr, self.context)
             else:
                 alias = None
 

--- a/posthog/hogql/test/__snapshots__/test_query.ambr
+++ b/posthog/hogql/test/__snapshots__/test_query.ambr
@@ -43,7 +43,7 @@
   '''
   -- ClickHouse
   
-  SELECT arrayMap(x -> multiply(x, 2), [1, 2, 3]), 1 
+  SELECT arrayMap(x -> multiply(x, 2), [1, 2, 3]) AS `arrayMap(x -> multiply(x, 2), [1, 2, 3])`, 1 
   LIMIT 100 
   SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1, format_csv_allow_double_quotes=0, max_ast_elements=4000000, max_expanded_ast_elements=4000000, max_bytes_before_external_group_by=0, transform_null_in=1
   
@@ -339,7 +339,7 @@
   '''
   -- ClickHouse
   
-  SELECT events.event AS event, count() 
+  SELECT events.event AS event, count() AS `count()` 
   FROM events LEFT OUTER JOIN (
   SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id, person_distinct_id_overrides.distinct_id AS distinct_id 
   FROM person_distinct_id_overrides 
@@ -375,7 +375,7 @@
   '''
   -- ClickHouse
   
-  SELECT events.event AS event, count(*) 
+  SELECT events.event AS event, count(*) AS `count(*)` 
   FROM events 
   WHERE and(equals(events.team_id, 99999), in(events.person_id, (
   SELECT cohortpeople.person_id AS person_id 
@@ -405,7 +405,7 @@
   '''
   -- ClickHouse
   
-  SELECT events.event AS event, count() 
+  SELECT events.event AS event, count() AS `count()` 
   FROM events LEFT OUTER JOIN (
   SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id, person_distinct_id_overrides.distinct_id AS distinct_id 
   FROM person_distinct_id_overrides 
@@ -437,7 +437,7 @@
   '''
   -- ClickHouse
   
-  SELECT events.event AS event, count(*) 
+  SELECT events.event AS event, count(*) AS `count(*)` 
   FROM events 
   WHERE and(equals(events.team_id, 99999), in(events.person_id, (
   SELECT person_static_cohort.person_id AS person_id 
@@ -463,7 +463,7 @@
   '''
   -- ClickHouse
   
-  SELECT count(), events.event AS event 
+  SELECT count() AS `count()`, events.event AS event 
   FROM events 
   WHERE and(equals(events.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', ''), %(hogql_val_1)s), 0)) 
   GROUP BY events.event 
@@ -680,7 +680,7 @@
   '''
   -- ClickHouse
   
-  SELECT s__pdi__person.properties___sneaky_mail AS sneaky_mail, count() 
+  SELECT s__pdi__person.properties___sneaky_mail AS sneaky_mail, count() AS `count()` 
   FROM events AS s INNER JOIN (
   SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS s__pdi___person_id, argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id AS distinct_id 
   FROM person_distinct_id2 
@@ -902,7 +902,7 @@
   '''
   -- ClickHouse
   
-  SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(s.person_properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', '') AS sneaky_mail, count() 
+  SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(s.person_properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', '') AS sneaky_mail, count() AS `count()` 
   FROM events AS s 
   WHERE equals(s.team_id, 99999) 
   GROUP BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(s.person_properties, %(hogql_val_1)s), ''), 'null'), '^"|"$', '') 

--- a/posthog/hogql/test/__snapshots__/test_query.ambr
+++ b/posthog/hogql/test/__snapshots__/test_query.ambr
@@ -43,7 +43,7 @@
   '''
   -- ClickHouse
   
-  SELECT arrayMap(x -> multiply(x, 2), [1, 2, 3]) AS _arrayMap_x_multiply_x_2_1_2_3, 1 
+  SELECT arrayMap(x -> multiply(x, 2), [1, 2, 3]) AS `arrayMap(x -> multiply(x, 2), [1, 2, 3])`, 1 
   LIMIT 100 
   SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1, format_csv_allow_double_quotes=0, max_ast_elements=4000000, max_expanded_ast_elements=4000000, max_bytes_before_external_group_by=0, transform_null_in=1
   
@@ -339,7 +339,7 @@
   '''
   -- ClickHouse
   
-  SELECT events.event AS event, count() AS _count 
+  SELECT events.event AS event, count() AS `count()` 
   FROM events LEFT OUTER JOIN (
   SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id, person_distinct_id_overrides.distinct_id AS distinct_id 
   FROM person_distinct_id_overrides 
@@ -375,7 +375,7 @@
   '''
   -- ClickHouse
   
-  SELECT events.event AS event, count(*) AS _count 
+  SELECT events.event AS event, count(*) AS `count(*)` 
   FROM events 
   WHERE and(equals(events.team_id, 99999), in(events.person_id, (
   SELECT cohortpeople.person_id AS person_id 
@@ -405,7 +405,7 @@
   '''
   -- ClickHouse
   
-  SELECT events.event AS event, count() AS _count 
+  SELECT events.event AS event, count() AS `count()` 
   FROM events LEFT OUTER JOIN (
   SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id, person_distinct_id_overrides.distinct_id AS distinct_id 
   FROM person_distinct_id_overrides 
@@ -437,7 +437,7 @@
   '''
   -- ClickHouse
   
-  SELECT events.event AS event, count(*) AS _count 
+  SELECT events.event AS event, count(*) AS `count(*)` 
   FROM events 
   WHERE and(equals(events.team_id, 99999), in(events.person_id, (
   SELECT person_static_cohort.person_id AS person_id 
@@ -463,7 +463,7 @@
   '''
   -- ClickHouse
   
-  SELECT count() AS _count, events.event AS event 
+  SELECT count() AS `count()`, events.event AS event 
   FROM events 
   WHERE and(equals(events.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', ''), %(hogql_val_1)s), 0)) 
   GROUP BY events.event 
@@ -680,7 +680,7 @@
   '''
   -- ClickHouse
   
-  SELECT s__pdi__person.properties___sneaky_mail AS sneaky_mail, count() AS _count 
+  SELECT s__pdi__person.properties___sneaky_mail AS sneaky_mail, count() AS `count()` 
   FROM events AS s INNER JOIN (
   SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS s__pdi___person_id, argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id AS distinct_id 
   FROM person_distinct_id2 
@@ -902,7 +902,7 @@
   '''
   -- ClickHouse
   
-  SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(s.person_properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', '') AS sneaky_mail, count() AS _count 
+  SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(s.person_properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', '') AS sneaky_mail, count() AS `count()` 
   FROM events AS s 
   WHERE equals(s.team_id, 99999) 
   GROUP BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(s.person_properties, %(hogql_val_1)s), ''), 'null'), '^"|"$', '') 

--- a/posthog/hogql/test/__snapshots__/test_query.ambr
+++ b/posthog/hogql/test/__snapshots__/test_query.ambr
@@ -43,7 +43,7 @@
   '''
   -- ClickHouse
   
-  SELECT arrayMap(x -> multiply(x, 2), [1, 2, 3]) AS `arrayMap(x -> multiply(x, 2), [1, 2, 3])`, 1 
+  SELECT arrayMap(x -> multiply(x, 2), [1, 2, 3]) AS _arrayMap_x_multiply_x_2_1_2_3, 1 
   LIMIT 100 
   SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1, format_csv_allow_double_quotes=0, max_ast_elements=4000000, max_expanded_ast_elements=4000000, max_bytes_before_external_group_by=0, transform_null_in=1
   
@@ -339,7 +339,7 @@
   '''
   -- ClickHouse
   
-  SELECT events.event AS event, count() AS `count()` 
+  SELECT events.event AS event, count() AS _count 
   FROM events LEFT OUTER JOIN (
   SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id, person_distinct_id_overrides.distinct_id AS distinct_id 
   FROM person_distinct_id_overrides 
@@ -375,7 +375,7 @@
   '''
   -- ClickHouse
   
-  SELECT events.event AS event, count(*) AS `count(*)` 
+  SELECT events.event AS event, count(*) AS _count 
   FROM events 
   WHERE and(equals(events.team_id, 99999), in(events.person_id, (
   SELECT cohortpeople.person_id AS person_id 
@@ -405,7 +405,7 @@
   '''
   -- ClickHouse
   
-  SELECT events.event AS event, count() AS `count()` 
+  SELECT events.event AS event, count() AS _count 
   FROM events LEFT OUTER JOIN (
   SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id, person_distinct_id_overrides.distinct_id AS distinct_id 
   FROM person_distinct_id_overrides 
@@ -437,7 +437,7 @@
   '''
   -- ClickHouse
   
-  SELECT events.event AS event, count(*) AS `count(*)` 
+  SELECT events.event AS event, count(*) AS _count 
   FROM events 
   WHERE and(equals(events.team_id, 99999), in(events.person_id, (
   SELECT person_static_cohort.person_id AS person_id 
@@ -463,7 +463,7 @@
   '''
   -- ClickHouse
   
-  SELECT count() AS `count()`, events.event AS event 
+  SELECT count() AS _count, events.event AS event 
   FROM events 
   WHERE and(equals(events.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', ''), %(hogql_val_1)s), 0)) 
   GROUP BY events.event 
@@ -680,7 +680,7 @@
   '''
   -- ClickHouse
   
-  SELECT s__pdi__person.properties___sneaky_mail AS sneaky_mail, count() AS `count()` 
+  SELECT s__pdi__person.properties___sneaky_mail AS sneaky_mail, count() AS _count 
   FROM events AS s INNER JOIN (
   SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS s__pdi___person_id, argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id, person_distinct_id2.distinct_id AS distinct_id 
   FROM person_distinct_id2 
@@ -902,7 +902,7 @@
   '''
   -- ClickHouse
   
-  SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(s.person_properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', '') AS sneaky_mail, count() AS `count()` 
+  SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(s.person_properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', '') AS sneaky_mail, count() AS _count 
   FROM events AS s 
   WHERE equals(s.team_id, 99999) 
   GROUP BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(s.person_properties, %(hogql_val_1)s), ''), 'null'), '^"|"$', '') 

--- a/posthog/hogql/test/__snapshots__/test_resolver.ambr
+++ b/posthog/hogql/test/__snapshots__/test_resolver.ambr
@@ -7641,7 +7641,9 @@
     type: {
       aliases: {}
       anonymous_tables: []
-      columns: {}
+      columns: {
+        max(timestamp): <recursion ...>
+      }
       ctes: {}
       tables: {
         events: <recursion ...>

--- a/posthog/hogql/test/__snapshots__/test_resolver.ambr
+++ b/posthog/hogql/test/__snapshots__/test_resolver.ambr
@@ -7642,7 +7642,7 @@
       aliases: {}
       anonymous_tables: []
       columns: {
-        _max_timestamp: <recursion ...>
+        max(timestamp): <recursion ...>
       }
       ctes: {}
       tables: {

--- a/posthog/hogql/test/__snapshots__/test_resolver.ambr
+++ b/posthog/hogql/test/__snapshots__/test_resolver.ambr
@@ -7642,7 +7642,7 @@
       aliases: {}
       anonymous_tables: []
       columns: {
-        max(timestamp): <recursion ...>
+        _max_timestamp: <recursion ...>
       }
       ctes: {}
       tables: {

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -597,20 +597,20 @@ class TestPrinter(BaseTest):
         # Comparing against a (non-empty) string value lets us avoid checking if the key exists or not, and lets us use
         # the bloom filter indices on both keys and values to optimize the comparison operation.
         self._test_property_group_comparison(
-            "properties.key = 'value'",
-            "equals(events.properties_group_custom[%(hogql_val_0)s], %(hogql_val_1)s)",
+            "properties.key = 'value' as eq",
+            "equals(events.properties_group_custom[%(hogql_val_0)s], %(hogql_val_1)s) AS eq",
             {"hogql_val_0": "key", "hogql_val_1": "value"},
             expected_skip_indexes_used={"properties_group_custom_keys_bf", "properties_group_custom_values_bf"},
         )
         self._test_property_group_comparison(
-            "'value' = properties.key",
-            "equals(events.properties_group_custom[%(hogql_val_0)s], %(hogql_val_1)s)",
+            "'value' = properties.key as eq",
+            "equals(events.properties_group_custom[%(hogql_val_0)s], %(hogql_val_1)s) AS eq",
             {"hogql_val_0": "key", "hogql_val_1": "value"},
             expected_skip_indexes_used={"properties_group_custom_keys_bf", "properties_group_custom_values_bf"},
         )
         self._test_property_group_comparison(
-            "equals(properties.key, 'value')",
-            "equals(events.properties_group_custom[%(hogql_val_0)s], %(hogql_val_1)s)",
+            "equals(properties.key, 'value') as eq",
+            "equals(events.properties_group_custom[%(hogql_val_0)s], %(hogql_val_1)s) AS eq",
             {"hogql_val_0": "key", "hogql_val_1": "value"},
             expected_skip_indexes_used={"properties_group_custom_keys_bf", "properties_group_custom_values_bf"},
         )
@@ -660,14 +660,14 @@ class TestPrinter(BaseTest):
         # not. We can still utilize the bloom filter index on keys, but the empty string isn't stored in the bloom
         # filter so it won't be used here.
         self._test_property_group_comparison(
-            "properties.key = ''",
-            "and(has(events.properties_group_custom, %(hogql_val_0)s), equals(events.properties_group_custom[%(hogql_val_0)s], %(hogql_val_1)s))",
+            "properties.key = '' as eq",
+            "and(has(events.properties_group_custom, %(hogql_val_0)s), equals(events.properties_group_custom[%(hogql_val_0)s], %(hogql_val_1)s)) AS eq",
             {"hogql_val_0": "key", "hogql_val_1": ""},
             expected_skip_indexes_used={"properties_group_custom_keys_bf"},
         )
         self._test_property_group_comparison(
-            "equals(properties.key, '')",
-            "and(has(events.properties_group_custom, %(hogql_val_0)s), equals(events.properties_group_custom[%(hogql_val_0)s], %(hogql_val_1)s))",
+            "equals(properties.key, '') as eq",
+            "and(has(events.properties_group_custom, %(hogql_val_0)s), equals(events.properties_group_custom[%(hogql_val_0)s], %(hogql_val_1)s)) AS eq",
             {"hogql_val_0": "key", "hogql_val_1": ""},
             expected_skip_indexes_used={"properties_group_custom_keys_bf"},
         )
@@ -676,20 +676,20 @@ class TestPrinter(BaseTest):
         # NOT NULL comparisons should check to see if the key exists within the map (and should use the bloom filter to
         # optimize the check), but do not need to load the values subcolumn.
         self._test_property_group_comparison(
-            "properties.key is not null",
-            "has(events.properties_group_custom, %(hogql_val_0)s)",
+            "properties.key is not null as p",
+            "has(events.properties_group_custom, %(hogql_val_0)s) AS p",
             {"hogql_val_0": "key"},
             expected_skip_indexes_used={"properties_group_custom_keys_bf"},
         )
         self._test_property_group_comparison(
-            "properties.key != null",
-            "has(events.properties_group_custom, %(hogql_val_0)s)",
+            "properties.key != null as p",
+            "has(events.properties_group_custom, %(hogql_val_0)s) AS p",
             {"hogql_val_0": "key"},
             expected_skip_indexes_used={"properties_group_custom_keys_bf"},
         )
         self._test_property_group_comparison(
-            "isNotNull(properties.key)",
-            "has(events.properties_group_custom, %(hogql_val_0)s)",
+            "isNotNull(properties.key) as p",
+            "has(events.properties_group_custom, %(hogql_val_0)s) AS p",
             {"hogql_val_0": "key"},
             expected_skip_indexes_used={"properties_group_custom_keys_bf"},
         )
@@ -697,25 +697,25 @@ class TestPrinter(BaseTest):
         # NULL comparisons don't really benefit from the bloom filter index like NOT NULL comparisons do, but like
         # above, only need to check the keys subcolumn and not the values subcolumn.
         self._test_property_group_comparison(
-            "properties.key is null",
-            "not(has(events.properties_group_custom, %(hogql_val_0)s))",
+            "properties.key is null as p",
+            "not(has(events.properties_group_custom, %(hogql_val_0)s)) AS p",
             {"hogql_val_0": "key"},
         )
         self._test_property_group_comparison(
-            "properties.key = null",
-            "not(has(events.properties_group_custom, %(hogql_val_0)s))",
+            "properties.key = null as p",
+            "not(has(events.properties_group_custom, %(hogql_val_0)s)) AS p",
             {"hogql_val_0": "key"},
         )
         self._test_property_group_comparison(
-            "isNull(properties.key)",
-            "not(has(events.properties_group_custom, %(hogql_val_0)s))",
+            "isNull(properties.key) as p",
+            "not(has(events.properties_group_custom, %(hogql_val_0)s)) AS p",
             {"hogql_val_0": "key"},
         )
 
     def test_property_groups_optimized_has(self) -> None:
         self._test_property_group_comparison(
-            "JSONHas(properties, 'key')",
-            "has(events.properties_group_custom, %(hogql_val_0)s)",
+            "JSONHas(properties, 'key') as j",
+            "has(events.properties_group_custom, %(hogql_val_0)s) AS j",
             {"hogql_val_0": "key"},
             expected_skip_indexes_used={"properties_group_custom_keys_bf"},
         )
@@ -725,8 +725,8 @@ class TestPrinter(BaseTest):
 
         with materialized("events", "key"):
             self._test_property_group_comparison(
-                "JSONHas(properties, 'key')",
-                "has(events.properties_group_custom, %(hogql_val_0)s)",
+                "JSONHas(properties, 'key') as j",
+                "has(events.properties_group_custom, %(hogql_val_0)s) AS j",
                 {"hogql_val_0": "key"},
                 expected_skip_indexes_used={"properties_group_custom_keys_bf"},
             )
@@ -1358,20 +1358,20 @@ class TestPrinter(BaseTest):
 
     def test_count_distinct(self):
         self.assertEqual(
-            self._select("SELECT count(distinct event) FROM events"),
-            f"SELECT count(DISTINCT events.event) FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS}",
+            self._select("SELECT count(distinct event) as count FROM events"),
+            f"SELECT count(DISTINCT events.event) AS count FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS}",
         )
 
     def test_count_star(self):
         self.assertEqual(
-            self._select("SELECT count(*) FROM events"),
-            f"SELECT count(*) FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS}",
+            self._select("SELECT count(*) as count FROM events"),
+            f"SELECT count(*) AS count FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS}",
         )
 
     def test_count_if_distinct(self):
         self.assertEqual(
-            self._select("SELECT countIf(distinct event, event like '%a%') FROM events"),
-            f"SELECT countIf(DISTINCT events.event, like(events.event, %(hogql_val_0)s)) FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS}",
+            self._select("SELECT countIf(distinct event, event like '%a%') as count FROM events"),
+            f"SELECT countIf(DISTINCT events.event, like(events.event, %(hogql_val_0)s)) AS count FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS}",
         )
 
     def test_print_timezone(self):
@@ -1384,10 +1384,10 @@ class TestPrinter(BaseTest):
 
         self.assertEqual(
             self._select(
-                "SELECT now(), toDateTime(timestamp), toDate(test_date), toDateTime('2020-02-02'), toDateTime('2020-02-02 12:25') FROM events",
+                "SELECT now() as a, toDateTime(timestamp) as b, toDate(test_date) as c, toDateTime('2020-02-02') as d, toDateTime('2020-02-02 12:25') as e FROM events",
                 context,
             ),
-            f"SELECT now64(6, %(hogql_val_0)s), toDateTime(toTimeZone(events.timestamp, %(hogql_val_1)s), %(hogql_val_2)s), toDate(events.test_date), toDateTime(%(hogql_val_3)s, %(hogql_val_4)s), parseDateTime64BestEffort(%(hogql_val_5)s, 6, %(hogql_val_6)s) FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS}",
+            f"SELECT now64(6, %(hogql_val_0)s) AS a, toDateTime(toTimeZone(events.timestamp, %(hogql_val_1)s), %(hogql_val_2)s) AS b, toDate(events.test_date) AS c, toDateTime(%(hogql_val_3)s, %(hogql_val_4)s) AS d, parseDateTime64BestEffort(%(hogql_val_5)s, 6, %(hogql_val_6)s) AS e FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS}",
         )
         self.assertEqual(
             context.values,
@@ -1408,10 +1408,10 @@ class TestPrinter(BaseTest):
         context = HogQLContext(team_id=self.team.pk, enable_select_queries=True)
         self.assertEqual(
             self._select(
-                "SELECT now(), toDateTime(timestamp), toDateTime('2020-02-02') FROM events",
+                "SELECT now() as a, toDateTime(timestamp) as b, toDateTime('2020-02-02') as c FROM events",
                 context,
             ),
-            f"SELECT now64(6, %(hogql_val_0)s), toDateTime(toTimeZone(events.timestamp, %(hogql_val_1)s), %(hogql_val_2)s), toDateTime(%(hogql_val_3)s, %(hogql_val_4)s) FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS}",
+            f"SELECT now64(6, %(hogql_val_0)s) AS a, toDateTime(toTimeZone(events.timestamp, %(hogql_val_1)s), %(hogql_val_2)s) AS b, toDateTime(%(hogql_val_3)s, %(hogql_val_4)s) AS c FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS}",
         )
         self.assertEqual(
             context.values,
@@ -1535,47 +1535,47 @@ class TestPrinter(BaseTest):
 
     def test_functions_expecting_datetime_arg(self):
         self.assertEqual(
-            self._expr("tumble(toDateTime('2023-06-12'), toIntervalDay('1'))"),
-            f"tumble(assumeNotNull(toDateTime(toDateTime(%(hogql_val_0)s, %(hogql_val_1)s))), toIntervalDay(%(hogql_val_2)s))",
+            self._expr("tumble(toDateTime('2023-06-12'), toIntervalDay('1')) as t"),
+            f"tumble(assumeNotNull(toDateTime(toDateTime(%(hogql_val_0)s, %(hogql_val_1)s))), toIntervalDay(%(hogql_val_2)s)) AS t",
         )
         self.assertEqual(
-            self._expr("tumble(now(), toIntervalDay('1'))"),
-            f"tumble(toDateTime(now64(6, %(hogql_val_0)s), 'UTC'), toIntervalDay(%(hogql_val_1)s))",
+            self._expr("tumble(now(), toIntervalDay('1')) as t"),
+            f"tumble(toDateTime(now64(6, %(hogql_val_0)s), 'UTC'), toIntervalDay(%(hogql_val_1)s)) AS t",
         )
         self.assertEqual(
-            self._expr("tumble(parseDateTime('2021-01-04+23:00:00', '%Y-%m-%d+%H:%i:%s'), toIntervalDay('1'))"),
-            f"tumble(assumeNotNull(toDateTime(parseDateTimeOrNull(%(hogql_val_0)s, %(hogql_val_1)s, %(hogql_val_2)s))), toIntervalDay(%(hogql_val_3)s))",
+            self._expr("tumble(parseDateTime('2021-01-04+23:00:00', '%Y-%m-%d+%H:%i:%s'), toIntervalDay('1')) as t"),
+            f"tumble(assumeNotNull(toDateTime(parseDateTimeOrNull(%(hogql_val_0)s, %(hogql_val_1)s, %(hogql_val_2)s))), toIntervalDay(%(hogql_val_3)s)) AS t",
         )
         self.assertEqual(
-            self._expr("tumble(parseDateTimeBestEffort('23/10/2020 12:12:57'), toIntervalDay('1'))"),
-            f"tumble(assumeNotNull(toDateTime(parseDateTime64BestEffort(%(hogql_val_0)s, 6, %(hogql_val_1)s))), toIntervalDay(%(hogql_val_2)s))",
+            self._expr("tumble(parseDateTimeBestEffort('23/10/2020 12:12:57'), toIntervalDay('1')) as t"),
+            f"tumble(assumeNotNull(toDateTime(parseDateTime64BestEffort(%(hogql_val_0)s, 6, %(hogql_val_1)s))), toIntervalDay(%(hogql_val_2)s)) AS t",
         )
         self.assertEqual(
-            self._select("SELECT tumble(timestamp, toIntervalDay('1')) FROM events"),
-            f"SELECT tumble(toDateTime(toTimeZone(events.timestamp, %(hogql_val_0)s), 'UTC'), toIntervalDay(%(hogql_val_1)s)) FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS}",
+            self._select("SELECT tumble(timestamp, toIntervalDay('1')) as t FROM events"),
+            f"SELECT tumble(toDateTime(toTimeZone(events.timestamp, %(hogql_val_0)s), 'UTC'), toIntervalDay(%(hogql_val_1)s)) AS t FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS}",
         )
 
     def test_field_nullable_equals(self):
         generated_sql_statements1 = self._select(
             "SELECT "
-            "start_time = toStartOfMonth(now()), "
-            "1 = 1, "
-            "click_count = 1, "
-            "1 = click_count, "
-            "click_count = keypress_count, "
-            "click_count = null, "
-            "null = click_count "
+            "start_time = toStartOfMonth(now()) as a, "
+            "1 = 1 as b, "
+            "click_count = 1 as c, "
+            "1 = click_count as d, "
+            "click_count = keypress_count as e, "
+            "click_count = null as f, "
+            "null = click_count as g "
             "FROM session_replay_events"
         )
         generated_sql_statements2 = self._select(
             "SELECT "
-            "equals(start_time, toStartOfMonth(now())), "
-            "equals(1, 1), "
-            "equals(click_count, 1), "
-            "equals(1, click_count), "
-            "equals(click_count, keypress_count), "
-            "equals(click_count, null), "
-            "equals(null, click_count) "
+            "equals(start_time, toStartOfMonth(now())) as a, "
+            "equals(1, 1) as b, "
+            "equals(click_count, 1) as c, "
+            "equals(1, click_count) as d, "
+            "equals(click_count, keypress_count) as e, "
+            "equals(click_count, null) as f, "
+            "equals(null, click_count) as g "
             "FROM session_replay_events"
         )
         assert generated_sql_statements1 == generated_sql_statements2
@@ -1584,32 +1584,32 @@ class TestPrinter(BaseTest):
             # start_time = toStartOfMonth(now())
             # (the return of toStartOfMonth() is treated as "potentially nullable" since we yet have full typing support)
             f"ifNull(equals(session_replay_events.start_time, toStartOfMonth(now64(6, %(hogql_val_1)s))), "
-            f"isNull(session_replay_events.start_time) and isNull(toStartOfMonth(now64(6, %(hogql_val_1)s)))), "
+            f"isNull(session_replay_events.start_time) and isNull(toStartOfMonth(now64(6, %(hogql_val_1)s)))) AS a, "
             # 1 = 1
-            f"1, "
+            f"1 AS b, "
             # click_count = 1
-            f"ifNull(equals(session_replay_events.click_count, 1), 0), "
+            f"ifNull(equals(session_replay_events.click_count, 1), 0) AS c, "
             # 1 = click_count
-            f"ifNull(equals(1, session_replay_events.click_count), 0), "
+            f"ifNull(equals(1, session_replay_events.click_count), 0) AS d, "
             # click_count = keypress_count
-            f"ifNull(equals(session_replay_events.click_count, session_replay_events.keypress_count), isNull(session_replay_events.click_count) and isNull(session_replay_events.keypress_count)), "
+            f"ifNull(equals(session_replay_events.click_count, session_replay_events.keypress_count), isNull(session_replay_events.click_count) and isNull(session_replay_events.keypress_count)) AS e, "
             # click_count = null
-            f"isNull(session_replay_events.click_count), "
+            f"isNull(session_replay_events.click_count) AS f, "
             # null = click_count
-            f"isNull(session_replay_events.click_count) "
+            f"isNull(session_replay_events.click_count) AS g "
             # ...
             f"FROM (SELECT min(toTimeZone(session_replay_events.min_first_timestamp, %(hogql_val_0)s)) AS start_time, sum(session_replay_events.click_count) AS click_count, sum(session_replay_events.keypress_count) AS keypress_count FROM session_replay_events WHERE equals(session_replay_events.team_id, {self.team.pk})) AS session_replay_events LIMIT {MAX_SELECT_RETURNED_ROWS}"
         )
 
     def test_field_nullable_not_equals(self):
         generated_sql1 = self._select(
-            "SELECT start_time != toStartOfMonth(now()), 1 != 1, "
-            "click_count != 1, 1 != click_count, click_count != keypress_count, click_count != null, null != click_count "
+            "SELECT start_time != toStartOfMonth(now()) as a, 1 != 1 as b, "
+            "click_count != 1 as c, 1 != click_count as d, click_count != keypress_count as e, click_count != null as f, null != click_count as g "
             "FROM session_replay_events"
         )
         generated_sql2 = self._select(
-            "SELECT notEquals(start_time, toStartOfMonth(now())), notEquals(1, 1), "
-            "notEquals(click_count, 1), notEquals(1, click_count), notEquals(click_count, keypress_count), notEquals(click_count, null), notEquals(null, click_count) "
+            "SELECT notEquals(start_time, toStartOfMonth(now())) as a, notEquals(1, 1) as b, "
+            "notEquals(click_count, 1) as c, notEquals(1, click_count) as d, notEquals(click_count, keypress_count) as e, notEquals(click_count, null) as f, notEquals(null, click_count) as g "
             "FROM session_replay_events"
         )
         assert generated_sql1 == generated_sql2
@@ -1618,19 +1618,19 @@ class TestPrinter(BaseTest):
             # start_time = toStartOfMonth(now())
             # (the return of toStartOfMonth() is treated as "potentially nullable" since we yet have full typing support)
             f"ifNull(notEquals(session_replay_events.start_time, toStartOfMonth(now64(6, %(hogql_val_1)s))), "
-            f"isNotNull(session_replay_events.start_time) or isNotNull(toStartOfMonth(now64(6, %(hogql_val_1)s)))), "
+            f"isNotNull(session_replay_events.start_time) or isNotNull(toStartOfMonth(now64(6, %(hogql_val_1)s)))) AS a, "
             # 1 = 1
-            f"0, "
+            f"0 AS b, "
             # click_count = 1
-            f"ifNull(notEquals(session_replay_events.click_count, 1), 1), "
+            f"ifNull(notEquals(session_replay_events.click_count, 1), 1) AS c, "
             # 1 = click_count
-            f"ifNull(notEquals(1, session_replay_events.click_count), 1), "
+            f"ifNull(notEquals(1, session_replay_events.click_count), 1) AS d, "
             # click_count = keypress_count
-            f"ifNull(notEquals(session_replay_events.click_count, session_replay_events.keypress_count), isNotNull(session_replay_events.click_count) or isNotNull(session_replay_events.keypress_count)), "
+            f"ifNull(notEquals(session_replay_events.click_count, session_replay_events.keypress_count), isNotNull(session_replay_events.click_count) or isNotNull(session_replay_events.keypress_count)) AS e, "
             # click_count = null
-            f"isNotNull(session_replay_events.click_count), "
+            f"isNotNull(session_replay_events.click_count) AS f, "
             # null = click_count
-            f"isNotNull(session_replay_events.click_count) "
+            f"isNotNull(session_replay_events.click_count) AS g "
             # ...
             f"FROM (SELECT min(toTimeZone(session_replay_events.min_first_timestamp, %(hogql_val_0)s)) AS start_time, sum(session_replay_events.click_count) AS click_count, sum(session_replay_events.keypress_count) AS keypress_count FROM session_replay_events WHERE equals(session_replay_events.team_id, {self.team.pk})) AS session_replay_events LIMIT {MAX_SELECT_RETURNED_ROWS}"
         )
@@ -1676,12 +1676,12 @@ class TestPrinter(BaseTest):
         context.database.events.fields["nullable_field"] = StringDatabaseField(name="nullable_field", nullable=True)  # type: ignore
         generated_sql_statements1 = self._select(
             "SELECT "
-            "nullable_field like 'a', "
-            "nullable_field like null, "
-            "null like nullable_field, "
-            "null like 'a', "
-            "'a' like nullable_field, "
-            "'a' like null "
+            "nullable_field like 'a' as a, "
+            "nullable_field like null as b, "
+            "null like nullable_field as c, "
+            "null like 'a' as d, "
+            "'a' like nullable_field as e, "
+            "'a' like null as f "
             "FROM events",
             context,
         )
@@ -1690,12 +1690,12 @@ class TestPrinter(BaseTest):
         context.database.events.fields["nullable_field"] = StringDatabaseField(name="nullable_field", nullable=True)  # type: ignore
         generated_sql_statements2 = self._select(
             "SELECT "
-            "like(nullable_field, 'a'), "
-            "like(nullable_field, null), "
-            "like(null, nullable_field), "
-            "like(null, 'a'), "
-            "like('a', nullable_field), "
-            "like('a', null) "
+            "like(nullable_field, 'a') as a, "
+            "like(nullable_field, null) as b, "
+            "like(null, nullable_field) as c, "
+            "like(null, 'a') as d, "
+            "like('a', nullable_field) as e, "
+            "like('a', null) as f "
             "FROM events",
             context,
         )
@@ -1703,17 +1703,17 @@ class TestPrinter(BaseTest):
         assert generated_sql_statements1 == (
             f"SELECT "
             # event like 'a',
-            "ifNull(like(events.nullable_field, %(hogql_val_0)s), 0), "
+            "ifNull(like(events.nullable_field, %(hogql_val_0)s), 0) AS a, "
             # event like null,
-            "isNull(events.nullable_field), "
+            "isNull(events.nullable_field) AS b, "
             # null like event,
-            "isNull(events.nullable_field), "
+            "isNull(events.nullable_field) AS c, "
             # null like 'a',
-            "ifNull(like(NULL, %(hogql_val_1)s), 0), "
+            "ifNull(like(NULL, %(hogql_val_1)s), 0) AS d, "
             # 'a' like event,
-            "ifNull(like(%(hogql_val_2)s, events.nullable_field), 0), "
+            "ifNull(like(%(hogql_val_2)s, events.nullable_field), 0) AS e, "
             # 'a' like null
-            "isNull(%(hogql_val_3)s) "
+            "isNull(%(hogql_val_3)s) AS f "
             f"FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS}"
         )
 
@@ -1722,12 +1722,12 @@ class TestPrinter(BaseTest):
         context.database.events.fields["nullable_field"] = StringDatabaseField(name="nullable_field", nullable=True)  # type: ignore
         generated_sql_statements1 = self._select(
             "SELECT "
-            "nullable_field not like 'a', "
-            "nullable_field not like null, "
-            "null not like nullable_field, "
-            "null not like 'a', "
-            "'a' not like nullable_field, "
-            "'a' not like null "
+            "nullable_field not like 'a' as a, "
+            "nullable_field not like null as b, "
+            "null not like nullable_field as c, "
+            "null not like 'a' as d, "
+            "'a' not like nullable_field as e, "
+            "'a' not like null as f "
             "FROM events",
             context,
         )
@@ -1736,12 +1736,12 @@ class TestPrinter(BaseTest):
         context.database.events.fields["nullable_field"] = StringDatabaseField(name="nullable_field", nullable=True)  # type: ignore
         generated_sql_statements2 = self._select(
             "SELECT "
-            "notLike(nullable_field, 'a'), "
-            "notLike(nullable_field, null), "
-            "notLike(null, nullable_field), "
-            "notLike(null, 'a'), "
-            "notLike('a', nullable_field), "
-            "notLike('a', null) "
+            "notLike(nullable_field, 'a') as a, "
+            "notLike(nullable_field, null) as b, "
+            "notLike(null, nullable_field) as c, "
+            "notLike(null, 'a') as d, "
+            "notLike('a', nullable_field) as e, "
+            "notLike('a', null) as f "
             "FROM events",
             context,
         )
@@ -1749,17 +1749,17 @@ class TestPrinter(BaseTest):
         assert generated_sql_statements1 == (
             f"SELECT "
             # event like 'a',
-            "ifNull(notLike(events.nullable_field, %(hogql_val_0)s), 1), "
+            "ifNull(notLike(events.nullable_field, %(hogql_val_0)s), 1) AS a, "
             # event like null,
-            "isNotNull(events.nullable_field), "
+            "isNotNull(events.nullable_field) AS b, "
             # null like event,
-            "isNotNull(events.nullable_field), "
+            "isNotNull(events.nullable_field) AS c, "
             # null like 'a',
-            "ifNull(notLike(NULL, %(hogql_val_1)s), 1), "
+            "ifNull(notLike(NULL, %(hogql_val_1)s), 1) AS d, "
             # 'a' like event,
-            "ifNull(notLike(%(hogql_val_2)s, events.nullable_field), 1), "
+            "ifNull(notLike(%(hogql_val_2)s, events.nullable_field), 1) AS e, "
             # 'a' like null
-            "isNotNull(%(hogql_val_3)s) "
+            "isNotNull(%(hogql_val_3)s) AS f "
             f"FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS}"
         )
 
@@ -1971,7 +1971,7 @@ class TestPrinter(BaseTest):
         )
 
     def test_lookup_domain_type(self):
-        query = parse_select("select hogql_lookupDomainType('www.google.com') from events")
+        query = parse_select("select hogql_lookupDomainType('www.google.com') as domain from events")
         printed = print_ast(
             query,
             HogQLContext(team_id=self.team.pk, enable_select_queries=True),
@@ -1983,7 +1983,7 @@ class TestPrinter(BaseTest):
                 "SELECT coalesce(dictGetOrNull('channel_definition_dict', 'domain_type', "
                 "(coalesce(%(hogql_val_0)s, ''), 'source')), "
                 "dictGetOrNull('channel_definition_dict', 'domain_type', "
-                "(cutToFirstSignificantSubdomain(coalesce(%(hogql_val_0)s, '')), 'source'))) "
+                "(cutToFirstSignificantSubdomain(coalesce(%(hogql_val_0)s, '')), 'source'))) AS domain "
                 f"FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 50000 SETTINGS "
                 "readonly=2, max_execution_time=10, allow_experimental_object_type=1, "
                 "format_csv_allow_double_quotes=0, max_ast_elements=4000000, "
@@ -1993,7 +1993,7 @@ class TestPrinter(BaseTest):
         )
 
     def test_lookup_paid_source_type(self):
-        query = parse_select("select hogql_lookupPaidSourceType('google') from events")
+        query = parse_select("select hogql_lookupPaidSourceType('google') as source from events")
         printed = print_ast(
             query,
             HogQLContext(team_id=self.team.pk, enable_select_queries=True),
@@ -2005,7 +2005,7 @@ class TestPrinter(BaseTest):
                 "SELECT coalesce(dictGetOrNull('channel_definition_dict', 'type_if_paid', "
                 "(coalesce(%(hogql_val_0)s, ''), 'source')) , "
                 "dictGetOrNull('channel_definition_dict', 'type_if_paid', "
-                "(cutToFirstSignificantSubdomain(coalesce(%(hogql_val_0)s, '')), 'source'))) "
+                "(cutToFirstSignificantSubdomain(coalesce(%(hogql_val_0)s, '')), 'source'))) AS source "
                 f"FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 50000 SETTINGS "
                 "readonly=2, max_execution_time=10, allow_experimental_object_type=1, "
                 "format_csv_allow_double_quotes=0, max_ast_elements=4000000, "
@@ -2015,7 +2015,7 @@ class TestPrinter(BaseTest):
         )
 
     def test_lookup_paid_medium_type(self):
-        query = parse_select("select hogql_lookupPaidMediumType('social') from events")
+        query = parse_select("select hogql_lookupPaidMediumType('social') as medium from events")
         printed = print_ast(
             query,
             HogQLContext(team_id=self.team.pk, enable_select_queries=True),
@@ -2025,7 +2025,7 @@ class TestPrinter(BaseTest):
         self.assertEqual(
             (
                 "SELECT dictGetOrNull('channel_definition_dict', 'type_if_paid', "
-                "(coalesce(%(hogql_val_0)s, ''), 'medium')) "
+                "(coalesce(%(hogql_val_0)s, ''), 'medium')) AS medium "
                 f"FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS} SETTINGS "
                 "readonly=2, max_execution_time=10, allow_experimental_object_type=1, format_csv_allow_double_quotes=0, max_ast_elements=4000000, max_expanded_ast_elements=4000000, max_bytes_before_external_group_by=0, transform_null_in=1"
             ),
@@ -2033,7 +2033,7 @@ class TestPrinter(BaseTest):
         )
 
     def test_lookup_organic_source_type(self):
-        query = parse_select("select hogql_lookupOrganicSourceType('google') from events")
+        query = parse_select("select hogql_lookupOrganicSourceType('google') as source  from events")
         printed = print_ast(
             query,
             HogQLContext(team_id=self.team.pk, enable_select_queries=True),
@@ -2045,7 +2045,7 @@ class TestPrinter(BaseTest):
                 "SELECT coalesce(dictGetOrNull('channel_definition_dict', 'type_if_organic', "
                 "(coalesce(%(hogql_val_0)s, ''), 'source')), "
                 "dictGetOrNull('channel_definition_dict', 'type_if_organic', "
-                "(cutToFirstSignificantSubdomain(coalesce(%(hogql_val_0)s, '')), 'source'))) "
+                "(cutToFirstSignificantSubdomain(coalesce(%(hogql_val_0)s, '')), 'source'))) AS source "
                 f"FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 50000 SETTINGS "
                 "readonly=2, max_execution_time=10, allow_experimental_object_type=1, "
                 "format_csv_allow_double_quotes=0, max_ast_elements=4000000, "
@@ -2055,7 +2055,7 @@ class TestPrinter(BaseTest):
         )
 
     def test_lookup_organic_medium_type(self):
-        query = parse_select("select hogql_lookupOrganicMediumType('social') from events")
+        query = parse_select("select hogql_lookupOrganicMediumType('social') as medium from events")
         printed = print_ast(
             query,
             HogQLContext(team_id=self.team.pk, enable_select_queries=True),
@@ -2065,7 +2065,7 @@ class TestPrinter(BaseTest):
         self.assertEqual(
             (
                 "SELECT dictGetOrNull('channel_definition_dict', 'type_if_organic', "
-                "(coalesce(%(hogql_val_0)s, ''), 'medium')) "
+                "(coalesce(%(hogql_val_0)s, ''), 'medium')) AS medium "
                 f"FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS} SETTINGS "
                 "readonly=2, max_execution_time=10, allow_experimental_object_type=1, format_csv_allow_double_quotes=0, max_ast_elements=4000000, max_expanded_ast_elements=4000000, max_bytes_before_external_group_by=0, transform_null_in=1"
             ),
@@ -2073,7 +2073,7 @@ class TestPrinter(BaseTest):
         )
 
     def test_currency_conversion(self):
-        query = parse_select("select convertCurrency('USD', 'EUR', 100, toDate('2021-01-01'))")
+        query = parse_select("select convertCurrency('USD', 'EUR', 100, toDate('2021-01-01')) as currency")
         printed = print_ast(
             query,
             HogQLContext(team_id=self.team.pk, enable_select_queries=True),
@@ -2082,14 +2082,14 @@ class TestPrinter(BaseTest):
         )
         self.assertEqual(
             (
-                f"SELECT if(equals(%(hogql_val_0)s, %(hogql_val_1)s), toDecimal64(100, 10), if(dictGetOrDefault(`{CLICKHOUSE_DATABASE}`.`{EXCHANGE_RATE_DICTIONARY_NAME}`, 'rate', %(hogql_val_0)s, toDateOrNull(%(hogql_val_2)s), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(100, 10), dictGetOrDefault(`{CLICKHOUSE_DATABASE}`.`{EXCHANGE_RATE_DICTIONARY_NAME}`, 'rate', %(hogql_val_0)s, toDateOrNull(%(hogql_val_2)s), toDecimal64(0, 10))), dictGetOrDefault(`{CLICKHOUSE_DATABASE}`.`{EXCHANGE_RATE_DICTIONARY_NAME}`, 'rate', %(hogql_val_1)s, toDateOrNull(%(hogql_val_2)s), toDecimal64(0, 10))))) "
+                f"SELECT if(equals(%(hogql_val_0)s, %(hogql_val_1)s), toDecimal64(100, 10), if(dictGetOrDefault(`{CLICKHOUSE_DATABASE}`.`{EXCHANGE_RATE_DICTIONARY_NAME}`, 'rate', %(hogql_val_0)s, toDateOrNull(%(hogql_val_2)s), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(100, 10), dictGetOrDefault(`{CLICKHOUSE_DATABASE}`.`{EXCHANGE_RATE_DICTIONARY_NAME}`, 'rate', %(hogql_val_0)s, toDateOrNull(%(hogql_val_2)s), toDecimal64(0, 10))), dictGetOrDefault(`{CLICKHOUSE_DATABASE}`.`{EXCHANGE_RATE_DICTIONARY_NAME}`, 'rate', %(hogql_val_1)s, toDateOrNull(%(hogql_val_2)s), toDecimal64(0, 10))))) AS currency "
                 "LIMIT 50000 SETTINGS readonly=2, max_execution_time=10, allow_experimental_object_type=1, format_csv_allow_double_quotes=0, max_ast_elements=4000000, max_expanded_ast_elements=4000000, max_bytes_before_external_group_by=0, transform_null_in=1"
             ),
             printed,
         )
 
     def test_currency_conversion_without_date(self):
-        query = parse_select("select convertCurrency('USD', 'EUR', 100)")
+        query = parse_select("select convertCurrency('USD', 'EUR', 100) as currency")
         printed = print_ast(
             query,
             HogQLContext(team_id=self.team.pk, enable_select_queries=True),
@@ -2098,7 +2098,7 @@ class TestPrinter(BaseTest):
         )
         self.assertEqual(
             (
-                f"SELECT if(equals(%(hogql_val_0)s, %(hogql_val_1)s), toDecimal64(100, 10), if(dictGetOrDefault(`{CLICKHOUSE_DATABASE}`.`{EXCHANGE_RATE_DICTIONARY_NAME}`, 'rate', %(hogql_val_0)s, today(), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(100, 10), dictGetOrDefault(`{CLICKHOUSE_DATABASE}`.`{EXCHANGE_RATE_DICTIONARY_NAME}`, 'rate', %(hogql_val_0)s, today(), toDecimal64(0, 10))), dictGetOrDefault(`{CLICKHOUSE_DATABASE}`.`{EXCHANGE_RATE_DICTIONARY_NAME}`, 'rate', %(hogql_val_1)s, today(), toDecimal64(0, 10))))) "
+                f"SELECT if(equals(%(hogql_val_0)s, %(hogql_val_1)s), toDecimal64(100, 10), if(dictGetOrDefault(`{CLICKHOUSE_DATABASE}`.`{EXCHANGE_RATE_DICTIONARY_NAME}`, 'rate', %(hogql_val_0)s, today(), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(100, 10), dictGetOrDefault(`{CLICKHOUSE_DATABASE}`.`{EXCHANGE_RATE_DICTIONARY_NAME}`, 'rate', %(hogql_val_0)s, today(), toDecimal64(0, 10))), dictGetOrDefault(`{CLICKHOUSE_DATABASE}`.`{EXCHANGE_RATE_DICTIONARY_NAME}`, 'rate', %(hogql_val_1)s, today(), toDecimal64(0, 10))))) AS currency "
                 "LIMIT 50000 SETTINGS readonly=2, max_execution_time=10, allow_experimental_object_type=1, format_csv_allow_double_quotes=0, max_ast_elements=4000000, max_expanded_ast_elements=4000000, max_bytes_before_external_group_by=0, transform_null_in=1"
             ),
             printed,
@@ -2168,15 +2168,15 @@ class TestPrinter(BaseTest):
             self._select(
                 """
                     SELECT
-                        toDateTime(timestamp),
-                        toDateTime(timestamp, 'US/Pacific'),
-                        now(),
-                        now('US/Pacific')
+                        toDateTime(timestamp) as ts,
+                        toDateTime(timestamp, 'US/Pacific') as tsz,
+                        now() as now,
+                        now('US/Pacific') as nowz
                     FROM events
                 """,
                 context,
             ),
-            f"SELECT toDateTime(toTimeZone(events.timestamp, %(hogql_val_0)s), %(hogql_val_1)s), toDateTime(toTimeZone(events.timestamp, %(hogql_val_2)s), %(hogql_val_3)s), now64(6, %(hogql_val_4)s), now64(6, %(hogql_val_5)s) FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS}",
+            f"SELECT toDateTime(toTimeZone(events.timestamp, %(hogql_val_0)s), %(hogql_val_1)s) AS ts, toDateTime(toTimeZone(events.timestamp, %(hogql_val_2)s), %(hogql_val_3)s) AS tsz, now64(6, %(hogql_val_4)s) AS now, now64(6, %(hogql_val_5)s) AS nowz FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS}",
         )
         self.assertEqual(
             context.values,
@@ -2192,7 +2192,7 @@ class TestPrinter(BaseTest):
 
     def test_trim_leading_trailing_both(self):
         query = parse_select(
-            "select trim(LEADING 'xy' FROM 'media'), trim(TRAILING 'xy' FROM 'media'), trim(BOTH 'xy' FROM 'media')"
+            "select trim(LEADING 'xy' FROM 'media') as a, trim(TRAILING 'xy' FROM 'media') as b, trim(BOTH 'xy' FROM 'media') as c"
         )
         printed = print_ast(
             query,
@@ -2201,10 +2201,12 @@ class TestPrinter(BaseTest):
             settings=HogQLGlobalSettings(max_execution_time=10),
         )
         assert printed == (
-            f"SELECT trim(LEADING %(hogql_val_1)s FROM %(hogql_val_0)s), trim(TRAILING %(hogql_val_3)s FROM %(hogql_val_2)s), trim(BOTH %(hogql_val_5)s FROM %(hogql_val_4)s) LIMIT {MAX_SELECT_RETURNED_ROWS} SETTINGS "
+            f"SELECT trim(LEADING %(hogql_val_1)s FROM %(hogql_val_0)s) AS a, trim(TRAILING %(hogql_val_3)s FROM %(hogql_val_2)s) AS b, trim(BOTH %(hogql_val_5)s FROM %(hogql_val_4)s) AS c LIMIT {MAX_SELECT_RETURNED_ROWS} SETTINGS "
             "readonly=2, max_execution_time=10, allow_experimental_object_type=1, format_csv_allow_double_quotes=0, max_ast_elements=4000000, max_expanded_ast_elements=4000000, max_bytes_before_external_group_by=0, transform_null_in=1"
         )
-        query2 = parse_select("select trimLeft('media', 'xy'), trimRight('media', 'xy'), trim('media', 'xy')")
+        query2 = parse_select(
+            "select trimLeft('media', 'xy') as a, trimRight('media', 'xy') as b, trim('media', 'xy') as c"
+        )
         printed2 = print_ast(
             query2,
             HogQLContext(team_id=self.team.pk, enable_select_queries=True),

--- a/posthog/hogql/transforms/test/__snapshots__/test_lazy_tables.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_lazy_tables.ambr
@@ -288,7 +288,7 @@
 # name: TestLazyJoins.test_select_count_from_lazy_table
   '''
   
-  SELECT count() 
+  SELECT count() AS `count()` 
   FROM (
   SELECT person.id AS id 
   FROM person 

--- a/posthog/hogql/transforms/test/__snapshots__/test_lazy_tables.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_lazy_tables.ambr
@@ -288,7 +288,7 @@
 # name: TestLazyJoins.test_select_count_from_lazy_table
   '''
   
-  SELECT count() AS _count 
+  SELECT count() AS `count()` 
   FROM (
   SELECT person.id AS id 
   FROM person 

--- a/posthog/hogql/transforms/test/__snapshots__/test_lazy_tables.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_lazy_tables.ambr
@@ -288,7 +288,7 @@
 # name: TestLazyJoins.test_select_count_from_lazy_table
   '''
   
-  SELECT count() AS `count()` 
+  SELECT count() AS _count 
   FROM (
   SELECT person.id AS id 
   FROM person 

--- a/posthog/hogql_queries/ai/test/__snapshots__/test_actors_property_taxonomy_query_runner.ambr
+++ b/posthog/hogql_queries/ai/test/__snapshots__/test_actors_property_taxonomy_query_runner.ambr
@@ -1,8 +1,8 @@
 # serializer version: 1
 # name: TestActorsPropertyTaxonomyQueryRunner.test_group_property_taxonomy_query_runner
   '''
-  SELECT groupArray(5)(prop) AS _groupArray_5_prop,
-         count() AS _count
+  SELECT groupArray(5)(prop) AS `groupArray(5)(prop)`,
+         count() AS `count()`
   FROM
     (SELECT DISTINCT groups.properties___industry AS prop
      FROM
@@ -28,8 +28,8 @@
 # ---
 # name: TestActorsPropertyTaxonomyQueryRunner.test_group_property_taxonomy_query_runner.1
   '''
-  SELECT groupArray(5)(prop) AS _groupArray_5_prop,
-         count() AS _count
+  SELECT groupArray(5)(prop) AS `groupArray(5)(prop)`,
+         count() AS `count()`
   FROM
     (SELECT DISTINCT groups.`properties___does not exist` AS prop
      FROM
@@ -55,8 +55,8 @@
 # ---
 # name: TestActorsPropertyTaxonomyQueryRunner.test_group_property_taxonomy_query_runner.2
   '''
-  SELECT groupArray(5)(prop) AS _groupArray_5_prop,
-         count() AS _count
+  SELECT groupArray(5)(prop) AS `groupArray(5)(prop)`,
+         count() AS `count()`
   FROM
     (SELECT DISTINCT groups.properties___employee_count AS prop
      FROM
@@ -82,8 +82,8 @@
 # ---
 # name: TestActorsPropertyTaxonomyQueryRunner.test_max_value_count
   '''
-  SELECT groupArray(1)(prop) AS _groupArray_1_prop,
-         count() AS _count
+  SELECT groupArray(1)(prop) AS `groupArray(1)(prop)`,
+         count() AS `count()`
   FROM
     (SELECT DISTINCT persons.properties___age AS prop
      FROM
@@ -111,8 +111,8 @@
 # ---
 # name: TestActorsPropertyTaxonomyQueryRunner.test_person_property_taxonomy_query_runner
   '''
-  SELECT groupArray(5)(prop) AS _groupArray_5_prop,
-         count() AS _count
+  SELECT groupArray(5)(prop) AS `groupArray(5)(prop)`,
+         count() AS `count()`
   FROM
     (SELECT DISTINCT persons.properties___email AS prop
      FROM
@@ -140,8 +140,8 @@
 # ---
 # name: TestActorsPropertyTaxonomyQueryRunner.test_person_property_taxonomy_query_runner.1
   '''
-  SELECT groupArray(5)(prop) AS _groupArray_5_prop,
-         count() AS _count
+  SELECT groupArray(5)(prop) AS `groupArray(5)(prop)`,
+         count() AS `count()`
   FROM
     (SELECT DISTINCT persons.`properties___does not exist` AS prop
      FROM
@@ -169,8 +169,8 @@
 # ---
 # name: TestActorsPropertyTaxonomyQueryRunner.test_person_property_taxonomy_query_runner.2
   '''
-  SELECT groupArray(5)(prop) AS _groupArray_5_prop,
-         count() AS _count
+  SELECT groupArray(5)(prop) AS `groupArray(5)(prop)`,
+         count() AS `count()`
   FROM
     (SELECT DISTINCT persons.properties___age AS prop
      FROM

--- a/posthog/hogql_queries/ai/test/__snapshots__/test_actors_property_taxonomy_query_runner.ambr
+++ b/posthog/hogql_queries/ai/test/__snapshots__/test_actors_property_taxonomy_query_runner.ambr
@@ -1,7 +1,8 @@
 # serializer version: 1
 # name: TestActorsPropertyTaxonomyQueryRunner.test_group_property_taxonomy_query_runner
   '''
-  SELECT groupArray(5)(prop), count()
+  SELECT groupArray(5)(prop) AS `groupArray(5)(prop)`,
+         count() AS `count()`
   FROM
     (SELECT DISTINCT groups.properties___industry AS prop
      FROM
@@ -27,7 +28,8 @@
 # ---
 # name: TestActorsPropertyTaxonomyQueryRunner.test_group_property_taxonomy_query_runner.1
   '''
-  SELECT groupArray(5)(prop), count()
+  SELECT groupArray(5)(prop) AS `groupArray(5)(prop)`,
+         count() AS `count()`
   FROM
     (SELECT DISTINCT groups.`properties___does not exist` AS prop
      FROM
@@ -53,7 +55,8 @@
 # ---
 # name: TestActorsPropertyTaxonomyQueryRunner.test_group_property_taxonomy_query_runner.2
   '''
-  SELECT groupArray(5)(prop), count()
+  SELECT groupArray(5)(prop) AS `groupArray(5)(prop)`,
+         count() AS `count()`
   FROM
     (SELECT DISTINCT groups.properties___employee_count AS prop
      FROM
@@ -79,7 +82,8 @@
 # ---
 # name: TestActorsPropertyTaxonomyQueryRunner.test_max_value_count
   '''
-  SELECT groupArray(1)(prop), count()
+  SELECT groupArray(1)(prop) AS `groupArray(1)(prop)`,
+         count() AS `count()`
   FROM
     (SELECT DISTINCT persons.properties___age AS prop
      FROM
@@ -107,7 +111,8 @@
 # ---
 # name: TestActorsPropertyTaxonomyQueryRunner.test_person_property_taxonomy_query_runner
   '''
-  SELECT groupArray(5)(prop), count()
+  SELECT groupArray(5)(prop) AS `groupArray(5)(prop)`,
+         count() AS `count()`
   FROM
     (SELECT DISTINCT persons.properties___email AS prop
      FROM
@@ -135,7 +140,8 @@
 # ---
 # name: TestActorsPropertyTaxonomyQueryRunner.test_person_property_taxonomy_query_runner.1
   '''
-  SELECT groupArray(5)(prop), count()
+  SELECT groupArray(5)(prop) AS `groupArray(5)(prop)`,
+         count() AS `count()`
   FROM
     (SELECT DISTINCT persons.`properties___does not exist` AS prop
      FROM
@@ -163,7 +169,8 @@
 # ---
 # name: TestActorsPropertyTaxonomyQueryRunner.test_person_property_taxonomy_query_runner.2
   '''
-  SELECT groupArray(5)(prop), count()
+  SELECT groupArray(5)(prop) AS `groupArray(5)(prop)`,
+         count() AS `count()`
   FROM
     (SELECT DISTINCT persons.properties___age AS prop
      FROM

--- a/posthog/hogql_queries/ai/test/__snapshots__/test_actors_property_taxonomy_query_runner.ambr
+++ b/posthog/hogql_queries/ai/test/__snapshots__/test_actors_property_taxonomy_query_runner.ambr
@@ -1,8 +1,8 @@
 # serializer version: 1
 # name: TestActorsPropertyTaxonomyQueryRunner.test_group_property_taxonomy_query_runner
   '''
-  SELECT groupArray(5)(prop) AS `groupArray(5)(prop)`,
-         count() AS `count()`
+  SELECT groupArray(5)(prop) AS _groupArray_5_prop,
+         count() AS _count
   FROM
     (SELECT DISTINCT groups.properties___industry AS prop
      FROM
@@ -28,8 +28,8 @@
 # ---
 # name: TestActorsPropertyTaxonomyQueryRunner.test_group_property_taxonomy_query_runner.1
   '''
-  SELECT groupArray(5)(prop) AS `groupArray(5)(prop)`,
-         count() AS `count()`
+  SELECT groupArray(5)(prop) AS _groupArray_5_prop,
+         count() AS _count
   FROM
     (SELECT DISTINCT groups.`properties___does not exist` AS prop
      FROM
@@ -55,8 +55,8 @@
 # ---
 # name: TestActorsPropertyTaxonomyQueryRunner.test_group_property_taxonomy_query_runner.2
   '''
-  SELECT groupArray(5)(prop) AS `groupArray(5)(prop)`,
-         count() AS `count()`
+  SELECT groupArray(5)(prop) AS _groupArray_5_prop,
+         count() AS _count
   FROM
     (SELECT DISTINCT groups.properties___employee_count AS prop
      FROM
@@ -82,8 +82,8 @@
 # ---
 # name: TestActorsPropertyTaxonomyQueryRunner.test_max_value_count
   '''
-  SELECT groupArray(1)(prop) AS `groupArray(1)(prop)`,
-         count() AS `count()`
+  SELECT groupArray(1)(prop) AS _groupArray_1_prop,
+         count() AS _count
   FROM
     (SELECT DISTINCT persons.properties___age AS prop
      FROM
@@ -111,8 +111,8 @@
 # ---
 # name: TestActorsPropertyTaxonomyQueryRunner.test_person_property_taxonomy_query_runner
   '''
-  SELECT groupArray(5)(prop) AS `groupArray(5)(prop)`,
-         count() AS `count()`
+  SELECT groupArray(5)(prop) AS _groupArray_5_prop,
+         count() AS _count
   FROM
     (SELECT DISTINCT persons.properties___email AS prop
      FROM
@@ -140,8 +140,8 @@
 # ---
 # name: TestActorsPropertyTaxonomyQueryRunner.test_person_property_taxonomy_query_runner.1
   '''
-  SELECT groupArray(5)(prop) AS `groupArray(5)(prop)`,
-         count() AS `count()`
+  SELECT groupArray(5)(prop) AS _groupArray_5_prop,
+         count() AS _count
   FROM
     (SELECT DISTINCT persons.`properties___does not exist` AS prop
      FROM
@@ -169,8 +169,8 @@
 # ---
 # name: TestActorsPropertyTaxonomyQueryRunner.test_person_property_taxonomy_query_runner.2
   '''
-  SELECT groupArray(5)(prop) AS `groupArray(5)(prop)`,
-         count() AS `count()`
+  SELECT groupArray(5)(prop) AS _groupArray_5_prop,
+         count() AS _count
   FROM
     (SELECT DISTINCT persons.properties___age AS prop
      FROM

--- a/posthog/hogql_queries/groups/test/__snapshots__/test_groups_query_runner.ambr
+++ b/posthog/hogql_queries/groups/test/__snapshots__/test_groups_query_runner.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestGroupsQueryRunner.test_groups_query_runner
   '''
-  SELECT coalesce(groups.properties___name, groups.key),
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
          groups.key AS key
   FROM
     (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
@@ -27,7 +27,7 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_normalize_multiple_groups
   '''
-  SELECT coalesce(groups.properties___name, groups.key),
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
          groups.key AS key,
          accurateCastOrNull(groups.properties___arr, 'Float64') AS arr
   FROM
@@ -55,7 +55,7 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_numeric_property
   '''
-  SELECT coalesce(groups.properties___name, groups.key),
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
          groups.key AS key,
          accurateCastOrNull(groups.properties___arr, 'Float64') AS arr
   FROM
@@ -83,7 +83,7 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_offset
   '''
-  SELECT coalesce(groups.properties___name, groups.key),
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
          groups.key AS key
   FROM
     (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
@@ -109,7 +109,7 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_order_by
   '''
-  SELECT coalesce(groups.properties___name, groups.key),
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
          groups.key AS key,
          accurateCastOrNull(groups.properties___arr, 'Float64') AS arr
   FROM
@@ -136,7 +136,7 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_order_by.1
   '''
-  SELECT coalesce(groups.properties___name, groups.key),
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
          groups.key AS key,
          accurateCastOrNull(groups.properties___arr, 'Float64') AS arr
   FROM
@@ -163,7 +163,7 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_order_by.2
   '''
-  SELECT coalesce(groups.properties___name, groups.key),
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
          groups.key AS key
   FROM
     (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
@@ -188,7 +188,7 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_property_columns
   '''
-  SELECT coalesce(groups.properties___name, groups.key),
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
          groups.key AS key,
          accurateCastOrNull(groups.properties___arr, 'Float64') AS arr
   FROM
@@ -216,7 +216,7 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_search
   '''
-  SELECT coalesce(groups.properties___name, groups.key),
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
          groups.key AS key
   FROM
     (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
@@ -242,7 +242,7 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_string_property
   '''
-  SELECT coalesce(groups.properties___name, groups.key),
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
          groups.key AS key
   FROM
     (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,

--- a/posthog/hogql_queries/groups/test/__snapshots__/test_groups_query_runner.ambr
+++ b/posthog/hogql_queries/groups/test/__snapshots__/test_groups_query_runner.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestGroupsQueryRunner.test_groups_query_runner
   '''
-  SELECT coalesce(groups.properties___name, groups.key) AS _coalesce_properties_name_key,
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
          groups.key AS key
   FROM
     (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
@@ -27,7 +27,7 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_normalize_multiple_groups
   '''
-  SELECT coalesce(groups.properties___name, groups.key) AS _coalesce_properties_name_key,
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
          groups.key AS key,
          accurateCastOrNull(groups.properties___arr, 'Float64') AS arr
   FROM
@@ -55,7 +55,7 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_numeric_property
   '''
-  SELECT coalesce(groups.properties___name, groups.key) AS _coalesce_properties_name_key,
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
          groups.key AS key,
          accurateCastOrNull(groups.properties___arr, 'Float64') AS arr
   FROM
@@ -83,7 +83,7 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_offset
   '''
-  SELECT coalesce(groups.properties___name, groups.key) AS _coalesce_properties_name_key,
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
          groups.key AS key
   FROM
     (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
@@ -109,7 +109,7 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_order_by
   '''
-  SELECT coalesce(groups.properties___name, groups.key) AS _coalesce_properties_name_key,
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
          groups.key AS key,
          accurateCastOrNull(groups.properties___arr, 'Float64') AS arr
   FROM
@@ -136,7 +136,7 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_order_by.1
   '''
-  SELECT coalesce(groups.properties___name, groups.key) AS _coalesce_properties_name_key,
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
          groups.key AS key,
          accurateCastOrNull(groups.properties___arr, 'Float64') AS arr
   FROM
@@ -163,7 +163,7 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_order_by.2
   '''
-  SELECT coalesce(groups.properties___name, groups.key) AS _coalesce_properties_name_key,
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
          groups.key AS key
   FROM
     (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
@@ -188,7 +188,7 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_property_columns
   '''
-  SELECT coalesce(groups.properties___name, groups.key) AS _coalesce_properties_name_key,
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
          groups.key AS key,
          accurateCastOrNull(groups.properties___arr, 'Float64') AS arr
   FROM
@@ -216,7 +216,7 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_search
   '''
-  SELECT coalesce(groups.properties___name, groups.key) AS _coalesce_properties_name_key,
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
          groups.key AS key
   FROM
     (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
@@ -242,7 +242,7 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_string_property
   '''
-  SELECT coalesce(groups.properties___name, groups.key) AS _coalesce_properties_name_key,
+  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
          groups.key AS key
   FROM
     (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,

--- a/posthog/hogql_queries/groups/test/__snapshots__/test_groups_query_runner.ambr
+++ b/posthog/hogql_queries/groups/test/__snapshots__/test_groups_query_runner.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestGroupsQueryRunner.test_groups_query_runner
   '''
-  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
+  SELECT coalesce(groups.properties___name, groups.key) AS _coalesce_properties_name_key,
          groups.key AS key
   FROM
     (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
@@ -27,7 +27,7 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_normalize_multiple_groups
   '''
-  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
+  SELECT coalesce(groups.properties___name, groups.key) AS _coalesce_properties_name_key,
          groups.key AS key,
          accurateCastOrNull(groups.properties___arr, 'Float64') AS arr
   FROM
@@ -55,7 +55,7 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_numeric_property
   '''
-  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
+  SELECT coalesce(groups.properties___name, groups.key) AS _coalesce_properties_name_key,
          groups.key AS key,
          accurateCastOrNull(groups.properties___arr, 'Float64') AS arr
   FROM
@@ -83,7 +83,7 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_offset
   '''
-  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
+  SELECT coalesce(groups.properties___name, groups.key) AS _coalesce_properties_name_key,
          groups.key AS key
   FROM
     (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
@@ -109,7 +109,7 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_order_by
   '''
-  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
+  SELECT coalesce(groups.properties___name, groups.key) AS _coalesce_properties_name_key,
          groups.key AS key,
          accurateCastOrNull(groups.properties___arr, 'Float64') AS arr
   FROM
@@ -136,7 +136,7 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_order_by.1
   '''
-  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
+  SELECT coalesce(groups.properties___name, groups.key) AS _coalesce_properties_name_key,
          groups.key AS key,
          accurateCastOrNull(groups.properties___arr, 'Float64') AS arr
   FROM
@@ -163,7 +163,7 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_order_by.2
   '''
-  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
+  SELECT coalesce(groups.properties___name, groups.key) AS _coalesce_properties_name_key,
          groups.key AS key
   FROM
     (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
@@ -188,7 +188,7 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_property_columns
   '''
-  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
+  SELECT coalesce(groups.properties___name, groups.key) AS _coalesce_properties_name_key,
          groups.key AS key,
          accurateCastOrNull(groups.properties___arr, 'Float64') AS arr
   FROM
@@ -216,7 +216,7 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_search
   '''
-  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
+  SELECT coalesce(groups.properties___name, groups.key) AS _coalesce_properties_name_key,
          groups.key AS key
   FROM
     (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,
@@ -242,7 +242,7 @@
 # ---
 # name: TestGroupsQueryRunner.test_groups_query_runner_with_string_property
   '''
-  SELECT coalesce(groups.properties___name, groups.key) AS `coalesce(properties.name, key)`,
+  SELECT coalesce(groups.properties___name, groups.key) AS _coalesce_properties_name_key,
          groups.key AS key
   FROM
     (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name,

--- a/posthog/hogql_queries/test/__snapshots__/test_events_query_runner.ambr
+++ b/posthog/hogql_queries/test/__snapshots__/test_events_query_runner.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestEventsQueryRunner.test_absolute_date_range
   '''
-  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'))
+  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC')) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'UTC'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'UTC'))`
   FROM events
   WHERE and(equals(events.team_id, 99999), equals(events.event, '$pageview'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-12 23:59:59.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-12 00:00:00.000000', 6, 'UTC')))
   ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
@@ -18,7 +18,7 @@
 # ---
 # name: TestEventsQueryRunner.test_absolute_date_range_minus_utc
   '''
-  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'America/Phoenix'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'America/Phoenix'))
+  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'America/Phoenix'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'America/Phoenix')) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'America/Phoenix'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'America/Phoenix'))`
   FROM events
   WHERE and(equals(events.team_id, 99999), equals(events.event, '$pageview'), less(toTimeZone(events.timestamp, 'America/Phoenix'), toDateTime64('2020-01-12 23:59:59.000000', 6, 'America/Phoenix')), greater(toTimeZone(events.timestamp, 'America/Phoenix'), toDateTime64('2020-01-12 00:00:00.000000', 6, 'America/Phoenix')))
   ORDER BY toTimeZone(events.timestamp, 'America/Phoenix') ASC
@@ -35,7 +35,7 @@
 # ---
 # name: TestEventsQueryRunner.test_absolute_date_range_plus_utc
   '''
-  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'Asia/Tokyo'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'Asia/Tokyo'))
+  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'Asia/Tokyo'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'Asia/Tokyo')) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'Asia/Tokyo'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'Asia/Tokyo'))`
   FROM events
   WHERE and(equals(events.team_id, 99999), equals(events.event, '$pageview'), less(toTimeZone(events.timestamp, 'Asia/Tokyo'), toDateTime64('2020-01-12 23:59:59.000000', 6, 'Asia/Tokyo')), greater(toTimeZone(events.timestamp, 'Asia/Tokyo'), toDateTime64('2020-01-12 00:00:00.000000', 6, 'Asia/Tokyo')))
   ORDER BY toTimeZone(events.timestamp, 'Asia/Tokyo') ASC
@@ -52,7 +52,7 @@
 # ---
 # name: TestEventsQueryRunner.test_element_chain_property_filter
   '''
-  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC'))
+  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC')) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'UTC'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'UTC'))`
   FROM events
   WHERE and(equals(events.team_id, 99999), notILike(toString(events.elements_chain), '%div%'), equals(events.event, '$autocapture'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2021-01-20 00:00:00.000000', 6, 'UTC')))
   ORDER BY toTimeZone(events.timestamp, 'UTC') ASC

--- a/posthog/hogql_queries/test/__snapshots__/test_events_query_runner.ambr
+++ b/posthog/hogql_queries/test/__snapshots__/test_events_query_runner.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestEventsQueryRunner.test_absolute_date_range
   '''
-  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC')) AS _tuple_uuid_event_properties_toTimeZone_timestamp_UTC_team_id_distinct_id_elements_chain_toTimeZone_created_at_UTC
+  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC')) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'UTC'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'UTC'))`
   FROM events
   WHERE and(equals(events.team_id, 99999), equals(events.event, '$pageview'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-12 23:59:59.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-12 00:00:00.000000', 6, 'UTC')))
   ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
@@ -18,7 +18,7 @@
 # ---
 # name: TestEventsQueryRunner.test_absolute_date_range_minus_utc
   '''
-  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'America/Phoenix'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'America/Phoenix')) AS _tuple_uuid_event_properties_toTimeZone_timestamp_America_Phoenix_team_id_distinct_id_elements_chain_toTimeZone_created_at_America_Phoenix
+  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'America/Phoenix'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'America/Phoenix')) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'America/Phoenix'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'America/Phoenix'))`
   FROM events
   WHERE and(equals(events.team_id, 99999), equals(events.event, '$pageview'), less(toTimeZone(events.timestamp, 'America/Phoenix'), toDateTime64('2020-01-12 23:59:59.000000', 6, 'America/Phoenix')), greater(toTimeZone(events.timestamp, 'America/Phoenix'), toDateTime64('2020-01-12 00:00:00.000000', 6, 'America/Phoenix')))
   ORDER BY toTimeZone(events.timestamp, 'America/Phoenix') ASC
@@ -35,7 +35,7 @@
 # ---
 # name: TestEventsQueryRunner.test_absolute_date_range_plus_utc
   '''
-  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'Asia/Tokyo'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'Asia/Tokyo')) AS _tuple_uuid_event_properties_toTimeZone_timestamp_Asia_Tokyo_team_id_distinct_id_elements_chain_toTimeZone_created_at_Asia_Tokyo
+  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'Asia/Tokyo'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'Asia/Tokyo')) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'Asia/Tokyo'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'Asia/Tokyo'))`
   FROM events
   WHERE and(equals(events.team_id, 99999), equals(events.event, '$pageview'), less(toTimeZone(events.timestamp, 'Asia/Tokyo'), toDateTime64('2020-01-12 23:59:59.000000', 6, 'Asia/Tokyo')), greater(toTimeZone(events.timestamp, 'Asia/Tokyo'), toDateTime64('2020-01-12 00:00:00.000000', 6, 'Asia/Tokyo')))
   ORDER BY toTimeZone(events.timestamp, 'Asia/Tokyo') ASC
@@ -52,7 +52,7 @@
 # ---
 # name: TestEventsQueryRunner.test_element_chain_property_filter
   '''
-  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC')) AS _tuple_uuid_event_properties_toTimeZone_timestamp_UTC_team_id_distinct_id_elements_chain_toTimeZone_created_at_UTC
+  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC')) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'UTC'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'UTC'))`
   FROM events
   WHERE and(equals(events.team_id, 99999), notILike(toString(events.elements_chain), '%div%'), equals(events.event, '$autocapture'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2021-01-20 00:00:00.000000', 6, 'UTC')))
   ORDER BY toTimeZone(events.timestamp, 'UTC') ASC

--- a/posthog/hogql_queries/test/__snapshots__/test_events_query_runner.ambr
+++ b/posthog/hogql_queries/test/__snapshots__/test_events_query_runner.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestEventsQueryRunner.test_absolute_date_range
   '''
-  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC')) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'UTC'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'UTC'))`
+  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC')) AS _tuple_uuid_event_properties_toTimeZone_timestamp_UTC_team_id_distinct_id_elements_chain_toTimeZone_created_at_UTC
   FROM events
   WHERE and(equals(events.team_id, 99999), equals(events.event, '$pageview'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-12 23:59:59.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-01-12 00:00:00.000000', 6, 'UTC')))
   ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
@@ -18,7 +18,7 @@
 # ---
 # name: TestEventsQueryRunner.test_absolute_date_range_minus_utc
   '''
-  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'America/Phoenix'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'America/Phoenix')) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'America/Phoenix'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'America/Phoenix'))`
+  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'America/Phoenix'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'America/Phoenix')) AS _tuple_uuid_event_properties_toTimeZone_timestamp_America_Phoenix_team_id_distinct_id_elements_chain_toTimeZone_created_at_America_Phoenix
   FROM events
   WHERE and(equals(events.team_id, 99999), equals(events.event, '$pageview'), less(toTimeZone(events.timestamp, 'America/Phoenix'), toDateTime64('2020-01-12 23:59:59.000000', 6, 'America/Phoenix')), greater(toTimeZone(events.timestamp, 'America/Phoenix'), toDateTime64('2020-01-12 00:00:00.000000', 6, 'America/Phoenix')))
   ORDER BY toTimeZone(events.timestamp, 'America/Phoenix') ASC
@@ -35,7 +35,7 @@
 # ---
 # name: TestEventsQueryRunner.test_absolute_date_range_plus_utc
   '''
-  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'Asia/Tokyo'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'Asia/Tokyo')) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'Asia/Tokyo'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'Asia/Tokyo'))`
+  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'Asia/Tokyo'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'Asia/Tokyo')) AS _tuple_uuid_event_properties_toTimeZone_timestamp_Asia_Tokyo_team_id_distinct_id_elements_chain_toTimeZone_created_at_Asia_Tokyo
   FROM events
   WHERE and(equals(events.team_id, 99999), equals(events.event, '$pageview'), less(toTimeZone(events.timestamp, 'Asia/Tokyo'), toDateTime64('2020-01-12 23:59:59.000000', 6, 'Asia/Tokyo')), greater(toTimeZone(events.timestamp, 'Asia/Tokyo'), toDateTime64('2020-01-12 00:00:00.000000', 6, 'Asia/Tokyo')))
   ORDER BY toTimeZone(events.timestamp, 'Asia/Tokyo') ASC
@@ -52,7 +52,7 @@
 # ---
 # name: TestEventsQueryRunner.test_element_chain_property_filter
   '''
-  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC')) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'UTC'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'UTC'))`
+  SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC')) AS _tuple_uuid_event_properties_toTimeZone_timestamp_UTC_team_id_distinct_id_elements_chain_toTimeZone_created_at_UTC
   FROM events
   WHERE and(equals(events.team_id, 99999), notILike(toString(events.elements_chain), '%div%'), equals(events.event, '$autocapture'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2021-01-20 00:00:00.000000', 6, 'UTC')))
   ORDER BY toTimeZone(events.timestamp, 'UTC') ASC

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_revenue_example_events_query_runner.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_revenue_example_events_query_runner.ambr
@@ -1,13 +1,13 @@
 # serializer version: 1
 # name: TestRevenueExampleEventsQueryRunner.test_multiple_events
   '''
-  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS _tuple_uuid_event_distinct_id_properties,
+  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(uuid, event, distinct_id, properties)`,
          events.event AS event,
          multiIf(equals(events.event, 'purchase_a'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), equals(events.event, 'purchase_b'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS original_revenue,
          multiIf(equals(events.event, 'purchase_a'), 'USD', equals(events.event, 'purchase_b'), 'USD', NULL) AS original_currency,
          multiIf(equals(events.event, 'purchase_a'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), equals(events.event, 'purchase_b'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS revenue,
          'USD' AS currency,
-         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS _tuple_person_id_person_created_at_distinct_id_person_properties,
+         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(person.id, person.created_at, distinct_id, person.properties)`,
          nullIf(nullIf(events.`$session_id`, ''), 'null') AS session_id,
          toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
@@ -44,13 +44,13 @@
 # ---
 # name: TestRevenueExampleEventsQueryRunner.test_no_crash_when_no_data
   '''
-  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS _tuple_uuid_event_distinct_id_properties,
+  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(uuid, event, distinct_id, properties)`,
          events.event AS event,
          NULL AS original_revenue,
          NULL AS original_currency,
          NULL AS revenue,
          'USD' AS currency,
-         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS _tuple_person_id_person_created_at_distinct_id_person_properties,
+         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(person.id, person.created_at, distinct_id, person.properties)`,
          nullIf(nullIf(events.`$session_id`, ''), 'null') AS session_id,
          toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
@@ -87,13 +87,13 @@
 # ---
 # name: TestRevenueExampleEventsQueryRunner.test_revenue_currency_property
   '''
-  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS _tuple_uuid_event_distinct_id_properties,
+  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(uuid, event, distinct_id, properties)`,
          events.event AS event,
          multiIf(equals(events.event, 'purchase_a'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), equals(events.event, 'purchase_b'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS original_revenue,
          multiIf(equals(events.event, 'purchase_a'), 'GBP', equals(events.event, 'purchase_b'), upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), NULL) AS original_currency,
          multiIf(equals(events.event, 'purchase_a'), if(isNull('GBP'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), if(equals('GBP', 'EUR'), toDecimal64(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'EUR', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))), equals(events.event, 'purchase_b'), if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), 'EUR'), toDecimal64(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'EUR', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))), NULL) AS revenue,
          'EUR' AS currency,
-         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS _tuple_person_id_person_created_at_distinct_id_person_properties,
+         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(person.id, person.created_at, distinct_id, person.properties)`,
          nullIf(nullIf(events.`$session_id`, ''), 'null') AS session_id,
          toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
@@ -130,13 +130,13 @@
 # ---
 # name: TestRevenueExampleEventsQueryRunner.test_revenue_currency_property_without_feature_flag
   '''
-  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS _tuple_uuid_event_distinct_id_properties,
+  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(uuid, event, distinct_id, properties)`,
          events.event AS event,
          multiIf(equals(events.event, 'purchase_a'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), equals(events.event, 'purchase_b'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS original_revenue,
          multiIf(equals(events.event, 'purchase_a'), 'GBP', equals(events.event, 'purchase_b'), upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), NULL) AS original_currency,
          multiIf(equals(events.event, 'purchase_a'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), equals(events.event, 'purchase_b'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS revenue,
          'EUR' AS currency,
-         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS _tuple_person_id_person_created_at_distinct_id_person_properties,
+         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(person.id, person.created_at, distinct_id, person.properties)`,
          nullIf(nullIf(events.`$session_id`, ''), 'null') AS session_id,
          toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
@@ -173,13 +173,13 @@
 # ---
 # name: TestRevenueExampleEventsQueryRunner.test_single_event
   '''
-  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS _tuple_uuid_event_distinct_id_properties,
+  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(uuid, event, distinct_id, properties)`,
          events.event AS event,
          multiIf(equals(events.event, 'purchase'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS original_revenue,
          multiIf(equals(events.event, 'purchase'), 'USD', NULL) AS original_currency,
          multiIf(equals(events.event, 'purchase'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS revenue,
          'USD' AS currency,
-         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS _tuple_person_id_person_created_at_distinct_id_person_properties,
+         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(person.id, person.created_at, distinct_id, person.properties)`,
          nullIf(nullIf(events.`$session_id`, ''), 'null') AS session_id,
          toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_revenue_example_events_query_runner.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_revenue_example_events_query_runner.ambr
@@ -1,13 +1,13 @@
 # serializer version: 1
 # name: TestRevenueExampleEventsQueryRunner.test_multiple_events
   '''
-  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(uuid, event, distinct_id, properties)`,
+  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS _tuple_uuid_event_distinct_id_properties,
          events.event AS event,
          multiIf(equals(events.event, 'purchase_a'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), equals(events.event, 'purchase_b'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS original_revenue,
          multiIf(equals(events.event, 'purchase_a'), 'USD', equals(events.event, 'purchase_b'), 'USD', NULL) AS original_currency,
          multiIf(equals(events.event, 'purchase_a'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), equals(events.event, 'purchase_b'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS revenue,
          'USD' AS currency,
-         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(person.id, person.created_at, distinct_id, person.properties)`,
+         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS _tuple_person_id_person_created_at_distinct_id_person_properties,
          nullIf(nullIf(events.`$session_id`, ''), 'null') AS session_id,
          toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
@@ -44,13 +44,13 @@
 # ---
 # name: TestRevenueExampleEventsQueryRunner.test_no_crash_when_no_data
   '''
-  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(uuid, event, distinct_id, properties)`,
+  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS _tuple_uuid_event_distinct_id_properties,
          events.event AS event,
          NULL AS original_revenue,
          NULL AS original_currency,
          NULL AS revenue,
          'USD' AS currency,
-         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(person.id, person.created_at, distinct_id, person.properties)`,
+         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS _tuple_person_id_person_created_at_distinct_id_person_properties,
          nullIf(nullIf(events.`$session_id`, ''), 'null') AS session_id,
          toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
@@ -87,13 +87,13 @@
 # ---
 # name: TestRevenueExampleEventsQueryRunner.test_revenue_currency_property
   '''
-  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(uuid, event, distinct_id, properties)`,
+  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS _tuple_uuid_event_distinct_id_properties,
          events.event AS event,
          multiIf(equals(events.event, 'purchase_a'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), equals(events.event, 'purchase_b'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS original_revenue,
          multiIf(equals(events.event, 'purchase_a'), 'GBP', equals(events.event, 'purchase_b'), upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), NULL) AS original_currency,
          multiIf(equals(events.event, 'purchase_a'), if(isNull('GBP'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), if(equals('GBP', 'EUR'), toDecimal64(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'EUR', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))), equals(events.event, 'purchase_b'), if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), 'EUR'), toDecimal64(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'EUR', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))), NULL) AS revenue,
          'EUR' AS currency,
-         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(person.id, person.created_at, distinct_id, person.properties)`,
+         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS _tuple_person_id_person_created_at_distinct_id_person_properties,
          nullIf(nullIf(events.`$session_id`, ''), 'null') AS session_id,
          toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
@@ -130,13 +130,13 @@
 # ---
 # name: TestRevenueExampleEventsQueryRunner.test_revenue_currency_property_without_feature_flag
   '''
-  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(uuid, event, distinct_id, properties)`,
+  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS _tuple_uuid_event_distinct_id_properties,
          events.event AS event,
          multiIf(equals(events.event, 'purchase_a'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), equals(events.event, 'purchase_b'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS original_revenue,
          multiIf(equals(events.event, 'purchase_a'), 'GBP', equals(events.event, 'purchase_b'), upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), NULL) AS original_currency,
          multiIf(equals(events.event, 'purchase_a'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), equals(events.event, 'purchase_b'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS revenue,
          'EUR' AS currency,
-         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(person.id, person.created_at, distinct_id, person.properties)`,
+         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS _tuple_person_id_person_created_at_distinct_id_person_properties,
          nullIf(nullIf(events.`$session_id`, ''), 'null') AS session_id,
          toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
@@ -173,13 +173,13 @@
 # ---
 # name: TestRevenueExampleEventsQueryRunner.test_single_event
   '''
-  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(uuid, event, distinct_id, properties)`,
+  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS _tuple_uuid_event_distinct_id_properties,
          events.event AS event,
          multiIf(equals(events.event, 'purchase'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS original_revenue,
          multiIf(equals(events.event, 'purchase'), 'USD', NULL) AS original_currency,
          multiIf(equals(events.event, 'purchase'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS revenue,
          'USD' AS currency,
-         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(person.id, person.created_at, distinct_id, person.properties)`,
+         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS _tuple_person_id_person_created_at_distinct_id_person_properties,
          nullIf(nullIf(events.`$session_id`, ''), 'null') AS session_id,
          toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_revenue_example_events_query_runner.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_revenue_example_events_query_runner.ambr
@@ -1,13 +1,13 @@
 # serializer version: 1
 # name: TestRevenueExampleEventsQueryRunner.test_multiple_events
   '''
-  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties),
+  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(uuid, event, distinct_id, properties)`,
          events.event AS event,
          multiIf(equals(events.event, 'purchase_a'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), equals(events.event, 'purchase_b'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS original_revenue,
          multiIf(equals(events.event, 'purchase_a'), 'USD', equals(events.event, 'purchase_b'), 'USD', NULL) AS original_currency,
          multiIf(equals(events.event, 'purchase_a'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), equals(events.event, 'purchase_b'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS revenue,
          'USD' AS currency,
-         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties),
+         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(person.id, person.created_at, distinct_id, person.properties)`,
          nullIf(nullIf(events.`$session_id`, ''), 'null') AS session_id,
          toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
@@ -44,13 +44,13 @@
 # ---
 # name: TestRevenueExampleEventsQueryRunner.test_no_crash_when_no_data
   '''
-  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties),
+  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(uuid, event, distinct_id, properties)`,
          events.event AS event,
          NULL AS original_revenue,
          NULL AS original_currency,
          NULL AS revenue,
          'USD' AS currency,
-         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties),
+         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(person.id, person.created_at, distinct_id, person.properties)`,
          nullIf(nullIf(events.`$session_id`, ''), 'null') AS session_id,
          toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
@@ -87,13 +87,13 @@
 # ---
 # name: TestRevenueExampleEventsQueryRunner.test_revenue_currency_property
   '''
-  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties),
+  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(uuid, event, distinct_id, properties)`,
          events.event AS event,
          multiIf(equals(events.event, 'purchase_a'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), equals(events.event, 'purchase_b'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS original_revenue,
          multiIf(equals(events.event, 'purchase_a'), 'GBP', equals(events.event, 'purchase_b'), upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), NULL) AS original_currency,
          multiIf(equals(events.event, 'purchase_a'), if(isNull('GBP'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), if(equals('GBP', 'EUR'), toDecimal64(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'EUR', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))), equals(events.event, 'purchase_b'), if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), 'EUR'), toDecimal64(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'EUR', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))), NULL) AS revenue,
          'EUR' AS currency,
-         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties),
+         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(person.id, person.created_at, distinct_id, person.properties)`,
          nullIf(nullIf(events.`$session_id`, ''), 'null') AS session_id,
          toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
@@ -130,13 +130,13 @@
 # ---
 # name: TestRevenueExampleEventsQueryRunner.test_revenue_currency_property_without_feature_flag
   '''
-  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties),
+  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(uuid, event, distinct_id, properties)`,
          events.event AS event,
          multiIf(equals(events.event, 'purchase_a'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), equals(events.event, 'purchase_b'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS original_revenue,
          multiIf(equals(events.event, 'purchase_a'), 'GBP', equals(events.event, 'purchase_b'), upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), NULL) AS original_currency,
          multiIf(equals(events.event, 'purchase_a'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), equals(events.event, 'purchase_b'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS revenue,
          'EUR' AS currency,
-         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties),
+         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(person.id, person.created_at, distinct_id, person.properties)`,
          nullIf(nullIf(events.`$session_id`, ''), 'null') AS session_id,
          toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events
@@ -173,13 +173,13 @@
 # ---
 # name: TestRevenueExampleEventsQueryRunner.test_single_event
   '''
-  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties),
+  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(uuid, event, distinct_id, properties)`,
          events.event AS event,
          multiIf(equals(events.event, 'purchase'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS original_revenue,
          multiIf(equals(events.event, 'purchase'), 'USD', NULL) AS original_currency,
          multiIf(equals(events.event, 'purchase'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS revenue,
          'USD' AS currency,
-         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties),
+         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(person.id, person.created_at, distinct_id, person.properties)`,
          nullIf(nullIf(events.`$session_id`, ''), 'null') AS session_id,
          toTimeZone(events.timestamp, 'UTC') AS timestamp
   FROM events

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_overview.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_overview.ambr
@@ -12,15 +12,15 @@
 # ---
 # name: TestWebOverviewQueryRunner.test_all_time.1
   '''
-  SELECT uniq(session_person_id),
+  SELECT uniq(session_person_id) AS `uniq(session_person_id)`,
          NULL AS previous_unique_users,
-         sum(filtered_pageview_count),
+         sum(filtered_pageview_count) AS `sum(filtered_pageview_count)`,
          NULL AS previous_filtered_pageview_count,
-         uniq(session_id),
+         uniq(session_id) AS `uniq(session_id)`,
          NULL AS previous_unique_sessions,
-         avg(session_duration),
+         avg(session_duration) AS `avg(session_duration)`,
          NULL AS prev_avg_duration_s,
-         avg(is_bounce),
+         avg(is_bounce) AS `avg(is_bounce)`,
          NULL AS prev_bounce_rate
   FROM
     (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS session_person_id,

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_overview.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_overview.ambr
@@ -12,15 +12,15 @@
 # ---
 # name: TestWebOverviewQueryRunner.test_all_time.1
   '''
-  SELECT uniq(session_person_id) AS _uniq_session_person_id,
+  SELECT uniq(session_person_id) AS `uniq(session_person_id)`,
          NULL AS previous_unique_users,
-         sum(filtered_pageview_count) AS _sum_filtered_pageview_count,
+         sum(filtered_pageview_count) AS `sum(filtered_pageview_count)`,
          NULL AS previous_filtered_pageview_count,
-         uniq(session_id) AS _uniq_session_id,
+         uniq(session_id) AS `uniq(session_id)`,
          NULL AS previous_unique_sessions,
-         avg(session_duration) AS _avg_session_duration,
+         avg(session_duration) AS `avg(session_duration)`,
          NULL AS prev_avg_duration_s,
-         avg(is_bounce) AS _avg_is_bounce,
+         avg(is_bounce) AS `avg(is_bounce)`,
          NULL AS prev_bounce_rate
   FROM
     (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS session_person_id,

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_overview.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_overview.ambr
@@ -12,15 +12,15 @@
 # ---
 # name: TestWebOverviewQueryRunner.test_all_time.1
   '''
-  SELECT uniq(session_person_id) AS `uniq(session_person_id)`,
+  SELECT uniq(session_person_id) AS _uniq_session_person_id,
          NULL AS previous_unique_users,
-         sum(filtered_pageview_count) AS `sum(filtered_pageview_count)`,
+         sum(filtered_pageview_count) AS _sum_filtered_pageview_count,
          NULL AS previous_filtered_pageview_count,
-         uniq(session_id) AS `uniq(session_id)`,
+         uniq(session_id) AS _uniq_session_id,
          NULL AS previous_unique_sessions,
-         avg(session_duration) AS `avg(session_duration)`,
+         avg(session_duration) AS _avg_session_duration,
          NULL AS prev_avg_duration_s,
-         avg(is_bounce) AS `avg(is_bounce)`,
+         avg(is_bounce) AS _avg_is_bounce,
          NULL AS prev_bounce_rate
   FROM
     (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS session_person_id,

--- a/posthog/session_recordings/queries/test/listing_recordings/__snapshots__/test_session_recording_list_from_query.ambr
+++ b/posthog/session_recordings/queries/test/listing_recordings/__snapshots__/test_session_recording_list_from_query.ambr
@@ -2,8 +2,8 @@
 # name: TestSessionRecordingsListFromQuery.test_action_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -43,8 +43,8 @@
 # name: TestSessionRecordingsListFromQuery.test_action_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -84,8 +84,8 @@
 # name: TestSessionRecordingsListFromQuery.test_action_filter.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -125,8 +125,8 @@
 # name: TestSessionRecordingsListFromQuery.test_action_filter.3
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -166,8 +166,8 @@
 # name: TestSessionRecordingsListFromQuery.test_all_filters_at_once
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -216,8 +216,8 @@
 # name: TestSessionRecordingsListFromQuery.test_any_event_filter_with_properties
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -257,8 +257,8 @@
 # name: TestSessionRecordingsListFromQuery.test_any_event_filter_with_properties.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -298,8 +298,8 @@
 # name: TestSessionRecordingsListFromQuery.test_any_event_filter_with_properties.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -339,8 +339,8 @@
 # name: TestSessionRecordingsListFromQuery.test_any_event_filter_with_properties_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -380,8 +380,8 @@
 # name: TestSessionRecordingsListFromQuery.test_any_event_filter_with_properties_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -421,8 +421,8 @@
 # name: TestSessionRecordingsListFromQuery.test_any_event_filter_with_properties_materialized.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -462,8 +462,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -498,8 +498,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query_active_sessions
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -534,8 +534,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query_active_sessions.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -570,8 +570,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query_active_sessions.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -606,8 +606,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query_with_ordering
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -642,8 +642,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query_with_ordering.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -678,8 +678,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query_with_ordering.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -714,8 +714,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query_with_paging
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -750,8 +750,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query_with_paging.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -786,8 +786,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query_with_paging.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -822,8 +822,8 @@
 # name: TestSessionRecordingsListFromQuery.test_can_filter_for_does_not_contain_event_properties
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -863,8 +863,8 @@
 # name: TestSessionRecordingsListFromQuery.test_can_filter_for_does_not_match_regex_event_properties
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -904,8 +904,8 @@
 # name: TestSessionRecordingsListFromQuery.test_can_filter_for_flags_0_session_1_matches_target_flag_is_True
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -945,8 +945,8 @@
 # name: TestSessionRecordingsListFromQuery.test_can_filter_for_flags_1_session_2_matches_target_flag_is_False
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -986,8 +986,8 @@
 # name: TestSessionRecordingsListFromQuery.test_can_filter_for_flags_2_sessions_1_and_2_match_target_flag_is_set
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1027,8 +1027,8 @@
 # name: TestSessionRecordingsListFromQuery.test_can_filter_for_flags_3_sessions_3_and_4_match_target_flag_is_not_set
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1068,8 +1068,8 @@
 # name: TestSessionRecordingsListFromQuery.test_can_filter_for_two_is_not_event_properties
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1109,8 +1109,8 @@
 # name: TestSessionRecordingsListFromQuery.test_date_from_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1145,8 +1145,8 @@
 # name: TestSessionRecordingsListFromQuery.test_date_from_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1181,8 +1181,8 @@
 # name: TestSessionRecordingsListFromQuery.test_date_from_filter_cannot_search_before_ttl
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1217,8 +1217,8 @@
 # name: TestSessionRecordingsListFromQuery.test_date_from_filter_cannot_search_before_ttl.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1253,8 +1253,8 @@
 # name: TestSessionRecordingsListFromQuery.test_date_from_filter_cannot_search_before_ttl.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1289,8 +1289,8 @@
 # name: TestSessionRecordingsListFromQuery.test_date_to_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1325,8 +1325,8 @@
 # name: TestSessionRecordingsListFromQuery.test_date_to_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1361,8 +1361,8 @@
 # name: TestSessionRecordingsListFromQuery.test_duration_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1397,8 +1397,8 @@
 # name: TestSessionRecordingsListFromQuery.test_duration_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1433,8 +1433,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1474,8 +1474,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1515,8 +1515,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_has_ttl_applied_too
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1556,8 +1556,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_has_ttl_applied_too.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1592,8 +1592,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_active_sessions
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1633,8 +1633,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_active_sessions.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1674,8 +1674,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_group_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1720,8 +1720,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_group_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1766,8 +1766,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_group_filter.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1812,8 +1812,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_event_properties_test_accounts_excluded
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1853,8 +1853,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_event_properties_test_accounts_excluded.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1909,8 +1909,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_event_properties_test_accounts_excluded.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1965,8 +1965,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_event_properties_test_accounts_excluded_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2006,8 +2006,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_event_properties_test_accounts_excluded_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2062,8 +2062,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_event_properties_test_accounts_excluded_materialized.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2118,8 +2118,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_person_properties
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2174,8 +2174,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_person_properties.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2230,8 +2230,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_properties
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2271,8 +2271,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_properties.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2312,8 +2312,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_properties_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2353,8 +2353,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_properties_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2394,8 +2394,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_matching_on_session_id
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2435,8 +2435,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_matching_on_session_id.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2476,8 +2476,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_properties
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2517,8 +2517,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_properties.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2558,8 +2558,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_properties.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2599,8 +2599,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_properties.3
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2640,8 +2640,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_properties_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2681,8 +2681,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_properties_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2722,8 +2722,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_properties_materialized.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2763,8 +2763,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_properties_materialized.3
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2804,8 +2804,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_test_accounts_excluded
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2860,8 +2860,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_test_accounts_excluded.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2901,8 +2901,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_test_accounts_excluded_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2957,8 +2957,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_test_accounts_excluded_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2998,8 +2998,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_two_events_and_multiple_teams
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3039,8 +3039,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_by_distinct_ids_0_single_distinct_id
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3075,8 +3075,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_by_distinct_ids_1_multiple_distinct_ids
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3111,8 +3111,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_by_distinct_ids_2_non_existent_distinct_id
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3147,8 +3147,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_by_distinct_ids_3_empty_distinct_ids
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3183,8 +3183,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_by_console_text_0__key_level_value_warn_error_operator_exact_type_log_entry_key_message_value_message_4_operator_icontains_type_log_entry_
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3225,8 +3225,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_by_console_text_1__key_level_value_warn_error_operator_exact_type_log_entry_key_message_value_message_4_operator_icontains_type_log_entry_
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3267,8 +3267,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_by_console_text_2__key_level_value_warn_error_operator_exact_type_log_entry_key_message_value_message_5_operator_icontains_type_log_entry_
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3309,8 +3309,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_by_console_text_3__key_level_value_info_operator_exact_type_log_entry_key_message_value_message_5_operator_icontains_type_log_entry_
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3351,8 +3351,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_by_snapshot_source
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3387,8 +3387,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_by_snapshot_source.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3423,8 +3423,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_with_console_errors
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3465,8 +3465,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_with_console_errors.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3507,8 +3507,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_with_console_logs
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3549,8 +3549,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_with_console_logs.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3591,8 +3591,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_with_console_warns
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3633,8 +3633,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_with_console_warns.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3675,8 +3675,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_with_mixed_console_counts
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3717,8 +3717,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_with_mixed_console_counts.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3759,8 +3759,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_on_session_ids
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3800,8 +3800,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_on_session_ids.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3841,8 +3841,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_with_person_properties_exact
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3897,8 +3897,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_with_person_properties_not_contains
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3953,8 +3953,8 @@
 # name: TestSessionRecordingsListFromQuery.test_listing_ignores_future_replays
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3989,8 +3989,8 @@
 # name: TestSessionRecordingsListFromQuery.test_multiple_event_filters
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4030,8 +4030,8 @@
 # name: TestSessionRecordingsListFromQuery.test_multiple_event_filters.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4071,8 +4071,8 @@
 # name: TestSessionRecordingsListFromQuery.test_multiple_event_filters.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4112,8 +4112,8 @@
 # name: TestSessionRecordingsListFromQuery.test_multiple_event_filters.3
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4153,8 +4153,8 @@
 # name: TestSessionRecordingsListFromQuery.test_multiple_event_filters.4
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4194,8 +4194,8 @@
 # name: TestSessionRecordingsListFromQuery.test_multiple_event_filters.5
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4235,8 +4235,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_event_filters
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4276,8 +4276,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_event_filters.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4317,8 +4317,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_filters_0__key_level_value_warn_operator_exact_type_log_entry_key_message_value_random_operator_exact_type_log_entry_
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4359,8 +4359,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_filters_1__key_level_value_info_operator_exact_type_log_entry_key_message_value_random_operator_exact_type_log_entry_
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4401,8 +4401,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_filters_2__key_level_value_warn_operator_exact_type_log_entry_
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4443,8 +4443,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_filters_3__key_message_value_random_operator_exact_type_log_entry_
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4485,8 +4485,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_filters_4__key_level_value_warn_operator_exact_type_log_entry_key_message_value_random_operator_exact_type_log_entry_
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4527,8 +4527,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_mandatory_filters
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4577,8 +4577,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_mandatory_filters.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4627,8 +4627,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_mandatory_filters.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4668,8 +4668,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_mandatory_filters.3
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4709,8 +4709,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_person_filters
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4765,8 +4765,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_person_filters.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4821,8 +4821,8 @@
 # name: TestSessionRecordingsListFromQuery.test_ordering
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4857,8 +4857,8 @@
 # name: TestSessionRecordingsListFromQuery.test_ordering.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4893,8 +4893,8 @@
 # name: TestSessionRecordingsListFromQuery.test_person_id_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4938,8 +4938,8 @@
 # name: TestSessionRecordingsListFromQuery.test_sessions_with_current_data
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4974,8 +4974,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_host_property_test_account_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5015,8 +5015,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_host_property_test_account_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5056,8 +5056,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_host_property_test_account_filter_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5097,8 +5097,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_host_property_test_account_filter_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5138,8 +5138,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_property_test_account_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5179,8 +5179,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_property_test_account_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5220,8 +5220,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_property_test_account_filter_allowing_denormalized_props
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5261,8 +5261,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_property_test_account_filter_allowing_denormalized_props.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5302,8 +5302,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_property_test_account_filter_allowing_denormalized_props_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5343,8 +5343,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_property_test_account_filter_allowing_denormalized_props_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5384,8 +5384,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_property_test_account_filter_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5425,8 +5425,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_property_test_account_filter_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5466,8 +5466,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_hogql_event_property_test_account_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5507,8 +5507,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_hogql_event_property_test_account_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5548,8 +5548,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_hogql_event_property_test_account_filter_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5589,8 +5589,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_hogql_event_property_test_account_filter_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5630,8 +5630,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_hogql_person_property_test_account_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5671,8 +5671,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_hogql_person_property_test_account_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5727,8 +5727,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_hogql_person_property_test_account_filter_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5768,8 +5768,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_hogql_person_property_test_account_filter_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5824,8 +5824,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_person_property_test_account_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5865,8 +5865,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_person_property_test_account_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5921,8 +5921,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_person_property_test_account_filter_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5962,8 +5962,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_person_property_test_account_filter_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,

--- a/posthog/session_recordings/queries/test/listing_recordings/__snapshots__/test_session_recording_list_from_query.ambr
+++ b/posthog/session_recordings/queries/test/listing_recordings/__snapshots__/test_session_recording_list_from_query.ambr
@@ -2,8 +2,8 @@
 # name: TestSessionRecordingsListFromQuery.test_action_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -43,8 +43,8 @@
 # name: TestSessionRecordingsListFromQuery.test_action_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -84,8 +84,8 @@
 # name: TestSessionRecordingsListFromQuery.test_action_filter.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -125,8 +125,8 @@
 # name: TestSessionRecordingsListFromQuery.test_action_filter.3
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -166,8 +166,8 @@
 # name: TestSessionRecordingsListFromQuery.test_all_filters_at_once
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -216,8 +216,8 @@
 # name: TestSessionRecordingsListFromQuery.test_any_event_filter_with_properties
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -257,8 +257,8 @@
 # name: TestSessionRecordingsListFromQuery.test_any_event_filter_with_properties.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -298,8 +298,8 @@
 # name: TestSessionRecordingsListFromQuery.test_any_event_filter_with_properties.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -339,8 +339,8 @@
 # name: TestSessionRecordingsListFromQuery.test_any_event_filter_with_properties_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -380,8 +380,8 @@
 # name: TestSessionRecordingsListFromQuery.test_any_event_filter_with_properties_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -421,8 +421,8 @@
 # name: TestSessionRecordingsListFromQuery.test_any_event_filter_with_properties_materialized.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -462,8 +462,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -498,8 +498,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query_active_sessions
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -534,8 +534,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query_active_sessions.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -570,8 +570,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query_active_sessions.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -606,8 +606,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query_with_ordering
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -642,8 +642,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query_with_ordering.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -678,8 +678,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query_with_ordering.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -714,8 +714,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query_with_paging
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -750,8 +750,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query_with_paging.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -786,8 +786,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query_with_paging.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -822,8 +822,8 @@
 # name: TestSessionRecordingsListFromQuery.test_can_filter_for_does_not_contain_event_properties
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -863,8 +863,8 @@
 # name: TestSessionRecordingsListFromQuery.test_can_filter_for_does_not_match_regex_event_properties
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -904,8 +904,8 @@
 # name: TestSessionRecordingsListFromQuery.test_can_filter_for_flags_0_session_1_matches_target_flag_is_True
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -945,8 +945,8 @@
 # name: TestSessionRecordingsListFromQuery.test_can_filter_for_flags_1_session_2_matches_target_flag_is_False
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -986,8 +986,8 @@
 # name: TestSessionRecordingsListFromQuery.test_can_filter_for_flags_2_sessions_1_and_2_match_target_flag_is_set
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1027,8 +1027,8 @@
 # name: TestSessionRecordingsListFromQuery.test_can_filter_for_flags_3_sessions_3_and_4_match_target_flag_is_not_set
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1068,8 +1068,8 @@
 # name: TestSessionRecordingsListFromQuery.test_can_filter_for_two_is_not_event_properties
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1109,8 +1109,8 @@
 # name: TestSessionRecordingsListFromQuery.test_date_from_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1145,8 +1145,8 @@
 # name: TestSessionRecordingsListFromQuery.test_date_from_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1181,8 +1181,8 @@
 # name: TestSessionRecordingsListFromQuery.test_date_from_filter_cannot_search_before_ttl
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1217,8 +1217,8 @@
 # name: TestSessionRecordingsListFromQuery.test_date_from_filter_cannot_search_before_ttl.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1253,8 +1253,8 @@
 # name: TestSessionRecordingsListFromQuery.test_date_from_filter_cannot_search_before_ttl.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1289,8 +1289,8 @@
 # name: TestSessionRecordingsListFromQuery.test_date_to_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1325,8 +1325,8 @@
 # name: TestSessionRecordingsListFromQuery.test_date_to_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1361,8 +1361,8 @@
 # name: TestSessionRecordingsListFromQuery.test_duration_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1397,8 +1397,8 @@
 # name: TestSessionRecordingsListFromQuery.test_duration_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1433,8 +1433,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1474,8 +1474,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1515,8 +1515,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_has_ttl_applied_too
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1556,8 +1556,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_has_ttl_applied_too.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1592,8 +1592,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_active_sessions
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1633,8 +1633,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_active_sessions.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1674,8 +1674,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_group_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1720,8 +1720,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_group_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1766,8 +1766,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_group_filter.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1812,8 +1812,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_event_properties_test_accounts_excluded
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1853,8 +1853,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_event_properties_test_accounts_excluded.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1909,8 +1909,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_event_properties_test_accounts_excluded.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1965,8 +1965,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_event_properties_test_accounts_excluded_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2006,8 +2006,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_event_properties_test_accounts_excluded_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2062,8 +2062,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_event_properties_test_accounts_excluded_materialized.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2118,8 +2118,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_person_properties
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2174,8 +2174,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_person_properties.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2230,8 +2230,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_properties
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2271,8 +2271,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_properties.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2312,8 +2312,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_properties_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2353,8 +2353,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_properties_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2394,8 +2394,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_matching_on_session_id
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2435,8 +2435,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_matching_on_session_id.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2476,8 +2476,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_properties
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2517,8 +2517,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_properties.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2558,8 +2558,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_properties.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2599,8 +2599,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_properties.3
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2640,8 +2640,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_properties_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2681,8 +2681,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_properties_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2722,8 +2722,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_properties_materialized.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2763,8 +2763,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_properties_materialized.3
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2804,8 +2804,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_test_accounts_excluded
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2860,8 +2860,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_test_accounts_excluded.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2901,8 +2901,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_test_accounts_excluded_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2957,8 +2957,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_test_accounts_excluded_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2998,8 +2998,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_two_events_and_multiple_teams
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3039,8 +3039,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_by_distinct_ids_0_single_distinct_id
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3075,8 +3075,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_by_distinct_ids_1_multiple_distinct_ids
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3111,8 +3111,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_by_distinct_ids_2_non_existent_distinct_id
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3147,8 +3147,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_by_distinct_ids_3_empty_distinct_ids
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3183,8 +3183,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_by_console_text_0__key_level_value_warn_error_operator_exact_type_log_entry_key_message_value_message_4_operator_icontains_type_log_entry_
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3225,8 +3225,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_by_console_text_1__key_level_value_warn_error_operator_exact_type_log_entry_key_message_value_message_4_operator_icontains_type_log_entry_
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3267,8 +3267,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_by_console_text_2__key_level_value_warn_error_operator_exact_type_log_entry_key_message_value_message_5_operator_icontains_type_log_entry_
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3309,8 +3309,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_by_console_text_3__key_level_value_info_operator_exact_type_log_entry_key_message_value_message_5_operator_icontains_type_log_entry_
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3351,8 +3351,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_by_snapshot_source
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3387,8 +3387,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_by_snapshot_source.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3423,8 +3423,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_with_console_errors
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3465,8 +3465,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_with_console_errors.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3507,8 +3507,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_with_console_logs
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3549,8 +3549,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_with_console_logs.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3591,8 +3591,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_with_console_warns
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3633,8 +3633,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_with_console_warns.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3675,8 +3675,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_with_mixed_console_counts
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3717,8 +3717,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_with_mixed_console_counts.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3759,8 +3759,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_on_session_ids
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3800,8 +3800,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_on_session_ids.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3841,8 +3841,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_with_person_properties_exact
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3897,8 +3897,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_with_person_properties_not_contains
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3953,8 +3953,8 @@
 # name: TestSessionRecordingsListFromQuery.test_listing_ignores_future_replays
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3989,8 +3989,8 @@
 # name: TestSessionRecordingsListFromQuery.test_multiple_event_filters
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4030,8 +4030,8 @@
 # name: TestSessionRecordingsListFromQuery.test_multiple_event_filters.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4071,8 +4071,8 @@
 # name: TestSessionRecordingsListFromQuery.test_multiple_event_filters.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4112,8 +4112,8 @@
 # name: TestSessionRecordingsListFromQuery.test_multiple_event_filters.3
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4153,8 +4153,8 @@
 # name: TestSessionRecordingsListFromQuery.test_multiple_event_filters.4
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4194,8 +4194,8 @@
 # name: TestSessionRecordingsListFromQuery.test_multiple_event_filters.5
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4235,8 +4235,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_event_filters
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4276,8 +4276,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_event_filters.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4317,8 +4317,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_filters_0__key_level_value_warn_operator_exact_type_log_entry_key_message_value_random_operator_exact_type_log_entry_
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4359,8 +4359,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_filters_1__key_level_value_info_operator_exact_type_log_entry_key_message_value_random_operator_exact_type_log_entry_
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4401,8 +4401,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_filters_2__key_level_value_warn_operator_exact_type_log_entry_
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4443,8 +4443,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_filters_3__key_message_value_random_operator_exact_type_log_entry_
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4485,8 +4485,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_filters_4__key_level_value_warn_operator_exact_type_log_entry_key_message_value_random_operator_exact_type_log_entry_
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4527,8 +4527,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_mandatory_filters
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4577,8 +4577,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_mandatory_filters.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4627,8 +4627,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_mandatory_filters.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4668,8 +4668,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_mandatory_filters.3
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4709,8 +4709,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_person_filters
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4765,8 +4765,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_person_filters.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4821,8 +4821,8 @@
 # name: TestSessionRecordingsListFromQuery.test_ordering
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4857,8 +4857,8 @@
 # name: TestSessionRecordingsListFromQuery.test_ordering.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4893,8 +4893,8 @@
 # name: TestSessionRecordingsListFromQuery.test_person_id_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4938,8 +4938,8 @@
 # name: TestSessionRecordingsListFromQuery.test_sessions_with_current_data
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4974,8 +4974,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_host_property_test_account_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5015,8 +5015,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_host_property_test_account_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5056,8 +5056,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_host_property_test_account_filter_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5097,8 +5097,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_host_property_test_account_filter_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5138,8 +5138,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_property_test_account_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5179,8 +5179,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_property_test_account_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5220,8 +5220,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_property_test_account_filter_allowing_denormalized_props
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5261,8 +5261,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_property_test_account_filter_allowing_denormalized_props.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5302,8 +5302,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_property_test_account_filter_allowing_denormalized_props_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5343,8 +5343,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_property_test_account_filter_allowing_denormalized_props_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5384,8 +5384,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_property_test_account_filter_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5425,8 +5425,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_property_test_account_filter_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5466,8 +5466,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_hogql_event_property_test_account_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5507,8 +5507,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_hogql_event_property_test_account_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5548,8 +5548,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_hogql_event_property_test_account_filter_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5589,8 +5589,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_hogql_event_property_test_account_filter_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5630,8 +5630,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_hogql_person_property_test_account_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5671,8 +5671,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_hogql_person_property_test_account_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5727,8 +5727,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_hogql_person_property_test_account_filter_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5768,8 +5768,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_hogql_person_property_test_account_filter_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5824,8 +5824,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_person_property_test_account_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5865,8 +5865,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_person_property_test_account_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5921,8 +5921,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_person_property_test_account_filter_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5962,8 +5962,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_person_property_test_account_filter_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,

--- a/posthog/session_recordings/queries/test/listing_recordings/__snapshots__/test_session_recording_list_from_query.ambr
+++ b/posthog/session_recordings/queries/test/listing_recordings/__snapshots__/test_session_recording_list_from_query.ambr
@@ -2,8 +2,8 @@
 # name: TestSessionRecordingsListFromQuery.test_action_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -43,8 +43,8 @@
 # name: TestSessionRecordingsListFromQuery.test_action_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -84,8 +84,8 @@
 # name: TestSessionRecordingsListFromQuery.test_action_filter.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -125,8 +125,8 @@
 # name: TestSessionRecordingsListFromQuery.test_action_filter.3
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -166,8 +166,8 @@
 # name: TestSessionRecordingsListFromQuery.test_all_filters_at_once
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -216,8 +216,8 @@
 # name: TestSessionRecordingsListFromQuery.test_any_event_filter_with_properties
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -257,8 +257,8 @@
 # name: TestSessionRecordingsListFromQuery.test_any_event_filter_with_properties.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -298,8 +298,8 @@
 # name: TestSessionRecordingsListFromQuery.test_any_event_filter_with_properties.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -339,8 +339,8 @@
 # name: TestSessionRecordingsListFromQuery.test_any_event_filter_with_properties_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -380,8 +380,8 @@
 # name: TestSessionRecordingsListFromQuery.test_any_event_filter_with_properties_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -421,8 +421,8 @@
 # name: TestSessionRecordingsListFromQuery.test_any_event_filter_with_properties_materialized.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -462,8 +462,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -498,8 +498,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query_active_sessions
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -534,8 +534,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query_active_sessions.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -570,8 +570,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query_active_sessions.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -606,8 +606,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query_with_ordering
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -642,8 +642,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query_with_ordering.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -678,8 +678,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query_with_ordering.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -714,8 +714,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query_with_paging
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -750,8 +750,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query_with_paging.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -786,8 +786,8 @@
 # name: TestSessionRecordingsListFromQuery.test_basic_query_with_paging.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -822,8 +822,8 @@
 # name: TestSessionRecordingsListFromQuery.test_can_filter_for_does_not_contain_event_properties
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -863,8 +863,8 @@
 # name: TestSessionRecordingsListFromQuery.test_can_filter_for_does_not_match_regex_event_properties
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -904,8 +904,8 @@
 # name: TestSessionRecordingsListFromQuery.test_can_filter_for_flags_0_session_1_matches_target_flag_is_True
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -945,8 +945,8 @@
 # name: TestSessionRecordingsListFromQuery.test_can_filter_for_flags_1_session_2_matches_target_flag_is_False
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -986,8 +986,8 @@
 # name: TestSessionRecordingsListFromQuery.test_can_filter_for_flags_2_sessions_1_and_2_match_target_flag_is_set
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1027,8 +1027,8 @@
 # name: TestSessionRecordingsListFromQuery.test_can_filter_for_flags_3_sessions_3_and_4_match_target_flag_is_not_set
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1068,8 +1068,8 @@
 # name: TestSessionRecordingsListFromQuery.test_can_filter_for_two_is_not_event_properties
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1109,8 +1109,8 @@
 # name: TestSessionRecordingsListFromQuery.test_date_from_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1145,8 +1145,8 @@
 # name: TestSessionRecordingsListFromQuery.test_date_from_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1181,8 +1181,8 @@
 # name: TestSessionRecordingsListFromQuery.test_date_from_filter_cannot_search_before_ttl
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1217,8 +1217,8 @@
 # name: TestSessionRecordingsListFromQuery.test_date_from_filter_cannot_search_before_ttl.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1253,8 +1253,8 @@
 # name: TestSessionRecordingsListFromQuery.test_date_from_filter_cannot_search_before_ttl.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1289,8 +1289,8 @@
 # name: TestSessionRecordingsListFromQuery.test_date_to_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1325,8 +1325,8 @@
 # name: TestSessionRecordingsListFromQuery.test_date_to_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1361,8 +1361,8 @@
 # name: TestSessionRecordingsListFromQuery.test_duration_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1397,8 +1397,8 @@
 # name: TestSessionRecordingsListFromQuery.test_duration_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1433,8 +1433,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1474,8 +1474,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1515,8 +1515,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_has_ttl_applied_too
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1556,8 +1556,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_has_ttl_applied_too.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1592,8 +1592,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_active_sessions
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1633,8 +1633,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_active_sessions.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1674,8 +1674,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_group_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1720,8 +1720,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_group_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1766,8 +1766,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_group_filter.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1812,8 +1812,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_event_properties_test_accounts_excluded
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1853,8 +1853,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_event_properties_test_accounts_excluded.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1909,8 +1909,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_event_properties_test_accounts_excluded.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -1965,8 +1965,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_event_properties_test_accounts_excluded_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2006,8 +2006,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_event_properties_test_accounts_excluded_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2062,8 +2062,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_event_properties_test_accounts_excluded_materialized.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2118,8 +2118,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_person_properties
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2174,8 +2174,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_person_properties.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2230,8 +2230,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_properties
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2271,8 +2271,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_properties.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2312,8 +2312,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_properties_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2353,8 +2353,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_hogql_properties_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2394,8 +2394,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_matching_on_session_id
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2435,8 +2435,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_matching_on_session_id.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2476,8 +2476,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_properties
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2517,8 +2517,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_properties.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2558,8 +2558,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_properties.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2599,8 +2599,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_properties.3
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2640,8 +2640,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_properties_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2681,8 +2681,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_properties_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2722,8 +2722,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_properties_materialized.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2763,8 +2763,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_properties_materialized.3
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2804,8 +2804,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_test_accounts_excluded
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2860,8 +2860,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_test_accounts_excluded.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2901,8 +2901,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_test_accounts_excluded_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2957,8 +2957,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_test_accounts_excluded_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -2998,8 +2998,8 @@
 # name: TestSessionRecordingsListFromQuery.test_event_filter_with_two_events_and_multiple_teams
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3039,8 +3039,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_by_distinct_ids_0_single_distinct_id
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3075,8 +3075,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_by_distinct_ids_1_multiple_distinct_ids
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3111,8 +3111,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_by_distinct_ids_2_non_existent_distinct_id
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3147,8 +3147,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_by_distinct_ids_3_empty_distinct_ids
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3183,8 +3183,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_by_console_text_0__key_level_value_warn_error_operator_exact_type_log_entry_key_message_value_message_4_operator_icontains_type_log_entry_
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3225,8 +3225,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_by_console_text_1__key_level_value_warn_error_operator_exact_type_log_entry_key_message_value_message_4_operator_icontains_type_log_entry_
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3267,8 +3267,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_by_console_text_2__key_level_value_warn_error_operator_exact_type_log_entry_key_message_value_message_5_operator_icontains_type_log_entry_
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3309,8 +3309,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_by_console_text_3__key_level_value_info_operator_exact_type_log_entry_key_message_value_message_5_operator_icontains_type_log_entry_
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3351,8 +3351,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_by_snapshot_source
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3387,8 +3387,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_by_snapshot_source.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3423,8 +3423,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_with_console_errors
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3465,8 +3465,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_with_console_errors.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3507,8 +3507,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_with_console_logs
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3549,8 +3549,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_with_console_logs.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3591,8 +3591,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_with_console_warns
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3633,8 +3633,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_with_console_warns.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3675,8 +3675,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_with_mixed_console_counts
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3717,8 +3717,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_for_recordings_with_mixed_console_counts.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3759,8 +3759,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_on_session_ids
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3800,8 +3800,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_on_session_ids.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3841,8 +3841,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_with_person_properties_exact
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3897,8 +3897,8 @@
 # name: TestSessionRecordingsListFromQuery.test_filter_with_person_properties_not_contains
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3953,8 +3953,8 @@
 # name: TestSessionRecordingsListFromQuery.test_listing_ignores_future_replays
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -3989,8 +3989,8 @@
 # name: TestSessionRecordingsListFromQuery.test_multiple_event_filters
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4030,8 +4030,8 @@
 # name: TestSessionRecordingsListFromQuery.test_multiple_event_filters.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4071,8 +4071,8 @@
 # name: TestSessionRecordingsListFromQuery.test_multiple_event_filters.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4112,8 +4112,8 @@
 # name: TestSessionRecordingsListFromQuery.test_multiple_event_filters.3
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4153,8 +4153,8 @@
 # name: TestSessionRecordingsListFromQuery.test_multiple_event_filters.4
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4194,8 +4194,8 @@
 # name: TestSessionRecordingsListFromQuery.test_multiple_event_filters.5
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4235,8 +4235,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_event_filters
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4276,8 +4276,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_event_filters.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4317,8 +4317,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_filters_0__key_level_value_warn_operator_exact_type_log_entry_key_message_value_random_operator_exact_type_log_entry_
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4359,8 +4359,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_filters_1__key_level_value_info_operator_exact_type_log_entry_key_message_value_random_operator_exact_type_log_entry_
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4401,8 +4401,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_filters_2__key_level_value_warn_operator_exact_type_log_entry_
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4443,8 +4443,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_filters_3__key_message_value_random_operator_exact_type_log_entry_
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4485,8 +4485,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_filters_4__key_level_value_warn_operator_exact_type_log_entry_key_message_value_random_operator_exact_type_log_entry_
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4527,8 +4527,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_mandatory_filters
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4577,8 +4577,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_mandatory_filters.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4627,8 +4627,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_mandatory_filters.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4668,8 +4668,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_mandatory_filters.3
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4709,8 +4709,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_person_filters
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4765,8 +4765,8 @@
 # name: TestSessionRecordingsListFromQuery.test_operand_or_person_filters.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4821,8 +4821,8 @@
 # name: TestSessionRecordingsListFromQuery.test_ordering
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4857,8 +4857,8 @@
 # name: TestSessionRecordingsListFromQuery.test_ordering.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4893,8 +4893,8 @@
 # name: TestSessionRecordingsListFromQuery.test_person_id_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4938,8 +4938,8 @@
 # name: TestSessionRecordingsListFromQuery.test_sessions_with_current_data
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -4974,8 +4974,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_host_property_test_account_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5015,8 +5015,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_host_property_test_account_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5056,8 +5056,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_host_property_test_account_filter_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5097,8 +5097,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_host_property_test_account_filter_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5138,8 +5138,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_property_test_account_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5179,8 +5179,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_property_test_account_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5220,8 +5220,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_property_test_account_filter_allowing_denormalized_props
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5261,8 +5261,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_property_test_account_filter_allowing_denormalized_props.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5302,8 +5302,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_property_test_account_filter_allowing_denormalized_props_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5343,8 +5343,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_property_test_account_filter_allowing_denormalized_props_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5384,8 +5384,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_property_test_account_filter_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5425,8 +5425,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_event_property_test_account_filter_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5466,8 +5466,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_hogql_event_property_test_account_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5507,8 +5507,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_hogql_event_property_test_account_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5548,8 +5548,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_hogql_event_property_test_account_filter_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5589,8 +5589,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_hogql_event_property_test_account_filter_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5630,8 +5630,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_hogql_person_property_test_account_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5671,8 +5671,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_hogql_person_property_test_account_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5727,8 +5727,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_hogql_person_property_test_account_filter_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5768,8 +5768,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_hogql_person_property_test_account_filter_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5824,8 +5824,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_person_property_test_account_filter
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5865,8 +5865,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_person_property_test_account_filter.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5921,8 +5921,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_person_property_test_account_filter_materialized
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -5962,8 +5962,8 @@
 # name: TestSessionRecordingsListFromQuery.test_top_level_person_property_test_account_filter_materialized.1
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,

--- a/posthog/session_recordings/queries/test/listing_recordings/__snapshots__/test_session_recordings_list_by_cohort.ambr
+++ b/posthog/session_recordings/queries/test/listing_recordings/__snapshots__/test_session_recordings_list_by_cohort.ambr
@@ -22,8 +22,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_cohort_properties.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -72,8 +72,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_cohort_properties.3
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -142,8 +142,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_events_and_cohorts.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -197,8 +197,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_events_and_cohorts.3
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -271,8 +271,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_static_and_dynamic_cohort_properties.10
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -357,8 +357,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_static_and_dynamic_cohort_properties.5
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -407,8 +407,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_static_and_dynamic_cohort_properties.6
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -457,8 +457,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_static_and_dynamic_cohort_properties.7
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -507,8 +507,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_static_and_dynamic_cohort_properties.8
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -557,8 +557,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_static_and_dynamic_cohort_properties.9
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -633,8 +633,8 @@
 # name: TestSessionRecordingsListByCohort.test_internal_account_filter_with_cohort_properties.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,

--- a/posthog/session_recordings/queries/test/listing_recordings/__snapshots__/test_session_recordings_list_by_cohort.ambr
+++ b/posthog/session_recordings/queries/test/listing_recordings/__snapshots__/test_session_recordings_list_by_cohort.ambr
@@ -22,8 +22,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_cohort_properties.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -72,8 +72,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_cohort_properties.3
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -142,8 +142,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_events_and_cohorts.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -197,8 +197,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_events_and_cohorts.3
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -271,8 +271,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_static_and_dynamic_cohort_properties.10
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -357,8 +357,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_static_and_dynamic_cohort_properties.5
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -407,8 +407,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_static_and_dynamic_cohort_properties.6
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -457,8 +457,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_static_and_dynamic_cohort_properties.7
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -507,8 +507,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_static_and_dynamic_cohort_properties.8
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -557,8 +557,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_static_and_dynamic_cohort_properties.9
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -633,8 +633,8 @@
 # name: TestSessionRecordingsListByCohort.test_internal_account_filter_with_cohort_properties.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS _any_s_team_id,
-         any(s.distinct_id) AS _any_s_distinct_id,
+         any(s.team_id) AS `any(s.team_id)`,
+         any(s.distinct_id) AS `any(s.distinct_id)`,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,

--- a/posthog/session_recordings/queries/test/listing_recordings/__snapshots__/test_session_recordings_list_by_cohort.ambr
+++ b/posthog/session_recordings/queries/test/listing_recordings/__snapshots__/test_session_recordings_list_by_cohort.ambr
@@ -22,8 +22,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_cohort_properties.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -72,8 +72,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_cohort_properties.3
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -142,8 +142,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_events_and_cohorts.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -197,8 +197,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_events_and_cohorts.3
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -271,8 +271,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_static_and_dynamic_cohort_properties.10
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -357,8 +357,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_static_and_dynamic_cohort_properties.5
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -407,8 +407,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_static_and_dynamic_cohort_properties.6
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -457,8 +457,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_static_and_dynamic_cohort_properties.7
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -507,8 +507,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_static_and_dynamic_cohort_properties.8
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -557,8 +557,8 @@
 # name: TestSessionRecordingsListByCohort.test_filter_with_static_and_dynamic_cohort_properties.9
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,
@@ -633,8 +633,8 @@
 # name: TestSessionRecordingsListByCohort.test_internal_account_filter_with_cohort_properties.2
   '''
   SELECT s.session_id AS session_id,
-         any(s.team_id) AS `any(s.team_id)`,
-         any(s.distinct_id) AS `any(s.distinct_id)`,
+         any(s.team_id) AS _any_s_team_id,
+         any(s.distinct_id) AS _any_s_distinct_id,
          min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
          max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
          dateDiff('SECOND', start_time, end_time) AS duration,


### PR DESCRIPTION
## Problem
- When saving views (saved queries), we require all fields to have an alias if it doesn't already have a explicit name, for example, running a function over a column without an explicit alias would break querying from the view and so we have view having disabled when there's an un-aliased function call (aka `ast.Call()`

## Changes
- When running HogQL, always alias `ast.Call` nodes like we already do for `ast.Field` nodes - we get the name from the printer running over the `ast.Call` node (the same method we use for printing column names in the SQL editor)
- I've not relaxed the constraint for saving views without unaliased calls yet, I wanna get this in and do some further testing before opening that up


## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
tested locally