### PR TITLE
feat(project-tree): link files and folders

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -40,6 +40,7 @@ export function ProjectTree(): JSX.Element {
         setLastNewOperation,
         onItemChecked,
         moveCheckedItems,
+        linkCheckedItems,
         setCheckedItems,
     } = useActions(projectTreeLogic)
 
@@ -80,6 +81,17 @@ export function ProjectTree(): JSX.Element {
                     }}
                 >
                     <ButtonPrimitive menuItem>Move {checkedItemsCount} selected items here</ButtonPrimitive>
+                </MenuItem>
+            ) : null}
+            {checkedItemsCount !== '0' && item.record?.type === 'folder' ? (
+                <MenuItem
+                    asChild
+                    onClick={(e: any) => {
+                        e.stopPropagation()
+                        linkCheckedItems(item.record.path)
+                    }}
+                >
+                    <ButtonPrimitive menuItem>Link {checkedItemsCount} selected items here</ButtonPrimitive>
                 </MenuItem>
             ) : null}
             {item.record?.path ? (

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
@@ -46,6 +46,7 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
         deleteItem: (item: FileSystemEntry) => ({ item }),
         moveItem: (oldPath: string, newPath: string, force = false) => ({ oldPath, newPath, force }),
         movedItem: (item: FileSystemEntry, oldPath: string, newPath: string) => ({ item, oldPath, newPath }),
+        linkItem: (oldPath: string, newPath: string, force = false) => ({ oldPath, newPath, force }),
         queueAction: (action: ProjectTreeAction) => ({ action }),
         removeQueuedAction: (action: ProjectTreeAction) => ({ action }),
         createSavedItem: (savedItem: FileSystemEntry) => ({ savedItem }),
@@ -74,6 +75,7 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
         setCheckedItems: (checkedItems: Record<string, boolean>) => ({ checkedItems }),
         expandProjectFolder: (path: string) => ({ path }),
         moveCheckedItems: (path: string) => ({ path }),
+        linkCheckedItems: (path: string) => ({ path }),
         checkSelectedFolders: true,
     }),
     loaders(({ actions, values }) => ({
@@ -130,20 +132,22 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
             {
                 queueAction: async ({ action }) => {
                     actions.removeQueuedAction(action)
-                    if (action.type === 'prepare-move' && action.newPath) {
+                    if ((action.type === 'prepare-move' || action.type === 'prepare-link') && action.newPath) {
+                        const verb = action.type === 'prepare-link' ? 'link' : 'move'
+                        const verbing = action.type === 'prepare-link' ? 'linking' : 'moving'
                         try {
                             const response = await api.fileSystem.count(action.item.id)
                             if (response && response.count > MOVE_ALERT_LIMIT) {
-                                const confirmMessage = `You're about to move ${response.count} items. Are you sure?`
+                                const confirmMessage = `You're about to ${verb} ${response.count} items. Are you sure?`
                                 if (!confirm(confirmMessage)) {
                                     actions.removeQueuedAction(action)
                                     return false
                                 }
                             }
-                            actions.queueAction({ ...action, type: 'move' })
+                            actions.queueAction({ ...action, type: verb })
                         } catch (error) {
-                            console.error('Error moving item:', error)
-                            lemonToast.error(`Error moving item: ${error}`)
+                            console.error(`Error ${verbing} item:`, error)
+                            lemonToast.error(`Error ${verbing} item: ${error}`)
                         }
                     } else if (action.type === 'move' && action.newPath) {
                         try {
@@ -163,6 +167,21 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                         } catch (error) {
                             console.error('Error moving item:', error)
                             lemonToast.error(`Error moving item: ${error}`)
+                        }
+                    } else if (action.type === 'link' && action.newPath) {
+                        try {
+                            const newPath = action.newPath
+                            const response = await api.fileSystem.link(action.item.id, newPath)
+                            if (response.result) {
+                                actions.createSavedItem(response.result)
+                            }
+                            if (action.item.type === 'folder') {
+                                actions.loadFolder(newPath)
+                            }
+                            lemonToast.success('Item linked successfully') // TODO: undo for linking
+                        } catch (error) {
+                            console.error('Error linking item:', error)
+                            lemonToast.error(`Error linking item: ${error}`)
                         }
                     } else if (action.type === 'create') {
                         try {
@@ -706,6 +725,9 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
         movedItem: () => {
             actions.checkSelectedFolders()
         },
+        linkedItem: () => {
+            actions.checkSelectedFolders()
+        },
         checkSelectedFolders: () => {
             // Select items added into folders that are selected
             const checkedItems = values.checkedItems
@@ -813,6 +835,45 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                 }
                 actions.queueAction({
                     type: !force && item.type === 'folder' ? 'prepare-move' : 'move',
+                    item,
+                    path: item.path,
+                    newPath: newPath + item.path.slice(oldPath.length),
+                })
+            }
+        },
+        linkCheckedItems: ({ path }) => {
+            const { checkedItems } = values
+            let skipInFolder: string | null = null
+            for (const item of values.sortedItems) {
+                if (skipInFolder !== null) {
+                    if (item.path.startsWith(skipInFolder + '/')) {
+                        continue
+                    } else {
+                        skipInFolder = null
+                    }
+                }
+                const itemId = item.type === 'folder' ? `project-folder/${item.path}` : `project/${item.id}`
+                if (checkedItems[itemId]) {
+                    actions.linkItem(item.path, joinPath([...splitPath(path), ...splitPath(item.path).slice(-1)]), true)
+                    if (item.type === 'folder') {
+                        skipInFolder = item.path
+                    }
+                }
+            }
+        },
+        linkItem: async ({ oldPath, newPath, force }) => {
+            if (newPath === oldPath) {
+                lemonToast.error('Cannot link folder into itself')
+                return
+            }
+            const item = values.viableItems.find((item) => item.path === oldPath)
+            if (item && item.path === oldPath) {
+                if (!item.id) {
+                    lemonToast.error("Sorry, can't link an unsaved item (no id)")
+                    return
+                }
+                actions.queueAction({
+                    type: !force && item.type === 'folder' ? 'prepare-link' : 'link',
                     item,
                     path: item.path,
                     newPath: newPath + item.path.slice(oldPath.length),

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
@@ -171,9 +171,9 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                     } else if (action.type === 'link' && action.newPath) {
                         try {
                             const newPath = action.newPath
-                            const response = await api.fileSystem.link(action.item.id, newPath)
-                            if (response.result) {
-                                actions.createSavedItem(response.result)
+                            const newItem = await api.fileSystem.link(action.item.id, newPath)
+                            if (newItem) {
+                                actions.createSavedItem(newItem)
                             }
                             if (action.item.type === 'folder') {
                                 actions.loadFolder(newPath)

--- a/frontend/src/layout/panel-layout/ProjectTree/types.ts
+++ b/frontend/src/layout/panel-layout/ProjectTree/types.ts
@@ -1,7 +1,7 @@
 import { FileSystemEntry } from '~/queries/schema/schema-general'
 
 export interface ProjectTreeAction {
-    type: 'prepare-move' | 'move' | 'create' | 'prepare-delete' | 'delete'
+    type: 'prepare-move' | 'move' | 'link' | 'prepare-link' | 'create' | 'prepare-delete' | 'delete'
     item: FileSystemEntry
     path: string
     newPath?: string

--- a/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
@@ -89,7 +89,8 @@ export function convertFileSystemEntryToTreeDataItem({
 
         let accumulatedChildren: TreeDataItem[] = []
         if (item.type === 'folder') {
-            const folderMatch = (node): boolean => node.record?.path === item.path && node.record?.type === 'folder'
+            const folderMatch = (node: TreeDataItem): boolean =>
+                node.record?.path === item.path && node.record?.type === 'folder'
             const existingFolder = currentLevel.find(folderMatch)
             if (existingFolder) {
                 if (existingFolder.id) {

--- a/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
@@ -50,7 +50,7 @@ export function convertFileSystemEntryToTreeDataItem({
                 id,
                 name: folderName,
                 displayName: <SearchHighlightMultiple string={folderName} substring={searchTerm ?? ''} />,
-                record: { type: 'folder', id, path: fullPath },
+                record: { type: 'folder', id: null, path: fullPath },
                 children: [],
                 checked: checkedItems[id],
             }
@@ -87,11 +87,21 @@ export function convertFileSystemEntryToTreeDataItem({
             currentLevel = folderNode.children!
         }
 
-        if (
-            item.type === 'folder' &&
-            currentLevel.find((node) => node.record?.path === item.path && node.record?.type === 'folder')
-        ) {
-            continue
+        let accumulatedChildren: TreeDataItem[] = []
+        if (item.type === 'folder') {
+            const folderMatch = (node): boolean => node.record?.path === item.path && node.record?.type === 'folder'
+            const existingFolder = currentLevel.find(folderMatch)
+            if (existingFolder) {
+                if (existingFolder.id) {
+                    continue
+                } else {
+                    // We have a folder without an id, but the incoming one has an id. Remove the current one
+                    currentLevel = currentLevel.filter((node) => !folderMatch(node))
+                    if (existingFolder.children) {
+                        accumulatedChildren = [...accumulatedChildren, ...existingFolder.children]
+                    }
+                }
+            }
         }
 
         // Create the actual item node.
@@ -119,6 +129,9 @@ export function convertFileSystemEntryToTreeDataItem({
         if (item.type === 'folder') {
             if (!node.children) {
                 node.children = []
+            }
+            if (accumulatedChildren) {
+                node.children = [...node.children, ...accumulatedChildren]
             }
             if (folderStates[item.path] === 'has-more') {
                 node.children.push({

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -390,6 +390,9 @@ class ApiRequest {
     public fileSystemMove(id: NonNullable<FileSystemEntry['id']>, projectId?: ProjectType['id']): ApiRequest {
         return this.fileSystem(projectId).addPathComponent(id).addPathComponent('move')
     }
+    public fileSystemLink(id: NonNullable<FileSystemEntry['id']>, projectId?: ProjectType['id']): ApiRequest {
+        return this.fileSystem(projectId).addPathComponent(id).addPathComponent('link')
+    }
     public fileSystemCount(id: NonNullable<FileSystemEntry['id']>, projectId?: ProjectType['id']): ApiRequest {
         return this.fileSystem(projectId).addPathComponent(id).addPathComponent('count')
     }
@@ -1283,6 +1286,9 @@ const api = {
         },
         async move(id: NonNullable<FileSystemEntry['id']>, newPath: string): Promise<FileSystemEntry> {
             return await new ApiRequest().fileSystemMove(id).create({ data: { new_path: newPath } })
+        },
+        async link(id: NonNullable<FileSystemEntry['id']>, newPath: string): Promise<FileSystemEntry> {
+            return await new ApiRequest().fileSystemLink(id).create({ data: { new_path: newPath } })
         },
         async count(id: NonNullable<FileSystemEntry['id']>): Promise<FileSystemCount> {
             return await new ApiRequest().fileSystemCount(id).create()

--- a/posthog/api/file_system.py
+++ b/posthog/api/file_system.py
@@ -171,6 +171,8 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         if not new_path:
             return Response({"detail": "new_path is required"}, status=status.HTTP_400_BAD_REQUEST)
 
+        assure_parent_folders(new_path, self.team, cast(User, request.user))
+
         if instance.type == "folder":
             if new_path == instance.path:
                 return Response({"detail": "Cannot move folder into itself"}, status=status.HTTP_400_BAD_REQUEST)
@@ -197,7 +199,52 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             instance.save()
 
         return Response(
-            "OK",
+            {
+                "result": FileSystemSerializer(instance).data,
+            },
+            status=status.HTTP_200_OK,
+        )
+
+    @action(methods=["POST"], detail=True)
+    def link(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        instance = self.get_object()
+        new_path = request.data.get("new_path")
+        if not new_path:
+            return Response({"detail": "new_path is required"}, status=status.HTTP_400_BAD_REQUEST)
+
+        assure_parent_folders(new_path, self.team, cast(User, request.user))
+
+        if instance.type == "folder":
+            if new_path == instance.path:
+                return Response({"detail": "Cannot link folder into itself"}, status=status.HTTP_400_BAD_REQUEST)
+
+            with transaction.atomic():
+                for file in FileSystem.objects.filter(team=self.team, path__startswith=f"{instance.path}/"):
+                    file.pk = None  # This removes the id
+                    file.path = new_path + file.path[len(instance.path) :]
+                    file.depth = len(split_path(file.path))
+                    file.save()  # A new instance is created with a new id
+
+                targets = FileSystem.objects.filter(team=self.team, path=new_path).all()
+                if any(target.type == "folder" for target in targets):
+                    # We're a folder, and we're link into a folder with the same name. Noop.
+                    pass
+                else:
+                    instance.pk = None  # This removes the id
+                    instance.path = new_path
+                    instance.depth = len(split_path(instance.path))
+                    instance.save()  # A new instance is created with a new id
+
+        else:
+            instance.pk = None  # This removes the id
+            instance.path = new_path + instance.path[len(instance.path) :]
+            instance.depth = len(split_path(instance.path))
+            instance.save()  # A new instance is created with a new id
+
+        return Response(
+            {
+                "result": FileSystemSerializer(instance).data,
+            },
             status=status.HTTP_200_OK,
         )
 
@@ -209,6 +256,25 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             return Response({"detail": "Count can only be called on folders"}, status=status.HTTP_400_BAD_REQUEST)
         count = FileSystem.objects.filter(team=self.team, path__startswith=f"{instance.path}/").count()
         return Response({"count": count}, status=status.HTTP_200_OK)
+
+
+def assure_parent_folders(path: str, team: Team, created_by: User) -> None:
+    """
+    Ensure that all parent folders for the given path exist for the provided team.
+    For example, if the path is "a/b/c/d", this will ensure that "a", "a/b", and "a/b/c"
+    all exist as folder type FileSystem entries.
+    """
+    segments = split_path(path)
+    for depth_index in range(1, len(segments)):
+        parent_path = join_path(segments[:depth_index])
+        if not FileSystem.objects.filter(team=team, path=parent_path).exists():
+            FileSystem.objects.create(
+                team=team,
+                path=parent_path,
+                depth=depth_index,
+                type="folder",
+                created_by=created_by,
+            )
 
 
 def retroactively_fix_folders_and_depth(team: Team, user: User) -> None:

--- a/posthog/api/file_system.py
+++ b/posthog/api/file_system.py
@@ -199,9 +199,7 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             instance.save()
 
         return Response(
-            {
-                "result": FileSystemSerializer(instance).data,
-            },
+            FileSystemSerializer(instance).data,
             status=status.HTTP_200_OK,
         )
 
@@ -242,9 +240,7 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             instance.save()  # A new instance is created with a new id
 
         return Response(
-            {
-                "result": FileSystemSerializer(instance).data,
-            },
+            FileSystemSerializer(instance).data,
             status=status.HTTP_200_OK,
         )
 

--- a/posthog/api/test/test_file_system.py
+++ b/posthog/api/test/test_file_system.py
@@ -605,7 +605,7 @@ class TestFileSystemAPI(APIBaseTest):
         self.assertEqual(result["depth"], 1)
         # Verify that the child file was linked with its path updated.
         linked_child = FileSystem.objects.filter(team=self.team, path="LinkedFolder/Child.txt", type="doc").first()
-        self.assertIsNotNone(linked_child)
+        assert linked_child is not None
         self.assertEqual(linked_child.depth, 2)
 
     def test_link_folder_into_itself(self):
@@ -641,9 +641,9 @@ class TestFileSystemAPI(APIBaseTest):
         # For the path "A/B/C", we expect the parent folders "A" and "A/B" to be created.
         folder_a = FileSystem.objects.filter(team=self.team, path="A", type="folder").first()
         folder_ab = FileSystem.objects.filter(team=self.team, path="A/B", type="folder").first()
-        self.assertIsNotNone(folder_a)
+        assert folder_a is not None
         self.assertEqual(folder_a.depth, 1)
-        self.assertIsNotNone(folder_ab)
+        assert folder_ab is not None
         self.assertEqual(folder_ab.depth, 2)
         # The full path "A/B/C" should NOT be created by assure_parent_folders.
         folder_abc = FileSystem.objects.filter(team=self.team, path="A/B/C").first()

--- a/posthog/api/test/test_file_system.py
+++ b/posthog/api/test/test_file_system.py
@@ -551,3 +551,100 @@ class TestFileSystemAPI(APIBaseTest):
         # Expecting only the item with ref "unique-ref-123"
         self.assertEqual(data["count"], 1)
         self.assertEqual(data["results"][0]["ref"], "unique-ref-123")
+
+    def test_link_file_endpoint(self):
+        """
+        Test linking a file creates a new file with an updated path and that missing parent folders are auto-created.
+        """
+        # Create an original file.
+        file_obj = FileSystem.objects.create(
+            team=self.team,
+            path="OriginalFile.txt",
+            type="doc",
+            created_by=self.user,
+        )
+        new_path = "NewFolder/NewFile.txt"
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/file_system/{file_obj.pk}/link",
+            {"new_path": new_path},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        result = response.json()
+        self.assertEqual(result["path"], new_path)
+        # "NewFolder/NewFile.txt" should have a depth of 2.
+        self.assertEqual(result["depth"], 2)
+        # Ensure that the parent folder "NewFolder" was auto-created as a folder.
+        self.assertTrue(FileSystem.objects.filter(team=self.team, path="NewFolder", type="folder").exists())
+
+    def test_link_folder_endpoint(self):
+        """
+        Test linking a folder creates a new folder instance and also clones its child items with updated paths.
+        """
+        # Create a folder and a child file.
+        folder_obj = FileSystem.objects.create(
+            team=self.team,
+            path="Folder1",
+            type="folder",
+            created_by=self.user,
+        )
+        FileSystem.objects.create(
+            team=self.team,
+            path="Folder1/Child.txt",
+            type="doc",
+            created_by=self.user,
+        )
+        new_path = "LinkedFolder"
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/file_system/{folder_obj.pk}/link",
+            {"new_path": new_path},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        result = response.json()
+        self.assertEqual(result["path"], new_path)
+        # A single-segment folder should have depth 1.
+        self.assertEqual(result["depth"], 1)
+        # Verify that the child file was linked with its path updated.
+        linked_child = FileSystem.objects.filter(team=self.team, path="LinkedFolder/Child.txt", type="doc").first()
+        self.assertIsNotNone(linked_child)
+        self.assertEqual(linked_child.depth, 2)
+
+    def test_link_folder_into_itself(self):
+        """
+        Test that linking a folder into itself is rejected.
+        """
+        folder_obj = FileSystem.objects.create(
+            team=self.team,
+            path="Folder2",
+            type="folder",
+            created_by=self.user,
+        )
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/file_system/{folder_obj.pk}/link",
+            {"new_path": "Folder2"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.json())
+        self.assertIn("detail", response.json())
+        self.assertEqual(response.json()["detail"], "Cannot link folder into itself")
+
+    def test_assure_parent_folders(self):
+        """
+        Test that assure_parent_folders creates all missing parent folder entries for a given path.
+        """
+        # Clear existing FileSystem entries to start fresh.
+        FileSystem.objects.all().delete()
+        test_path = "A/B/C"
+        # Import the function to be tested.
+        from posthog.api.file_system import assure_parent_folders
+
+        assure_parent_folders(test_path, self.team, self.user)
+
+        # For the path "A/B/C", we expect the parent folders "A" and "A/B" to be created.
+        folder_a = FileSystem.objects.filter(team=self.team, path="A", type="folder").first()
+        folder_ab = FileSystem.objects.filter(team=self.team, path="A/B", type="folder").first()
+        self.assertIsNotNone(folder_a)
+        self.assertEqual(folder_a.depth, 1)
+        self.assertIsNotNone(folder_ab)
+        self.assertEqual(folder_ab.depth, 2)
+        # The full path "A/B/C" should NOT be created by assure_parent_folders.
+        folder_abc = FileSystem.objects.filter(team=self.team, path="A/B/C").first()
+        self.assertIsNone(folder_abc)


### PR DESCRIPTION
## Problem

In addition to moving items, another thing we can do is to copy/link them. 

## Changes

In addition to moving files and folders via the context menu, you can now also "link" them. The entire tree is a list of symlinks, and this essentially copies the symlinks.

![2025-04-04 17 52 03](https://github.com/user-attachments/assets/3840ee2a-5967-4681-9692-9f2395564333)

## How did you test this code?

Added tests for the backend. Clicked around in the frontend.