### PR TITLE
feat: implement optional layered cache with redis

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4629,6 +4629,7 @@ version = "0.1.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
+ "async-stream",
  "async-trait",
  "axum 0.7.9",
  "chrono",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3810,9 +3810,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c28b3fb6d753d28c20e826cd46ee611fda1cf3cde03a443a974043247c065a"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
 dependencies = [
  "cfg-if",
  "downcast",
@@ -3824,9 +3824,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "341014e7f530314e9a1fdbc7400b244efea7122662c96bfa248c31da5bfb2020"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
 dependencies = [
  "cfg-if",
  "proc-macro2",
@@ -4614,6 +4614,7 @@ dependencies = [
  "futures",
  "health",
  "metrics",
+ "mockall",
  "quick_cache",
  "rand",
  "redis 0.29.2",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -152,6 +152,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1250,7 +1256,7 @@ dependencies = [
  "opentelemetry_sdk",
  "rand",
  "rdkafka",
- "redis",
+ "redis 0.23.3",
  "reqwest 0.12.3",
  "serde",
  "serde_json",
@@ -1490,7 +1496,7 @@ name = "common-redis"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "redis",
+ "redis 0.23.3",
  "serde-pickle",
  "thiserror 1.0.69",
  "tokio",
@@ -2257,7 +2263,7 @@ dependencies = [
  "once_cell",
  "petgraph",
  "rand",
- "redis",
+ "redis 0.23.3",
  "regex",
  "reqwest 0.12.3",
  "rstest",
@@ -3947,9 +3953,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -4601,6 +4607,7 @@ dependencies = [
  "metrics",
  "quick_cache",
  "rand",
+ "redis 0.29.2",
  "regex",
  "serde",
  "serde_json",
@@ -4864,6 +4871,23 @@ dependencies = [
  "socket2 0.4.10",
  "tokio",
  "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "redis"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b110459d6e323b7cda23980c46c77157601199c9da6241552b284cd565a7a133"
+dependencies = [
+ "arc-swap",
+ "combine",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.5.5",
  "url",
 ]
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1988,6 +1988,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2335,6 +2341,15 @@ checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
  "miniz_oxide 0.8.0",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3950,6 +3965,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4556,12 +4577,16 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "predicates"
-version = "3.1.2"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]
@@ -4615,6 +4640,7 @@ dependencies = [
  "health",
  "metrics",
  "mockall",
+ "predicates",
  "quick_cache",
  "rand",
  "redis 0.29.2",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -844,19 +844,19 @@ dependencies = [
  "rustversion",
  "serde",
  "sync_wrapper 0.1.2",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum"
-version = "0.7.5"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core 0.4.3",
+ "axum-core 0.4.5",
  "axum-macros",
  "bytes",
  "futures-util",
@@ -878,7 +878,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
  "tokio",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -890,7 +890,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72188bed20deb981f3a4a9fe674e5980fd9e9c2bd880baa94715ad5d60d64c67"
 dependencies = [
- "axum 0.7.5",
+ "axum 0.7.9",
  "forwarded-header-value",
  "serde",
 ]
@@ -914,9 +914,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
 dependencies = [
  "async-trait",
  "bytes",
@@ -927,7 +927,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 0.1.2",
+ "sync_wrapper 1.0.1",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -935,11 +935,10 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c055ee2d014ae5981ce1016374e8213682aa14d9bf40e48ab48b5f3ef20eaa"
+checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
 dependencies = [
- "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.89",
@@ -950,7 +949,7 @@ name = "axum-test-helper"
 version = "0.4.0"
 source = "git+https://github.com/posthog/axum-test-helper.git#002d45d8bbbac04e6a474e9a850b7f023a87d32f"
 dependencies = [
- "axum 0.7.5",
+ "axum 0.7.9",
  "bytes",
  "http 1.1.0",
  "http-body 1.0.0",
@@ -958,8 +957,17 @@ dependencies = [
  "reqwest 0.11.24",
  "serde",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tower-service",
+]
+
+[[package]]
+name = "backon"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "970d91570c01a8a5959b36ad7dd1c30642df24b6b3068710066f6809f7033bb7"
+dependencies = [
+ "fastrand 2.2.0",
 ]
 
 [[package]]
@@ -1039,7 +1047,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-s3",
- "axum 0.7.5",
+ "axum 0.7.9",
  "base64 0.22.0",
  "celes",
  "chrono",
@@ -1234,7 +1242,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-s3",
- "axum 0.7.5",
+ "axum 0.7.9",
  "axum-client-ip",
  "axum-test-helper",
  "base64 0.22.0",
@@ -1264,7 +1272,7 @@ dependencies = [
  "thiserror 1.0.69",
  "time",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tower-http",
  "tracing",
  "tracing-opentelemetry",
@@ -1485,7 +1493,7 @@ dependencies = [
 name = "common-metrics"
 version = "0.1.0"
 dependencies = [
- "axum 0.7.5",
+ "axum 0.7.9",
  "metrics",
  "metrics-exporter-prometheus",
  "tokio",
@@ -1727,7 +1735,7 @@ dependencies = [
 name = "cyclotron-fetch"
 version = "0.1.0"
 dependencies = [
- "axum 0.7.5",
+ "axum 0.7.9",
  "chrono",
  "common-alloc",
  "common-dns",
@@ -1757,7 +1765,7 @@ dependencies = [
 name = "cyclotron-janitor"
 version = "0.1.0"
 dependencies = [
- "axum 0.7.5",
+ "axum 0.7.9",
  "chrono",
  "common-alloc",
  "common-kafka",
@@ -1796,7 +1804,7 @@ version = "0.1.0"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",
- "axum 0.7.5",
+ "axum 0.7.9",
  "base64 0.22.0",
  "chrono",
  "common-alloc",
@@ -2241,7 +2249,7 @@ dependencies = [
  "anyhow",
  "assert-json-diff",
  "async-trait",
- "axum 0.7.5",
+ "axum 0.7.9",
  "axum-client-ip",
  "base64 0.22.0",
  "bytes",
@@ -2276,7 +2284,7 @@ dependencies = [
  "strum",
  "thiserror 1.0.69",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -2426,9 +2434,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2436,9 +2444,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
@@ -2464,9 +2472,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -2498,9 +2506,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2509,15 +2517,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-timer"
@@ -2527,9 +2535,9 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2740,7 +2748,7 @@ dependencies = [
 name = "health"
 version = "0.1.0"
 dependencies = [
- "axum 0.7.5",
+ "axum 0.7.9",
  "time",
  "tokio",
  "tracing",
@@ -2807,7 +2815,7 @@ dependencies = [
 name = "hook-api"
 version = "0.1.0"
 dependencies = [
- "axum 0.7.5",
+ "axum 0.7.9",
  "common-alloc",
  "common-metrics",
  "envconfig",
@@ -2820,7 +2828,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -2849,7 +2857,7 @@ name = "hook-janitor"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "axum 0.7.5",
+ "axum 0.7.9",
  "common-alloc",
  "common-kafka",
  "common-metrics",
@@ -2874,7 +2882,7 @@ dependencies = [
 name = "hook-worker"
 version = "0.1.0"
 dependencies = [
- "axum 0.7.5",
+ "axum 0.7.9",
  "chrono",
  "common-alloc",
  "common-dns",
@@ -3113,7 +3121,7 @@ dependencies = [
  "pin-project-lite",
  "socket2 0.5.5",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tower-service",
  "tracing",
 ]
@@ -4596,7 +4604,8 @@ version = "0.1.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
- "axum 0.7.5",
+ "async-trait",
+ "axum 0.7.9",
  "chrono",
  "common-alloc",
  "common-kafka",
@@ -4881,13 +4890,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b110459d6e323b7cda23980c46c77157601199c9da6241552b284cd565a7a133"
 dependencies = [
  "arc-swap",
+ "backon",
+ "bytes",
  "combine",
+ "futures-channel",
+ "futures-util",
  "itoa",
  "num-bigint",
  "percent-encoding",
+ "pin-project-lite",
  "ryu",
  "sha1_smol",
  "socket2 0.5.5",
+ "tokio",
+ "tokio-util",
  "url",
 ]
 
@@ -5538,7 +5554,7 @@ dependencies = [
 name = "serve-metrics"
 version = "0.1.0"
 dependencies = [
- "axum 0.7.5",
+ "axum 0.7.9",
  "metrics",
  "metrics-exporter-prometheus",
  "tokio",
@@ -6687,7 +6703,7 @@ dependencies = [
  "prost",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6714,6 +6730,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 1.0.1",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower-http"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6732,15 +6764,15 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -44,7 +44,7 @@ enum_glob_use = "deny"
 anyhow = "1.0"
 assert-json-diff = "2.0.2"
 async-trait = "0.1.74"
-axum = { version = "0.7.5", features = ["http2", "macros", "matched-path"] }
+axum = { version = "0.7.9", features = ["http2", "macros", "matched-path"] }
 axum-client-ip = "0.6.0"
 base64 = "0.22.0"
 bytes = "1"
@@ -107,7 +107,7 @@ mockall = "0.13.0"
 moka = { version = "0.12.8", features = ["sync", "future"] }
 posthog-rs = { version = "0.3.5", features = ["async-client"] }
 regex = "1.11.1"
-redis = "0.29.2"
+redis = { version = "0.29.2", features = ["tokio-comp", "connection-manager"] }
 
 # Used for decrypting django encrypted fields
 fernet = "0.2"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -107,6 +107,7 @@ mockall = "0.13.0"
 moka = { version = "0.12.8", features = ["sync", "future"] }
 posthog-rs = { version = "0.3.5", features = ["async-client"] }
 regex = "1.11.1"
+redis = "0.29.2"
 
 # Used for decrypting django encrypted fields
 fernet = "0.2"

--- a/rust/property-defs-rs/Cargo.toml
+++ b/rust/property-defs-rs/Cargo.toml
@@ -31,6 +31,7 @@ thiserror.workspace = true
 regex.workspace = true
 redis = { workspace = true }
 async-trait = "0.1.77"
+async-stream = "0.3.5"
 
 [dev-dependencies]
 mockall = "0.13.1"

--- a/rust/property-defs-rs/Cargo.toml
+++ b/rust/property-defs-rs/Cargo.toml
@@ -30,6 +30,7 @@ anyhow = { workspace = true }
 thiserror.workspace = true
 regex.workspace = true
 redis = { workspace = true }
+async-trait = "0.1.77"
 
 [lints]
 workspace = true

--- a/rust/property-defs-rs/Cargo.toml
+++ b/rust/property-defs-rs/Cargo.toml
@@ -29,6 +29,7 @@ rand = { workspace = true }
 anyhow = { workspace = true }
 thiserror.workspace = true
 regex.workspace = true
+redis = { workspace = true }
 
 [lints]
 workspace = true

--- a/rust/property-defs-rs/Cargo.toml
+++ b/rust/property-defs-rs/Cargo.toml
@@ -34,6 +34,7 @@ async-trait = "0.1.77"
 
 [dev-dependencies]
 mockall = "0.13.1"
+predicates = "3.1.3"
 
 [lints]
 workspace = true

--- a/rust/property-defs-rs/Cargo.toml
+++ b/rust/property-defs-rs/Cargo.toml
@@ -32,5 +32,8 @@ regex.workspace = true
 redis = { workspace = true }
 async-trait = "0.1.77"
 
+[dev-dependencies]
+mockall = "0.13.1"
+
 [lints]
 workspace = true

--- a/rust/property-defs-rs/src/cache/layered_cache.rs
+++ b/rust/property-defs-rs/src/cache/layered_cache.rs
@@ -22,9 +22,9 @@ impl<S: SecondaryCacheOperations> LayeredCache<S> {
 
         for key in &keys {
             if self.memory.get(key).is_none() {
+                self.memory.insert(key.clone(), ());
                 new_keys.push(key.clone());
             }
-            self.memory.insert(key.clone(), ());
         }
 
         if !new_keys.is_empty() {

--- a/rust/property-defs-rs/src/cache/layered_cache.rs
+++ b/rust/property-defs-rs/src/cache/layered_cache.rs
@@ -4,7 +4,8 @@ use crate::types::Update;
 use crate::errors::CacheError;
 use crate::cache::secondary_cache::SecondaryCacheOperations;
 use crate::cache::secondary_cache::SecondaryCache;
-use tracing::warn;
+use futures::Stream;
+use std::pin::Pin;
 
 #[derive(Clone)]
 pub struct LayeredCache<S: SecondaryCacheOperations = SecondaryCache> {
@@ -17,7 +18,7 @@ impl<S: SecondaryCacheOperations> LayeredCache<S> {
         Self { memory, secondary }
     }
 
-    pub async fn insert_batch(&self, keys: Vec<Update>) {
+    pub async fn insert_batch(&self, keys: Vec<Update>) -> Result<(), CacheError> {
         let mut new_keys = Vec::new();
 
         for key in &keys {
@@ -28,15 +29,12 @@ impl<S: SecondaryCacheOperations> LayeredCache<S> {
         }
 
         if !new_keys.is_empty() {
-            match self.secondary.insert_batch(&new_keys).await {
-                Ok(()) => (),
-                Err(CacheError::NotSupported) => (),
-                Err(e) => warn!("Failed to insert batch into secondary cache: {}", e),
-            }
+            self.secondary.insert_batch(&new_keys).await?;
         }
+        Ok(())
     }
 
-    pub async fn filter_cached_updates(&self, updates: Vec<Update>) -> Vec<Update> {
+    pub async fn filter_cached_updates(&self, updates: Vec<Update>) -> Pin<Box<dyn Stream<Item = Update> + Send + '_>> {
         let mut check_secondary = Vec::new();
 
         // First pass: check memory cache and collect items not in memory
@@ -47,18 +45,12 @@ impl<S: SecondaryCacheOperations> LayeredCache<S> {
         }
 
         if check_secondary.is_empty() {
-            return check_secondary;
+            return Box::pin(futures::stream::empty());
         }
 
         // Second pass: check secondary cache
-        match self.secondary.filter_cached_updates(&check_secondary).await {
-            Ok(not_in_cache) => not_in_cache,
-            Err(CacheError::NotSupported) => check_secondary,
-            Err(e) => {
-                warn!("Failed to check secondary cache: {}", e);
-                check_secondary
-            }
-        }
+        let secondary_stream = self.secondary.filter_cached_updates(check_secondary).await;
+        Box::pin(secondary_stream)
     }
 
     pub fn len(&self) -> usize {

--- a/rust/property-defs-rs/src/cache/layered_cache.rs
+++ b/rust/property-defs-rs/src/cache/layered_cache.rs
@@ -2,17 +2,18 @@ use std::sync::Arc;
 use quick_cache::sync::Cache as InMemoryCache;
 use crate::types::Update;
 use crate::errors::CacheError;
-use super::{SecondaryCache, CacheOperations};
+use crate::cache::secondary_cache::SecondaryCacheOperations;
+use crate::cache::secondary_cache::SecondaryCache;
 use tracing::warn;
 
 #[derive(Clone)]
-pub struct LayeredCache {
+pub struct LayeredCache<S: SecondaryCacheOperations = SecondaryCache> {
     memory: Arc<InMemoryCache<Update, ()>>,
-    secondary: SecondaryCache,
+    secondary: S,
 }
 
-impl LayeredCache {
-    pub fn new(memory: Arc<InMemoryCache<Update, ()>>, secondary: SecondaryCache) -> Self {
+impl<S: SecondaryCacheOperations> LayeredCache<S> {
+    pub fn new(memory: Arc<InMemoryCache<Update, ()>>, secondary: S) -> Self {
         Self { memory, secondary }
     }
 
@@ -66,63 +67,5 @@ impl LayeredCache {
 
     pub fn remove(&self, key: &Update) -> Option<()> {
         self.memory.remove(key).map(|_| ())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::cache::noop_cache::NoOpCache;
-    use crate::types::{Update, EventDefinition};
-    use chrono::Utc;
-
-    #[tokio::test]
-    async fn test_layered_cache_basic() {
-        let memory = Arc::new(InMemoryCache::new(1000));
-        let secondary = SecondaryCache::NoOp(NoOpCache::new());
-        let cache = LayeredCache::new(memory, secondary);
-
-        let events: Vec<Update> = (0..3)
-            .map(|i| {
-                Update::Event(EventDefinition {
-                    name: format!("test_{}", i),
-                    team_id: 1,
-                    project_id: 1,
-                    last_seen_at: Utc::now(),
-                })
-            })
-            .collect();
-
-        // First insert the events
-        cache.insert_batch(events.clone()).await;
-
-        // Then verify none of them are returned by filter_cached_updates
-        let not_in_cache = cache.filter_cached_updates(events.clone()).await;
-        assert_eq!(not_in_cache.len(), 0);
-    }
-
-    #[tokio::test]
-    async fn test_layered_cache_large() {
-        let memory = Arc::new(InMemoryCache::new(10000));
-        let secondary = SecondaryCache::NoOp(NoOpCache::new());
-        let cache = LayeredCache::new(memory, secondary);
-
-        let events: Vec<Update> = (0..3)
-            .map(|i| {
-                Update::Event(EventDefinition {
-                    name: format!("test_{}", i),
-                    team_id: 1,
-                    project_id: 1,
-                    last_seen_at: Utc::now(),
-                })
-            })
-            .collect();
-
-        // First insert the events
-        cache.insert_batch(events.clone()).await;
-
-        // Then verify none of them are returned by filter_cached_updates
-        let not_in_cache = cache.filter_cached_updates(events.clone()).await;
-        assert_eq!(not_in_cache.len(), 0);
     }
 }

--- a/rust/property-defs-rs/src/cache/layered_cache.rs
+++ b/rust/property-defs-rs/src/cache/layered_cache.rs
@@ -47,7 +47,7 @@ impl<S: SecondaryCacheOperations> LayeredCache<S> {
         }
 
         if check_secondary.is_empty() {
-            return Vec::new();
+            return check_secondary;
         }
 
         // Second pass: check secondary cache

--- a/rust/property-defs-rs/src/cache/layered_cache.rs
+++ b/rust/property-defs-rs/src/cache/layered_cache.rs
@@ -1,0 +1,117 @@
+use std::sync::Arc;
+use quick_cache::sync::Cache as InMemoryCache;
+use crate::types::Update;
+use super::secondary_cache::SecondaryCache;
+use tracing::warn;
+
+pub struct LayeredCache<T: SecondaryCache> {
+    memory: Arc<InMemoryCache<Update, ()>>,
+    secondary: T,
+}
+
+impl<T: SecondaryCache> LayeredCache<T> {
+    pub fn new(memory: Arc<InMemoryCache<Update, ()>>, secondary: T) -> Self {
+        Self { memory, secondary }
+    }
+
+    pub fn insert_batch(&mut self, keys: Vec<Update>) {
+        let mut new_keys = Vec::new();
+
+        for key in keys {
+            if self.memory.get(&key).is_none() {
+                new_keys.push(key.clone());
+            }
+            self.memory.insert(key, ());
+        }
+
+        if !new_keys.is_empty() {
+            if let Err(e) = self.secondary.insert_batch(&new_keys) {
+                warn!("Failed to insert batch into secondary cache: {}", e);
+            }
+        }
+    }
+
+    pub fn get_batch(&self, keys: &[Update]) -> Vec<Update> {
+        let mut found = Vec::new();
+        let mut missing = Vec::new();
+
+        for key in keys {
+            if self.memory.get(key).is_some() {
+                found.push(key.clone());
+            } else {
+                missing.push(key.clone());
+            }
+        }
+
+        if !missing.is_empty() {
+            match self.secondary.get_batch(&missing) {
+                Ok(updates) => {
+                    for update in updates {
+                        self.memory.insert(update.clone(), ());
+                        found.push(update);
+                    }
+                }
+                Err(e) => {
+                    warn!("Failed to get batch from secondary cache: {}", e);
+                }
+            }
+        }
+
+        found
+    }
+
+    pub fn len(&self) -> usize {
+        self.memory.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::EventDefinition;
+    use super::super::redis_cache::RedisCache;
+    use super::super::noop_cache::NoOpCache;
+    use chrono::Utc;
+
+    #[test]
+    fn test_layered_cache_batch() {
+        let noop = NoOpCache::new();
+        let mut cache = LayeredCache::new(Arc::new(InMemoryCache::new(100)), noop);
+
+        let events: Vec<Update> = (0..3)
+            .map(|i| {
+                Update::Event(EventDefinition {
+                    name: format!("test_{}", i),
+                    team_id: 1,
+                    project_id: 1,
+                    last_seen_at: Utc::now(),
+                })
+            })
+            .collect();
+
+        cache.insert_batch(events.clone());
+        let found = cache.get_batch(&events);
+        assert_eq!(found.len(), events.len());
+    }
+
+    #[test]
+    fn test_layered_cache_batch_with_redis() {
+        let redis = RedisCache::new("redis://127.0.0.1/", 3600).unwrap();
+        let mut cache = LayeredCache::new(Arc::new(InMemoryCache::new(100)), redis);
+
+        let events: Vec<Update> = (0..3)
+            .map(|i| {
+                Update::Event(EventDefinition {
+                    name: format!("test_{}", i),
+                    team_id: 1,
+                    project_id: 1,
+                    last_seen_at: Utc::now(),
+                })
+            })
+            .collect();
+
+        cache.insert_batch(events.clone());
+        let found = cache.get_batch(&events);
+        assert_eq!(found.len(), events.len());
+    }
+}

--- a/rust/property-defs-rs/src/cache/layered_cache.rs
+++ b/rust/property-defs-rs/src/cache/layered_cache.rs
@@ -4,6 +4,7 @@ use crate::types::Update;
 use super::secondary_cache::SecondaryCache;
 use tracing::warn;
 
+#[derive(Clone)]
 pub struct LayeredCache<T: SecondaryCache> {
     memory: Arc<InMemoryCache<Update, ()>>,
     secondary: T,

--- a/rust/property-defs-rs/src/cache/mod.rs
+++ b/rust/property-defs-rs/src/cache/mod.rs
@@ -1,40 +1,9 @@
-use crate::types::Update;
-use crate::errors::CacheError;
-use async_trait::async_trait;
-
 pub mod layered_cache;
 pub mod noop_cache;
 pub mod redis_cache;
+pub mod secondary_cache;
 
 pub use layered_cache::LayeredCache;
 pub use noop_cache::NoOpCache;
 pub use redis_cache::RedisCache;
-
-#[async_trait]
-pub trait CacheOperations {
-    async fn insert_batch(&self, updates: &[Update]) -> Result<(), CacheError>;
-    async fn filter_cached_updates(&self, updates: &[Update]) -> Result<Vec<Update>, CacheError>;
-}
-
-#[derive(Clone)]
-pub enum SecondaryCache {
-    Redis(RedisCache),
-    NoOp(NoOpCache),
-}
-
-#[async_trait]
-impl CacheOperations for SecondaryCache {
-    async fn insert_batch(&self, updates: &[Update]) -> Result<(), CacheError> {
-        match self {
-            SecondaryCache::Redis(cache) => cache.insert_batch(updates).await,
-            SecondaryCache::NoOp(cache) => cache.insert_batch(updates).await,
-        }
-    }
-
-    async fn filter_cached_updates(&self, updates: &[Update]) -> Result<Vec<Update>, CacheError> {
-        match self {
-            SecondaryCache::Redis(cache) => cache.filter_cached_updates(updates).await,
-            SecondaryCache::NoOp(cache) => cache.filter_cached_updates(updates).await,
-        }
-    }
-}
+pub use secondary_cache::{SecondaryCache, CacheOperations};

--- a/rust/property-defs-rs/src/cache/mod.rs
+++ b/rust/property-defs-rs/src/cache/mod.rs
@@ -1,5 +1,5 @@
 use crate::types::Update;
-use redis::RedisError;
+use crate::errors::CacheError;
 use async_trait::async_trait;
 
 pub mod layered_cache;
@@ -12,8 +12,8 @@ pub use redis_cache::RedisCache;
 
 #[async_trait]
 pub trait CacheOperations {
-    async fn insert_batch(&self, updates: &[Update]) -> Result<(), RedisError>;
-    async fn filter_cached_updates(&self, updates: &[Update]) -> Result<Vec<Update>, RedisError>;
+    async fn insert_batch(&self, updates: &[Update]) -> Result<(), CacheError>;
+    async fn filter_cached_updates(&self, updates: &[Update]) -> Result<Vec<Update>, CacheError>;
 }
 
 #[derive(Clone)]
@@ -24,14 +24,14 @@ pub enum SecondaryCache {
 
 #[async_trait]
 impl CacheOperations for SecondaryCache {
-    async fn insert_batch(&self, updates: &[Update]) -> Result<(), RedisError> {
+    async fn insert_batch(&self, updates: &[Update]) -> Result<(), CacheError> {
         match self {
             SecondaryCache::Redis(cache) => cache.insert_batch(updates).await,
             SecondaryCache::NoOp(cache) => cache.insert_batch(updates).await,
         }
     }
 
-    async fn filter_cached_updates(&self, updates: &[Update]) -> Result<Vec<Update>, RedisError> {
+    async fn filter_cached_updates(&self, updates: &[Update]) -> Result<Vec<Update>, CacheError> {
         match self {
             SecondaryCache::Redis(cache) => cache.filter_cached_updates(updates).await,
             SecondaryCache::NoOp(cache) => cache.filter_cached_updates(updates).await,

--- a/rust/property-defs-rs/src/cache/mod.rs
+++ b/rust/property-defs-rs/src/cache/mod.rs
@@ -1,0 +1,9 @@
+mod layered_cache;
+mod redis_cache;
+mod noop_cache;
+mod secondary_cache;
+
+pub use layered_cache::LayeredCache;
+pub use redis_cache::RedisCache;
+pub use noop_cache::NoOpCache;
+pub use secondary_cache::SecondaryCache;

--- a/rust/property-defs-rs/src/cache/mod.rs
+++ b/rust/property-defs-rs/src/cache/mod.rs
@@ -1,9 +1,40 @@
-mod layered_cache;
-mod redis_cache;
-mod noop_cache;
-mod secondary_cache;
+use crate::types::Update;
+use redis::RedisError;
+use async_trait::async_trait;
+
+pub mod layered_cache;
+pub mod noop_cache;
+pub mod redis_cache;
 
 pub use layered_cache::LayeredCache;
-pub use redis_cache::RedisCache;
 pub use noop_cache::NoOpCache;
-pub use secondary_cache::SecondaryCache;
+pub use redis_cache::RedisCache;
+
+#[async_trait]
+pub trait CacheOperations {
+    async fn insert_batch(&self, updates: &[Update]) -> Result<(), RedisError>;
+    async fn filter_cached_updates(&self, updates: &[Update]) -> Result<Vec<Update>, RedisError>;
+}
+
+#[derive(Clone)]
+pub enum SecondaryCache {
+    Redis(RedisCache),
+    NoOp(NoOpCache),
+}
+
+#[async_trait]
+impl CacheOperations for SecondaryCache {
+    async fn insert_batch(&self, updates: &[Update]) -> Result<(), RedisError> {
+        match self {
+            SecondaryCache::Redis(cache) => cache.insert_batch(updates).await,
+            SecondaryCache::NoOp(cache) => cache.insert_batch(updates).await,
+        }
+    }
+
+    async fn filter_cached_updates(&self, updates: &[Update]) -> Result<Vec<Update>, RedisError> {
+        match self {
+            SecondaryCache::Redis(cache) => cache.filter_cached_updates(updates).await,
+            SecondaryCache::NoOp(cache) => cache.filter_cached_updates(updates).await,
+        }
+    }
+}

--- a/rust/property-defs-rs/src/cache/noop_cache.rs
+++ b/rust/property-defs-rs/src/cache/noop_cache.rs
@@ -1,8 +1,6 @@
 use crate::types::Update;
 use crate::errors::CacheError;
 use super::CacheOperations;
-use futures::Stream;
-use std::pin::Pin;
 
 /// A no-op cache implementation that can be used in place of RedisCache when Redis caching is not desired
 #[derive(Clone)]
@@ -20,7 +18,7 @@ impl CacheOperations for NoOpCache {
         Ok(())
     }
 
-    async fn filter_cached_updates(&self, updates: Vec<Update>) -> Pin<Box<dyn Stream<Item = Update> + Send + '_>> {
-        Box::pin(futures::stream::iter(updates))
+    async fn filter_cached_updates(&self, updates: Vec<Update>) -> Vec<Update> {
+        updates
     }
 }

--- a/rust/property-defs-rs/src/cache/noop_cache.rs
+++ b/rust/property-defs-rs/src/cache/noop_cache.rs
@@ -1,5 +1,5 @@
 use crate::types::Update;
-use super::secondary_cache::SecondaryCache;
+use super::CacheOperations;
 use redis::RedisError;
 
 /// A no-op cache implementation that can be used in place of RedisCache when Redis caching is not desired
@@ -13,7 +13,7 @@ impl NoOpCache {
 }
 
 #[async_trait::async_trait]
-impl SecondaryCache for NoOpCache {
+impl CacheOperations for NoOpCache {
     async fn insert_batch(&self, _updates: &[Update]) -> Result<(), RedisError> {
         Ok(())
     }

--- a/rust/property-defs-rs/src/cache/noop_cache.rs
+++ b/rust/property-defs-rs/src/cache/noop_cache.rs
@@ -1,8 +1,9 @@
 use crate::types::Update;
 use super::secondary_cache::SecondaryCache;
+use redis::RedisError;
 
 /// A no-op cache implementation that can be used in place of RedisCache when Redis caching is not desired
-#[derive(Clone, Debug, Default)]
+#[derive(Clone)]
 pub struct NoOpCache;
 
 impl NoOpCache {
@@ -11,12 +12,13 @@ impl NoOpCache {
     }
 }
 
+#[async_trait::async_trait]
 impl SecondaryCache for NoOpCache {
-    fn insert_batch(&self, _keys: &[Update]) -> Result<(), redis::RedisError> {
+    async fn insert_batch(&self, _updates: &[Update]) -> Result<(), RedisError> {
         Ok(())
     }
 
-    fn get_batch(&self, _keys: &[Update]) -> Result<Vec<Update>, redis::RedisError> {
+    async fn get_batch(&self, _updates: &[Update]) -> Result<Vec<Update>, RedisError> {
         Ok(Vec::new())
     }
 }

--- a/rust/property-defs-rs/src/cache/noop_cache.rs
+++ b/rust/property-defs-rs/src/cache/noop_cache.rs
@@ -1,0 +1,22 @@
+use crate::types::Update;
+use super::secondary_cache::SecondaryCache;
+
+/// A no-op cache implementation that can be used in place of RedisCache when Redis caching is not desired
+#[derive(Clone, Debug, Default)]
+pub struct NoOpCache;
+
+impl NoOpCache {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl SecondaryCache for NoOpCache {
+    fn insert_batch(&self, _keys: &[Update]) -> Result<(), redis::RedisError> {
+        Ok(())
+    }
+
+    fn get_batch(&self, _keys: &[Update]) -> Result<Vec<Update>, redis::RedisError> {
+        Ok(Vec::new())
+    }
+}

--- a/rust/property-defs-rs/src/cache/noop_cache.rs
+++ b/rust/property-defs-rs/src/cache/noop_cache.rs
@@ -1,6 +1,6 @@
 use crate::types::Update;
+use crate::errors::CacheError;
 use super::CacheOperations;
-use redis::RedisError;
 
 /// A no-op cache implementation that can be used in place of RedisCache when Redis caching is not desired
 #[derive(Clone)]
@@ -14,12 +14,12 @@ impl NoOpCache {
 
 #[async_trait::async_trait]
 impl CacheOperations for NoOpCache {
-    async fn insert_batch(&self, _updates: &[Update]) -> Result<(), RedisError> {
-        Ok(())
+    async fn insert_batch(&self, _updates: &[Update]) -> Result<(), CacheError> {
+        Err(CacheError::NotSupported)
     }
 
-    async fn filter_cached_updates(&self, updates: &[Update]) -> Result<Vec<Update>, RedisError> {
-        // NoOpCache assumes nothing is cached, so return all updates
-        Ok(updates.to_vec())
+    async fn filter_cached_updates(&self, _updates: &[Update]) -> Result<Vec<Update>, CacheError> {
+        // NoOpCache returns a NotSupported error to avoid copying updates, since layered cache will fail open
+        Err(CacheError::NotSupported)
     }
 }

--- a/rust/property-defs-rs/src/cache/noop_cache.rs
+++ b/rust/property-defs-rs/src/cache/noop_cache.rs
@@ -18,7 +18,8 @@ impl SecondaryCache for NoOpCache {
         Ok(())
     }
 
-    async fn get_batch(&self, _updates: &[Update]) -> Result<Vec<Update>, RedisError> {
-        Ok(Vec::new())
+    async fn filter_cached_updates(&self, updates: &[Update]) -> Result<Vec<Update>, RedisError> {
+        // NoOpCache assumes nothing is cached, so return all updates
+        Ok(updates.to_vec())
     }
 }

--- a/rust/property-defs-rs/src/cache/redis_cache.rs
+++ b/rust/property-defs-rs/src/cache/redis_cache.rs
@@ -7,12 +7,19 @@ use redis::RedisError;
 pub struct RedisCache {
     conn: redis::aio::ConnectionManager,
     ttl: u64,
+    batch_fetch_limit: usize,
+    batch_update_limit: usize,
 }
 
 impl RedisCache {
-    pub async fn new(client: redis::Client, ttl: u64) -> Result<Self, RedisError> {
+    pub async fn new(client: redis::Client, ttl: u64, batch_fetch_limit: usize, batch_update_limit: usize) -> Result<Self, RedisError> {
         let conn = redis::aio::ConnectionManager::new(client).await?;
-        Ok(Self { conn, ttl })
+        Ok(Self {
+            conn,
+            ttl,
+            batch_fetch_limit,
+            batch_update_limit,
+        })
     }
 }
 
@@ -23,8 +30,14 @@ impl CacheOperations for RedisCache {
             return Ok(());
         }
 
+        let updates_to_process = if self.batch_update_limit > 0 {
+            &updates[..std::cmp::min(updates.len(), self.batch_update_limit)]
+        } else {
+            updates
+        };
+
         let mut pipe = redis::pipe();
-        for update in updates {
+        for update in updates_to_process {
             let key = update.key();
             pipe.set_ex(
                 key,
@@ -43,8 +56,15 @@ impl CacheOperations for RedisCache {
             return Ok(Vec::new());
         }
 
+        let limit = if self.batch_fetch_limit > 0 {
+            std::cmp::min(updates.len(), self.batch_fetch_limit)
+        } else {
+            updates.len()
+        };
+        let (updates_to_check, remaining_updates) = updates.split_at(limit);
+
         let mut conn = self.conn.clone();
-        let redis_keys: Vec<String> = updates.iter().map(|u| u.key()).collect();
+        let redis_keys: Vec<String> = updates_to_check.iter().map(|u| u.key()).collect();
         let values: Vec<Option<String>> = redis::cmd("MGET")
             .arg(&redis_keys)
             .query_async(&mut conn)
@@ -52,11 +72,14 @@ impl CacheOperations for RedisCache {
             .map_err(CacheError::from)?;
 
         let mut not_in_cache = Vec::new();
-        for (update, value) in updates.iter().zip(values.iter()) {
+        for (update, value) in updates_to_check.iter().zip(values.iter()) {
             if value.is_none() {
                 not_in_cache.push(update.clone());
             }
         }
+
+        // Add all remaining updates that weren't checked
+        not_in_cache.extend(remaining_updates.iter().cloned());
 
         Ok(not_in_cache)
     }

--- a/rust/property-defs-rs/src/cache/redis_cache.rs
+++ b/rust/property-defs-rs/src/cache/redis_cache.rs
@@ -4,7 +4,7 @@ use super::CacheOperations;
 use redis::RedisError;
 
 #[derive(Clone)]
-struct RedisCacheClient {
+pub struct RedisCacheClient {
     conn: redis::aio::ConnectionManager,
 }
 

--- a/rust/property-defs-rs/src/cache/redis_cache.rs
+++ b/rust/property-defs-rs/src/cache/redis_cache.rs
@@ -1,0 +1,55 @@
+use redis::Client;
+use crate::types::Update;
+use super::secondary_cache::SecondaryCache;
+
+pub struct RedisCache {
+    client: Client,
+    ttl: u64,
+}
+
+impl RedisCache {
+    pub fn new(redis_url: &str, ttl: u64) -> Result<Self, redis::RedisError> {
+        let client = Client::open(redis_url)?;
+        Ok(Self { client, ttl })
+    }
+}
+
+impl SecondaryCache for RedisCache {
+    fn insert_batch(&self, updates: &[Update]) -> Result<(), redis::RedisError> {
+        if updates.is_empty() {
+            return Ok(());
+        }
+
+        let mut conn = self.client.get_connection()?;
+        let mut pipe = redis::pipe();
+
+        for update in updates {
+            let key = update.key();
+            pipe.set_ex(
+                key,
+                serde_json::to_string(&update).unwrap_or_default(),
+                self.ttl,
+            );
+        }
+
+        let _: () = pipe.query(&mut conn)?;
+        Ok(())
+    }
+
+    fn get_batch(&self, updates: &[Update]) -> Result<Vec<Update>, redis::RedisError> {
+        if updates.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut conn = self.client.get_connection()?;
+        let redis_keys: Vec<String> = updates.iter().map(|u| u.key()).collect();
+        let values: Vec<Option<String>> = redis::cmd("MGET").arg(&redis_keys).query(&mut conn)?;
+
+        Ok(values
+            .into_iter()
+            .filter_map(|opt_str| {
+                opt_str.and_then(|s| serde_json::from_str(&s).ok())
+            })
+            .collect())
+    }
+}

--- a/rust/property-defs-rs/src/cache/redis_cache.rs
+++ b/rust/property-defs-rs/src/cache/redis_cache.rs
@@ -2,6 +2,7 @@ use redis::Client;
 use crate::types::Update;
 use super::secondary_cache::SecondaryCache;
 
+#[derive(Clone)]
 pub struct RedisCache {
     client: Client,
     ttl: u64,

--- a/rust/property-defs-rs/src/cache/redis_cache.rs
+++ b/rust/property-defs-rs/src/cache/redis_cache.rs
@@ -1,5 +1,5 @@
 use crate::types::Update;
-use super::secondary_cache::SecondaryCache;
+use super::CacheOperations;
 use redis::RedisError;
 
 #[derive(Clone)]
@@ -11,13 +11,12 @@ pub struct RedisCache {
 impl RedisCache {
     pub async fn new(client: redis::Client, ttl: u64) -> Result<Self, RedisError> {
         let conn = redis::aio::ConnectionManager::new(client).await?;
-
         Ok(Self { conn, ttl })
     }
 }
 
 #[async_trait::async_trait]
-impl SecondaryCache for RedisCache {
+impl CacheOperations for RedisCache {
     async fn insert_batch(&self, updates: &[Update]) -> Result<(), RedisError> {
         if updates.is_empty() {
             return Ok(());

--- a/rust/property-defs-rs/src/cache/secondary_cache.rs
+++ b/rust/property-defs-rs/src/cache/secondary_cache.rs
@@ -1,11 +1,13 @@
 use crate::types::Update;
 use crate::errors::CacheError;
 use super::{RedisCache, NoOpCache};
+use futures::Stream;
+use std::pin::Pin;
 
 #[async_trait::async_trait]
 pub trait CacheOperations {
     async fn insert_batch(&self, updates: &[Update]) -> Result<(), CacheError>;
-    async fn filter_cached_updates(&self, updates: &[Update]) -> Result<Vec<Update>, CacheError>;
+    async fn filter_cached_updates(&self, updates: Vec<Update>) -> Pin<Box<dyn Stream<Item = Update> + Send + '_>>;
 }
 
 #[async_trait::async_trait]
@@ -14,7 +16,7 @@ pub trait SecondaryCacheOperations: Send + Sync {
     async fn insert_batch(&self, updates: &[Update]) -> Result<(), CacheError>;
 
     /// Filter out updates that exist in the cache, returns updates that are not in the cache
-    async fn filter_cached_updates(&self, updates: &[Update]) -> Result<Vec<Update>, CacheError>;
+    async fn filter_cached_updates(&self, updates: Vec<Update>) -> Pin<Box<dyn Stream<Item = Update> + Send + '_>>;
 }
 
 #[derive(Clone)]
@@ -32,7 +34,7 @@ impl SecondaryCacheOperations for SecondaryCache {
         }
     }
 
-    async fn filter_cached_updates(&self, updates: &[Update]) -> Result<Vec<Update>, CacheError> {
+    async fn filter_cached_updates(&self, updates: Vec<Update>) -> Pin<Box<dyn Stream<Item = Update> + Send + '_>> {
         match self {
             SecondaryCache::Redis(cache) => cache.filter_cached_updates(updates).await,
             SecondaryCache::NoOp(cache) => cache.filter_cached_updates(updates).await,

--- a/rust/property-defs-rs/src/cache/secondary_cache.rs
+++ b/rust/property-defs-rs/src/cache/secondary_cache.rs
@@ -4,6 +4,6 @@ use crate::types::Update;
 pub trait SecondaryCache: Send + Sync + Clone {
     /// Insert multiple updates into the cache
     async fn insert_batch(&self, updates: &[Update]) -> Result<(), redis::RedisError>;
-    /// Get multiple updates from the cache, returns only the found updates
-    async fn get_batch(&self, updates: &[Update]) -> Result<Vec<Update>, redis::RedisError>;
+    /// Filter out updates that exist in the cache, returns updates that are not in the cache
+    async fn filter_cached_updates(&self, updates: &[Update]) -> Result<Vec<Update>, redis::RedisError>;
 }

--- a/rust/property-defs-rs/src/cache/secondary_cache.rs
+++ b/rust/property-defs-rs/src/cache/secondary_cache.rs
@@ -9,9 +9,10 @@ pub trait CacheOperations {
 }
 
 #[async_trait::async_trait]
-pub trait SecondaryCacheOperations: Send + Sync + Clone {
+pub trait SecondaryCacheOperations: Send + Sync {
     /// Insert multiple updates into the cache
     async fn insert_batch(&self, updates: &[Update]) -> Result<(), CacheError>;
+
     /// Filter out updates that exist in the cache, returns updates that are not in the cache
     async fn filter_cached_updates(&self, updates: &[Update]) -> Result<Vec<Update>, CacheError>;
 }
@@ -23,7 +24,7 @@ pub enum SecondaryCache {
 }
 
 #[async_trait::async_trait]
-impl CacheOperations for SecondaryCache {
+impl SecondaryCacheOperations for SecondaryCache {
     async fn insert_batch(&self, updates: &[Update]) -> Result<(), CacheError> {
         match self {
             SecondaryCache::Redis(cache) => cache.insert_batch(updates).await,

--- a/rust/property-defs-rs/src/cache/secondary_cache.rs
+++ b/rust/property-defs-rs/src/cache/secondary_cache.rs
@@ -1,9 +1,9 @@
 use crate::types::Update;
 
-/// Trait defining the interface for secondary caches that can be used with LayeredCache
-pub trait SecondaryCache: Clone {
+#[async_trait::async_trait]
+pub trait SecondaryCache: Send + Sync + Clone {
     /// Insert multiple updates into the cache
-    fn insert_batch(&self, updates: &[Update]) -> Result<(), redis::RedisError>;
+    async fn insert_batch(&self, updates: &[Update]) -> Result<(), redis::RedisError>;
     /// Get multiple updates from the cache, returns only the found updates
-    fn get_batch(&self, updates: &[Update]) -> Result<Vec<Update>, redis::RedisError>;
+    async fn get_batch(&self, updates: &[Update]) -> Result<Vec<Update>, redis::RedisError>;
 }

--- a/rust/property-defs-rs/src/cache/secondary_cache.rs
+++ b/rust/property-defs-rs/src/cache/secondary_cache.rs
@@ -1,9 +1,9 @@
 use crate::types::Update;
 
 /// Trait defining the interface for secondary caches that can be used with LayeredCache
-pub trait SecondaryCache {
+pub trait SecondaryCache: Clone {
     /// Insert multiple updates into the cache
-    fn insert_batch(&self, keys: &[Update]) -> Result<(), redis::RedisError>;
+    fn insert_batch(&self, updates: &[Update]) -> Result<(), redis::RedisError>;
     /// Get multiple updates from the cache, returns only the found updates
-    fn get_batch(&self, keys: &[Update]) -> Result<Vec<Update>, redis::RedisError>;
+    fn get_batch(&self, updates: &[Update]) -> Result<Vec<Update>, redis::RedisError>;
 }

--- a/rust/property-defs-rs/src/cache/secondary_cache.rs
+++ b/rust/property-defs-rs/src/cache/secondary_cache.rs
@@ -1,0 +1,9 @@
+use crate::types::Update;
+
+/// Trait defining the interface for secondary caches that can be used with LayeredCache
+pub trait SecondaryCache {
+    /// Insert multiple updates into the cache
+    fn insert_batch(&self, keys: &[Update]) -> Result<(), redis::RedisError>;
+    /// Get multiple updates from the cache, returns only the found updates
+    fn get_batch(&self, keys: &[Update]) -> Result<Vec<Update>, redis::RedisError>;
+}

--- a/rust/property-defs-rs/src/config.rs
+++ b/rust/property-defs-rs/src/config.rs
@@ -14,6 +14,9 @@ pub struct RedisConfig {
 
     #[envconfig(default = "100")]
     pub batch_update_limit: usize,
+
+    #[envconfig(default = "900")]
+    pub ttl: u64,
 }
 
 impl RedisConfig {

--- a/rust/property-defs-rs/src/config.rs
+++ b/rust/property-defs-rs/src/config.rs
@@ -1,7 +1,23 @@
 use std::{num::ParseIntError, str::FromStr};
+use redis::IntoConnectionInfo;
 
 use common_kafka::config::{ConsumerConfig, KafkaConfig};
 use envconfig::Envconfig;
+
+#[derive(Envconfig, Clone)]
+pub struct RedisConfig {
+    #[envconfig(default = "")]
+    pub url: String,
+}
+
+impl RedisConfig {
+    pub fn get_connection_info(&self) -> Option<redis::ConnectionInfo> {
+        if self.url.is_empty() {
+            return None;
+        }
+        self.url.clone().into_connection_info().ok()
+    }
+}
 
 #[derive(Envconfig, Clone)]
 pub struct Config {
@@ -16,6 +32,9 @@ pub struct Config {
 
     #[envconfig(nested = true)]
     pub consumer: ConsumerConfig,
+
+    #[envconfig(nested = true)]
+    pub redis: RedisConfig,
 
     // TODO(eli): after observing retry change, consider reducing potential tx contention by 20% (to "8")
     #[envconfig(default = "10")]

--- a/rust/property-defs-rs/src/config.rs
+++ b/rust/property-defs-rs/src/config.rs
@@ -8,6 +8,12 @@ use envconfig::Envconfig;
 pub struct RedisConfig {
     #[envconfig(default = "")]
     pub url: String,
+
+    #[envconfig(default = "100")]
+    pub batch_fetch_limit: usize,
+
+    #[envconfig(default = "100")]
+    pub batch_update_limit: usize,
 }
 
 impl RedisConfig {

--- a/rust/property-defs-rs/src/errors.rs
+++ b/rust/property-defs-rs/src/errors.rs
@@ -2,8 +2,7 @@ use redis::RedisError;
 
 #[derive(Debug)]
 pub enum CacheError {
-    Redis(RedisError),
-    NotSupported,
+    Redis(RedisError)
 }
 
 impl From<RedisError> for CacheError {
@@ -16,7 +15,6 @@ impl std::fmt::Display for CacheError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             CacheError::Redis(err) => write!(f, "Redis error: {}", err),
-            CacheError::NotSupported => write!(f, "Operation not supported"),
         }
     }
 }

--- a/rust/property-defs-rs/src/errors.rs
+++ b/rust/property-defs-rs/src/errors.rs
@@ -1,0 +1,24 @@
+use redis::RedisError;
+
+#[derive(Debug)]
+pub enum CacheError {
+    Redis(RedisError),
+    NotSupported,
+}
+
+impl From<RedisError> for CacheError {
+    fn from(err: RedisError) -> Self {
+        CacheError::Redis(err)
+    }
+}
+
+impl std::fmt::Display for CacheError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CacheError::Redis(err) => write!(f, "Redis error: {}", err),
+            CacheError::NotSupported => write!(f, "Operation not supported"),
+        }
+    }
+}
+
+impl std::error::Error for CacheError {}

--- a/rust/property-defs-rs/src/lib.rs
+++ b/rust/property-defs-rs/src/lib.rs
@@ -13,7 +13,6 @@ use metrics_consts::{
 use types::{Event, Update};
 use quick_cache::sync::Cache;
 use crate::cache::{LayeredCache, NoOpCache};
-use tokio::sync::Mutex;
 use v2_batch_ingestion::process_batch_v2;
 
 use ahash::AHashSet;
@@ -35,7 +34,7 @@ const UPDATE_RETRY_DELAY_MS: u64 = 50;
 pub async fn update_consumer_loop(
     config: Config,
     cache: Arc<Cache<Update, ()>>,
-    layered_cache: Arc<Mutex<LayeredCache<NoOpCache>>>,
+    layered_cache: Arc<LayeredCache<NoOpCache>>,
     context: Arc<AppContext>,
     mut channel: mpsc::Receiver<Update>,
 ) {

--- a/rust/property-defs-rs/src/lib.rs
+++ b/rust/property-defs-rs/src/lib.rs
@@ -26,6 +26,7 @@ pub mod config;
 pub mod metrics_consts;
 pub mod types;
 pub mod v2_batch_ingestion;
+pub mod errors;
 
 const BATCH_UPDATE_MAX_ATTEMPTS: u64 = 2;
 const UPDATE_RETRY_DELAY_MS: u64 = 50;

--- a/rust/property-defs-rs/src/lib.rs
+++ b/rust/property-defs-rs/src/lib.rs
@@ -21,6 +21,7 @@ use tracing::{error, warn};
 
 pub mod api;
 pub mod app_context;
+pub mod cache;
 pub mod config;
 pub mod metrics_consts;
 pub mod types;

--- a/rust/property-defs-rs/src/main.rs
+++ b/rust/property-defs-rs/src/main.rs
@@ -85,7 +85,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let secondary_cache = if let Some(conn_info) = config.redis.get_connection_info() {
         let redis_client = redis::Client::open(conn_info)
             .map_err(|e| format!("Failed to create Redis client: {}", e))?;
-        SecondaryCache::Redis(RedisCache::new(
+        SecondaryCache::Redis(RedisCache::new_redis(
             redis_client,
             config.redis.ttl,
             config.redis.batch_fetch_limit,

--- a/rust/property-defs-rs/src/main.rs
+++ b/rust/property-defs-rs/src/main.rs
@@ -85,7 +85,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let secondary_cache = if let Some(conn_info) = config.redis.get_connection_info() {
         let redis_client = redis::Client::open(conn_info)
             .map_err(|e| format!("Failed to create Redis client: {}", e))?;
-        SecondaryCache::Redis(RedisCache::new(redis_client, 3600).await
+        SecondaryCache::Redis(RedisCache::new(
+            redis_client,
+            3600,
+            config.redis.batch_fetch_limit,
+            config.redis.batch_update_limit
+        ).await
             .map_err(|e| format!("Failed to create Redis cache: {}", e))?)
     } else {
         SecondaryCache::NoOp(NoOpCache::new())

--- a/rust/property-defs-rs/src/main.rs
+++ b/rust/property-defs-rs/src/main.rs
@@ -87,7 +87,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .map_err(|e| format!("Failed to create Redis client: {}", e))?;
         SecondaryCache::Redis(RedisCache::new(
             redis_client,
-            3600,
+            config.redis.ttl,
             config.redis.batch_fetch_limit,
             config.redis.batch_update_limit
         ).await

--- a/rust/property-defs-rs/src/main.rs
+++ b/rust/property-defs-rs/src/main.rs
@@ -2,14 +2,14 @@ use std::sync::Arc;
 
 use axum::{routing::get, Router};
 use common_kafka::kafka_consumer::SingleTopicConsumer;
+use quick_cache::sync::Cache as InMemoryCache;
 
 use futures::future::ready;
 use property_defs_rs::{
     api::v1::query::Manager, api::v1::routing::apply_routes, app_context::AppContext,
-    config::Config, update_consumer_loop, update_producer_loop, cache::{LayeredCache, NoOpCache},
+    config::Config, update_consumer_loop, update_producer_loop, cache::{LayeredCache, NoOpCache, RedisCache, SecondaryCache},
 };
 
-use quick_cache::sync::Cache as InMemoryCache;
 use serve_metrics::{serve, setup_metrics_routes};
 use sqlx::postgres::PgPoolOptions;
 use tokio::{
@@ -81,8 +81,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let (tx, rx) = mpsc::channel(config.update_batch_size * config.channel_slots_per_worker);
 
-    let cache = Arc::new(InMemoryCache::new(config.cache_capacity));
-    let layered_cache = Arc::new(LayeredCache::new(cache.clone(), NoOpCache::new()));
+    // Set up secondary cache based on Redis configuration
+    let secondary_cache = if let Some(conn_info) = config.redis.get_connection_info() {
+        let redis_client = redis::Client::open(conn_info)
+            .map_err(|e| format!("Failed to create Redis client: {}", e))?;
+        SecondaryCache::Redis(RedisCache::new(redis_client, 3600).await
+            .map_err(|e| format!("Failed to create Redis cache: {}", e))?)
+    } else {
+        SecondaryCache::NoOp(NoOpCache::new())
+    };
+
+    let memory_cache = Arc::new(InMemoryCache::new(config.cache_capacity));
+    let layered_cache = Arc::new(LayeredCache::new(memory_cache, secondary_cache));
 
     let mut handles = Vec::new();
 
@@ -91,7 +101,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             config.clone(),
             consumer.clone(),
             tx.clone(),
-            cache.clone(),
             layered_cache.clone(),
         ));
 
@@ -100,7 +109,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     handles.push(tokio::spawn(update_consumer_loop(
         config.clone(),
-        cache,
         layered_cache,
         context,
         rx,

--- a/rust/property-defs-rs/src/metrics_consts.rs
+++ b/rust/property-defs-rs/src/metrics_consts.rs
@@ -35,14 +35,13 @@ pub const SINGLE_UPDATE_ISSUE_TIME: &str = "prop_defs_single_update_issue_time_m
 pub const V2_EVENT_DEFS_BATCH_WRITE_TIME: &str = "propdefs_v2_eventdefs_batch_ms";
 pub const V2_EVENT_DEFS_BATCH_ATTEMPT: &str = "propdefs_v2_eventdefs_batch_attempt";
 pub const V2_EVENT_DEFS_BATCH_ROWS_AFFECTED: &str = "propdefs_v2_eventdefs_batch_rows";
-pub const V2_EVENT_DEFS_BATCH_CACHE_TIME: &str = "propdefs_v2_eventdefs_batch_cache_time_ms";
 
 pub const V2_EVENT_PROPS_BATCH_WRITE_TIME: &str = "propdefs_v2_eventprops_batch_ms";
 pub const V2_EVENT_PROPS_BATCH_ATTEMPT: &str = "propdefs_v2_eventprops_batch_attempt";
 pub const V2_EVENT_PROPS_BATCH_ROWS_AFFECTED: &str = "propdefs_v2_eventprops_batch_rows";
-pub const V2_EVENT_PROPS_BATCH_CACHE_TIME: &str = "propdefs_v2_eventprops_batch_cache_time_ms";
 
 pub const V2_PROP_DEFS_BATCH_WRITE_TIME: &str = "propdefs_v2_propdefs_batch_ms";
 pub const V2_PROP_DEFS_BATCH_ATTEMPT: &str = "propdefs_v2_propdefs_batch_attempt";
 pub const V2_PROP_DEFS_BATCH_ROWS_AFFECTED: &str = "propdefs_v2_propdefs_batch_rows";
-pub const V2_PROP_DEFS_BATCH_CACHE_TIME: &str = "propdefs_v2_propdefs_batch_cache_time_ms";
+
+pub const V2_BATCH_CACHE_TIME: &str = "propdefs_v2_batch_cache_time";

--- a/rust/property-defs-rs/src/v2_batch_ingestion.rs
+++ b/rust/property-defs-rs/src/v2_batch_ingestion.rs
@@ -280,7 +280,9 @@ pub async fn process_batch_v2(
 
 async fn cache_updates(cache: &LayeredCache, updates: Vec<Update>) {
     let timer = common_metrics::timing_guard(V2_BATCH_CACHE_TIME, &[]);
-    cache.insert_batch(updates).await;
+    if let Err(e) = cache.insert_batch(updates).await {
+        warn!("Failed to insert updates into cache: {:?}", e);
+    }
     timer.fin();
 }
 

--- a/rust/property-defs-rs/tests/cache/layered_cache.rs
+++ b/rust/property-defs-rs/tests/cache/layered_cache.rs
@@ -3,17 +3,19 @@ use property_defs_rs::cache::secondary_cache::SecondaryCacheOperations;
 use property_defs_rs::types::{Update, EventDefinition};
 use property_defs_rs::errors::CacheError;
 use quick_cache::sync::Cache as InMemoryCache;
-use std::sync::Arc;
+use std::{sync::Arc, pin::Pin};
 use chrono::{Utc, DateTime};
 use mockall::mock;
 use predicates::prelude::*;
+use futures::{Stream, StreamExt};
 
 mock! {
-    SecondaryCache {}
+    pub SecondaryCache {}
+
     #[async_trait::async_trait]
     impl SecondaryCacheOperations for SecondaryCache {
-        async fn insert_batch(&self, updates: &[Update]) -> Result<(), CacheError>;
-        async fn filter_cached_updates(&self, updates: &[Update]) -> Result<Vec<Update>, CacheError>;
+        async fn insert_batch(&'_ self, updates: &[Update]) -> Result<(), CacheError>;
+        async fn filter_cached_updates<'life0>(&'life0 self, updates: Vec<Update>) -> Pin<Box<dyn Stream<Item = Update> + Send + 'life0>>;
     }
 }
 
@@ -39,58 +41,23 @@ async fn test_layered_cache_basic() {
         .times(1)
         .with(predicate::eq(events.clone()))
         .returning(|_| Ok(()));
+
     mock_secondary
         .expect_filter_cached_updates()
         .times(1)
-        .returning(|updates| Ok(updates.to_vec()));
+        .returning(|updates| Box::pin(futures::stream::iter(updates)));
 
     let cache = LayeredCache::new(memory, mock_secondary);
 
-    let not_in_cache = cache.filter_cached_updates(events.clone()).await;
+    let stream = cache.filter_cached_updates(events.clone()).await;
+    let not_in_cache: Vec<_> = stream.collect().await;
     assert_eq!(not_in_cache, events, "All events should not be in cache initially");
 
-    cache.insert_batch(events.clone()).await;
+    cache.insert_batch(events.clone()).await.unwrap();
 
-    let not_in_cache = cache.filter_cached_updates(events.clone()).await;
+    let stream = cache.filter_cached_updates(events.clone()).await;
+    let not_in_cache: Vec<_> = stream.collect().await;
     assert_eq!(not_in_cache.len(), 0, "All events should be in cache after insertion");
-}
-
-#[tokio::test]
-async fn test_layered_cache_not_supported() {
-    let memory = Arc::new(InMemoryCache::new(1000));
-    let mut mock_secondary = MockSecondaryCache::new();
-
-    let timestamp = DateTime::parse_from_rfc3339("2024-03-15T10:30:00Z").unwrap().with_timezone(&Utc);
-    let events: Vec<Update> = (0..3)
-        .map(|i| {
-            Update::Event(EventDefinition {
-                name: format!("test_{}", i),
-                team_id: 2345,
-                project_id: 6789,
-                last_seen_at: timestamp,
-            })
-        })
-        .collect();
-
-    mock_secondary
-        .expect_insert_batch()
-        .times(1)
-        .with(predicate::eq(events.clone()))
-        .returning(|_| Err(CacheError::NotSupported));
-    mock_secondary
-        .expect_filter_cached_updates()
-        .times(1)
-        .returning(|_| Err(CacheError::NotSupported));
-
-    let cache = LayeredCache::new(memory, mock_secondary);
-
-    let not_in_cache = cache.filter_cached_updates(events.clone()).await;
-    assert_eq!(not_in_cache, events, "All events should be returned when secondary cache is not supported");
-
-    cache.insert_batch(events.clone()).await;
-
-    let not_in_cache = cache.filter_cached_updates(events.clone()).await;
-    assert_eq!(not_in_cache.len(), 0, "All events should be in memory cache after insertion");
 }
 
 #[tokio::test]
@@ -118,13 +85,14 @@ async fn test_layered_cache_skips_secondary_cache() {
     mock_secondary
         .expect_filter_cached_updates()
         .times(0)
-        .returning(|_| Ok(vec![]));
+        .returning(|_| Box::pin(futures::stream::iter(vec![])));
 
     let cache = LayeredCache::new(memory, mock_secondary);
 
-    cache.insert_batch(events.clone()).await;
+    cache.insert_batch(events.clone()).await.unwrap();
 
-    let not_in_cache = cache.filter_cached_updates(events.clone()).await;
+    let stream = cache.filter_cached_updates(events.clone()).await;
+    let not_in_cache: Vec<_> = stream.collect().await;
     assert_eq!(not_in_cache.len(), 0, "All events should be in memory cache");
 }
 
@@ -158,13 +126,14 @@ async fn test_layered_cache_partial_hit() {
         .expect_filter_cached_updates()
         .times(1)
         .with(predicate::eq(events_to_check.clone()))
-        .returning(move |_| Ok(events_secondary_returns.clone()));
+        .returning(move |_| Box::pin(futures::stream::iter(events_secondary_returns.clone())));
 
     let cache = LayeredCache::new(memory, mock_secondary);
 
-    cache.insert_batch(events_to_cache).await;
+    cache.insert_batch(events_to_cache).await.unwrap();
 
-    let not_in_cache = cache.filter_cached_updates(all_events.clone()).await;
+    let stream = cache.filter_cached_updates(all_events.clone()).await;
+    let not_in_cache: Vec<_> = stream.collect().await;
     assert_eq!(not_in_cache, vec![all_events[0].clone(), all_events[4].clone()]);
 }
 
@@ -198,53 +167,14 @@ async fn test_layered_cache_full_hit() {
         .expect_filter_cached_updates()
         .times(1)
         .with(predicate::eq(events_to_check.clone()))
-        .returning(move |_| Ok(events_secondary_returns.clone()));
+        .returning(move |_| Box::pin(futures::stream::iter(events_secondary_returns.clone())));
 
     let cache = LayeredCache::new(memory, mock_secondary);
+    cache.insert_batch(events_to_cache).await.unwrap();
 
-    cache.insert_batch(events_to_cache).await;
-
-    let not_in_cache = cache.filter_cached_updates(all_events.clone()).await;
+    let stream = cache.filter_cached_updates(all_events.clone()).await;
+    let not_in_cache: Vec<_> = stream.collect().await;
     assert_eq!(not_in_cache.len(), 0);
-}
-
-#[tokio::test]
-async fn test_layered_cache_fail_open() {
-    let memory = Arc::new(InMemoryCache::new(1000));
-    let mut mock_secondary = MockSecondaryCache::new();
-
-    let timestamp = DateTime::parse_from_rfc3339("2024-03-15T10:30:00Z").unwrap().with_timezone(&Utc);
-    let all_events: Vec<Update> = (1..=6)
-        .map(|i| {
-            Update::Event(EventDefinition {
-                name: format!("test_{}", i),
-                team_id: 6789,
-                project_id: 1234,
-                last_seen_at: timestamp,
-            })
-        })
-        .collect();
-
-    let events_to_cache = all_events[1..4].to_vec();
-    let events_to_check = vec![all_events[0].clone(), all_events[4].clone(), all_events[5].clone()];
-
-    mock_secondary
-        .expect_insert_batch()
-        .times(1)
-        .with(predicate::eq(events_to_cache.clone()))
-        .returning(|_| Ok(()));
-    mock_secondary
-        .expect_filter_cached_updates()
-        .times(1)
-        .with(predicate::eq(events_to_check.clone()))
-        .returning(|_| Err(CacheError::NotSupported));
-
-    let cache = LayeredCache::new(memory, mock_secondary);
-
-    cache.insert_batch(events_to_cache).await;
-
-    let not_in_cache = cache.filter_cached_updates(all_events.clone()).await;
-    assert_eq!(not_in_cache, events_to_check);
 }
 
 #[tokio::test]
@@ -291,10 +221,10 @@ async fn test_layered_cache_len() {
 
     assert_eq!(cache.len(), 0, "Empty cache should have length 0");
 
-    cache.insert_batch(first_batch.clone()).await;
+    cache.insert_batch(first_batch.clone()).await.unwrap();
     assert_eq!(cache.len(), 3, "Cache should have length 3 after first batch");
 
-    cache.insert_batch(second_batch.clone()).await;
+    cache.insert_batch(second_batch.clone()).await.unwrap();
     assert_eq!(cache.len(), 6, "Cache should have length 6 after second batch");
 }
 
@@ -333,13 +263,14 @@ async fn test_layered_cache_duplicates() {
 
     let cache = LayeredCache::new(memory, mock_secondary);
 
-    cache.insert_batch(first_batch.clone()).await;
+    cache.insert_batch(first_batch.clone()).await.unwrap();
     assert_eq!(cache.len(), 3, "Cache should have length 3 after first batch");
 
-    cache.insert_batch(second_batch.clone()).await;
+    cache.insert_batch(second_batch.clone()).await.unwrap();
     assert_eq!(cache.len(), 4, "Cache should have length 4 after second batch");
 
-    let not_in_cache = cache.filter_cached_updates(all_events.clone()).await;
+    let stream = cache.filter_cached_updates(all_events.clone()).await;
+    let not_in_cache: Vec<_> = stream.collect().await;
     assert_eq!(not_in_cache.len(), 0, "All events should be in cache");
 }
 
@@ -371,10 +302,10 @@ async fn test_layered_cache_no_secondary_call_for_cached_events() {
 
     let cache = LayeredCache::new(memory, mock_secondary);
 
-    cache.insert_batch(first_batch.clone()).await;
+    cache.insert_batch(first_batch.clone()).await.unwrap();
     assert_eq!(cache.len(), 3, "Cache should have length 3 after first batch");
 
-    cache.insert_batch(second_batch.clone()).await;
+    cache.insert_batch(second_batch.clone()).await.unwrap();
     assert_eq!(cache.len(), 3, "Cache should still have length 3 after second batch");
 }
 
@@ -395,34 +326,47 @@ async fn test_layered_cache_remove() {
         })
         .collect();
 
+    let filter_returns_0 = vec![events[1].clone()];
+    let filter_returns_1 = vec![events[0].clone()];
     mock_secondary
         .expect_insert_batch()
         .times(1)
         .with(predicate::eq(events.clone()))
-        .returning(|_| Err(CacheError::NotSupported));
-
+        .returning(|_| Ok(()));
     mock_secondary
         .expect_filter_cached_updates()
-        .times(2)
-        .returning(|_| Err(CacheError::NotSupported));
+        .times(1)
+        .with(predicate::eq(vec![events[1].clone()]))
+        .returning(move |_| Box::pin(futures::stream::iter(filter_returns_0.clone())));
+    mock_secondary
+        .expect_filter_cached_updates()
+        .times(1)
+        .with(predicate::eq(vec![events[0].clone()]))
+        .returning(move |_| Box::pin(futures::stream::iter(filter_returns_1.clone())));
 
     let cache = LayeredCache::new(memory, mock_secondary);
 
-    cache.insert_batch(events.clone()).await;
+    cache.insert_batch(events.clone()).await.unwrap();
     assert_eq!(cache.len(), 3, "Cache should have length 3 after insertion");
 
-    let not_in_cache = cache.filter_cached_updates(events.clone()).await;
+    let stream = cache.filter_cached_updates(events.clone()).await;
+    let not_in_cache: Vec<_> = stream.collect().await;
     assert_eq!(not_in_cache.len(), 0, "All events should be in cache");
 
     cache.remove(&events[1]);
     assert_eq!(cache.len(), 2, "Cache should have length 2 after removing middle event");
 
-    let not_in_cache = cache.filter_cached_updates(vec![events[1].clone()]).await;
+    let stream = cache.filter_cached_updates(vec![events[1].clone()]).await;
+    let not_in_cache: Vec<_> = stream.collect().await;
     assert_eq!(not_in_cache.len(), 1, "Removed event should not be in cache");
 
     cache.remove(&events[0]);
     assert_eq!(cache.len(), 1, "Cache should have length 1 after removing first event");
 
-    let not_in_cache = cache.filter_cached_updates(vec![events[0].clone()]).await;
+    let mut stream = cache.filter_cached_updates(vec![events[0].clone()]).await;
+    let mut not_in_cache = Vec::new();
+    while let Some(update) = stream.next().await {
+        not_in_cache.push(update);
+    }
     assert_eq!(not_in_cache.len(), 1, "Removed event should not be in cache");
 }

--- a/rust/property-defs-rs/tests/cache/layered_cache.rs
+++ b/rust/property-defs-rs/tests/cache/layered_cache.rs
@@ -1,0 +1,51 @@
+use property_defs_rs::cache::layered_cache::LayeredCache;
+use property_defs_rs::cache::secondary_cache::SecondaryCacheOperations;
+use property_defs_rs::types::{Update, EventDefinition};
+use property_defs_rs::errors::CacheError;
+use quick_cache::sync::Cache as InMemoryCache;
+use std::sync::Arc;
+use chrono::Utc;
+use mockall::mock;
+
+mock! {
+    SecondaryCache {}
+    #[async_trait::async_trait]
+    impl SecondaryCacheOperations for SecondaryCache {
+        async fn insert_batch(&self, updates: &[Update]) -> Result<(), CacheError>;
+        async fn filter_cached_updates(&self, updates: &[Update]) -> Result<Vec<Update>, CacheError>;
+    }
+}
+
+#[tokio::test]
+async fn test_layered_cache_basic() {
+    let memory = Arc::new(InMemoryCache::new(1000));
+    let mut mock_secondary = MockSecondaryCache::new();
+
+    // Set up expectations
+    mock_secondary
+        .expect_insert_batch()
+        .returning(|_| Ok(()));
+    mock_secondary
+        .expect_filter_cached_updates()
+        .returning(|_| Ok(vec![]));
+
+    let cache = LayeredCache::new(memory, mock_secondary);
+
+    let events: Vec<Update> = (0..3)
+        .map(|i| {
+            Update::Event(EventDefinition {
+                name: format!("test_{}", i),
+                team_id: 1,
+                project_id: 1,
+                last_seen_at: Utc::now(),
+            })
+        })
+        .collect();
+
+    // First insert the events
+    cache.insert_batch(events.clone()).await;
+
+    // Then verify none of them are returned by filter_cached_updates
+    let not_in_cache = cache.filter_cached_updates(events.clone()).await;
+    assert_eq!(not_in_cache.len(), 0);
+}

--- a/rust/property-defs-rs/tests/cache/layered_cache.rs
+++ b/rust/property-defs-rs/tests/cache/layered_cache.rs
@@ -4,8 +4,9 @@ use property_defs_rs::types::{Update, EventDefinition};
 use property_defs_rs::errors::CacheError;
 use quick_cache::sync::Cache as InMemoryCache;
 use std::sync::Arc;
-use chrono::Utc;
+use chrono::{Utc, DateTime};
 use mockall::mock;
+use predicates::prelude::*;
 
 mock! {
     SecondaryCache {}
@@ -21,31 +22,407 @@ async fn test_layered_cache_basic() {
     let memory = Arc::new(InMemoryCache::new(1000));
     let mut mock_secondary = MockSecondaryCache::new();
 
-    // Set up expectations
-    mock_secondary
-        .expect_insert_batch()
-        .returning(|_| Ok(()));
-    mock_secondary
-        .expect_filter_cached_updates()
-        .returning(|_| Ok(vec![]));
-
-    let cache = LayeredCache::new(memory, mock_secondary);
-
+    let timestamp = DateTime::parse_from_rfc3339("2024-03-15T10:30:00Z").unwrap().with_timezone(&Utc);
     let events: Vec<Update> = (0..3)
         .map(|i| {
             Update::Event(EventDefinition {
                 name: format!("test_{}", i),
-                team_id: 1,
-                project_id: 1,
-                last_seen_at: Utc::now(),
+                team_id: 1234,
+                project_id: 5678,
+                last_seen_at: timestamp,
             })
         })
         .collect();
 
-    // First insert the events
+    mock_secondary
+        .expect_insert_batch()
+        .times(1)
+        .with(predicate::eq(events.clone()))
+        .returning(|_| Ok(()));
+    mock_secondary
+        .expect_filter_cached_updates()
+        .times(1)
+        .returning(|updates| Ok(updates.to_vec()));
+
+    let cache = LayeredCache::new(memory, mock_secondary);
+
+    let not_in_cache = cache.filter_cached_updates(events.clone()).await;
+    assert_eq!(not_in_cache, events, "All events should not be in cache initially");
+
     cache.insert_batch(events.clone()).await;
 
-    // Then verify none of them are returned by filter_cached_updates
     let not_in_cache = cache.filter_cached_updates(events.clone()).await;
+    assert_eq!(not_in_cache.len(), 0, "All events should be in cache after insertion");
+}
+
+#[tokio::test]
+async fn test_layered_cache_not_supported() {
+    let memory = Arc::new(InMemoryCache::new(1000));
+    let mut mock_secondary = MockSecondaryCache::new();
+
+    let timestamp = DateTime::parse_from_rfc3339("2024-03-15T10:30:00Z").unwrap().with_timezone(&Utc);
+    let events: Vec<Update> = (0..3)
+        .map(|i| {
+            Update::Event(EventDefinition {
+                name: format!("test_{}", i),
+                team_id: 2345,
+                project_id: 6789,
+                last_seen_at: timestamp,
+            })
+        })
+        .collect();
+
+    mock_secondary
+        .expect_insert_batch()
+        .times(1)
+        .with(predicate::eq(events.clone()))
+        .returning(|_| Err(CacheError::NotSupported));
+    mock_secondary
+        .expect_filter_cached_updates()
+        .times(1)
+        .returning(|_| Err(CacheError::NotSupported));
+
+    let cache = LayeredCache::new(memory, mock_secondary);
+
+    let not_in_cache = cache.filter_cached_updates(events.clone()).await;
+    assert_eq!(not_in_cache, events, "All events should be returned when secondary cache is not supported");
+
+    cache.insert_batch(events.clone()).await;
+
+    let not_in_cache = cache.filter_cached_updates(events.clone()).await;
+    assert_eq!(not_in_cache.len(), 0, "All events should be in memory cache after insertion");
+}
+
+#[tokio::test]
+async fn test_layered_cache_skips_secondary_cache() {
+    let memory = Arc::new(InMemoryCache::new(1000));
+    let mut mock_secondary = MockSecondaryCache::new();
+
+    let timestamp = DateTime::parse_from_rfc3339("2024-03-15T10:30:00Z").unwrap().with_timezone(&Utc);
+    let events: Vec<Update> = (0..3)
+        .map(|i| {
+            Update::Event(EventDefinition {
+                name: format!("test_{}", i),
+                team_id: 3456,
+                project_id: 7890,
+                last_seen_at: timestamp,
+            })
+        })
+        .collect();
+
+    mock_secondary
+        .expect_insert_batch()
+        .times(1)
+        .with(predicate::eq(events.clone()))
+        .returning(|_| Ok(()));
+    mock_secondary
+        .expect_filter_cached_updates()
+        .times(0)
+        .returning(|_| Ok(vec![]));
+
+    let cache = LayeredCache::new(memory, mock_secondary);
+
+    cache.insert_batch(events.clone()).await;
+
+    let not_in_cache = cache.filter_cached_updates(events.clone()).await;
+    assert_eq!(not_in_cache.len(), 0, "All events should be in memory cache");
+}
+
+#[tokio::test]
+async fn test_layered_cache_partial_hit() {
+    let memory = Arc::new(InMemoryCache::new(1000));
+    let mut mock_secondary = MockSecondaryCache::new();
+
+    let timestamp = DateTime::parse_from_rfc3339("2024-03-15T10:30:00Z").unwrap().with_timezone(&Utc);
+    let all_events: Vec<Update> = (1..=6)
+        .map(|i| {
+            Update::Event(EventDefinition {
+                name: format!("test_{}", i),
+                team_id: 4567,
+                project_id: 8901,
+                last_seen_at: timestamp,
+            })
+        })
+        .collect();
+
+    let events_to_cache = all_events[1..4].to_vec();
+    let events_to_check = vec![all_events[0].clone(), all_events[4].clone(), all_events[5].clone()];
+    let events_secondary_returns = vec![all_events[0].clone(), all_events[4].clone()];
+
+    mock_secondary
+        .expect_insert_batch()
+        .times(1)
+        .with(predicate::eq(events_to_cache.clone()))
+        .returning(|_| Ok(()));
+    mock_secondary
+        .expect_filter_cached_updates()
+        .times(1)
+        .with(predicate::eq(events_to_check.clone()))
+        .returning(move |_| Ok(events_secondary_returns.clone()));
+
+    let cache = LayeredCache::new(memory, mock_secondary);
+
+    cache.insert_batch(events_to_cache).await;
+
+    let not_in_cache = cache.filter_cached_updates(all_events.clone()).await;
+    assert_eq!(not_in_cache, vec![all_events[0].clone(), all_events[4].clone()]);
+}
+
+#[tokio::test]
+async fn test_layered_cache_full_hit() {
+    let memory = Arc::new(InMemoryCache::new(1000));
+    let mut mock_secondary = MockSecondaryCache::new();
+
+    let timestamp = DateTime::parse_from_rfc3339("2024-03-15T10:30:00Z").unwrap().with_timezone(&Utc);
+    let all_events: Vec<Update> = (1..=6)
+        .map(|i| {
+            Update::Event(EventDefinition {
+                name: format!("test_{}", i),
+                team_id: 5678,
+                project_id: 9012,
+                last_seen_at: timestamp,
+            })
+        })
+        .collect();
+
+    let events_to_cache = all_events[1..4].to_vec();
+    let events_to_check = vec![all_events[0].clone(), all_events[4].clone(), all_events[5].clone()];
+    let events_secondary_returns = vec![];
+
+    mock_secondary
+        .expect_insert_batch()
+        .times(1)
+        .with(predicate::eq(events_to_cache.clone()))
+        .returning(|_| Ok(()));
+    mock_secondary
+        .expect_filter_cached_updates()
+        .times(1)
+        .with(predicate::eq(events_to_check.clone()))
+        .returning(move |_| Ok(events_secondary_returns.clone()));
+
+    let cache = LayeredCache::new(memory, mock_secondary);
+
+    cache.insert_batch(events_to_cache).await;
+
+    let not_in_cache = cache.filter_cached_updates(all_events.clone()).await;
     assert_eq!(not_in_cache.len(), 0);
+}
+
+#[tokio::test]
+async fn test_layered_cache_fail_open() {
+    let memory = Arc::new(InMemoryCache::new(1000));
+    let mut mock_secondary = MockSecondaryCache::new();
+
+    let timestamp = DateTime::parse_from_rfc3339("2024-03-15T10:30:00Z").unwrap().with_timezone(&Utc);
+    let all_events: Vec<Update> = (1..=6)
+        .map(|i| {
+            Update::Event(EventDefinition {
+                name: format!("test_{}", i),
+                team_id: 6789,
+                project_id: 1234,
+                last_seen_at: timestamp,
+            })
+        })
+        .collect();
+
+    let events_to_cache = all_events[1..4].to_vec();
+    let events_to_check = vec![all_events[0].clone(), all_events[4].clone(), all_events[5].clone()];
+
+    mock_secondary
+        .expect_insert_batch()
+        .times(1)
+        .with(predicate::eq(events_to_cache.clone()))
+        .returning(|_| Ok(()));
+    mock_secondary
+        .expect_filter_cached_updates()
+        .times(1)
+        .with(predicate::eq(events_to_check.clone()))
+        .returning(|_| Err(CacheError::NotSupported));
+
+    let cache = LayeredCache::new(memory, mock_secondary);
+
+    cache.insert_batch(events_to_cache).await;
+
+    let not_in_cache = cache.filter_cached_updates(all_events.clone()).await;
+    assert_eq!(not_in_cache, events_to_check);
+}
+
+#[tokio::test]
+async fn test_layered_cache_len() {
+    let memory = Arc::new(InMemoryCache::new(1000));
+    let mut mock_secondary = MockSecondaryCache::new();
+
+    let timestamp = DateTime::parse_from_rfc3339("2024-03-15T10:30:00Z").unwrap().with_timezone(&Utc);
+    let first_batch: Vec<Update> = (0..3)
+        .map(|i| {
+            Update::Event(EventDefinition {
+                name: format!("test_{}", i),
+                team_id: 1234,
+                project_id: 5678,
+                last_seen_at: timestamp,
+            })
+        })
+        .collect();
+
+    let second_batch: Vec<Update> = (3..6)
+        .map(|i| {
+            Update::Event(EventDefinition {
+                name: format!("test_{}", i),
+                team_id: 2345,
+                project_id: 6789,
+                last_seen_at: timestamp,
+            })
+        })
+        .collect();
+
+    mock_secondary
+        .expect_insert_batch()
+        .times(1)
+        .with(predicate::eq(first_batch.clone()))
+        .returning(|_| Ok(()));
+
+    mock_secondary
+        .expect_insert_batch()
+        .times(1)
+        .with(predicate::eq(second_batch.clone()))
+        .returning(|_| Ok(()));
+
+    let cache = LayeredCache::new(memory, mock_secondary);
+
+    assert_eq!(cache.len(), 0, "Empty cache should have length 0");
+
+    cache.insert_batch(first_batch.clone()).await;
+    assert_eq!(cache.len(), 3, "Cache should have length 3 after first batch");
+
+    cache.insert_batch(second_batch.clone()).await;
+    assert_eq!(cache.len(), 6, "Cache should have length 6 after second batch");
+}
+
+#[tokio::test]
+async fn test_layered_cache_duplicates() {
+    let memory = Arc::new(InMemoryCache::new(1000));
+    let mut mock_secondary = MockSecondaryCache::new();
+
+    let timestamp = DateTime::parse_from_rfc3339("2024-03-15T10:30:00Z").unwrap().with_timezone(&Utc);
+    let all_events: Vec<Update> = (0..4)
+        .map(|i| {
+            Update::Event(EventDefinition {
+                name: format!("test_{}", i),
+                team_id: 1234,
+                project_id: 5678,
+                last_seen_at: timestamp,
+            })
+        })
+        .collect();
+
+    let first_batch = all_events[0..3].to_vec();
+    let second_batch = all_events[1..4].to_vec();
+    let new_events = vec![all_events[3].clone()];
+
+    mock_secondary
+        .expect_insert_batch()
+        .times(1)
+        .with(predicate::eq(first_batch.clone()))
+        .returning(|_| Ok(()));
+
+    mock_secondary
+        .expect_insert_batch()
+        .times(1)
+        .with(predicate::eq(new_events.clone()))
+        .returning(|_| Ok(()));
+
+    let cache = LayeredCache::new(memory, mock_secondary);
+
+    cache.insert_batch(first_batch.clone()).await;
+    assert_eq!(cache.len(), 3, "Cache should have length 3 after first batch");
+
+    cache.insert_batch(second_batch.clone()).await;
+    assert_eq!(cache.len(), 4, "Cache should have length 4 after second batch");
+
+    let not_in_cache = cache.filter_cached_updates(all_events.clone()).await;
+    assert_eq!(not_in_cache.len(), 0, "All events should be in cache");
+}
+
+#[tokio::test]
+async fn test_layered_cache_no_secondary_call_for_cached_events() {
+    let memory = Arc::new(InMemoryCache::new(1000));
+    let mut mock_secondary = MockSecondaryCache::new();
+
+    let timestamp = DateTime::parse_from_rfc3339("2024-03-15T10:30:00Z").unwrap().with_timezone(&Utc);
+    let all_events: Vec<Update> = (0..4)
+        .map(|i| {
+            Update::Event(EventDefinition {
+                name: format!("test_{}", i),
+                team_id: 2345,
+                project_id: 6789,
+                last_seen_at: timestamp,
+            })
+        })
+        .collect();
+
+    let first_batch = all_events[0..3].to_vec();
+    let second_batch = all_events[0..3].to_vec();
+
+    mock_secondary
+        .expect_insert_batch()
+        .times(1)
+        .with(predicate::eq(first_batch.clone()))
+        .returning(|_| Ok(()));
+
+    let cache = LayeredCache::new(memory, mock_secondary);
+
+    cache.insert_batch(first_batch.clone()).await;
+    assert_eq!(cache.len(), 3, "Cache should have length 3 after first batch");
+
+    cache.insert_batch(second_batch.clone()).await;
+    assert_eq!(cache.len(), 3, "Cache should still have length 3 after second batch");
+}
+
+#[tokio::test]
+async fn test_layered_cache_remove() {
+    let memory = Arc::new(InMemoryCache::new(1000));
+    let mut mock_secondary = MockSecondaryCache::new();
+
+    let timestamp = DateTime::parse_from_rfc3339("2024-03-15T10:30:00Z").unwrap().with_timezone(&Utc);
+    let events: Vec<Update> = (0..3)
+        .map(|i| {
+            Update::Event(EventDefinition {
+                name: format!("test_{}", i),
+                team_id: 1234,
+                project_id: 5678,
+                last_seen_at: timestamp,
+            })
+        })
+        .collect();
+
+    mock_secondary
+        .expect_insert_batch()
+        .times(1)
+        .with(predicate::eq(events.clone()))
+        .returning(|_| Err(CacheError::NotSupported));
+
+    mock_secondary
+        .expect_filter_cached_updates()
+        .times(2)
+        .returning(|_| Err(CacheError::NotSupported));
+
+    let cache = LayeredCache::new(memory, mock_secondary);
+
+    cache.insert_batch(events.clone()).await;
+    assert_eq!(cache.len(), 3, "Cache should have length 3 after insertion");
+
+    let not_in_cache = cache.filter_cached_updates(events.clone()).await;
+    assert_eq!(not_in_cache.len(), 0, "All events should be in cache");
+
+    cache.remove(&events[1]);
+    assert_eq!(cache.len(), 2, "Cache should have length 2 after removing middle event");
+
+    let not_in_cache = cache.filter_cached_updates(vec![events[1].clone()]).await;
+    assert_eq!(not_in_cache.len(), 1, "Removed event should not be in cache");
+
+    cache.remove(&events[0]);
+    assert_eq!(cache.len(), 1, "Cache should have length 1 after removing first event");
+
+    let not_in_cache = cache.filter_cached_updates(vec![events[0].clone()]).await;
+    assert_eq!(not_in_cache.len(), 1, "Removed event should not be in cache");
 }

--- a/rust/property-defs-rs/tests/cache/mod.rs
+++ b/rust/property-defs-rs/tests/cache/mod.rs
@@ -1,1 +1,2 @@
 mod layered_cache;
+mod redis_cache;

--- a/rust/property-defs-rs/tests/cache/mod.rs
+++ b/rust/property-defs-rs/tests/cache/mod.rs
@@ -1,0 +1,1 @@
+mod layered_cache;

--- a/rust/property-defs-rs/tests/cache/redis_cache.rs
+++ b/rust/property-defs-rs/tests/cache/redis_cache.rs
@@ -1,0 +1,285 @@
+use property_defs_rs::cache::redis_cache::{RedisCache, RedisClientOperations};
+use property_defs_rs::cache::CacheOperations;
+use property_defs_rs::types::{Update, EventDefinition};
+use redis::RedisError;
+use chrono::{Utc, DateTime};
+use mockall::mock;
+use predicates::prelude::*;
+
+mock! {
+    pub RedisClient {}
+
+    #[async_trait::async_trait]
+    impl RedisClientOperations for RedisClient {
+        async fn get_keys(&self, keys: &[String]) -> Result<Vec<Option<String>>, RedisError>;
+        async fn set_keys(&self, updates: &[(String, String)], ttl: u64) -> Result<(), RedisError>;
+    }
+
+    impl Clone for RedisClient {
+        fn clone(&self) -> Self;
+    }
+}
+
+#[tokio::test]
+async fn test_insert_single_update() {
+    let mut mock_client = MockRedisClient::new();
+    let timestamp = DateTime::parse_from_rfc3339("2024-03-15T10:30:00Z").unwrap().with_timezone(&Utc);
+    let event = Update::Event(EventDefinition {
+        name: "test_0".to_string(),
+        team_id: 1234,
+        project_id: 5678,
+        last_seen_at: timestamp,
+    });
+
+    mock_client
+        .expect_set_keys()
+        .times(1)
+        .with(
+            predicate::eq(vec![(event.key(), String::new())]),
+            predicate::eq(3600)
+        )
+        .returning(|_, _| Ok(()));
+
+    let cache = RedisCache::new(mock_client, 3600, 1000, 1000);
+    cache.insert_batch(&[event]).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_insert_multiple_within_limit() {
+    let mut mock_client = MockRedisClient::new();
+    let timestamp = DateTime::parse_from_rfc3339("2024-03-15T10:30:00Z").unwrap().with_timezone(&Utc);
+    let events: Vec<Update> = (0..3)
+        .map(|i| Update::Event(EventDefinition {
+            name: format!("test_{}", i),
+            team_id: 1234,
+            project_id: 5678,
+            last_seen_at: timestamp,
+        }))
+        .collect();
+
+    let key_value_pairs: Vec<(String, String)> = events.iter()
+        .map(|e| (e.key(), String::new()))
+        .collect();
+
+    mock_client
+        .expect_set_keys()
+        .times(1)
+        .with(predicate::eq(key_value_pairs), predicate::eq(3600))
+        .returning(|_, _| Ok(()));
+
+    let cache = RedisCache::new(mock_client, 3600, 1000, 5);
+    cache.insert_batch(&events).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_insert_exceeds_batch_limit() {
+    let mut mock_client = MockRedisClient::new();
+    let timestamp = DateTime::parse_from_rfc3339("2024-03-15T10:30:00Z").unwrap().with_timezone(&Utc);
+    let events: Vec<Update> = (0..5)
+        .map(|i| Update::Event(EventDefinition {
+            name: format!("test_{}", i),
+            team_id: 1234,
+            project_id: 5678,
+            last_seen_at: timestamp,
+        }))
+        .collect();
+
+    let first_three_pairs: Vec<(String, String)> = events[..3].iter()
+        .map(|e| (e.key(), String::new()))
+        .collect();
+
+    mock_client
+        .expect_set_keys()
+        .times(1)
+        .with(predicate::eq(first_three_pairs), predicate::eq(3600))
+        .returning(|_, _| Ok(()));
+
+    let cache = RedisCache::new(mock_client, 3600, 1000, 3);
+    cache.insert_batch(&events).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_insert_custom_ttl() {
+    let mut mock_client = MockRedisClient::new();
+    let timestamp = DateTime::parse_from_rfc3339("2024-03-15T10:30:00Z").unwrap().with_timezone(&Utc);
+    let event = Update::Event(EventDefinition {
+        name: "test_0".to_string(),
+        team_id: 1234,
+        project_id: 5678,
+        last_seen_at: timestamp,
+    });
+
+    mock_client
+        .expect_set_keys()
+        .times(1)
+        .with(
+            predicate::eq(vec![(event.key(), String::new())]),
+            predicate::eq(7200)
+        )
+        .returning(|_, _| Ok(()));
+
+    let cache = RedisCache::new(mock_client, 7200, 1000, 1000);
+    cache.insert_batch(&[event]).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_filter_all_missing() {
+    let mut mock_client = MockRedisClient::new();
+    let timestamp = DateTime::parse_from_rfc3339("2024-03-15T10:30:00Z").unwrap().with_timezone(&Utc);
+    let events: Vec<Update> = (0..3)
+        .map(|i| Update::Event(EventDefinition {
+            name: format!("test_{}", i),
+            team_id: 1234,
+            project_id: 5678,
+            last_seen_at: timestamp,
+        }))
+        .collect();
+
+    let keys: Vec<String> = events.iter().map(|e| e.key()).collect();
+
+    mock_client
+        .expect_get_keys()
+        .times(1)
+        .with(predicate::eq(keys))
+        .returning(|keys| Ok(vec![None; keys.len()]));
+
+    let cache = RedisCache::new(mock_client, 3600, 1000, 1000);
+    let not_in_cache = cache.filter_cached_updates(events.clone()).await;
+    assert_eq!(not_in_cache, events, "All events should be returned as missing");
+}
+
+#[tokio::test]
+async fn test_filter_all_present() {
+    let mut mock_client = MockRedisClient::new();
+    let timestamp = DateTime::parse_from_rfc3339("2024-03-15T10:30:00Z").unwrap().with_timezone(&Utc);
+    let events: Vec<Update> = (0..3)
+        .map(|i| Update::Event(EventDefinition {
+            name: format!("test_{}", i),
+            team_id: 1234,
+            project_id: 5678,
+            last_seen_at: timestamp,
+        }))
+        .collect();
+
+    let keys: Vec<String> = events.iter().map(|e| e.key()).collect();
+
+    mock_client
+        .expect_get_keys()
+        .times(1)
+        .with(predicate::eq(keys))
+        .returning(|keys| Ok(vec![Some(String::new()); keys.len()]));
+
+    let cache = RedisCache::new(mock_client, 3600, 1000, 1000);
+    let not_in_cache = cache.filter_cached_updates(events).await;
+    assert_eq!(not_in_cache.len(), 0, "No events should be returned as all are present");
+}
+
+#[tokio::test]
+async fn test_filter_partial_hits() {
+    let mut mock_client = MockRedisClient::new();
+    let timestamp = DateTime::parse_from_rfc3339("2024-03-15T10:30:00Z").unwrap().with_timezone(&Utc);
+    let events: Vec<Update> = (0..3)
+        .map(|i| Update::Event(EventDefinition {
+            name: format!("test_{}", i),
+            team_id: 1234,
+            project_id: 5678,
+            last_seen_at: timestamp,
+        }))
+        .collect();
+
+    let keys: Vec<String> = events.iter().map(|e| e.key()).collect();
+
+    mock_client
+        .expect_get_keys()
+        .times(1)
+        .with(predicate::eq(keys))
+        .returning(|_| Ok(vec![Some(String::new()), None, Some(String::new())]));
+
+    let cache = RedisCache::new(mock_client, 3600, 1000, 1000);
+    let not_in_cache = cache.filter_cached_updates(events.clone()).await;
+    assert_eq!(not_in_cache.len(), 1, "One event should be missing");
+    assert_eq!(not_in_cache[0].key(), events[1].key(), "Middle event should be missing");
+}
+
+#[tokio::test]
+async fn test_filter_batch_limit() {
+    let mut mock_client = MockRedisClient::new();
+    let timestamp = DateTime::parse_from_rfc3339("2024-03-15T10:30:00Z").unwrap().with_timezone(&Utc);
+    let events: Vec<Update> = (0..5)
+        .map(|i| Update::Event(EventDefinition {
+            name: format!("test_{}", i),
+            team_id: 1234,
+            project_id: 5678,
+            last_seen_at: timestamp,
+        }))
+        .collect();
+
+    let last_three_keys: Vec<String> = events[2..].iter().map(|e| e.key()).collect();
+
+    mock_client
+        .expect_get_keys()
+        .times(1)
+        .with(predicate::eq(last_three_keys))
+        .returning(|_| Ok(vec![Some(String::new()), None, Some(String::new())]));
+
+    let cache = RedisCache::new(mock_client, 3600, 3, 1000);
+    let not_in_cache = cache.filter_cached_updates(events.clone()).await;
+    assert_eq!(not_in_cache.len(), 3, "First two events and one uncached event should be returned");
+    assert_eq!(not_in_cache[0].key(), events[0].key(), "First event should be returned");
+    assert_eq!(not_in_cache[1].key(), events[1].key(), "Second event should be returned");
+    assert_eq!(not_in_cache[2].key(), events[3].key(), "Fourth event should be returned as uncached");
+}
+
+#[tokio::test]
+async fn test_filter_connection_error_fails_open() {
+    let mut mock_client = MockRedisClient::new();
+    let timestamp = DateTime::parse_from_rfc3339("2024-03-15T10:30:00Z").unwrap().with_timezone(&Utc);
+    let events: Vec<Update> = (0..3)
+        .map(|i| Update::Event(EventDefinition {
+            name: format!("test_{}", i),
+            team_id: 1234,
+            project_id: 5678,
+            last_seen_at: timestamp,
+        }))
+        .collect();
+
+    let keys: Vec<String> = events.iter().map(|e| e.key()).collect();
+
+    mock_client
+        .expect_get_keys()
+        .times(1)
+        .with(predicate::eq(keys))
+        .returning(|_| Err(RedisError::from((redis::ErrorKind::IoError, "Connection refused"))));
+
+    let cache = RedisCache::new(mock_client, 3600, 1000, 1000);
+    let not_in_cache = cache.filter_cached_updates(events.clone()).await;
+    assert_eq!(not_in_cache, events, "All events should be returned on connection error");
+}
+
+#[tokio::test]
+async fn test_insert_redis_error() {
+    let mut mock_client = MockRedisClient::new();
+    let timestamp = DateTime::parse_from_rfc3339("2024-03-15T10:30:00Z").unwrap().with_timezone(&Utc);
+    let events: Vec<Update> = (0..3)
+        .map(|i| Update::Event(EventDefinition {
+            name: format!("test_{}", i),
+            team_id: 1234,
+            project_id: 5678,
+            last_seen_at: timestamp,
+        }))
+        .collect();
+
+    let key_value_pairs: Vec<(String, String)> = events.iter()
+        .map(|e| (e.key(), String::new()))
+        .collect();
+
+    mock_client
+        .expect_set_keys()
+        .times(1)
+        .with(predicate::eq(key_value_pairs), predicate::eq(3600))
+        .returning(|_, _| Err(RedisError::from((redis::ErrorKind::ResponseError, "Mock error"))));
+
+    let cache = RedisCache::new(mock_client, 3600, 1000, 1000);
+    let result = cache.insert_batch(&events).await;
+    assert!(result.is_err(), "Insert should return error on Redis failure");
+}

--- a/rust/property-defs-rs/tests/mod.rs
+++ b/rust/property-defs-rs/tests/mod.rs
@@ -1,0 +1,5 @@
+mod cache;
+mod queries;
+mod types;
+mod updates;
+mod v2_batch_ingestion;


### PR DESCRIPTION
## Problem

Propdefs consumers are partitioned by distinct id, so the property definitions are duplicated across the consumers. We believe a shared cache (which could be properly sharded later) could help us scale the service horizontally by reducing the amount of local cache that we need.

## Changes

Adds a layered cache with the first line in memory cache and an optional secondary redis cache:

- Redis cache is enabled and configured using env variables
- Layered cache fails open, so that Redis issues can be absorbed by propdefs and RDS
- There are throttling mechanisms in the Redis cache config, so we'll be able to do some tuning

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

- Added unit tests
- Will be tested first on the mirror deployment