### PR TITLE
chore(crm): Add soft delete column to groups

### DIFF
--- a/posthog/clickhouse/migrations/0111_add_soft_delete_column_on_groups.py
+++ b/posthog/clickhouse/migrations/0111_add_soft_delete_column_on_groups.py
@@ -1,3 +1,4 @@
+from posthog.clickhouse.client.connection import NodeRole
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
 
 DROP_COLUMNS_INDEX_GROUPS = """
@@ -21,8 +22,8 @@ ADD INDEX IF NOT EXISTS is_deleted_idx (is_deleted) TYPE minmax GRANULARITY 1
 """
 
 operations = [
-    run_sql_with_exceptions(DROP_COLUMNS_INDEX_GROUPS),
-    run_sql_with_exceptions(DROP_COLUMNS_GROUPS),
-    run_sql_with_exceptions(ADD_COLUMNS_GROUPS),
-    run_sql_with_exceptions(ADD_COLUMNS_INDEX_GROUPS),
+    run_sql_with_exceptions(DROP_COLUMNS_INDEX_GROUPS, node_role=NodeRole.ALL),
+    run_sql_with_exceptions(DROP_COLUMNS_GROUPS, node_role=NodeRole.ALL),
+    run_sql_with_exceptions(ADD_COLUMNS_GROUPS, node_role=NodeRole.ALL),
+    run_sql_with_exceptions(ADD_COLUMNS_INDEX_GROUPS, node_role=NodeRole.ALL),
 ]

--- a/posthog/clickhouse/migrations/0111_add_soft_delete_column_on_groups.py
+++ b/posthog/clickhouse/migrations/0111_add_soft_delete_column_on_groups.py
@@ -1,32 +1,28 @@
-from infi.clickhouse_orm import migrations
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
 
-from posthog.clickhouse.client.connection import get_client_from_pool
-from posthog.settings import CLICKHOUSE_CLUSTER
-
+DROP_COLUMNS_INDEX_GROUPS = """
+ALTER TABLE groups
+DROP INDEX IF EXISTS is_deleted_idx
+"""
 
 DROP_COLUMNS_GROUPS = """
-ALTER TABLE {table} ON CLUSTER {cluster}
+ALTER TABLE groups
 DROP COLUMN IF EXISTS is_deleted
 """
 
 ADD_COLUMNS_GROUPS = """
-ALTER TABLE {table} ON CLUSTER {cluster}
+ALTER TABLE groups
 ADD COLUMN IF NOT EXISTS is_deleted Boolean
 """
 
 ADD_COLUMNS_INDEX_GROUPS = """
-ALTER TABLE {table} ON CLUSTER {cluster}
+ALTER TABLE groups
 ADD INDEX IF NOT EXISTS is_deleted_idx (is_deleted) TYPE minmax GRANULARITY 1
 """
 
-
-def add_columns_to_required_tables(_):
-    with get_client_from_pool() as client:
-        client.execute(DROP_COLUMNS_GROUPS.format(table="groups", cluster=CLICKHOUSE_CLUSTER))
-        client.execute(ADD_COLUMNS_GROUPS.format(table="groups", cluster=CLICKHOUSE_CLUSTER))
-        client.execute(ADD_COLUMNS_INDEX_GROUPS.format(table="groups", cluster=CLICKHOUSE_CLUSTER))
-
-
 operations = [
-    migrations.RunPython(add_columns_to_required_tables),
+    run_sql_with_exceptions(DROP_COLUMNS_INDEX_GROUPS),
+    run_sql_with_exceptions(DROP_COLUMNS_GROUPS),
+    run_sql_with_exceptions(ADD_COLUMNS_GROUPS),
+    run_sql_with_exceptions(ADD_COLUMNS_INDEX_GROUPS),
 ]

--- a/posthog/clickhouse/migrations/0111_add_soft_delete_column_on_groups.py
+++ b/posthog/clickhouse/migrations/0111_add_soft_delete_column_on_groups.py
@@ -1,0 +1,32 @@
+from infi.clickhouse_orm import migrations
+
+from posthog.clickhouse.client.connection import get_client_from_pool
+from posthog.settings import CLICKHOUSE_CLUSTER
+
+
+DROP_COLUMNS_GROUPS = """
+ALTER TABLE {table} ON CLUSTER {cluster}
+DROP COLUMN IF EXISTS is_deleted
+"""
+
+ADD_COLUMNS_GROUPS = """
+ALTER TABLE {table} ON CLUSTER {cluster}
+ADD COLUMN IF NOT EXISTS is_deleted Boolean
+"""
+
+ADD_COLUMNS_INDEX_GROUPS = """
+ALTER TABLE {table} ON CLUSTER {cluster}
+ADD INDEX IF NOT EXISTS is_deleted_idx (is_deleted) TYPE minmax GRANULARITY 1
+"""
+
+
+def add_columns_to_required_tables(_):
+    with get_client_from_pool() as client:
+        client.execute(DROP_COLUMNS_GROUPS.format(table="groups", cluster=CLICKHOUSE_CLUSTER))
+        client.execute(ADD_COLUMNS_GROUPS.format(table="groups", cluster=CLICKHOUSE_CLUSTER))
+        client.execute(ADD_COLUMNS_INDEX_GROUPS.format(table="groups", cluster=CLICKHOUSE_CLUSTER))
+
+
+operations = [
+    migrations.RunPython(add_columns_to_required_tables),
+]


### PR DESCRIPTION
Needed for https://github.com/PostHog/posthog/pull/30618
See https://posthog.slack.com/archives/C076R4753Q8/p1743461157422029

## Changes

Adds `is_deleted` to `groups` so we can insert `is_deleted=true` when reacting to the user, and then handle the actual delete in a Dagster job.

Cribbed from https://github.com/PostHog/posthog/pull/24581

## How did you test this code?

I ran the migration locally and verified the column was created as expected.