### PR TITLE
refactor(max): Make `answer` required

### DIFF
--- a/ee/hogai/query_executor/test/test_nodes.py
+++ b/ee/hogai/query_executor/test/test_nodes.py
@@ -163,24 +163,6 @@ class TestQueryExecutorNode(ClickhouseTestMixin, BaseTest):
                 {},
             )
 
-    def test_node_requires_viz_message_in_state_to_have_query(self):
-        node = QueryExecutorNode(self.team)
-
-        with self.assertRaisesMessage(ValueError, "Did not find query in the visualization message"):
-            node.run(
-                AssistantState(
-                    messages=[
-                        VisualizationMessage(answer=None, plan="Plan", id="test"),
-                    ],
-                    plan="Plan",
-                    start_id="test",
-                    root_tool_call_id="tool1",
-                    root_tool_insight_plan="test query",
-                    root_tool_insight_type="trends",
-                ),
-                {},
-            )
-
     def test_fallback_to_json(self):
         node = QueryExecutorNode(self.team)
         with patch("ee.hogai.query_executor.nodes.process_query_dict") as mock_process_query_dict:

--- a/ee/hogai/test/test_utils.py
+++ b/ee/hogai/test/test_utils.py
@@ -19,7 +19,6 @@ class TestTrendsUtils(BaseTest):
             HumanMessage(content="Text2"),
         ]
         messages = filter_and_merge_messages(conversation)
-        self.assertEqual(len(messages), 4)
         self.assertEqual(
             [
                 HumanMessage(content="Text\nText"),

--- a/ee/hogai/test/test_utils.py
+++ b/ee/hogai/test/test_utils.py
@@ -17,7 +17,6 @@ class TestTrendsUtils(BaseTest):
             HumanMessage(content="Text"),
             VisualizationMessage(answer=AssistantTrendsQuery(series=[]), plan="plan"),
             HumanMessage(content="Text2"),
-            VisualizationMessage(answer=None, plan="plan"),
         ]
         messages = filter_and_merge_messages(conversation)
         self.assertEqual(len(messages), 4)
@@ -26,7 +25,6 @@ class TestTrendsUtils(BaseTest):
                 HumanMessage(content="Text\nText"),
                 VisualizationMessage(answer=AssistantTrendsQuery(series=[]), plan="plan"),
                 HumanMessage(content="Text2"),
-                VisualizationMessage(answer=None, plan="plan"),
             ],
             messages,
         )

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -16947,7 +16947,7 @@
                     "type": "string"
                 }
             },
-            "required": ["type", "query"],
+            "required": ["type", "query", "answer"],
             "type": "object"
         },
         "VizSpecificOptions": {

--- a/frontend/src/queries/schema/schema-assistant-messages.ts
+++ b/frontend/src/queries/schema/schema-assistant-messages.ts
@@ -60,7 +60,7 @@ export interface VisualizationMessage extends BaseAssistantMessage {
     /** @default '' */
     query: string
     plan?: string
-    answer?: AssistantTrendsQuery | AssistantFunnelsQuery | AssistantRetentionQuery | AssistantHogQLQuery
+    answer: AssistantTrendsQuery | AssistantFunnelsQuery | AssistantRetentionQuery | AssistantHogQLQuery
     initiator?: string
 }
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -7001,9 +7001,7 @@ class VisualizationMessage(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    answer: Optional[
-        Union[AssistantTrendsQuery, AssistantFunnelsQuery, AssistantRetentionQuery, AssistantHogQLQuery]
-    ] = None
+    answer: Union[AssistantTrendsQuery, AssistantFunnelsQuery, AssistantRetentionQuery, AssistantHogQLQuery]
     id: Optional[str] = None
     initiator: Optional[str] = None
     plan: Optional[str] = None


### PR DESCRIPTION
## Problem

Way back it was possible to get a `VisualizationMessage` without an `answer` from Max. Types still allow it, but it should _not_ be possible anymore.

## Changes

`VisualizationMessage` now must have `answer`.
