### PR TITLE
perf: Disable hedged requests for offline workload

### DIFF
--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -160,6 +160,13 @@ def sync_execute(
         "query_id": query_id,
     }
 
+    if workload == Workload.OFFLINE:
+        # disabling hedged requests for offline queries reduces the likelihood of these queries bleeding over into the
+        # online resource pool when the offline resource pool is under heavy load. this comes at the cost of higher and
+        # more variable latency and a higher likelihood of query failures - but offline workloads should be tolerant to
+        # these disruptions
+        settings["use_hedged_requests"] = "0"
+
     try:
         with sync_client or get_client_from_pool(workload, team_id, readonly) as client:
             result = client.execute(


### PR DESCRIPTION
## Problem

When the offline resource pool is under heavy load, the offline servers may not respond under `receive_data_timeout` which causes these queries to be retried on the next available replica - which ends up being an online node. This is not ideal because:

1. it allows offline workloads to bleed over into the online resource pool, potentially impacting user-facing queries
2. we end up running the same query on multiple hosts for some period of time, wasting resources unnecessarily when we are already dealing with saturation/starvation issues

This is particularly problematic if the query has many distributed depth levels as the number of retries can be around `shard count ** depth level` due to the increased parallel query count on leaf nodes of the query tree.

## Changes

Turns off [`use_hedged_requests` setting](https://clickhouse.com/docs/operations/settings/settings#use_hedged_requests) for offline workloads.

There is the potential for this to counterintuitively increase the load on the offline cluster because queries that would have otherwise succeeded with hedged requests enabled (because they were allowed to spill over into the online pool due to a lack of available resources in the offline pool) are more likely to fail outright and then be retried later by the issuer, so we will need to keep an eye on this. But in this case the impact should be limited to the offline pool aside from issues like potential replication queue backlogs, etc.

This doesn't prevent offline workloads from ending up on the online pool if the applicable offline replica is considered _inactive_ prior to the query starting, so these queries should still be fault tolerant in the event of node going offline/being lost.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Path should be indirectly covered by existing tests