### PR TITLE
fix: run alter table on replicated tables just once

### DIFF
--- a/posthog/clickhouse/client/migration_tools.py
+++ b/posthog/clickhouse/client/migration_tools.py
@@ -24,7 +24,7 @@ def run_sql_with_exceptions(sql: str, node_role: NodeRole = NodeRole.DATA, shard
     cluster = get_migrations_cluster()
 
     def is_alter_on_replicated_table(sql: str) -> bool:
-        return sql.strip().startswith("ALTER TABLE") and re.search(r"replicated\w*mergetree", sql.lower())
+        return sql.strip().lower().startswith("alter table") and re.search(r"replicated\w*mergetree", sql.lower())
 
     def run_migration():
         query = Query(sql)


### PR DESCRIPTION
## Problem

We run alter statements in parallel on all replicas.

## Changes

Non-sharded, replicated tables only need to execute the alter once.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes


