### PR TITLE
fix(propdevs-v2): fix additional metric skew

### DIFF
--- a/rust/property-defs-rs/src/metrics_consts.rs
+++ b/rust/property-defs-rs/src/metrics_consts.rs
@@ -38,6 +38,7 @@ pub const V2_EVENT_DEFS_BATCH_ROWS_AFFECTED: &str = "propdefs_v2_eventdefs_batch
 pub const V2_EVENT_DEFS_BATCH_CACHE_TIME: &str = "propdefs_v2_eventdefs_batch_cache_time_ms";
 pub const V2_EVENT_DEFS_CACHE_HIT: &str = "propdefs_v2_eventdefs_cache_hit";
 pub const V2_EVENT_DEFS_CACHE_MISS: &str = "propdefs_v2_eventdefs_cache_miss";
+pub const V2_EVENT_DEFS_BATCH_SIZE: &str = "propdefs_v2_eventdefs_batch_size";
 
 pub const V2_EVENT_PROPS_BATCH_WRITE_TIME: &str = "propdefs_v2_eventprops_batch_ms";
 pub const V2_EVENT_PROPS_BATCH_ATTEMPT: &str = "propdefs_v2_eventprops_batch_attempt";
@@ -45,6 +46,7 @@ pub const V2_EVENT_PROPS_BATCH_ROWS_AFFECTED: &str = "propdefs_v2_eventprops_bat
 pub const V2_EVENT_PROPS_BATCH_CACHE_TIME: &str = "propdefs_v2_eventprops_batch_cache_time_ms";
 pub const V2_EVENT_PROPS_CACHE_HIT: &str = "propdefs_v2_eventprops_cache_hit";
 pub const V2_EVENT_PROPS_CACHE_MISS: &str = "propdefs_v2_eventprops_cache_miss";
+pub const V2_EVENT_PROPS_BATCH_SIZE: &str = "propdefs_v2_event_props_batch_size";
 
 pub const V2_PROP_DEFS_BATCH_WRITE_TIME: &str = "propdefs_v2_propdefs_batch_ms";
 pub const V2_PROP_DEFS_BATCH_ATTEMPT: &str = "propdefs_v2_propdefs_batch_attempt";
@@ -52,3 +54,4 @@ pub const V2_PROP_DEFS_BATCH_ROWS_AFFECTED: &str = "propdefs_v2_propdefs_batch_r
 pub const V2_PROP_DEFS_BATCH_CACHE_TIME: &str = "propdefs_v2_propdefs_batch_cache_time_ms";
 pub const V2_PROP_DEFS_CACHE_HIT: &str = "propdefs_v2_propdefs_cache_hit";
 pub const V2_PROP_DEFS_CACHE_MISS: &str = "propdefs_v2_propdefs_cache_miss";
+pub const V2_PROP_DEFS_BATCH_SIZE: &str = "propdefs_v2_propdefs_batch_size";

--- a/rust/property-defs-rs/src/v2_batch_ingestion.rs
+++ b/rust/property-defs-rs/src/v2_batch_ingestion.rs
@@ -11,12 +11,14 @@ use crate::{
     config::Config,
     metrics_consts::{
         CACHE_CONSUMED, V2_EVENT_DEFS_BATCH_ATTEMPT, V2_EVENT_DEFS_BATCH_CACHE_TIME,
-        V2_EVENT_DEFS_BATCH_ROWS_AFFECTED, V2_EVENT_DEFS_BATCH_WRITE_TIME, V2_EVENT_DEFS_CACHE_HIT,
-        V2_EVENT_DEFS_CACHE_MISS, V2_EVENT_PROPS_BATCH_ATTEMPT, V2_EVENT_PROPS_BATCH_CACHE_TIME,
-        V2_EVENT_PROPS_BATCH_ROWS_AFFECTED, V2_EVENT_PROPS_BATCH_WRITE_TIME,
-        V2_EVENT_PROPS_CACHE_HIT, V2_EVENT_PROPS_CACHE_MISS, V2_PROP_DEFS_BATCH_ATTEMPT,
-        V2_PROP_DEFS_BATCH_CACHE_TIME, V2_PROP_DEFS_BATCH_ROWS_AFFECTED,
-        V2_PROP_DEFS_BATCH_WRITE_TIME, V2_PROP_DEFS_CACHE_HIT, V2_PROP_DEFS_CACHE_MISS,
+        V2_EVENT_DEFS_BATCH_ROWS_AFFECTED, V2_EVENT_DEFS_BATCH_SIZE,
+        V2_EVENT_DEFS_BATCH_WRITE_TIME, V2_EVENT_DEFS_CACHE_HIT, V2_EVENT_DEFS_CACHE_MISS,
+        V2_EVENT_PROPS_BATCH_ATTEMPT, V2_EVENT_PROPS_BATCH_CACHE_TIME,
+        V2_EVENT_PROPS_BATCH_ROWS_AFFECTED, V2_EVENT_PROPS_BATCH_SIZE,
+        V2_EVENT_PROPS_BATCH_WRITE_TIME, V2_EVENT_PROPS_CACHE_HIT, V2_EVENT_PROPS_CACHE_MISS,
+        V2_PROP_DEFS_BATCH_ATTEMPT, V2_PROP_DEFS_BATCH_CACHE_TIME,
+        V2_PROP_DEFS_BATCH_ROWS_AFFECTED, V2_PROP_DEFS_BATCH_SIZE, V2_PROP_DEFS_BATCH_WRITE_TIME,
+        V2_PROP_DEFS_CACHE_HIT, V2_PROP_DEFS_CACHE_MISS,
     },
     types::{
         EventDefinition, EventProperty, GroupType, PropertyDefinition, PropertyParentType, Update,
@@ -59,12 +61,16 @@ impl EventPropertiesBatch {
         self.to_cache.push_back(Update::EventProperty(ep));
     }
 
+    pub fn len(&self) -> usize {
+        self.team_ids.len()
+    }
+
     pub fn should_flush_batch(&self) -> bool {
-        self.team_ids.len() >= self.batch_size
+        self.len() >= self.batch_size
     }
 
     pub fn is_empty(&self) -> bool {
-        self.team_ids.len() == 0
+        self.len() == 0
     }
 
     pub fn cache_batch(&mut self, cache: &Arc<Cache<Update, ()>>) {
@@ -116,15 +122,19 @@ impl EventDefinitionsBatch {
         self.to_cache.push_back(Update::Event(ed));
     }
 
+    pub fn len(&self) -> usize {
+        self.ids.len()
+    }
+
     pub fn should_flush_batch(&self) -> bool {
-        self.ids.len() >= self.batch_size
+        self.len() >= self.batch_size
     }
 
     pub fn is_empty(&self) -> bool {
-        self.ids.len() == 0
+        self.len() == 0
     }
 
-    pub fn cache_batch(mut self, cache: &Arc<Cache<Update, ()>>) {
+    pub fn cache_batch(&mut self, cache: &Arc<Cache<Update, ()>>) {
         let timer = common_metrics::timing_guard(V2_EVENT_DEFS_BATCH_CACHE_TIME, &[]);
         for update in self.to_cache.drain(..) {
             if cache.contains_key(&update) {
@@ -207,12 +217,16 @@ impl PropertyDefinitionsBatch {
         self.to_cache.push_back(Update::Property(pd));
     }
 
+    pub fn len(&self) -> usize {
+        self.ids.len()
+    }
+
     pub fn should_flush_batch(&self) -> bool {
-        self.ids.len() >= self.batch_size
+        self.len() >= self.batch_size
     }
 
     pub fn is_empty(&self) -> bool {
-        self.ids.len() == 0
+        self.len() == 0
     }
 
     pub fn cache_batch(&mut self, cache: &Arc<Cache<Update, ()>>) {
@@ -260,10 +274,11 @@ pub async fn process_batch_v2(
                 if event_defs.should_flush_batch() {
                     let pool = pool.clone();
                     let cache = cache.clone();
-                    handles.push(tokio::spawn(async move {
-                        write_event_definitions_batch(cache, event_defs, &pool).await
-                    }));
+                    let outbound = event_defs;
                     event_defs = EventDefinitionsBatch::new(config.v2_ingest_batch_size);
+                    handles.push(tokio::spawn(async move {
+                        write_event_definitions_batch(cache, outbound, &pool).await
+                    }));
                 }
             }
             Update::EventProperty(ep) => {
@@ -271,10 +286,11 @@ pub async fn process_batch_v2(
                 if event_props.should_flush_batch() {
                     let pool = pool.clone();
                     let cache = cache.clone();
-                    handles.push(tokio::spawn(async move {
-                        write_event_properties_batch(cache, event_props, &pool).await
-                    }));
+                    let outbound = event_props;
                     event_props = EventPropertiesBatch::new(config.v2_ingest_batch_size);
+                    handles.push(tokio::spawn(async move {
+                        write_event_properties_batch(cache, outbound, &pool).await
+                    }));
                 }
             }
             Update::Property(pd) => {
@@ -282,10 +298,11 @@ pub async fn process_batch_v2(
                 if prop_defs.should_flush_batch() {
                     let pool = pool.clone();
                     let cache = cache.clone();
-                    handles.push(tokio::spawn(async move {
-                        write_property_definitions_batch(cache, prop_defs, &pool).await
-                    }));
+                    let outbound = prop_defs;
                     prop_defs = PropertyDefinitionsBatch::new(config.v2_ingest_batch_size);
+                    handles.push(tokio::spawn(async move {
+                        write_property_definitions_batch(cache, outbound, &pool).await
+                    }));
                 }
             }
         }
@@ -316,6 +333,7 @@ pub async fn process_batch_v2(
 
     for handle in handles {
         match handle.await {
+            // metrics are statted in write_*_batch methods so we just log here
             Ok(result) => match result {
                 Ok(_) => continue,
                 Err(db_err) => {
@@ -382,9 +400,11 @@ async fn write_event_properties_batch(
                 // don't report success if the batch cache insetions failed!
                 metrics::counter!(V2_EVENT_PROPS_BATCH_ATTEMPT, &[("result", "success")])
                     .increment(1);
+                metrics::counter!(V2_EVENT_PROPS_BATCH_SIZE).increment(batch.len() as u64);
                 metrics::counter!(V2_EVENT_PROPS_BATCH_ROWS_AFFECTED).increment(count);
                 info!(
-                    "Event properties batch of size {} written successfully",
+                    "Event properties batch of size {} written successfully with {} rows changed",
+                    batch.len(),
                     count
                 );
 
@@ -457,9 +477,11 @@ async fn write_property_definitions_batch(
                 // don't report success if the batch cache insetions failed!
                 metrics::counter!(V2_PROP_DEFS_BATCH_ATTEMPT, &[("result", "success")])
                     .increment(1);
+                metrics::counter!(V2_PROP_DEFS_BATCH_SIZE).increment(batch.len() as u64);
                 metrics::counter!(V2_PROP_DEFS_BATCH_ROWS_AFFECTED).increment(count);
                 info!(
-                    "Property definitions batch of size {} written successfully",
+                    "Property definitions batch of size {} written successfully with {} rows changed",
+                    batch.len(),
                     count
                 );
 
@@ -471,7 +493,7 @@ async fn write_property_definitions_batch(
 
 async fn write_event_definitions_batch(
     cache: Arc<Cache<Update, ()>>,
-    batch: EventDefinitionsBatch,
+    mut batch: EventDefinitionsBatch,
     pool: &PgPool,
 ) -> Result<(), sqlx::Error> {
     let total_time = common_metrics::timing_guard(V2_EVENT_DEFS_BATCH_WRITE_TIME, &[]);
@@ -525,9 +547,11 @@ async fn write_event_definitions_batch(
 
                 // don't report success if the batch cache insertions failed!
                 metrics::counter!(V2_EVENT_DEFS_BATCH_ATTEMPT, &[("result", "retry")]).increment(1);
+                metrics::counter!(V2_EVENT_DEFS_BATCH_SIZE).increment(batch.len() as u64);
                 metrics::counter!(V2_EVENT_DEFS_BATCH_ROWS_AFFECTED).increment(count);
                 info!(
-                    "Event definitions batch of size {} written successfully",
+                    "Event definitions batch of size {} written successfully with {} rows changed",
+                    batch.len(),
                     count
                 );
 

--- a/rust/property-defs-rs/src/v2_batch_ingestion.rs
+++ b/rust/property-defs-rs/src/v2_batch_ingestion.rs
@@ -546,7 +546,7 @@ async fn write_event_definitions_batch(
                 batch.cache_batch(&cache);
 
                 // don't report success if the batch cache insertions failed!
-                metrics::counter!(V2_EVENT_DEFS_BATCH_ATTEMPT, &[("result", "retry")]).increment(1);
+                metrics::counter!(V2_EVENT_DEFS_BATCH_ATTEMPT, &[("result", "success")]).increment(1);
                 metrics::counter!(V2_EVENT_DEFS_BATCH_SIZE).increment(batch.len() as u64);
                 metrics::counter!(V2_EVENT_DEFS_BATCH_ROWS_AFFECTED).increment(count);
                 info!(

--- a/rust/property-defs-rs/src/v2_batch_ingestion.rs
+++ b/rust/property-defs-rs/src/v2_batch_ingestion.rs
@@ -546,7 +546,8 @@ async fn write_event_definitions_batch(
                 batch.cache_batch(&cache);
 
                 // don't report success if the batch cache insertions failed!
-                metrics::counter!(V2_EVENT_DEFS_BATCH_ATTEMPT, &[("result", "success")]).increment(1);
+                metrics::counter!(V2_EVENT_DEFS_BATCH_ATTEMPT, &[("result", "success")])
+                    .increment(1);
                 metrics::counter!(V2_EVENT_DEFS_BATCH_SIZE).increment(batch.len() as u64);
                 metrics::counter!(V2_EVENT_DEFS_BATCH_ROWS_AFFECTED).increment(count);
                 info!(


### PR DESCRIPTION
## Problem
Some of the logging/metric are confusing during deploy test b/c incoming batch size vs. rows affected on write were not separated properly

## Changes
Fixes that ☝️ plus a couple of clarity changes. also normalize handling of `cache_batch` where one of the 3 batch types was doing something slightly different than the others.

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally, in CI, and when landed in next round of deploy testing/observation 👍 