### PR TITLE
feat: usage report split queries

### DIFF
--- a/posthog/tasks/test/__snapshots__/test_usage_report.ambr
+++ b/posthog/tasks/test/__snapshots__/test_usage_report.ambr
@@ -6,7 +6,7 @@
          multiIf(event LIKE 'helicone%', 'helicone_events', event LIKE 'langfuse%', 'langfuse_events', event LIKE 'keywords_ai%', 'keywords_ai_events', event LIKE 'traceloop%', 'traceloop_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'web', 'web_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'js', 'web_lite_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-node', 'node_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-android', 'android_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-flutter', 'flutter_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-ios', 'ios_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-go', 'go_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-java', 'java_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-react-native', 'react_native_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-ruby', 'ruby_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-python', 'python_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-php', 'php_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-dotnet', 'dotnet_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-elixir', 'elixir_events', 'other') AS metric,
          count(1) as count
   FROM events
-  WHERE timestamp BETWEEN '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+  WHERE timestamp BETWEEN '2022-01-10 00:00:00' AND '2022-01-10 12:00:00'
   GROUP BY team_id,
            metric
   HAVING metric != 'other'
@@ -15,19 +15,81 @@
 # name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.1
   '''
   
-  SELECT JSONExtractInt(log_comment, 'team_id') team_id,
-         count(1) cnt,
-         sum(read_bytes) read_bytes
-  FROM clusterAllReplicas(posthog, system.query_log)
-  WHERE type != 'QueryStart'
-    AND is_initial_query
-    AND event_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-    AND team_id > 0
-    AND JSONExtractBool(log_comment, 'chargeable')
-  GROUP BY team_id
+  SELECT team_id,
+         multiIf(event LIKE 'helicone%', 'helicone_events', event LIKE 'langfuse%', 'langfuse_events', event LIKE 'keywords_ai%', 'keywords_ai_events', event LIKE 'traceloop%', 'traceloop_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'web', 'web_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'js', 'web_lite_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-node', 'node_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-android', 'android_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-flutter', 'flutter_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-ios', 'ios_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-go', 'go_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-java', 'java_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-react-native', 'react_native_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-ruby', 'ruby_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-python', 'python_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-php', 'php_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-dotnet', 'dotnet_events', replaceRegexpAll(JSONExtractRaw(properties, '$lib'), '^"|"$', '') = 'posthog-elixir', 'elixir_events', 'other') AS metric,
+         count(1) as count
+  FROM events
+  WHERE timestamp BETWEEN '2022-01-10 12:00:00' AND '2022-01-10 23:59:59'
+  GROUP BY team_id,
+           metric
+  HAVING metric != 'other'
   '''
 # ---
 # name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.10
+  '''
+  
+  SELECT team_id,
+         count(distinct session_id) as count
+  FROM
+    (SELECT any(team_id) as team_id,
+            session_id
+     FROM session_replay_events
+     WHERE min_first_timestamp BETWEEN '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+     GROUP BY session_id
+     HAVING ifNull(argMinMerge(snapshot_source), 'web') == 'mobile')
+  WHERE session_id NOT IN
+      (SELECT DISTINCT session_id
+       FROM session_replay_events
+       WHERE min_first_timestamp BETWEEN '2022-01-09 00:00:00' AND '2022-01-10 00:00:00'
+       GROUP BY session_id)
+  GROUP BY team_id
+  '''
+# ---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.11
+  '''
+  
+  SELECT team_id,
+         sum(total_size) as bytes
+  FROM
+    (SELECT any(team_id) as team_id,
+            session_id,
+            sum(size) as total_size
+     FROM session_replay_events
+     WHERE min_first_timestamp BETWEEN '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+     GROUP BY session_id
+     HAVING ifNull(argMinMerge(snapshot_source), 'web') == 'mobile')
+  WHERE session_id NOT IN
+      (SELECT DISTINCT session_id
+       FROM session_replay_events
+       WHERE min_first_timestamp BETWEEN '2022-01-09 00:00:00' AND '2022-01-10 00:00:00'
+       GROUP BY session_id)
+  GROUP BY team_id
+  '''
+# ---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.12
+  '''
+  
+  SELECT team_id,
+         count(distinct session_id) as count
+  FROM
+    (SELECT any(team_id) as team_id,
+            session_id
+     FROM session_replay_events
+     WHERE min_first_timestamp BETWEEN '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+     GROUP BY session_id
+     HAVING (ifNull(argMinMerge(snapshot_source), '') == 'mobile'
+             AND ifNull(argMinMerge(snapshot_library), '') IN ('posthog-ios',
+                                                               'posthog-android',
+                                                               'posthog-react-native')))
+  WHERE session_id NOT IN
+      (SELECT DISTINCT session_id
+       FROM session_replay_events
+       WHERE min_first_timestamp BETWEEN '2022-01-09 00:00:00' AND '2022-01-10 00:00:00'
+       GROUP BY session_id)
+  GROUP BY team_id
+  '''
+# ---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.13
   '''
   
   SELECT distinct_id as team,
@@ -40,7 +102,7 @@
   GROUP BY team
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.11
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.14
   '''
   
   SELECT distinct_id as team,
@@ -51,54 +113,6 @@
     AND timestamp between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
     AND has(['correct'], replaceRegexpAll(JSONExtractRaw(properties, 'token'), '^"|"$', ''))
   GROUP BY team
-  '''
-# ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.12
-  '''
-  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
-       JSONExtractString(log_comment, 'query_type') as query_type,
-       JSONExtractString(log_comment, 'access_method') as access_method
-  SELECT team_id,
-         sum(read_bytes) as count
-  FROM clusterAllReplicas(posthog, system.query_log)
-  WHERE (type = 'QueryFinish'
-         OR type = 'ExceptionWhileProcessing')
-    AND is_initial_query = 1
-    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-    AND access_method = ''
-  GROUP BY team_id
-  '''
-# ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.13
-  '''
-  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
-       JSONExtractString(log_comment, 'query_type') as query_type,
-       JSONExtractString(log_comment, 'access_method') as access_method
-  SELECT team_id,
-         sum(read_rows) as count
-  FROM clusterAllReplicas(posthog, system.query_log)
-  WHERE (type = 'QueryFinish'
-         OR type = 'ExceptionWhileProcessing')
-    AND is_initial_query = 1
-    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-    AND access_method = ''
-  GROUP BY team_id
-  '''
-# ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.14
-  '''
-  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
-       JSONExtractString(log_comment, 'query_type') as query_type,
-       JSONExtractString(log_comment, 'access_method') as access_method
-  SELECT team_id,
-         sum(query_duration_ms) as count
-  FROM clusterAllReplicas(posthog, system.query_log)
-  WHERE (type = 'QueryFinish'
-         OR type = 'ExceptionWhileProcessing')
-    AND is_initial_query = 1
-    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-    AND access_method = ''
-  GROUP BY team_id
   '''
 # ---
 # name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.15
@@ -113,7 +127,7 @@
          OR type = 'ExceptionWhileProcessing')
     AND is_initial_query = 1
     AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-    AND access_method = 'personal_api_key'
+    AND access_method = ''
   GROUP BY team_id
   '''
 # ---
@@ -129,7 +143,7 @@
          OR type = 'ExceptionWhileProcessing')
     AND is_initial_query = 1
     AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-    AND access_method = 'personal_api_key'
+    AND access_method = ''
   GROUP BY team_id
   '''
 # ---
@@ -145,7 +159,7 @@
          OR type = 'ExceptionWhileProcessing')
     AND is_initial_query = 1
     AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-    AND access_method = 'personal_api_key'
+    AND access_method = ''
   GROUP BY team_id
   '''
 # ---
@@ -160,9 +174,8 @@
   WHERE (type = 'QueryFinish'
          OR type = 'ExceptionWhileProcessing')
     AND is_initial_query = 1
-    AND query_type IN (['EventsQuery'])
     AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-    AND access_method = ''
+    AND access_method = 'personal_api_key'
   GROUP BY team_id
   '''
 # ---
@@ -177,24 +190,23 @@
   WHERE (type = 'QueryFinish'
          OR type = 'ExceptionWhileProcessing')
     AND is_initial_query = 1
-    AND query_type IN (['EventsQuery'])
     AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-    AND access_method = ''
+    AND access_method = 'personal_api_key'
   GROUP BY team_id
   '''
 # ---
 # name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.2
   '''
   
-  SELECT team_id,
-         count(distinct toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid)) as count
-  FROM events
-  WHERE timestamp between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-    AND event NOT IN ('$feature_flag_called',
-                      'survey sent',
-                      'survey shown',
-                      'survey dismissed',
-                      '$exception')
+  SELECT JSONExtractInt(log_comment, 'team_id') team_id,
+         count(1) cnt,
+         sum(read_bytes) read_bytes
+  FROM clusterAllReplicas(posthog, system.query_log)
+  WHERE type != 'QueryStart'
+    AND is_initial_query
+    AND event_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND team_id > 0
+    AND JSONExtractBool(log_comment, 'chargeable')
   GROUP BY team_id
   '''
 # ---
@@ -209,9 +221,8 @@
   WHERE (type = 'QueryFinish'
          OR type = 'ExceptionWhileProcessing')
     AND is_initial_query = 1
-    AND query_type IN (['EventsQuery'])
     AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-    AND access_method = ''
+    AND access_method = 'personal_api_key'
   GROUP BY team_id
   '''
 # ---
@@ -228,7 +239,7 @@
     AND is_initial_query = 1
     AND query_type IN (['EventsQuery'])
     AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-    AND access_method = 'personal_api_key'
+    AND access_method = ''
   GROUP BY team_id
   '''
 # ---
@@ -245,7 +256,7 @@
     AND is_initial_query = 1
     AND query_type IN (['EventsQuery'])
     AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-    AND access_method = 'personal_api_key'
+    AND access_method = ''
   GROUP BY team_id
   '''
 # ---
@@ -262,11 +273,62 @@
     AND is_initial_query = 1
     AND query_type IN (['EventsQuery'])
     AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-    AND access_method = 'personal_api_key'
+    AND access_method = ''
   GROUP BY team_id
   '''
 # ---
 # name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.24
+  '''
+  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
+       JSONExtractString(log_comment, 'query_type') as query_type,
+       JSONExtractString(log_comment, 'access_method') as access_method
+  SELECT team_id,
+         sum(read_bytes) as count
+  FROM clusterAllReplicas(posthog, system.query_log)
+  WHERE (type = 'QueryFinish'
+         OR type = 'ExceptionWhileProcessing')
+    AND is_initial_query = 1
+    AND query_type IN (['EventsQuery'])
+    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND access_method = 'personal_api_key'
+  GROUP BY team_id
+  '''
+# ---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.25
+  '''
+  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
+       JSONExtractString(log_comment, 'query_type') as query_type,
+       JSONExtractString(log_comment, 'access_method') as access_method
+  SELECT team_id,
+         sum(read_rows) as count
+  FROM clusterAllReplicas(posthog, system.query_log)
+  WHERE (type = 'QueryFinish'
+         OR type = 'ExceptionWhileProcessing')
+    AND is_initial_query = 1
+    AND query_type IN (['EventsQuery'])
+    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND access_method = 'personal_api_key'
+  GROUP BY team_id
+  '''
+# ---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.26
+  '''
+  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
+       JSONExtractString(log_comment, 'query_type') as query_type,
+       JSONExtractString(log_comment, 'access_method') as access_method
+  SELECT team_id,
+         sum(query_duration_ms) as count
+  FROM clusterAllReplicas(posthog, system.query_log)
+  WHERE (type = 'QueryFinish'
+         OR type = 'ExceptionWhileProcessing')
+    AND is_initial_query = 1
+    AND query_type IN (['EventsQuery'])
+    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND access_method = 'personal_api_key'
+  GROUP BY team_id
+  '''
+# ---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.27
   '''
   
   SELECT team_id,
@@ -277,7 +339,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.25
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.28
   '''
   
   SELECT team_id,
@@ -289,7 +351,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.26
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.29
   '''
   
   SELECT team_id,
@@ -303,7 +365,22 @@
            metric_name
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.27
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.3
+  '''
+  
+  SELECT team_id,
+         count(distinct toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid)) as count
+  FROM events
+  WHERE timestamp between '2022-01-10 00:00:00' AND '2022-01-10 12:00:00'
+    AND event NOT IN ('$feature_flag_called',
+                      'survey sent',
+                      'survey shown',
+                      'survey dismissed',
+                      '$exception')
+  GROUP BY team_id
+  '''
+# ---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.30
   '''
   
   SELECT team_id,
@@ -316,7 +393,7 @@
            metric_name
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.28
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.31
   '''
   
   SELECT team_id,
@@ -327,13 +404,28 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.3
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.4
   '''
   
   SELECT team_id,
          count(distinct toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid)) as count
   FROM events
-  WHERE timestamp between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+  WHERE timestamp between '2022-01-10 12:00:00' AND '2022-01-10 23:59:59'
+    AND event NOT IN ('$feature_flag_called',
+                      'survey sent',
+                      'survey shown',
+                      'survey dismissed',
+                      '$exception')
+  GROUP BY team_id
+  '''
+# ---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.5
+  '''
+  
+  SELECT team_id,
+         count(distinct toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid)) as count
+  FROM events
+  WHERE timestamp between '2022-01-10 00:00:00' AND '2022-01-10 12:00:00'
     AND event NOT IN ('$feature_flag_called',
                       'survey sent',
                       'survey shown',
@@ -344,7 +436,24 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.4
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.6
+  '''
+  
+  SELECT team_id,
+         count(distinct toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid)) as count
+  FROM events
+  WHERE timestamp between '2022-01-10 12:00:00' AND '2022-01-10 23:59:59'
+    AND event NOT IN ('$feature_flag_called',
+                      'survey sent',
+                      'survey shown',
+                      'survey dismissed',
+                      '$exception')
+    AND person_mode IN ('full',
+                        'force_upgrade')
+  GROUP BY team_id
+  '''
+# ---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.7
   '''
   
   SELECT team_id,
@@ -359,80 +468,18 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.5
-  '''
-  
-  SELECT team_id,
-         count(distinct session_id) as count
-  FROM
-    (SELECT any(team_id) as team_id,
-            session_id
-     FROM session_replay_events
-     WHERE min_first_timestamp BETWEEN '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-     GROUP BY session_id
-     HAVING ifNull(argMinMerge(snapshot_source), 'web') == 'web')
-  WHERE session_id NOT IN
-      (SELECT DISTINCT session_id
-       FROM session_replay_events
-       WHERE min_first_timestamp BETWEEN '2022-01-09 00:00:00' AND '2022-01-10 00:00:00'
-       GROUP BY session_id)
-  GROUP BY team_id
-  '''
-# ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.6
-  '''
-  
-  SELECT team_id,
-         sum(total_size) as bytes
-  FROM
-    (SELECT any(team_id) as team_id,
-            session_id,
-            sum(size) as total_size
-     FROM session_replay_events
-     WHERE min_first_timestamp BETWEEN '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-     GROUP BY session_id
-     HAVING ifNull(argMinMerge(snapshot_source), 'web') == 'web')
-  WHERE session_id NOT IN
-      (SELECT DISTINCT session_id
-       FROM session_replay_events
-       WHERE min_first_timestamp BETWEEN '2022-01-09 00:00:00' AND '2022-01-10 00:00:00'
-       GROUP BY session_id)
-  GROUP BY team_id
-  '''
-# ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.7
-  '''
-  
-  SELECT team_id,
-         count(distinct session_id) as count
-  FROM
-    (SELECT any(team_id) as team_id,
-            session_id
-     FROM session_replay_events
-     WHERE min_first_timestamp BETWEEN '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-     GROUP BY session_id
-     HAVING ifNull(argMinMerge(snapshot_source), 'web') == 'mobile')
-  WHERE session_id NOT IN
-      (SELECT DISTINCT session_id
-       FROM session_replay_events
-       WHERE min_first_timestamp BETWEEN '2022-01-09 00:00:00' AND '2022-01-10 00:00:00'
-       GROUP BY session_id)
-  GROUP BY team_id
-  '''
-# ---
 # name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.8
   '''
   
   SELECT team_id,
-         sum(total_size) as bytes
+         count(distinct session_id) as count
   FROM
     (SELECT any(team_id) as team_id,
-            session_id,
-            sum(size) as total_size
+            session_id
      FROM session_replay_events
      WHERE min_first_timestamp BETWEEN '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
      GROUP BY session_id
-     HAVING ifNull(argMinMerge(snapshot_source), 'web') == 'mobile')
+     HAVING ifNull(argMinMerge(snapshot_source), 'web') == 'web')
   WHERE session_id NOT IN
       (SELECT DISTINCT session_id
        FROM session_replay_events
@@ -445,17 +492,15 @@
   '''
   
   SELECT team_id,
-         count(distinct session_id) as count
+         sum(total_size) as bytes
   FROM
     (SELECT any(team_id) as team_id,
-            session_id
+            session_id,
+            sum(size) as total_size
      FROM session_replay_events
      WHERE min_first_timestamp BETWEEN '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
      GROUP BY session_id
-     HAVING (ifNull(argMinMerge(snapshot_source), '') == 'mobile'
-             AND ifNull(argMinMerge(snapshot_library), '') IN ('posthog-ios',
-                                                               'posthog-android',
-                                                               'posthog-react-native')))
+     HAVING ifNull(argMinMerge(snapshot_source), 'web') == 'web')
   WHERE session_id NOT IN
       (SELECT DISTINCT session_id
        FROM session_replay_events

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -2076,7 +2076,9 @@ class SendUsageNoLicenseTest(APIBaseTest):
 
 
 class TestQuerySplitting(ClickhouseTestMixin, TestCase):
-    """Tests for the query splitting functionality in usage_report.py."""
+    team: Team = None  # type: ignore
+    begin: datetime = None  # type: ignore
+    end: datetime = None  # type: ignore
 
     @classmethod
     def setUpTestData(cls) -> None:

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -156,6 +156,11 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
         # make sure we don't collapse duplicate rows
         sync_execute("SYSTEM STOP MERGES")
 
+        # Clear existing data
+        sync_execute("TRUNCATE TABLE events")
+        sync_execute("TRUNCATE TABLE person")
+        sync_execute("TRUNCATE TABLE person_distinct_id")
+
         self.expected_properties: dict = {}
 
     def _create_sample_usage_data(self, include_mobile_replay: bool) -> None:
@@ -2068,3 +2073,237 @@ class SendUsageNoLicenseTest(APIBaseTest):
         # This field is not included in the original team query, so should require an additional query
         with self.assertNumQueries(1):
             _ = team.organization.for_internal_metrics
+
+
+class TestQuerySplitting(ClickhouseTestMixin, TestCase):
+    """Tests for the query splitting functionality in usage_report.py."""
+
+    @classmethod
+    def setUpTestData(cls):
+        # Clear existing ClickHouse data
+        sync_execute("TRUNCATE TABLE events")
+        sync_execute("TRUNCATE TABLE person")
+        sync_execute("TRUNCATE TABLE person_distinct_id")
+
+        # Clear existing Django data
+        Team.objects.all().delete()
+        Organization.objects.all().delete()
+
+        # Create a fresh team for testing
+        cls.team = Team.objects.create(organization=Organization.objects.create(name="test"))
+        # Create test events across a time period
+        cls.begin = datetime(2023, 1, 1, 0, 0)
+        cls.end = datetime(2023, 1, 2, 0, 0)
+
+        # Create 10 events in the time period
+        for i in range(10):
+            _create_event(
+                event="test_event",
+                team=cls.team,
+                distinct_id=f"user_{i}",
+                timestamp=cls.begin + relativedelta(hours=i),
+                properties={},
+                person_mode="propertyless",
+            )
+
+        # Create some events with person_mode for enhanced persons test
+        for i in range(5):
+            _create_event(
+                event="enhanced_event",
+                team=cls.team,
+                distinct_id=f"enhanced_user_{i}",
+                timestamp=cls.begin + relativedelta(hours=i),
+                properties={"$lib": "web"},
+                person_mode="full",
+            )
+
+        # Create survey sent and feature flag called events
+        for i in range(3):
+            _create_event(
+                event="survey sent",
+                team=cls.team,
+                distinct_id=f"survey_user_{i}",
+                timestamp=cls.begin + relativedelta(hours=i),
+                properties={"survey_id": f"survey_{i}"},
+                person_mode="full",
+            )
+
+        for i in range(3):
+            _create_event(
+                event="$feature_flag_called",
+                team=cls.team,
+                distinct_id=f"ff_user_{i}",
+                timestamp=cls.begin + relativedelta(hours=i),
+                properties={"$feature_flag": f"flag_{i}"},
+                person_mode="full",
+            )
+
+        flush_persons_and_events()
+
+    @patch("posthog.tasks.usage_report.sync_execute")
+    def test_execute_split_query_splits_correctly(self, mock_sync_execute: MagicMock) -> None:
+        """Test that _execute_split_query correctly splits the time period and combines results."""
+        # Mock the sync_execute to return test data
+        mock_sync_execute.side_effect = [
+            [(self.team.id, 5)],  # First split returns 5 events
+            [(self.team.id, 5)],  # Second split returns 5 events
+        ]
+
+        # Test with 2 splits
+        query_template = """
+            SELECT team_id, count(1) as count
+            FROM events
+            WHERE timestamp BETWEEN %(begin)s AND %(end)s
+            GROUP BY team_id
+        """
+
+        from posthog.tasks.usage_report import _execute_split_query
+
+        result = _execute_split_query(
+            begin=self.begin, end=self.end, query_template=query_template, params={}, num_splits=2
+        )
+
+        # Verify sync_execute was called twice with different time ranges
+        self.assertEqual(mock_sync_execute.call_count, 2)
+
+        # First call should use the first half of the time range
+        first_call_args = mock_sync_execute.call_args_list[0][0]
+        self.assertEqual(first_call_args[1]["begin"], self.begin)
+        mid_point = self.begin + (self.end - self.begin) / 2
+        self.assertEqual(first_call_args[1]["end"], mid_point)
+
+        # Second call should use the second half of the time range
+        second_call_args = mock_sync_execute.call_args_list[1][0]
+        self.assertEqual(second_call_args[1]["begin"], mid_point)
+        self.assertEqual(second_call_args[1]["end"], self.end)
+
+        # Result should combine both splits (5 + 5 = 10)
+        self.assertEqual(result, [(self.team.id, 10)])
+
+    @patch("posthog.tasks.usage_report.sync_execute")
+    def test_execute_split_query_with_custom_combiner(self, mock_sync_execute: MagicMock) -> None:
+        """Test that _execute_split_query works with a custom result combiner function."""
+        # Mock the sync_execute to return test data for event metrics
+        mock_sync_execute.side_effect = [
+            [(self.team.id, "web_events", 3)],  # First split
+            [(self.team.id, "web_events", 2), (self.team.id, "mobile_events", 1)],  # Second split
+        ]
+
+        # Define a custom combiner function similar to what we use in get_all_event_metrics_in_period
+        def custom_combiner(results_list):
+            metrics = {
+                "web_events": {},
+                "mobile_events": {},
+            }
+
+            for results in results_list:
+                for team_id, metric, count in results:
+                    if team_id in metrics[metric]:
+                        metrics[metric][team_id] += count
+                    else:
+                        metrics[metric][team_id] = count
+
+            return {metric: list(team_counts.items()) for metric, team_counts in metrics.items()}
+
+        query_template = """
+            SELECT team_id, 'web_events' as metric, count(1) as count
+            FROM events
+            WHERE timestamp BETWEEN %(begin)s AND %(end)s
+            GROUP BY team_id, metric
+        """
+
+        from posthog.tasks.usage_report import _execute_split_query
+
+        result = _execute_split_query(
+            begin=self.begin,
+            end=self.end,
+            query_template=query_template,
+            params={},
+            num_splits=2,
+            combine_results_func=custom_combiner,
+        )
+
+        # Verify the custom combiner worked correctly
+        self.assertEqual(result["web_events"], [(self.team.id, 5)])
+        self.assertEqual(result["mobile_events"], [(self.team.id, 1)])
+
+    def test_get_teams_with_billable_event_count_in_period(self) -> None:
+        """Test that get_teams_with_billable_event_count_in_period returns correct results after splitting."""
+        from posthog.tasks.usage_report import get_teams_with_billable_event_count_in_period
+
+        # Run the function with our test data
+        result = get_teams_with_billable_event_count_in_period(self.begin, self.end)
+
+        # We should get 10 events for our team
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0][0], self.team.id)
+        self.assertEqual(result[0][1], 15)
+
+        # Test with count_distinct=True
+        result_distinct = get_teams_with_billable_event_count_in_period(self.begin, self.end, count_distinct=True)
+        self.assertEqual(len(result_distinct), 1)
+        self.assertEqual(result_distinct[0][0], self.team.id)
+        # Should still be 15 since we created 15 distinct events
+        self.assertEqual(result_distinct[0][1], 15)
+
+    def test_get_teams_with_billable_enhanced_persons_event_count_in_period(self) -> None:
+        """Test that get_teams_with_billable_enhanced_persons_event_count_in_period returns correct results after splitting."""
+        from posthog.tasks.usage_report import get_teams_with_billable_enhanced_persons_event_count_in_period
+
+        # Run the function with our test data
+        result = get_teams_with_billable_enhanced_persons_event_count_in_period(self.begin, self.end)
+
+        # We should get 5 enhanced events for our team
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0][0], self.team.id)
+        self.assertEqual(result[0][1], 5)
+
+    @patch("posthog.tasks.usage_report._execute_split_query")
+    def test_split_query_with_different_num_splits(self, mock_execute_split_query: MagicMock) -> None:
+        """Test that functions call _execute_split_query with the correct number of splits."""
+        mock_execute_split_query.return_value = [(self.team.id, 10)]
+
+        from posthog.tasks.usage_report import (
+            get_teams_with_billable_event_count_in_period,
+            get_all_event_metrics_in_period,
+        )
+
+        # Call the functions
+        get_teams_with_billable_event_count_in_period(self.begin, self.end)
+        get_all_event_metrics_in_period(self.begin, self.end)
+
+        # Verify the calls
+        self.assertEqual(mock_execute_split_query.call_count, 2)
+
+        # First call (get_teams_with_billable_event_count_in_period) should use 2 splits
+        first_call_kwargs = mock_execute_split_query.call_args_list[0][1]
+        self.assertEqual(first_call_kwargs["num_splits"], 2)
+
+        # Second call (get_all_event_metrics_in_period) should use 4 splits
+        second_call_kwargs = mock_execute_split_query.call_args_list[1][1]
+        self.assertEqual(second_call_kwargs["num_splits"], 2)
+
+    def test_integration_with_usage_report(self) -> None:
+        """Test that the usage report generation still works with the new query splitting."""
+        period_start, period_end = get_previous_day(at=self.end)
+
+        # Create some events in the period
+        for i in range(5):
+            _create_event(
+                event="$pageview",
+                team=self.team,
+                distinct_id=f"user_{i}",
+                timestamp=period_start + relativedelta(hours=i),
+                properties={},
+            )
+
+        flush_persons_and_events()
+
+        # Get the usage data
+        all_data = _get_all_usage_data_as_team_rows(period_start, period_end)
+
+        # Verify the data
+        self.assertIn("teams_with_event_count_in_period", all_data)
+        self.assertEqual(len(all_data["teams_with_event_count_in_period"]), 1)
+        self.assertEqual(next(iter(all_data["teams_with_event_count_in_period"].keys())), self.team.id)
+        self.assertEqual(all_data["teams_with_event_count_in_period"][self.team.id], 20)

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -2140,6 +2140,12 @@ class TestQuerySplitting(ClickhouseTestMixin, TestCase):
 
         flush_persons_and_events()
 
+    def setUp(self) -> None:
+        # Copy class attributes to instance attributes
+        self.team = self.__class__.team
+        self.begin = self.__class__.begin
+        self.end = self.__class__.end
+
     @patch("posthog.tasks.usage_report.sync_execute")
     def test_execute_split_query_splits_correctly(self, mock_sync_execute: MagicMock) -> None:
         """Test that _execute_split_query correctly splits the time period and combines results."""

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -2279,7 +2279,7 @@ class TestQuerySplitting(ClickhouseTestMixin, TestCase):
         first_call_kwargs = mock_execute_split_query.call_args_list[0][1]
         self.assertEqual(first_call_kwargs["num_splits"], 2)
 
-        # Second call (get_all_event_metrics_in_period) should use 4 splits
+        # Second call (get_all_event_metrics_in_period) should use 2 splits
         second_call_kwargs = mock_execute_split_query.call_args_list[1][1]
         self.assertEqual(second_call_kwargs["num_splits"], 2)
 

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -2079,7 +2079,7 @@ class TestQuerySplitting(ClickhouseTestMixin, TestCase):
     """Tests for the query splitting functionality in usage_report.py."""
 
     @classmethod
-    def setUpTestData(cls):
+    def setUpTestData(cls) -> None:
         # Clear existing ClickHouse data
         sync_execute("TRUNCATE TABLE events")
         sync_execute("TRUNCATE TABLE person")
@@ -2190,8 +2190,8 @@ class TestQuerySplitting(ClickhouseTestMixin, TestCase):
         ]
 
         # Define a custom combiner function similar to what we use in get_all_event_metrics_in_period
-        def custom_combiner(results_list):
-            metrics = {
+        def custom_combiner(results_list: list) -> dict[str, list[tuple[int, int]]]:
+            metrics: dict[str, dict[int, int]] = {
                 "web_events": {},
                 "mobile_events": {},
             }

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -453,18 +453,14 @@ def get_teams_with_billable_event_count_in_period(
         distinct_expression = "1"
 
     # We are excluding $exception events during the beta
-    result = sync_execute(
-        f"""
+    query_template = f"""
         SELECT team_id, count({distinct_expression}) as count
         FROM events
         WHERE timestamp between %(begin)s AND %(end)s AND event NOT IN ('$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception')
         GROUP BY team_id
-    """,
-        {"begin": begin, "end": end},
-        workload=Workload.OFFLINE,
-        settings=CH_BILLING_SETTINGS,
-    )
-    return result
+    """
+
+    return _execute_split_query(begin, end, query_template, {}, num_splits=2)
 
 
 @timed_log()
@@ -483,18 +479,14 @@ def get_teams_with_billable_enhanced_persons_event_count_in_period(
     else:
         distinct_expression = "1"
 
-    result = sync_execute(
-        f"""
+    query_template = f"""
         SELECT team_id, count({distinct_expression}) as count
         FROM events
         WHERE timestamp between %(begin)s AND %(end)s AND event NOT IN ('$feature_flag_called', 'survey sent', 'survey shown', 'survey dismissed', '$exception') AND person_mode IN ('full', 'force_upgrade')
         GROUP BY team_id
-    """,
-        {"begin": begin, "end": end},
-        workload=Workload.OFFLINE,
-        settings=CH_BILLING_SETTINGS,
-    )
-    return result
+    """
+
+    return _execute_split_query(begin, end, query_template, {}, num_splits=2)
 
 
 @timed_log()

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -499,7 +499,7 @@ def get_teams_with_event_count_with_groups_in_period(begin: datetime, end: datet
         WHERE timestamp between %(begin)s AND %(end)s
         AND ($group_0 != '' OR $group_1 != '' OR $group_2 != '' OR $group_3 != '' OR $group_4 != '')
         GROUP BY team_id
-    """,
+        """,
         {"begin": begin, "end": end},
         workload=Workload.OFFLINE,
         settings=CH_BILLING_SETTINGS,

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -589,7 +589,7 @@ def get_all_event_metrics_in_period(begin: datetime, end: datetime) -> dict[str,
         end=end,
         query_template=query_template,
         params={},
-        num_splits=4,
+        num_splits=2,
         combine_results_func=combine_event_metrics_results,
     )
 

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -7,6 +7,7 @@ from collections import Counter
 from collections.abc import Sequence
 from datetime import datetime
 from typing import Any, Literal, Optional, TypedDict, Union
+from collections.abc import Callable
 
 import requests
 import structlog
@@ -356,7 +357,12 @@ def send_report_to_billing_service(org_id: str, report: dict[str, Any]) -> None:
 
 
 def _execute_split_query(
-    begin: datetime, end: datetime, query_template: str, params: dict, num_splits: int = 2, combine_results_func=None
+    begin: datetime,
+    end: datetime,
+    query_template: str,
+    params: dict,
+    num_splits: int = 2,
+    combine_results_func: Optional[Callable[[list], Any]] = None,
 ) -> Any:
     """
     Helper function to execute a query split into multiple parts to reduce load.
@@ -420,7 +426,7 @@ def _combine_team_count_results(results_list: list) -> list[tuple[int, int]]:
     Returns:
         Combined list of (team_id, count) tuples
     """
-    team_counts = {}
+    team_counts: dict[int, int] = {}
 
     # Combine all results
     for results in results_list:
@@ -543,8 +549,8 @@ def get_all_event_metrics_in_period(begin: datetime, end: datetime) -> dict[str,
     """
 
     # Define a custom function to combine results from multiple queries
-    def combine_event_metrics_results(results_list):
-        metrics = {
+    def combine_event_metrics_results(results_list: list) -> dict[str, list[tuple[int, int]]]:
+        metrics: dict[str, dict[int, int]] = {
             "helicone_events": {},
             "langfuse_events": {},
             "keywords_ai_events": {},

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -355,8 +355,6 @@ def send_report_to_billing_service(org_id: str, report: dict[str, Any]) -> None:
         raise
 
 
-@timed_log()
-@retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
 def _execute_split_query(
     begin: datetime, end: datetime, query_template: str, params: dict, num_splits: int = 2, combine_results_func=None
 ) -> Any:


### PR DESCRIPTION
## Changes

Usage reports are failing because we've hit the max size a query can return because the daily event volume is so high - yay us!

This is rewriting the usage report query logic for the event table to split into multiple queries over the course of the day and then pull it all together.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

It doesn't have an impact.

## How did you test this code?

Added tests + tested manually. 
