### PR TITLE
feat(cdp): enable setting execution_order on create and update of hogFn

### DIFF
--- a/posthog/api/hog_function.py
+++ b/posthog/api/hog_function.py
@@ -332,15 +332,14 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
         if validated_data.get("type") == "transformation":
             requested_order = validated_data.get("execution_order")
 
-            with transaction.atomic():
-                # For transformations, we need to determine the execution_order
-                if requested_order is None:
-                    # If no order specified, add at the end
-                    highest_order = self._get_highest_execution_order(validated_data["team"].id)
-                    validated_data["execution_order"] = highest_order + 1
+            # For transformations, we need to determine the execution_order
+            if requested_order is None:
+                # If no order specified, add at the end
+                highest_order = self._get_highest_execution_order(validated_data["team"].id)
+                validated_data["execution_order"] = highest_order + 1
 
-                # Create the function with the execution_order
-                return super().create(validated_data=validated_data)
+            # Create the function with the execution_order
+            return super().create(validated_data=validated_data)
         else:
             # For non-transformation types, just create normally
             return super().create(validated_data=validated_data)

--- a/posthog/api/hog_function.py
+++ b/posthog/api/hog_function.py
@@ -328,23 +328,47 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
         request = self.context["request"]
         validated_data["created_by"] = request.user
 
-        # Set execution_order for transformation type
+        # Handle execution_order for transformation type
         if validated_data.get("type") == "transformation":
-            # Get the highest execution_order for existing transformations
-            highest_order = (
-                HogFunction.objects.filter(team_id=validated_data["team"].id, type="transformation", deleted=False)
-                .order_by("-execution_order")
-                .values_list("execution_order", flat=True)
-                .first()
-            )
+            requested_order = validated_data.get("execution_order")
 
-            # Set to 1 if no existing transformations, otherwise increment by 1
-            validated_data["execution_order"] = (highest_order or 0) + 1
+            with transaction.atomic():
+                # For transformations, we need to determine the execution_order
+                if requested_order is None:
+                    # If no order specified, add at the end
+                    highest_order = self._get_highest_execution_order(validated_data["team"].id)
+                    validated_data["execution_order"] = highest_order + 1
 
-        hog_function = super().create(validated_data=validated_data)
-        return hog_function
+                # Create the function with the execution_order
+                return super().create(validated_data=validated_data)
+        else:
+            # For non-transformation types, just create normally
+            return super().create(validated_data=validated_data)
+
+    def _get_highest_execution_order(self, team_id: int) -> int:
+        """Get the highest execution_order for transformations in a team."""
+        highest_order = (
+            HogFunction.objects.filter(team_id=team_id, type="transformation", deleted=False)
+            .order_by("-execution_order")
+            .values_list("execution_order", flat=True)
+            .first()
+        )
+        return highest_order or 0
 
     def update(self, instance: HogFunction, validated_data: dict, *args, **kwargs) -> HogFunction:
+        # Handle undeletion or re-enabling by placing at the end when needed
+        if instance.type == "transformation" and (
+            (instance.deleted and validated_data.get("deleted") is False)
+            or (
+                not instance.enabled
+                and validated_data.get("enabled") is True
+                and "execution_order" not in validated_data
+            )
+        ):
+            highest_order = self._get_highest_execution_order(instance.team_id)
+            validated_data["execution_order"] = highest_order + 1
+
+        # Standard update
         res: HogFunction = super().update(instance, validated_data)
 
         if res.enabled and res.status.get("state", 0) >= HogFunctionState.DISABLED_TEMPORARILY.value:
@@ -394,7 +418,7 @@ class HogFunctionViewSet(
             queryset = queryset.filter(deleted=False)
 
         if self.action == "list":
-            queryset = queryset.order_by("execution_order", "created_at")
+            queryset = queryset.order_by("execution_order", "-updated_at")
 
         if self.request.GET.get("filters"):
             try:

--- a/posthog/api/test/test_hog_function.py
+++ b/posthog/api/test/test_hog_function.py
@@ -2155,10 +2155,10 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 [f for f in results if f["type"] == "transformation"], key=lambda x: x["execution_order"] or 999
             )
 
-            fn_orders = {f["name"]: f["execution_order"] for f in transformations}
-            assert fn_orders["Transform A"] == 1
-            assert fn_orders["Transform C"] == 3
-            assert fn_orders["Transform B"] == 4  # It's now at the end
+            fn_orders = {f["name"]: int(f["execution_order"]) for f in transformations}
+            assert fn_orders["Transform A"] == 1, "A should still have order 1"
+            assert fn_orders["Transform C"] == 3, "C should remain at order 3"
+            assert fn_orders["Transform B"] == 4, "B should now be at the end (order 4)"
 
     def test_transformation_normal_execution_order_update(self, *args):
         """Test updating execution_order for a transformation function directly."""
@@ -2215,7 +2215,7 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             transformations = [f for f in results if f["type"] == "transformation"]
             assert len(transformations) == 3
 
-            fn_orders = {f["name"]: f["execution_order"] for f in transformations}
+            fn_orders = {f["name"]: int(f["execution_order"]) for f in transformations}
             assert fn_orders["Transform A"] == 1
             assert fn_orders["Transform B"] == 2
             assert fn_orders["Transform C"] == 3
@@ -2233,7 +2233,7 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             transformations = [f for f in results if f["type"] == "transformation"]
 
             # Order by function name for verification
-            fn_orders = {f["name"]: f["execution_order"] for f in transformations}
+            fn_orders = {f["name"]: int(f["execution_order"]) for f in transformations}
             assert fn_orders["Transform A"] == 1, "A should still have order 1"
             assert fn_orders["Transform B"] == 1, "B should now have order 1"
             assert fn_orders["Transform C"] == 3, "C should remain at order 3"

--- a/posthog/api/test/test_hog_function.py
+++ b/posthog/api/test/test_hog_function.py
@@ -1568,8 +1568,9 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             assert response3.status_code == status.HTTP_201_CREATED
             assert response3.json()["execution_order"] is None
 
-    def test_list_hog_functions_ordered_by_execution_order_and_created_at(self):
-        # Create functions with different execution orders and creation times
+    def test_list_hog_functions_ordered_by_execution_order_and_updated_at(self):
+        # Create functions with different execution orders and update times
+        # First create all functions with the same timestamp
         with freeze_time("2024-01-01T00:00:00Z"):
             self.client.post(
                 f"/api/projects/{self.team.id}/hog_functions/",
@@ -1580,7 +1581,6 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 },
             ).json()
 
-        with freeze_time("2024-01-02T00:00:00Z"):
             self.client.post(
                 f"/api/projects/{self.team.id}/hog_functions/",
                 data={
@@ -1590,7 +1590,6 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 },
             ).json()
 
-        with freeze_time("2024-01-03T00:00:00Z"):
             self.client.post(
                 f"/api/projects/{self.team.id}/hog_functions/",
                 data={
@@ -1600,7 +1599,6 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 },
             ).json()
 
-        with freeze_time("2024-01-04T00:00:00Z"):
             self.client.post(
                 f"/api/projects/{self.team.id}/hog_functions/",
                 data={
@@ -1984,3 +1982,264 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 },
             )
             assert response.status_code == status.HTTP_201_CREATED, response.json()
+
+    def test_transformation_undeletion_puts_at_end(self, *args):
+        """Test that undeleted transformation functions are placed at the end of the execution order sequence."""
+        with patch("posthog.api.hog_function_template.HogFunctionTemplates.template") as mock_template:
+            mock_template.return_value = template_slack
+
+            # Create initial transformations
+            response1 = self.client.post(
+                f"/api/projects/{self.team.id}/hog_functions/",
+                data={
+                    "name": "Transform A",
+                    "type": "transformation",
+                    "template_id": template_slack.id,
+                    "inputs": {
+                        "slack_workspace": {"value": 1},
+                        "channel": {"value": "#general"},
+                    },
+                },
+            )
+            assert response1.status_code == status.HTTP_201_CREATED
+
+            response2 = self.client.post(
+                f"/api/projects/{self.team.id}/hog_functions/",
+                data={
+                    "name": "Transform B",
+                    "type": "transformation",
+                    "template_id": template_slack.id,
+                    "inputs": {
+                        "slack_workspace": {"value": 1},
+                        "channel": {"value": "#general"},
+                    },
+                },
+            )
+            assert response2.status_code == status.HTTP_201_CREATED
+            fn_b_id = response2.json()["id"]
+
+            # Delete function B
+            delete_response = self.client.patch(
+                f"/api/projects/{self.team.id}/hog_functions/{fn_b_id}/",
+                data={"deleted": True},
+            )
+            assert delete_response.status_code == status.HTTP_200_OK
+
+            # Create a third function
+            response3 = self.client.post(
+                f"/api/projects/{self.team.id}/hog_functions/",
+                data={
+                    "name": "Transform C",
+                    "type": "transformation",
+                    "template_id": template_slack.id,
+                    "inputs": {
+                        "slack_workspace": {"value": 1},
+                        "channel": {"value": "#general"},
+                    },
+                },
+            )
+            assert response3.status_code == status.HTTP_201_CREATED
+            # At this point we should have A with order 1 and C with order 2
+            list_response = self.client.get(f"/api/projects/{self.team.id}/hog_functions/")
+            results = list_response.json()["results"]
+            transformations = [f for f in results if f["type"] == "transformation"]
+            assert len(transformations) == 2
+
+            # Verify current order
+            fn_orders = {f["name"]: f["execution_order"] for f in transformations}
+            assert fn_orders["Transform A"] == 1
+            assert fn_orders["Transform C"] == 2
+
+            # Now undelete function B
+            undelete_response = self.client.patch(
+                f"/api/projects/{self.team.id}/hog_functions/{fn_b_id}/",
+                data={"deleted": False},
+            )
+            assert undelete_response.status_code == status.HTTP_200_OK
+
+            # Check order - B should now be at the end (order 3)
+            list_response = self.client.get(f"/api/projects/{self.team.id}/hog_functions/")
+            results = list_response.json()["results"]
+            transformations = [f for f in results if f["type"] == "transformation"]
+            assert len(transformations) == 3
+
+            fn_orders = {f["name"]: f["execution_order"] for f in transformations}
+            assert fn_orders["Transform A"] == 1
+            assert fn_orders["Transform C"] == 2
+            assert fn_orders["Transform B"] == 3
+
+    def test_transformation_reenabling_puts_at_end(self, *args):
+        """Test that re-enabled transformation functions are placed at the end of the execution order sequence."""
+        with patch("posthog.api.hog_function_template.HogFunctionTemplates.template") as mock_template:
+            mock_template.return_value = template_slack
+
+            # Create initial transformations - all enabled
+            response1 = self.client.post(
+                f"/api/projects/{self.team.id}/hog_functions/",
+                data={
+                    "name": "Transform A",
+                    "type": "transformation",
+                    "template_id": template_slack.id,
+                    "enabled": True,
+                    "inputs": {
+                        "slack_workspace": {"value": 1},
+                        "channel": {"value": "#general"},
+                    },
+                },
+            )
+            assert response1.status_code == status.HTTP_201_CREATED
+
+            response2 = self.client.post(
+                f"/api/projects/{self.team.id}/hog_functions/",
+                data={
+                    "name": "Transform B",
+                    "type": "transformation",
+                    "template_id": template_slack.id,
+                    "enabled": True,
+                    "inputs": {
+                        "slack_workspace": {"value": 1},
+                        "channel": {"value": "#general"},
+                    },
+                },
+            )
+            assert response2.status_code == status.HTTP_201_CREATED
+            fn_b_id = response2.json()["id"]
+
+            # Disable function B
+            disable_response = self.client.patch(
+                f"/api/projects/{self.team.id}/hog_functions/{fn_b_id}/",
+                data={"enabled": False},
+            )
+            assert disable_response.status_code == status.HTTP_200_OK
+
+            # Create a third function
+            response3 = self.client.post(
+                f"/api/projects/{self.team.id}/hog_functions/",
+                data={
+                    "name": "Transform C",
+                    "type": "transformation",
+                    "template_id": template_slack.id,
+                    "enabled": True,
+                    "inputs": {
+                        "slack_workspace": {"value": 1},
+                        "channel": {"value": "#general"},
+                    },
+                },
+            )
+            assert response3.status_code == status.HTTP_201_CREATED
+
+            # Check current order before re-enabling
+            list_response = self.client.get(f"/api/projects/{self.team.id}/hog_functions/")
+            results = list_response.json()["results"]
+            transformations = sorted(
+                [f for f in results if f["type"] == "transformation"], key=lambda x: x["execution_order"] or 999
+            )
+
+            # Verify current order (B is disabled but still in the list)
+            fn_orders = {f["name"]: {"order": f["execution_order"], "enabled": f["enabled"]} for f in transformations}
+            assert fn_orders["Transform A"]["order"] == 1
+            assert fn_orders["Transform B"]["order"] == 2 and not fn_orders["Transform B"]["enabled"]
+            assert fn_orders["Transform C"]["order"] == 3
+
+            # Now re-enable function B without specifying an execution_order
+            reenable_response = self.client.patch(
+                f"/api/projects/{self.team.id}/hog_functions/{fn_b_id}/",
+                data={"enabled": True},
+            )
+            assert reenable_response.status_code == status.HTTP_200_OK
+
+            # Check order - B should now be at the end
+            list_response = self.client.get(f"/api/projects/{self.team.id}/hog_functions/")
+            results = list_response.json()["results"]
+            transformations = sorted(
+                [f for f in results if f["type"] == "transformation"], key=lambda x: x["execution_order"] or 999
+            )
+
+            fn_orders = {f["name"]: f["execution_order"] for f in transformations}
+            assert fn_orders["Transform A"] == 1
+            assert fn_orders["Transform C"] == 3
+            assert fn_orders["Transform B"] == 4  # It's now at the end
+
+    def test_transformation_normal_execution_order_update(self, *args):
+        """Test updating execution_order for a transformation function directly."""
+        with patch("posthog.api.hog_function_template.HogFunctionTemplates.template") as mock_template:
+            mock_template.return_value = template_slack
+
+            # Create three transformations with consecutive orders
+            response1 = self.client.post(
+                f"/api/projects/{self.team.id}/hog_functions/",
+                data={
+                    "name": "Transform A",
+                    "type": "transformation",
+                    "template_id": template_slack.id,
+                    "inputs": {
+                        "slack_workspace": {"value": 1},
+                        "channel": {"value": "#general"},
+                    },
+                },
+            )
+            assert response1.status_code == status.HTTP_201_CREATED
+
+            response2 = self.client.post(
+                f"/api/projects/{self.team.id}/hog_functions/",
+                data={
+                    "name": "Transform B",
+                    "type": "transformation",
+                    "template_id": template_slack.id,
+                    "inputs": {
+                        "slack_workspace": {"value": 1},
+                        "channel": {"value": "#general"},
+                    },
+                },
+            )
+            assert response2.status_code == status.HTTP_201_CREATED
+            fn_b_id = response2.json()["id"]
+
+            response3 = self.client.post(
+                f"/api/projects/{self.team.id}/hog_functions/",
+                data={
+                    "name": "Transform C",
+                    "type": "transformation",
+                    "template_id": template_slack.id,
+                    "inputs": {
+                        "slack_workspace": {"value": 1},
+                        "channel": {"value": "#general"},
+                    },
+                },
+            )
+            assert response3.status_code == status.HTTP_201_CREATED
+
+            # Verify initial order: A=1, B=2, C=3
+            list_response = self.client.get(f"/api/projects/{self.team.id}/hog_functions/")
+            results = list_response.json()["results"]
+            transformations = [f for f in results if f["type"] == "transformation"]
+            assert len(transformations) == 3
+
+            fn_orders = {f["name"]: f["execution_order"] for f in transformations}
+            assert fn_orders["Transform A"] == 1
+            assert fn_orders["Transform B"] == 2
+            assert fn_orders["Transform C"] == 3
+
+            # Test 1: Update B's execution_order to match A (both will have order 1)
+            update_response = self.client.patch(
+                f"/api/projects/{self.team.id}/hog_functions/{fn_b_id}/",
+                data={"execution_order": 1},
+            )
+            assert update_response.status_code == status.HTTP_200_OK
+
+            # Check the updated orders
+            list_response = self.client.get(f"/api/projects/{self.team.id}/hog_functions/")
+            results = list_response.json()["results"]
+            transformations = [f for f in results if f["type"] == "transformation"]
+
+            # Order by function name for verification
+            fn_orders = {f["name"]: f["execution_order"] for f in transformations}
+            assert fn_orders["Transform A"] == 1, "A should still have order 1"
+            assert fn_orders["Transform B"] == 1, "B should now have order 1"
+            assert fn_orders["Transform C"] == 3, "C should remain at order 3"
+
+            # In results, B should be first because it was most recently updated
+            names_in_order = [f["name"] for f in transformations]
+            assert names_in_order[0] == "Transform B", "B should be first (order 1, most recently updated)"
+            assert names_in_order[1] == "Transform A", "A should be second (order 1, updated earlier)"
+            assert names_in_order[2] == "Transform C", "C should be last (order 3)"

--- a/posthog/api/test/test_hog_function.py
+++ b/posthog/api/test/test_hog_function.py
@@ -1938,7 +1938,6 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
 
             assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
             assert "Your function is taking too long to run (over 0.1 seconds)" in response.json()["detail"]
-
             # Test that the same code is allowed for destinations
             response = self.client.post(
                 f"/api/projects/{self.team.id}/hog_functions/",
@@ -2155,10 +2154,10 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
                 [f for f in results if f["type"] == "transformation"], key=lambda x: x["execution_order"] or 999
             )
 
-            fn_orders = {f["name"]: int(f["execution_order"]) for f in transformations}
-            assert fn_orders["Transform A"] == 1, "A should still have order 1"
-            assert fn_orders["Transform C"] == 3, "C should remain at order 3"
-            assert fn_orders["Transform B"] == 4, "B should now be at the end (order 4)"
+            fn_orders = {f["name"]: f["execution_order"] for f in transformations}
+            assert str(fn_orders["Transform A"]) == "1", "A should still have order 1"
+            assert str(fn_orders["Transform C"]) == "3", "C should remain at order 3"
+            assert str(fn_orders["Transform B"]) == "4", "B should now be at the end (order 4)"
 
     def test_transformation_normal_execution_order_update(self, *args):
         """Test updating execution_order for a transformation function directly."""
@@ -2215,10 +2214,10 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             transformations = [f for f in results if f["type"] == "transformation"]
             assert len(transformations) == 3
 
-            fn_orders = {f["name"]: int(f["execution_order"]) for f in transformations}
-            assert fn_orders["Transform A"] == 1
-            assert fn_orders["Transform B"] == 2
-            assert fn_orders["Transform C"] == 3
+            fn_orders = {f["name"]: f["execution_order"] for f in transformations}
+            assert str(fn_orders["Transform A"]) == "1"
+            assert str(fn_orders["Transform B"]) == "2"
+            assert str(fn_orders["Transform C"]) == "3"
 
             # Test 1: Update B's execution_order to match A (both will have order 1)
             update_response = self.client.patch(
@@ -2233,10 +2232,10 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             transformations = [f for f in results if f["type"] == "transformation"]
 
             # Order by function name for verification
-            fn_orders = {f["name"]: int(f["execution_order"]) for f in transformations}
-            assert fn_orders["Transform A"] == 1, "A should still have order 1"
-            assert fn_orders["Transform B"] == 1, "B should now have order 1"
-            assert fn_orders["Transform C"] == 3, "C should remain at order 3"
+            fn_orders = {f["name"]: f["execution_order"] for f in transformations}
+            assert str(fn_orders["Transform A"]) == "1", "A should still have order 1"
+            assert str(fn_orders["Transform B"]) == "1", "B should now have order 1"
+            assert str(fn_orders["Transform C"]) == "3", "C should remain at order 3"
 
             # In results, B should be first because it was most recently updated
             names_in_order = [f["name"] for f in transformations]

--- a/posthog/api/test/test_plugin.py
+++ b/posthog/api/test/test_plugin.py
@@ -1576,7 +1576,7 @@ class TestPluginAPI(APIBaseTest, QueryMatchingTest):
                 {
                     "plugin": mock_geoip_plugin.id,
                     "enabled": True,
-                    "order": 0,
+                    "order": 1,
                     "config": json.dumps({"bar": "very secret value"}),
                 },
                 format="multipart",


### PR DESCRIPTION
## Problem

We currently don't support creation / updates of the execution_order of hogfunctions via the API but only via the rearrange api. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- enabled setting the execution_order for hogfunctions via the api 
- re-enabled and un-deleted functions are appended to the end 
- changed the sorting to respect updated_at instead of created_at of returning all hogfunctions if the execution_order is conflicting.. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- added tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
