### PR TITLE
fix(sql-editor): Fix insight edit popup for moving to sql editor

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -397,6 +397,20 @@ export function objectCleanWithEmpty<T extends Record<string | number | symbol, 
     return response
 }
 
+export const removeUndefinedAndNull = (obj: any): any => {
+    if (Array.isArray(obj)) {
+        return obj.map(removeUndefinedAndNull)
+    } else if (obj && typeof obj === 'object') {
+        return Object.entries(obj).reduce((acc, [key, value]) => {
+            if (value !== undefined && value !== null) {
+                acc[key] = removeUndefinedAndNull(value)
+            }
+            return acc
+        }, {} as Record<string, any>)
+    }
+    return obj
+}
+
 /** Returns "response" from: obj2 = { ...obj1, ...response }  */
 export function objectDiffShallow(obj1: Record<string, any>, obj2: Record<string, any>): Record<string, any> {
     const response: Record<string, any> = { ...obj2 }

--- a/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
@@ -8,6 +8,7 @@ import api from 'lib/api'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { initModel } from 'lib/monaco/CodeEditor'
 import { codeEditorLogic } from 'lib/monaco/codeEditorLogic'
+import { removeUndefinedAndNull } from 'lib/utils'
 import isEqual from 'lodash.isequal'
 import { editor, Uri } from 'monaco-editor'
 import { insightsApi } from 'scenes/insights/utils/api'
@@ -49,20 +50,6 @@ export const activeModelStateKey = (key: string | number): string => `${key}/act
 export const activeModelVariablesStateKey = (key: string | number): string => `${key}/activeModelVariables`
 
 export const NEW_QUERY = 'Untitled'
-
-const removeUndefinedAndNull = (obj: object): object => {
-    if (Array.isArray(obj)) {
-        return obj.map(removeUndefinedAndNull)
-    } else if (obj && typeof obj === 'object') {
-        return Object.entries(obj).reduce((acc, [key, value]) => {
-            if (value !== undefined && value !== null) {
-                acc[key] = removeUndefinedAndNull(value)
-            }
-            return acc
-        }, {} as Record<string, any>)
-    }
-    return obj
-}
 
 const getNextUntitledNumber = (tabs: QueryTab[]): number => {
     const untitledNumbers = tabs

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -381,7 +381,13 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                     minAccessLevel="editor"
                                     resourceType={AccessControlResourceType.Insight}
                                     type="primary"
-                                    onClick={() => setInsightMode(ItemMode.Edit, null)}
+                                    onClick={() => {
+                                        if (isDataVisualizationNode(query) && insight.short_id) {
+                                            router.actions.push(urls.sqlEditor(undefined, undefined, insight.short_id))
+                                        } else {
+                                            setInsightMode(ItemMode.Edit, null)
+                                        }
+                                    }}
                                     data-attr="insight-edit-button"
                                 >
                                     Edit

--- a/frontend/src/scenes/insights/utils/queryUtils.ts
+++ b/frontend/src/scenes/insights/utils/queryUtils.ts
@@ -1,4 +1,4 @@
-import { objectCleanWithEmpty, objectsEqual } from 'lib/utils'
+import { objectCleanWithEmpty, objectsEqual, removeUndefinedAndNull } from 'lib/utils'
 
 import { DataNode, InsightQueryNode, Node } from '~/queries/schema/schema-general'
 import {
@@ -41,14 +41,19 @@ export const compareQuery = (a: Node, b: Node, opts?: CompareQueryOpts): boolean
         const { source: sourceA, ...restA } = a
         const { source: sourceB, ...restB } = b
         return (
-            objectsEqual(objectCleanWithEmpty(restA), objectCleanWithEmpty(restB)) &&
-            compareDataNodeQuery(sourceA, sourceB, opts)
+            objectsEqual(
+                objectCleanWithEmpty(removeUndefinedAndNull(restA)),
+                objectCleanWithEmpty(removeUndefinedAndNull(restB))
+            ) && compareDataNodeQuery(sourceA, sourceB, opts)
         )
     } else if (isInsightQueryNode(a) && isInsightQueryNode(b)) {
-        return compareDataNodeQuery(a, b, opts)
+        return compareDataNodeQuery(removeUndefinedAndNull(a), removeUndefinedAndNull(b), opts)
     }
 
-    return objectsEqual(objectCleanWithEmpty(a as any), objectCleanWithEmpty(b as any))
+    return objectsEqual(
+        objectCleanWithEmpty(removeUndefinedAndNull(a as any)),
+        objectCleanWithEmpty(removeUndefinedAndNull(b as any))
+    )
 }
 
 export const haveVariablesOrFiltersChanged = (a: Node, b: Node): boolean => {


### PR DESCRIPTION
## Problem
- https://posthog.slack.com/archives/C0351B1DMUY/p1743588786787189
- Hitting "edit" on a SQL insight would cause a pop-up suggesting there are unsaved changes (there are no unsaved changes)

## Changes
- Updated the logic of deciding whether a query has changed to remove undefined/null fields from the nodes before comparing them
- Updated the "Edit" button to link directly to the SQL editor instead of going through the `InsightScene` when we know its a data viz node

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Tested locally 