### PR TITLE
feat(edit-and-rematerialize): Re-materialize on update of a view

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
@@ -46,6 +46,8 @@ export function QueryWindow({ onSetMonacoAndEditor }: QueryWindowProps): JSX.Ele
     const { sidebarWidth } = useValues(editorSizingLogic)
     const { resetDefaultSidebarWidth } = useActions(editorSizingLogic)
 
+    const isMaterializedView = !!editingView?.status
+
     return (
         <div className="flex flex-1 flex-col h-full overflow-hidden">
             <div className="flex flex-row overflow-x-auto">
@@ -72,7 +74,7 @@ export function QueryWindow({ onSetMonacoAndEditor }: QueryWindowProps): JSX.Ele
                     <span className="pl-2 text-xs">
                         {editingView && (
                             <>
-                                Editing {editingView.last_run_at ? 'materialized view' : 'view'} "{editingView.name}"
+                                Editing {isMaterializedView ? 'materialized view' : 'view'} "{editingView.name}"
                             </>
                         )}
                         {editingInsight && <>Editing insight "{editingInsight.name}"</>}
@@ -92,6 +94,7 @@ export function QueryWindow({ onSetMonacoAndEditor }: QueryWindowProps): JSX.Ele
                                     query: queryInput,
                                 },
                                 types: response?.types ?? [],
+                                shouldRematerialize: isMaterializedView,
                             })
                         }
                         disabledReason={
@@ -105,7 +108,7 @@ export function QueryWindow({ onSetMonacoAndEditor }: QueryWindowProps): JSX.Ele
                         type="tertiary"
                         size="xsmall"
                     >
-                        Update view
+                        {isMaterializedView ? 'Update and re-materialize view' : 'Update view'}
                     </LemonButton>
                 ) : (
                     <LemonButton

--- a/frontend/src/scenes/data-warehouse/saved_queries/dataWarehouseViewsLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/saved_queries/dataWarehouseViewsLogic.tsx
@@ -66,6 +66,7 @@ export const dataWarehouseViewsLogic = kea<dataWarehouseViewsLogicType>([
                         types: string[][]
                         sync_frequency?: string
                         lifecycle?: string
+                        shouldRematerialize?: boolean
                     }
                 ) => {
                     const newView = await api.dataWarehouseSavedQueries.update(view.id, view)
@@ -98,6 +99,11 @@ export const dataWarehouseViewsLogic = kea<dataWarehouseViewsLogicType>([
                     sync_frequency: payload.sync_frequency,
                 })
             }
+
+            if (payload?.shouldRematerialize) {
+                actions.runDataWarehouseSavedQuery(payload.id)
+            }
+
             actions.loadDatabase()
             lemonToast.success('View updated')
         },


### PR DESCRIPTION
## Problem

When editing a view that is materialized, it makes sense to auto re-materilize it instead of just letting the schedule pick it up. This is because a user would expect the updated view to not be stale when attempting to run a query joining the updated view.

### Just an ordinary view
<img width="944" alt="image" src="https://github.com/user-attachments/assets/60ca96fc-ccd8-4c41-8be8-e7d395a43467" />

### A materialized view
<img width="945" alt="image" src="https://github.com/user-attachments/assets/07b1a6ab-0d04-480a-acd8-b21310fd28ca" />
and after a click
<img width="953" alt="image" src="https://github.com/user-attachments/assets/7aa96162-98dc-44f1-b53c-8f78212e2b81" />


## Changes

- [x] Update Mat View now will also run an out of band (unscheduled) materialization

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Tested on saved and unsaved views, as well as materialized views... I think that covers our possible combinations.

