### PR TITLE
fix: looser UUID check in ingestion

### DIFF
--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -355,13 +355,15 @@ pub async fn process_replay_events<'a>(
     // Validate session_id is a valid UUID
     let session_id_str = session_id.as_str().ok_or(CaptureError::InvalidSessionId)?;
 
-    // Reject session_ids that are too long, this is a proxy for "not a valid UUID"
-    // versions of PostHog JS in the wild are still pre-version 1.73.0 
+    // Reject session_ids that are too long, or that contains non-alphanumeric characters,
+    // this is a proxy for "not a valid UUID"
+    // we can't just reject non-UUIDv7 strings because
+    // some running versions of PostHog JS in the wild are still pre-version 1.73.0 
     // when we started sending valid UUIDv7 session_ids
     // at time of writing they are ~4-5% of all sessions
     // they'll be having a bad time generally but replay probably works a little for them
     // so we don't drop non-UUID strings, but we use length as a proxy definitely bad UUIDs
-    if session_id_str.len() > 70 {
+    if session_id_str.len() > 70 || !session_id_str.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
         return Err(CaptureError::InvalidSessionId);
     }
 

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -363,7 +363,11 @@ pub async fn process_replay_events<'a>(
     // at time of writing they are ~4-5% of all sessions
     // they'll be having a bad time generally but replay probably works a little for them
     // so we don't drop non-UUID strings, but we use length as a proxy definitely bad UUIDs
-    if session_id_str.len() > 70 || !session_id_str.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+    if session_id_str.len() > 70
+        || !session_id_str
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-')
+    {
         return Err(CaptureError::InvalidSessionId);
     }
 

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -1,6 +1,5 @@
 use std::ops::Deref;
 use std::sync::Arc;
-use uuid::Uuid;
 
 use axum::{debug_handler, Json};
 use bytes::Bytes;
@@ -355,7 +354,9 @@ pub async fn process_replay_events<'a>(
 
     // Validate session_id is a valid UUID
     let session_id_str = session_id.as_str().ok_or(CaptureError::InvalidSessionId)?;
-    if Uuid::parse_str(session_id_str).is_err() {
+
+    // Reject session_ids that are too long
+    if session_id_str.len() > 100 {
         return Err(CaptureError::InvalidSessionId);
     }
 

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -358,7 +358,7 @@ pub async fn process_replay_events<'a>(
     // Reject session_ids that are too long, or that contains non-alphanumeric characters,
     // this is a proxy for "not a valid UUID"
     // we can't just reject non-UUIDv7 strings because
-    // some running versions of PostHog JS in the wild are still pre-version 1.73.0 
+    // some running versions of PostHog JS in the wild are still pre-version 1.73.0
     // when we started sending valid UUIDv7 session_ids
     // at time of writing they are ~4-5% of all sessions
     // they'll be having a bad time generally but replay probably works a little for them

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -355,8 +355,13 @@ pub async fn process_replay_events<'a>(
     // Validate session_id is a valid UUID
     let session_id_str = session_id.as_str().ok_or(CaptureError::InvalidSessionId)?;
 
-    // Reject session_ids that are too long
-    if session_id_str.len() > 100 {
+    // Reject session_ids that are too long, this is a proxy for "not a valid UUID"
+    // versions of PostHog JS in the wild are still pre-version 1.73.0 
+    // when we started sending valid UUIDv7 session_ids
+    // at time of writing they are ~4-5% of all sessions
+    // they'll be having a bad time generally but replay probably works a little for them
+    // so we don't drop non-UUID strings, but we use length as a proxy definitely bad UUIDs
+    if session_id_str.len() > 70 {
         return Err(CaptureError::InvalidSessionId);
     }
 

--- a/rust/capture/tests/recordings.rs
+++ b/rust/capture/tests/recordings.rs
@@ -175,7 +175,7 @@ async fn it_rejects_bad_session_id() -> Result<()> {
 }
 
 #[tokio::test]
-async fn it_rejects_non_uuid_session_id() -> Result<()> {
+async fn it_rejects_too_long_session_id() -> Result<()> {
     setup_tracing();
     let token = random_string("token", 16);
     let distinct_id = random_string("id", 16);
@@ -188,9 +188,9 @@ async fn it_rejects_non_uuid_session_id() -> Result<()> {
         "token": token,
         "event": "testing",
         "distinct_id": distinct_id,
-        "$session_id": "not-a-uuid-string",
+        "$session_id": "not-a-uuid-string".repeat(10),
         "properties": {
-            "$session_id": "not-a-uuid-string",
+            "$session_id": "not-a-uuid-string".repeat(10),
             "$window_id": window_id,
             "$snapshot_data": [],
         }

--- a/rust/capture/tests/recordings.rs
+++ b/rust/capture/tests/recordings.rs
@@ -175,28 +175,91 @@ async fn it_rejects_bad_session_id() -> Result<()> {
 }
 
 #[tokio::test]
-async fn it_rejects_too_long_session_id() -> Result<()> {
+async fn it_validates_session_id_formats() -> Result<()> {
     setup_tracing();
     let token = random_string("token", 16);
     let distinct_id = random_string("id", 16);
     let window_id = random_string("id", 16);
 
+    // These are valid session IDs that should pass validation
+    let valid_session_ids = vec![
+        // UUIDv7 style
+        Uuid::now_v7().to_string(),
+        // UUIDv4 style
+        "f47ac10b-58cc-4372-a567-0e02b2c3d479".to_string(),
+        // The example UUIDs that were previously problematic but should now pass
+        "1960056980813e1-0a097dad71d3f-26011d51-144000-19600569809bc5".to_string(),
+        "196007bca5942f-076a0cca0e9058-b457454-4e000-196007bca5a9ca".to_string(),
+        "19600767475aa8-0ee6565b416bd78-f407878-61d78-19600767476811d".to_string(),
+        "196007e76cb16e2-0587fb99f6dd4e-1b525636-157188-196007e76cc35cc".to_string(),
+        "19600495cc74f8-068f4554dc7281-26011d51-1fa400-19600495cc81cc8".to_string(),
+    ];
+
+    // These are invalid session IDs that should be rejected
+    let invalid_session_ids = vec![
+        // Very long string that exceeds length limit
+        "not-a-uuid-string".repeat(10),
+        // Similar pattern to the example UUIDs but with extra length
+        "1960056980813e1-0a097dad71d3f-26011d51-144000-19600569809bc5".repeat(2),
+        // Extremely long version of the problematic format
+        "19600767475aa8-0ee6565b416bd78-f407878-61d78-19600767476811d".repeat(3),
+        // Extremely long session ID
+        "x".repeat(200),
+        // URL-encoded string
+        "%3Cscript%3Ealert%28%27hello%27%29%3C%2Fscript%3E".to_string(),
+        // Session ID with invalid characters
+        "1234-5678-9abc-def!@#".to_string(),
+        // Session ID with spaces
+        "1234 5678 9abc def".to_string(),
+    ];
+
     let main_topic = EphemeralTopic::new().await;
     let server = ServerHandle::for_recordings(&main_topic).await;
 
-    let event = json!({
-        "token": token,
-        "event": "testing",
-        "distinct_id": distinct_id,
-        "$session_id": "not-a-uuid-string".repeat(10),
-        "properties": {
-            "$session_id": "not-a-uuid-string".repeat(10),
-            "$window_id": window_id,
-            "$snapshot_data": [],
-        }
-    });
-    let res = server.capture_recording(event.to_string(), None).await;
-    assert_eq!(StatusCode::BAD_REQUEST, res.status());
+    // Test valid session IDs (should be accepted)
+    for session_id in valid_session_ids {
+        let event = json!({
+            "token": token,
+            "event": "testing",
+            "distinct_id": distinct_id,
+            "$session_id": session_id,
+            "properties": {
+                "$session_id": session_id,
+                "$window_id": window_id,
+                "$snapshot_data": [],
+            }
+        });
+        let res = server.capture_recording(event.to_string(), None).await;
+        assert_eq!(
+            StatusCode::OK, 
+            res.status(), 
+            "Expected session ID '{}' to be accepted, but got error status", 
+            session_id
+        );
+    }
+
+    // Test invalid session IDs (should be rejected)
+    for session_id in invalid_session_ids {
+        let event = json!({
+            "token": token,
+            "event": "testing",
+            "distinct_id": distinct_id,
+            "$session_id": session_id,
+            "properties": {
+                "$session_id": session_id,
+                "$window_id": window_id,
+                "$snapshot_data": [],
+            }
+        });
+        let res = server.capture_recording(event.to_string(), None).await;
+        assert_eq!(
+            StatusCode::BAD_REQUEST, 
+            res.status(), 
+            "Expected session ID '{}' to be rejected, but was accepted", 
+            session_id
+        );
+    }
+
     Ok(())
 }
 

--- a/rust/capture/tests/recordings.rs
+++ b/rust/capture/tests/recordings.rs
@@ -231,9 +231,9 @@ async fn it_validates_session_id_formats() -> Result<()> {
         });
         let res = server.capture_recording(event.to_string(), None).await;
         assert_eq!(
-            StatusCode::OK, 
-            res.status(), 
-            "Expected session ID '{}' to be accepted, but got error status", 
+            StatusCode::OK,
+            res.status(),
+            "Expected session ID '{}' to be accepted, but got error status",
             session_id
         );
     }
@@ -253,9 +253,9 @@ async fn it_validates_session_id_formats() -> Result<()> {
         });
         let res = server.capture_recording(event.to_string(), None).await;
         assert_eq!(
-            StatusCode::BAD_REQUEST, 
-            res.status(), 
-            "Expected session ID '{}' to be rejected, but was accepted", 
+            StatusCode::BAD_REQUEST,
+            res.status(),
+            "Expected session ID '{}' to be rejected, but was accepted",
             session_id
         );
     }


### PR DESCRIPTION
turns out dropping all non-UUID session ids is ~5% of traffic

this is no bueno (both dropping it and the fact that we're receiving it)