### PR TITLE
chore(crm): Track usage of the column configurator

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -269,6 +269,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             success,
             error,
         }),
+        reportDataTableColumnsUpdated: (context_type: string) => ({ context_type }),
         // insight filters
         reportFunnelStepReordered: true,
         reportInsightFilterRemoved: (index: number) => ({ index }),
@@ -725,6 +726,9 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         },
         reportFunnelStepReordered: async () => {
             posthog.capture('funnel step reordered')
+        },
+        reportDataTableColumnsUpdated: async ({ context_type }) => {
+            posthog.capture('data table columns updated', { context_type })
         },
         reportPersonPropertyUpdated: async ({ action, totalProperties, oldPropertyType, newPropertyType }) => {
             posthog.capture(`person property ${action}`, {

--- a/frontend/src/queries/nodes/DataTable/ColumnConfigurator/columnConfiguratorLogic.tsx
+++ b/frontend/src/queries/nodes/DataTable/ColumnConfigurator/columnConfiguratorLogic.tsx
@@ -1,6 +1,7 @@
 import { actions, connect, kea, key, listeners, path, props, propsChanged, reducers, selectors } from 'kea'
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { groupsModel } from '~/models/groupsModel'
@@ -26,7 +27,7 @@ export const columnConfiguratorLogic = kea<columnConfiguratorLogicType>([
     path(['queries', 'nodes', 'DataTable', 'columnConfiguratorLogic']),
     key((props) => props.key),
     connect({
-        actions: [groupsModel, ['setDefaultColumns']],
+        actions: [eventUsageLogic, ['reportDataTableColumnsUpdated'], groupsModel, ['setDefaultColumns']],
     }),
     actions({
         showModal: true,
@@ -82,6 +83,7 @@ export const columnConfiguratorLogic = kea<columnConfiguratorLogicType>([
     }),
     listeners(({ actions, values, props }) => ({
         save: async () => {
+            actions.reportDataTableColumnsUpdated(props.context?.type ?? 'live_events')
             if (!props.isPersistent || !values.saveAsDefault) {
                 props.setColumns(values.columns)
                 return


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/29881
Previously https://github.com/PostHog/posthog/pull/30463

## Changes

Tracks usage of the column configurator with `data table columns updated`.

## How did you test this code?

I used the column configurator and then verified an event was recorded.