### PR TITLE
fix: URL encode sessionID

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/session-manager.ts
@@ -17,15 +17,7 @@ import { ObjectStorage } from '../../../../utils/object_storage'
 import { captureException } from '../../../../utils/posthog'
 import { asyncTimeoutGuard } from '../../../../utils/timing'
 import { IncomingRecordingMessage } from '../types'
-import {
-    bufferFileDir,
-    convertForPersistence,
-    fileSafeBase64,
-    getLagMultiplier,
-    maxDefined,
-    minDefined,
-    now,
-} from '../utils'
+import { bufferFileDir, convertForPersistence, getLagMultiplier, maxDefined, minDefined, now } from '../utils'
 import { OffsetHighWaterMarker } from './offset-high-water-marker'
 import { RealtimeManager } from './realtime-manager'
 
@@ -116,6 +108,7 @@ export class SessionManager {
     unsubscribe: () => void
     flushJitterMultiplier: number
     realtimeTail: Tail | null = null
+    encodedSessionId: string
 
     constructor(
         public readonly serverConfig: PluginsServerConfig,
@@ -128,12 +121,13 @@ export class SessionManager {
         public readonly topic: string,
         public readonly debug: boolean = false
     ) {
+        this.encodedSessionId = encodeURIComponent(sessionId)
         this.buffer = this.createBuffer()
 
         // NOTE: a new SessionManager indicates that either everything has been flushed or a rebalance occured so we should clear the existing redis messages
-        void realtimeManager.clearAllMessages(this.teamId, this.sessionId)
+        void realtimeManager.clearAllMessages(this.teamId, this.encodedSessionId)
 
-        this.unsubscribe = realtimeManager.onSubscriptionEvent(this.teamId, this.sessionId, () => {
+        this.unsubscribe = realtimeManager.onSubscriptionEvent(this.teamId, this.encodedSessionId, () => {
             void this.startRealtime()
         })
 
@@ -357,7 +351,7 @@ export class SessionManager {
             }
 
             const { firstTimestamp, lastTimestamp } = eventsRange
-            const baseKey = `${this.serverConfig.SESSION_RECORDING_REMOTE_FOLDER}/team_id/${this.teamId}/session_id/${this.sessionId}`
+            const baseKey = `${this.serverConfig.SESSION_RECORDING_REMOTE_FOLDER}/team_id/${this.teamId}/session_id/${this.encodedSessionId}`
             const timeRange = `${firstTimestamp}-${lastTimestamp}`
             const dataKey = `${baseKey}/data/${timeRange}`
 
@@ -448,7 +442,7 @@ export class SessionManager {
             if (offsets.highest) {
                 void this.offsetHighWaterMarker.add(
                     { topic: this.topic, partition: this.partition },
-                    this.sessionId,
+                    this.encodedSessionId,
                     offsets.highest
                 )
             }
@@ -462,10 +456,9 @@ export class SessionManager {
     private createBuffer(): SessionBuffer {
         try {
             const id = randomUUID()
-            const encodedSessionId = fileSafeBase64(this.sessionId)
             const fileBase = path.join(
                 bufferFileDir(this.serverConfig.SESSION_RECORDING_LOCAL_DIRECTORY),
-                `${this.teamId}.${encodedSessionId}.${id}`
+                `${this.teamId}.${this.encodedSessionId}.${id}`
             )
 
             const file = (type: 'jsonl' | 'gz') => `${fileBase}.${type}`
@@ -519,19 +512,19 @@ export class SessionManager {
             return
         }
 
-        this.debugLog('⚡️', `[session-manager][realtime] Started `, { sessionId: this.sessionId })
+        this.debugLog('⚡️', `[session-manager][realtime] Started `, { sessionId: this.encodedSessionId })
 
         this.realtimeTail = new Tail(this.buffer.file('jsonl'), {
             fromBeginning: true,
         })
 
         this.realtimeTail.on('line', async (data: string) => {
-            await this.realtimeManager.addMessagesFromBuffer(this.teamId, this.sessionId, data, Date.now())
+            await this.realtimeManager.addMessagesFromBuffer(this.teamId, this.encodedSessionId, data, Date.now())
         })
 
         this.realtimeTail.on('error', (error) => {
             logger.error('🧨', '[session-manager][realtime] failed to watch buffer file', {
-                sessionId: this.sessionId,
+                sessionId: this.encodedSessionId,
                 teamId: this.teamId,
             })
             this.captureException(error)

--- a/plugin-server/src/main/ingestion-queues/session-recording/utils.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/utils.ts
@@ -426,7 +426,3 @@ export const allSettledWithConcurrency = async <T, Q>(
         run()
     })
 }
-
-export const fileSafeBase64 = (str: string) => {
-    return Buffer.from(str, 'utf-8').toString('base64').replace(/\+/g, '-').replace(/\//g, '_')
-}

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
@@ -4,8 +4,6 @@ import { mkdirSync, readdirSync, rmSync } from 'node:fs'
 import { Message, TopicPartitionOffset } from 'node-rdkafka'
 import path from 'path'
 
-import { fileSafeBase64 } from '~/src/main/ingestion-queues/session-recording/utils'
-
 import { defaultConfig } from '../../../../src/config/config'
 import { SessionRecordingIngester } from '../../../../src/main/ingestion-queues/session-recording/session-recordings-consumer'
 import { Hub, PluginsServerConfig, Team } from '../../../../src/types'
@@ -585,17 +583,13 @@ describe.each([[true], [false]])('ingester with consumeOverflow=%p', (consumeOve
                     noop
                 )
 
-                const sid1 = fileSafeBase64('sid1')
-                const sid2 = fileSafeBase64('sid2')
-                const sid3 = fileSafeBase64('sid3')
-
                 expect(readdirSync(config.SESSION_RECORDING_LOCAL_DIRECTORY + '/session-buffer-files')).toEqual([
-                    expect.stringContaining(`${team.id}.${sid1}.`), // gz
-                    expect.stringContaining(`${team.id}.${sid1}.`), // json
-                    expect.stringContaining(`${team.id}.${sid2}.`), // gz
-                    expect.stringContaining(`${team.id}.${sid2}.`), // json
-                    expect.stringContaining(`${team.id}.${sid3}.`), // gz
-                    expect.stringContaining(`${team.id}.${sid3}.`), // json
+                    expect.stringContaining(`${team.id}.sid1.`), // gz
+                    expect.stringContaining(`${team.id}.sid1.`), // json
+                    expect.stringContaining(`${team.id}.sid2.`), // gz
+                    expect.stringContaining(`${team.id}.sid2.`), // json
+                    expect.stringContaining(`${team.id}.sid3.`), // gz
+                    expect.stringContaining(`${team.id}.sid3.`), // json
                 ])
 
                 const revokePromise = ingester.onRevokePartitions([createTP(1, consumedTopic)])
@@ -606,8 +600,8 @@ describe.each([[true], [false]])('ingester with consumeOverflow=%p', (consumeOve
 
                 // Only files left on the system should be the sid3 ones
                 expect(readdirSync(config.SESSION_RECORDING_LOCAL_DIRECTORY + '/session-buffer-files')).toEqual([
-                    expect.stringContaining(`${team.id}.${sid3}.`), // gz
-                    expect.stringContaining(`${team.id}.${sid3}.`), // json
+                    expect.stringContaining(`${team.id}.sid3.`), // gz
+                    expect.stringContaining(`${team.id}.sid3.`), // json
                 ])
 
                 expect(mockConsumer.offsetsStore).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
## Problem

Realised that base64 just for the filename locally isn't ideal. Instead urlencoding it and using that for all file-esque things (local files, s3) is the way to go.

## Changes

* does that

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
