### PR TITLE
feat(crm): Add 'Event Metadata' as filter option for dashboards

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardEditBar.tsx
+++ b/frontend/src/scenes/dashboard/DashboardEditBar.tsx
@@ -102,6 +102,7 @@ export function DashboardEditBar(): JSX.Element {
                         TaxonomicFilterGroupType.EventProperties,
                         TaxonomicFilterGroupType.PersonProperties,
                         TaxonomicFilterGroupType.EventFeatureFlags,
+                        TaxonomicFilterGroupType.EventMetadata,
                         ...groupsTaxonomicTypes,
                         TaxonomicFilterGroupType.Cohorts,
                         TaxonomicFilterGroupType.Elements,

--- a/frontend/src/scenes/groups/GroupOverview.tsx
+++ b/frontend/src/scenes/groups/GroupOverview.tsx
@@ -16,6 +16,7 @@ function GroupOverviewDashboard({
     groupTypeDetailDashboard: number
     groupData: Group
 }): JSX.Element {
+    const { groupTypeName } = useValues(groupLogic)
     const { setProperties } = useActions(dashboardLogic({ id: groupTypeDetailDashboard }))
 
     useEffect(() => {
@@ -24,12 +25,13 @@ function GroupOverviewDashboard({
                 {
                     type: PropertyFilterType.EventMetadata,
                     key: `$group_${groupData.group_type_index}`,
+                    label: groupTypeName,
                     value: groupData.group_key,
                     operator: PropertyOperator.Exact,
                 },
             ])
         }
-    }, [groupTypeDetailDashboard, groupData, setProperties])
+    }, [groupTypeDetailDashboard, groupData, groupTypeName, setProperties])
 
     return <Dashboard id={groupTypeDetailDashboard.toString()} placement={DashboardPlacement.Group} />
 }


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/29881

## Changes

Adds 'Event Metadata' as a filter option for dashboards, and passes the group type name as a label to the property filter.

**Before**

https://github.com/user-attachments/assets/2fe257a1-f027-48d5-8f3d-bd64e257a17e

**After**

https://github.com/user-attachments/assets/182b5086-dcf4-43f7-be3e-6a438d0aeae6

## How did you test this code?

I verified that the filter appeared as expected when I clicked "Edit dashboard template". The filter seems to work fine on standard dashboard insights too:

https://github.com/user-attachments/assets/60ffdbc0-0a82-48b0-85aa-86eed338ff83