### PR TITLE
chore: API queries report usage only on successfully finished queries.

### DIFF
--- a/posthog/tasks/test/__snapshots__/test_usage_report.ambr
+++ b/posthog/tasks/test/__snapshots__/test_usage_report.ambr
@@ -202,7 +202,7 @@
          count(1) cnt,
          sum(read_bytes) read_bytes
   FROM clusterAllReplicas(posthog, system.query_log)
-  WHERE type != 'QueryStart'
+  WHERE type = 'QueryFinish'
     AND is_initial_query
     AND event_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
     AND team_id > 0

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -684,7 +684,7 @@ def get_teams_with_api_queries_metrics(
     query = f"""
         SELECT JSONExtractInt(log_comment, 'team_id') team_id, count(1) cnt, sum(read_bytes) read_bytes
         FROM clusterAllReplicas({CLICKHOUSE_CLUSTER}, system.query_log)
-        WHERE type != 'QueryStart'
+        WHERE type = 'QueryFinish'
         AND is_initial_query
         AND event_time between %(begin)s AND %(end)s
         AND team_id > 0


### PR DESCRIPTION
## Problem

We should not charge on failed queries.

## Changes

Change API Queries usage report SQL

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Have tests + run locally