### PR TITLE
fix(rust-ci): Remove rdkafka crate "cmake-build" feature

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1381,15 +1381,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
-name = "cmake"
-version = "0.1.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4834,7 +4825,6 @@ version = "4.8.0+2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced38182dc436b3d9df0c77976f37a67134df26b050df1f0006688e46fc4c8be"
 dependencies = [
- "cmake",
  "libc",
  "libz-sys",
  "num_enum",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -67,7 +67,7 @@ opentelemetry-otlp = "0.15.0"
 opentelemetry_sdk = { version = "0.22.1", features = ["trace", "rt-tokio"] }
 public-suffix = "0.1.2"
 rand = "0.8.5"
-rdkafka = { version = "0.37.0", features = ["cmake-build", "ssl", "tracing"] }
+rdkafka = { version = "0.37.0", features = ["ssl", "tracing"] }
 reqwest = { version = "0.12.3", features = ["json", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = { version = "1.0" }


### PR DESCRIPTION
## Problem
CI is broken in the Rust workspace right now because a CMake is failing to build `rdkafka-sys`, a wrapper for `librdkafka` in the `rdkafka` crate many of our projects depend on.

## Changes
[According to the docs](https://github.com/fede1024/rust-rdkafka/tree/master/rdkafka-sys#features), removing this feature just falls back on the `librdkafka` author's own build tool, and it fixed my broken PR in CI.

## Does this work well for both Cloud and self-hosted?
If it works at all 🍻 yes!
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Locally and in CI, pending poorly-thought-out YOLO deploy test 🚀 

