### PR TITLE
feat(crm): Remove annoying parens from pluralized group name

### DIFF
--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -48,6 +48,7 @@ import {
     shortTimeZone,
     stringOperatorMap,
     toParams,
+    wordPluralize,
 } from './utils'
 
 describe('lib/utils', () => {
@@ -206,6 +207,17 @@ describe('lib/utils', () => {
             expect(pluralize(28321, 'member')).toEqual('28,321 members')
             expect(pluralize(99, 'bacterium', 'bacteria')).toEqual('99 bacteria')
             expect(pluralize(3, 'word', undefined, false)).toEqual('words')
+        })
+    })
+
+    describe('wordPluralize()', () => {
+        it('handles singular cases', () => {
+            expect(wordPluralize('company')).toEqual('companies')
+            expect(wordPluralize('person')).toEqual('people')
+            expect(wordPluralize('bacterium')).toEqual('bacteria')
+            expect(wordPluralize('word')).toEqual('words')
+            expect(wordPluralize('child')).toEqual('children')
+            expect(wordPluralize('knife')).toEqual('knives')
         })
     })
 

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1399,6 +1399,49 @@ export function pluralize(count: number, singular: string, plural?: string, incl
     return includeNumber ? `${humanFriendlyNumber(count)} ${form}` : form
 }
 
+const WORD_PLURALIZATION_RULES = [
+    [/s?$/i, 's'],
+    [/([^aeiou]ese)$/i, '$1'],
+    [/(ax|test)is$/i, '$1es'],
+    [/(alias|[^aou]us|t[lm]as|gas|ris)$/i, '$1es'],
+    [/(e[mn]u)s?$/i, '$1s'],
+    [/([^l]ias|[aeiou]las|[ejzr]as|[iu]am)$/i, '$1'],
+    [/(alumn|syllab|vir|radi|nucle|fung|cact|stimul|termin|bacill|foc|uter|loc|strat)(?:us|i)$/i, '$1i'],
+    [/(alumn|alg|vertebr)(?:a|ae)$/i, '$1ae'],
+    [/(seraph|cherub)(?:im)?$/i, '$1im'],
+    [/(her|at|gr)o$/i, '$1oes'],
+    [
+        /(agend|addend|millenni|dat|extrem|bacteri|desiderat|strat|candelabr|errat|ov|symposi|curricul|automat|quor)(?:a|um)$/i,
+        '$1a',
+    ],
+    [/(apheli|hyperbat|periheli|asyndet|noumen|phenomen|criteri|organ|prolegomen|hedr|automat)(?:a|on)$/i, '$1a'],
+    [/sis$/i, 'ses'],
+    [/(?:(kni|wi|li)fe|(ar|l|ea|eo|oa|hoo)f)$/i, '$1$2ves'],
+    [/([^aeiouy]|qu)y$/i, '$1ies'],
+    [/([^ch][ieo][ln])ey$/i, '$1ies'],
+    [/(x|ch|ss|sh|zz)$/i, '$1es'],
+    [/(matr|cod|mur|sil|vert|ind|append)(?:ix|ex)$/i, '$1ices'],
+    [/\b((?:tit)?m|l)(?:ice|ouse)$/i, '$1ice'],
+    [/(pe)(?:rson|ople)$/i, '$1ople'],
+    [/(child)(?:ren)?$/i, '$1ren'],
+    [/eaux$/i, '$0'],
+    [/m[ae]n$/i, 'men'],
+]
+
+export function wordPluralize(word: string): string {
+    let len = WORD_PLURALIZATION_RULES.length
+
+    // Iterate over the sanitization rules and use the first one to match.
+    while (len--) {
+        const [regex, replacement] = WORD_PLURALIZATION_RULES[len]
+        if (regex.test(word)) {
+            return word.replace(regex, replacement)
+        }
+    }
+
+    return word
+}
+
 const COMPACT_NUMBER_MAGNITUDES = ['', 'K', 'M', 'B', 'T', 'P', 'E', 'Z', 'Y']
 
 /** Return a number in a compact format, with a SI suffix if applicable.

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1426,7 +1426,7 @@ const WORD_PLURALIZATION_RULES = [
     [/(child)(?:ren)?$/i, '$1ren'],
     [/eaux$/i, '$0'],
     [/m[ae]n$/i, 'men'],
-]
+] as [RegExp, string][]
 
 export function wordPluralize(word: string): string {
     let len = WORD_PLURALIZATION_RULES.length

--- a/frontend/src/models/groupsModel.ts
+++ b/frontend/src/models/groupsModel.ts
@@ -112,7 +112,7 @@ export const groupsModel = kea<groupsModelType>([
                         if (groupType) {
                             return {
                                 singular: groupType.name_singular || groupType.group_type,
-                                plural: groupType.name_plural || `${groupType.group_type}(s)`,
+                                plural: groupType.name_plural || `${groupType.group_type}s`,
                             }
                         }
                         return {

--- a/frontend/src/models/groupsModel.ts
+++ b/frontend/src/models/groupsModel.ts
@@ -4,12 +4,12 @@ import { subscriptions } from 'kea-subscriptions'
 import api from 'lib/api'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { groupsAccessLogic, GroupsAccessStatus } from 'lib/introductions/groupsAccessLogic'
+import { wordPluralize } from 'lib/utils'
 import { projectLogic } from 'scenes/projectLogic'
 
 import { GroupType, GroupTypeIndex } from '~/types'
 
 import type { groupsModelType } from './groupsModelType'
-
 export interface Noun {
     singular: string
     plural: string
@@ -112,7 +112,7 @@ export const groupsModel = kea<groupsModelType>([
                         if (groupType) {
                             return {
                                 singular: groupType.name_singular || groupType.group_type,
-                                plural: groupType.name_plural || `${groupType.group_type}s`,
+                                plural: groupType.name_plural || wordPluralize(groupType.group_type),
                             }
                         }
                         return {


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/29881

## Changes

Turns `Organization(s)` into `Organizations`

**Before**

![CleanShot 2025-04-03 at 08 14 44@2x](https://github.com/user-attachments/assets/26908c66-ddd4-4949-a70c-bd6f16ae1bc8)

**After**

![CleanShot 2025-04-03 at 08 38 11@2x](https://github.com/user-attachments/assets/1720a0a7-6e38-4e74-a81c-b1a438a7a611)

## How did you test this code?

Tests should pass.
