### PR TITLE
chore: Add jest rule to block expect(...).toBeDefined

### DIFF
--- a/common/eslint_rules/no-jest-to-be-defined.js
+++ b/common/eslint_rules/no-jest-to-be-defined.js
@@ -8,7 +8,7 @@ module.exports = {
             recommended: true,
         },
         messages: {
-            noToBeDefined: 'Do not use .toBeDefined() in tests, use .toBeTruthy() instead.',
+            noToBeDefined: 'Do not use .toBeDefined() in tests, use .toBeTruthy() or .not.toBeUndefined() instead.',
         },
         schema: [],
     },

--- a/common/eslint_rules/no-jest-to-be-defined.js
+++ b/common/eslint_rules/no-jest-to-be-defined.js
@@ -1,0 +1,34 @@
+module.exports = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description:
+                "Disallow use of jest's .toBeDefined() inside expect() calls. This is because expect(null).toBeDefined() will succeed, so if a function returns null this will count as being defined, which is probably not what you intended.",
+            category: 'Best Practices',
+            recommended: true,
+        },
+        messages: {
+            noToBeDefined: 'Do not use .toBeDefined() in tests, use .toBeTruthy() instead.',
+        },
+        schema: [],
+    },
+
+    create(context) {
+        return {
+            CallExpression(node) {
+                // Matches expect(...).toBeDefined()
+                if (
+                    node.callee?.type === 'MemberExpression' &&
+                    node.callee.property?.name === 'toBeDefined' &&
+                    node.callee.object?.type === 'CallExpression' &&
+                    node.callee.object.callee?.name === 'expect'
+                ) {
+                    context.report({
+                        node: node.callee.property,
+                        messageId: 'noToBeDefined',
+                    })
+                }
+            },
+        }
+    },
+}

--- a/frontend/src/lib/lemon-ui/LemonCalendar/LemonCalendar.test.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCalendar/LemonCalendar.test.tsx
@@ -31,13 +31,13 @@ describe('LemonCalendar', () => {
         expect(lemonCalendarWeeks.length).toBe(5)
 
         // find February 2020
-        expect(await within(calendar).findByText('February 2020')).toBeDefined()
+        expect(await within(calendar).findByText('February 2020')).toBeTruthy()
 
         // go to January 2020
         const previousMonth = getByDataAttr(container, 'lemon-calendar-month-previous')
         userEvent.click(previousMonth)
         expect(onLeftmostMonthChanged).toHaveBeenCalledWith(dayjs('2020-01-01'))
-        expect(await within(calendar).findByText('January 2020')).toBeDefined()
+        expect(await within(calendar).findByText('January 2020')).toBeTruthy()
 
         // click on 15
         let fifteenth = await within(container).findByText('15')
@@ -50,7 +50,7 @@ describe('LemonCalendar', () => {
         userEvent.click(nextMonth)
         expect(onLeftmostMonthChanged).toHaveBeenCalledWith(dayjs('2020-02-01'))
         expect(onLeftmostMonthChanged).toHaveBeenCalledWith(dayjs('2020-03-01'))
-        expect(await within(calendar).findByText('March 2020')).toBeDefined()
+        expect(await within(calendar).findByText('March 2020')).toBeTruthy()
 
         // click on 15
         fifteenth = await within(container).findByText('15') // the cell moved
@@ -77,15 +77,15 @@ describe('LemonCalendar', () => {
         const [cal1, cal2] = lemonCalendars
 
         // find February 2020
-        expect(await within(cal1).findByText('February 2020')).toBeDefined()
-        expect(await within(cal2).findByText('March 2020')).toBeDefined()
+        expect(await within(cal1).findByText('February 2020')).toBeTruthy()
+        expect(await within(cal2).findByText('March 2020')).toBeTruthy()
 
         // go to January 2020
         const previousMonth = getByDataAttr(container, 'lemon-calendar-month-previous')
         userEvent.click(previousMonth)
         expect(onLeftmostMonthChanged).toHaveBeenCalledWith(dayjs('2020-01-01'))
-        expect(await within(cal1).findByText('January 2020')).toBeDefined()
-        expect(await within(cal2).findByText('February 2020')).toBeDefined()
+        expect(await within(cal1).findByText('January 2020')).toBeTruthy()
+        expect(await within(cal2).findByText('February 2020')).toBeTruthy()
 
         // click on 15
         let fifteenth = await within(cal1).findByText('15')
@@ -98,8 +98,8 @@ describe('LemonCalendar', () => {
         userEvent.click(nextMonth)
         expect(onLeftmostMonthChanged).toHaveBeenCalledWith(dayjs('2020-02-01'))
         expect(onLeftmostMonthChanged).toHaveBeenCalledWith(dayjs('2020-03-01'))
-        expect(await within(cal1).findByText('March 2020')).toBeDefined()
-        expect(await within(cal2).findByText('April 2020')).toBeDefined()
+        expect(await within(cal1).findByText('March 2020')).toBeTruthy()
+        expect(await within(cal2).findByText('April 2020')).toBeTruthy()
 
         // click on 15
         fifteenth = await within(cal1).findByText('15') // the cell moved
@@ -123,7 +123,7 @@ describe('LemonCalendar', () => {
 
         const calendar = getByDataAttr(container, 'lemon-calendar')
         const thisMonth = dayjs().format('MMMM YYYY')
-        expect(await within(calendar).findByText(thisMonth)).toBeDefined()
+        expect(await within(calendar).findByText(thisMonth)).toBeTruthy()
     })
 
     test('calls getLemonButtonProps for each day', async () => {
@@ -181,7 +181,7 @@ describe('LemonCalendar', () => {
             [dayjs('2020-02-29'), { className: 'flex-col' }],
         ])
         const fourteen = getByDataAttr(container, 's6brap2ev')
-        expect(fourteen).toBeDefined()
+        expect(fourteen).toBeTruthy()
         expect(fourteen.className.split(' ')).toContain('yolo')
     })
 

--- a/frontend/src/lib/lemon-ui/LemonCalendar/LemonCalendarSelect.test.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCalendar/LemonCalendarSelect.test.tsx
@@ -84,10 +84,10 @@ describe('LemonCalendarSelect', () => {
 
         // find just one month
         const calendar = getByDataAttr(container, 'lemon-calendar')
-        expect(calendar).toBeDefined()
+        expect(calendar).toBeTruthy()
 
         // find February 2022
-        expect(await within(calendar).findByText('February 2022')).toBeDefined()
+        expect(await within(calendar).findByText('February 2022')).toBeTruthy()
 
         // click on 15
         await clickOnDate('15')

--- a/frontend/src/lib/lemon-ui/LemonCalendarRange/LemonCalendarRange.test.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCalendarRange/LemonCalendarRange.test.tsx
@@ -29,10 +29,10 @@ describe('LemonCalendarRange', () => {
 
         // find just one month
         const calendar = getByDataAttr(container, 'lemon-calendar')
-        expect(calendar).toBeDefined()
+        expect(calendar).toBeTruthy()
 
         // find February 2022
-        expect(await within(calendar).findByText('February 2022')).toBeDefined()
+        expect(await within(calendar).findByText('February 2022')).toBeTruthy()
 
         async function clickOn(day: string): Promise<void> {
             userEvent.click(await within(container).findByText(day))

--- a/plugin-server/functional_tests/analytics-ingestion/error-handling.test.ts
+++ b/plugin-server/functional_tests/analytics-ingestion/error-handling.test.ts
@@ -79,7 +79,7 @@ test.concurrent('consumer produces ingest warnings for messages over 1MB', async
                 return details.eventUuid === personEventUuid && details.distinctId === distinctId
             }
         })
-        expect(message).toBeDefined()
+        expect(message).toBeTruthy()
         return message
     })
 })

--- a/plugin-server/functional_tests/analytics-ingestion/happy-path.test.ts
+++ b/plugin-server/functional_tests/analytics-ingestion/happy-path.test.ts
@@ -195,7 +195,7 @@ test.concurrent(`event ingestion: handles $groupidentify with no properties`, as
 
     const event = await waitForExpect(async () => {
         const [event] = await fetchEvents(teamId, firstEventUuid)
-        expect(event).toBeDefined()
+        expect(event).toBeTruthy()
         return event
     })
 
@@ -583,7 +583,7 @@ test.concurrent(`event ingestion: initial login flow keeps the same person_id`, 
     await waitForExpect(async () => {
         const events = await fetchEvents(teamId)
         expect(events.length).toBe(2)
-        expect(events[0].person_id).toBeDefined()
+        expect(events[0].person_id).toBeTruthy()
         expect(events[0].person_id).not.toBe('00000000-0000-0000-0000-000000000000')
         expect(new Set(events.map((event) => event.person_id)).size).toBe(1)
     }, 10000)
@@ -623,7 +623,7 @@ test.concurrent(`events still ingested even if merge fails`, async () => {
     await waitForExpect(async () => {
         const events = await fetchEvents(teamId)
         expect(events.length).toBe(3)
-        expect(events[0].person_id).toBeDefined()
+        expect(events[0].person_id).toBeTruthy()
         expect(events[0].person_id).not.toBe('00000000-0000-0000-0000-000000000000')
         expect(new Set(events.map((event) => event.person_id)).size).toBe(2)
     }, 10000)
@@ -714,7 +714,7 @@ test.concurrent(`single merge results in all events resolving to the same person
     await waitForExpect(async () => {
         const events = await fetchEvents(teamId)
         expect(events.length).toBe(4)
-        expect(events[0].person_id).toBeDefined()
+        expect(events[0].person_id).toBeTruthy()
         expect(events[0].person_id).not.toBe('00000000-0000-0000-0000-000000000000')
         expect(new Set(events.map((event) => event.person_id)).size).toBe(1)
     }, 10000)
@@ -769,7 +769,7 @@ test.concurrent(`chained merge results in all events resolving to the same perso
     await waitForExpect(async () => {
         const events = await fetchEvents(teamId)
         expect(events.length).toBe(5)
-        expect(events[0].person_id).toBeDefined()
+        expect(events[0].person_id).toBeTruthy()
         expect(events[0].person_id).not.toBe('00000000-0000-0000-0000-000000000000')
         expect(new Set(events.map((event) => event.person_id)).size).toBe(1)
     }, 20000)
@@ -837,7 +837,7 @@ test.concurrent(`complex chained merge adds results in all events resolving to t
     await waitForExpect(async () => {
         const events = await fetchEvents(teamId)
         expect(events.length).toBe(7)
-        expect(events[0].person_id).toBeDefined()
+        expect(events[0].person_id).toBeTruthy()
         expect(events[0].person_id).not.toBe('00000000-0000-0000-0000-000000000000')
         expect(new Set(events.map((event) => event.person_id)).size).toBe(1)
     }, 20000)
@@ -993,9 +993,9 @@ test.skip(`person properties can't see properties from merge descendants`, async
         const [second] = await fetchEvents(teamId, secondUuid)
         const [third] = await fetchEvents(teamId, thirdUuid)
 
-        expect(first).toBeDefined()
-        expect(second).toBeDefined()
-        expect(third).toBeDefined()
+        expect(first).toBeTruthy()
+        expect(second).toBeTruthy()
+        expect(third).toBeTruthy()
 
         return [first, second, third]
     })

--- a/plugin-server/functional_tests/plugins.test.ts
+++ b/plugin-server/functional_tests/plugins.test.ts
@@ -322,7 +322,7 @@ test.concurrent(`plugin method tests: can drop events via processEvent`, async (
 
     await waitForExpect(async () => {
         const [event] = await fetchEvents(teamId, customEventUuid)
-        expect(event).toBeDefined()
+        expect(event).toBeTruthy()
     })
 
     const [event] = await fetchEvents(teamId, dropMeUuid)

--- a/plugin-server/src/cdp/legacy-plugins/_transformations/posthog-app-url-parameters-to-event-properties/index.test.ts
+++ b/plugin-server/src/cdp/legacy-plugins/_transformations/posthog-app-url-parameters-to-event-properties/index.test.ts
@@ -135,7 +135,7 @@ describe('ParamsToPropertiesPlugin', () => {
 
     describe('plugin.json', () => {
         it('should contain all properties of PluginConfig', () => {
-            expect(pluginJSON.config).toBeDefined()
+            expect(pluginJSON.config).toBeTruthy()
             if (pluginJSON.config) {
                 const fields = new Set<string>()
                 for (const item of pluginJSON.config) {
@@ -154,7 +154,7 @@ describe('ParamsToPropertiesPlugin', () => {
         })
 
         it('should match types of all properties of PluginConfig', () => {
-            expect(pluginJSON.config).toBeDefined()
+            expect(pluginJSON.config).toBeTruthy()
             if (pluginJSON.config) {
                 const fields = new Map<string, string>()
                 for (const item of pluginJSON.config) {
@@ -182,10 +182,10 @@ describe('ParamsToPropertiesPlugin', () => {
                 if (processedEvent.properties) {
                     expect(Object.keys(processedEvent.properties).length).toEqual(sourcePropertiesCount)
                 } else {
-                    expect(processedEvent.properties).toBeDefined()
+                    expect(processedEvent.properties).toBeTruthy()
                 }
             } else {
-                expect(sourceEvent.properties).toBeDefined()
+                expect(sourceEvent.properties).toBeTruthy()
             }
         })
 
@@ -193,7 +193,7 @@ describe('ParamsToPropertiesPlugin', () => {
             const sourceEvent = buildPageViewEvent('https://posthog.com/test?plugin=1&myUrlParameter=1')
 
             if (sourceEvent.properties) {
-                expect(sourceEvent.properties['myUrlParameter']).not.toBeDefined()
+                expect(sourceEvent.properties['myUrlParameter']).not.toBeTruthy()
                 expect(mockMeta.global.alwaysJson).toBeFalsy()
 
                 const sourcePropertiesCount = Object.keys(sourceEvent?.properties).length
@@ -202,13 +202,13 @@ describe('ParamsToPropertiesPlugin', () => {
                 if (processedEvent.properties) {
                     expect(Object.keys(processedEvent.properties).length).toBeGreaterThan(sourcePropertiesCount)
                     expect(Object.keys(processedEvent.properties).length).toEqual(sourcePropertiesCount + 1)
-                    expect(processedEvent.properties['myUrlParameter']).toBeDefined()
+                    expect(processedEvent.properties['myUrlParameter']).toBeTruthy()
                     expect(processedEvent.properties.myUrlParameter).toEqual('1')
                 } else {
-                    expect(processedEvent.properties).toBeDefined()
+                    expect(processedEvent.properties).toBeTruthy()
                 }
             } else {
-                expect(sourceEvent.properties).toBeDefined()
+                expect(sourceEvent.properties).toBeTruthy()
             }
         })
 
@@ -216,7 +216,7 @@ describe('ParamsToPropertiesPlugin', () => {
             const sourceEvent = buildPageViewEvent('https://posthog.com/test?plugin=1&myUrlParameter=1')
 
             if (sourceEvent.properties) {
-                expect(sourceEvent.properties['myUrlParameter']).not.toBeDefined()
+                expect(sourceEvent.properties['myUrlParameter']).not.toBeTruthy()
 
                 const sourcePropertiesCount = Object.keys(sourceEvent?.properties).length
                 const processedEvent = processEvent(
@@ -227,13 +227,13 @@ describe('ParamsToPropertiesPlugin', () => {
                 if (processedEvent.properties) {
                     expect(Object.keys(processedEvent.properties).length).toBeGreaterThan(sourcePropertiesCount)
                     expect(Object.keys(processedEvent.properties).length).toEqual(sourcePropertiesCount + 2)
-                    expect(processedEvent.properties['plugin']).toBeDefined()
-                    expect(processedEvent.properties['myUrlParameter']).toBeDefined()
+                    expect(processedEvent.properties['plugin']).toBeTruthy()
+                    expect(processedEvent.properties['myUrlParameter']).toBeTruthy()
                 } else {
-                    expect(processedEvent.properties).toBeDefined()
+                    expect(processedEvent.properties).toBeTruthy()
                 }
             } else {
-                expect(sourceEvent.properties).toBeDefined()
+                expect(sourceEvent.properties).toBeTruthy()
             }
         })
 
@@ -241,8 +241,8 @@ describe('ParamsToPropertiesPlugin', () => {
             const sourceEvent = buildPageViewEvent('https://posthog.com/test?plugin=1&myUrlParameter=1')
 
             if (sourceEvent.properties) {
-                expect(sourceEvent.properties['myUrlParameter']).not.toBeDefined()
-                expect(sourceEvent.properties['$set']).not.toBeDefined()
+                expect(sourceEvent.properties['myUrlParameter']).not.toBeTruthy()
+                expect(sourceEvent.properties['$set']).not.toBeTruthy()
 
                 const sourcePropertiesCount = Object.keys(sourceEvent?.properties).length
                 const processedEvent = processEvent(sourceEvent, buildMockMeta({ setAsUserProperties: 'true' }))
@@ -250,14 +250,14 @@ describe('ParamsToPropertiesPlugin', () => {
                 if (processedEvent.properties) {
                     expect(Object.keys(processedEvent.properties).length).toBeGreaterThan(sourcePropertiesCount)
                     expect(Object.keys(processedEvent.properties).length).toEqual(sourcePropertiesCount + 2)
-                    expect(processedEvent.properties['myUrlParameter']).toBeDefined()
-                    expect(processedEvent.properties['$set']).toBeDefined()
-                    expect(processedEvent.properties.$set['myUrlParameter']).toBeDefined()
+                    expect(processedEvent.properties['myUrlParameter']).toBeTruthy()
+                    expect(processedEvent.properties['$set']).toBeTruthy()
+                    expect(processedEvent.properties.$set['myUrlParameter']).toBeTruthy()
                 } else {
-                    expect(processedEvent.properties).toBeDefined()
+                    expect(processedEvent.properties).toBeTruthy()
                 }
             } else {
-                expect(sourceEvent.properties).toBeDefined()
+                expect(sourceEvent.properties).toBeTruthy()
             }
         })
 
@@ -265,8 +265,8 @@ describe('ParamsToPropertiesPlugin', () => {
             const sourceEvent = buildPageViewEvent('https://posthog.com/test?plugin=1&myUrlParameter=1')
 
             if (sourceEvent.properties) {
-                expect(sourceEvent.properties['myUrlParameter']).not.toBeDefined()
-                expect(sourceEvent.properties['$set_once']).not.toBeDefined()
+                expect(sourceEvent.properties['myUrlParameter']).not.toBeTruthy()
+                expect(sourceEvent.properties['$set_once']).not.toBeTruthy()
 
                 const sourcePropertiesCount = Object.keys(sourceEvent?.properties).length
                 const processedEvent = processEvent(sourceEvent, buildMockMeta({ setAsInitialUserProperties: 'true' }))
@@ -274,14 +274,14 @@ describe('ParamsToPropertiesPlugin', () => {
                 if (processedEvent.properties) {
                     expect(Object.keys(processedEvent.properties).length).toBeGreaterThan(sourcePropertiesCount)
                     expect(Object.keys(processedEvent.properties).length).toEqual(sourcePropertiesCount + 2)
-                    expect(processedEvent.properties['myUrlParameter']).toBeDefined()
-                    expect(processedEvent.properties['$set_once']).toBeDefined()
-                    expect(processedEvent.properties.$set_once['initial_myUrlParameter']).toBeDefined()
+                    expect(processedEvent.properties['myUrlParameter']).toBeTruthy()
+                    expect(processedEvent.properties['$set_once']).toBeTruthy()
+                    expect(processedEvent.properties.$set_once['initial_myUrlParameter']).toBeTruthy()
                 } else {
-                    expect(processedEvent.properties).toBeDefined()
+                    expect(processedEvent.properties).toBeTruthy()
                 }
             } else {
-                expect(sourceEvent.properties).toBeDefined()
+                expect(sourceEvent.properties).toBeTruthy()
             }
         })
 
@@ -289,9 +289,9 @@ describe('ParamsToPropertiesPlugin', () => {
             const sourceEvent = buildPageViewEvent('https://posthog.com/test?plugin=1&myUrlParameter=1')
 
             if (sourceEvent.properties) {
-                expect(sourceEvent.properties['myUrlParameter']).not.toBeDefined()
-                expect(sourceEvent.properties['$set']).not.toBeDefined()
-                expect(sourceEvent.properties['$set_once']).not.toBeDefined()
+                expect(sourceEvent.properties['myUrlParameter']).not.toBeTruthy()
+                expect(sourceEvent.properties['$set']).not.toBeTruthy()
+                expect(sourceEvent.properties['$set_once']).not.toBeTruthy()
 
                 const sourcePropertiesCount = Object.keys(sourceEvent?.properties).length
                 const processedEvent = processEvent(
@@ -302,16 +302,16 @@ describe('ParamsToPropertiesPlugin', () => {
                 if (processedEvent.properties) {
                     expect(Object.keys(processedEvent.properties).length).toBeGreaterThan(sourcePropertiesCount)
                     expect(Object.keys(processedEvent.properties).length).toEqual(sourcePropertiesCount + 3)
-                    expect(processedEvent.properties['myUrlParameter']).toBeDefined()
-                    expect(processedEvent.properties['$set']).toBeDefined()
-                    expect(processedEvent.properties['$set_once']).toBeDefined()
-                    expect(processedEvent.properties.$set['myUrlParameter']).toBeDefined()
-                    expect(processedEvent.properties.$set_once['initial_myUrlParameter']).toBeDefined()
+                    expect(processedEvent.properties['myUrlParameter']).toBeTruthy()
+                    expect(processedEvent.properties['$set']).toBeTruthy()
+                    expect(processedEvent.properties['$set_once']).toBeTruthy()
+                    expect(processedEvent.properties.$set['myUrlParameter']).toBeTruthy()
+                    expect(processedEvent.properties.$set_once['initial_myUrlParameter']).toBeTruthy()
                 } else {
-                    expect(processedEvent.properties).toBeDefined()
+                    expect(processedEvent.properties).toBeTruthy()
                 }
             } else {
-                expect(sourceEvent.properties).toBeDefined()
+                expect(sourceEvent.properties).toBeTruthy()
             }
         })
 

--- a/plugin-server/src/cdp/services/hog-executor.service.test.ts
+++ b/plugin-server/src/cdp/services/hog-executor.service.test.ts
@@ -171,7 +171,7 @@ describe('Hog Executor', () => {
 
             expect(result.finished).toBe(false)
             expect(result.invocation.queue).toBe('fetch')
-            expect(result.invocation.vmState).toBeDefined()
+            expect(result.invocation.vmState).toBeTruthy()
 
             // Simulate what the callback does
             setupFetchResponse(result.invocation)

--- a/plugin-server/src/cdp/services/legacy-plugin-executor.service.test.ts
+++ b/plugin-server/src/cdp/services/legacy-plugin-executor.service.test.ts
@@ -130,7 +130,7 @@ describe('LegacyPluginExecutorService', () => {
                 service.execute(createInvocation(fn, globals)),
             ])
 
-            expect(service['pluginState'][fn.id]).toBeDefined()
+            expect(service['pluginState'][fn.id]).toBeTruthy()
 
             expect(await results).toMatchObject([{ finished: true }, { finished: true }, { finished: true }])
 

--- a/plugin-server/src/ingestion/ai-costs/process-ai-event.test.ts
+++ b/plugin-server/src/ingestion/ai-costs/process-ai-event.test.ts
@@ -28,16 +28,16 @@ describe('processAiEvent()', () => {
     describe('event matching', () => {
         it('matches $ai_generation events', () => {
             const result = processAiEvent(event)
-            expect(result.properties!.$ai_total_cost_usd).toBeDefined()
-            expect(result.properties!.$ai_input_cost_usd).toBeDefined()
-            expect(result.properties!.$ai_output_cost_usd).toBeDefined()
+            expect(result.properties!.$ai_total_cost_usd).toBeTruthy()
+            expect(result.properties!.$ai_input_cost_usd).toBeTruthy()
+            expect(result.properties!.$ai_output_cost_usd).toBeTruthy()
         })
 
         it('matches $ai_embedding events', () => {
             event.event = '$ai_embedding'
             const result = processAiEvent(event)
-            expect(result.properties!.$ai_total_cost_usd).toBeDefined()
-            expect(result.properties!.$ai_input_cost_usd).toBeDefined()
+            expect(result.properties!.$ai_total_cost_usd).toBeTruthy()
+            expect(result.properties!.$ai_input_cost_usd).toBeTruthy()
             expect(result.properties!.$ai_output_cost_usd).toBeDefined()
         })
 

--- a/plugin-server/src/ingestion/cookieless/cookieless-manager.test.ts
+++ b/plugin-server/src/ingestion/cookieless/cookieless-manager.test.ts
@@ -285,7 +285,7 @@ describe('CookielessManager', () => {
                 }
                 expect(actual.distinct_id).not.toEqual(COOKIELESS_SENTINEL_VALUE)
                 expect(actual.distinct_id.startsWith('cookieless_')).toBe(true)
-                expect(actual.properties.$session_id).toBeDefined()
+                expect(actual.properties.$session_id).toBeTruthy()
             })
             it('should give the same session id and distinct id to events with the same hash properties and within the same day and session timeout period', async () => {
                 const actual1 = await hub.cookielessManager.processEvent(event)

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.test.ts
@@ -1332,7 +1332,7 @@ describe('SessionBatchRecorder', () => {
 
             // All sessions should have the same batch ID
             const batchId = storedBlocks[0].batchId
-            expect(batchId).toBeDefined()
+            expect(batchId).toBeTruthy()
             expect(typeof batchId).toBe('string')
             expect(storedBlocks[1].batchId).toBe(batchId)
         })

--- a/plugin-server/src/utils/geoip.test.ts
+++ b/plugin-server/src/utils/geoip.test.ts
@@ -26,7 +26,7 @@ describe('GeoIp', () => {
     describe('from disk', () => {
         it('should load the mmdb from disk if set', async () => {
             const geoip = await service.get()
-            expect(geoip).toBeDefined()
+            expect(geoip).toBeTruthy()
             commonCheck(geoip)
         })
 
@@ -53,7 +53,7 @@ describe('GeoIp', () => {
         it('should not refresh the mmdb if there is no metadata', async () => {
             jest.spyOn(service as any, 'loadMmdbMetadata').mockResolvedValue(undefined)
             const geoip = await service.get()
-            expect(geoip).toBeDefined()
+            expect(geoip).toBeTruthy()
             expect(service['_mmdbMetadata']).toBeUndefined()
             expect(jest.mocked(service['loadMmdb'])).toHaveBeenCalledTimes(1)
 
@@ -71,7 +71,7 @@ describe('GeoIp', () => {
                 date: '2025-01-01',
             })
             const geoip = await service.get()
-            expect(geoip).toBeDefined()
+            expect(geoip).toBeTruthy()
             expect(service['_mmdbMetadata']).toEqual({ date: '2025-01-01' })
             expect(jest.mocked(service['loadMmdb'])).toHaveBeenCalledTimes(1)
 
@@ -85,7 +85,7 @@ describe('GeoIp', () => {
                 date: '2025-01-01',
             })
             const geoip = await service.get()
-            expect(geoip).toBeDefined()
+            expect(geoip).toBeTruthy()
             expect(service['_mmdbMetadata']).toEqual({ date: '2025-01-01' })
             expect(jest.mocked(service['loadMmdb'])).toHaveBeenCalledTimes(1)
 

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
@@ -178,8 +178,8 @@ describe.each([[true], [false]])('ingester with consumeOverflow=%p', (consumeOve
         ingester.partitionMetrics[1] = { lastMessageTimestamp: 1000000, offsetLag: 0 }
 
         expect(Object.keys(ingester.sessions).length).toBe(2)
-        expect(ingester.sessions['2-sid1-throw']).toBeDefined()
-        expect(ingester.sessions['2-sid2']).toBeDefined()
+        expect(ingester.sessions['2-sid1-throw']).toBeTruthy()
+        expect(ingester.sessions['2-sid2']).toBeTruthy()
 
         await expect(() => ingester.flushAllReadySessions(noop)).rejects.toThrow(
             'Failed to flush sessions. With 1 errors out of 2 sessions.'
@@ -237,7 +237,7 @@ describe.each([[true], [false]])('ingester with consumeOverflow=%p', (consumeOve
             await ingester.consume(event)
             await waitForExpect(() => {
                 expect(Object.keys(ingester.sessions).length).toBe(1)
-                expect(ingester.sessions['1-session_id_1']).toBeDefined()
+                expect(ingester.sessions['1-session_id_1']).toBeTruthy()
             })
         })
 
@@ -246,13 +246,13 @@ describe.each([[true], [false]])('ingester with consumeOverflow=%p', (consumeOve
             await ingester.consume(createIncomingRecordingMessage({ team_id: 2, session_id: 'session_id_2' }))
 
             expect(Object.keys(ingester.sessions).length).toBe(2)
-            expect(ingester.sessions['2-session_id_1']).toBeDefined()
-            expect(ingester.sessions['2-session_id_2']).toBeDefined()
+            expect(ingester.sessions['2-session_id_1']).toBeTruthy()
+            expect(ingester.sessions['2-session_id_2']).toBeTruthy()
 
             await ingester.destroySessions([['2-session_id_1', ingester.sessions['2-session_id_1']]])
 
             expect(Object.keys(ingester.sessions).length).toBe(1)
-            expect(ingester.sessions['2-session_id_2']).toBeDefined()
+            expect(ingester.sessions['2-session_id_2']).toBeTruthy()
         })
 
         it('handles multiple incoming sessions', async () => {
@@ -262,8 +262,8 @@ describe.each([[true], [false]])('ingester with consumeOverflow=%p', (consumeOve
             })
             await Promise.all([ingester.consume(event), ingester.consume(event2)])
             expect(Object.keys(ingester.sessions).length).toBe(2)
-            expect(ingester.sessions['1-session_id_1']).toBeDefined()
-            expect(ingester.sessions['1-session_id_2']).toBeDefined()
+            expect(ingester.sessions['1-session_id_1']).toBeTruthy()
+            expect(ingester.sessions['1-session_id_2']).toBeTruthy()
         })
 
         // This test is flaky and no-one has time to look into it https://posthog.slack.com/archives/C0460HY55M0/p1696437876690329
@@ -273,7 +273,7 @@ describe.each([[true], [false]])('ingester with consumeOverflow=%p', (consumeOve
                 session_id: sessionId,
             })
             await ingester.consume(event)
-            expect(ingester.sessions[`1-${sessionId}`]).toBeDefined()
+            expect(ingester.sessions[`1-${sessionId}`]).toBeTruthy()
             // Force the flush
             ingester.partitionMetrics[event.metadata.partition] = {
                 lastMessageTimestamp: Date.now() + defaultConfig.SESSION_RECORDING_MAX_BUFFER_AGE_SECONDS,
@@ -282,7 +282,7 @@ describe.each([[true], [false]])('ingester with consumeOverflow=%p', (consumeOve
             await ingester.flushAllReadySessions(noop)
 
             await waitForExpect(() => {
-                expect(ingester.sessions[`1-${sessionId}`]).not.toBeDefined()
+                expect(ingester.sessions[`1-${sessionId}`]).not.toBeTruthy()
             }, 10000)
         })
 

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -645,7 +645,7 @@ test('anonymized ip capture', async () => {
     )
 
     const [event] = await hub.db.fetchEvents()
-    expect(event.properties['$ip']).not.toBeDefined()
+    expect(event.properties['$ip']).not.toBeTruthy()
 })
 
 test('merge_dangerously', async () => {
@@ -1662,7 +1662,7 @@ describe('validates eventUuid', () => {
         const runner = new EventPipelineRunner(hub, pluginEvent)
         const result = await runner.runEventPipeline(pluginEvent)
 
-        expect(result.error).toBeDefined()
+        expect(result.error).toBeTruthy()
         expect(result.error).toEqual('Not a valid UUID: "i_am_not_a_uuid"')
     })
     test('null value in eventUUID returns an error', async () => {
@@ -1681,7 +1681,7 @@ describe('validates eventUuid', () => {
         const runner = new EventPipelineRunner(hub, pluginEvent)
         const result = await runner.runEventPipeline(pluginEvent)
 
-        expect(result.error).toBeDefined()
+        expect(result.error).toBeTruthy()
         expect(result.error).toEqual('Not a valid UUID: "null"')
     })
 })

--- a/plugin-server/tests/worker/ingestion/event-pipeline/event-pipeline-integration.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/event-pipeline-integration.test.ts
@@ -306,7 +306,7 @@ describe('Event Pipeline integration test', () => {
         }
         expect(events.length).toEqual(2)
         expect(events[0].distinct_id.slice(0, 11)).toEqual('cookieless_') // should have set a distict id
-        expect(events[0].properties.$session_id).toBeDefined() // should have set a session id
+        expect(events[0].properties.$session_id).toBeTruthy() // should have set a session id
         expect(events[0].properties.$raw_user_agent).toBeUndefined() // should have removed personal data
         expect(events[0].distinct_id).toEqual(events[1].distinct_id) // events with the same hash should be assigned to the same user
         expect(events[0].properties.$session_id).toEqual(events[1].properties.$session_id)

--- a/plugin-server/tests/worker/plugins.test.ts
+++ b/plugin-server/tests/worker/plugins.test.ts
@@ -76,15 +76,15 @@ describe('plugins', () => {
                 contents: pluginAttachment1.contents,
             },
         })
-        expect(pluginConfig.instance).toBeDefined()
+        expect(pluginConfig.instance).toBeTruthy()
         const instance = pluginConfig.instance!
 
-        expect(instance.getPluginMethod('composeWebhook')).toBeDefined()
-        expect(instance.getPluginMethod('getSettings')).toBeDefined()
-        expect(instance.getPluginMethod('onEvent')).toBeDefined()
-        expect(instance.getPluginMethod('processEvent')).toBeDefined()
-        expect(instance.getPluginMethod('setupPlugin')).toBeDefined()
-        expect(instance.getPluginMethod('teardownPlugin')).toBeDefined()
+        expect(instance.getPluginMethod('composeWebhook')).toBeTruthy()
+        expect(instance.getPluginMethod('getSettings')).toBeTruthy()
+        expect(instance.getPluginMethod('onEvent')).toBeTruthy()
+        expect(instance.getPluginMethod('processEvent')).toBeTruthy()
+        expect(instance.getPluginMethod('setupPlugin')).toBeTruthy()
+        expect(instance.getPluginMethod('teardownPlugin')).toBeTruthy()
 
         // async loading of capabilities
         expect(setPluginCapabilities).toHaveBeenCalled()
@@ -132,8 +132,8 @@ describe('plugins', () => {
         expect(pluginConfigTeam1.plugin).toEqual(plugin)
         expect(pluginConfigTeam2.plugin).toEqual(plugin)
 
-        expect(pluginConfigTeam1.instance).toBeDefined()
-        expect(pluginConfigTeam2.instance).toBeDefined()
+        expect(pluginConfigTeam1.instance).toBeTruthy()
+        expect(pluginConfigTeam2.instance).toBeTruthy()
 
         expect(pluginConfigTeam1.instance).toEqual(pluginConfigTeam2.instance)
     })

--- a/plugin-server/tests/worker/vm-recorded-fetch.test.ts
+++ b/plugin-server/tests/worker/vm-recorded-fetch.test.ts
@@ -191,7 +191,7 @@ describe('VM with recorded fetch', () => {
         expect(recordedCalls[0].request.url).toBe('https://example.com/api/error')
         expect(recordedCalls[0].response.status).toBe(0)
         expect(recordedCalls[0].response.statusText).toBe('Network error')
-        expect(recordedCalls[0].error).toBeDefined()
+        expect(recordedCalls[0].error).toBeTruthy()
         expect(recordedCalls[0].error!.message).toBe('Network error')
     })
 
@@ -206,7 +206,7 @@ describe('VM with recorded fetch', () => {
                 // First, fetch user data
                 const userResponse = await fetch('https://example.com/api/users/' + event.distinct_id)
                 const userData = await userResponse.json()
-                
+
                 // Then use the user data to make a second request
                 const analyticsResponse = await fetch('https://example.com/api/analytics', {
                     method: 'POST',
@@ -220,12 +220,12 @@ describe('VM with recorded fetch', () => {
                         timestamp: new Date().toISOString()
                     })
                 })
-                
+
                 // Add the user data to the event properties
                 event.properties.user_id = userData.id
                 event.properties.user_name = userData.name
                 event.properties.user_email = userData.email
-                
+
                 return event
             }
         `
@@ -285,7 +285,7 @@ describe('VM with recorded fetch', () => {
                 await fetch('https://example.com/api/direct-json', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: { 
+                    body: {
                         eventName: event.event,
                         properties: event.properties,
                         timestamp: new Date().toISOString()


### PR DESCRIPTION
## Problem

I found a bug where someone was using expect(x).toBeDefined(), but x was null, and the test was not failing (even though it should have been).

It's easy to make a lint rule so let's just do that.

This was where I fixed the bug: https://github.com/PostHog/posthog/pull/29369

## Changes
Add a lint rule so that people use .toBeTruthy() instead, or if they really want to they can use .not.toBeUndefined() which is identical and IMO much clearer about how null is treated.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
Updated the tests that used .toBeDefined()