### PR TITLE
fix(flags): add timing spans to expensive operations and fix a potential looping DB query bug with new flags

### DIFF
--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -886,16 +886,18 @@ impl FeatureFlagMatcher {
             // Evaluate cohort filters, if any.
             if !cohort_filters.is_empty() {
                 // Get the person ID for the current distinct ID – this value should be cached at this point, but as a fallback we fetch from the database
-                let person_id = self.get_person_id().await?;
-                if !self
-                    .evaluate_cohort_filters(
-                        &cohort_filters,
-                        &person_or_group_properties,
-                        person_id,
-                    )
-                    .await?
-                {
-                    return Ok((false, FeatureFlagMatchReason::NoConditionMatch));
+                let person_id = self.get_person_id().await;
+                if let Some(person_id) = person_id {
+                    if !self
+                        .evaluate_cohort_filters(
+                            &cohort_filters,
+                            &person_or_group_properties,
+                            person_id,
+                        )
+                        .await?
+                    {
+                        return Ok((false, FeatureFlagMatchReason::NoConditionMatch));
+                    }
                 }
             }
         }
@@ -947,7 +949,7 @@ impl FeatureFlagMatcher {
     /// Retrieves the `PersonId` from the properties cache.
     /// If the cache does not contain a `PersonId`, it fetches it from the database
     /// and updates the cache accordingly.
-    async fn get_person_id(&mut self) -> Result<PersonId, FlagError> {
+    async fn get_person_id(&mut self) -> Option<PersonId> {
         match self.properties_cache.person_id {
             Some(id) => {
                 inc(
@@ -955,7 +957,7 @@ impl FeatureFlagMatcher {
                     &[("type".to_string(), "person_id".to_string())],
                     1,
                 );
-                Ok(id)
+                Some(id)
             }
             None => {
                 inc(
@@ -963,27 +965,9 @@ impl FeatureFlagMatcher {
                     &[("type".to_string(), "person_id".to_string())],
                     1,
                 );
-                let id = self.get_person_id_from_db().await?;
-                inc(
-                    DB_PERSON_PROPERTIES_READS_COUNTER,
-                    &[("team_id".to_string(), self.team_id.to_string())],
-                    1,
-                );
-                self.properties_cache.person_id = Some(id);
-                Ok(id)
+                None
             }
         }
-    }
-
-    /// Fetches the `PersonId` from the database based on the current `distinct_id` and `team_id`.
-    /// This method is called when the `PersonId` is not present in the properties cache.
-    async fn get_person_id_from_db(&mut self) -> Result<PersonId, FlagError> {
-        let reader = self.reader.clone();
-        let distinct_id = self.distinct_id.clone();
-        let team_id = self.team_id;
-        fetch_person_properties_from_db(reader, distinct_id, team_id)
-            .await
-            .map(|(_, person_id)| person_id)
     }
 
     /// Get person properties from overrides, cache or database.

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -7,8 +7,10 @@ use crate::flags::flag_match_reason::FeatureFlagMatchReason;
 use crate::flags::flag_models::{FeatureFlag, FeatureFlagList, FlagGroupType};
 use crate::metrics::metrics_consts::{
     DB_GROUP_PROPERTIES_READS_COUNTER, DB_PERSON_AND_GROUP_PROPERTIES_READS_COUNTER,
-    DB_PERSON_PROPERTIES_READS_COUNTER, FLAG_EVALUATION_ERROR_COUNTER,
-    FLAG_HASH_KEY_WRITES_COUNTER, PROPERTY_CACHE_HITS_COUNTER, PROPERTY_CACHE_MISSES_COUNTER,
+    DB_PERSON_PROPERTIES_READS_COUNTER, FLAG_DB_PROPERTIES_FETCH_TIME,
+    FLAG_EVALUATION_ERROR_COUNTER, FLAG_EVALUATION_TIME, FLAG_HASH_KEY_PROCESSING_TIME,
+    FLAG_HASH_KEY_WRITES_COUNTER, FLAG_LOCAL_EVALUATION_TIME, PROPERTY_CACHE_HITS_COUNTER,
+    PROPERTY_CACHE_MISSES_COUNTER,
 };
 use crate::metrics::metrics_utils::parse_exception_for_prometheus_label;
 use crate::properties::property_matching::match_property;
@@ -270,12 +272,15 @@ impl FeatureFlagMatcher {
         group_property_overrides: Option<HashMap<String, HashMap<String, Value>>>,
         hash_key_override: Option<String>,
     ) -> FlagsResponse {
+        let eval_timer = common_metrics::timing_guard(FLAG_EVALUATION_TIME, &[]);
+
         let flags_have_experience_continuity_enabled = feature_flags
             .flags
             .iter()
             .any(|flag| flag.ensure_experience_continuity);
 
         // Process any hash key overrides
+        let hash_key_timer = common_metrics::timing_guard(FLAG_HASH_KEY_PROCESSING_TIME, &[]);
         let (hash_key_overrides, initial_error) = if flags_have_experience_continuity_enabled {
             match hash_key_override {
                 Some(hash_key) => {
@@ -291,6 +296,9 @@ impl FeatureFlagMatcher {
             // if experience continuity is not enabled, we don't need to worry about hash key overrides
             (None, false)
         };
+        hash_key_timer
+            .label("outcome", if initial_error { "error" } else { "success" })
+            .fin();
 
         // If there was an initial error in processing hash key overrides, increment the error counter
         if initial_error {
@@ -302,6 +310,7 @@ impl FeatureFlagMatcher {
             );
         }
 
+        let local_eval_timer = common_metrics::timing_guard(FLAG_LOCAL_EVALUATION_TIME, &[]);
         let flags_response = self
             .evaluate_flags_with_overrides(
                 feature_flags,
@@ -310,6 +319,28 @@ impl FeatureFlagMatcher {
                 hash_key_overrides,
             )
             .await;
+
+        local_eval_timer
+            .label(
+                "outcome",
+                if flags_response.errors_while_computing_flags {
+                    "error"
+                } else {
+                    "success"
+                },
+            )
+            .fin();
+
+        eval_timer
+            .label(
+                "outcome",
+                if flags_response.errors_while_computing_flags || initial_error {
+                    "error"
+                } else {
+                    "success"
+                },
+            )
+            .fin();
 
         FlagsResponse::new(
             initial_error || flags_response.errors_while_computing_flags,
@@ -517,7 +548,8 @@ impl FeatureFlagMatcher {
             let distinct_id = self.distinct_id.clone();
             let team_id = self.team_id;
 
-            match fetch_and_locally_cache_all_relevant_properties(
+            let db_fetch_timer = common_metrics::timing_guard(FLAG_DB_PROPERTIES_FETCH_TIME, &[]);
+            let fetch_result = fetch_and_locally_cache_all_relevant_properties(
                 &mut self.properties_cache,
                 reader,
                 distinct_id,
@@ -525,14 +557,16 @@ impl FeatureFlagMatcher {
                 &group_type_indexes,
                 &group_keys,
             )
-            .await
-            {
+            .await;
+
+            match fetch_result {
                 Ok(_) => {
                     inc(
                         DB_PERSON_AND_GROUP_PROPERTIES_READS_COUNTER,
                         &[("team_id".to_string(), team_id.to_string())],
                         1,
                     );
+                    db_fetch_timer.label("outcome", "success").fin();
                 }
                 Err(e) => {
                     errors_while_computing_flags = true;
@@ -544,8 +578,9 @@ impl FeatureFlagMatcher {
                         &[("reason".to_string(), reason.to_string())],
                         1,
                     );
+                    db_fetch_timer.label("outcome", "error").fin();
                 }
-            }
+            };
 
             // Step 3: Evaluate remaining flags with cached properties
             for flag in flags_needing_db_properties {

--- a/rust/feature-flags/src/metrics/metrics_consts.rs
+++ b/rust/feature-flags/src/metrics/metrics_consts.rs
@@ -24,3 +24,9 @@ pub const DB_PERSON_AND_GROUP_PROPERTIES_READS_COUNTER: &str =
     "flags_db_person_and_group_properties_reads_total";
 pub const DB_PERSON_PROPERTIES_READS_COUNTER: &str = "flags_db_person_properties_reads_total";
 pub const DB_GROUP_PROPERTIES_READS_COUNTER: &str = "flags_db_group_properties_reads_total";
+
+// Timing metrics
+pub const FLAG_EVALUATION_TIME: &str = "flags_evaluation_time";
+pub const FLAG_HASH_KEY_PROCESSING_TIME: &str = "flags_hash_key_processing_time";
+pub const FLAG_LOCAL_EVALUATION_TIME: &str = "flags_local_evaluation_time";
+pub const FLAG_DB_PROPERTIES_FETCH_TIME: &str = "flags_db_properties_fetch_time";


### PR DESCRIPTION
## Problem

new flags is slow in production, big ol' thread on it: https://posthog.slack.com/archives/C07Q2U4BH4L/p1743527419875229

Had a chat with Olly and we found that this method may potentially loop DB calls if fetching the person_id <-> distinct_id mapping didn't work on the initial step (it'd run each time we called `is_condition_match` on a flag with a cohort filter)

There may be a problem we can solve down the line with ingestion delays for person IDs, but this seemed like the most obvious DB pain point.  Given that flags is wicked fast locally when there's no network latency, not hitting postgres a bunch of extra times seemed prudent.

I also added some timing spans to see if we could find more metrics about this stuff.