### PR TITLE
fix: don't render billing alerts if product is hidden

### DIFF
--- a/frontend/src/scenes/billing/billingLogic.tsx
+++ b/frontend/src/scenes/billing/billingLogic.tsx
@@ -669,6 +669,12 @@ export const billingLogic = kea<billingLogicType>([
                 return x.percentage_usage > 1 && x.usage_key
             })
 
+            const hideProductFlag = `billing_hide_product_${productOverLimit?.type}`
+            const isHidden = values.featureFlags[hideProductFlag] === true
+            if (isHidden) {
+                return
+            }
+
             if (productOverLimit) {
                 actions.setBillingAlert({
                     status: 'error',

--- a/frontend/src/scenes/billing/billingLogic.tsx
+++ b/frontend/src/scenes/billing/billingLogic.tsx
@@ -669,13 +669,12 @@ export const billingLogic = kea<billingLogicType>([
                 return x.percentage_usage > 1 && x.usage_key
             })
 
-            const hideProductFlag = `billing_hide_product_${productOverLimit?.type}`
-            const isHidden = values.featureFlags[hideProductFlag] === true
-            if (isHidden) {
-                return
-            }
-
             if (productOverLimit) {
+                const hideProductFlag = `billing_hide_product_${productOverLimit?.type}`
+                const isHidden = values.featureFlags[hideProductFlag] === true
+                if (isHidden) {
+                    return
+                }
                 actions.setBillingAlert({
                     status: 'error',
                     title: 'Usage limit exceeded',
@@ -700,6 +699,11 @@ export const billingLogic = kea<billingLogicType>([
             )
 
             if (productApproachingLimit) {
+                const hideProductFlag = `billing_hide_product_${productApproachingLimit?.type}`
+                const isHidden = values.featureFlags[hideProductFlag] === true
+                if (isHidden) {
+                    return
+                }
                 actions.setBillingAlert({
                     status: 'info',
                     title: 'You will soon hit your usage limit',


### PR DESCRIPTION
## Changes

Error tracking was merged but it's a hidden product so we don't want to show any related errors.

This happens because the plans map hasn't been backfilled so it thinks the org is on free plan for the limit and it's checking against that. 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Manually
