### PR TITLE
fix(devex): lemon tree ux updates 

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -283,6 +283,21 @@ export function ProjectTree(): JSX.Element {
                     }
                     return <DropdownMenuGroup>{renderMenuItems(item, DropdownMenuItem)}</DropdownMenuGroup>
                 }}
+                emptySpaceContextMenu={() => {
+                    return (
+                        <ContextMenuGroup>
+                            <ContextMenuItem
+                                asChild
+                                onClick={(e: any) => {
+                                    e.stopPropagation()
+                                    createFolder('')
+                                }}
+                            >
+                                <ButtonPrimitive menuItem>New folder</ButtonPrimitive>
+                            </ContextMenuItem>
+                        </ContextMenuGroup>
+                    )
+                }}
             />
         </PanelLayoutPanel>
     )

--- a/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
@@ -184,9 +184,9 @@ export function convertFileSystemEntryToTreeDataItem({
             folderNode.children.push({
                 id: `${root}-folder-empty/${folderNode.id}`,
                 name: 'Empty folder',
-                displayName: <em className="text-muted">Empty folder</em>,
-                icon: <IconPlus />,
+                displayName: <span className="italic text-tertiary pl-2">Empty folder</span>,
                 disableSelect: true,
+                type: 'empty-folder',
             })
         }
         if (indeterminateFolders[folderNode.id] && !folderNode.checked) {

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -377,7 +377,7 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                                         </ContextMenuTrigger>
 
                                         {isContextMenuOpenForItem === item.id && itemContextMenu?.(item) ? (
-                                            <ContextMenuContent loop className="max-w-[250px]">
+                                            <ContextMenuContent loop className="max-w-[250px]" collisionPadding={100}>
                                                 {itemContextMenu(item)}
                                             </ContextMenuContent>
                                         ) : null}
@@ -1079,7 +1079,7 @@ const LemonTree = forwardRef<LemonTreeRef, LemonTreeProps>(
                             <ContextMenuTrigger className="flex-1 w-full">
                                 <div className="h-full w-full" />
                             </ContextMenuTrigger>
-                            <ContextMenuContent>{emptySpaceContextMenu?.()}</ContextMenuContent>
+                            <ContextMenuContent collisionPadding={100}>{emptySpaceContextMenu?.()}</ContextMenuContent>
                         </ContextMenu>
                     </TreeNodeDroppable>
                 </ScrollableShadows>

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -66,7 +66,7 @@ export type TreeDataItem = {
 
 type LemonTreeBaseProps = Omit<HTMLAttributes<HTMLDivElement>, 'onDragEnd'> & {
     /** The data to render in the tree. */
-    data: TreeDataItem[] | TreeDataItem
+    data: TreeDataItem[]
     /** The ID of the folder/node to select by default. Will expand the node if it has children. */
     defaultSelectedFolderOrNodeId?: string
     /** The IDs of the expanded items. */
@@ -103,6 +103,8 @@ type LemonTreeBaseProps = Omit<HTMLAttributes<HTMLDivElement>, 'onDragEnd'> & {
     /** Pass true if you need to wait for async events to populate the tree.
      * If present and true will trigger: scrolling to focused item */
     isFinishedBuildingTreeData?: boolean
+    /** The context menu to render for the empty space. */
+    emptySpaceContextMenu?: () => React.ReactNode
 }
 
 export type LemonTreeProps = LemonTreeBaseProps & {
@@ -455,6 +457,7 @@ const LemonTree = forwardRef<LemonTreeRef, LemonTreeProps>(
             isFinishedBuildingTreeData,
             enableMultiSelection = false,
             onItemChecked,
+            emptySpaceContextMenu,
             ...props
         },
         ref: ForwardedRef<LemonTreeRef>
@@ -1070,6 +1073,14 @@ const LemonTree = forwardRef<LemonTreeRef, LemonTreeProps>(
                             onItemChecked={onItemChecked}
                             {...props}
                         />
+
+                        {/* Context menu for empty space, takes up remaining space */}
+                        <ContextMenu>
+                            <ContextMenuTrigger className="flex-1 w-full">
+                                <div className="h-full w-full" />
+                            </ContextMenuTrigger>
+                            <ContextMenuContent>{emptySpaceContextMenu?.()}</ContextMenuContent>
+                        </ContextMenu>
                     </TreeNodeDroppable>
                 </ScrollableShadows>
             </DndContext>

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -55,7 +55,7 @@ export type TreeDataItem = {
      * Type node, normal behavior
      * Type separator, render as separator
      */
-    type?: 'node' | 'separator'
+    type?: 'node' | 'separator' | 'empty-folder'
 
     /**
      * Handle a click on the item.
@@ -190,8 +190,9 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
         return (
             <ul className={cn('list-none m-0 p-0', className)} role="group">
                 {data.map((item) => {
-                    // Clean up display name by replacing escaped characters
                     const displayName = item.displayName ?? item.name
+                    const isFolder = item.record?.type === 'folder'
+                    const isEmptyFolder = item.type === 'empty-folder'
 
                     if (item.type === 'separator') {
                         return (
@@ -200,8 +201,6 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                             </div>
                         )
                     }
-
-                    const isFolder = item.record?.type === 'folder'
 
                     const content = (
                         <AccordionPrimitive.Root
@@ -264,12 +263,12 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                                                             'bg-fill-button-tertiary-active': getItemActiveState(item),
                                                             'pl-1': !enableMultiSelection,
                                                             'pl-8': enableMultiSelection,
+                                                            'pointer-events-none': isEmptyFolder,
                                                         }
                                                     )}
                                                     onClick={() => {
                                                         handleClick(item)
                                                     }}
-                                                    // onKeyDown={(e) => e.key === 'Enter' && handleClick(item, true)}
                                                     href={item.record?.href}
                                                     role="treeitem"
                                                     data-id={item.id}
@@ -277,8 +276,10 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                                                     menuItem
                                                     size="base"
                                                     sideActionLeft
-                                                    tooltip={displayName}
+                                                    tooltip={isEmptyFolder ? undefined : displayName}
                                                     tooltipPlacement="right"
+                                                    disabled={isEmptyFolder}
+                                                    tabIndex={isEmptyFolder ? -1 : 0}
                                                     buttonWrapper={
                                                         enableDragAndDrop &&
                                                         isItemDraggable?.(item) &&
@@ -307,11 +308,15 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                                                         />
                                                     )}
 
-                                                    {renderTreeNodeDisplayIcon({
-                                                        item,
-                                                        expandedItemIds: expandedItemIds ?? [],
-                                                        defaultNodeIcon,
-                                                    })}
+                                                    {!isEmptyFolder && (
+                                                        <div className="flex items-center justify-center bg-transparent pointer-events-none flex-shrink-0 h-[var(--button-height-base)]">
+                                                            {renderTreeNodeDisplayIcon({
+                                                                item,
+                                                                expandedItemIds: expandedItemIds ?? [],
+                                                                defaultNodeIcon,
+                                                            })}
+                                                        </div>
+                                                    )}
 
                                                     {/* Render contents */}
                                                     {renderItem ? (
@@ -342,7 +347,8 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                                                         </span>
                                                     )}
                                                 </ButtonPrimitive>
-                                                {itemSideAction && (
+
+                                                {itemSideAction && !isEmptyFolder && (
                                                     <DropdownMenu>
                                                         <DropdownMenuTrigger asChild>
                                                             <ButtonPrimitive

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTreeUtils.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTreeUtils.tsx
@@ -166,7 +166,7 @@ export const TreeNodeDroppable = (props: DroppableProps): JSX.Element => {
         <div
             ref={setNodeRef}
             className={cn(
-                'transition-all duration-150 rounded',
+                'flex flex-col transition-all duration-150 rounded',
                 props.className,
                 props.isDroppable && isOver && 'ring-2 ring-inset ring-accent bg-accent-highlight-secondary'
             )}


### PR DESCRIPTION
## Problem
Our new "empty folder" element had a broken context menu and a side action that didn't make sense.
Context menu wasn't properly colliding with document edge
Empty space below tree items was missing context menu 
Drag/Dropping a tree item (With href) triggered a routing and a hard refresh.

![2025-04-07 22 41 46](https://github.com/user-attachments/assets/a0d2378d-3a66-4919-a118-32cca1b5617f)

## Changes
Made a special case for this empty folder item, omitting some stuff on render if true.
Increased surface area of context menu (added new context menu) to take up remaining space below tree items.
Changed collision for lemon tree context menus to make sure it worked closer to bottom of screen.

## How did you test this code?
Locally