### PR TITLE
fix: Base64 blobby filename

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager.ts
@@ -454,7 +454,11 @@ export class SessionManager {
     private createBuffer(): SessionBuffer {
         try {
             const id = randomUUID()
-            const encodedSessionId = Buffer.from(`${this.sessionId}`, 'utf-8').toString('base64')
+            // Encode url safe base64
+            const encodedSessionId = Buffer.from(`${this.sessionId}`, 'utf-8')
+                .toString('base64')
+                .replace(/\+/g, '-')
+                .replace(/\//g, '_')
             const fileBase = path.join(
                 bufferFileDir(this.serverConfig.SESSION_RECORDING_LOCAL_DIRECTORY),
                 `${this.teamId}.${encodedSessionId}.${id}`

--- a/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager.ts
@@ -17,7 +17,15 @@ import { ObjectStorage } from '../../../../utils/object_storage'
 import { captureException } from '../../../../utils/posthog'
 import { asyncTimeoutGuard } from '../../../../utils/timing'
 import { IncomingRecordingMessage } from '../types'
-import { bufferFileDir, convertForPersistence, getLagMultiplier, maxDefined, minDefined, now } from '../utils'
+import {
+    bufferFileDir,
+    convertForPersistence,
+    fileSafeBase64,
+    getLagMultiplier,
+    maxDefined,
+    minDefined,
+    now,
+} from '../utils'
 import { OffsetHighWaterMarker } from './offset-high-water-marker'
 import { RealtimeManager } from './realtime-manager'
 
@@ -454,11 +462,7 @@ export class SessionManager {
     private createBuffer(): SessionBuffer {
         try {
             const id = randomUUID()
-            // Encode url safe base64
-            const encodedSessionId = Buffer.from(`${this.sessionId}`, 'utf-8')
-                .toString('base64')
-                .replace(/\+/g, '-')
-                .replace(/\//g, '_')
+            const encodedSessionId = fileSafeBase64(this.sessionId)
             const fileBase = path.join(
                 bufferFileDir(this.serverConfig.SESSION_RECORDING_LOCAL_DIRECTORY),
                 `${this.teamId}.${encodedSessionId}.${id}`

--- a/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager.ts
@@ -454,9 +454,10 @@ export class SessionManager {
     private createBuffer(): SessionBuffer {
         try {
             const id = randomUUID()
+            const encodedSessionId = Buffer.from(`${this.sessionId}`, 'utf-8').toString('base64')
             const fileBase = path.join(
                 bufferFileDir(this.serverConfig.SESSION_RECORDING_LOCAL_DIRECTORY),
-                Buffer.from(`${this.teamId}.${this.sessionId}.${id}`, 'utf-8').toString('base64')
+                `${this.teamId}.${encodedSessionId}.${id}`
             )
 
             const file = (type: 'jsonl' | 'gz') => `${fileBase}.${type}`

--- a/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager.ts
@@ -456,7 +456,7 @@ export class SessionManager {
             const id = randomUUID()
             const fileBase = path.join(
                 bufferFileDir(this.serverConfig.SESSION_RECORDING_LOCAL_DIRECTORY),
-                `${this.teamId}.${this.sessionId}.${id}`
+                Buffer.from(`${this.teamId}.${this.sessionId}.${id}`, 'utf-8').toString('base64')
             )
 
             const file = (type: 'jsonl' | 'gz') => `${fileBase}.${type}`

--- a/plugin-server/src/main/ingestion-queues/session-recording/utils.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/utils.ts
@@ -426,3 +426,7 @@ export const allSettledWithConcurrency = async <T, Q>(
         run()
     })
 }
+
+export const fileSafeBase64 = (str: string) => {
+    return Buffer.from(str, 'utf-8').toString('base64').replace(/\+/g, '-').replace(/\//g, '_')
+}

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
@@ -4,6 +4,8 @@ import { mkdirSync, readdirSync, rmSync } from 'node:fs'
 import { Message, TopicPartitionOffset } from 'node-rdkafka'
 import path from 'path'
 
+import { fileSafeBase64 } from '~/src/main/ingestion-queues/session-recording/utils'
+
 import { defaultConfig } from '../../../../src/config/config'
 import { SessionRecordingIngester } from '../../../../src/main/ingestion-queues/session-recording/session-recordings-consumer'
 import { Hub, PluginsServerConfig, Team } from '../../../../src/types'
@@ -583,13 +585,17 @@ describe.each([[true], [false]])('ingester with consumeOverflow=%p', (consumeOve
                     noop
                 )
 
+                const sid1 = fileSafeBase64('sid1')
+                const sid2 = fileSafeBase64('sid2')
+                const sid3 = fileSafeBase64('sid3')
+
                 expect(readdirSync(config.SESSION_RECORDING_LOCAL_DIRECTORY + '/session-buffer-files')).toEqual([
-                    expect.stringContaining(`${team.id}.sid1.`), // gz
-                    expect.stringContaining(`${team.id}.sid1.`), // json
-                    expect.stringContaining(`${team.id}.sid2.`), // gz
-                    expect.stringContaining(`${team.id}.sid2.`), // json
-                    expect.stringContaining(`${team.id}.sid3.`), // gz
-                    expect.stringContaining(`${team.id}.sid3.`), // json
+                    expect.stringContaining(`${team.id}.${sid1}.`), // gz
+                    expect.stringContaining(`${team.id}.${sid1}.`), // json
+                    expect.stringContaining(`${team.id}.${sid2}.`), // gz
+                    expect.stringContaining(`${team.id}.${sid2}.`), // json
+                    expect.stringContaining(`${team.id}.${sid3}.`), // gz
+                    expect.stringContaining(`${team.id}.${sid3}.`), // json
                 ])
 
                 const revokePromise = ingester.onRevokePartitions([createTP(1, consumedTopic)])
@@ -600,8 +606,8 @@ describe.each([[true], [false]])('ingester with consumeOverflow=%p', (consumeOve
 
                 // Only files left on the system should be the sid3 ones
                 expect(readdirSync(config.SESSION_RECORDING_LOCAL_DIRECTORY + '/session-buffer-files')).toEqual([
-                    expect.stringContaining(`${team.id}.sid3.`), // gz
-                    expect.stringContaining(`${team.id}.sid3.`), // json
+                    expect.stringContaining(`${team.id}.${sid3}.`), // gz
+                    expect.stringContaining(`${team.id}.${sid3}.`), // json
                 ])
 
                 expect(mockConsumer.offsetsStore).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
## Problem

We don't want to use the sessionID directly as it can be malformed in all sorts of ways.


## Changes

* base64 encode it

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
