### PR TITLE
fix(devex): tree view panel dropdowns styling, nav bar links work as expected.

### DIFF
--- a/frontend/src/layout/panel-layout/OrganizationDropdownMenu.tsx
+++ b/frontend/src/layout/panel-layout/OrganizationDropdownMenu.tsx
@@ -35,7 +35,7 @@ export function OrganizationDropdownMenu(): JSX.Element {
     return (
         <DropdownMenu>
             <DropdownMenuTrigger asChild>
-                <ButtonPrimitive className="max-w-[210px]">
+                <ButtonPrimitive className="max-w-[210px]" iconOnly={isLayoutNavCollapsed ? true : false}>
                     {currentOrganization ? (
                         <UploadedLogo
                             name={currentOrganization.name}
@@ -44,7 +44,12 @@ export function OrganizationDropdownMenu(): JSX.Element {
                             size={isLayoutNavCollapsed ? 'medium' : 'xsmall'}
                         />
                     ) : (
-                        <IconPlusSmall />
+                        <UploadedLogo
+                            name="?"
+                            entityId=""
+                            mediaId=""
+                            size={isLayoutNavCollapsed ? 'medium' : 'xsmall'}
+                        />
                     )}
                     {!isLayoutNavCollapsed && (
                         <>
@@ -56,19 +61,32 @@ export function OrganizationDropdownMenu(): JSX.Element {
                     )}
                 </ButtonPrimitive>
             </DropdownMenuTrigger>
-            <DropdownMenuContent loop align="start" className="w-fit min-w-[240px]">
+            <DropdownMenuContent
+                loop
+                align="start"
+                className={`
+                min-w-[200px] 
+                max-w-[var(--project-panel-inner-width)] 
+                max-h-[calc(var(--radix-dropdown-menu-content-available-height)-100px)]
+            `}
+            >
                 <DropdownMenuLabel>Organizations</DropdownMenuLabel>
                 <DropdownMenuSeparator />
                 {currentOrganization && (
                     <DropdownMenuItem asChild>
-                        <ButtonPrimitive menuItem active>
+                        <ButtonPrimitive
+                            menuItem
+                            active
+                            tooltip={`Current organization: ${currentOrganization.name}`}
+                            tooltipPlacement="right"
+                        >
                             <UploadedLogo
                                 size="xsmall"
                                 name={currentOrganization.name}
                                 entityId={currentOrganization.id}
                                 mediaId={currentOrganization.logo_media_id}
                             />
-                            {currentOrganization.name}
+                            <span className="truncate">{currentOrganization.name}</span>
                             <div className="ml-auto">
                                 <AccessLevelIndicator organization={currentOrganization} />
                             </div>
@@ -77,7 +95,12 @@ export function OrganizationDropdownMenu(): JSX.Element {
                 )}
                 {otherOrganizations.map((otherOrganization) => (
                     <DropdownMenuItem key={otherOrganization.id} asChild>
-                        <ButtonPrimitive menuItem onClick={() => updateCurrentOrganization(otherOrganization.id)}>
+                        <ButtonPrimitive
+                            menuItem
+                            onClick={() => updateCurrentOrganization(otherOrganization.id)}
+                            tooltip={`Switch to organization: ${otherOrganization.name}`}
+                            tooltipPlacement="right"
+                        >
                             <UploadedLogo
                                 size="xsmall"
                                 name={otherOrganization.name}
@@ -108,6 +131,8 @@ export function OrganizationDropdownMenu(): JSX.Element {
                                     }
                                 )
                             }
+                            tooltip="Create a new organization"
+                            tooltipPlacement="right"
                         >
                             <IconPlusSmall className="size-4" />
                             New organization

--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -216,7 +216,7 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
                     )}
                     ref={containerRef}
                 >
-                    <div className="flex justify-between p-1">
+                    <div className={`flex justify-between p-1 ${isLayoutNavCollapsed ? 'justify-center' : ''}`}>
                         <OrganizationDropdownMenu />
 
                         {!isLayoutNavCollapsed && (

--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -466,6 +466,9 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
                             )}
                             <ButtonPrimitive
                                 menuItem={!isLayoutNavCollapsed}
+                                onClick={() => {
+                                    handleStaticNavbarItemClick(urls.toolbarLaunch(), true)
+                                }}
                                 href={urls.toolbarLaunch()}
                                 data-attr={Scene.ToolbarLaunch}
                                 tooltip={isLayoutNavCollapsed ? 'Toolbar' : undefined}
@@ -485,6 +488,9 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
 
                             <ButtonPrimitive
                                 menuItem={!isLayoutNavCollapsed}
+                                onClick={() => {
+                                    handleStaticNavbarItemClick(urls.settings('project'), true)
+                                }}
                                 href={urls.settings('project')}
                                 data-attr={Scene.Settings}
                                 tooltip={isLayoutNavCollapsed ? 'Settings' : undefined}

--- a/frontend/src/layout/panel-layout/PanelLayoutPanel.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutPanel.tsx
@@ -25,7 +25,9 @@ export function PanelLayoutPanel({ searchPlaceholder, panelActions, children }: 
     return (
         <>
             <nav
-                className={clsx('flex flex-col max-h-screen min-h-screen relative w-[320px] border-r border-primary')}
+                className={clsx(
+                    'flex flex-col max-h-screen min-h-screen relative w-[var(--project-panel-width)] border-r border-primary'
+                )}
                 ref={containerRef}
             >
                 <div className="flex justify-between p-1 bg-surface-tertiary">

--- a/frontend/src/layout/panel-layout/ProjectDropdownMenu.tsx
+++ b/frontend/src/layout/panel-layout/ProjectDropdownMenu.tsx
@@ -49,6 +49,7 @@ function OtherProjectButton({ team }: { team: TeamBasicType }): JSX.Element {
                     href={relativeOtherProjectPath}
                     sideActionLeft
                     tooltip={`Switch to project: ${team.name}`}
+                    tooltipPlacement="right"
                 >
                     <ProjectName team={team} />
                 </ButtonPrimitive>
@@ -58,6 +59,7 @@ function OtherProjectButton({ team }: { team: TeamBasicType }): JSX.Element {
                 iconOnly
                 sideActionRight
                 tooltip={`View settings for project: ${team.name}`}
+                tooltipPlacement="right"
             >
                 <IconGear />
             </ButtonPrimitive>
@@ -113,6 +115,7 @@ export function ProjectDropdownMenu(): JSX.Element | null {
                                 disabled
                                 sideActionLeft
                                 tooltip={`Current project: ${currentTeam.name}`}
+                                tooltipPlacement="right"
                             >
                                 <ProjectName team={currentTeam} />
                             </ButtonPrimitive>
@@ -122,6 +125,7 @@ export function ProjectDropdownMenu(): JSX.Element | null {
                                 iconOnly
                                 sideActionRight
                                 tooltip={`View settings for project: ${currentTeam.name}`}
+                                tooltipPlacement="right"
                             >
                                 <IconGear className="text-tertiary" />
                             </ButtonPrimitive>
@@ -144,7 +148,12 @@ export function ProjectDropdownMenu(): JSX.Element | null {
                                 })
                             }
                         >
-                            <ButtonPrimitive menuItem data-attr="new-project-button" tooltip="Create a new project">
+                            <ButtonPrimitive
+                                menuItem
+                                data-attr="new-project-button"
+                                tooltip="Create a new project"
+                                tooltipPlacement="right"
+                            >
                                 <IconPlusSmall className="text-tertiary" />
                                 New project
                             </ButtonPrimitive>

--- a/frontend/src/layout/panel-layout/ProjectDropdownMenu.tsx
+++ b/frontend/src/layout/panel-layout/ProjectDropdownMenu.tsx
@@ -2,6 +2,7 @@ import { IconChevronRight, IconFolderOpen, IconGear, IconPlusSmall } from '@post
 import { LemonSnack } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
+import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
 import { upgradeModalLogic } from 'lib/components/UpgradeModal/upgradeModalLogic'
 import { ButtonGroupPrimitive, ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import {
@@ -25,8 +26,8 @@ import { AvailableFeature, TeamBasicType } from '~/types'
 
 export function ProjectName({ team }: { team: TeamBasicType }): JSX.Element {
     return (
-        <div className="flex items-center">
-            <span>{team.name}</span>
+        <div className="flex items-center max-w-full">
+            <span className="truncate">{team.name}</span>
             {team.is_demo ? <LemonSnack className="ml-2 text-xs shrink-0">Demo</LemonSnack> : null}
         </div>
     )
@@ -41,16 +42,26 @@ function OtherProjectButton({ team }: { team: TeamBasicType }): JSX.Element {
     }, [location.pathname, team.id, team.project_id, currentTeam?.project_id])
 
     return (
-        <DropdownMenuItem asChild>
-            <ButtonGroupPrimitive menuItem fullWidth groupVariant="side-action-group">
-                <ButtonPrimitive menuItem href={relativeOtherProjectPath} sideActionLeft>
+        <ButtonGroupPrimitive menuItem fullWidth groupVariant="side-action-group">
+            <DropdownMenuItem asChild>
+                <ButtonPrimitive
+                    menuItem
+                    href={relativeOtherProjectPath}
+                    sideActionLeft
+                    tooltip={`Switch to project: ${team.name}`}
+                >
                     <ProjectName team={team} />
                 </ButtonPrimitive>
-                <ButtonPrimitive href={urls.project(team.id, urls.settings('project'))} iconOnly sideActionRight>
-                    <IconGear />
-                </ButtonPrimitive>
-            </ButtonGroupPrimitive>
-        </DropdownMenuItem>
+            </DropdownMenuItem>
+            <ButtonPrimitive
+                href={urls.project(team.id, urls.settings('project'))}
+                iconOnly
+                sideActionRight
+                tooltip={`View settings for project: ${team.name}`}
+            >
+                <IconGear />
+            </ButtonPrimitive>
+        </ButtonGroupPrimitive>
     )
 }
 
@@ -68,17 +79,41 @@ export function ProjectDropdownMenu(): JSX.Element | null {
                 <ButtonPrimitive>
                     <IconFolderOpen className="text-tertiary" />
                     Project
-                    <IconChevronRight className="size-3 text-secondary rotate-90 group-data-[state=open]/button-primitive:rotate-270 transition-transform duration-200 prefers-reduced-motion:transition-none" />
+                    <IconChevronRight
+                        className={`
+                        size-3 
+                        text-secondary 
+                        rotate-90 
+                        group-data-[state=open]/button-primitive:rotate-270 
+                        transition-transform 
+                        duration-200 
+                        prefers-reduced-motion:transition-none
+                    `}
+                    />
                 </ButtonPrimitive>
             </DropdownMenuTrigger>
 
-            <DropdownMenuContent loop align="start" className="min-w-[200px]">
+            <DropdownMenuContent
+                loop
+                align="start"
+                className={`
+                min-w-[200px] 
+                max-w-[var(--project-panel-inner-width)] 
+                max-h-[calc(var(--radix-dropdown-menu-content-available-height)-100px)]
+            `}
+            >
                 <DropdownMenuLabel>Projects</DropdownMenuLabel>
                 <DropdownMenuSeparator />
-                <div className="flex flex-col gap-px">
+                <ScrollableShadows direction="vertical" className="flex flex-col gap-px w-auto" styledScrollbars>
                     <DropdownMenuItem asChild>
                         <ButtonGroupPrimitive fullWidth groupVariant="side-action-group">
-                            <ButtonPrimitive menuItem active disabled sideActionLeft>
+                            <ButtonPrimitive
+                                menuItem
+                                active
+                                disabled
+                                sideActionLeft
+                                tooltip={`Current project: ${currentTeam.name}`}
+                            >
                                 <ProjectName team={currentTeam} />
                             </ButtonPrimitive>
                             <ButtonPrimitive
@@ -86,6 +121,7 @@ export function ProjectDropdownMenu(): JSX.Element | null {
                                 href={urls.project(currentTeam.id, urls.settings('project'))}
                                 iconOnly
                                 sideActionRight
+                                tooltip={`View settings for project: ${currentTeam.name}`}
                             >
                                 <IconGear className="text-tertiary" />
                             </ButtonPrimitive>
@@ -108,13 +144,13 @@ export function ProjectDropdownMenu(): JSX.Element | null {
                                 })
                             }
                         >
-                            <ButtonPrimitive menuItem data-attr="new-project-button">
+                            <ButtonPrimitive menuItem data-attr="new-project-button" tooltip="Create a new project">
                                 <IconPlusSmall className="text-tertiary" />
                                 New project
                             </ButtonPrimitive>
                         </DropdownMenuItem>
                     )}
-                </div>
+                </ScrollableShadows>
             </DropdownMenuContent>
         </DropdownMenu>
     ) : null

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
@@ -304,7 +304,7 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                 setExpandedSearchFolders: (_, { folderIds }) => folderIds,
                 loadSearchResultsSuccess: (state, { searchResults: { results, lastCount } }) => {
                     const folders: Record<string, boolean> = state.reduce(
-                        (acc, folderId) => {
+                        (acc: Record<string, boolean>, folderId) => {
                             acc[folderId] = true
                             return acc
                         },

--- a/frontend/src/lib/ui/Button/ButtonPrimitives.tsx
+++ b/frontend/src/lib/ui/Button/ButtonPrimitives.tsx
@@ -303,6 +303,18 @@ export const ButtonPrimitive = forwardRef<HTMLButtonElement | HTMLAnchorElement,
     // Determine the element props
     const elementProps = href ? { href, ...rest } : rest
 
+    // If the button is an anchor and has an onClick, and is not external, prevent the default action and call the onClick
+    if (href && rest.onClick && !external) {
+        const handleClick = (e: React.MouseEvent): void => {
+            // Allow command/ctrl click to open in new tab
+            if (!e.metaKey && !e.ctrlKey) {
+                e.preventDefault()
+            }
+            rest?.onClick?.(e as any)
+        }
+        elementProps.onClick = handleClick
+    }
+
     let buttonComponent: JSX.Element = React.createElement(
         Comp,
         {

--- a/frontend/src/lib/ui/Button/ButtonPrimitives.tsx
+++ b/frontend/src/lib/ui/Button/ButtonPrimitives.tsx
@@ -132,6 +132,7 @@ const buttonVariants = cva({
     base: `
         button-primitive
         group/button-primitive
+        cursor-pointer
         inline-flex
         w-fit
         relative
@@ -139,7 +140,6 @@ const buttonVariants = cva({
         rounded-md
         font-normal
         aria-disabled:cursor-not-allowed
-        aria-disabled:pointer-events-none
         aria-disabled:opacity-50
         text-current
         [&_svg]:shrink-0
@@ -152,12 +152,12 @@ const buttonVariants = cva({
                 text-primary 
                 max-w-full
                 not-disabled:hover:bg-fill-button-tertiary-hover 
-                data-[focused=true]:bg-fill-button-tertiary-hover 
-                data-[active=true]:bg-fill-button-tertiary-active 
-                data-[current=true]:bg-fill-button-tertiary-active 
-                data-[state=open]:bg-fill-button-tertiary-active 
-                data-[state=checked]:bg-fill-button-tertiary-active
-                data-highlighted:bg-fill-button-tertiary-active
+                not-disabled:data-[focused=true]:bg-fill-button-tertiary-hover 
+                not-disabled:data-[active=true]:bg-fill-button-tertiary-active 
+                not-disabled:data-[current=true]:bg-fill-button-tertiary-active 
+                not-disabled:data-[state=open]:bg-fill-button-tertiary-active 
+                not-disabled:data-[state=checked]:bg-fill-button-tertiary-active
+                not-disabled:data-highlighted:bg-fill-button-tertiary-active
             `,
             // Outline variant (aka posthog secondary button)
             outline: `

--- a/frontend/src/lib/ui/DropdownMenu/DropdownMenu.tsx
+++ b/frontend/src/lib/ui/DropdownMenu/DropdownMenu.tsx
@@ -60,7 +60,7 @@ const DropdownMenuSubContent = React.forwardRef<
         <DropdownMenuPrimitive.SubContent
             ref={ref}
             className={cn(
-                'z-top min-w-[8rem] max-w-[200px] overflow-hidden rounded-md border bg-surface-primary p-1 text-primary shadow',
+                'z-[var(--z-popover)] min-w-[8rem] max-w-[200px] overflow-hidden rounded-md border bg-surface-primary p-1 text-primary shadow',
                 className
             )}
             {...props}
@@ -81,7 +81,7 @@ const DropdownMenuContent = React.forwardRef<
                 ref={ref}
                 sideOffset={sideOffset}
                 className={cn(
-                    'z-top min-w-[8rem] overflow-hidden rounded-md border bg-surface-primary p-1 text-primary shadow flex flex-col gap-px',
+                    'z-[var(--z-popover)] min-w-[8rem] overflow-hidden rounded-md border bg-surface-primary p-1 text-primary shadow flex flex-col gap-px',
                     'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
                     matchTriggerWidth && 'min-w-[var(--radix-dropdown-menu-trigger-width)]',
                     className

--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -588,6 +588,7 @@
     --project-navbar-width: 250px;
     --project-navbar-width-collapsed: 45px;
     --project-panel-width: 320px;
+    --project-panel-inner-width: calc(var(--project-panel-width) - (var(--spacing) * 2));
 
     // Toasts
     // Update and override from react-toastify


### PR DESCRIPTION
## Problem
* Dropdowns were too long and not scrollable.
* Dropdowns were missing tooltips
* Nav bar items when links, caused a page reload
* Nav bar items didn't support command click (to open new tab)
* Buttons didn't have `cursor-pointer`
* Panel view z-index was too high, which was over tooltips

<img width="660" alt="image" src="https://github.com/user-attachments/assets/5f2802d8-7a4d-439f-b05c-c3a16037a384" />

## Changes
* Added max height/width to dropdowns with scrollable shadows where needed.
* Button Primitive now prevents default if href && !external, allowing users to have a native link feel.
* Add `cursor-pointer` to button
* Fixed z-index for panels


### Fixes:
![2025-04-02 12 26 50](https://github.com/user-attachments/assets/a9cb4526-cb85-46c4-8d30-b3ab824e962a)


## How did you test this code?
Locally