### PR TITLE
feat(propdefs): isolate new DB client access for mirror deployment

### DIFF
--- a/rust/property-defs-rs/src/config.rs
+++ b/rust/property-defs-rs/src/config.rs
@@ -183,17 +183,7 @@ impl TeamFilterMode {
 
 impl Config {
     pub fn init_with_defaults() -> Result<Self, envconfig::Error> {
-        let consumer_group = match std::env::var("ENABLE_V2") {
-            Ok(enabled_v2) => {
-                if enabled_v2.to_lowercase() == "true" {
-                    "property-defs-rs-v2"
-                } else {
-                    "property_defs_rs"
-                }
-            }
-            _ => "property-defs-rs",
-        };
-        ConsumerConfig::set_defaults(consumer_group, "clickhouse_events_json", true);
+        ConsumerConfig::set_defaults("property-defs-rs", "clickhouse_events_json", true);
         Config::init_from_env()
     }
 }

--- a/rust/property-defs-rs/src/config.rs
+++ b/rust/property-defs-rs/src/config.rs
@@ -19,13 +19,9 @@ pub struct Config {
     #[envconfig(nested = true)]
     pub consumer: ConsumerConfig,
 
-    // TODO(eli): after observing retry change, consider reducing potential tx contention by 20% (to "8")
     #[envconfig(default = "10")]
     pub max_concurrent_transactions: usize,
 
-    // We issue writes (UPSERTS) to postgres in batches of this size.
-    // Total concurrent DB ops is max_concurrent_transactions * update_batch_size
-    // TODO(eli): after observing retry change, consider reducing "unchunked" batch size by 20% (to "800")
     #[envconfig(default = "1000")]
     pub update_batch_size: usize,
 
@@ -112,9 +108,15 @@ pub struct Config {
     #[envconfig(default = "opt_in")]
     pub filter_mode: TeamFilterMode,
 
-    // flag for "v2" deployment that will initially point to an
-    // isolated Postgres instance per deploy env, and will include
-    // bundled ingest pipeline refactors
+    // this enables codepaths used by the new mirror deployment
+    // property-defs-rs-v2 in ArgoCD. The main thing we're gating
+    // at first is use of the DB client for the new isolated Postgres
+    // on all write paths."
+    #[envconfig(default = "false")]
+    pub enable_mirror: bool,
+
+    // TEMP: used to gate the new process_batch_v2 write path code in
+    // the current property-defs-rs deployments *and* new mirror
     #[envconfig(default = "false")]
     pub enable_v2: bool,
 
@@ -122,7 +124,7 @@ pub struct Config {
     pub v2_ingest_batch_size: usize,
 
     // *ONLY* for use in the new property-defs-rs-v2 mirror deploy, and (for now)
-    // behind `enable_v2` flag during the refactor/transition. Maps to the new
+    // behind `enable_mirror` flag during the refactor/transition. Maps to the new
     // PROPDEFS isolated PG DB instances in production.
     #[envconfig(default = "postgres://posthog:posthog@localhost:5432/posthog")]
     pub database_propdefs_url: String,

--- a/rust/property-defs-rs/src/metrics_consts.rs
+++ b/rust/property-defs-rs/src/metrics_consts.rs
@@ -32,6 +32,8 @@ pub const SINGLE_UPDATE_ISSUE_TIME: &str = "prop_defs_single_update_issue_time_m
 // property-defs-rs "v2" (mirror deploy) metric keys below
 //
 
+pub const V2_ISOLATED_DB_SELECTED: &str = "propdefs_v2_isolated_db_selected";
+
 pub const V2_EVENT_DEFS_BATCH_WRITE_TIME: &str = "propdefs_v2_eventdefs_batch_ms";
 pub const V2_EVENT_DEFS_BATCH_ATTEMPT: &str = "propdefs_v2_eventdefs_batch_attempt";
 pub const V2_EVENT_DEFS_BATCH_ROWS_AFFECTED: &str = "propdefs_v2_eventdefs_batch_rows";


### PR DESCRIPTION
## Problem
We can't roll out the `property-defs-rs` mirror deployment safely until we've isolated DB client usage to the new propdefs DB for the mirror deploy, and the old cloud DB for the orig deployment, on all write paths.


## Changes
* Adds the `ENABLE_MIRROR` config flag
* Create new PG client and connection pool pointed at new `database_propdefs_url`
* Conditions use of this new connection pool on `ENABLE_MIRROR` flag and `database_propdefs_url` being populated in the deploy env

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally and in CI, soon in `dev` mirror deployment
