### PR TITLE
fix(experiments): fix bug when adding secondary metrics

### DIFF
--- a/frontend/src/scenes/experiments/Metrics/ExperimentMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/ExperimentMetricModal.tsx
@@ -37,7 +37,7 @@ export function ExperimentMetricModal({
 
     const handleSetMetric = useCallback(
         (newMetric: ExperimentMetric): void => {
-            if (!metricIdx) {
+            if (metricIdx == null) {
                 return
             }
             setMetric({ metricIdx, metric: newMetric, isSecondary })
@@ -45,7 +45,7 @@ export function ExperimentMetricModal({
         [metricIdx, isSecondary, setMetric]
     )
 
-    if (!metricIdx && metricIdx !== 0) {
+    if (metricIdx == null) {
         return <></>
     }
 


### PR DESCRIPTION
## Problem
Adding secondary metrics in the new query runner is broken at the moment (only we are using it, so limited impact)

## Changes
Fix the conditional for early return. It was erroneously evaluating to true when `metricIdx` was 0. This logic could benefit for some refactoring to avoid such bugs. But for now, just fixing the bug.

## How did you test this code?
* tested locally that adding both primary and secondary metrics works as expected
