### PR TITLE
chore: allow toolbar full throttle

### DIFF
--- a/frontend/build.mjs
+++ b/frontend/build.mjs
@@ -55,9 +55,6 @@ await buildInParallel(
             // This isn't great, but we load some static assets at runtime for the toolbar, and we can't sub in
             // a variable at runtime it seems...
             publicPath: isDev ? '/static/' : 'https://us.posthog.com/static/',
-            alias: {
-                'posthog-js': 'posthog-js-lite',
-            },
             writeMetaFile: true,
             extraPlugins: [
                 {

--- a/frontend/build.mjs
+++ b/frontend/build.mjs
@@ -49,6 +49,21 @@ await buildInParallel(
             entryPoints: ['src/toolbar/index.tsx'],
             format: 'iife',
             outfile: path.resolve(__dirname, 'dist', 'toolbar.js'),
+            external: ['@posthog/apps-common/world-map-vectors'],
+            plugins: [
+                {
+                    // Monaco is a big dependency and we don't use it in the toolbar, so we can remove it
+                    name: 'empty-monaco',
+                    setup(build) {
+                        build.onResolve({ filter: /^monaco-editor/ }, () => {
+                            return { path: 'monaco-editor', namespace: 'empty-module' }
+                        })
+                        build.onLoad({ filter: /.*/, namespace: 'empty-module' }, () => {
+                            return { contents: 'module.exports = {}' }
+                        })
+                    },
+                },
+            ],
             // make sure we don't link to a global window.define
             banner: { js: 'var posthogToolbar = (function () { var define = undefined;' },
             footer: { js: 'return posthogToolbar })();' },

--- a/frontend/build.mjs
+++ b/frontend/build.mjs
@@ -49,21 +49,6 @@ await buildInParallel(
             entryPoints: ['src/toolbar/index.tsx'],
             format: 'iife',
             outfile: path.resolve(__dirname, 'dist', 'toolbar.js'),
-            external: ['@posthog/apps-common/world-map-vectors'],
-            plugins: [
-                {
-                    // Monaco is a big dependency and we don't use it in the toolbar, so we can remove it
-                    name: 'empty-monaco',
-                    setup(build) {
-                        build.onResolve({ filter: /^monaco-editor/ }, () => {
-                            return { path: 'monaco-editor', namespace: 'empty-module' }
-                        })
-                        build.onLoad({ filter: /.*/, namespace: 'empty-module' }, () => {
-                            return { contents: 'module.exports = {}' }
-                        })
-                    },
-                },
-            ],
             // make sure we don't link to a global window.define
             banner: { js: 'var posthogToolbar = (function () { var define = undefined;' },
             footer: { js: 'return posthogToolbar })();' },

--- a/frontend/src/toolbar/index.tsx
+++ b/frontend/src/toolbar/index.tsx
@@ -1,14 +1,75 @@
 import '~/styles'
 import './styles.scss'
 
+import { KeaPlugin, resetContext } from 'kea'
+import { formsPlugin } from 'kea-forms'
+import { loadersPlugin } from 'kea-loaders'
+import { localStoragePlugin } from 'kea-localstorage'
+import { routerPlugin } from 'kea-router'
+import { subscriptionsPlugin } from 'kea-subscriptions'
+import { waitForPlugin } from 'kea-waitfor'
+import { windowValuesPlugin } from 'kea-window-values'
 import type { PostHog } from 'posthog-js'
 import { createRoot } from 'react-dom/client'
 
-import { initKea } from '~/initKea'
 import { ToolbarApp } from '~/toolbar/ToolbarApp'
 import { ToolbarParams } from '~/types'
-;(window as any)['ph_load_toolbar'] = function (toolbarParams: ToolbarParams, posthog: PostHog) {
-    initKea()
+
+interface InitKeaProps {
+    state?: Record<string, any>
+    routerHistory?: any
+    routerLocation?: any
+    beforePlugins?: KeaPlugin[]
+}
+
+const initKeaInToolbar = ({ routerHistory, routerLocation, beforePlugins }: InitKeaProps = {}): void => {
+    const plugins = [
+        ...(beforePlugins || []),
+        localStoragePlugin(),
+        windowValuesPlugin({ window: window }),
+        routerPlugin({
+            history: routerHistory,
+            location: routerLocation,
+            urlPatternOptions: {
+                // :TRICKY: What chars to allow in named segment values i.e. ":key"
+                // in "/url/:key". Default: "a-zA-Z0-9-_~ %".
+                segmentValueCharset: "a-zA-Z0-9-_~ %.@()!'|",
+            },
+        }),
+        formsPlugin,
+        loadersPlugin({
+            onFailure({ error, reducerKey, actionKey }: { error: any; reducerKey: string; actionKey: string }) {
+                console.error('toolbar fetch failed', error, reducerKey, actionKey)
+            },
+        }),
+        subscriptionsPlugin,
+        waitForPlugin,
+    ]
+
+    resetContext({
+        plugins: plugins,
+        createStore: {
+            compose: (...funcs: any[]) => {
+                if (funcs.length === 0) {
+                    return <T,>(arg: T) => arg
+                }
+                if (funcs.length === 1) {
+                    return funcs[0]
+                }
+                return funcs.reduce(
+                    (a, b) =>
+                        (...args: any) =>
+                            a(b(...args))
+                )
+            },
+        },
+    })
+}
+
+const win = window as any
+
+win['ph_load_toolbar'] = function (toolbarParams: ToolbarParams, posthog: PostHog) {
+    initKeaInToolbar()
     const container = document.createElement('div')
     const root = createRoot(container)
 
@@ -29,5 +90,6 @@ import { ToolbarParams } from '~/types'
         />
     )
 }
+
 /** @deprecated, use "ph_load_toolbar" instead */
-;(window as any)['ph_load_editor'] = (window as any)['ph_load_toolbar']
+win['ph_load_editor'] = win['ph_load_toolbar']


### PR DESCRIPTION
let's not swap out posthog in the toolbar for posthog-js-lite
