### PR TITLE
feat: supporting v2 rollout

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -355,12 +355,15 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
                     if (breakpointLength) {
                         await breakpoint(breakpointLength)
                     }
-                    const response = await api.recordings.listSnapshotSources(props.sessionRecordingId)
+                    const blob_v2 = values.featureFlags[FEATURE_FLAGS.RECORDINGS_BLOBBY_V2_REPLAY]
+                    const response = await api.recordings.listSnapshotSources(props.sessionRecordingId, {
+                        blob_v2,
+                    })
                     if (!response.sources) {
                         return []
                     }
                     const anyBlobV2 = response.sources.some((s) => s.source === SnapshotSourceType.blob_v2)
-                    if (values.featureFlags[FEATURE_FLAGS.RECORDINGS_BLOBBY_V2_REPLAY] && anyBlobV2) {
+                    if (anyBlobV2) {
                         return response.sources.filter((s) => s.source === SnapshotSourceType.blob_v2)
                     }
                     return response.sources.filter((s) => s.source !== SnapshotSourceType.blob_v2)

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -620,7 +620,7 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, U
             raise exceptions.NotFound("Recording not found")
 
         source = request.GET.get("source")
-        is_v2_enabled = request.GET.get("allow_blob_v2", "false") == "true"
+        is_v2_enabled = request.GET.get("blob_v2", "false") == "true"
 
         event_properties = {
             "team_id": self.team.pk,

--- a/posthog/session_recordings/test/test_session_recordings.py
+++ b/posthog/session_recordings/test/test_session_recordings.py
@@ -1330,7 +1330,7 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
         )
         assert response.status_code == status.HTTP_200_OK, response.json()
 
-        assert mock_capture.call_args_list[0] == call(
+        assert mock_capture.call_args_list[1] == call(
             self.user.distinct_id,
             "snapshots_api_called_with_personal_api_key",
             {
@@ -1340,5 +1340,6 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
                 "session_requested": session_id,
                 # none because it's all mock data
                 "recording_start_time": None,
+                "source": None,
             },
         )

--- a/posthog/session_recordings/test/test_session_recordings.py
+++ b/posthog/session_recordings/test/test_session_recordings.py
@@ -16,8 +16,10 @@ from rest_framework import status
 
 from posthog.api.test.test_team import create_team
 from posthog.clickhouse.client import sync_execute
-from posthog.models import Organization, Person, SessionRecording, User
+from posthog.models import Organization, Person, SessionRecording, User, PersonalAPIKey
+from posthog.models.personal_api_key import hash_key_value
 from posthog.models.team import Team
+from posthog.models.utils import generate_random_token_personal
 from posthog.schema import RecordingsQuery, LogEntryPropertyFilter
 from posthog.session_recordings.models.session_recording_event import (
     SessionRecordingViewed,
@@ -1062,7 +1064,6 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
 
         response = self.client.get(url)
         assert response.status_code == status.HTTP_404_NOT_FOUND
-        assert mock_presigned_url.call_count == 0
 
     @patch("posthog.session_recordings.session_recording_api.object_storage.get_presigned_url")
     def test_can_not_get_session_recording_blob_that_does_not_exist(self, mock_presigned_url) -> None:
@@ -1307,3 +1308,37 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
             in response.json()["detail"]
         )
         assert response.json() == self.snapshot
+
+    @patch("posthoganalytics.capture")
+    def test_snapshots_api_called_with_personal_api_key(self, mock_capture):
+        session_id = str(uuid.uuid4())
+        self.produce_replay_summary("user", session_id, now() - relativedelta(days=1))
+
+        personal_api_key = generate_random_token_personal()
+        PersonalAPIKey.objects.create(
+            label="X",
+            user=self.user,
+            last_used_at="2021-08-25T21:09:14",
+            secure_value=hash_key_value(personal_api_key),
+            scopes=["session_recording:read"],
+            scoped_teams=[self.team.pk],
+        )
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/session_recordings/{session_id}/snapshots",
+            HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+        )
+        assert response.status_code == status.HTTP_200_OK, response.json()
+
+        assert mock_capture.call_args_list[0] == call(
+            self.user.distinct_id,
+            "snapshots_api_called_with_personal_api_key",
+            {
+                "key_label": "X",
+                "key_scopes": ["session_recording:read"],
+                "key_scoped_teams": [self.team.pk],
+                "session_requested": session_id,
+                # none because it's all mock data
+                "recording_start_time": None,
+            },
+        )


### PR DESCRIPTION
if we roll out blobby v2 without warning people then we'll break API users
if we remove blobby v1 without warning people then we'll break API users

folk can't stay on v1 forever
because we don't want to run blobby v1 forever

the sooner we can warn people, the better

let's

* allow people to opt in to blobby v2 via query param so that API users can test the response
* log events when people are calling snapshots with a personal API key - this should be low enough volume this is fine 🙈 