### PR TITLE
fix(data-warehouse): Support unsigned integers for MySQL data sources

### DIFF
--- a/posthog/temporal/data_imports/pipelines/mysql/mysql.py
+++ b/posthog/temporal/data_imports/pipelines/mysql/mysql.py
@@ -141,13 +141,13 @@ def _get_arrow_schema_from_type_name(table_structure: list[TableStructureRow]) -
 
     for col in table_structure:
         name = col.column_name
-        mysql_data_type = col.data_type
-        mysql_col_type = col.column_type
+        mysql_data_type = col.data_type.lower()
+        mysql_col_type = col.column_type.lower()
 
         # Note that deltalake doesn't support unsigned types, so we need to convert integer types to larger types
         # For example an uint32 should support values up to 2^32, but deltalake will only support 2^31
         # so in order to support unsigned types we need to convert to int64
-        is_unsigned = "unsigned" in mysql_col_type.lower()
+        is_unsigned = "unsigned" in mysql_col_type
 
         arrow_type: pa.DataType
 

--- a/posthog/temporal/data_imports/pipelines/mysql/mysql.py
+++ b/posthog/temporal/data_imports/pipelines/mysql/mysql.py
@@ -94,6 +94,7 @@ def _get_primary_keys(cursor: Cursor, schema: str, table_name: str) -> list[str]
 class TableStructureRow:
     column_name: str
     data_type: str
+    column_type: str
     is_nullable: bool
     numeric_precision: Optional[int]
     numeric_scale: Optional[int]
@@ -104,6 +105,7 @@ def _get_table_structure(cursor: Cursor, schema: str, table_name: str) -> list[T
         SELECT
             column_name,
             data_type,
+            column_type,
             is_nullable,
             numeric_precision,
             numeric_scale
@@ -123,7 +125,12 @@ def _get_table_structure(cursor: Cursor, schema: str, table_name: str) -> list[T
     rows = cursor.fetchall()
     return [
         TableStructureRow(
-            column_name=row[0], data_type=row[1], is_nullable=row[2], numeric_precision=row[3], numeric_scale=row[4]
+            column_name=row[0],
+            data_type=row[1],
+            column_type=row[2],
+            is_nullable=row[3],
+            numeric_precision=row[4],
+            numeric_scale=row[5],
         )
         for row in rows
     ]
@@ -134,24 +141,29 @@ def _get_arrow_schema_from_type_name(table_structure: list[TableStructureRow]) -
 
     for col in table_structure:
         name = col.column_name
-        mysql_type = col.data_type
+        mysql_data_type = col.data_type
+        mysql_col_type = col.column_type
+
+        # Note that deltalake doesn't support unsigned types, so we need to convert integer types to larger types
+        # For example an uint32 should support values up to 2^32, but deltalake will only support 2^31
+        # so in order to support unsigned types we need to convert to int64
+        is_unsigned = "unsigned" in mysql_col_type
 
         arrow_type: pa.DataType
 
         # Map MySQL type names to PyArrow types
-        match mysql_type:
+        match mysql_data_type:
             case "bigint":
-                arrow_type = pa.int64()
+                arrow_type = pa.uint64() if is_unsigned else pa.int64()
             case "int" | "integer" | "mediumint":
-                arrow_type = pa.int32()
+                arrow_type = pa.uint64() if is_unsigned else pa.int32()
             case "smallint":
-                arrow_type = pa.int16()
+                arrow_type = pa.uint32() if is_unsigned else pa.int16()
             case "tinyint":
-                arrow_type = pa.int8()
+                arrow_type = pa.uint16() if is_unsigned else pa.int8()
             case "decimal" | "numeric":
                 precision = col.numeric_precision if col.numeric_precision is not None else DEFAULT_NUMERIC_PRECISION
                 scale = col.numeric_scale if col.numeric_scale is not None else DEFAULT_NUMERIC_SCALE
-
                 arrow_type = build_pyarrow_decimal_type(precision, scale)
             case "float":
                 arrow_type = pa.float32()
@@ -173,7 +185,7 @@ def _get_arrow_schema_from_type_name(table_structure: list[TableStructureRow]) -
                 arrow_type = pa.string()
             case "json":
                 arrow_type = pa.string()
-            case _ if mysql_type.endswith("[]"):  # Array types (though not native in MySQL)
+            case _ if mysql_data_type.endswith("[]"):  # Array types (though not native in MySQL)
                 arrow_type = pa.string()
             case _:
                 arrow_type = pa.string()

--- a/posthog/temporal/data_imports/pipelines/mysql/mysql.py
+++ b/posthog/temporal/data_imports/pipelines/mysql/mysql.py
@@ -147,7 +147,7 @@ def _get_arrow_schema_from_type_name(table_structure: list[TableStructureRow]) -
         # Note that deltalake doesn't support unsigned types, so we need to convert integer types to larger types
         # For example an uint32 should support values up to 2^32, but deltalake will only support 2^31
         # so in order to support unsigned types we need to convert to int64
-        is_unsigned = "unsigned" in mysql_col_type
+        is_unsigned = "unsigned" in mysql_col_type.lower()
 
         arrow_type: pa.DataType
 

--- a/posthog/temporal/data_imports/pipelines/mysql/mysql.py
+++ b/posthog/temporal/data_imports/pipelines/mysql/mysql.py
@@ -154,6 +154,7 @@ def _get_arrow_schema_from_type_name(table_structure: list[TableStructureRow]) -
         # Map MySQL type names to PyArrow types
         match mysql_data_type:
             case "bigint":
+                # There's no larger type than (u)int64
                 arrow_type = pa.uint64() if is_unsigned else pa.int64()
             case "int" | "integer" | "mediumint":
                 arrow_type = pa.uint64() if is_unsigned else pa.int32()

--- a/posthog/temporal/tests/data_imports/conftest.py
+++ b/posthog/temporal/tests/data_imports/conftest.py
@@ -1,6 +1,154 @@
+import functools
 import json
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from unittest import mock
 
+import aioboto3
 import pytest
+import pytest_asyncio
+from asgiref.sync import sync_to_async
+from django.conf import settings
+from django.test import override_settings
+from dlt.common.configuration.specs.aws_credentials import AwsCredentials
+from temporalio.common import RetryPolicy
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+
+from posthog.constants import DATA_WAREHOUSE_TASK_QUEUE
+from posthog.hogql.query import execute_hogql_query
+from posthog.temporal.data_imports.external_data_job import ExternalDataJobWorkflow
+from posthog.temporal.data_imports.settings import ACTIVITIES
+from posthog.temporal.utils import ExternalDataWorkflowInputs
+from posthog.warehouse.models import ExternalDataJob
+from posthog.warehouse.models.external_data_job import get_latest_run_if_exists
+from posthog.warehouse.models.external_table_definitions import external_tables
+
+BUCKET_NAME = "test-pipeline"
+SESSION = aioboto3.Session()
+create_test_client = functools.partial(SESSION.client, endpoint_url=settings.OBJECT_STORAGE_ENDPOINT)
+
+
+@pytest_asyncio.fixture
+async def minio_client():
+    """Manage an S3 client to interact with a MinIO bucket.
+
+    Yields the client after creating a bucket. Upon resuming, we delete
+    the contents and the bucket itself.
+    """
+    async with create_test_client(
+        "s3",
+        aws_access_key_id=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
+        aws_secret_access_key=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
+    ) as minio_client:
+        try:
+            await minio_client.head_bucket(Bucket=BUCKET_NAME)
+        except:
+            await minio_client.create_bucket(Bucket=BUCKET_NAME)
+
+        yield minio_client
+
+
+def _mock_to_session_credentials(class_self):
+    return {
+        "aws_access_key_id": settings.OBJECT_STORAGE_ACCESS_KEY_ID,
+        "aws_secret_access_key": settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
+        "endpoint_url": settings.OBJECT_STORAGE_ENDPOINT,
+        "aws_session_token": None,
+        "AWS_ALLOW_HTTP": "true",
+        "AWS_S3_ALLOW_UNSAFE_RENAME": "true",
+    }
+
+
+def _mock_to_object_store_rs_credentials(class_self):
+    return {
+        "aws_access_key_id": settings.OBJECT_STORAGE_ACCESS_KEY_ID,
+        "aws_secret_access_key": settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
+        "endpoint_url": settings.OBJECT_STORAGE_ENDPOINT,
+        "region": "us-east-1",
+        "AWS_ALLOW_HTTP": "true",
+        "AWS_S3_ALLOW_UNSAFE_RENAME": "true",
+    }
+
+
+async def run_external_data_job_workflow(
+    team,
+    external_data_source,
+    external_data_schema,
+    table_name,
+    expected_rows_synced,
+    expected_total_rows,
+):
+    workflow_id = str(uuid.uuid4())
+    inputs = ExternalDataWorkflowInputs(
+        team_id=team.id,
+        external_data_source_id=external_data_source.pk,
+        external_data_schema_id=external_data_schema.id,
+        billable=False,
+    )
+
+    with (
+        override_settings(
+            BUCKET_URL=f"s3://{BUCKET_NAME}",
+            AIRBYTE_BUCKET_KEY=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
+            AIRBYTE_BUCKET_SECRET=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
+            AIRBYTE_BUCKET_REGION="us-east-1",
+            AIRBYTE_BUCKET_DOMAIN="objectstorage:19000",
+        ),
+        mock.patch(
+            "posthog.temporal.data_imports.pipelines.pipeline.pipeline.trigger_compaction_job"
+        ) as mock_trigger_compaction_job,
+        mock.patch(
+            "posthog.temporal.data_imports.external_data_job.get_data_import_finished_metric"
+        ) as mock_get_data_import_finished_metric,
+        mock.patch.object(AwsCredentials, "to_session_credentials", _mock_to_session_credentials),
+        mock.patch.object(AwsCredentials, "to_object_store_rs_credentials", _mock_to_object_store_rs_credentials),
+    ):
+        async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
+            async with Worker(
+                activity_environment.client,
+                task_queue=DATA_WAREHOUSE_TASK_QUEUE,
+                workflows=[ExternalDataJobWorkflow],
+                activities=ACTIVITIES,  # type: ignore
+                workflow_runner=UnsandboxedWorkflowRunner(),
+                activity_executor=ThreadPoolExecutor(max_workers=50),
+                max_concurrent_activities=50,
+            ):
+                await activity_environment.client.execute_workflow(
+                    ExternalDataJobWorkflow.run,
+                    inputs,
+                    id=workflow_id,
+                    task_queue=DATA_WAREHOUSE_TASK_QUEUE,
+                    retry_policy=RetryPolicy(maximum_attempts=1),
+                )
+
+    # if not ignore_assertions:
+    run: ExternalDataJob = await get_latest_run_if_exists(team_id=team.pk, pipeline_id=external_data_source.pk)
+
+    assert run is not None
+    assert run.status == ExternalDataJob.Status.COMPLETED
+    assert run.rows_synced == expected_rows_synced
+
+    mock_trigger_compaction_job.assert_called()
+    mock_get_data_import_finished_metric.assert_called_with(
+        source_type=external_data_source.source_type, status=ExternalDataJob.Status.COMPLETED.lower()
+    )
+
+    await external_data_schema.arefresh_from_db()
+
+    assert external_data_schema.last_synced_at == run.created_at
+
+    res = await sync_to_async(execute_hogql_query)(f"SELECT * FROM {table_name}", team)
+    assert len(res.results) == expected_total_rows
+
+    for name, field in external_tables.get(table_name, {}).items():
+        if field.hidden:
+            continue
+        assert name in (res.columns or [])
+
+    await external_data_schema.arefresh_from_db()
+    assert external_data_schema.sync_type_config.get("reset_pipeline") is None
+    return res.results
 
 
 @pytest.fixture

--- a/posthog/temporal/tests/data_imports/stripe/test_stripe_source.py
+++ b/posthog/temporal/tests/data_imports/stripe/test_stripe_source.py
@@ -1,81 +1,16 @@
-import functools
 import uuid
-from concurrent.futures import ThreadPoolExecutor
 from unittest import mock
 from urllib.parse import parse_qs, urlparse
 
-import aioboto3
 import pytest
-import pytest_asyncio
-from asgiref.sync import sync_to_async
-from django.conf import settings
-from django.test import override_settings
-from dlt.common.configuration.specs.aws_credentials import AwsCredentials
-from temporalio.common import RetryPolicy
-from temporalio.testing import WorkflowEnvironment
-from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
-from posthog.constants import DATA_WAREHOUSE_TASK_QUEUE
-from posthog.hogql.query import execute_hogql_query
-from posthog.temporal.data_imports.external_data_job import ExternalDataJobWorkflow
 from posthog.temporal.data_imports.pipelines.pipeline.pipeline import PipelineNonDLT
-from posthog.temporal.data_imports.settings import ACTIVITIES
-from posthog.temporal.utils import ExternalDataWorkflowInputs
-from posthog.warehouse.models import (
-    ExternalDataJob,
-    ExternalDataSchema,
-    ExternalDataSource,
-)
-from posthog.warehouse.models.external_data_job import get_latest_run_if_exists
-from posthog.warehouse.models.external_table_definitions import external_tables
+from posthog.temporal.tests.data_imports.conftest import run_external_data_job_workflow
+from posthog.warehouse.models import ExternalDataSchema, ExternalDataSource
 
 from .data import BALANCE_TRANSACTIONS
 
-BUCKET_NAME = "test-pipeline"
-SESSION = aioboto3.Session()
-create_test_client = functools.partial(SESSION.client, endpoint_url=settings.OBJECT_STORAGE_ENDPOINT)
-
-
-@pytest_asyncio.fixture(autouse=True)
-async def minio_client():
-    """Manage an S3 client to interact with a MinIO bucket.
-
-    Yields the client after creating a bucket. Upon resuming, we delete
-    the contents and the bucket itself.
-    """
-    async with create_test_client(
-        "s3",
-        aws_access_key_id=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
-        aws_secret_access_key=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
-    ) as minio_client:
-        try:
-            await minio_client.head_bucket(Bucket=BUCKET_NAME)
-        except:
-            await minio_client.create_bucket(Bucket=BUCKET_NAME)
-
-        yield minio_client
-
-
-def _mock_to_session_credentials(class_self):
-    return {
-        "aws_access_key_id": settings.OBJECT_STORAGE_ACCESS_KEY_ID,
-        "aws_secret_access_key": settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
-        "endpoint_url": settings.OBJECT_STORAGE_ENDPOINT,
-        "aws_session_token": None,
-        "AWS_ALLOW_HTTP": "true",
-        "AWS_S3_ALLOW_UNSAFE_RENAME": "true",
-    }
-
-
-def _mock_to_object_store_rs_credentials(class_self):
-    return {
-        "aws_access_key_id": settings.OBJECT_STORAGE_ACCESS_KEY_ID,
-        "aws_secret_access_key": settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
-        "endpoint_url": settings.OBJECT_STORAGE_ENDPOINT,
-        "region": "us-east-1",
-        "AWS_ALLOW_HTTP": "true",
-        "AWS_S3_ALLOW_UNSAFE_RENAME": "true",
-    }
+pytestmark = pytest.mark.usefixtures("minio_client")
 
 
 @pytest.fixture
@@ -116,89 +51,9 @@ def external_data_schema_incremental(external_data_source, team):
     return schema
 
 
-async def _run_test(
-    team,
-    external_data_source,
-    external_data_schema,
-    mock_stripe_api,
-    table_name,
-    expected_rows_synced,
-    expected_total_rows,
-):
-    workflow_id = str(uuid.uuid4())
-    inputs = ExternalDataWorkflowInputs(
-        team_id=team.id,
-        external_data_source_id=external_data_source.pk,
-        external_data_schema_id=external_data_schema.id,
-        billable=False,
-    )
-
-    with (
-        override_settings(
-            BUCKET_URL=f"s3://{BUCKET_NAME}",
-            AIRBYTE_BUCKET_KEY=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
-            AIRBYTE_BUCKET_SECRET=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
-            AIRBYTE_BUCKET_REGION="us-east-1",
-            AIRBYTE_BUCKET_DOMAIN="objectstorage:19000",
-        ),
-        mock.patch(
-            "posthog.temporal.data_imports.pipelines.pipeline.pipeline.trigger_compaction_job"
-        ) as mock_trigger_compaction_job,
-        mock.patch(
-            "posthog.temporal.data_imports.external_data_job.get_data_import_finished_metric"
-        ) as mock_get_data_import_finished_metric,
-        # mock the chunk size to 1 so we can test how iterating over chunks of data works, particularly with updating
-        # the incremental field last value
-        mock.patch.object(PipelineNonDLT, "_chunk_size", 1),
-        mock.patch.object(AwsCredentials, "to_session_credentials", _mock_to_session_credentials),
-        mock.patch.object(AwsCredentials, "to_object_store_rs_credentials", _mock_to_object_store_rs_credentials),
-    ):
-        async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
-            async with Worker(
-                activity_environment.client,
-                task_queue=DATA_WAREHOUSE_TASK_QUEUE,
-                workflows=[ExternalDataJobWorkflow],
-                activities=ACTIVITIES,  # type: ignore
-                workflow_runner=UnsandboxedWorkflowRunner(),
-                activity_executor=ThreadPoolExecutor(max_workers=50),
-                max_concurrent_activities=50,
-            ):
-                await activity_environment.client.execute_workflow(
-                    ExternalDataJobWorkflow.run,
-                    inputs,
-                    id=workflow_id,
-                    task_queue=DATA_WAREHOUSE_TASK_QUEUE,
-                    retry_policy=RetryPolicy(maximum_attempts=1),
-                )
-
-    # if not ignore_assertions:
-    run: ExternalDataJob = await get_latest_run_if_exists(team_id=team.pk, pipeline_id=external_data_source.pk)
-
-    assert run is not None
-    assert run.status == ExternalDataJob.Status.COMPLETED
-    assert run.rows_synced == expected_rows_synced
-
-    mock_trigger_compaction_job.assert_called()
-    mock_get_data_import_finished_metric.assert_called_with(
-        source_type=external_data_source.source_type, status=ExternalDataJob.Status.COMPLETED.lower()
-    )
-
-    await external_data_schema.arefresh_from_db()
-
-    assert external_data_schema.last_synced_at == run.created_at
-
-    res = await sync_to_async(execute_hogql_query)(f"SELECT * FROM {table_name}", team)
-    assert len(res.results) == expected_total_rows
-
-    for name, field in external_tables.get(table_name, {}).items():
-        if field.hidden:
-            continue
-        assert name in (res.columns or [])
-
-    await external_data_schema.arefresh_from_db()
-    assert external_data_schema.sync_type_config.get("reset_pipeline", None) is None
-
-
+# mock the chunk size to 1 so we can test how iterating over chunks of data works, particularly with updating the
+# incremental field last value
+@mock.patch.object(PipelineNonDLT, "_chunk_size", 1)
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_stripe_source_full_refresh(
@@ -211,11 +66,10 @@ async def test_stripe_source_full_refresh(
     table_name = "stripe_balancetransaction"
     expected_num_rows = len(BALANCE_TRANSACTIONS)
 
-    await _run_test(
+    await run_external_data_job_workflow(
         team=team,
         external_data_source=external_data_source,
         external_data_schema=external_data_schema_full_refresh,
-        mock_stripe_api=mock_stripe_api,
         table_name=table_name,
         expected_rows_synced=expected_num_rows,
         expected_total_rows=expected_num_rows,
@@ -227,6 +81,9 @@ async def test_stripe_source_full_refresh(
     assert api_calls_made[0].url == "https://api.stripe.com/v1/balance_transactions?limit=100"
 
 
+# mock the chunk size to 1 so we can test how iterating over chunks of data works, particularly with updating the
+# incremental field last value
+@mock.patch.object(PipelineNonDLT, "_chunk_size", 1)
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_stripe_source_incremental(team, mock_stripe_api, external_data_source, external_data_schema_incremental):
@@ -246,11 +103,10 @@ async def test_stripe_source_incremental(team, mock_stripe_api, external_data_so
     expected_rows_synced = 3
     expected_total_rows = 3
 
-    await _run_test(
+    await run_external_data_job_workflow(
         team=team,
         external_data_source=external_data_source,
         external_data_schema=external_data_schema_incremental,
-        mock_stripe_api=mock_stripe_api,
         table_name=table_name,
         expected_rows_synced=expected_rows_synced,
         expected_total_rows=expected_total_rows,
@@ -270,11 +126,10 @@ async def test_stripe_source_incremental(team, mock_stripe_api, external_data_so
     expected_rows_synced = 2
     expected_total_rows = len(BALANCE_TRANSACTIONS)
 
-    await _run_test(
+    await run_external_data_job_workflow(
         team=team,
         external_data_source=external_data_source,
         external_data_schema=external_data_schema_incremental,
-        mock_stripe_api=mock_stripe_api,
         table_name=table_name,
         expected_rows_synced=expected_rows_synced,
         expected_total_rows=expected_total_rows,

--- a/posthog/temporal/tests/data_imports/test_mysql_source.py
+++ b/posthog/temporal/tests/data_imports/test_mysql_source.py
@@ -44,9 +44,9 @@ REQUIRED_ENV_VARS = (
 MYSQL_TABLE_NAME = "test_table"
 
 TEST_DATA = [
-    (1, "John Doe", "john@example.com", dt.datetime(2025, 1, 1, tzinfo=dt.UTC)),
-    (2, "Jane Smith", "jane@example.com", dt.datetime(2025, 1, 2, tzinfo=dt.UTC)),
-    (3, "Bob Wilson", "bob@example.com", dt.datetime(2025, 1, 3, tzinfo=dt.UTC)),
+    (1, "John Doe", "john@example.com", dt.datetime(2025, 1, 1, tzinfo=dt.UTC), 100),
+    (2, "Jane Smith", "jane@example.com", dt.datetime(2025, 1, 2, tzinfo=dt.UTC), 2000000),
+    (3, "Bob Wilson", "bob@example.com", dt.datetime(2025, 1, 3, tzinfo=dt.UTC), 3409892966),
 ]
 
 
@@ -100,13 +100,15 @@ def mysql_source_table(mysql_connection):
                 id INT,
                 name VARCHAR(255),
                 email VARCHAR(255),
-                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                unsigned_int INT UNSIGNED
             )
         """)
 
         # Insert test data
         cursor.executemany(
-            f"INSERT INTO {MYSQL_TABLE_NAME} (id, name, email, created_at) VALUES (%s, %s, %s, %s)", TEST_DATA
+            f"INSERT INTO {MYSQL_TABLE_NAME} (id, name, email, created_at, unsigned_int) VALUES (%s, %s, %s, %s, %s)",
+            TEST_DATA,
         )
         conn.commit()
 

--- a/posthog/temporal/tests/data_imports/test_mysql_source.py
+++ b/posthog/temporal/tests/data_imports/test_mysql_source.py
@@ -1,0 +1,165 @@
+"""Tests for the MySQL source.
+
+NOTE: These tests require a MySQL server to be running locally (or somewhere else).
+Therefore these tests will only run if the required environment variables are set.
+
+You can run a local MySQL server using Docker:
+
+```
+docker run -d --name mysql-test -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=test -p 3306:3306 mysql:9.2
+```
+
+Then you can run these tests using:
+
+```
+OBJECT_STORAGE_ENDPOINT=http://localhost:19000 \
+    MYSQL_HOST=localhost \
+    MYSQL_USER=root \
+    MYSQL_PASSWORD=root \
+    MYSQL_DATABASE=test \
+    pytest posthog/temporal/tests/data_imports/test_mysql_source.py
+```
+
+"""
+
+import datetime as dt
+import os
+import uuid
+
+import pymysql
+import pytest
+
+from posthog.temporal.tests.data_imports.conftest import run_external_data_job_workflow
+from posthog.warehouse.models import ExternalDataSchema, ExternalDataSource
+
+pytestmark = pytest.mark.usefixtures("minio_client")
+
+REQUIRED_ENV_VARS = (
+    "MYSQL_HOST",
+    "MYSQL_USER",
+    "MYSQL_PASSWORD",
+    "MYSQL_DATABASE",
+)
+
+MYSQL_TABLE_NAME = "test_table"
+
+TEST_DATA = [
+    (1, "John Doe", "john@example.com", dt.datetime(2025, 1, 1, tzinfo=dt.UTC)),
+    (2, "Jane Smith", "jane@example.com", dt.datetime(2025, 1, 2, tzinfo=dt.UTC)),
+    (3, "Bob Wilson", "bob@example.com", dt.datetime(2025, 1, 3, tzinfo=dt.UTC)),
+]
+
+
+def mysql_env_vars_are_set():
+    if not all(env_var in os.environ for env_var in REQUIRED_ENV_VARS):
+        return False
+    return True
+
+
+SKIP_IF_MISSING_MYSQL_CREDENTIALS = pytest.mark.skipif(
+    not mysql_env_vars_are_set(),
+    reason="MySQL required env vars are not set",
+)
+
+
+@pytest.fixture
+def mysql_config():
+    return {
+        "host": os.environ["MYSQL_HOST"],
+        "port": os.environ.get("MYSQL_PORT", 3306),
+        "user": os.environ["MYSQL_USER"],
+        "password": os.environ["MYSQL_PASSWORD"],
+        "database": os.environ["MYSQL_DATABASE"],
+        # TODO: I don't think this is needed
+        "schema": os.environ["MYSQL_DATABASE"],
+        "using_ssl": False,
+    }
+
+
+@pytest.fixture
+def mysql_connection(mysql_config):
+    with pymysql.connect(
+        host=mysql_config["host"],
+        port=mysql_config["port"],
+        database=mysql_config["database"],
+        user=mysql_config["user"],
+        password=mysql_config["password"],
+        connect_timeout=5,
+    ) as connection:
+        yield connection
+
+
+@pytest.fixture
+def mysql_source_table(mysql_connection):
+    """Create a MySQL table with test data and clean it up after the test."""
+    conn = mysql_connection
+    with conn.cursor() as cursor:
+        # Create test table
+        cursor.execute(f"""
+            CREATE TABLE IF NOT EXISTS {MYSQL_TABLE_NAME} (
+                id INT,
+                name VARCHAR(255),
+                email VARCHAR(255),
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+
+        # Insert test data
+        cursor.executemany(
+            f"INSERT INTO {MYSQL_TABLE_NAME} (id, name, email, created_at) VALUES (%s, %s, %s, %s)", TEST_DATA
+        )
+        conn.commit()
+
+        yield cursor
+
+        # Cleanup
+        cursor.execute(f"DROP TABLE IF EXISTS {MYSQL_TABLE_NAME}")
+        conn.commit()
+
+
+@pytest.fixture
+def external_data_source(mysql_config, team):
+    source = ExternalDataSource.objects.create(
+        source_id=str(uuid.uuid4()),
+        connection_id=str(uuid.uuid4()),
+        destination_id=str(uuid.uuid4()),
+        team=team,
+        status="running",
+        source_type="MySQL",
+        job_inputs=mysql_config,
+    )
+    return source
+
+
+@pytest.fixture
+def external_data_schema_full_refresh(external_data_source, team):
+    schema = ExternalDataSchema.objects.create(
+        name=MYSQL_TABLE_NAME,
+        team_id=team.pk,
+        source_id=external_data_source.pk,
+        sync_type="full_refresh",
+        sync_type_config={},
+    )
+    return schema
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+@SKIP_IF_MISSING_MYSQL_CREDENTIALS
+async def test_mysql_source_full_refresh(
+    team, mysql_source_table, external_data_source, external_data_schema_full_refresh
+):
+    """Test that a full refresh sync works as expected."""
+    table_name = f"mysql_{MYSQL_TABLE_NAME}"
+    expected_num_rows = len(TEST_DATA)
+
+    res = await run_external_data_job_workflow(
+        team=team,
+        external_data_source=external_data_source,
+        external_data_schema=external_data_schema_full_refresh,
+        table_name=table_name,
+        expected_rows_synced=expected_num_rows,
+        expected_total_rows=expected_num_rows,
+    )
+
+    assert res == TEST_DATA

--- a/posthog/temporal/tests/data_imports/test_mysql_source.py
+++ b/posthog/temporal/tests/data_imports/test_mysql_source.py
@@ -162,6 +162,7 @@ async def test_mysql_source_full_refresh(
         table_name=table_name,
         expected_rows_synced=expected_num_rows,
         expected_total_rows=expected_num_rows,
+        expected_columns=["id", "name", "email", "created_at", "unsigned_int"],
     )
 
-    assert res == TEST_DATA
+    assert res.results == TEST_DATA

--- a/posthog/temporal/tests/data_imports/test_postgres_source.py
+++ b/posthog/temporal/tests/data_imports/test_postgres_source.py
@@ -1,0 +1,146 @@
+"""Tests for the Postgres source.
+
+These tests use the Postgres database running in the Docker Compose stack.
+"""
+
+import datetime as dt
+import uuid
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import psycopg
+import pytest
+import pytest_asyncio
+from django.conf import settings
+from psycopg import AsyncConnection, AsyncCursor, sql
+from psycopg.rows import TupleRow
+
+from posthog.temporal.tests.data_imports.conftest import run_external_data_job_workflow
+from posthog.warehouse.models import ExternalDataSchema, ExternalDataSource
+
+pytestmark = pytest.mark.usefixtures("minio_client")
+
+
+POSTGRES_TABLE_NAME = "test_table"
+
+TEST_DATA = [
+    (1, "John Doe", "john@example.com", dt.datetime(2025, 1, 1, tzinfo=dt.UTC), 100),
+    (2, "Jane Smith", "jane@example.com", dt.datetime(2025, 1, 2, tzinfo=dt.UTC), 2000000),
+    (3, "Bob Wilson", "bob@example.com", dt.datetime(2025, 1, 3, tzinfo=dt.UTC), 3409892966),
+]
+
+
+@pytest.fixture
+def postgres_config() -> dict[str, Any]:
+    return {
+        "user": settings.PG_USER,
+        "password": settings.PG_PASSWORD,
+        "database": "data_imports_test_database",
+        "schema": "data_imports_test_schema",
+        "host": settings.PG_HOST,
+        "port": int(settings.PG_PORT),
+    }
+
+
+@pytest_asyncio.fixture
+async def postgres_connection(
+    postgres_config: dict[str, Any], setup_postgres_test_db: None
+) -> AsyncGenerator[AsyncConnection, None]:
+    connection = await psycopg.AsyncConnection.connect(
+        host=postgres_config["host"],
+        port=postgres_config["port"],
+        dbname=postgres_config["database"],
+        user=postgres_config["user"],
+        password=postgres_config["password"],
+        autocommit=True,
+    )
+
+    yield connection
+
+    await connection.close()
+
+
+@pytest_asyncio.fixture
+async def postgres_source_table(
+    postgres_connection: AsyncConnection, postgres_config: dict[str, Any]
+) -> AsyncGenerator[AsyncCursor[TupleRow], None]:
+    """Create a Postgres table with test data and clean it up after the test."""
+    async with postgres_connection.cursor() as cursor:
+        full_table_name = sql.Identifier(postgres_config["schema"], POSTGRES_TABLE_NAME)
+        # Create test table
+        await cursor.execute(
+            sql.SQL("""
+            CREATE TABLE IF NOT EXISTS {} (
+                id INTEGER,
+                name VARCHAR(255),
+                email VARCHAR(255),
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                big_int BIGINT
+            )
+        """).format(full_table_name)
+        )
+
+        # Insert test data
+        await cursor.executemany(
+            sql.SQL("INSERT INTO {} (id, name, email, created_at, big_int) VALUES (%s, %s, %s, %s, %s)").format(
+                full_table_name
+            ),
+            TEST_DATA,
+        )
+
+    yield cursor
+
+    # Cleanup
+    async with postgres_connection.cursor() as cursor:
+        await cursor.execute(sql.SQL("DROP TABLE IF EXISTS {}").format(full_table_name))
+
+
+@pytest.fixture
+def external_data_source(postgres_config: dict[str, Any], team) -> ExternalDataSource:
+    source = ExternalDataSource.objects.create(
+        source_id=str(uuid.uuid4()),
+        connection_id=str(uuid.uuid4()),
+        destination_id=str(uuid.uuid4()),
+        team=team,
+        status="running",
+        source_type="Postgres",
+        job_inputs=postgres_config,
+    )
+    return source
+
+
+@pytest.fixture
+def external_data_schema_full_refresh(external_data_source: ExternalDataSource, team) -> ExternalDataSchema:
+    schema = ExternalDataSchema.objects.create(
+        name=POSTGRES_TABLE_NAME,
+        team_id=team.pk,
+        source_id=external_data_source.pk,
+        sync_type="full_refresh",
+        sync_type_config={},
+    )
+    return schema
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_postgres_source_full_refresh(
+    team,
+    postgres_source_table: AsyncCursor[TupleRow],
+    external_data_source: ExternalDataSource,
+    external_data_schema_full_refresh: ExternalDataSchema,
+):
+    """Test that a full refresh sync works as expected."""
+    table_name = f"postgres_{POSTGRES_TABLE_NAME}"
+    expected_num_rows = len(TEST_DATA)
+
+    res = await run_external_data_job_workflow(
+        team=team,
+        external_data_source=external_data_source,
+        external_data_schema=external_data_schema_full_refresh,
+        table_name=table_name,
+        expected_rows_synced=expected_num_rows,
+        expected_total_rows=expected_num_rows,
+        expected_columns=["id", "name", "email", "created_at", "big_int"],
+    )
+
+    assert res.results == TEST_DATA


### PR DESCRIPTION
## Problem

Currently our data imports have limited support for MySQL unsigned integers, in that it will work as long as they don't exceed the size of the signed version. For example `int` supports numbers from -2^31 -> 2^31 whereas `unsigned int` supports 0 -> 2^32.

## Changes

Check an additional column in `information_schema.columns` to see if it's `unsigned` and map to the correct pyarrows type.

Unfortunately [deltalake doesn't support unsigned integers](https://github.com/delta-io/delta-rs/issues/2175), and maps these to the signed version. So we actually need to convert the types to larger ones; for example instead of mapping to `uint32` we need to use `uint64` or `int64` to ensure we still support larger values that wouldn't fit in `int32`.

Since [deltalake converts unsigned ints to ints](https://github.com/delta-io/delta-rs/blob/python-v0.25.2/python/deltalake/schema.py#L35-L54) we could have just mapped an unsigned int to `int64` rather than `uint64` but feels better to keep the unsigned version in our code for clarity and in case we move away from deltalake at some point.

~We will likely need to do the same for Postgres, but can do this in a follow up PR.~
Postgres doesn't actually support unsigned integers.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Added new tests for MySQL :)

Added some tests for Postgres too (I found out that Postgres doesn't support unsigned integers so no fixes to the code needed)