### PR TITLE
fix(err): actually put the geoip properties on the event

### DIFF
--- a/bin/start-rust-service
+++ b/bin/start-rust-service
@@ -36,7 +36,7 @@ case "$RS_SVC" in
     # NOTE: to ensure the exceptions topic exists and avoid crash loops in dev:
     # cd rust
     # cargo run --bin generate_test_events
-    export RUST_LOG=debug
+    export RUST_LOG=debug,rdkafka=warn
     export RUST_BACKTRACE=1
     export KAFKA_CONSUMER_GROUP=cymbal
     export KAFKA_CONSUMER_TOPIC=exception_symbolification_events

--- a/rust/cymbal/src/metric_consts.rs
+++ b/rust/cymbal/src/metric_consts.rs
@@ -52,3 +52,4 @@ pub const EVENT_BATCH_SIZE: &str = "cymbal_event_batch_size";
 pub const HANDLE_BATCH_TIME: &str = "cymbal_handle_batch_time";
 pub const EVENTS_WRITTEN: &str = "cymbal_events_written";
 pub const EMIT_EVENTS_TIME: &str = "cymbal_emit_events_time";
+pub const GEOIP_PROCESSED: &str = "cymbal_geoip_processed";

--- a/rust/cymbal/src/pipeline/geoip.rs
+++ b/rust/cymbal/src/pipeline/geoip.rs
@@ -6,7 +6,6 @@ use serde_json::Value;
 
 use crate::{app_context::AppContext, error::PipelineResult, metric_consts::GEOIP_PROCESSED};
 
-// Delete the $IP property from the event if it exists, doing geoip lookup unless $geoip_disable is true
 pub fn add_geoip(mut buffer: Vec<PipelineResult>, context: &AppContext) -> Vec<PipelineResult> {
     #[derive(Debug, Clone, Serialize, Deserialize)]
     struct GeoIpProps {

--- a/rust/cymbal/src/pipeline/geoip.rs
+++ b/rust/cymbal/src/pipeline/geoip.rs
@@ -9,10 +9,10 @@ use crate::{app_context::AppContext, error::PipelineResult, metric_consts::GEOIP
 pub fn add_geoip(mut buffer: Vec<PipelineResult>, context: &AppContext) -> Vec<PipelineResult> {
     #[derive(Debug, Clone, Serialize, Deserialize)]
     struct GeoIpProps {
-        #[serde(rename = "$ip")]
+        #[serde(rename = "$ip", skip_serializing_if = "Option::is_none")]
         ip: Option<String>,
 
-        #[serde(rename = "$geoip_disable")]
+        #[serde(rename = "$geoip_disable", skip_serializing_if = "Option::is_none")]
         disabled: Option<bool>,
 
         #[serde(flatten)]
@@ -50,6 +50,9 @@ pub fn add_geoip(mut buffer: Vec<PipelineResult>, context: &AppContext) -> Vec<P
         ip_props
             .other
             .extend(lookup.into_iter().map(|(k, v)| (k, Value::String(v))));
+
+        event.properties =
+            Some(serde_json::to_string(&ip_props).expect("serialization should not fail"));
     }
 
     buffer


### PR DESCRIPTION
`serde::from_str` copies the properties, I have to put them back on the object to actually persist any of the processing I'm doing, doh