### PR TITLE
fix: timestamp format choosing

### DIFF
--- a/frontend/src/scenes/session-recordings/player/controller/PlayerControllerTime.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/PlayerControllerTime.tsx
@@ -33,10 +33,10 @@ function RelativeTimestampLabel({ size }: { size: 'small' | 'normal' }): JSX.Ele
     )
     return size === 'small' ? (
         <Tooltip title={fullDisplay}>
-            <span>{current}</span>
+            <span className="text-muted text-xs">{current}</span>
         </Tooltip>
     ) : (
-        <span>{fullDisplay}</span>
+        <span className="text-muted text-xs">{fullDisplay}</span>
     )
 }
 
@@ -44,13 +44,22 @@ export function Timestamp({ size }: { size: 'small' | 'normal' }): JSX.Element {
     const { logicProps, currentTimestamp, sessionPlayerData } = useValues(sessionRecordingPlayerLogic)
     const { isScrubbing, scrubbingTime } = useValues(seekbarLogic(logicProps))
     const { timestampFormat } = useValues(playerSettingsLogic)
+    const { setTimestampFormat } = useActions(playerSettingsLogic)
 
     const scrubbingTimestamp = sessionPlayerData.start?.valueOf()
         ? scrubbingTime + sessionPlayerData.start?.valueOf()
         : undefined
 
     return (
-        <div data-attr="recording-timestamp" className="text-center whitespace-nowrap font-mono text-xs">
+        <LemonButton
+            data-attr="recording-timestamp"
+            className="text-center whitespace-nowrap font-mono text-xs"
+            onClick={() => {
+                const values = Object.values(TimestampFormat)
+                const nextIndex = (values.indexOf(timestampFormat) + 1) % values.length
+                setTimestampFormat(values[nextIndex])
+            }}
+        >
             {timestampFormat === TimestampFormat.Relative ? (
                 <RelativeTimestampLabel size={size} />
             ) : (
@@ -60,7 +69,7 @@ export function Timestamp({ size }: { size: 'small' | 'normal' }): JSX.Element {
                     containerSize={size}
                 />
             )}
-        </div>
+        </LemonButton>
     )
 }
 

--- a/frontend/src/scenes/session-recordings/player/player-meta/PlayerMetaBottomSettings.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/PlayerMetaBottomSettings.tsx
@@ -1,4 +1,4 @@
-import { IconClock, IconEllipsis, IconHourglass, IconRabbit, IconSearch, IconTortoise } from '@posthog/icons'
+import { IconEllipsis, IconHourglass, IconRabbit, IconSearch, IconTortoise } from '@posthog/icons'
 import { Tooltip } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { FlaggedFeature } from 'lib/components/FlaggedFeature'
@@ -15,12 +15,11 @@ import {
 } from 'scenes/session-recordings/components/PanelSettings'
 import { PlayerInspectorButton } from 'scenes/session-recordings/player/player-meta/PlayerInspectorButton'
 import { PlayerMetaBreakpoints } from 'scenes/session-recordings/player/player-meta/PlayerMeta'
-import { playerSettingsLogic, TimestampFormat } from 'scenes/session-recordings/player/playerSettingsLogic'
+import { playerSettingsLogic } from 'scenes/session-recordings/player/playerSettingsLogic'
 import {
     PLAYBACK_SPEEDS,
     sessionRecordingPlayerLogic,
 } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
-import { TimestampFormatToLabel } from 'scenes/session-recordings/utils'
 
 function SetPlaybackSpeed(): JSX.Element {
     const { speed, sessionPlayerData } = useValues(sessionRecordingPlayerLogic)
@@ -67,37 +66,6 @@ function SkipInactivity(): JSX.Element {
     )
 }
 
-function SetTimeFormat(): JSX.Element {
-    const { timestampFormat } = useValues(playerSettingsLogic)
-    const { setTimestampFormat } = useActions(playerSettingsLogic)
-
-    return (
-        <SettingsMenu
-            matchWidth={true}
-            highlightWhenActive={false}
-            items={[
-                {
-                    label: 'UTC',
-                    onClick: () => setTimestampFormat(TimestampFormat.UTC),
-                    active: timestampFormat === TimestampFormat.UTC,
-                },
-                {
-                    label: 'Device',
-                    onClick: () => setTimestampFormat(TimestampFormat.Device),
-                    active: timestampFormat === TimestampFormat.Device,
-                },
-                {
-                    label: 'Relative',
-                    onClick: () => setTimestampFormat(TimestampFormat.Relative),
-                    active: timestampFormat === TimestampFormat.Relative,
-                },
-            ]}
-            icon={<IconClock />}
-            label={TimestampFormatToLabel[timestampFormat]}
-        />
-    )
-}
-
 function InspectDOM(): JSX.Element {
     const { sessionPlayerMetaData } = useValues(sessionRecordingPlayerLogic)
     const { openExplorer } = useActions(sessionRecordingPlayerLogic)
@@ -121,40 +89,11 @@ export function PlayerMetaBottomSettings({ size }: { size: PlayerMetaBreakpoints
         logicProps: { noInspector },
     } = useValues(sessionRecordingPlayerLogic)
     const { setPause, openHeatmap } = useActions(sessionRecordingPlayerLogic)
-    const { skipInactivitySetting, timestampFormat } = useValues(playerSettingsLogic)
-    const { setSkipInactivitySetting, setTimestampFormat } = useActions(playerSettingsLogic)
+    const { skipInactivitySetting } = useValues(playerSettingsLogic)
+    const { setSkipInactivitySetting } = useActions(playerSettingsLogic)
     const isSmall = size === 'small'
 
     const menuItems: LemonMenuItem[] = [
-        isSmall
-            ? {
-                  label: TimestampFormatToLabel[timestampFormat],
-                  icon: <IconClock />,
-                  'data-attr': 'time-format-in-menu',
-                  matchWidth: true,
-
-                  items: [
-                      {
-                          label: 'UTC',
-                          onClick: () => setTimestampFormat(TimestampFormat.UTC),
-                          active: timestampFormat === TimestampFormat.UTC,
-                          size: 'xsmall',
-                      },
-                      {
-                          label: 'Device',
-                          onClick: () => setTimestampFormat(TimestampFormat.Device),
-                          active: timestampFormat === TimestampFormat.Device,
-                          size: 'xsmall',
-                      },
-                      {
-                          label: 'Relative',
-                          onClick: () => setTimestampFormat(TimestampFormat.Relative),
-                          active: timestampFormat === TimestampFormat.Relative,
-                          size: 'xsmall',
-                      },
-                  ],
-              }
-            : undefined,
         isSmall
             ? {
                   label: 'Skip inactivity',
@@ -171,7 +110,6 @@ export function PlayerMetaBottomSettings({ size }: { size: PlayerMetaBreakpoints
             <div className="flex w-full justify-between items-center gap-0.5">
                 <div className="flex flex-row gap-0.5 h-full items-center">
                     <SetPlaybackSpeed />
-                    {!isSmall && <SetTimeFormat />}
                     {!isSmall && <SkipInactivity />}
                     {isSmall && (
                         <SettingsMenu


### PR DESCRIPTION
as we've reorganised settings bars the timestamp format chooser is nowhere near any of the timestamps

and folk keep not finding it

let's just make the timestamp on the player a button that cycles formats

![2025-04-02 20 38 37](https://github.com/user-attachments/assets/cad5a207-e113-4c5f-949e-75ac20a1eaa3)
