### PR TITLE
chore: don't run add_soft_delete_column migration for now

### DIFF
--- a/posthog/clickhouse/migrations/0111_add_soft_delete_column_on_groups.py
+++ b/posthog/clickhouse/migrations/0111_add_soft_delete_column_on_groups.py
@@ -1,29 +1,5 @@
-from posthog.clickhouse.client.connection import NodeRole
-from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from typing import Any
 
-DROP_COLUMNS_INDEX_GROUPS = """
-ALTER TABLE groups
-DROP INDEX IF EXISTS is_deleted_idx
-"""
 
-DROP_COLUMNS_GROUPS = """
-ALTER TABLE groups
-DROP COLUMN IF EXISTS is_deleted
-"""
-
-ADD_COLUMNS_GROUPS = """
-ALTER TABLE groups
-ADD COLUMN IF NOT EXISTS is_deleted Boolean
-"""
-
-ADD_COLUMNS_INDEX_GROUPS = """
-ALTER TABLE groups
-ADD INDEX IF NOT EXISTS is_deleted_idx (is_deleted) TYPE minmax GRANULARITY 1
-"""
-
-operations = [
-    run_sql_with_exceptions(DROP_COLUMNS_INDEX_GROUPS, node_role=NodeRole.ALL),
-    run_sql_with_exceptions(DROP_COLUMNS_GROUPS, node_role=NodeRole.ALL),
-    run_sql_with_exceptions(ADD_COLUMNS_GROUPS, node_role=NodeRole.ALL),
-    run_sql_with_exceptions(ADD_COLUMNS_INDEX_GROUPS, node_role=NodeRole.ALL),
-]
+# migration did not run
+operations: list[Any] = []


### PR DESCRIPTION
## Problem

We need a proper fix and this is blocking deployments.

## Changes

Do not run the migration for now.

## Does this work well for both Cloud and self-hosted?

Yes
