### PR TITLE
fix(devex): convert kea connects to functions everywhere

### DIFF
--- a/frontend/src/layout/FeaturePreviews/featurePreviewsLogic.tsx
+++ b/frontend/src/layout/FeaturePreviews/featurePreviewsLogic.tsx
@@ -21,10 +21,10 @@ export interface EnrichedEarlyAccessFeature extends Omit<EarlyAccessFeature, 'fl
 
 export const featurePreviewsLogic = kea<featurePreviewsLogicType>([
     path(['layout', 'FeaturePreviews', 'featurePreviewsLogic']),
-    connect({
+    connect(() => ({
         values: [featureFlagLogic, ['featureFlags'], userLogic, ['user']],
         actions: [supportLogic, ['submitZendeskTicket']],
-    }),
+    })),
     actions({
         updateEarlyAccessFeatureEnrollment: (flagKey: string, enabled: boolean) => ({ flagKey, enabled }),
         beginEarlyAccessFeatureFeedback: (flagKey: string) => ({ flagKey }),

--- a/frontend/src/layout/navigation-3000/sidebars/annotations.tsx
+++ b/frontend/src/layout/navigation-3000/sidebars/annotations.tsx
@@ -23,10 +23,10 @@ const fuse = new Fuse<AnnotationType>([], {
 
 export const annotationsSidebarLogic = kea<annotationsSidebarLogicType>([
     path(['layout', 'navigation-3000', 'sidebars', 'annotationsSidebarLogic']),
-    connect({
+    connect(() => ({
         values: [annotationsModel, ['annotations', 'annotationsLoading'], sceneLogic, ['activeScene', 'sceneParams']],
         actions: [annotationsModel, ['deleteAnnotation'], annotationModalLogic, ['openModalToCreateAnnotation']],
-    }),
+    })),
     selectors(({ actions }) => ({
         contents: [
             (s) => [s.relevantAnnotations, s.annotationsLoading],

--- a/frontend/src/layout/navigation-3000/sidebars/cohorts.ts
+++ b/frontend/src/layout/navigation-3000/sidebars/cohorts.ts
@@ -25,10 +25,10 @@ const fuse = new Fuse<CohortType>([], {
 
 export const cohortsSidebarLogic = kea<cohortsSidebarLogicType>([
     path(['layout', 'navigation-3000', 'sidebars', 'cohortsSidebarLogic']),
-    connect({
+    connect(() => ({
         values: [cohortsModel, ['cohorts', 'cohortsLoading'], sceneLogic, ['activeScene', 'sceneParams']],
         actions: [cohortsModel, ['loadCohorts', 'deleteCohort']],
-    }),
+    })),
     selectors(({ actions }) => ({
         contents: [
             (s) => [s.relevantCohorts, s.cohortsLoading],

--- a/frontend/src/layout/navigation-3000/sidebars/dashboards.tsx
+++ b/frontend/src/layout/navigation-3000/sidebars/dashboards.tsx
@@ -29,7 +29,7 @@ const fuse = new Fuse<DashboardType>([], {
 
 export const dashboardsSidebarLogic = kea<dashboardsSidebarLogicType>([
     path(['layout', 'navigation-3000', 'sidebars', 'dashboardsSidebarLogic']),
-    connect({
+    connect(() => ({
         values: [
             dashboardsModel,
             ['pinSortedDashboards', 'dashboardsLoading'],
@@ -46,7 +46,7 @@ export const dashboardsSidebarLogic = kea<dashboardsSidebarLogicType>([
             newDashboardLogic,
             ['showNewDashboardModal'],
         ],
-    }),
+    })),
     selectors(({ actions }) => ({
         contents: [
             (s) => [s.relevantDashboards, s.dashboardsLoading],

--- a/frontend/src/layout/navigation-3000/sidebars/experiments.ts
+++ b/frontend/src/layout/navigation-3000/sidebars/experiments.ts
@@ -25,10 +25,10 @@ const EXPERIMENT_STATUS_TO_RIBBON_STATUS = { draft: 'muted', running: 'success',
 
 export const experimentsSidebarLogic = kea<experimentsSidebarLogicType>([
     path(['layout', 'navigation-3000', 'sidebars', 'experimentsSidebarLogic']),
-    connect({
+    connect(() => ({
         values: [experimentsLogic, ['experiments', 'experimentsLoading'], sceneLogic, ['activeScene', 'sceneParams']],
         actions: [experimentsLogic, ['loadExperiments', 'deleteExperiment']],
-    }),
+    })),
     selectors(({ actions }) => ({
         contents: [
             (s) => [s.relevantExperiments, s.experimentsLoading],

--- a/frontend/src/layout/navigation-3000/sidebars/featureFlags.tsx
+++ b/frontend/src/layout/navigation-3000/sidebars/featureFlags.tsx
@@ -32,7 +32,7 @@ const fuse = new Fuse<FeatureFlagType>([], {
 
 export const featureFlagsSidebarLogic = kea<featureFlagsSidebarLogicType>([
     path(['layout', 'navigation-3000', 'sidebars', 'featureFlagsSidebarLogic']),
-    connect({
+    connect(() => ({
         values: [
             featureFlagsLogic,
             ['featureFlags', 'featureFlagsLoading'],
@@ -44,7 +44,7 @@ export const featureFlagsSidebarLogic = kea<featureFlagsSidebarLogicType>([
             ['aggregationLabel'],
         ],
         actions: [featureFlagsLogic, ['updateFeatureFlag', 'loadFeatureFlags']],
-    }),
+    })),
     selectors(({ actions }) => ({
         contents: [
             (s) => [s.relevantFeatureFlags, s.featureFlagsLoading, s.currentProjectId, s.aggregationLabel],

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/accessControlLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/accessControlLogic.ts
@@ -34,7 +34,7 @@ export const accessControlLogic = kea<accessControlLogicType>([
     props({} as AccessControlLogicProps),
     key((props) => `${props.resource}-${props.resource_id}`),
     path((key) => ['scenes', 'accessControl', 'accessControlLogic', key]),
-    connect({
+    connect(() => ({
         values: [
             membersLogic,
             ['sortedMembers'],
@@ -46,7 +46,7 @@ export const accessControlLogic = kea<accessControlLogicType>([
             ['guardAvailableFeature'],
         ],
         actions: [membersLogic, ['ensureAllMembersLoaded']],
-    }),
+    })),
     actions({
         updateAccessControl: (
             accessControl: Pick<AccessControlType, 'access_level' | 'organization_member' | 'role'>

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/roleBasedAccessControlLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/roleBasedAccessControlLogic.ts
@@ -27,10 +27,10 @@ export type RoleWithResourceAccessControls = {
 
 export const roleBasedAccessControlLogic = kea<roleBasedAccessControlLogicType>([
     path(['scenes', 'accessControl', 'roleBasedAccessControlLogic']),
-    connect({
+    connect(() => ({
         values: [membersLogic, ['sortedMembers'], teamLogic, ['currentTeam'], userLogic, ['hasAvailableFeature']],
         actions: [membersLogic, ['ensureAllMembersLoaded']],
-    }),
+    })),
     actions({
         updateRoleBasedAccessControls: (
             accessControls: Pick<AccessControlUpdateType, 'resource' | 'access_level' | 'role'>[]

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelActivityLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelActivityLogic.tsx
@@ -45,10 +45,10 @@ export enum SidePanelActivityTab {
 
 export const sidePanelActivityLogic = kea<sidePanelActivityLogicType>([
     path(['scenes', 'navigation', 'sidepanel', 'sidePanelActivityLogic']),
-    connect({
+    connect(() => ({
         values: [sidePanelContextLogic, ['sceneSidePanelContext'], projectLogic, ['currentProjectId']],
         actions: [sidePanelStateLogic, ['openSidePanel']],
-    }),
+    })),
     actions({
         togglePolling: (pageIsVisible: boolean) => ({ pageIsVisible }),
         incrementErrorCount: true,

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/discussion/sidePanelDiscussionLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/discussion/sidePanelDiscussionLogic.ts
@@ -15,9 +15,9 @@ export const sidePanelDiscussionLogic = kea<sidePanelDiscussionLogicType>([
         loadCommentCount: true,
         resetCommentCount: true,
     }),
-    connect({
+    connect(() => ({
         values: [featureFlagLogic, ['featureFlags'], sidePanelContextLogic, ['sceneSidePanelContext']],
-    }),
+    })),
     loaders(({ values }) => ({
         commentCount: [
             0,

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/exports/sidePanelExportsLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/exports/sidePanelExportsLogic.ts
@@ -7,10 +7,10 @@ import type { sidePanelExportsLogicType } from './sidePanelExportsLogicType'
 
 export const sidePanelExportsLogic = kea<sidePanelExportsLogicType>([
     path(['scenes', 'navigation', 'sidepanel', 'sidePanelExportsLogic']),
-    connect({
+    connect(() => ({
         values: [exportsLogic, ['exports', 'freshUndownloadedExports']],
         actions: [sidePanelStateLogic, ['openSidePanel'], exportsLogic, ['loadExports', 'removeFresh']],
-    }),
+    })),
     afterMount(({ actions }) => {
         actions.loadExports()
     }),

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelContextLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelContextLogic.ts
@@ -27,9 +27,9 @@ export const activityFiltersForScene = (sceneConfig: SceneConfig | null): SidePa
 
 export const sidePanelContextLogic = kea<sidePanelContextLogicType>([
     path(['scenes', 'navigation', 'sidepanel', 'sidePanelContextLogic']),
-    connect({
+    connect(() => ({
         values: [sceneLogic, ['sceneConfig']],
-    }),
+    })),
 
     selectors({
         sceneSidePanelContext: [

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelDocsLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelDocsLogic.ts
@@ -34,10 +34,10 @@ export type SidePanelDocsLogicProps = {
 export const sidePanelDocsLogic = kea<sidePanelDocsLogicType>([
     path(['scenes', 'navigation', 'sidepanel', 'sidePanelDocsLogic']),
     props({} as SidePanelDocsLogicProps),
-    connect({
+    connect(() => ({
         actions: [sidePanelStateLogic, ['openSidePanel', 'closeSidePanel', 'setSidePanelOptions']],
         values: [sceneLogic, ['sceneConfig'], sidePanelStateLogic, ['selectedTabOptions']],
-    }),
+    })),
 
     actions({
         updatePath: (path: string) => ({ path }),

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelSettingsLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelSettingsLogic.tsx
@@ -9,10 +9,10 @@ import type { sidePanelSettingsLogicType } from './sidePanelSettingsLogicType'
 
 export const sidePanelSettingsLogic = kea<sidePanelSettingsLogicType>([
     path(['scenes', 'navigation', 'sidepanel', 'sidePanelSettingsLogic']),
-    connect({
+    connect(() => ({
         values: [featureFlagLogic, ['featureFlags']],
         actions: [sidePanelStateLogic, ['openSidePanel', 'closeSidePanel']],
-    }),
+    })),
 
     actions({
         openSettingsPanel: (settingsLogicProps: SettingsLogicProps) => ({

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelStatusLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/sidePanelStatusLogic.tsx
@@ -92,9 +92,9 @@ export const REFRESH_INTERVAL = 60 * 1000 * 5 // 5 minutes
 
 export const sidePanelStatusLogic = kea<sidePanelStatusLogicType>([
     path(['scenes', 'navigation', 'sidepanel', 'sidePanelStatusLogic']),
-    connect({
+    connect(() => ({
         actions: [sidePanelStateLogic, ['openSidePanel', 'closeSidePanel']],
-    }),
+    })),
 
     actions({
         loadStatusPage: true,

--- a/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
@@ -25,7 +25,7 @@ const ALWAYS_EXTRA_TABS = [
 
 export const sidePanelLogic = kea<sidePanelLogicType>([
     path(['scenes', 'navigation', 'sidepanel', 'sidePanelLogic']),
-    connect({
+    connect(() => ({
         values: [
             featureFlagLogic,
             ['featureFlags'],
@@ -48,7 +48,7 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
             ['currentTeam'],
         ],
         actions: [sidePanelStateLogic, ['closeSidePanel', 'openSidePanel']],
-    }),
+    })),
 
     selectors({
         enabledTabs: [

--- a/frontend/src/layout/navigation-3000/themeLogic.ts
+++ b/frontend/src/layout/navigation-3000/themeLogic.ts
@@ -9,9 +9,9 @@ import { Theme, themes } from './themes'
 
 export const themeLogic = kea<themeLogicType>([
     path(['layout', 'navigation-3000', 'themeLogic']),
-    connect({
+    connect(() => ({
         values: [userLogic, ['themeMode'], featureFlagLogic, ['featureFlags']],
-    }),
+    })),
     actions({
         syncDarkModePreference: (darkModePreference: boolean) => ({ darkModePreference }),
         setTheme: (theme: string | null) => ({ theme }),

--- a/frontend/src/layout/navigation/environmentsSwitcherLogic.tsx
+++ b/frontend/src/layout/navigation/environmentsSwitcherLogic.tsx
@@ -22,9 +22,9 @@ export interface TeamBasicTypeWithProjectName extends TeamBasicType {
 
 export const environmentSwitcherLogic = kea<environmentSwitcherLogicType>([
     path(['layout', 'navigation', 'environmentsSwitcherLogic']),
-    connect({
+    connect(() => ({
         values: [userLogic, ['user'], teamLogic, ['currentTeam'], organizationLogic, ['currentOrganization']],
-    }),
+    })),
     actions({
         setEnvironmentSwitcherSearch: (input: string) => ({ input }),
     }),

--- a/frontend/src/layout/panel-layout/PersonsTree/personsTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/PersonsTree/personsTreeLogic.tsx
@@ -10,9 +10,9 @@ import type { personsTreeLogicType } from './personsTreeLogicType'
 
 export const personsTreeLogic = kea<personsTreeLogicType>([
     path(['layout', 'panel-layout', 'personsTreeLogic']),
-    connect({
+    connect(() => ({
         values: [panelLayoutLogic, ['searchTerm']],
-    }),
+    })),
     loaders(({ values }) => ({
         rawSearchResponse: [
             null as SearchResponse | null,

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
@@ -27,7 +27,7 @@ const DELETE_ALERT_LIMIT = 0
 
 export const projectTreeLogic = kea<projectTreeLogicType>([
     path(['layout', 'navigation-3000', 'components', 'projectTreeLogic']),
-    connect({
+    connect(() => ({
         values: [
             groupsModel,
             ['aggregationLabel', 'groupTypes', 'groupsAccessStatus'],
@@ -39,7 +39,7 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
             ['projectTreeRef'],
         ],
         actions: [panelLayoutLogic, ['setSearchTerm']],
-    }),
+    })),
     actions({
         loadUnfiledItems: true,
         addFolder: (folder: string) => ({ folder }),

--- a/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
+++ b/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
@@ -10,9 +10,9 @@ export type PanelLayoutMainContentRef = React.RefObject<HTMLElement> | null
 
 export const panelLayoutLogic = kea<panelLayoutLogicType>([
     path(['layout', 'panel-layout', 'panelLayoutLogic']),
-    connect({
+    connect(() => ({
         values: [navigation3000Logic, ['mobileLayout']],
-    }),
+    })),
     actions({
         showLayoutNavBar: (visible: boolean) => ({ visible }),
         showLayoutPanel: (visible: boolean) => ({ visible }),

--- a/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
+++ b/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
@@ -217,10 +217,10 @@ export const authorizedUrlListLogic = kea<authorizedUrlListLogicType>([
     path((key) => ['lib', 'components', 'AuthorizedUrlList', 'authorizedUrlListLogic', key]),
     key((props) => `${props.type}-${props.experimentId}-${props.actionId}`), // Some will be undefined but that's ok, this avoids experiment/action with same ID sharing same store
     props({} as AuthorizedUrlListLogicProps),
-    connect({
+    connect(() => ({
         values: [teamLogic, ['currentTeam', 'currentTeamId']],
         actions: [teamLogic, ['updateCurrentTeam']],
-    }),
+    })),
     actions(() => ({
         setAuthorizedUrls: (authorizedUrls: string[]) => ({ authorizedUrls }),
         addUrl: (url: string, launch?: boolean) => ({ url, launch }),

--- a/frontend/src/lib/components/Cards/TextCard/textCardModalLogic.ts
+++ b/frontend/src/lib/components/Cards/TextCard/textCardModalLogic.ts
@@ -27,7 +27,7 @@ export const textCardModalLogic = kea<textCardModalLogicType>([
     path(['scenes', 'dashboard', 'dashboardTextTileModal', 'logic']),
     props({} as TextCardModalProps),
     key((props) => `textCardModalLogic-${props.dashboard.id}-${props.textTileId}`),
-    connect({ actions: [dashboardsModel, ['updateDashboard']] }),
+    connect(() => ({ actions: [dashboardsModel, ['updateDashboard']] })),
     listeners(({ props, actions }) => ({
         submitTextTileFailure: (error) => {
             if (props.dashboard && props.textTileId) {

--- a/frontend/src/lib/components/CommandBar/actionBarLogic.ts
+++ b/frontend/src/lib/components/CommandBar/actionBarLogic.ts
@@ -9,7 +9,7 @@ import { BarStatus } from './types'
 
 export const actionBarLogic = kea<actionBarLogicType>([
     path(['lib', 'components', 'CommandBar', 'actionBarLogic']),
-    connect({
+    connect(() => ({
         actions: [
             commandBarLogic,
             ['hideCommandBar', 'setCommandBar', 'clearInitialQuery'],
@@ -31,7 +31,7 @@ export const actionBarLogic = kea<actionBarLogicType>([
                 'activeFlow',
             ],
         ],
-    }),
+    })),
     listeners(({ actions }) => ({
         hidePalette: () => {
             // listen on hide action from legacy palette, and hide command bar

--- a/frontend/src/lib/components/CommandBar/commandBarLogic.ts
+++ b/frontend/src/lib/components/CommandBar/commandBarLogic.ts
@@ -8,9 +8,9 @@ import { BarStatus } from './types'
 
 export const commandBarLogic = kea<commandBarLogicType>([
     path(['lib', 'components', 'CommandBar', 'commandBarLogic']),
-    connect({
+    connect(() => ({
         actions: [eventUsageLogic, ['reportCommandBarStatusChanged']],
-    }),
+    })),
     actions({
         setCommandBar: (status: BarStatus, initialQuery?: string) => ({ status, initialQuery }),
         hideCommandBar: true,

--- a/frontend/src/lib/components/CommandBar/searchBarLogic.ts
+++ b/frontend/src/lib/components/CommandBar/searchBarLogic.ts
@@ -45,7 +45,7 @@ function rankGroups(groups: Group[], query: string): GroupResult[] {
 
 export const searchBarLogic = kea<searchBarLogicType>([
     path(['lib', 'components', 'CommandBar', 'searchBarLogic']),
-    connect({
+    connect(() => ({
         values: [commandBarLogic, ['initialQuery', 'barStatus'], groupsModel, ['groupTypes', 'aggregationLabel']],
         actions: [
             commandBarLogic,
@@ -53,7 +53,7 @@ export const searchBarLogic = kea<searchBarLogicType>([
             eventUsageLogic,
             ['reportCommandBarSearch', 'reportCommandBarSearchResultOpened'],
         ],
-    }),
+    })),
     actions({
         search: true,
         setSearchQuery: (query: string) => ({ query }),

--- a/frontend/src/lib/components/CommandBar/shortcutsLogic.ts
+++ b/frontend/src/lib/components/CommandBar/shortcutsLogic.ts
@@ -5,9 +5,9 @@ import type { shortcutsLogicType } from './shortcutsLogicType'
 
 export const shortcutsLogic = kea<shortcutsLogicType>([
     path(['lib', 'components', 'CommandBar', 'shortcutsLogic']),
-    connect({
+    connect(() => ({
         actions: [commandBarLogic, ['hideCommandBar']],
-    }),
+    })),
     afterMount(({ actions, cache }) => {
         // register keyboard shortcuts
         cache.onKeyDown = (event: KeyboardEvent) => {

--- a/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
+++ b/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
@@ -140,7 +140,7 @@ function resolveCommand(source: Command | CommandFlow, argument?: string, prefix
 
 export const commandPaletteLogic = kea<commandPaletteLogicType>([
     path(['lib', 'components', 'CommandPalette', 'commandPaletteLogic']),
-    connect({
+    connect(() => ({
         actions: [
             router,
             ['push'],
@@ -168,7 +168,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
             ['sidePanelOpen'],
         ],
         logic: [preflightLogic],
-    }),
+    })),
     actions({
         hidePalette: true,
         showPalette: true,

--- a/frontend/src/lib/components/DefinitionPopover/definitionPopoverLogic.ts
+++ b/frontend/src/lib/components/DefinitionPopover/definitionPopoverLogic.ts
@@ -40,9 +40,9 @@ export interface DefinitionPopoverLogicProps {
 export const definitionPopoverLogic = kea<definitionPopoverLogicType>([
     props({} as DefinitionPopoverLogicProps),
     path(['lib', 'components', 'DefinitionPanel', 'definitionPopoverLogic']),
-    connect({
+    connect(() => ({
         values: [userLogic, ['hasAvailableFeature']],
-    }),
+    })),
     actions(({ values }) => ({
         setDefinition: (item: Partial<TaxonomicDefinitionTypes>) => ({ item, isDataWarehouse: values.isDataWarehouse }),
         setLocalDefinition: (item: Partial<TaxonomicDefinitionTypes>) => ({ item }),

--- a/frontend/src/lib/components/ExportButton/exportsLogic.ts
+++ b/frontend/src/lib/components/ExportButton/exportsLogic.ts
@@ -36,9 +36,9 @@ export const exportsLogic = kea<exportsLogicType>([
         createStaticCohort: (name: string, query: AnyDataNode) => ({ query, name }),
     }),
 
-    connect({
+    connect(() => ({
         actions: [sidePanelStateLogic, ['openSidePanel']],
-    }),
+    })),
 
     reducers({
         exports: [

--- a/frontend/src/lib/components/HelpButton/HelpButton.tsx
+++ b/frontend/src/lib/components/HelpButton/HelpButton.tsx
@@ -24,9 +24,9 @@ export const helpButtonLogic = kea<helpButtonLogicType>([
     ),
     key((props: { key?: string }) => props.key || 'global'),
     path((key) => ['lib', 'components', 'HelpButton', key]),
-    connect({
+    connect(() => ({
         actions: [eventUsageLogic, ['reportHelpButtonViewed']],
-    }),
+    })),
     actions({
         toggleHelp: true,
         showHelp: true,

--- a/frontend/src/lib/components/IframedToolbarBrowser/iframedToolbarBrowserLogic.ts
+++ b/frontend/src/lib/components/IframedToolbarBrowser/iframedToolbarBrowserLogic.ts
@@ -47,7 +47,7 @@ export const iframedToolbarBrowserLogic = kea<iframedToolbarBrowserLogicType>([
         automaticallyAuthorizeBrowserUrl: false,
     } as IframedToolbarBrowserLogicProps),
 
-    connect({
+    connect(() => ({
         values: [
             authorizedUrlListLogic({ ...defaultAuthorizedUrlProperties, type: AuthorizedUrlListType.TOOLBAR_URLS }),
             ['urlsKeyed', 'checkUrlIsAuthorized'],
@@ -60,7 +60,7 @@ export const iframedToolbarBrowserLogic = kea<iframedToolbarBrowserLogicType>([
             teamLogic,
             ['updateCurrentTeamSuccess'],
         ],
-    }),
+    })),
 
     actions({
         setBrowserUrl: (url: string | null) => ({ url }),

--- a/frontend/src/lib/components/Metalytics/metalyticsLogic.ts
+++ b/frontend/src/lib/components/Metalytics/metalyticsLogic.ts
@@ -13,9 +13,9 @@ import type { metalyticsLogicType } from './metalyticsLogicType'
 
 export const metalyticsLogic = kea<metalyticsLogicType>([
     path(['lib', 'components', 'metalytics', 'metalyticsLogic']),
-    connect({
+    connect(() => ({
         values: [sidePanelContextLogic, ['sceneSidePanelContext'], membersLogic, ['members']],
-    }),
+    })),
 
     loaders(({ values }) => ({
         viewCount: [

--- a/frontend/src/lib/components/PropertiesTimeline/propertiesTimelineLogic.ts
+++ b/frontend/src/lib/components/PropertiesTimeline/propertiesTimelineLogic.ts
@@ -39,9 +39,9 @@ export const propertiesTimelineLogic = kea<propertiesTimelineLogicType>([
     path(['lib', 'components', 'PropertiesTimeline', 'propertiesTimelineLogic']),
     props({} as PropertiesTimelineProps),
     key((props) => `${props.actor.id}-${JSON.stringify(props.filter)}`),
-    connect({
+    connect(() => ({
         values: [teamLogic, ['currentTeamId', 'timezone']],
-    }),
+    })),
     actions({
         setSelectedPointIndex: (index: number | null) => ({ index }),
     }),

--- a/frontend/src/lib/components/SceneDashboardChoice/sceneDashboardChoiceModalLogic.ts
+++ b/frontend/src/lib/components/SceneDashboardChoice/sceneDashboardChoiceModalLogic.ts
@@ -26,11 +26,11 @@ export const sceneDashboardChoiceModalLogic = kea<sceneDashboardChoiceModalLogic
     path((key) => ['lib', 'components', 'SceneDashboardChoice', 'sceneDashboardChoiceModalLogic', key || 'unknown']),
     props({} as SceneDashboardChoiceModalProps),
     key((props) => `${props.scene}`),
-    connect({
+    connect(() => ({
         logic: [eventUsageLogic],
         actions: [teamLogic, ['updateCurrentTeam'], userLogic, ['setUserScenePersonalisation']],
         values: [teamLogic, ['currentTeam'], userLogic, ['user'], dashboardsModel, ['nameSortedDashboards']],
-    }),
+    })),
     actions({
         showSceneDashboardChoiceModal: () => true,
         closeSceneDashboardChoiceModal: () => true,

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -96,7 +96,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
     props({} as TaxonomicFilterLogicProps),
     key((props) => `${props.taxonomicFilterLogicKey}`),
     path(['lib', 'components', 'TaxonomicFilter', 'taxonomicFilterLogic']),
-    connect({
+    connect(() => ({
         values: [
             teamLogic,
             ['currentTeamId'],
@@ -111,7 +111,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
             propertyDefinitionsModel,
             ['eventMetadataPropertyDefinitions'],
         ],
-    }),
+    })),
     actions(() => ({
         moveUp: true,
         moveDown: true,

--- a/frontend/src/lib/components/TimeSensitiveAuthentication/timeSensitiveAuthenticationLogic.ts
+++ b/frontend/src/lib/components/TimeSensitiveAuthentication/timeSensitiveAuthenticationLogic.ts
@@ -20,10 +20,10 @@ const LOOKAHEAD_EXPIRY_SECONDS = 60 * 5
 
 export const timeSensitiveAuthenticationLogic = kea<timeSensitiveAuthenticationLogicType>([
     path(['lib', 'components', 'timeSensitiveAuthenticationLogic']),
-    connect({
+    connect(() => ({
         values: [apiStatusLogic, ['timeSensitiveAuthenticationRequired'], userLogic, ['user']],
         actions: [apiStatusLogic, ['setTimeSensitiveAuthenticationRequired'], userLogic, ['loadUser']],
-    }),
+    })),
     actions({
         setDismissedReauthentication: (value: boolean) => ({ value }),
         setRequiresTwoFactor: (value: boolean) => ({ value }),

--- a/frontend/src/lib/components/ViewRecordingButton/sessionRecordingViewedLogic.ts
+++ b/frontend/src/lib/components/ViewRecordingButton/sessionRecordingViewedLogic.ts
@@ -18,9 +18,9 @@ export const sessionRecordingViewedLogic = kea<sessionRecordingViewedLogicType>(
     path(['lib', 'components', 'ViewRecordingButton', 'sessionRecordingViewedLogic']),
     key((props: Record<string, unknown>) => props.sessionRecordingId as string),
     props({} as unknown as SessionRecordingViewedProps),
-    connect({
+    connect(() => ({
         values: [teamLogic, ['currentTeamId']],
-    }),
+    })),
     loaders(({ props, values }) => ({
         recordingViewed: {
             loadRecordingViewed: async () => {

--- a/frontend/src/lib/integrations/integrationsLogic.ts
+++ b/frontend/src/lib/integrations/integrationsLogic.ts
@@ -36,9 +36,9 @@ const ICONS: Record<IntegrationKind, any> = {
 
 export const integrationsLogic = kea<integrationsLogicType>([
     path(['lib', 'integrations', 'integrationsLogic']),
-    connect({
+    connect(() => ({
         values: [preflightLogic, ['siteUrlMisconfigured', 'preflight']],
-    }),
+    })),
 
     actions({
         handleOauthCallback: (kind: IntegrationKind, searchParams: any) => ({ kind, searchParams }),

--- a/frontend/src/lib/integrations/slackIntegrationLogic.ts
+++ b/frontend/src/lib/integrations/slackIntegrationLogic.ts
@@ -11,9 +11,9 @@ export const slackIntegrationLogic = kea<slackIntegrationLogicType>([
     props({} as { id: number }),
     key((props) => props.id),
     path((key) => ['lib', 'integrations', 'slackIntegrationLogic', key]),
-    connect({
+    connect(() => ({
         values: [preflightLogic, ['siteUrlMisconfigured', 'preflight']],
-    }),
+    })),
     actions({
         loadAllSlackChannels: () => ({}),
         loadSlackChannelById: (channelId: string) => ({ channelId }),

--- a/frontend/src/lib/introductions/groupsAccessLogic.ts
+++ b/frontend/src/lib/introductions/groupsAccessLogic.ts
@@ -16,9 +16,9 @@ export enum GroupsAccessStatus {
 
 export const groupsAccessLogic = kea<groupsAccessLogicType>([
     path(['lib', 'introductions', 'groupsAccessLogic']),
-    connect({
+    connect(() => ({
         values: [teamLogic, ['currentTeam'], preflightLogic, ['preflight'], userLogic, ['hasAvailableFeature']],
-    }),
+    })),
     selectors({
         groupsEnabled: [
             (s) => [s.hasAvailableFeature],

--- a/frontend/src/lib/monaco/codeEditorLogic.tsx
+++ b/frontend/src/lib/monaco/codeEditorLogic.tsx
@@ -54,9 +54,9 @@ export const codeEditorLogic = kea<codeEditorLogicType>([
     actions({
         reloadMetadata: true,
     }),
-    connect({
+    connect(() => ({
         values: [featureFlagLogic, ['featureFlags']],
-    }),
+    })),
     loaders(({ props }) => ({
         metadata: [
             null as null | [string, HogQLMetadataResponse],

--- a/frontend/src/models/actionsModel.ts
+++ b/frontend/src/models/actionsModel.ts
@@ -19,9 +19,9 @@ export function findActionName(id: number): string | null {
 export const actionsModel = kea<actionsModelType>([
     props({} as ActionsModelProps),
     path(['models', 'actionsModel']),
-    connect({
+    connect(() => ({
         values: [teamLogic, ['currentTeam']],
-    }),
+    })),
     loaders(({ props, values, actions }) => ({
         actions: {
             __default: [] as ActionType[],

--- a/frontend/src/models/annotationsModel.ts
+++ b/frontend/src/models/annotationsModel.ts
@@ -31,7 +31,7 @@ export function serializeAnnotation(annotation: AnnotationType): RawAnnotationTy
 
 export const annotationsModel = kea<annotationsModelType>([
     path(['models', 'annotationsModel']),
-    connect({ values: [teamLogic, ['currentTeam', 'timezone']] }),
+    connect(() => ({ values: [teamLogic, ['currentTeam', 'timezone']] })),
     actions({
         deleteAnnotation: (annotation: AnnotationType) => ({ annotation }),
         loadAnnotationsNext: () => true,

--- a/frontend/src/models/dashboardsModel.tsx
+++ b/frontend/src/models/dashboardsModel.tsx
@@ -19,9 +19,9 @@ import type { dashboardsModelType } from './dashboardsModelType'
 
 export const dashboardsModel = kea<dashboardsModelType>([
     path(['models', 'dashboardsModel']),
-    connect({
+    connect(() => ({
         actions: [tagsModel, ['loadTags']],
-    }),
+    })),
     actions(() => ({
         // we page through the dashboards and need to manually track when that is finished
         dashboardsFullyLoaded: true,

--- a/frontend/src/models/groupPropertiesModel.ts
+++ b/frontend/src/models/groupPropertiesModel.ts
@@ -10,9 +10,9 @@ import type { groupPropertiesModelType } from './groupPropertiesModelType'
 
 export const groupPropertiesModel = kea<groupPropertiesModelType>([
     path(['models', 'groupPropertiesModel']),
-    connect({
+    connect(() => ({
         values: [projectLogic, ['currentProjectId'], groupsAccessLogic, ['groupsEnabled']],
-    }),
+    })),
     loaders(({ values }) => ({
         allGroupProperties: [
             {} as GroupTypeProperties,

--- a/frontend/src/models/groupsModel.ts
+++ b/frontend/src/models/groupsModel.ts
@@ -17,9 +17,9 @@ export interface Noun {
 
 export const groupsModel = kea<groupsModelType>([
     path(['models', 'groupsModel']),
-    connect({
+    connect(() => ({
         values: [projectLogic, ['currentProjectId'], groupsAccessLogic, ['groupsEnabled', 'groupsAccessStatus']],
-    }),
+    })),
     loaders(({ values }) => ({
         groupTypesRaw: [
             [] as Array<GroupType>,

--- a/frontend/src/models/insightsModel.tsx
+++ b/frontend/src/models/insightsModel.tsx
@@ -11,7 +11,7 @@ import type { insightsModelType } from './insightsModelType'
 
 export const insightsModel = kea<insightsModelType>([
     path(['models', 'insightsModel']),
-    connect({ logic: [teamLogic] }),
+    connect(() => ({ logic: [teamLogic] })),
     actions(() => ({
         renameInsight: (item: QueryBasedInsightModel) => ({ item }),
         renameInsightSuccess: (item: QueryBasedInsightModel) => ({ item }),

--- a/frontend/src/models/notebooksModel.ts
+++ b/frontend/src/models/notebooksModel.ts
@@ -74,9 +74,9 @@ export const notebooksModel = kea<notebooksModelType>([
         deleteNotebook: (shortId: NotebookListItemType['short_id'], title?: string) => ({ shortId, title }),
         createNotebookFromDashboard: (dashboard: DashboardType<QueryBasedInsightModel>) => ({ dashboard }),
     }),
-    connect({
+    connect(() => ({
         values: [projectLogic, ['currentProjectId']],
-    }),
+    })),
 
     reducers({
         scratchpadNotebook: [SCRATCHPAD_NOTEBOOK],

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -159,9 +159,9 @@ const constructValuesEndpoint = (
 
 export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
     path(['models', 'propertyDefinitionsModel']),
-    connect({
+    connect(() => ({
         values: [teamLogic, ['currentTeamId'], groupsModel, ['groupTypes']],
-    }),
+    })),
     actions({
         // public
         loadPropertyDefinitions: (

--- a/frontend/src/models/tagsModel.ts
+++ b/frontend/src/models/tagsModel.ts
@@ -7,7 +7,7 @@ import type { tagsModelType } from './tagsModelType'
 
 export const tagsModel = kea<tagsModelType>([
     path(['models', 'tagsModel']),
-    connect({ values: [organizationLogic, ['hasTagging']] }),
+    connect(() => ({ values: [organizationLogic, ['hasTagging']] })),
     loaders(({ values }) => ({
         tags: {
             __default: [] as string[],

--- a/frontend/src/queries/nodes/DataTable/ColumnConfigurator/columnConfiguratorLogic.tsx
+++ b/frontend/src/queries/nodes/DataTable/ColumnConfigurator/columnConfiguratorLogic.tsx
@@ -26,9 +26,9 @@ export const columnConfiguratorLogic = kea<columnConfiguratorLogicType>([
     props({} as ColumnConfiguratorLogicProps),
     path(['queries', 'nodes', 'DataTable', 'columnConfiguratorLogic']),
     key((props) => props.key),
-    connect({
+    connect(() => ({
         actions: [eventUsageLogic, ['reportDataTableColumnsUpdated'], groupsModel, ['setDefaultColumns']],
-    }),
+    })),
     actions({
         showModal: true,
         hideModal: true,

--- a/frontend/src/queries/nodes/DataVisualization/Components/ConditionalFormatting/conditionalFormattingLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/ConditionalFormatting/conditionalFormattingLogic.ts
@@ -18,9 +18,9 @@ export const conditionalFormattingLogic = kea<conditionalFormattingLogicType>([
     key((props) => props.rule.id),
     path(['queries', 'nodes', 'DataVisualization', 'Components', 'conditionalFormattingLogic']),
     props({ rule: { id: '' }, key: '' } as ConditionalFormattingLogicProps),
-    connect({
+    connect(() => ({
         actions: [dataVisualizationLogic, ['updateConditionalFormattingRule']],
-    }),
+    })),
     actions({
         selectColumn: (columnName: string) => ({ columnName }),
         updateInput: (input: string) => ({ input }),

--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/variableModalLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/variableModalLogic.ts
@@ -32,9 +32,9 @@ export const variableModalLogic = kea<variableModalLogicType>([
     path(['queries', 'nodes', 'DataVisualization', 'Components', 'Variables', 'variableLogic']),
     props({ key: '' } as AddVariableLogicProps),
     key((props) => props.key),
-    connect({
+    connect(() => ({
         actions: [variableDataLogic, ['getVariables'], variablesLogic, ['addVariable']],
-    }),
+    })),
     actions({
         openNewVariableModal: (variableType: VariableType) => ({ variableType }),
         openExistingVariableModal: (variable: Variable) => ({ variable }),

--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/variablesLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/variablesLogic.ts
@@ -39,10 +39,10 @@ export const variablesLogic = kea<variablesLogicType>([
     path(['queries', 'nodes', 'DataVisualization', 'Components', 'Variables', 'variablesLogic']),
     props({ key: '' } as VariablesLogicProps),
     key((props) => props.key),
-    connect({
+    connect(() => ({
         actions: [dataVisualizationLogic, ['setQuery', 'loadData'], variableDataLogic, ['getVariables']],
         values: [dataVisualizationLogic, ['query'], variableDataLogic, ['variables', 'variablesLoading']],
-    }),
+    })),
     actions(({ values }) => ({
         addVariable: (variable: HogQLVariable) => ({ variable }),
         _addVariable: (variable: HogQLVariable) => ({ variable }),

--- a/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
@@ -48,10 +48,10 @@ export const seriesBreakdownLogic = kea<seriesBreakdownLogicType>([
     path(['queries', 'nodes', 'DataVisualization', 'Components', 'seriesBreakdownLogic']),
     key((props) => props.key),
     props({ key: '' } as SeriesBreakdownLogicProps),
-    connect({
+    connect(() => ({
         actions: [dataVisualizationLogic, ['clearAxis', 'setQuery']],
         values: [dataVisualizationLogic, ['query', 'response', 'columns', 'selectedXAxis', 'selectedYAxis']],
-    }),
+    })),
     actions(({ values }) => ({
         addSeriesBreakdown: (columnName: string | null) => ({ columnName, response: values.response }),
         deleteSeriesBreakdown: () => ({}),

--- a/frontend/src/queries/nodes/DataVisualization/displayLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/displayLogic.ts
@@ -15,10 +15,10 @@ export const displayLogic = kea<displayLogicType>([
     key((props) => props.key),
     path(['queries', 'nodes', 'DataVisualization', 'displayLogic']),
     props({ key: '' } as DisplayLogicProps),
-    connect({
+    connect(() => ({
         values: [dataVisualizationLogic, ['yData', 'query', 'chartSettings']],
         actions: [dataVisualizationLogic, ['setQuery', 'updateChartSettings']],
-    }),
+    })),
     actions(({ values }) => ({
         addGoalLine: () => ({ yData: values.yData }),
         updateGoalLine: (goalLineIndex: number, key: string, value: string | number | boolean) => ({

--- a/frontend/src/queries/nodes/HogQLQuery/hogQLQueryEditorLogic.tsx
+++ b/frontend/src/queries/nodes/HogQLQuery/hogQLQueryEditorLogic.tsx
@@ -52,10 +52,10 @@ export const hogQLQueryEditorLogic = kea<hogQLQueryEditorLogicType>([
             actions.setQueryInput(props.query.query)
         }
     }),
-    connect({
+    connect(() => ({
         values: [featureFlagLogic, ['featureFlags']],
         actions: [dataWarehouseViewsLogic, ['createDataWarehouseSavedQuery'], dataWarehouseSceneLogic, ['updateView']],
-    }),
+    })),
     actions({
         saveQuery: (queryOverride?: string) => ({ queryOverride }),
         setQueryInput: (queryInput: string) => ({ queryInput }),

--- a/frontend/src/scenes/actions/actionEditLogic.tsx
+++ b/frontend/src/scenes/actions/actionEditLogic.tsx
@@ -35,7 +35,7 @@ export const actionEditLogic = kea<actionEditLogicType>([
     path((key) => ['scenes', 'actions', 'actionEditLogic', key]),
     props({} as ActionEditLogicProps),
     key((props) => props.id || 'new'),
-    connect({
+    connect(() => ({
         actions: [
             actionsModel,
             ['loadActions'],
@@ -45,7 +45,7 @@ export const actionEditLogic = kea<actionEditLogicType>([
             ['loadTags'],
         ],
         values: [sceneLogic, ['activeScene']],
-    }),
+    })),
     actions({
         setAction: (action: Partial<ActionType>, options: SetActionProps = { merge: true }) => ({
             action,

--- a/frontend/src/scenes/activity/explore/eventsSceneLogic.tsx
+++ b/frontend/src/scenes/activity/explore/eventsSceneLogic.tsx
@@ -17,7 +17,7 @@ import type { eventsSceneLogicType } from './eventsSceneLogicType'
 
 export const eventsSceneLogic = kea<eventsSceneLogicType>([
     path(['scenes', 'events', 'eventsSceneLogic']),
-    connect({ values: [teamLogic, ['currentTeam'], featureFlagLogic, ['featureFlags']] }),
+    connect(() => ({ values: [teamLogic, ['currentTeam'], featureFlagLogic, ['featureFlags']] })),
 
     actions({ setQuery: (query: Node) => ({ query }) }),
     reducers({ savedQuery: [null as Node | null, { setQuery: (_, { query }) => query }] }),

--- a/frontend/src/scenes/activity/live/liveEventsTableLogic.tsx
+++ b/frontend/src/scenes/activity/live/liveEventsTableLogic.tsx
@@ -17,9 +17,9 @@ export interface LiveEventsTableProps {
 export const liveEventsTableLogic = kea<liveEventsTableLogicType>([
     path(['scenes', 'activity', 'live-events', 'liveEventsTableLogic']),
     props({} as LiveEventsTableProps),
-    connect({
+    connect(() => ({
         values: [teamLogic, ['currentTeam']],
-    }),
+    })),
     actions(() => ({
         addEvents: (events) => ({ events }),
         clearEvents: true,

--- a/frontend/src/scenes/annotations/annotationModalLogic.ts
+++ b/frontend/src/scenes/annotations/annotationModalLogic.ts
@@ -39,7 +39,7 @@ export interface AnnotationModalForm {
 
 export const annotationModalLogic = kea<annotationModalLogicType>([
     path(['scenes', 'annotations', 'annotationModalLogic']),
-    connect({
+    connect(() => ({
         actions: [
             annotationsModel,
             [
@@ -60,7 +60,7 @@ export const annotationModalLogic = kea<annotationModalLogicType>([
             featureFlagLogic,
             ['featureFlags'],
         ],
-    }),
+    })),
     actions({
         openModalToCreateAnnotation: (
             initialDate?: Dayjs | null,

--- a/frontend/src/scenes/appContextLogic.ts
+++ b/frontend/src/scenes/appContextLogic.ts
@@ -13,7 +13,7 @@ import { userLogic } from './userLogic'
 
 export const appContextLogic = kea<appContextLogicType>([
     path(['scenes', 'appContextLogic']),
-    connect({
+    connect(() => ({
         actions: [
             userLogic,
             ['loadUserSuccess'],
@@ -24,7 +24,7 @@ export const appContextLogic = kea<appContextLogicType>([
             projectLogic,
             ['loadCurrentProject'],
         ],
-    }),
+    })),
     afterMount(({ actions }) => {
         const appContext = getAppContext()
         const preloadedUser = appContext?.current_user

--- a/frontend/src/scenes/authentication/login2FALogic.ts
+++ b/frontend/src/scenes/authentication/login2FALogic.ts
@@ -24,9 +24,9 @@ export enum LoginStep {
 
 export const login2FALogic = kea<login2FALogicType>([
     path(['scenes', 'authentication', 'login2FALogic']),
-    connect({
+    connect(() => ({
         values: [preflightLogic, ['preflight'], featureFlagLogic, ['featureFlags']],
-    }),
+    })),
     actions({
         setGeneralError: (code: string, detail: string) => ({ code, detail }),
         setLoginStep: (step: LoginStep) => ({ step }),

--- a/frontend/src/scenes/authentication/loginLogic.ts
+++ b/frontend/src/scenes/authentication/loginLogic.ts
@@ -52,9 +52,9 @@ export interface TwoFactorForm {
 
 export const loginLogic = kea<loginLogicType>([
     path(['scenes', 'authentication', 'loginLogic']),
-    connect({
+    connect(() => ({
         values: [preflightLogic, ['preflight'], featureFlagLogic, ['featureFlags']],
-    }),
+    })),
     actions({
         setGeneralError: (code: string, detail: string) => ({ code, detail }),
         clearGeneralError: true,

--- a/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
+++ b/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
@@ -36,9 +36,9 @@ export const emailRegex: RegExp =
 
 export const signupLogic = kea<signupLogicType>([
     path(['scenes', 'authentication', 'signupLogic']),
-    connect({
+    connect(() => ({
         values: [preflightLogic, ['preflight'], featureFlagLogic, ['featureFlags']],
-    }),
+    })),
     actions({
         setPanel: (panel: number) => ({ panel }),
     }),

--- a/frontend/src/scenes/authentication/twoFactorLogic.ts
+++ b/frontend/src/scenes/authentication/twoFactorLogic.ts
@@ -27,10 +27,10 @@ export interface TwoFactorLogicProps {
 export const twoFactorLogic = kea<twoFactorLogicType>([
     path(['scenes', 'authentication', 'loginLogic']),
     props({} as TwoFactorLogicProps),
-    connect({
+    connect(() => ({
         values: [preflightLogic, ['preflight'], featureFlagLogic, ['featureFlags'], userLogic, ['user']],
         actions: [userLogic, ['loadUser'], membersLogic, ['loadAllMembers']],
-    }),
+    })),
     actions({
         setGeneralError: (code: string, detail: string) => ({ code, detail }),
         clearGeneralError: true,

--- a/frontend/src/scenes/billing/billingProductLogic.ts
+++ b/frontend/src/scenes/billing/billingProductLogic.ts
@@ -50,7 +50,7 @@ export const billingProductLogic = kea<billingProductLogicType>([
     props({} as BillingProductLogicProps),
     key((props) => props.product.type),
     path(['scenes', 'billing', 'billingProductLogic']),
-    connect({
+    connect(() => ({
         values: [
             billingLogic,
             ['billing', 'isUnlicensedDebug', 'scrollToProductKey', 'unsubscribeError'],
@@ -70,7 +70,7 @@ export const billingProductLogic = kea<billingProductLogicType>([
                 'deactivateProductSuccess',
             ],
         ],
-    }),
+    })),
     actions({
         setIsEditingBillingLimit: (isEditingBillingLimit: boolean) => ({ isEditingBillingLimit }),
         setBillingLimitInput: (billingLimitInput: number | null) => ({ billingLimitInput }),

--- a/frontend/src/scenes/cohorts/CohortFilters/cohortFieldLogic.ts
+++ b/frontend/src/scenes/cohorts/CohortFilters/cohortFieldLogic.ts
@@ -26,9 +26,9 @@ export const cohortFieldLogic = kea<cohortFieldLogicType>([
     path(['scenes', 'cohorts', 'CohortFilters', 'cohortFieldLogic']),
     key((props) => `${props.cohortFilterLogicKey}`),
     props({} as CohortFieldLogicProps),
-    connect({
+    connect(() => ({
         values: [groupsModel, ['groupTypes', 'aggregationLabel'], userLogic, ['hasAvailableFeature']],
-    }),
+    })),
     propsChanged(({ actions, props }, oldProps) => {
         if (props.fieldKey && !objectsEqual(props.criteria, oldProps.criteria)) {
             actions.onChange(props.criteria)

--- a/frontend/src/scenes/dashboard/dashboardInsightColorsModalLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardInsightColorsModalLogic.ts
@@ -84,9 +84,9 @@ export function extractBreakdownValues(
 
 export const dashboardInsightColorsModalLogic = kea<dashboardInsightColorsModalLogicType>([
     path(['scenes', 'dashboard', 'dashboardInsightColorsModalLogic']),
-    connect({
+    connect(() => ({
         values: [cohortsModel, ['cohorts']],
-    }),
+    })),
     actions({
         showInsightColorsModal: (id: number) => ({ id }),
         hideInsightColorsModal: true,

--- a/frontend/src/scenes/dashboard/dashboardTemplateEditorLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardTemplateEditorLogic.ts
@@ -11,7 +11,7 @@ import type { dashboardTemplateEditorLogicType } from './dashboardTemplateEditor
 
 export const dashboardTemplateEditorLogic = kea<dashboardTemplateEditorLogicType>([
     path(['scenes', 'dashboard', 'dashboardTemplateEditorLogic']),
-    connect({ logic: [dashboardTemplatesLogic], values: [featureFlagLogic, ['featureFlags']] }),
+    connect(() => ({ logic: [dashboardTemplatesLogic], values: [featureFlagLogic, ['featureFlags']] })),
     actions({
         setEditorValue: (value: string) => ({ value }),
         setDashboardTemplate: (dashboardTemplate: DashboardTemplateEditorType) => ({

--- a/frontend/src/scenes/dashboard/dashboardTemplateVariablesLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardTemplateVariablesLogic.ts
@@ -29,9 +29,9 @@ const FALLBACK_EVENT = {
 export const dashboardTemplateVariablesLogic = kea<dashboardTemplateVariablesLogicType>([
     path(['scenes', 'dashboard', 'DashboardTemplateVariablesLogic']),
     props({ variables: [] } as DashboardTemplateVariablesLogicProps),
-    connect({
+    connect(() => ({
         actions: [iframedToolbarBrowserLogic, ['toolbarMessageReceived', 'disableElementSelector']],
-    }),
+    })),
     actions({
         setVariables: (variables: DashboardTemplateVariableType[]) => ({ variables }),
         setVariable: (variableName: string, filterGroup: Optional<FilterType, 'type'>) => ({

--- a/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
@@ -36,7 +36,7 @@ export type DashboardFuse = Fuse<DashboardBasicType> // This is exported for kea
 
 export const dashboardsLogic = kea<dashboardsLogicType>([
     path(['scenes', 'dashboard', 'dashboardsLogic']),
-    connect({ values: [userLogic, ['user'], featureFlagLogic, ['featureFlags']] }),
+    connect(() => ({ values: [userLogic, ['user'], featureFlagLogic, ['featureFlags']] })),
     actions({
         setCurrentTab: (tab: DashboardsTab) => ({ tab }),
         setFilters: (filters: Partial<DashboardsFilters>) => ({

--- a/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplatesLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplatesLogic.tsx
@@ -19,9 +19,9 @@ export const dashboardTemplatesLogic = kea<dashboardTemplatesLogicType>([
     path(['scenes', 'dashboard', 'dashboards', 'templates', 'dashboardTemplatesLogic']),
     props({} as DashboardTemplateProps),
     key(({ scope }) => scope ?? 'unknown'),
-    connect({
+    connect(() => ({
         values: [featureFlagLogic, ['featureFlags']],
-    }),
+    })),
     actions({
         setTemplates: (allTemplates: DashboardTemplateType[]) => ({ allTemplates }),
         setTemplateFilter: (search: string) => ({ search }),

--- a/frontend/src/scenes/dashboard/deleteDashboardLogic.ts
+++ b/frontend/src/scenes/dashboard/deleteDashboardLogic.ts
@@ -20,9 +20,9 @@ const defaultFormValues: DeleteDashboardForm = {
 
 export const deleteDashboardLogic = kea<deleteDashboardLogicType>([
     path(['scenes', 'dashboard', 'deleteDashboardLogic']),
-    connect({
+    connect(() => ({
         actions: [groupsModel, ['removeDetailDashboard']],
-    }),
+    })),
     actions({
         showDeleteDashboardModal: (id: number) => ({ id }),
         hideDeleteDashboardModal: true,

--- a/frontend/src/scenes/dashboard/duplicateDashboardLogic.ts
+++ b/frontend/src/scenes/dashboard/duplicateDashboardLogic.ts
@@ -24,7 +24,7 @@ const defaultFormValues: DuplicateDashboardForm = {
 
 export const duplicateDashboardLogic = kea<duplicateDashboardLogicType>([
     path(['scenes', 'dashboard', 'duplicateDashboardLogic']),
-    connect({ actions: [insightsModel, ['insightsAddedToDashboard']] }),
+    connect(() => ({ actions: [insightsModel, ['insightsAddedToDashboard']] })),
     actions({
         showDuplicateDashboardModal: (id: number, name: string) => ({
             id,

--- a/frontend/src/scenes/dashboard/newDashboardLogic.ts
+++ b/frontend/src/scenes/dashboard/newDashboardLogic.ts
@@ -102,10 +102,10 @@ export const newDashboardLogic = kea<newDashboardLogicType>([
     props({} as NewDashboardLogicProps),
     key(({ featureFlagId }) => featureFlagId ?? 'new'),
     path(['scenes', 'dashboard', 'newDashboardLogic']),
-    connect({
+    connect(() => ({
         logic: [dashboardsModel],
         values: [featureFlagLogic, ['featureFlags']],
-    }),
+    })),
     actions({
         setIsLoading: (isLoading: boolean) => ({ isLoading }),
         showNewDashboardModal: true,

--- a/frontend/src/scenes/data-management/DataManagementScene.tsx
+++ b/frontend/src/scenes/data-management/DataManagementScene.tsx
@@ -120,9 +120,9 @@ const tabs: Record<
 
 const dataManagementSceneLogic = kea<dataManagementSceneLogicType>([
     path(['scenes', 'events', 'dataManagementSceneLogic']),
-    connect({
+    connect(() => ({
         values: [featureFlagLogic, ['featureFlags']],
-    }),
+    })),
     actions({
         setTab: (tab: DataManagementTab) => ({ tab }),
     }),

--- a/frontend/src/scenes/data-management/ingestion-warnings/ingestionWarningsLogic.ts
+++ b/frontend/src/scenes/data-management/ingestion-warnings/ingestionWarningsLogic.ts
@@ -31,9 +31,9 @@ export interface IngestionWarning {
 export const ingestionWarningsLogic = kea<ingestionWarningsLogicType>([
     path(['scenes', 'data-management', 'ingestion-warnings', 'ingestionWarningsLogic']),
 
-    connect({
+    connect(() => ({
         values: [teamLogic, ['timezone'], projectLogic, ['currentProjectId']],
-    }),
+    })),
 
     actions({
         setSearchQuery: (search: string) => ({ search }),

--- a/frontend/src/scenes/data-management/properties/propertyDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/properties/propertyDefinitionsTableLogic.ts
@@ -48,9 +48,9 @@ export const propertyDefinitionsTableLogic = kea<propertyDefinitionsTableLogicTy
     path(['scenes', 'data-management', 'properties', 'propertyDefinitionsTableLogic']),
     props({} as PropertyDefinitionsTableLogicProps),
     key((props) => props.key || 'scene'),
-    connect({
+    connect(() => ({
         values: [groupsModel, ['groupTypes', 'aggregationLabel']],
-    }),
+    })),
     actions({
         loadPropertyDefinitions: (url: string | null = '') => ({
             url,

--- a/frontend/src/scenes/data-management/revenue/revenueEventsSettingsLogic.ts
+++ b/frontend/src/scenes/data-management/revenue/revenueEventsSettingsLogic.ts
@@ -31,10 +31,10 @@ const createEmptyConfig = (region: Region | null | undefined): RevenueTrackingCo
 
 export const revenueEventsSettingsLogic = kea<revenueEventsSettingsLogicType>([
     path(['scenes', 'data-management', 'revenue', 'revenueEventsSettingsLogic']),
-    connect({
+    connect(() => ({
         values: [teamLogic, ['currentTeam', 'currentTeamId'], preflightLogic, ['preflight']],
         actions: [teamLogic, ['updateCurrentTeam']],
-    }),
+    })),
     actions({
         updateBaseCurrency: (baseCurrency: CurrencyCode) => ({ baseCurrency }),
 

--- a/frontend/src/scenes/data-warehouse/editor/editorSceneLogic.ts
+++ b/frontend/src/scenes/data-warehouse/editor/editorSceneLogic.ts
@@ -47,7 +47,7 @@ export const editorSceneLogic = kea<editorSceneLogicType>([
             schema,
         }),
     }),
-    connect({
+    connect(() => ({
         values: [
             dataWarehouseJoinsLogic,
             ['joins', 'joinsLoading'],
@@ -64,7 +64,7 @@ export const editorSceneLogic = kea<editorSceneLogicType>([
             dataWarehouseJoinsLogic,
             ['loadJoins'],
         ],
-    }),
+    })),
     reducers({
         sidebarOverlayOpen: [
             false,

--- a/frontend/src/scenes/data-warehouse/editor/editorSidebarLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/editorSidebarLogic.tsx
@@ -42,7 +42,7 @@ const savedQueriesfuse = new Fuse<DataWarehouseSavedQuery>([], {
 
 export const editorSidebarLogic = kea<editorSidebarLogicType>([
     path(['data-warehouse', 'editor', 'editorSidebarLogic']),
-    connect({
+    connect(() => ({
         values: [
             sceneLogic,
             ['activeScene', 'sceneParams'],
@@ -61,7 +61,7 @@ export const editorSidebarLogic = kea<editorSidebarLogicType>([
             teamLogic,
             ['addProductIntent'],
         ],
-    }),
+    })),
     selectors(({ actions }) => ({
         contents: [
             (s) => [

--- a/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
@@ -85,7 +85,7 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
     path(['data-warehouse', 'editor', 'multitabEditorLogic']),
     props({} as MultitabEditorLogicProps),
     key((props) => props.key),
-    connect({
+    connect(() => ({
         values: [dataWarehouseViewsLogic, ['dataWarehouseSavedQueries'], userLogic, ['user']],
         actions: [
             dataWarehouseViewsLogic,
@@ -98,7 +98,7 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
             outputPaneLogic,
             ['setActiveTab'],
         ],
-    }),
+    })),
     actions({
         setQueryInput: (queryInput: string) => ({ queryInput }),
         updateState: (skipBreakpoint?: boolean) => ({ skipBreakpoint }),

--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -827,7 +827,7 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
         }),
         setIsProjectTime: (isProjectTime: boolean) => ({ isProjectTime }),
     }),
-    connect({
+    connect(() => ({
         values: [
             dataWarehouseTableLogic,
             ['tableLoading'],
@@ -844,7 +844,7 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
             teamLogic,
             ['addProductIntent'],
         ],
-    }),
+    })),
     reducers({
         manualLinkingProvider: [
             null as ManualLinkSourceType | null,

--- a/frontend/src/scenes/data-warehouse/settings/source/schemaLogLogic.ts
+++ b/frontend/src/scenes/data-warehouse/settings/source/schemaLogLogic.ts
@@ -19,9 +19,9 @@ export const schemaLogLogic = kea<schemaLogLogicType>([
     path(['scenes', 'data-warehouse', 'settings', 'source', 'schemaLogLogic']),
     props({} as SchemaLogLogicProps),
     key(({ job }) => job.id),
-    connect({
+    connect(() => ({
         values: [userLogic, ['user']],
-    }),
+    })),
     actions({
         clearBackgroundLogs: true,
         setSearchTerm: (searchTerm: string) => ({ searchTerm }),

--- a/frontend/src/scenes/data-warehouse/viewLinkLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/viewLinkLogic.tsx
@@ -25,10 +25,10 @@ export interface KeySelectOption {
 
 export const viewLinkLogic = kea<viewLinkLogicType>([
     path(['scenes', 'data-warehouse', 'viewLinkLogic']),
-    connect({
+    connect(() => ({
         values: [databaseTableListLogic, ['allTables']],
         actions: [databaseTableListLogic, ['loadDatabase'], dataWarehouseJoinsLogic, ['loadJoins']],
-    }),
+    })),
     actions(({ values }) => ({
         selectJoiningTable: (selectedTableName: string) => ({ selectedTableName }),
         selectSourceTable: (selectedTableName: string) => ({ selectedTableName }),

--- a/frontend/src/scenes/dataThemeLogic.tsx
+++ b/frontend/src/scenes/dataThemeLogic.tsx
@@ -31,7 +31,7 @@ export type DataThemeLogicProps = {
 export const dataThemeLogic = kea<dataThemeLogicType>([
     props({} as DataThemeLogicProps),
     path(['scenes', 'dataThemeLogic']),
-    connect({ values: [teamLogic, ['currentTeam']] }),
+    connect(() => ({ values: [teamLogic, ['currentTeam']] })),
     actions({ setThemes: (themes) => ({ themes }) }),
     loaders(({ props }) => ({
         themes: [

--- a/frontend/src/scenes/error-tracking/errorTrackingIssueSceneLogic.ts
+++ b/frontend/src/scenes/error-tracking/errorTrackingIssueSceneLogic.ts
@@ -34,10 +34,10 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
     props({} as ErrorTrackingIssueSceneLogicProps),
     key((props) => props.id),
 
-    connect({
+    connect(() => ({
         values: [errorTrackingLogic, ['dateRange', 'filterTestAccounts', 'filterGroup']],
         actions: [errorTrackingLogic, ['setDateRange', 'setFilterTestAccounts', 'setFilterGroup']],
-    }),
+    })),
 
     actions({
         loadIssue: true,

--- a/frontend/src/scenes/error-tracking/errorTrackingLogic.ts
+++ b/frontend/src/scenes/error-tracking/errorTrackingLogic.ts
@@ -19,9 +19,9 @@ export const DEFAULT_ERROR_TRACKING_FILTER_GROUP = {
 export const errorTrackingLogic = kea<errorTrackingLogicType>([
     path(['scenes', 'error-tracking', 'errorTrackingLogic']),
 
-    connect({
+    connect(() => ({
         values: [featureFlagLogic, ['featureFlags']],
-    }),
+    })),
 
     actions({
         setDateRange: (dateRange: DateRange) => ({ dateRange }),

--- a/frontend/src/scenes/error-tracking/errorTrackingSceneLogic.ts
+++ b/frontend/src/scenes/error-tracking/errorTrackingSceneLogic.ts
@@ -21,13 +21,13 @@ export type SparklineSelectedPeriod = 'custom' | 'day'
 export const errorTrackingSceneLogic = kea<errorTrackingSceneLogicType>([
     path(['scenes', 'error-tracking', 'errorTrackingSceneLogic']),
 
-    connect({
+    connect(() => ({
         values: [errorTrackingLogic, ['dateRange', 'assignee', 'filterTestAccounts', 'filterGroup', 'searchQuery']],
         actions: [
             errorTrackingLogic,
             ['setAssignee', 'setDateRange', 'setFilterGroup', 'setSearchQuery', 'setFilterTestAccounts'],
         ],
-    }),
+    })),
 
     actions({
         setOrderBy: (orderBy: ErrorTrackingQuery['orderBy']) => ({ orderBy }),

--- a/frontend/src/scenes/experiments/experimentsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.ts
@@ -37,7 +37,7 @@ export function getExperimentStatusColor(status: ProgressStatus): LemonTagType {
 
 export const experimentsLogic = kea<experimentsLogicType>([
     path(['scenes', 'experiments', 'experimentsLogic']),
-    connect({
+    connect(() => ({
         values: [
             projectLogic,
             ['currentProjectId'],
@@ -50,7 +50,7 @@ export const experimentsLogic = kea<experimentsLogicType>([
             router,
             ['location'],
         ],
-    }),
+    })),
     actions({
         setSearchTerm: (searchTerm: string) => ({ searchTerm }),
         setSearchStatus: (status: ProgressStatus | 'all') => ({ status }),

--- a/frontend/src/scenes/experiments/holdoutsLogic.tsx
+++ b/frontend/src/scenes/experiments/holdoutsLogic.tsx
@@ -43,9 +43,9 @@ export const holdoutsLogic = kea<holdoutsLogicType>([
         deleteHoldout: (id: number | null) => ({ id }),
         loadHoldout: (id: number | null) => ({ id }),
     }),
-    connect({
+    connect(() => ({
         actions: [eventUsageLogic, ['reportExperimentHoldoutCreated']],
-    }),
+    })),
     reducers({
         holdout: [
             NEW_HOLDOUT,

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsLogic.ts
@@ -32,9 +32,9 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
     path(['scenes', 'feature-flags', 'featureFlagReleaseConditionsLogic']),
     props({} as FeatureFlagReleaseConditionsLogicProps),
     key(({ id }) => id ?? 'unknown'),
-    connect({
+    connect(() => ({
         values: [projectLogic, ['currentProjectId'], groupsModel, ['groupTypes', 'aggregationLabel']],
-    }),
+    })),
     actions({
         setFilters: (filters: FeatureFlagFilters) => ({ filters }),
         setAggregationGroupTypeIndex: (value: number | null) => ({ value }),

--- a/frontend/src/scenes/feature-flags/featureFlagPermissionsLogic.tsx
+++ b/frontend/src/scenes/feature-flags/featureFlagPermissionsLogic.tsx
@@ -16,7 +16,7 @@ export const featureFlagPermissionsLogic = kea<featureFlagPermissionsLogicType>(
     path(['scenes', 'feature-flags', 'featureFlagPermissionsLogic']),
     props({} as FeatureFlagPermissionsLogicProps),
     key((props: FeatureFlagPermissionsLogicProps) => `${props.flagId}`),
-    connect({ values: [rolesLogic, ['roles']] }),
+    connect(() => ({ values: [rolesLogic, ['roles']] })),
     actions({
         setModalOpen: (visible: boolean) => ({ visible }),
         setRolesToAdd: (roleIds: string[]) => ({ roleIds }),
@@ -55,9 +55,8 @@ export const featureFlagPermissionsLogic = kea<featureFlagPermissionsLogicType>(
                         const response = await api.resourceAccessPermissions.featureFlags.list(props.flagId)
 
                         return response.results || []
-                    } else {
-                        return []
                     }
+                    return []
                 },
                 addAssociatedRoles: async (flagId?: number) => {
                     const { rolesToAdd } = values

--- a/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
@@ -61,9 +61,9 @@ export interface FlagLogicProps {
 export const featureFlagsLogic = kea<featureFlagsLogicType>([
     props({} as FlagLogicProps),
     path(['scenes', 'feature-flags', 'featureFlagsLogic']),
-    connect({
+    connect(() => ({
         values: [projectLogic, ['currentProjectId']],
-    }),
+    })),
     actions({
         updateFlag: (flag: FeatureFlagType) => ({ flag }),
         deleteFlag: (id: number) => ({ id }),

--- a/frontend/src/scenes/groups/groupLogic.ts
+++ b/frontend/src/scenes/groups/groupLogic.ts
@@ -50,7 +50,7 @@ export const groupLogic = kea<groupLogicType>([
     props({} as GroupLogicProps),
     key((props) => `${props.groupTypeIndex}-${props.groupKey}`),
     path((key) => ['scenes', 'groups', 'groupLogic', key]),
-    connect({
+    connect(() => ({
         actions: [groupsModel, ['createDetailDashboard']],
         values: [
             teamLogic,
@@ -60,7 +60,7 @@ export const groupLogic = kea<groupLogicType>([
             featureFlagLogic,
             ['featureFlags'],
         ],
-    }),
+    })),
     actions(() => ({
         setGroupData: (group: Group) => ({ group }),
         setGroupTab: (groupTab: string | null) => ({ groupTab }),

--- a/frontend/src/scenes/groups/groupsListLogic.ts
+++ b/frontend/src/scenes/groups/groupsListLogic.ts
@@ -18,7 +18,7 @@ export const groupsListLogic = kea<groupsListLogicType>([
     props({} as GroupsListLogicProps),
     key((props: GroupsListLogicProps) => props.groupTypeIndex),
     path(['groups', 'groupsListLogic']),
-    connect({
+    connect(() => ({
         values: [
             teamLogic,
             ['currentTeamId'],
@@ -27,7 +27,7 @@ export const groupsListLogic = kea<groupsListLogicType>([
             groupsAccessLogic,
             ['groupsEnabled'],
         ],
-    }),
+    })),
     actions(() => ({
         setQuery: (query: DataTableNode) => ({ query }),
     })),

--- a/frontend/src/scenes/groups/groupsSceneLogic.ts
+++ b/frontend/src/scenes/groups/groupsSceneLogic.ts
@@ -25,14 +25,14 @@ export type GroupsTabs = Record<string, { url: string; label: LemonTab<any>['lab
 
 export const groupsSceneLogic = kea<groupsSceneLogicType>([
     path(['scenes', 'groups', 'groupsSceneLogic']),
-    connect({
+    connect(() => ({
         values: [
             groupsModel,
             ['aggregationLabel', 'groupTypes', 'groupTypesLoading', 'groupsAccessStatus'],
             featureFlagLogic,
             ['featureFlags'],
         ],
-    }),
+    })),
     actions({
         setGroupTypeIndex: (groupTypeIndex: number) => ({ groupTypeIndex }),
         setTabKey: (tabKey: string) => ({ tabKey }),

--- a/frontend/src/scenes/groups/relatedGroupsLogic.ts
+++ b/frontend/src/scenes/groups/relatedGroupsLogic.ts
@@ -17,7 +17,7 @@ export const relatedGroupsLogic = kea<relatedGroupsLogicType>([
     ),
     key((props) => `${props.groupTypeIndex ?? 'person'}-${props.id}`),
     path(['scenes', 'groups', 'relatedGroupsLogic']),
-    connect({ values: [teamLogic, ['currentTeamId']] }),
+    connect(() => ({ values: [teamLogic, ['currentTeamId']] })),
     actions(() => ({
         loadRelatedActors: true,
     })),

--- a/frontend/src/scenes/heatmaps/heatmapsBrowserLogic.ts
+++ b/frontend/src/scenes/heatmaps/heatmapsBrowserLogic.ts
@@ -49,7 +49,7 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
     path(['scenes', 'heatmaps', 'heatmapsBrowserLogic']),
     props({} as HeatmapsBrowserLogicProps),
 
-    connect({
+    connect(() => ({
         values: [
             authorizedUrlListLogic({
                 ...defaultAuthorizedUrlProperties,
@@ -60,7 +60,7 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
             ['heatmapEmpty'],
         ],
         actions: [heatmapDataLogic, ['loadHeatmap', 'setFetchFn', 'setHref']],
-    }),
+    })),
 
     actions({
         setBrowserSearch: (searchTerm: string) => ({ searchTerm }),

--- a/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
@@ -74,9 +74,9 @@ export const entityFilterLogic = kea<entityFilterLogicType>([
     props({} as EntityFilterProps),
     key((props) => props.typeKey),
     path((key) => ['scenes', 'insights', 'ActionFilter', 'entityFilterLogic', key]),
-    connect({
+    connect(() => ({
         logic: [eventUsageLogic],
-    }),
+    })),
     actions({
         selectFilter: (filter: EntityFilter | ActionFilter | null) => ({ filter }),
         updateFilterMath: (

--- a/frontend/src/scenes/instance/AsyncMigrations/asyncMigrationsLogic.ts
+++ b/frontend/src/scenes/instance/AsyncMigrations/asyncMigrationsLogic.ts
@@ -71,9 +71,9 @@ export interface AsyncMigrationModalProps {
 
 export const asyncMigrationsLogic = kea<asyncMigrationsLogicType>([
     path(['scenes', 'instance', 'AsyncMigrations', 'asyncMigrationsLogic']),
-    connect({
+    connect(() => ({
         values: [preflightLogic, ['preflight']],
-    }),
+    })),
     actions({
         triggerMigration: (migration: AsyncMigration) => ({ migration }),
         resumeMigration: (migration: AsyncMigration) => ({ migration }),

--- a/frontend/src/scenes/instance/SystemStatus/staffUsersLogic.ts
+++ b/frontend/src/scenes/instance/SystemStatus/staffUsersLogic.ts
@@ -11,10 +11,10 @@ import type { staffUsersLogicType } from './staffUsersLogicType'
 
 export const staffUsersLogic = kea<staffUsersLogicType>([
     path(['scenes', 'instance', 'SystemStatus', 'staffUsersLogic']),
-    connect({
+    connect(() => ({
         values: [userLogic, ['user']],
         actions: [userLogic, ['loadUser']],
-    }),
+    })),
     actions({
         setStaffUsersToBeAdded: (userUuids: string[]) => ({ userUuids }),
         addStaffUsers: true,

--- a/frontend/src/scenes/max/maxGlobalLogic.ts
+++ b/frontend/src/scenes/max/maxGlobalLogic.ts
@@ -21,10 +21,10 @@ export interface ToolDefinition {
 
 export const maxGlobalLogic = kea<maxGlobalLogicType>([
     path(['scenes', 'max', 'maxGlobalLogic']),
-    connect({
+    connect(() => ({
         actions: [organizationLogic, ['updateOrganization']],
         values: [organizationLogic, ['currentOrganization']],
-    }),
+    })),
     actions({
         acceptDataProcessing: (testOnlyOverride?: boolean) => ({ testOnlyOverride }),
         registerTool: (tool: ToolDefinition) => ({ tool }),

--- a/frontend/src/scenes/max/maxLogic.ts
+++ b/frontend/src/scenes/max/maxLogic.ts
@@ -55,7 +55,7 @@ export const maxLogic = kea<maxLogicType>([
     path(['scenes', 'max', 'maxLogic']),
     props({} as MaxLogicProps),
     key(({ conversationId }) => conversationId || 'new-conversation'),
-    connect({
+    connect(() => ({
         values: [
             projectLogic,
             ['currentProject'],
@@ -67,7 +67,7 @@ export const maxLogic = kea<maxLogicType>([
             actionsModel({ params: 'include_count=1' }),
             ['actions'],
         ],
-    }),
+    })),
     actions({
         askMax: (prompt: string, generationAttempt: number = 0) => ({ prompt, generationAttempt }),
         stopGeneration: true,

--- a/frontend/src/scenes/notebooks/NotebookPanel/notebookPanelLogic.ts
+++ b/frontend/src/scenes/notebooks/NotebookPanel/notebookPanelLogic.ts
@@ -10,10 +10,10 @@ import type { notebookPanelLogicType } from './notebookPanelLogicType'
 
 export const notebookPanelLogic = kea<notebookPanelLogicType>([
     path(['scenes', 'notebooks', 'Notebook', 'notebookPanelLogic']),
-    connect({
+    connect(() => ({
         values: [sidePanelStateLogic, ['sidePanelOpen', 'selectedTab'], featureFlagLogic, ['featureFlags']],
         actions: [sidePanelStateLogic, ['openSidePanel', 'closeSidePanel']],
-    }),
+    })),
     actions({
         selectNotebook: (id: string, options: { autofocus?: EditorFocusPosition; silent?: boolean } = {}) => ({
             id,

--- a/frontend/src/scenes/notebooks/NotebooksTable/notebooksTableLogic.ts
+++ b/frontend/src/scenes/notebooks/NotebooksTable/notebooksTableLogic.ts
@@ -35,10 +35,10 @@ export const notebooksTableLogic = kea<notebooksTableLogicType>([
         }),
         setPage: (page: number) => ({ page }),
     }),
-    connect({
+    connect(() => ({
         values: [notebooksModel, ['notebookTemplates']],
         actions: [notebooksModel, ['deleteNotebookSuccess']],
-    }),
+    })),
     reducers({
         filters: [
             DEFAULT_FILTERS,

--- a/frontend/src/scenes/onboarding/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/onboardingLogic.tsx
@@ -73,7 +73,7 @@ export const onboardingLogic = kea<onboardingLogicType>([
     path(['scenes', 'onboarding', 'onboardingLogic']),
     // connect this so we start collecting live events the whole time during onboarding
     connect(liveEventsTableLogic({ showLiveStreamErrorToast: false })),
-    connect({
+    connect(() => ({
         values: [
             billingLogic,
             ['billing'],
@@ -96,7 +96,7 @@ export const onboardingLogic = kea<onboardingLogicType>([
             sidePanelStateLogic,
             ['openSidePanel'],
         ],
-    }),
+    })),
     actions({
         setProduct: (product: OnboardingProduct | null) => ({ product }),
         setProductKey: (productKey: string | null) => ({ productKey }),

--- a/frontend/src/scenes/onboarding/onboardingProductConfigurationLogic.ts
+++ b/frontend/src/scenes/onboarding/onboardingProductConfigurationLogic.ts
@@ -33,9 +33,9 @@ export type ProductConfigOption = ProductConfigurationToggle | ProductConfigurat
 
 export const onboardingProductConfigurationLogic = kea<onboardingProductConfigurationLogicType>([
     path(() => ['scenes', 'onboarding', 'onboardingProductConfigurationLogic']),
-    connect({
+    connect(() => ({
         actions: [teamLogic, ['updateCurrentTeam']],
-    }),
+    })),
     actions({
         setConfigOptions: (configOptions: ProductConfigOption[]) => ({ configOptions }),
         saveConfiguration: true,

--- a/frontend/src/scenes/onboarding/productAnalyticsSteps/onboardingTemplateConfigLogic.ts
+++ b/frontend/src/scenes/onboarding/productAnalyticsSteps/onboardingTemplateConfigLogic.ts
@@ -17,7 +17,7 @@ import type { onboardingTemplateConfigLogicType } from './onboardingTemplateConf
 
 export const onboardingTemplateConfigLogic = kea<onboardingTemplateConfigLogicType>([
     path(['scenes', 'onboarding', 'productAnalyticsSteps', 'onboardingTemplateConfigLogic']),
-    connect({
+    connect(() => ({
         values: [newDashboardLogic, ['activeDashboardTemplate'], dashboardTemplateVariablesLogic, ['activeVariable']],
         actions: [
             newDashboardLogic,
@@ -34,7 +34,7 @@ export const onboardingTemplateConfigLogic = kea<onboardingTemplateConfigLogicTy
             sidePanelStateLogic,
             ['closeSidePanel'],
         ],
-    }),
+    })),
     actions({
         setDashboardCreatedDuringOnboarding: (dashboard: DashboardType | null) => ({ dashboard }),
         showCustomEventField: true,

--- a/frontend/src/scenes/onboarding/sdks/sdksLogic.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdksLogic.tsx
@@ -44,7 +44,7 @@ export const multiInstallProducts = [ProductKey.PRODUCT_ANALYTICS, ProductKey.FE
 
 export const sdksLogic = kea<sdksLogicType>([
     path(['scenes', 'onboarding', 'sdks', 'sdksLogic']),
-    connect({
+    connect(() => ({
         values: [
             onboardingLogic,
             ['productKey'],
@@ -56,7 +56,7 @@ export const sdksLogic = kea<sdksLogicType>([
             ['user', 'isUserNonTechnical'],
         ],
         actions: [eventUsageLogic, ['reportSDKSelected']],
-    }),
+    })),
     actions({
         setSourceFilter: (sourceFilter: string | null) => ({ sourceFilter }),
         filterSDKs: true,

--- a/frontend/src/scenes/organization/membersLogic.tsx
+++ b/frontend/src/scenes/organization/membersLogic.tsx
@@ -20,9 +20,9 @@ const PAGINATION_LIMIT = 200
 
 export const membersLogic = kea<membersLogicType>([
     path(['scenes', 'organization', 'membersLogic']),
-    connect({
+    connect(() => ({
         values: [userLogic, ['user']],
-    }),
+    })),
     actions({
         ensureAllMembersLoaded: true,
         loadAllMembers: true,

--- a/frontend/src/scenes/persons-management/personsManagementSceneLogic.tsx
+++ b/frontend/src/scenes/persons-management/personsManagementSceneLogic.tsx
@@ -32,14 +32,14 @@ export type PersonsManagementTabs = Record<
 
 export const personsManagementSceneLogic = kea<personsManagementSceneLogicType>([
     path(['scenes', 'persons-management', 'personsManagementSceneLogic']),
-    connect({
+    connect(() => ({
         values: [
             groupsModel,
             ['aggregationLabel', 'groupTypes', 'groupTypesLoading', 'groupsAccessStatus'],
             featureFlagLogic,
             ['featureFlags'],
         ],
-    }),
+    })),
     actions({
         setTabKey: (tabKey: string) => ({ tabKey }),
     }),

--- a/frontend/src/scenes/persons/relatedFeatureFlagsLogic.ts
+++ b/frontend/src/scenes/persons/relatedFeatureFlagsLogic.ts
@@ -36,7 +36,7 @@ export interface RelatedFlagsFilters {
 
 export const relatedFeatureFlagsLogic = kea<relatedFeatureFlagsLogicType>([
     path(['scenes', 'persons', 'relatedFeatureFlagsLogic']),
-    connect({ values: [projectLogic, ['currentProjectId'], featureFlagsLogic, ['featureFlags']] }),
+    connect(() => ({ values: [projectLogic, ['currentProjectId'], featureFlagsLogic, ['featureFlags']] })),
     props(
         {} as {
             distinctId: string | null

--- a/frontend/src/scenes/pipeline/appsManagementLogic.tsx
+++ b/frontend/src/scenes/pipeline/appsManagementLogic.tsx
@@ -30,9 +30,9 @@ export interface PluginUpdateStatusType {
 
 export const appsManagementLogic = kea<appsManagementLogicType>([
     path(['scenes', 'pipeline', 'appsManagementLogic']),
-    connect({
+    connect(() => ({
         values: [userLogic, ['user'], pipelineAccessLogic, ['canGloballyManagePlugins']],
-    }),
+    })),
     actions({
         setPluginUrl: (pluginUrl: string) => ({ pluginUrl }),
         setLocalPluginPath: (localPluginPath: string) => ({ localPluginPath }),

--- a/frontend/src/scenes/pipeline/destinations/destinationsFiltersLogic.tsx
+++ b/frontend/src/scenes/pipeline/destinations/destinationsFiltersLogic.tsx
@@ -27,9 +27,9 @@ export const destinationsFiltersLogic = kea<destinationsFiltersLogicType>([
     path(() => ['scenes', 'pipeline', 'destinations', 'destinationsFiltersLogic']),
     props({} as DestinationsFiltersLogicProps),
     key((props) => props.types.join(',') ?? ''),
-    connect({
+    connect(() => ({
         values: [userLogic, ['user'], featureFlagLogic, ['featureFlags']],
-    }),
+    })),
     actions({
         setFilters: (filters: Partial<DestinationsFilters>) => ({ filters }),
         resetFilters: true,

--- a/frontend/src/scenes/pipeline/frontendAppsLogic.tsx
+++ b/frontend/src/scenes/pipeline/frontendAppsLogic.tsx
@@ -12,9 +12,9 @@ import { capturePluginEvent, checkPermissions, loadPluginsFromUrl } from './util
 
 export const frontendAppsLogic = kea<frontendAppsLogicType>([
     path(['scenes', 'pipeline', 'frontendAppsLogic']),
-    connect({
+    connect(() => ({
         values: [projectLogic, ['currentProjectId'], userLogic, ['user']],
-    }),
+    })),
     actions({
         loadPluginConfigs: true,
         updatePluginConfig: (pluginConfig: PluginConfigTypeNew) => ({ pluginConfig }),

--- a/frontend/src/scenes/pipeline/hogFunctionTestingLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogFunctionTestingLogic.tsx
@@ -31,14 +31,14 @@ export const hogFunctionTestingLogic = kea<hogFunctionTestingLogicType>([
     path((key) => ['scenes', 'pipeline', 'hogFunctionTestingLogic', key]),
     props({} as HogFunctionTestingLogicProps),
     key(({ id }: HogFunctionTestingLogicProps) => id),
-    connect({
+    connect(() => ({
         values: [
             hogFunctionConfigurationLogic,
             ['configuration', 'matchingFilters', 'templateId'],
             groupsModel,
             ['groupTypes'],
         ],
-    }),
+    })),
     actions({
         changeDateRange: (after: string | null, before: string | null) => ({ after, before }),
         addLoadingRetry: (eventId: string) => ({ eventId }),

--- a/frontend/src/scenes/pipeline/hogfunctions/email-templater/emailTemplaterLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/email-templater/emailTemplaterLogic.tsx
@@ -26,9 +26,9 @@ export interface EmailTemplaterLogicProps {
 
 export const emailTemplaterLogic = kea<emailTemplaterLogicType>([
     props({} as EmailTemplaterLogicProps),
-    connect({
+    connect(() => ({
         // values: [teamLogic, ['currentTeam'], groupsModel, ['groupTypes'], userLogic, ['hasAvailableFeature']],
-    }),
+    })),
     path(() => ['scenes', 'pipeline', 'hogfunctions', 'emailTemplaterLogic']),
     actions({
         onSave: true,

--- a/frontend/src/scenes/pipeline/hogfunctions/list/hogFunctionListLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/list/hogFunctionListLogic.tsx
@@ -47,7 +47,7 @@ export const hogFunctionListLogic = kea<hogFunctionListLogicType>([
     props({} as HogFunctionListLogicProps),
     key((props) => (props.syncFiltersWithUrl ? 'scene' : 'default') + (props.logicKey || props.type)),
     path((id) => ['scenes', 'pipeline', 'hogFunctionListLogic', id]),
-    connect({
+    connect(() => ({
         values: [
             projectLogic,
             ['currentProjectId'],
@@ -58,7 +58,7 @@ export const hogFunctionListLogic = kea<hogFunctionListLogicType>([
             featureFlagLogic,
             ['featureFlags'],
         ],
-    }),
+    })),
     actions({
         toggleEnabled: (hogFunction: HogFunctionType, enabled: boolean) => ({ hogFunction, enabled }),
         deleteHogFunction: (hogFunction: HogFunctionType) => ({ hogFunction }),

--- a/frontend/src/scenes/pipeline/hogfunctions/list/hogFunctionTemplateListLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/list/hogFunctionTemplateListLogic.tsx
@@ -63,7 +63,7 @@ export const hogFunctionTemplateListLogic = kea<hogFunctionTemplateListLogicType
             }`
     ),
     path((id) => ['scenes', 'pipeline', 'destinationsLogic', id]),
-    connect({
+    connect(() => ({
         values: [
             pipelineAccessLogic,
             ['canEnableNewDestinations'],
@@ -72,7 +72,7 @@ export const hogFunctionTemplateListLogic = kea<hogFunctionTemplateListLogicType
             userLogic,
             ['user'],
         ],
-    }),
+    })),
     actions({
         setFilters: (filters: Partial<HogFunctionTemplateListFilters>) => ({ filters }),
         resetFilters: true,

--- a/frontend/src/scenes/pipeline/importAppsLogic.tsx
+++ b/frontend/src/scenes/pipeline/importAppsLogic.tsx
@@ -12,9 +12,9 @@ import { capturePluginEvent, checkPermissions, loadPluginsFromUrl } from './util
 
 export const importAppsLogic = kea<importAppsLogicType>([
     path(['scenes', 'pipeline', 'importAppsLogic']),
-    connect({
+    connect(() => ({
         values: [projectLogic, ['currentProjectId'], userLogic, ['user']],
-    }),
+    })),
     actions({
         loadPluginConfigs: true,
         updatePluginConfig: (pluginConfig: PluginConfigTypeNew) => ({ pluginConfig }),

--- a/frontend/src/scenes/pipeline/overviewLogic.tsx
+++ b/frontend/src/scenes/pipeline/overviewLogic.tsx
@@ -8,7 +8,7 @@ import { pipelineTransformationsLogic } from './transformationsLogic'
 
 export const pipelineOverviewLogic = kea<pipelineOverviewLogicType>([
     path(['scenes', 'pipeline', 'overviewLogic']),
-    connect({
+    connect(() => ({
         values: [
             teamLogic,
             ['currentTeamId'],
@@ -27,5 +27,5 @@ export const pipelineOverviewLogic = kea<pipelineOverviewLogicType>([
                 'loadBatchExports as loadBatchExportConfigs',
             ],
         ],
-    }),
+    })),
 ])

--- a/frontend/src/scenes/pipeline/pipelineAccessLogic.tsx
+++ b/frontend/src/scenes/pipeline/pipelineAccessLogic.tsx
@@ -9,9 +9,9 @@ import { Destination, NewDestinationItemType, SiteApp, Transformation } from './
 
 export const pipelineAccessLogic = kea<pipelineAccessLogicType>([
     path(['scenes', 'pipeline', 'pipelineAccessLogic']),
-    connect({
+    connect(() => ({
         values: [userLogic, ['user', 'hasAvailableFeature']],
-    }),
+    })),
     selectors({
         // This is currently an organization level setting but might in the future be user level
         // it's better to add the permission checks everywhere now

--- a/frontend/src/scenes/pipeline/pipelineDefaultEnabledLogic.tsx
+++ b/frontend/src/scenes/pipeline/pipelineDefaultEnabledLogic.tsx
@@ -33,10 +33,10 @@ export interface DefaultEnabledType {
 
 export const pipelineDefaultEnabledLogic = kea<pipelineDefaultEnabledLogicType>([
     path(['scenes', 'pipeline', 'pipelineDefaultEnabledLogic']),
-    connect({
+    connect(() => ({
         values: [pipelineTransformationsLogic, ['plugins', 'pluginConfigs']],
         actions: [pipelineTransformationsLogic, ['toggleEnabled']],
-    }),
+    })),
     selectors({
         pipelineDefaultEnabled: [
             (s) => [s.plugins, s.pluginConfigs],

--- a/frontend/src/scenes/pipeline/pipelineLogic.tsx
+++ b/frontend/src/scenes/pipeline/pipelineLogic.tsx
@@ -16,9 +16,9 @@ export const humanFriendlyTabName = (tab: PipelineTab): string => {
 
 export const pipelineLogic = kea<pipelineLogicType>([
     path(['scenes', 'pipeline', 'pipelineLogic']),
-    connect({
+    connect(() => ({
         values: [userLogic, ['user', 'hasAvailableFeature']],
-    }),
+    })),
     actions({
         setCurrentTab: (tab: PipelineTab = PipelineTab.Destinations) => ({ tab }),
     }),

--- a/frontend/src/scenes/pipeline/pipelineNodeMetricsLogic.tsx
+++ b/frontend/src/scenes/pipeline/pipelineNodeMetricsLogic.tsx
@@ -51,9 +51,9 @@ export const pipelineNodeMetricsLogic = kea<pipelineNodeMetricsLogicType>([
     props({} as PipelineNodeMetricsProps),
     key(({ id }: PipelineNodeMetricsProps) => id),
     path((id) => ['scenes', 'pipeline', 'appMetricsLogic', id]),
-    connect({
+    connect(() => ({
         values: [projectLogic, ['currentProjectId']],
-    }),
+    })),
     actions({
         setDateRange: (from: string | null, to: string | null) => ({ from, to }),
         openErrorDetailsModal: (errorType: string) => ({

--- a/frontend/src/scenes/pipeline/pipelineNodeNewLogic.tsx
+++ b/frontend/src/scenes/pipeline/pipelineNodeNewLogic.tsx
@@ -26,9 +26,9 @@ export interface PipelineNodeNewLogicProps {
 
 export const pipelineNodeNewLogic = kea<pipelineNodeNewLogicType>([
     props({} as PipelineNodeNewLogicProps),
-    connect({
+    connect(() => ({
         values: [userLogic, ['user']],
-    }),
+    })),
     path((id) => ['scenes', 'pipeline', 'pipelineNodeNewLogic', id]),
 
     loaders({

--- a/frontend/src/scenes/pipeline/transformationsLogic.tsx
+++ b/frontend/src/scenes/pipeline/transformationsLogic.tsx
@@ -12,9 +12,9 @@ import { capturePluginEvent, checkPermissions, loadPluginsFromUrl } from './util
 
 export const pipelineTransformationsLogic = kea<pipelineTransformationsLogicType>([
     path(['scenes', 'pipeline', 'transformationsLogic']),
-    connect({
+    connect(() => ({
         values: [projectLogic, ['currentProjectId'], userLogic, ['user']],
-    }),
+    })),
     actions({
         loadPluginConfigs: true,
         openReorderModal: true,

--- a/frontend/src/scenes/products/productsLogic.ts
+++ b/frontend/src/scenes/products/productsLogic.ts
@@ -11,9 +11,9 @@ import type { productsLogicType } from './productsLogicType'
 
 export const productsLogic = kea<productsLogicType>([
     path(['scenes', 'products', 'productsLogic']),
-    connect({
+    connect(() => ({
         actions: [teamLogic, ['addProductIntent']],
-    }),
+    })),
     actions(() => ({
         toggleSelectedProduct: (productKey: ProductKey) => ({ productKey }),
         setFirstProductOnboarding: (productKey: ProductKey) => ({ productKey }),

--- a/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
+++ b/frontend/src/scenes/project-homepage/projectHomepageLogic.tsx
@@ -12,9 +12,9 @@ import type { projectHomepageLogicType } from './projectHomepageLogicType'
 
 export const projectHomepageLogic = kea<projectHomepageLogicType>([
     path(['scenes', 'project-homepage', 'projectHomepageLogic']),
-    connect({
+    connect(() => ({
         values: [teamLogic, ['currentTeam'], projectLogic, ['currentProjectId']],
-    }),
+    })),
 
     selectors({
         primaryDashboardId: [() => [teamLogic.selectors.currentTeam], (currentTeam) => currentTeam?.primary_dashboard],

--- a/frontend/src/scenes/saved-insights/addSavedInsightsModalLogic.ts
+++ b/frontend/src/scenes/saved-insights/addSavedInsightsModalLogic.ts
@@ -19,10 +19,10 @@ export const INSIGHTS_PER_PAGE = 30
 
 export const addSavedInsightsModalLogic = kea<addSavedInsightsModalLogicType>([
     path(['scenes', 'saved-insights', 'addSavedInsightsModalLogic']),
-    connect({
+    connect(() => ({
         values: [teamLogic, ['currentTeamId']],
         logic: [eventUsageLogic],
-    }),
+    })),
     actions({
         setModalFilters: (filters: Partial<SavedInsightFilters>, merge: boolean = true, debounce: boolean = true) => ({
             filters,

--- a/frontend/src/scenes/session-recordings/file-playback/sessionRecordingFilePlaybackSceneLogic.ts
+++ b/frontend/src/scenes/session-recordings/file-playback/sessionRecordingFilePlaybackSceneLogic.ts
@@ -82,10 +82,10 @@ const waitForDataLogic = async (playerKey: string): Promise<BuiltLogic<sessionRe
 
 export const sessionRecordingFilePlaybackSceneLogic = kea<sessionRecordingFilePlaybackSceneLogicType>([
     path(['scenes', 'session-recordings', 'detail', 'sessionRecordingFilePlaybackSceneLogic']),
-    connect({
+    connect(() => ({
         actions: [eventUsageLogic, ['reportRecordingLoadedFromFile']],
         values: [featureFlagLogic, ['featureFlags']],
-    }),
+    })),
 
     loaders(({ actions }) => ({
         sessionRecording: {

--- a/frontend/src/scenes/session-recordings/player/inspector/components/eventPropertyFilteringLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/eventPropertyFilteringLogic.ts
@@ -7,9 +7,9 @@ import type { eventPropertyFilteringLogicType } from './eventPropertyFilteringLo
 
 export const eventPropertyFilteringLogic = kea<eventPropertyFilteringLogicType>([
     path(['scenes', 'session-recordings', 'player', 'inspector', 'components', 'eventPropertyFilteringLogic']),
-    connect({
+    connect(() => ({
         values: [userPreferencesLogic, ['hidePostHogPropertiesInTable'], preflightLogic, ['isCloudOrDev']],
-    }),
+    })),
     selectors({
         filterProperties: [
             (s) => [s.hidePostHogPropertiesInTable, s.isCloudOrDev],

--- a/frontend/src/scenes/session-recordings/player/inspector/miniFiltersLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/miniFiltersLogic.ts
@@ -126,9 +126,9 @@ export const miniFiltersLogic = kea<miniFiltersLogicType>([
         setSearchQuery: (search: string) => ({ search }),
         resetMiniFilters: true,
     }),
-    connect({
+    connect(() => ({
         values: [teamLogic, ['currentTeam']],
-    }),
+    })),
     reducers(() => ({
         showOnlyMatching: [
             false,

--- a/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
@@ -35,9 +35,9 @@ export const playerSettingsLogic = kea<playerSettingsLogicType>([
         setSidebarOpen: (open: boolean) => ({ open }),
         setPlaylistOpen: (open: boolean) => ({ open }),
     }),
-    connect({
+    connect(() => ({
         values: [teamLogic, ['currentTeam']],
-    }),
+    })),
     reducers(({ values }) => ({
         showFilters: [true, { persist: true }, { setShowFilters: (_, { showFilters }) => showFilters }],
         sidebarOpen: [false, { persist: true }, { setSidebarOpen: (_, { open }) => open }],

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -232,10 +232,10 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
     path((key) => ['scenes', 'session-recordings', 'sessionRecordingDataLogic', key]),
     props({} as SessionRecordingDataLogicProps),
     key(({ sessionRecordingId }) => sessionRecordingId || 'no-session-recording-id'),
-    connect({
+    connect(() => ({
         logic: [eventUsageLogic],
         values: [featureFlagLogic, ['featureFlags'], teamLogic, ['currentTeam']],
-    }),
+    })),
     defaults({
         sessionPlayerMetaData: null as SessionRecordingType | null,
     }),

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -320,7 +320,7 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
         (props: SessionRecordingPlaylistLogicProps) =>
             `${props.logicKey}-${props.personUUID}-${props.updateSearchParams ? '-with-search' : ''}`
     ),
-    connect({
+    connect(() => ({
         actions: [
             eventUsageLogic,
             ['reportRecordingsListFetched', 'reportRecordingsListFilterAdded'],
@@ -335,7 +335,7 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
             playerSettingsLogic,
             ['autoplayDirection', 'hideViewedRecordings'],
         ],
-    }),
+    })),
 
     actions({
         setFilters: (filters: Partial<RecordingUniversalFilters>) => ({ filters }),

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistSceneLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistSceneLogic.ts
@@ -39,9 +39,9 @@ export const sessionRecordingsPlaylistSceneLogic = kea<sessionRecordingsPlaylist
     path((key) => ['scenes', 'session-recordings', 'playlist', 'sessionRecordingsPlaylistSceneLogic', key]),
     props({} as SessionRecordingsPlaylistLogicProps),
     key((props) => props.shortId),
-    connect({
+    connect(() => ({
         values: [cohortsModel, ['cohortsById'], sceneLogic, ['activeScene']],
-    }),
+    })),
     actions({
         updatePlaylist: (properties?: Partial<SessionRecordingPlaylistType>, silent = false) => ({
             properties,

--- a/frontend/src/scenes/session-recordings/saved-playlists/savedSessionRecordingPlaylistsLogic.ts
+++ b/frontend/src/scenes/session-recordings/saved-playlists/savedSessionRecordingPlaylistsLogic.ts
@@ -49,9 +49,9 @@ export const savedSessionRecordingPlaylistsLogic = kea<savedSessionRecordingPlay
     path((key) => ['scenes', 'session-recordings', 'saved-playlists', 'savedSessionRecordingPlaylistsLogic', key]),
     props({} as SavedSessionRecordingPlaylistsLogicProps),
     key((props) => props.tab),
-    connect({
+    connect(() => ({
         actions: [eventUsageLogic, ['reportRecordingPlaylistCreated']],
-    }),
+    })),
 
     actions(() => ({
         setSavedPlaylistsFilters: (filters: Partial<SavedSessionRecordingPlaylistsFilters>) => ({

--- a/frontend/src/scenes/session-recordings/templates/sessionRecordingTemplatesLogic.tsx
+++ b/frontend/src/scenes/session-recordings/templates/sessionRecordingTemplatesLogic.tsx
@@ -67,9 +67,9 @@ export const sessionReplayTemplatesLogic = kea<sessionReplayTemplatesLogicType>(
     path(() => ['scenes', 'session-recordings', 'templates', 'sessionReplayTemplatesLogic']),
     props({} as ReplayTemplateLogicPropsType),
     key((props) => `${props.category}-${props.template.key}`),
-    connect({
+    connect(() => ({
         values: [teamLogic, ['currentTeam']],
-    }),
+    })),
     actions({
         setVariables: (variables?: ReplayTemplateVariableType[]) => ({ variables }),
         setVariable: (variable: ReplayTemplateVariableType) => ({ variable }),

--- a/frontend/src/scenes/settings/environment/dataColorThemesLogic.ts
+++ b/frontend/src/scenes/settings/environment/dataColorThemesLogic.ts
@@ -6,10 +6,10 @@ import type { dataColorThemesLogicType } from './dataColorThemesLogicType'
 
 export const dataColorThemesLogic = kea<dataColorThemesLogicType>([
     path(['scenes', 'settings', 'environment', 'dataColorThemesLogic']),
-    connect({
+    connect(() => ({
         values: [dataThemeLogic, ['themes', 'themesLoading', 'defaultTheme', 'posthogTheme']],
         actions: [dataColorThemesModalLogic, ['openModal', 'submitThemeSuccess'], dataThemeLogic, ['setThemes']],
-    }),
+    })),
     actions({
         selectTheme: (id: 'new' | number | null) => ({ id }),
     }),

--- a/frontend/src/scenes/settings/environment/filterTestAccountDefaultsLogic.ts
+++ b/frontend/src/scenes/settings/environment/filterTestAccountDefaultsLogic.ts
@@ -5,9 +5,9 @@ import type { filterTestAccountsDefaultsLogicType } from './filterTestAccountDef
 
 export const filterTestAccountsDefaultsLogic = kea<filterTestAccountsDefaultsLogicType>([
     path(['scenes', 'project', 'Settings', 'filterTestAccountsDefaultLogic']),
-    connect({
+    connect(() => ({
         values: [teamLogic, ['currentTeam']],
-    }),
+    })),
     actions({
         setDefault: (value: boolean) => ({ value }),
         setTeamDefault: (value: boolean) => ({ value }),

--- a/frontend/src/scenes/settings/environment/groupAnalyticsConfigLogic.ts
+++ b/frontend/src/scenes/settings/environment/groupAnalyticsConfigLogic.ts
@@ -6,10 +6,10 @@ import type { groupAnalyticsConfigLogicType } from './groupAnalyticsConfigLogicT
 
 export const groupAnalyticsConfigLogic = kea<groupAnalyticsConfigLogicType>([
     path(['scenes', 'project', 'Settings', 'groupAnalyticsConfigLogic']),
-    connect({
+    connect(() => ({
         values: [groupsModel, ['groupTypes', 'groupTypesLoading']],
         actions: [groupsModel, ['updateGroupTypesMetadata']],
-    }),
+    })),
     actions({
         setSingular: (groupTypeIndex: number, value: string) => ({ groupTypeIndex, value }),
         setPlural: (groupTypeIndex: number, value: string) => ({ groupTypeIndex, value }),

--- a/frontend/src/scenes/settings/environment/proxyLogic.ts
+++ b/frontend/src/scenes/settings/environment/proxyLogic.ts
@@ -20,9 +20,9 @@ export type FormState = 'collapsed' | 'active' | 'complete'
 
 export const proxyLogic = kea<proxyLogicType>([
     path(['scenes', 'project', 'Settings', 'proxyLogic']),
-    connect({
+    connect(() => ({
         values: [organizationLogic, ['currentOrganization']],
-    }),
+    })),
     actions(() => ({
         collapseForm: true,
         showForm: true,

--- a/frontend/src/scenes/settings/environment/replayTriggersLogic.ts
+++ b/frontend/src/scenes/settings/environment/replayTriggersLogic.ts
@@ -42,7 +42,7 @@ export const replayTriggersLogic = kea<replayTriggersLogicType>([
         setEventTriggerConfig: (eventTriggerConfig: string[]) => ({ eventTriggerConfig }),
         updateEventTriggerConfig: (eventTriggerConfig: string[]) => ({ eventTriggerConfig }),
     }),
-    connect({ values: [teamLogic, ['currentTeam']], actions: [teamLogic, ['updateCurrentTeam']] }),
+    connect(() => ({ values: [teamLogic, ['currentTeam']], actions: [teamLogic, ['updateCurrentTeam']] })),
     reducers({
         urlTriggerConfig: [
             null as SessionReplayUrlTriggerConfig[] | null,

--- a/frontend/src/scenes/settings/environment/sessionReplayIngestionControlLogic.ts
+++ b/frontend/src/scenes/settings/environment/sessionReplayIngestionControlLogic.ts
@@ -14,7 +14,7 @@ export const sessionReplayIngestionControlLogic = kea<sessionReplayIngestionCont
     actions({
         selectFeatureFlag: (flag: FeatureFlagBasicType) => ({ flag }),
     }),
-    connect({ values: [teamLogic, ['currentTeam']], actions: [teamLogic, ['updateCurrentTeam']] }),
+    connect(() => ({ values: [teamLogic, ['currentTeam']], actions: [teamLogic, ['updateCurrentTeam']] })),
     reducers({
         selectedFlag: [
             null as FeatureFlagBasicType | null,

--- a/frontend/src/scenes/settings/environment/sessionReplayLinkedFlagLogic.ts
+++ b/frontend/src/scenes/settings/environment/sessionReplayLinkedFlagLogic.ts
@@ -18,7 +18,7 @@ export const sessionReplayLinkedFlagLogic = kea<sessionReplayLinkedFlagLogicType
     actions({
         selectFeatureFlag: (flag: FeatureFlagBasicType) => ({ flag }),
     }),
-    connect({ values: [teamLogic, ['currentTeam']] }),
+    connect(() => ({ values: [teamLogic, ['currentTeam']] })),
     reducers({
         selectedFlag: [
             null as FeatureFlagBasicType | null,

--- a/frontend/src/scenes/settings/organization/Permissions/Roles/rolesLogic.tsx
+++ b/frontend/src/scenes/settings/organization/Permissions/Roles/rolesLogic.tsx
@@ -10,7 +10,7 @@ import type { rolesLogicType } from './rolesLogicType'
 
 export const rolesLogic = kea<rolesLogicType>([
     path(['scenes', 'organization', 'rolesLogic']),
-    connect({ values: [teamMembersLogic, ['allMembers']] }),
+    connect(() => ({ values: [teamMembersLogic, ['allMembers']] })),
     actions({
         setCreateRoleModalShown: (shown: boolean) => ({ shown }),
         setRoleInFocus: (role: null | RoleType) => ({ role }),

--- a/frontend/src/scenes/settings/organization/Permissions/permissionsLogic.tsx
+++ b/frontend/src/scenes/settings/organization/Permissions/permissionsLogic.tsx
@@ -31,10 +31,10 @@ const ResourceAccessLevelMapping: Record<Resource, string> = {
 
 export const permissionsLogic = kea<permissionsLogicType>([
     path(['scenes', 'organization', 'Settings', 'Permissions', 'permissionsLogic']),
-    connect({
+    connect(() => ({
         values: [rolesLogic, ['roles']],
         actions: [rolesLogic, ['updateRole']],
-    }),
+    })),
     actions({
         updatePermission: (
             checked: boolean,
@@ -57,13 +57,12 @@ export const permissionsLogic = kea<permissionsLogicType>([
                         return values.organizationResourcePermissions.map((permission) =>
                             permission.id == response.id ? response : permission
                         )
-                    } else {
-                        const response = await api.resourcePermissions.create({
-                            resource: resource,
-                            access_level: access_level,
-                        })
-                        return [...values.organizationResourcePermissions, response]
                     }
+                    const response = await api.resourcePermissions.create({
+                        resource: resource,
+                        access_level: access_level,
+                    })
+                    return [...values.organizationResourcePermissions, response]
                 },
             },
         ],

--- a/frontend/src/scenes/settings/organization/VerifiedDomains/verifiedDomainsLogic.ts
+++ b/frontend/src/scenes/settings/organization/VerifiedDomains/verifiedDomainsLogic.ts
@@ -32,7 +32,7 @@ export const isSecureURL = (url: string): boolean => {
 
 export const verifiedDomainsLogic = kea<verifiedDomainsLogicType>([
     path(['scenes', 'organization', 'verifiedDomainsLogic']),
-    connect({ values: [organizationLogic, ['currentOrganization']], logic: [userLogic] }),
+    connect(() => ({ values: [organizationLogic, ['currentOrganization']], logic: [userLogic] })),
     actions({
         replaceDomain: (domain: OrganizationDomainType) => ({ domain }),
         setAddModalShown: (shown: boolean) => ({ shown }),

--- a/frontend/src/scenes/settings/organization/inviteLogic.ts
+++ b/frontend/src/scenes/settings/organization/inviteLogic.ts
@@ -30,10 +30,10 @@ const EMPTY_INVITE: InviteRowState = {
 
 export const inviteLogic = kea<inviteLogicType>([
     path(['scenes', 'organization', 'Settings', 'inviteLogic']),
-    connect({
+    connect(() => ({
         values: [preflightLogic, ['preflight']],
         actions: [router, ['locationChanged']],
-    }),
+    })),
     actions({
         showInviteModal: true,
         hideInviteModal: true,

--- a/frontend/src/scenes/settings/settingsLogic.ts
+++ b/frontend/src/scenes/settings/settingsLogic.ts
@@ -15,7 +15,7 @@ export const settingsLogic = kea<settingsLogicType>([
     props({} as SettingsLogicProps),
     key((props) => props.logicKey ?? 'global'),
     path((key) => ['scenes', 'settings', 'settingsLogic', key]),
-    connect({
+    connect(() => ({
         values: [
             featureFlagLogic,
             ['featureFlags'],
@@ -26,7 +26,7 @@ export const settingsLogic = kea<settingsLogicType>([
             teamLogic,
             ['currentTeam'],
         ],
-    }),
+    })),
 
     actions({
         selectLevel: (level: SettingLevelId) => ({ level }),

--- a/frontend/src/scenes/settings/user/changePasswordLogic.ts
+++ b/frontend/src/scenes/settings/user/changePasswordLogic.ts
@@ -14,9 +14,9 @@ export interface ChangePasswordForm {
 
 export const changePasswordLogic = kea<changePasswordLogicType>([
     path(['scenes', 'me', 'settings', 'changePasswordLogic']),
-    connect({
+    connect(() => ({
         values: [userLogic, ['user']],
-    }),
+    })),
     forms(({ values, actions }) => ({
         changePassword: {
             defaults: {} as unknown as ChangePasswordForm,

--- a/frontend/src/scenes/settings/user/personalAPIKeysLogic.tsx
+++ b/frontend/src/scenes/settings/user/personalAPIKeysLogic.tsx
@@ -113,9 +113,9 @@ export type EditingKeyFormValues = Pick<
 
 export const personalAPIKeysLogic = kea<personalAPIKeysLogicType>([
     path(['lib', 'components', 'PersonalAPIKeys', 'personalAPIKeysLogic']),
-    connect({
+    connect(() => ({
         values: [userLogic, ['user']],
-    }),
+    })),
     actions({
         setEditingKeyId: (id: PersonalAPIKeyType['id'] | null) => ({ id }),
         loadKeys: true,

--- a/frontend/src/scenes/trends/mathsLogic.tsx
+++ b/frontend/src/scenes/trends/mathsLogic.tsx
@@ -388,7 +388,7 @@ export function apiValueToMathType(math: string | undefined, groupTypeIndex: num
 
 export const mathsLogic = kea<mathsLogicType>([
     path(['scenes', 'trends', 'mathsLogic']),
-    connect({
+    connect(() => ({
         values: [
             groupsModel,
             ['groupTypes', 'aggregationLabel'],
@@ -397,7 +397,7 @@ export const mathsLogic = kea<mathsLogicType>([
             featureFlagLogic,
             ['featureFlags'],
         ],
-    }),
+    })),
     selectors({
         mathDefinitions: [
             (s) => [s.groupsMathDefinitions],

--- a/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
+++ b/frontend/src/scenes/trends/persons-modal/personsModalLogic.ts
@@ -73,10 +73,10 @@ export const personsModalLogic = kea<personsModalLogicType>([
         updateActorsQuery: (query: Partial<InsightActorsQuery>) => ({ query }),
         loadActorsQueryOptions: (query: InsightActorsQuery) => ({ query }),
     }),
-    connect({
+    connect(() => ({
         values: [groupsModel, ['groupTypes', 'aggregationLabel']],
         actions: [eventUsageLogic, ['reportPersonsModalViewed']],
-    }),
+    })),
 
     loaders(({ values, actions, props }) => ({
         actorsResponse: [

--- a/frontend/src/scenes/web-analytics/liveWebAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/liveWebAnalyticsLogic.tsx
@@ -8,9 +8,9 @@ export interface StatsResponse {
 }
 export const liveWebAnalyticsLogic = kea<liveWebAnalyticsLogicType>([
     path(['scenes', 'webAnalytics', 'liveWebAnalyticsLogic']),
-    connect({
+    connect(() => ({
         values: [teamLogic, ['currentTeam']],
-    }),
+    })),
     actions(() => ({
         pollStats: true,
         setLiveUserCount: ({ liveUserCount, now }: { liveUserCount: number; now: Date }) => ({

--- a/frontend/src/scenes/wizard/wizardLogic.tsx
+++ b/frontend/src/scenes/wizard/wizardLogic.tsx
@@ -12,9 +12,9 @@ export interface WizardTokenResponseType {
 
 export const wizardLogic = kea<wizardLogicType>([
     path(['scenes', 'wizard', 'wizardLogic']),
-    connect({
+    connect(() => ({
         values: [teamLogic, ['currentTeam']],
-    }),
+    })),
     actions({
         setWizardHash: (wizardHash: string | null) => ({ wizardHash }),
         setView: (view: 'pending' | 'creating' | 'success' | 'invalid') => ({ view }),

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
@@ -29,7 +29,7 @@ const emptyElementsStatsPages: PaginatedResponse<ElementsEventType> = {
 
 export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
     path(['toolbar', 'elements', 'heatmapToolbarMenuLogic']),
-    connect({
+    connect(() => ({
         values: [
             currentPageLogic,
             ['href', 'wildcardHref'],
@@ -66,7 +66,7 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
                 'setHeatmapScrollY',
             ],
         ],
-    }),
+    })),
     actions({
         getElementStats: (url?: string | null) => ({
             url,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1622,6 +1622,8 @@ importers:
         specifier: '*'
         version: 18.2.0
 
+  products/editor: {}
+
   products/experiments:
     dependencies:
       '@posthog/icons':

--- a/products/llm_observability/frontend/llmObservabilityLogic.tsx
+++ b/products/llm_observability/frontend/llmObservabilityLogic.tsx
@@ -47,7 +47,7 @@ export interface QueryTile {
 export const llmObservabilityLogic = kea<llmObservabilityLogicType>([
     path(['products', 'llm_observability', 'frontend', 'llmObservabilityLogic']),
 
-    connect({ values: [sceneLogic, ['sceneKey'], groupsModel, ['groupsEnabled']] }),
+    connect(() => ({ values: [sceneLogic, ['sceneKey'], groupsModel, ['groupsEnabled']] })),
 
     actions({
         setDates: (dateFrom: string | null, dateTo: string | null) => ({ dateFrom, dateTo }),

--- a/products/messaging/frontend/functionsTableLogic.tsx
+++ b/products/messaging/frontend/functionsTableLogic.tsx
@@ -22,9 +22,9 @@ export const functionsTableLogic = kea<functionsTableLogicType>([
     path(['products', 'messaging', 'frontend', 'functionsTableLogic']),
     props({} as FunctionsTableLogicProps),
     key((props: FunctionsTableLogicProps) => props.type ?? 'destination'),
-    connect({
+    connect(() => ({
         values: [projectLogic, ['currentProjectId']],
-    }),
+    })),
     actions({
         deleteHogFunction: (hogFunction: HogFunctionType) => ({ hogFunction }),
         setFilters: (filters: Partial<HogFunctionsFilter>) => ({ filters }),


### PR DESCRIPTION
## Problem

We often have JS errors when something changes in esbuild's import loading order. The fix is usually to change the Kea `connect({})` to `connect(() => ({})`.

## Changes

Does that change to all logics in the codebase.

## How did you test this code?

CI