### PR TITLE
fix(data-warehouse): Prevent importing single duplicate row on Stripe incremental syncs

### DIFF
--- a/posthog/temporal/data_imports/pipelines/stripe/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/stripe/__init__.py
@@ -40,7 +40,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
                 "path": "/v1/accounts",
                 "params": {
                     # the parameters below can optionally be configured
-                    "created[gte]": {
+                    "created[gt]": {
                         "type": "incremental",
                         "cursor_path": "created",
                         "initial_value": 0,  # type: ignore
@@ -75,7 +75,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
                 "path": "/v1/balance_transactions",
                 "params": {
                     # the parameters below can optionally be configured
-                    "created[gte]": {
+                    "created[gt]": {
                         "type": "incremental",
                         "cursor_path": "created",
                         "initial_value": 0,  # type: ignore
@@ -110,7 +110,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
                 "path": "/v1/charges",
                 "params": {
                     # the parameters below can optionally be configured
-                    "created[gte]": {
+                    "created[gt]": {
                         "type": "incremental",
                         "cursor_path": "created",
                         "initial_value": 0,  # type: ignore
@@ -144,7 +144,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
                 "path": "/v1/customers",
                 "params": {
                     # the parameters below can optionally be configured
-                    "created[gte]": {
+                    "created[gt]": {
                         "type": "incremental",
                         "cursor_path": "created",
                         "initial_value": 0,  # type: ignore
@@ -178,7 +178,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
                 "params": {
                     # the parameters below can optionally be configured
                     # "collection_method": "OPTIONAL_CONFIG",
-                    "created[gte]": {
+                    "created[gt]": {
                         "type": "incremental",
                         "cursor_path": "created",
                         "initial_value": 0,  # type: ignore
@@ -214,7 +214,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
                 "params": {
                     # the parameters below can optionally be configured
                     # "active": "OPTIONAL_CONFIG",
-                    "created[gte]": {
+                    "created[gt]": {
                         "type": "incremental",
                         "cursor_path": "created",
                         "initial_value": 0,  # type: ignore
@@ -251,7 +251,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
                 "params": {
                     # the parameters below can optionally be configured
                     # "active": "OPTIONAL_CONFIG",
-                    "created[gte]": {
+                    "created[gt]": {
                         "type": "incremental",
                         "cursor_path": "created",
                         "initial_value": 0,  # type: ignore
@@ -286,7 +286,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
                 "params": {
                     # the parameters below can optionally be configured
                     # "collection_method": "OPTIONAL_CONFIG",
-                    "created[gte]": {
+                    "created[gt]": {
                         "type": "incremental",
                         "cursor_path": "created",
                         "initial_value": 0,  # type: ignore

--- a/posthog/temporal/tests/data_imports/stripe/conftest.py
+++ b/posthog/temporal/tests/data_imports/stripe/conftest.py
@@ -55,6 +55,9 @@ class MockStripeAPI:
         if "created[gte]" in query:
             created_gte = int(query["created[gte]"][0])
             filtered_data = [tx for tx in filtered_data if tx["created"] >= created_gte]
+        elif "created[gt]" in query:
+            created_gt = int(query["created[gt]"][0])
+            filtered_data = [tx for tx in filtered_data if tx["created"] > created_gt]
 
         if "starting_after" in query:
             starting_after = query["starting_after"][0]

--- a/posthog/temporal/tests/data_imports/stripe/test_stripe_source.py
+++ b/posthog/temporal/tests/data_imports/stripe/test_stripe_source.py
@@ -260,14 +260,14 @@ async def test_stripe_source_incremental(team, mock_stripe_api, external_data_so
     api_calls_made = mock_stripe_api.get_all_api_calls()
     assert len(api_calls_made) == 1
     assert parse_qs(urlparse(api_calls_made[0].url).query) == {
-        "created[gte]": ["0"],
+        "created[gt]": ["0"],
         "limit": ["100"],
     }
 
     mock_stripe_api.reset_max_created()
     # run the incremental sync
-    # we expect this to bring in 2 more rows but we actually sync one row twice since we use 'gte' in the query
-    expected_rows_synced = 3
+    # we expect this to bring in 2 more rows
+    expected_rows_synced = 2
     expected_total_rows = len(BALANCE_TRANSACTIONS)
 
     await _run_test(
@@ -284,6 +284,6 @@ async def test_stripe_source_incremental(team, mock_stripe_api, external_data_so
     # Check that the API was called once more
     assert len(api_calls_made) == 2
     assert parse_qs(urlparse(api_calls_made[1].url).query) == {
-        "created[gte]": [f"{third_item_created}"],
+        "created[gt]": [f"{third_item_created}"],
         "limit": ["100"],
     }


### PR DESCRIPTION
## Problem

At the moment we use `created[gte]` in the query params to the API call to Stripe. This means we always bring in a row that we've previously imported, as there is always one row that matches the timestamp from the previous import. It's not a big deal since we merge this in but it does unnecessarily import an extra row and is potentially confusing.

## Changes

Use `created[gt]` instead of `created[gte]` so that we only pull in new data.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Updated existing test (which highlighted this bug in the first place).

Ran locally to ensure number of rows before and after my change remains the same.
