### PR TITLE
feat: add kafka topic metadata refresh interval setting for rust kafka sink

### DIFF
--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -110,4 +110,6 @@ pub struct KafkaConfig {
     pub kafka_producer_max_retries: u32,
     #[envconfig(default = "all")]
     pub kafka_producer_acks: String,
+    #[envconfig(default = "60000")]
+    pub kafka_topic_metadata_refresh_interval_ms: u32,
 }

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -410,6 +410,7 @@ mod tests {
             kafka_producer_linger_ms: 0,
             kafka_producer_queue_mib: 50,
             kafka_message_timeout_ms: 500,
+            kafka_topic_metadata_refresh_interval_ms: 20000,
             kafka_producer_message_max_bytes: message_max_bytes.unwrap_or(1000000),
             kafka_compression_codec: "none".to_string(),
             kafka_hosts: cluster.bootstrap_servers(),

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -140,6 +140,10 @@ impl KafkaSink {
                 config.kafka_metadata_max_age_ms.to_string(),
             )
             .set(
+                "topic.metadata.refresh.interval.ms",
+                config.kafka_topic_metadata_refresh_interval_ms.to_string(),
+            )
+            .set(
                 "message.send.max.retries",
                 config.kafka_producer_max_retries.to_string(),
             )

--- a/rust/capture/tests/common.rs
+++ b/rust/capture/tests/common.rs
@@ -44,6 +44,7 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
         kafka_producer_queue_mib: 10,
         kafka_message_timeout_ms: 10000, // 10s, ACKs can be slow on low volumes, should be tuned
         kafka_producer_message_max_bytes: 1000000, // 1MB, rdkafka default
+        kafka_topic_metadata_refresh_interval_ms: 10000,
         kafka_compression_codec: "none".to_string(),
         kafka_hosts: "kafka:9092".to_string(),
         kafka_topic: "events_plugin_ingestion".to_string(),


### PR DESCRIPTION

## Problem
topic metadata refresh by default is 5 minutes, but it should be much shorter so we don't hit issues when brokers restart

set the default to 60 seconds, but we'll probably make it even shorter through env vars (warpstream guys recommended 20 seconds)

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
