### PR TITLE
fix(flags): added try-except line to catch feature flags that don't exist

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1095,11 +1095,14 @@ class FeatureFlagViewSet(
     def remote_config(self, request: request.Request, **kwargs):
         is_flag_id_provided = kwargs["pk"].isdigit()
 
-        feature_flag = (
-            FeatureFlag.objects.get(pk=kwargs["pk"])
-            if is_flag_id_provided
-            else FeatureFlag.objects.get(key=kwargs["pk"], team__project_id=self.project_id)
-        )
+        try:
+            feature_flag = (
+                FeatureFlag.objects.get(pk=kwargs["pk"])
+                if is_flag_id_provided
+                else FeatureFlag.objects.get(key=kwargs["pk"], team__project_id=self.project_id)
+            )
+        except FeatureFlag.DoesNotExist:
+            return Response("", status=status.HTTP_404_NOT_FOUND)
 
         if not feature_flag.is_remote_configuration:
             return Response("", status=status.HTTP_404_NOT_FOUND)

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -1094,6 +1094,10 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             self.assertEqual(feature_flag.version, 3)
             self.assertEqual(feature_flag.name, "Yet another updated name")
 
+    def test_remote_config_returns_not_found_for_unknown_flag(self):
+        response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/nonexistent_key/remote_config")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
     def test_get_conflicting_changes(self):
         feature_flag = FeatureFlag.objects.create(
             team=self.team,


### PR DESCRIPTION
## Problem

A request to get the remote config settings of a feature flag that does not exist returns a bunch of HTML instead of a 404 Not Found error on localhost. 

Closes #30718

What a portion of the said HTML looks like
![image](https://github.com/user-attachments/assets/9f1d6e75-b614-415d-ad3a-88940d0e3ef4)


## Changes

Adding a try-except block in the remote config endpoint to catch flags that don't exist and return a 404 JSON response. The endpoint now handles both cases: when a flag doesn't exist and when a flag exists but doesn't have a remote config. 

Calling the same endpoint now leads to the right output:

![image](https://github.com/user-attachments/assets/22cd4fd9-6e87-4a96-8d0c-6247055cd098)


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes - this is a purely frontend change that works the same way regardless of deployment type.

## How did you test this code?

Manually tested the endpoints on terminal.
