### PR TITLE
feat(cdp): use empty strings tiktok conversions

### DIFF
--- a/plugin-server/src/cdp/templates/_destinations/tiktok_ads/tiktok.template.ts
+++ b/plugin-server/src/cdp/templates/_destinations/tiktok_ads/tiktok.template.ts
@@ -99,7 +99,7 @@ if (not empty(inputs.testEventCode)) {
 }
 
 for (let key, value in inputs.userProperties) {
-    if (not empty(value)) {
+    if (not empty(value) or value == '') {
         body.data.1.user[key] := value
     }
 }
@@ -154,14 +154,20 @@ if (res.status >= 400) {
             description:
                 'A map that contains customer information data. See this page for options: https://business-api.tiktok.com/portal/docs?id=1771101151059969#item-link-user%20parameters',
             default: {
-                email: '{sha256Hex(lower(person.properties.email))}',
+                email: '{not empty(person.properties.email) ? sha256Hex(lower(person.properties.email)) : ""}',
+                first_name:
+                    '{not empty(person.properties.first_name) ? sha256Hex(lower(person.properties.first_name)) : ""}',
+                last_name:
+                    '{not empty(person.properties.last_name) ? sha256Hex(lower(person.properties.last_name)) : ""}',
+                phone: '{not empty(person.properties.phone) ? sha256Hex(person.properties.phone) : ""}',
+                external_id: '{not empty(person.id) ? sha256Hex(person.id) : ""}',
+                city: "{replaceAll(lower(person.properties.$geoip_city_name), ' ', '')}",
+                state: '{lower(person.properties.$geoip_subdivision_1_code)}',
+                country: '{lower(person.properties.$geoip_country_code)}',
+                zip_code: "{sha256Hex(replaceAll(lower(person.properties.$geoip_postal_code), ' ', ''))}",
                 ttclid: '{person.properties.ttclid ?? person.properties.$initial_ttclid}',
-                phone: '{sha256Hex(person.properties.phone)}',
-                external_id: '{sha256Hex(person.id)}',
                 ip: '{event.properties.$ip}',
                 user_agent: '{event.properties.$raw_user_agent}',
-                first_name: '{sha256Hex(lower(person.properties.first_name))}',
-                last_name: '{sha256Hex(lower(person.properties.last_name))}',
             },
             secret: false,
             required: true,

--- a/posthog/cdp/templates/tiktok_ads/template_tiktok_pixel.py
+++ b/posthog/cdp/templates/tiktok_ads/template_tiktok_pixel.py
@@ -76,7 +76,7 @@ export function onLoad({ inputs }) {
 
     let userProperties = {};
     for (const [key, value] of Object.entries(inputs.userProperties)) {
-        if (value) {
+        if (value || value === '') {
             userProperties[key] = value;
         }
     };
@@ -120,9 +120,16 @@ export function onEvent({ inputs }) {
             "description": "Map of TikTok user parameters and their values. Check out this page for more details: https://business-api.tiktok.com/portal/docs?id=1739585700402178#item-link-Identity%20information%20supported",
             "label": "User parameters",
             "default": {
-                "email": "{sha256Hex(lower(person.properties.email))}",
-                "phone_number": "{sha256Hex(lower(person.properties.phone))}",
-                "external_id": "{sha256Hex(person.id)}",
+                "email": '{not empty(person.properties.email) ? sha256Hex(lower(person.properties.email)) : ""}',
+                "first_name": '{not empty(person.properties.first_name) ? sha256Hex(lower(person.properties.first_name)) : ""}',
+                "last_name": '{not empty(person.properties.last_name) ? sha256Hex(lower(person.properties.last_name)) : ""}',
+                "phone": '{not empty(person.properties.phone) ? sha256Hex(person.properties.phone) : ""}',
+                "external_id": '{not empty(person.id) ? sha256Hex(person.id) : ""}',
+                "city": "{replaceAll(lower(person.properties.$geoip_city_name), ' ', ''))}",
+                "state": "{lower(person.properties.$geoip_subdivision_1_code)}",
+                "country": "{lower(person.properties.$geoip_country_code)}",
+                "zip_code": "{sha256Hex(replaceAll(lower(person.properties.$geoip_postal_code), ' ', ''))}",
+                "ttclid": "{person.properties.ttclid ?? person.properties.$initial_ttclid}",
             },
             "secret": False,
             "required": False,


### PR DESCRIPTION
## Problem

TikTok wants us to send empty strings if the user data parameters are unavailable

based on https://github.com/PostHog/posthog/pull/30819

## Changes

Todos: 
- [x] send empty strings instead of removing values entriely
- [ ] fix tests

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
