### PR TITLE
fix(vscode): fix refactor ts in vscode

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,7 +49,7 @@
         "common/eslint_rules/*",
         "common/storybook/*"
     ],
-    "exclude": ["frontend/dist/**/*"],
+    "exclude": ["frontend/dist/**/*", "**/*.mdx"],
     "ts-node": {
         "compilerOptions": {
             "module": "commonjs"


### PR DESCRIPTION
## Problem

The refactor ts actions are broken in VS Code, as `getMoveToRefactoringFileSuggestions` errors with `File /Users/thomas/Posthog/posthog/frontend/src/lib/lemon-ui/LemonColor/LemonColor.stories.mdx has unknown extension.`.

## Changes

Exludes `.mdx` files, which are used exclusively for Storybook from the tsconfig.

## How did you test this code?

Checked that `.mdx` docs still load in Storybook