### PR TITLE
fix(flags): I have no idea if this will work

### DIFF
--- a/rust/feature-flags/Cargo.toml
+++ b/rust/feature-flags/Cargo.toml
@@ -51,6 +51,7 @@ serde_urlencoded = { workspace = true }
 urlencoding = "2.1.3"
 dateparser = "0.2.1"
 rust_decimal = "1.37.1"
+futures = "0.3.30"
 
 [lints]
 workspace = true

--- a/rust/feature-flags/src/api/request_handler.rs
+++ b/rust/feature-flags/src/api/request_handler.rs
@@ -1178,8 +1178,6 @@ mod tests {
 
         let result = evaluate_feature_flags(evaluation_context).await;
 
-        println!("result: {:?}", result);
-
         assert!(
             result.flags.contains_key("test_flag"),
             "test_flag not found in result flags"

--- a/rust/feature-flags/src/metrics/metrics_consts.rs
+++ b/rust/feature-flags/src/metrics/metrics_consts.rs
@@ -28,7 +28,6 @@ pub const DB_GROUP_PROPERTIES_READS_COUNTER: &str = "flags_db_group_properties_r
 // Timing metrics
 pub const FLAG_EVALUATION_TIME: &str = "flags_evaluation_time";
 pub const FLAG_HASH_KEY_PROCESSING_TIME: &str = "flags_hash_key_processing_time";
-pub const FLAG_LOCAL_EVALUATION_TIME: &str = "flags_local_evaluation_time";
 pub const FLAG_LOCAL_PROPERTY_OVERRIDE_MATCH_TIME: &str =
     "flags_local_property_override_match_time";
 pub const FLAG_DB_PROPERTIES_FETCH_TIME: &str = "flags_db_properties_fetch_time";


### PR DESCRIPTION
## Problem

I noticed that the latency of the majority of slow p99 flag requests is basically all coming from how fast we evaluate `get_match` for every flag.  So, I'm proposing this change to see if evaluating `get_match` greedily (i.e. concurrently, since these match results don't depend on each other) will help speed it up.

## Changes

- removed some oopsie println!s
- removed a superfluous metrics
- execute `get_match` concurrently and join the results on the task that takes the longest.