### PR TITLE
fix: drop long session ids

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -285,17 +285,6 @@ export class SessionRecordingIngester {
 
         const { team_id, session_id } = event
 
-        // added for incident 367 https://posthog.slack.com/archives/C08LPFEAUNR
-        // all session ids should be UUIDv7 and so 32 characters long
-        // we're now dropping invalid UUIDs at capture
-        // but have some naughty ones already in kafka
-        // this is a sanity check to get past those
-        if (session_id.length > 124) {
-            const semiValidTeamId = typeof team_id === 'number' || typeof team_id === 'string' ? team_id : 'unknown'
-            dropEvent(`session_id_too_long_${semiValidTeamId}`)
-            return
-        }
-
         const key = `${team_id}-${session_id}`
 
         const { partition, highOffset } = event.metadata
@@ -321,6 +310,17 @@ export class SessionRecordingIngester {
                     dropCause,
                 })
             }
+        }
+
+        // added for incident 367 https://posthog.slack.com/archives/C08LPFEAUNR
+        // all session ids should be UUIDv7 and so 32 characters long
+        // we're now dropping invalid UUIDs at capture
+        // but have some naughty ones already in kafka
+        // this is a sanity check to get past those
+        if (session_id.length > 124) {
+            const semiValidTeamId = typeof team_id === 'number' || typeof team_id === 'string' ? team_id : 'unknown'
+            dropEvent(`session_id_too_long_${semiValidTeamId}`)
+            return
         }
 
         // Check that we are not below the high-water mark for this partition (another consumer may have flushed further than us when revoking)

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -311,6 +311,16 @@ export class SessionRecordingIngester {
             }
         }
 
+        // added for incident 367 https://posthog.slack.com/archives/C08LPFEAUNR
+        // all session ids should be UUIDv7 and so 32 characters long
+        // we're now dropping invalid UUIDs at capture
+        // but have some naughty ones already in kafka
+        // this is a sanity check to get past those
+        if (session_id.length > 124) {
+            dropEvent('session_id_too_long')
+            return
+        }
+
         // Check that we are not below the high-water mark for this partition (another consumer may have flushed further than us when revoking)
         if (
             await this.persistentHighWaterMarker.isBelowHighWaterMark(event.metadata, this.consumerGroupId, highOffset)

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -284,6 +284,18 @@ export class SessionRecordingIngester {
         gaugeSessionsRevoked.reset()
 
         const { team_id, session_id } = event
+
+        // added for incident 367 https://posthog.slack.com/archives/C08LPFEAUNR
+        // all session ids should be UUIDv7 and so 32 characters long
+        // we're now dropping invalid UUIDs at capture
+        // but have some naughty ones already in kafka
+        // this is a sanity check to get past those
+        if (session_id.length > 124) {
+            const semiValidTeamId = typeof team_id === 'number' || typeof team_id === 'string' ? team_id : 'unknown'
+            dropEvent(`session_id_too_long_${semiValidTeamId}`)
+            return
+        }
+
         const key = `${team_id}-${session_id}`
 
         const { partition, highOffset } = event.metadata
@@ -309,16 +321,6 @@ export class SessionRecordingIngester {
                     dropCause,
                 })
             }
-        }
-
-        // added for incident 367 https://posthog.slack.com/archives/C08LPFEAUNR
-        // all session ids should be UUIDv7 and so 32 characters long
-        // we're now dropping invalid UUIDs at capture
-        // but have some naughty ones already in kafka
-        // this is a sanity check to get past those
-        if (session_id.length > 124) {
-            dropEvent('session_id_too_long')
-            return
         }
 
         // Check that we are not below the high-water mark for this partition (another consumer may have flushed further than us when revoking)


### PR DESCRIPTION
drop events where session ids are way longer than a UUID

see incident 367 https://posthog.slack.com/archives/C08LPFEAUNR