### PR TITLE
fix: heatmap enabled checks

### DIFF
--- a/frontend/src/lib/components/heatmaps/HeatmapCanvas.tsx
+++ b/frontend/src/lib/components/heatmaps/HeatmapCanvas.tsx
@@ -5,8 +5,6 @@ import { useShiftKeyPressed } from 'lib/components/heatmaps/useShiftKeyPressed'
 import { cn } from 'lib/utils/css-classes'
 import { MutableRefObject, useCallback, useEffect, useMemo, useRef } from 'react'
 
-import { heatmapToolbarMenuLogic } from '~/toolbar/elements/heatmapToolbarMenuLogic'
-
 import { useMousePosition } from './useMousePosition'
 
 function HeatmapMouseInfo({
@@ -16,18 +14,13 @@ function HeatmapMouseInfo({
     heatmapJsRef: MutableRefObject<HeatmapJS<'value', 'x', 'y'> | undefined>
     containerRef: MutableRefObject<HTMLDivElement | null | undefined>
 }): JSX.Element | null {
-    const { heatmapFilters } = useValues(heatmapDataLogic)
-    const { heatmapEnabled } = useValues(heatmapToolbarMenuLogic)
-
-    const shouldShowMouseInfo = heatmapEnabled && heatmapFilters.enabled && heatmapFilters.type !== 'scrolldepth'
-
     const shiftPressed = useShiftKeyPressed()
     const { heatmapTooltipLabel } = useValues(heatmapDataLogic)
 
     const mousePosition = useMousePosition(containerRef?.current)
     const value = heatmapJsRef.current?.getValueAt(mousePosition)
 
-    if (!shouldShowMouseInfo || !mousePosition || (!value && !shiftPressed)) {
+    if (!mousePosition || (!value && !shiftPressed)) {
         return null
     }
 
@@ -67,7 +60,7 @@ export function HeatmapCanvas({
 }): JSX.Element | null {
     const { heatmapJsData, heatmapFilters, windowWidth, windowHeight, heatmapColorPalette } =
         useValues(heatmapDataLogic)
-    const { heatmapEnabled } = useValues(heatmapToolbarMenuLogic)
+
     const heatmapsJsRef = useRef<HeatmapJS<'value', 'x', 'y'>>()
     const heatmapsJsContainerRef = useRef<HTMLDivElement | null>()
 
@@ -130,7 +123,7 @@ export function HeatmapCanvas({
         })
     }, [heatmapJSColorGradient])
 
-    if (!heatmapEnabled || !heatmapFilters.enabled || heatmapFilters.type === 'scrolldepth') {
+    if (!heatmapFilters.enabled || heatmapFilters.type === 'scrolldepth') {
         return null
     }
 

--- a/frontend/src/lib/components/heatmaps/HeatmapCanvas.tsx
+++ b/frontend/src/lib/components/heatmaps/HeatmapCanvas.tsx
@@ -5,6 +5,8 @@ import { useShiftKeyPressed } from 'lib/components/heatmaps/useShiftKeyPressed'
 import { cn } from 'lib/utils/css-classes'
 import { MutableRefObject, useCallback, useEffect, useMemo, useRef } from 'react'
 
+import { heatmapToolbarMenuLogic } from '~/toolbar/elements/heatmapToolbarMenuLogic'
+
 import { useMousePosition } from './useMousePosition'
 
 function HeatmapMouseInfo({
@@ -14,13 +16,18 @@ function HeatmapMouseInfo({
     heatmapJsRef: MutableRefObject<HeatmapJS<'value', 'x', 'y'> | undefined>
     containerRef: MutableRefObject<HTMLDivElement | null | undefined>
 }): JSX.Element | null {
+    const { heatmapFilters } = useValues(heatmapDataLogic)
+    const { heatmapEnabled } = useValues(heatmapToolbarMenuLogic)
+
+    const shouldShowMouseInfo = heatmapEnabled && heatmapFilters.enabled && heatmapFilters.type !== 'scrolldepth'
+
     const shiftPressed = useShiftKeyPressed()
     const { heatmapTooltipLabel } = useValues(heatmapDataLogic)
 
     const mousePosition = useMousePosition(containerRef?.current)
     const value = heatmapJsRef.current?.getValueAt(mousePosition)
 
-    if (!mousePosition || (!value && !shiftPressed)) {
+    if (!shouldShowMouseInfo || !mousePosition || (!value && !shiftPressed)) {
         return null
     }
 
@@ -60,6 +67,7 @@ export function HeatmapCanvas({
 }): JSX.Element | null {
     const { heatmapJsData, heatmapFilters, windowWidth, windowHeight, heatmapColorPalette } =
         useValues(heatmapDataLogic)
+    const { heatmapEnabled } = useValues(heatmapToolbarMenuLogic)
     const heatmapsJsRef = useRef<HeatmapJS<'value', 'x', 'y'>>()
     const heatmapsJsContainerRef = useRef<HTMLDivElement | null>()
 
@@ -122,7 +130,7 @@ export function HeatmapCanvas({
         })
     }, [heatmapJSColorGradient])
 
-    if (!heatmapFilters.enabled || heatmapFilters.type === 'scrolldepth') {
+    if (!heatmapEnabled || !heatmapFilters.enabled || heatmapFilters.type === 'scrolldepth') {
         return null
     }
 

--- a/frontend/src/toolbar/elements/Elements.tsx
+++ b/frontend/src/toolbar/elements/Elements.tsx
@@ -16,6 +16,7 @@ import { toolbarLogic } from '../bar/toolbarLogic'
 import { ScrollDepth } from './ScrollDepth'
 
 export function Elements(): JSX.Element {
+    const { visibleMenu: activeToolbarMode } = useValues(toolbarLogic)
     const {
         heatmapElements,
         elementsToDisplay,
@@ -57,8 +58,8 @@ export function Elements(): JSX.Element {
                     top: relativePositionCompensation,
                 }}
             >
-                <ScrollDepth />
-                <HeatmapCanvas />
+                {activeToolbarMode === 'heatmap' && <ScrollDepth />}
+                {activeToolbarMode === 'heatmap' && <HeatmapCanvas />}
                 {highlightElementMeta?.rect ? <FocusRect rect={highlightElementMeta.rect} /> : null}
 
                 {elementsToDisplay.map(({ rect, element, apparentZIndex }, index) => {


### PR DESCRIPTION
when checking if the heatmap is enabled, you have to check if the heatmap is enabled and if the heatmap is enabled

🫠 

that's because 

* heatmap is a mode of the toolbar
* heatmap is one of two modes of the heatmap

Also, now we have heatmap canvas in the app itself checking if the heatmap canvas should be visible isn't a toolbar only concern

So, we check the current active toolbar mode before drawing the heatmap canvas _at all_