### PR TITLE
fix: prevent query state reset when opening session recording modal

### DIFF
--- a/frontend/src/scenes/persons/PersonScene.tsx
+++ b/frontend/src/scenes/persons/PersonScene.tsx
@@ -16,6 +16,7 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { ProductIntentContext } from 'lib/utils/product-intents'
+import { useState } from 'react'
 import { RelatedGroups } from 'scenes/groups/RelatedGroups'
 import { NotebookSelectButton } from 'scenes/notebooks/NotebookSelectButton/NotebookSelectButton'
 import { PersonDeleteModal } from 'scenes/persons/PersonDeleteModal'
@@ -125,6 +126,18 @@ export function PersonScene(): JSX.Element | null {
     const { featureFlags } = useValues(featureFlagLogic)
     const { addProductIntentForCrossSell } = useActions(teamLogic)
 
+    const [eventsQuery, setEventsQuery] = useState({
+        kind: NodeKind.DataTableNode,
+        full: true,
+        hiddenColumns: ['person'],
+        source: {
+            kind: NodeKind.EventsQuery,
+            select: defaultDataTableColumns(NodeKind.EventsQuery),
+            personId: person?.id,
+            after: '-24h',
+        },
+    })
+
     if (personError) {
         throw new Error(personError)
     }
@@ -214,21 +227,7 @@ export function PersonScene(): JSX.Element | null {
                     {
                         key: PersonsTabType.EVENTS,
                         label: <span data-attr="persons-events-tab">Events</span>,
-                        content: (
-                            <Query
-                                query={{
-                                    kind: NodeKind.DataTableNode,
-                                    full: true,
-                                    hiddenColumns: ['person'],
-                                    source: {
-                                        kind: NodeKind.EventsQuery,
-                                        select: defaultDataTableColumns(NodeKind.EventsQuery),
-                                        personId: person.id,
-                                        after: '-24h',
-                                    },
-                                }}
-                            />
-                        ),
+                        content: <Query query={eventsQuery} setQuery={setEventsQuery} />,
                     },
                     {
                         key: PersonsTabType.SESSION_RECORDINGS,


### PR DESCRIPTION
## Problem

The `Query` component was experiencing unintended state resets when the session recording modal was opened (see #30732). This caused issues in the Person scene, such as the events table losing its filters. The problem occurred because opening the modal triggered a re-render of the `Query` component, which in turn reset its local state.

```tsx
const [localQuery, localSetQuery] = useState(propsQuery)
useEffect(() => {
    if (propsQuery !== localQuery) {
        localSetQuery(propsQuery)
    }
}, [propsQuery])
```

## Changes

Lifted the events query state management up to the PersonScene component to have control over the `setQuery` function, preventing unwanted state resets when the modal opens.

## Does this work well for both Cloud and self-hosted?

Yes, this change is purely frontend and doesn't affect any backend functionality or configuration differences between Cloud and self-hosted.

## How did you test this code?
 1. Opened a person's profile
 2. Navigated to the Events tab
 3. Clicked on a session recording button
 4. Verified that the events table state was preserved
 5. Verified that the modal opened correctly
 6. Checked that the events table remained stable when closing the modal

### Visual Proof
![CleanShot 2025-04-05 at 13 06 21](https://github.com/user-attachments/assets/eb0ed5e8-b408-4566-b238-e91d07d953d2)
