### PR TITLE
fix(crm): Fix persistent columns for event definitions

### DIFF
--- a/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
+++ b/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
@@ -21,7 +21,7 @@ import { useState } from 'react'
 import { AutoSizer } from 'react-virtualized/dist/es/AutoSizer'
 
 import { dataTableLogic } from '~/queries/nodes/DataTable/dataTableLogic'
-import { DataTableNode, GroupsQuery } from '~/queries/schema/schema-general'
+import { DataTableNode } from '~/queries/schema/schema-general'
 import {
     isEventsQuery,
     isGroupsQuery,
@@ -81,10 +81,11 @@ export function ColumnConfigurator({ query, setQuery }: ColumnConfiguratorProps)
                 setQuery?.({ ...query, columns })
             }
         },
-        context:
-            query.context || isGroupsQuery(query.source)
-                ? { type: 'groups', groupTypeIndex: (query.source as GroupsQuery).group_type_index as GroupTypeIndex }
-                : { type: 'team_columns' },
+        context: query.context
+            ? query.context
+            : isGroupsQuery(query.source)
+            ? { type: 'groups', groupTypeIndex: query.source.group_type_index as GroupTypeIndex }
+            : { type: 'team_columns' },
     }
     const { showModal } = useActions(columnConfiguratorLogic(columnConfiguratorLogicProps))
 


### PR DESCRIPTION
Introduced in https://github.com/PostHog/posthog/pull/30463
See https://github.com/PostHog/posthog/issues/29881

## Changes

Fixes a condition in `<ColumnConfigurator>` that broke persistent columns for event definitions (and caused buggy data for group persistent columns).

## How did you test this code?

I saved persistent columns on both an event definition and a group type list.