### PR TITLE
refactor(snowflake-batch-export): Skip results when not needed

### DIFF
--- a/posthog/temporal/batch_exports/snowflake_batch_export.py
+++ b/posthog/temporal/batch_exports/snowflake_batch_export.py
@@ -325,7 +325,7 @@ class SnowflakeClient:
         self.ensure_snowflake_logger_level("DEBUG")
 
         await self.use_namespace()
-        await self.execute_async_query("SET ABORT_DETACHED_QUERY = FALSE")
+        await self.execute_async_query("SET ABORT_DETACHED_QUERY = FALSE", fetch_results=False)
 
         try:
             yield self
@@ -344,8 +344,8 @@ class SnowflakeClient:
 
         This allows all queries that follow to ignore database and schema.
         """
-        await self.execute_async_query(f'USE DATABASE "{self.database}"')
-        await self.execute_async_query(f'USE SCHEMA "{self.schema}"')
+        await self.execute_async_query(f'USE DATABASE "{self.database}"', fetch_results=False)
+        await self.execute_async_query(f'USE SCHEMA "{self.schema}"', fetch_results=False)
 
     async def execute_async_query(
         self,
@@ -353,7 +353,8 @@ class SnowflakeClient:
         parameters: dict | None = None,
         file_stream=None,
         poll_interval: float = 1.0,
-    ) -> tuple[list[tuple] | list[dict], list[ResultMetadata]]:
+        fetch_results: bool = True,
+    ) -> tuple[list[tuple] | list[dict], list[ResultMetadata]] | None:
         """Wrap Snowflake connector's polling API in a coroutine.
 
         This enables asynchronous execution of queries to release the event loop to execute other tasks
@@ -364,12 +365,16 @@ class SnowflakeClient:
             query: A query string to run asynchronously.
             parameters: An optional dictionary of parameters to bind to the query.
             poll_interval: Specify how long to wait in between polls.
+            fetch_results: Whether any result should be fetched from the query.
 
         Returns:
-            A tuple containing:
+            If `fetch_results` is `True`, a tuple containing:
             - The query results as a list of tuples or dicts
             - The cursor description (containing list of fields in result)
+            Else when `fetch_results` is `False` we return `None`.
         """
+        await self.logger.ainfo("Executing async query %s", query)
+
         with self.connection.cursor() as cursor:
             # Snowflake docs incorrectly state that the 'params' argument is named 'parameters'.
             result = await asyncio.to_thread(cursor.execute_async, query, params=parameters, file_stream=file_stream)
@@ -382,10 +387,20 @@ class SnowflakeClient:
             query_status = await asyncio.to_thread(self.connection.get_query_status_throw_if_error, query_id)
             await asyncio.sleep(poll_interval)
 
+        await self.logger.ainfo("Async query finished with status %s", query_status)
+
+        if fetch_results is False:
+            return None
+
+        await self.logger.ainfo("Fetching query results for %s", query)
+
         with self.connection.cursor() as cursor:
             await asyncio.to_thread(cursor.get_results_from_sfqid, query_id)
             results = await asyncio.to_thread(cursor.fetchall)
             description = cursor.description
+
+        await self.logger.ainfo("Finished fetching query results for %s", query)
+
         return results, description
 
     async def aremove_internal_stage_files(self, table_name: str, table_stage_prefix: str) -> None:
@@ -395,7 +410,7 @@ class SnowflakeClient:
             table_name: The name of the table whose internal stage to clear.
             table_stage_prefix: Prefix to path of internal stage files.
         """
-        await self.execute_async_query(f"""REMOVE '@%"{table_name}"/{table_stage_prefix}'""")
+        await self.execute_async_query(f"""REMOVE '@%"{table_name}"/{table_stage_prefix}'""", fetch_results=False)
 
     async def acreate_table(self, table_name: str, fields: list[SnowflakeField]) -> None:
         """Asynchronously create the table if it doesn't exist.
@@ -413,6 +428,7 @@ class SnowflakeClient:
             )
             COMMENT = 'PostHog generated table'
             """,
+            fetch_results=False,
         )
 
     async def adelete_table(
@@ -426,8 +442,7 @@ class SnowflakeClient:
         else:
             query = f'DROP TABLE "{table_name}"'
 
-        await self.execute_async_query(query)
-        return None
+        await self.execute_async_query(query, fetch_results=False)
 
     async def aget_table_columns(self, table_name: str) -> list[str]:
         """Get the column names for a given table.
@@ -439,9 +454,11 @@ class SnowflakeClient:
             A list of column names.
         """
         try:
-            _, metadata = await self.execute_async_query(f"""
+            result = await self.execute_async_query(f"""
                 SELECT * FROM "{table_name}" LIMIT 0
             """)
+            assert result is not None
+            _, metadata = result
         except snowflake.connector.errors.ProgrammingError as e:
             if "does not exist" in str(e):
                 raise SnowflakeTableNotFoundError(table_name)
@@ -512,7 +529,7 @@ class SnowflakeClient:
             await loop.run_in_executor(None, func=execute_put)
             reader.detach()  # BufferedReader closes the file otherwise.
 
-            result = cursor.fetchone()
+            result = await asyncio.to_thread(cursor.fetchone)
 
             if not isinstance(result, tuple):
                 # Mostly to appease mypy, as this query should always return a tuple.
@@ -542,7 +559,9 @@ class SnowflakeClient:
         MATCH_BY_COLUMN_NAME = CASE_SENSITIVE
         PURGE = TRUE
         """
-        results, _ = await self.execute_async_query(query)
+        result = await self.execute_async_query(query)
+        assert result is not None
+        results, _ = result
 
         for query_result in results:
             if not isinstance(query_result, tuple):
@@ -624,7 +643,7 @@ class SnowflakeClient:
             VALUES ({values});
         """
 
-        await self.execute_async_query(merge_query)
+        await self.execute_async_query(merge_query, fetch_results=False)
 
 
 def snowflake_default_fields() -> list[BatchExportField]:


### PR DESCRIPTION
# Problem

A lot queries we do in Snowflake do not require parsing results. For example we don't need the 'Statement executed successfully' result that comes from running "USE SCHEMA {schema}"; the result is immediately discarded. Moreover, fetching the results can be quite slow.

For this reason, we have made fetching results optional via the `fetch_result` parameter to `execute_async_query`. By default, we still fetch results, but a handful of queries have been marked as `fetch_results=False` and no longer incur that cost.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
