### PR TITLE
chore: fix flapping annotations test

### DIFF
--- a/frontend/src/lib/components/ProductIntroduction/ProductIntroduction.tsx
+++ b/frontend/src/lib/components/ProductIntroduction/ProductIntroduction.tsx
@@ -59,7 +59,10 @@ export const ProductIntroduction = ({
 
     const actionable = action || actionElementOverride
     return (
-        <div className="border-2 border-dashed border-primary w-full p-8 justify-center rounded mt-2 mb-4">
+        <div
+            className="border-2 border-dashed border-primary w-full p-8 justify-center rounded mt-2 mb-4"
+            data-attr={`product-introduction-${thingName}`}
+        >
             {!isEmpty && (
                 <div className="flex justify-end -mb-6 -mt-2 -mr-2">
                     <div>

--- a/playwright/e2e/annotations.spec.ts
+++ b/playwright/e2e/annotations.spec.ts
@@ -7,7 +7,7 @@ test.describe('Annotations', () => {
     })
 
     test('Annotations loaded', async ({ page }) => {
-        await expect(page.locator('text=Create your first annotation')).toBeVisible()
+        await expect(page.getByTestId('product-introduction-annotation')).toBeVisible()
         await expect(page.locator('[data-attr="product-introduction-docs-link"]')).toContainText('Learn more')
     })
 


### PR DESCRIPTION
the annotations playwright test is flapping

it assumes an annotation has never been created and checks for the "create your first annotation" button

but because playwright runs in parallel it sometimes runs after the tests create an annotation

so, put a test id on the welcome container, and just check it is visible