### PR TITLE
fix: trim url and CSS selector for survey display conditions

### DIFF
--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -44,6 +44,7 @@ import {
     getResponseFieldWithId,
     sanitizeHTML,
     sanitizeSurveyAppearance,
+    sanitizeSurveyDisplayConditions,
     validateColor,
 } from './utils'
 
@@ -1613,6 +1614,7 @@ export const surveyLogic = kea<surveyLogicType>([
 
                 const payload = {
                     ...surveyPayload,
+                    conditions: sanitizeSurveyDisplayConditions(surveyPayload.conditions),
                     appearance: sanitizeSurveyAppearance(surveyPayload.appearance),
                 }
 

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -2,7 +2,7 @@ import DOMPurify from 'dompurify'
 import { SURVEY_RESPONSE_PROPERTY } from 'scenes/surveys/constants'
 import { SurveyRatingResults } from 'scenes/surveys/surveyLogic'
 
-import { EventPropertyFilter, Survey, SurveyAppearance } from '~/types'
+import { EventPropertyFilter, Survey, SurveyAppearance, SurveyDisplayConditions } from '~/types'
 
 const sanitizeConfig = { ADD_ATTR: ['target'] }
 
@@ -77,6 +77,20 @@ export const getMultipleChoiceResponseFieldCondition = (questionIndex: number, q
         JSONExtractArrayRaw(properties, '${ids.idBasedKey}'),
         JSONExtractArrayRaw(properties, '${ids.indexBasedKey}')
     )`
+}
+
+export function sanitizeSurveyDisplayConditions(
+    displayConditions: SurveyDisplayConditions | null
+): SurveyDisplayConditions | null {
+    if (!displayConditions) {
+        return null
+    }
+
+    return {
+        ...displayConditions,
+        url: displayConditions.url.trim(),
+        selector: displayConditions.selector?.trim(),
+    }
 }
 
 export function sanitizeSurveyAppearance(appearance: SurveyAppearance | null): SurveyAppearance | null {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2866,6 +2866,27 @@ export enum SurveyPartialResponses {
     No = 'false',
 }
 
+export interface SurveyDisplayConditions {
+    url: string
+    selector?: string
+    seenSurveyWaitPeriodInDays?: number
+    urlMatchType?: SurveyMatchType
+    deviceTypes?: string[]
+    deviceTypesMatchType?: SurveyMatchType
+    actions: {
+        values: {
+            id: number
+            name: string
+        }[]
+    } | null
+    events: {
+        repeatedActivation?: boolean
+        values: {
+            name: string
+        }[]
+    } | null
+}
+
 export interface Survey {
     /** UUID */
     id: string
@@ -2877,26 +2898,7 @@ export interface Survey {
     linked_flag: FeatureFlagBasicType | null
     targeting_flag: FeatureFlagBasicType | null
     targeting_flag_filters?: FeatureFlagFilters
-    conditions: {
-        url: string
-        selector?: string
-        seenSurveyWaitPeriodInDays?: number
-        urlMatchType?: SurveyMatchType
-        deviceTypes?: string[]
-        deviceTypesMatchType?: SurveyMatchType
-        actions: {
-            values: {
-                id: number
-                name: string
-            }[]
-        } | null
-        events: {
-            repeatedActivation?: boolean
-            values: {
-                name: string
-            }[]
-        } | null
-    } | null
+    conditions: SurveyDisplayConditions | null
     appearance: SurveyAppearance | null
     questions: (BasicSurveyQuestion | LinkSurveyQuestion | RatingSurveyQuestion | MultipleSurveyQuestion)[]
     created_at: string


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/30772

## Changes

trim whitespaces for string fields in the survey display conditions

## Does this work well for both Cloud and self-hosted?

yes

## How did you test this code?

verified it's trimming spaces as expected after saving a survey