### PR TITLE
feat: adds API_QUERIES_ENABLED env switching controlling related changes.

### DIFF
--- a/posthog/constants.py
+++ b/posthog/constants.py
@@ -39,6 +39,7 @@ class AvailableFeature(StrEnum):
     DATA_PIPELINES = "data_pipelines"
     ALERTS = "alerts"
     DATA_COLOR_THEMES = "data_color_themes"
+    API_QUERIES_CONCURRENCY = "api_queries_concurrency"
 
 
 TREND_FILTER_TYPE_ACTIONS = "actions"

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -9,6 +9,7 @@ from prometheus_client import Counter
 from pydantic import BaseModel, ConfigDict
 from sentry_sdk import get_traceparent, push_scope, set_tag
 
+from posthog import settings
 from posthog.caching.utils import ThresholdMode, cache_target_age, is_stale, last_refresh_from_cached_result
 from posthog.clickhouse.client.execute_async import QueryNotFoundError, enqueue_process_query_task, get_query_status
 from posthog.clickhouse.client.limit import get_api_personal_rate_limiter
@@ -775,8 +776,13 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             self.modifiers = create_default_modifiers_for_user(user, self.team, self.modifiers)
             self.modifiers.useMaterializedViews = True
 
+        concurrency_limit = self.get_api_queries_concurrency_limit()
         with get_api_personal_rate_limiter().run(
-            is_api=self.is_query_service, team_id=self.team.pk, task_id=self.query_id
+            is_api=self.is_query_service,
+            team_id=self.team.pk,
+            org_id=self.team.organization.id,
+            task_id=self.query_id,
+            limit=concurrency_limit,
         ):
             if self.is_query_service:
                 tag_queries(chargeable=1)
@@ -807,6 +813,29 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             QUERY_CACHE_WRITE_COUNTER.labels(team_id=self.team.pk).inc()
 
         return fresh_response
+
+    def get_api_queries_concurrency_limit(self):
+        """
+        :return: None - no feature, 0 - rate limited, 1,3,<other> for actual concurrency limit
+        """
+
+        if not settings.EE_AVAILABLE:
+            return None
+
+        from ee.billing.quota_limiting import list_limited_team_attributes, QuotaLimitingCaches, QuotaResource
+
+        if self.team.api_token in list_limited_team_attributes(
+            QuotaResource.API_QUERIES, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
+        ):
+            return 0
+
+        feature = next(
+            filter(
+                lambda f: f.get("key") == "api_queries_concurrency", self.team.organization.available_product_features
+            ),
+            None,
+        )
+        return feature.get("limit") if feature else None
 
     @abstractmethod
     def to_query(self) -> ast.SelectQuery | ast.SelectSetQuery:

--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -222,9 +222,10 @@ class Organization(UUIDModel):
 
         return self.available_product_features
 
-    def get_available_feature(self, feature: Union[AvailableFeature, str]) -> dict | None:
+    def get_available_feature(self, feature: Union[AvailableFeature, str]) -> Optional[dict]:
+        vals: list[dict[str, Any]] = self.available_product_features or []
         return next(
-            filter(lambda f: f.get("key") == feature, self.available_product_features or []),
+            filter(lambda f: f and f.get("key") == feature, vals),
             None,
         )
 

--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -222,7 +222,7 @@ class Organization(UUIDModel):
 
         return self.available_product_features
 
-    def get_available_feature(self, feature: Union[AvailableFeature, str]) -> dict:
+    def get_available_feature(self, feature: Union[AvailableFeature, str]) -> dict | None:
         return next(
             filter(lambda f: f.get("key") == feature, self.available_product_features or []),
             None,

--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -222,9 +222,14 @@ class Organization(UUIDModel):
 
         return self.available_product_features
 
+    def get_available_feature(self, feature: Union[AvailableFeature, str]) -> dict:
+        return next(
+            filter(lambda f: f.get("key") == feature, self.available_product_features or []),
+            None,
+        )
+
     def is_feature_available(self, feature: Union[AvailableFeature, str]) -> bool:
-        available_product_feature_keys = [feature["key"] for feature in self.available_product_features or []]
-        return feature in available_product_feature_keys
+        return bool(self.get_available_feature(feature))
 
     @property
     def active_invites(self) -> QuerySet:

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -8,7 +8,6 @@ from prometheus_client import Counter
 from rest_framework.throttling import SimpleRateThrottle, BaseThrottle, UserRateThrottle
 from rest_framework.request import Request
 
-from posthog import settings
 from posthog.exceptions_capture import capture_exception
 from statshog.defaults.django import statsd
 from posthog.auth import PersonalAPIKeyAuthentication
@@ -325,7 +324,12 @@ class AISustainedRateThrottle(UserRateThrottle):
 class HogQLQueryThrottle(PersonalApiKeyRateThrottle):
     # Lower rate limit for HogQL queries
     scope = "query"
-    rate = "3600/hour" if settings.API_QUERIES_ENABLED else "120/hour"
+    rate = "120/hour"
+
+
+class APIQueriesThrottle(PersonalApiKeyRateThrottle):
+    scope = "query"
+    rate = "3600/hour"
 
 
 class UserPasswordResetThrottle(UserOrEmailRateThrottle):

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -7,6 +7,8 @@ from typing import Optional
 from prometheus_client import Counter
 from rest_framework.throttling import SimpleRateThrottle, BaseThrottle, UserRateThrottle
 from rest_framework.request import Request
+
+from posthog import settings
 from posthog.exceptions_capture import capture_exception
 from statshog.defaults.django import statsd
 from posthog.auth import PersonalAPIKeyAuthentication
@@ -323,7 +325,7 @@ class AISustainedRateThrottle(UserRateThrottle):
 class HogQLQueryThrottle(PersonalApiKeyRateThrottle):
     # Lower rate limit for HogQL queries
     scope = "query"
-    rate = "120/hour"
+    rate = "3600/hour" if settings.API_QUERIES_ENABLED else "120/hour"
 
 
 class UserPasswordResetThrottle(UserOrEmailRateThrottle):

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -329,7 +329,7 @@ class HogQLQueryThrottle(PersonalApiKeyRateThrottle):
 
 class APIQueriesThrottle(PersonalApiKeyRateThrottle):
     scope = "query"
-    rate = "3600/hour"
+    rate = "1200/hour"
 
 
 class UserPasswordResetThrottle(UserOrEmailRateThrottle):

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -59,6 +59,9 @@ DECIDE_SESSION_REPLAY_QUOTA_CHECK = get_from_env("DECIDE_SESSION_REPLAY_QUOTA_CH
 # if `true` we disable feature flags if over quota
 DECIDE_FEATURE_FLAG_QUOTA_CHECK = get_from_env("DECIDE_FEATURE_FLAG_QUOTA_CHECK", False, type_cast=str_to_bool)
 
+# if `true` we highly increase the rate limit on /query endpoint and limit the number of concurrent queries
+API_QUERIES_ENABLED = get_from_env("API_QUERIES_ENABLED", False, type_cast=str_to_bool)
+
 # Application definition
 
 INSTALLED_APPS = [

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -12,7 +12,7 @@ from prometheus_client import Gauge
 from redis import Redis
 from structlog import get_logger
 
-from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded, limit_concurrency, get_api_personal_rate_limiter
+from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded, limit_concurrency
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.cloud_utils import is_cloud
 from posthog.errors import CHQueryErrorTooManySimultaneousQueries
@@ -72,20 +72,19 @@ def process_query_task(
     Kick off query
     Once complete save results to redis
     """
-    with get_api_personal_rate_limiter().run(is_api=is_query_service, team_id=team_id, task_id=query_id):
-        from posthog.clickhouse.client import execute_process_query
+    from posthog.clickhouse.client import execute_process_query
 
-        if is_query_service:
-            tag_queries(chargeable=1)
+    if is_query_service:
+        tag_queries(chargeable=1)
 
-        execute_process_query(
-            team_id=team_id,
-            user_id=user_id,
-            query_id=query_id,
-            query_json=query_json,
-            limit_context=limit_context,
-            is_query_service=is_query_service,
-        )
+    execute_process_query(
+        team_id=team_id,
+        user_id=user_id,
+        query_id=query_id,
+        query_json=query_json,
+        limit_context=limit_context,
+        is_query_service=is_query_service,
+    )
 
 
 @shared_task(ignore_result=True)


### PR DESCRIPTION
## Problem

Prepare for API Queries launch

## Changes

What happens when the API_QUERIES_ENABLED=1:
 - `/query` rate limit is lifted to `1200/h` (this limits only HTTP in this case)
 - max concurrency level for `/query` issued ClickHouse queries is set based on selected billing plan:
   -  **1** (free plan, default if missing)
   - **3** (paid, ask for more).
## Does this work well for both Cloud and self-hosted?

Yes/yes.

## How did you test this code?

Extended tests, mock billing values on local setup.
