### PR TITLE
fix: Add flags polyfill to other places

### DIFF
--- a/common/tailwind/tailwind.config.js
+++ b/common/tailwind/tailwind.config.js
@@ -703,6 +703,7 @@ const config = {
             },
             fontFamily: {
                 sans: [
+                    'Emoji Flags Polyfill',
                     '-apple-system',
                     'BlinkMacSystemFont',
                     'Inter',
@@ -717,6 +718,7 @@ const config = {
                     'Segoe UI Symbol',
                 ],
                 title: [
+                    'Emoji Flags Polyfill',
                     'MatterSQ',
                     '-apple-system',
                     'BlinkMacSystemFont',
@@ -731,7 +733,16 @@ const config = {
                     'Segoe UI Emoji',
                     'Segoe UI Symbol',
                 ],
-                mono: ['ui-monospace', 'SFMono-Regular', 'SF Mono', 'Menlo', 'Consolas', 'Liberation Mono', 'monospace'],
+                mono: [
+                    'Emoji Flags Polyfill',
+                    'ui-monospace',
+                    'SFMono-Regular',
+                    'SF Mono',
+                    'Menlo',
+                    'Consolas',
+                    'Liberation Mono',
+                    'monospace',
+                ],
             },
             screens: {
                 // Sync with vars.scss
@@ -797,7 +808,6 @@ const config = {
         plugin(({ addUtilities, theme }) => {
             const spacing = theme("spacing");
             const newUtilities = {};
-            
 
             // Standard spacing utilities for backwards compatibility
             for (const [key, value] of Object.entries(spacing)) {

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -264,7 +264,7 @@ export const LineGraph = (): JSX.Element => {
         const tickOptions: Partial<TickOptions> = {
             color: colors.axisLabel as Color,
             font: {
-                family: '-apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", "Roboto", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
+                family: '"Emoji Flags Polyfill", -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", "Roboto", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
                 size: 12,
                 weight: 'normal',
             },

--- a/frontend/src/scenes/insights/views/Histogram/Histogram.scss
+++ b/frontend/src/scenes/insights/views/Histogram/Histogram.scss
@@ -67,7 +67,7 @@
 
         g#labels {
             text.bar-label {
-                font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+                font-family: 'Emoji Flags Polyfill', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 
                 // same as chart-js
                 font-size: 12px;

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -590,7 +590,7 @@ export function LineGraph_({
         const tickOptions: Partial<TickOptions> = {
             color: colors.axisLabel as Color,
             font: {
-                family: '-apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", "Roboto", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
+                family: '"Emoji Flags Polyfill", -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", "Roboto", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
                 size: 12,
                 weight: 'normal',
             },

--- a/frontend/src/toolbar/elements/AutocaptureElementLabel.tsx
+++ b/frontend/src/toolbar/elements/AutocaptureElementLabel.tsx
@@ -9,7 +9,7 @@ const heatmapLabelStyle = {
     boxShadow: 'hsla(54, 100%, 32%, 1) 0px 1px 5px 1px',
     fontSize: 16,
     fontWeight: 'bold' as const,
-    fontFamily: 'monospace',
+    fontFamily: '"Emoji Flags Polyfill", monospace',
 }
 
 interface AutocaptureElementLabelProps extends React.PropsWithoutRef<JSX.IntrinsicElements['div']> {


### PR DESCRIPTION
Some places still aren't displaying flags in Windows OS. The reason behind this is twofold:
- When we changed to Tailwind we didnt configure this properly
- Some charts are overriding the config

Extracted from https://github.com/PostHog/posthog/pull/30704
