### PR TITLE
chore: Add `is_cached` to `query completed` event

### DIFF
--- a/frontend/src/queries/query.test.ts
+++ b/frontend/src/queries/query.test.ts
@@ -14,7 +14,10 @@ describe('query', () => {
                 '/api/environments/:team_id/query': (req) => {
                     const data = req.body as any
                     if (data.query?.kind === 'HogQLQuery') {
-                        return [200, { results: [], clickhouse: 'clickhouse string', hogql: 'hogql string' }]
+                        return [
+                            200,
+                            { results: [], clickhouse: 'clickhouse string', hogql: 'hogql string', is_cached: false },
+                        ]
                     }
                     if (data.query?.kind === 'EventsQuery' && data.query.select[0] === 'error') {
                         return [500, { detail: 'error' }]
@@ -94,6 +97,7 @@ describe('query', () => {
             query: q,
             duration: expect.any(Number),
             clickhouse_sql: expect.any(String),
+            is_cached: false,
         })
     })
 

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -265,6 +265,7 @@ export async function performQuery<N extends DataNode>(
             query: queryNode,
             queryId,
             duration: performance.now() - startTime,
+            is_cached: response?.is_cached,
             ...logParams,
         })
         return response


### PR DESCRIPTION
## Changes

I'd like to know the cache hit/miss ratio for my queries.

## How did you test this code?

I triggered `query completed` and verified the property was present.