### PR TITLE
chore: add product intent activation criteria for surveys

### DIFF
--- a/posthog/models/product_intent/product_intent.py
+++ b/posthog/models/product_intent/product_intent.py
@@ -107,7 +107,7 @@ class ProductIntent(UUIDModel):
         return ErrorTrackingIssue.objects.filter(team=self.team, status=ErrorTrackingIssue.Status.RESOLVED).exists()
 
     def has_activated_surveys(self) -> bool:
-        return Survey.objects.filter(team=self.team, start_date__isnull=False).exists()
+        return Survey.objects.filter(team__project_id=self.team.project_id, start_date__isnull=False).exists()
 
     def has_activated_feature_flags(self) -> bool:
         # Get feature flags that have at least one filter group, excluding ones used by experiments and surveys

--- a/posthog/models/product_intent/product_intent.py
+++ b/posthog/models/product_intent/product_intent.py
@@ -106,6 +106,9 @@ class ProductIntent(UUIDModel):
         # the team has resolved any issues
         return ErrorTrackingIssue.objects.filter(team=self.team, status=ErrorTrackingIssue.Status.RESOLVED).exists()
 
+    def has_activated_surveys(self) -> bool:
+        return Survey.objects.filter(team=self.team, start_date__isnull=False).exists()
+
     def has_activated_feature_flags(self) -> bool:
         # Get feature flags that have at least one filter group, excluding ones used by experiments and surveys
         experiment_flags = Experiment.objects.filter(team=self.team).values_list("feature_flag_id", flat=True)
@@ -159,6 +162,7 @@ class ProductIntent(UUIDModel):
             "feature_flags": self.has_activated_feature_flags,
             "session_replay": self.has_activated_session_replay,
             "error_tracking": self.has_activated_error_tracking,
+            "surveys": self.has_activated_surveys,
         }
 
         if self.product_type in activation_checks and activation_checks[self.product_type]():

--- a/posthog/models/test/test_product_intent.py
+++ b/posthog/models/test/test_product_intent.py
@@ -262,3 +262,23 @@ class TestProductIntent(BaseTest):
             recording.check_viewed_for_user(self.user, save_viewed=True)
 
         assert self.product_intent.has_activated_session_replay() is False
+
+    def test_has_activated_surveys_with_launched(self):
+        self.product_intent.product_type = "surveys"
+        self.product_intent.save()
+
+        Survey.objects.create(team=self.team, name="Survey Test", start_date=datetime.now(tz=UTC))
+        assert self.product_intent.has_activated_surveys() is True
+
+    def test_has_not_activated_surveys_with_no_surveys(self):
+        self.product_intent.product_type = "surveys"
+        self.product_intent.save()
+
+        assert self.product_intent.has_activated_surveys() is False
+
+    def test_has_not_activated_surveys_with_unlaunched_survey(self):
+        self.product_intent.product_type = "surveys"
+        self.product_intent.save()
+
+        Survey.objects.create(team=self.team, name="Survey Test")
+        assert self.product_intent.has_activated_surveys() is False


### PR DESCRIPTION
## Problem

Currently there is no activation criteria registered for surveys

## Changes

This adds the criteria of 1 launched survey

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added unit tests
