### PR TITLE
chore(editor-3001): add viz button and disabled state

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.tsx
@@ -1,5 +1,5 @@
 import { IconGraph, IconLifecycle, IconTrends } from '@posthog/icons'
-import { LemonSelect, LemonSelectOptions } from '@posthog/lemon-ui'
+import { LemonSelect, LemonSelectOptions, LemonSelectProps } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { Icon123, IconAreaChart, IconTableChart } from 'lib/lemon-ui/icons'
 
@@ -7,7 +7,9 @@ import { ChartDisplayType } from '~/types'
 
 import { dataVisualizationLogic } from '../dataVisualizationLogic'
 
-export const TableDisplay = (): JSX.Element => {
+interface TableDisplayProps extends Pick<LemonSelectProps<ChartDisplayType>, 'disabledReason'> {}
+
+export const TableDisplay = ({ disabledReason }: TableDisplayProps): JSX.Element => {
     const { setVisualizationType } = useActions(dataVisualizationLogic)
     const { visualizationType } = useValues(dataVisualizationLogic)
 
@@ -56,6 +58,7 @@ export const TableDisplay = (): JSX.Element => {
 
     return (
         <LemonSelect
+            disabledReason={disabledReason}
             value={visualizationType}
             onChange={(value) => {
                 setVisualizationType(value)

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -282,6 +282,8 @@ export function OutputPane(): JSX.Element {
         })
     }, [response])
 
+    const hasColumns = columns.length > 1
+
     return (
         <div className="OutputPane flex flex-col w-full flex-1 bg-primary">
             <div className="flex flex-row justify-between align-center py-2 px-4 w-full h-[50px] border-b">
@@ -313,8 +315,9 @@ export function OutputPane(): JSX.Element {
                             }}
                         />
                     )}
-                    {activeTab === OutputTab.Results && exportContext && columns.length > 0 && (
+                    {activeTab === OutputTab.Results && exportContext && (
                         <ExportButton
+                            disabledReason={!hasColumns ? 'No results to export' : undefined}
                             type="secondary"
                             items={[
                                 {
@@ -328,15 +331,18 @@ export function OutputPane(): JSX.Element {
                             ]}
                         />
                     )}
-                    {activeTab === OutputTab.Visualization && columns.length > 0 && (
+                    {activeTab === OutputTab.Visualization && (
                         <>
                             <div className="flex justify-between flex-wrap">
                                 <div className="flex items-center" />
                                 <div className="flex items-center">
                                     <div className="flex gap-2 items-center flex-wrap">
-                                        <TableDisplay />
+                                        <TableDisplay
+                                            disabledReason={!hasColumns ? 'No results to visualize' : undefined}
+                                        />
 
                                         <LemonButton
+                                            disabledReason={!hasColumns ? 'No results to visualize' : undefined}
                                             type="secondary"
                                             icon={<IconGear />}
                                             onClick={() => toggleChartSettingsPanel()}
@@ -352,7 +358,11 @@ export function OutputPane(): JSX.Element {
                                             </LemonButton>
                                         )}
                                         {!editingInsight && (
-                                            <LemonButton type="primary" onClick={() => saveAsInsight()}>
+                                            <LemonButton
+                                                disabledReason={!hasColumns ? 'No results to save' : undefined}
+                                                type="primary"
+                                                onClick={() => saveAsInsight()}
+                                            >
                                                 Create insight
                                             </LemonButton>
                                         )}
@@ -360,6 +370,15 @@ export function OutputPane(): JSX.Element {
                                 </div>
                             </div>
                         </>
+                    )}
+                    {activeTab === OutputTab.Results && (
+                        <LemonButton
+                            disabledReason={!hasColumns ? 'No results to visualize' : undefined}
+                            type="primary"
+                            onClick={() => setActiveTab(OutputTab.Visualization)}
+                        >
+                            Visualize
+                        </LemonButton>
                     )}
                 </div>
             </div>


### PR DESCRIPTION
## Problem

- hard to tell you can visualize in results tab

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- add a viz button. This probably can be removed over time but helps for now

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
