### PR TITLE
chore(err): temp disable quota limits

### DIFF
--- a/rust/cymbal/src/pipeline/billing.rs
+++ b/rust/cymbal/src/pipeline/billing.rs
@@ -6,7 +6,7 @@ use super::IncomingEvent;
 
 pub async fn apply_billing_limits(
     in_buf: Vec<IncomingEvent>,
-    context: &AppContext,
+    _context: &AppContext,
 ) -> Result<Vec<IncomingEvent>, PipelineFailure> {
     let start_count = in_buf.len();
 

--- a/rust/cymbal/src/pipeline/billing.rs
+++ b/rust/cymbal/src/pipeline/billing.rs
@@ -20,9 +20,11 @@ pub async fn apply_billing_limits(
             continue;
         };
 
-        if context.billing_limiter.is_limited(&e.token).await {
-            continue;
-        }
+        // TODO - re-enable quota limiting once we've figure out how billing handles
+        // customers with no plan.
+        // if context.billing_limiter.is_limited(&e.token).await {
+        //     continue;
+        // }
         out.push(IncomingEvent::Captured(e));
     }
 


### PR DESCRIPTION
We're unsure how to handle users not on any plan yet, and want to get that nailed down before we start enforcing limits.