### PR TITLE
fix(propdefs-v2): fix bug causing metric skew in v2 deploy testing

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4696,13 +4696,13 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.6.9"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7c94f8935a9df96bb6380e8592c70edf497a643f94bd23b2f76b399385dbf4"
+checksum = "8f8ed0655cbaf18a26966142ad23b95d8ab47221c50c4f73a1db7d0d2d6e3da8"
 dependencies = [
  "ahash 0.8.11",
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
  "parking_lot",
 ]
 

--- a/rust/property-defs-rs/src/metrics_consts.rs
+++ b/rust/property-defs-rs/src/metrics_consts.rs
@@ -36,13 +36,19 @@ pub const V2_EVENT_DEFS_BATCH_WRITE_TIME: &str = "propdefs_v2_eventdefs_batch_ms
 pub const V2_EVENT_DEFS_BATCH_ATTEMPT: &str = "propdefs_v2_eventdefs_batch_attempt";
 pub const V2_EVENT_DEFS_BATCH_ROWS_AFFECTED: &str = "propdefs_v2_eventdefs_batch_rows";
 pub const V2_EVENT_DEFS_BATCH_CACHE_TIME: &str = "propdefs_v2_eventdefs_batch_cache_time_ms";
+pub const V2_EVENT_DEFS_CACHE_HIT: &str = "propdefs_v2_eventdefs_cache_hit";
+pub const V2_EVENT_DEFS_CACHE_MISS: &str = "propdefs_v2_eventdefs_cache_miss";
 
 pub const V2_EVENT_PROPS_BATCH_WRITE_TIME: &str = "propdefs_v2_eventprops_batch_ms";
 pub const V2_EVENT_PROPS_BATCH_ATTEMPT: &str = "propdefs_v2_eventprops_batch_attempt";
 pub const V2_EVENT_PROPS_BATCH_ROWS_AFFECTED: &str = "propdefs_v2_eventprops_batch_rows";
 pub const V2_EVENT_PROPS_BATCH_CACHE_TIME: &str = "propdefs_v2_eventprops_batch_cache_time_ms";
+pub const V2_EVENT_PROPS_CACHE_HIT: &str = "propdefs_v2_eventprops_cache_hit";
+pub const V2_EVENT_PROPS_CACHE_MISS: &str = "propdefs_v2_eventprops_cache_miss";
 
 pub const V2_PROP_DEFS_BATCH_WRITE_TIME: &str = "propdefs_v2_propdefs_batch_ms";
 pub const V2_PROP_DEFS_BATCH_ATTEMPT: &str = "propdefs_v2_propdefs_batch_attempt";
 pub const V2_PROP_DEFS_BATCH_ROWS_AFFECTED: &str = "propdefs_v2_propdefs_batch_rows";
 pub const V2_PROP_DEFS_BATCH_CACHE_TIME: &str = "propdefs_v2_propdefs_batch_cache_time_ms";
+pub const V2_PROP_DEFS_CACHE_HIT: &str = "propdefs_v2_propdefs_cache_hit";
+pub const V2_PROP_DEFS_CACHE_MISS: &str = "propdefs_v2_propdefs_cache_miss";

--- a/rust/property-defs-rs/src/v2_batch_ingestion.rs
+++ b/rust/property-defs-rs/src/v2_batch_ingestion.rs
@@ -340,20 +340,12 @@ async fn write_event_properties_batch(
         match result {
             Err(e) => {
                 if tries == V2_BATCH_MAX_RETRY_ATTEMPTS {
-                    common_metrics::inc(
-                        V2_EVENT_PROPS_BATCH_ATTEMPT,
-                        &[(String::from("result"), String::from("failed"))],
-                        1,
-                    );
+                    metrics::counter!(V2_EVENT_PROPS_BATCH_ATTEMPT, &[("result", "failed")]).increment(1);
                     total_time.fin();
                     return Err(e);
                 }
 
-                common_metrics::inc(
-                    V2_EVENT_PROPS_BATCH_ATTEMPT,
-                    &[(String::from("result"), String::from("retry"))],
-                    1,
-                );
+                metrics::counter!(V2_EVENT_PROPS_BATCH_ATTEMPT, &[("result", "retry")]).increment(1);
                 let jitter = rand::random::<u64>() % 50;
                 let delay: u64 = tries * V2_BATCH_RETRY_DELAY_MS + jitter;
                 tokio::time::sleep(Duration::from_millis(delay)).await;
@@ -369,12 +361,8 @@ async fn write_event_properties_batch(
                 batch.cache_batch(&mut cache);
 
                 // don't report success if the batch cache insetions failed!
-                common_metrics::inc(
-                    V2_EVENT_PROPS_BATCH_ATTEMPT,
-                    &[(String::from("result"), String::from("success"))],
-                    1,
-                );
-                common_metrics::inc(V2_EVENT_PROPS_BATCH_ROWS_AFFECTED, &[], count);
+                metrics::counter!(V2_EVENT_PROPS_BATCH_ATTEMPT, &[("result", "success")]).increment(1);
+                metrics::counter!(V2_EVENT_PROPS_BATCH_ROWS_AFFECTED).increment(count);
                 info!(
                     "Event properties batch of size {} written successfully",
                     count
@@ -426,20 +414,12 @@ async fn write_property_definitions_batch(
         match result {
             Err(e) => {
                 if tries == V2_BATCH_MAX_RETRY_ATTEMPTS {
-                    common_metrics::inc(
-                        V2_PROP_DEFS_BATCH_ATTEMPT,
-                        &[(String::from("result"), String::from("failed"))],
-                        1,
-                    );
+                    metrics::counter!(V2_PROP_DEFS_BATCH_ATTEMPT, &[("result", "failed")]).increment(1);
                     total_time.fin();
                     return Err(e);
                 }
 
-                common_metrics::inc(
-                    V2_PROP_DEFS_BATCH_ATTEMPT,
-                    &[(String::from("result"), String::from("retry"))],
-                    1,
-                );
+                metrics::counter!(V2_PROP_DEFS_BATCH_ATTEMPT, &[("result", "retry")]).increment(1);
                 let jitter = rand::random::<u64>() % 50;
                 let delay: u64 = tries * V2_BATCH_RETRY_DELAY_MS + jitter;
                 tokio::time::sleep(Duration::from_millis(delay)).await;
@@ -454,12 +434,8 @@ async fn write_property_definitions_batch(
                 batch.cache_batch(&mut cache);
 
                 // don't report success if the batch cache insetions failed!
-                common_metrics::inc(
-                    V2_PROP_DEFS_BATCH_ATTEMPT,
-                    &[(String::from("result"), String::from("success"))],
-                    1,
-                );
-                common_metrics::inc(V2_PROP_DEFS_BATCH_ROWS_AFFECTED, &[], count);
+                metrics::counter!(V2_PROP_DEFS_BATCH_ATTEMPT, &[("result", "success")]).increment(1);
+                metrics::counter!(V2_PROP_DEFS_BATCH_ROWS_AFFECTED).increment(count);
                 info!(
                     "Property definitions batch of size {} written successfully",
                     count
@@ -506,20 +482,12 @@ async fn write_event_definitions_batch(
         match result {
             Err(e) => {
                 if tries == V2_BATCH_MAX_RETRY_ATTEMPTS {
-                    common_metrics::inc(
-                        V2_EVENT_DEFS_BATCH_ATTEMPT,
-                        &[(String::from("result"), String::from("failed"))],
-                        1,
-                    );
+                    metrics::counter!(V2_EVENT_DEFS_BATCH_ATTEMPT, &[("result", "failed")]).increment(1);
                     total_time.fin();
                     return Err(e);
                 }
 
-                common_metrics::inc(
-                    V2_EVENT_DEFS_BATCH_ATTEMPT,
-                    &[(String::from("result"), String::from("retry"))],
-                    1,
-                );
+                metrics::counter!(V2_EVENT_DEFS_BATCH_ATTEMPT, &[("result", "retry")]).increment(1);
                 let jitter = rand::random::<u64>() % 50;
                 let delay: u64 = tries * V2_BATCH_RETRY_DELAY_MS + jitter;
                 tokio::time::sleep(Duration::from_millis(delay)).await;
@@ -533,12 +501,8 @@ async fn write_event_definitions_batch(
                 batch.cache_batch(&mut cache);
 
                 // don't report success if the batch cache insertions failed!
-                common_metrics::inc(
-                    V2_EVENT_DEFS_BATCH_ATTEMPT,
-                    &[(String::from("result"), String::from("success"))],
-                    1,
-                );
-                common_metrics::inc(V2_EVENT_DEFS_BATCH_ROWS_AFFECTED, &[], count);
+                metrics::counter!(V2_EVENT_DEFS_BATCH_ATTEMPT, &[("result", "retry")]).increment(1);
+                metrics::counter!(V2_EVENT_DEFS_BATCH_ROWS_AFFECTED).increment(count);
                 info!(
                     "Event definitions batch of size {} written successfully",
                     count

--- a/rust/property-defs-rs/src/v2_batch_ingestion.rs
+++ b/rust/property-defs-rs/src/v2_batch_ingestion.rs
@@ -59,11 +59,11 @@ impl EventPropertiesBatch {
     }
 
     pub fn should_flush_batch(&self) -> bool {
-        self.to_cache.len() >= self.batch_size
+        self.team_ids.len() >= self.batch_size
     }
 
     pub fn is_empty(&self) -> bool {
-        self.to_cache.len() == 0
+        self.team_ids.len() == 0
     }
 
     pub fn cache_batch(&mut self, cache: &mut Arc<Cache<Update, ()>>) {
@@ -110,11 +110,11 @@ impl EventDefinitionsBatch {
     }
 
     pub fn should_flush_batch(&self) -> bool {
-        self.to_cache.len() >= self.batch_size
+        self.ids.len() >= self.batch_size
     }
 
     pub fn is_empty(&self) -> bool {
-        self.to_cache.len() == 0
+        self.ids.len() == 0
     }
 
     pub fn cache_batch(mut self, cache: &mut Arc<Cache<Update, ()>>) {
@@ -196,11 +196,11 @@ impl PropertyDefinitionsBatch {
     }
 
     pub fn should_flush_batch(&self) -> bool {
-        self.to_cache.len() >= self.batch_size
+        self.ids.len() >= self.batch_size
     }
 
     pub fn is_empty(&self) -> bool {
-        self.to_cache.len() == 0
+        self.ids.len() == 0
     }
 
     pub fn cache_batch(&mut self, cache: &mut Arc<Cache<Update, ()>>) {


### PR DESCRIPTION
## Problem
The field I've been using to count values in batches is the only one in the `Batch` structs that we drain at the end of the run, prior to counting things 🤦 this is suboptimal.

## Changes
Use stable fields in `Batch` for counting that aren't drained when the cache insertions take place.

Also adds some more metrics that are no longer emitted on the v1 write path

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally and in CI; more in next round in deploy tests when this PR lands 👍 
