### PR TITLE
chore(dashboards): Rename insight titles to say SQL instead of Data Viz

### DIFF
--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -200,7 +200,7 @@ export const QUERY_TYPES_METADATA: Record<NodeKind, InsightTypeMetadata> = {
         inMenu: true,
     },
     [NodeKind.DataVisualizationNode]: {
-        name: 'Data visualization',
+        name: 'SQL',
         description: 'Slice and dice your data in a table or chart.',
         icon: IconTableChart,
         inMenu: false,


### PR DESCRIPTION
## Problem
- On dashboards, we display the insight type on the card, e.g. "Trends", "Funnel", etc. For SQL insights, we list "Data visualization" - this doesn't really mean much to a user, they created a SQL insight!

<img width="390" alt="image" src="https://github.com/user-attachments/assets/d905b142-ebfa-4aa5-8377-9f79e19c22f9" />


## Changes
- Rename "Data visualization" to "SQL"

<img width="434" alt="image" src="https://github.com/user-attachments/assets/c0c4f0e8-d0f8-48a0-acc6-90e033e4c4b8" />


