### PR TITLE
chore: update chrome extension denylist

### DIFF
--- a/frontend/src/scenes/session-recordings/player/snapshot-processing/chrome-extension-stripping.ts
+++ b/frontend/src/scenes/session-recordings/player/snapshot-processing/chrome-extension-stripping.ts
@@ -13,6 +13,8 @@ const CHROME_EXTENSION_DENY_LIST: Record<string, string> = {
     mloajfnmjckfjbeeofcdaecbelnblden: 'snap and read',
     aitopia: 'aitopia',
     becfinhbfclcgokjlobojlnldbfillpf: 'aitopia',
+    fnliebffpgomomjeflboommgbdnjadbh: 'sublime pop-up',
+    'sublime-root': 'sublime pop-up',
 }
 
 interface IsStrippable {


### PR DESCRIPTION
we've had this one reported in the past too

https://posthoghelp.zendesk.com/agent/tickets/15832 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/18415)
https://chromewebstore.google.com/detail/sublime/fnliebffpgomomjeflboommgbdnjadbh?hl=en

makes me think it'd be good to be able to be a little more targeted with selectors but for now since we report these in the doctor tab this is good enough for rock and roll