### PR TITLE
fix(messaging): allow enabling/disabling broadcast hog functions

### DIFF
--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionConfiguration.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionConfiguration.tsx
@@ -216,9 +216,15 @@ export function HogFunctionConfiguration({
         displayOptions.showStatus ?? ['destination', 'internal_destination', 'email', 'transformation'].includes(type)
     const showEnabled =
         displayOptions.showEnabled ??
-        ['destination', 'internal_destination', 'email', 'site_destination', 'site_app', 'transformation'].includes(
-            type
-        )
+        [
+            'destination',
+            'internal_destination',
+            'email',
+            'site_destination',
+            'site_app',
+            'transformation',
+            'broadcast',
+        ].includes(type)
     const canEditSource =
         displayOptions.canEditSource ??
         // Never allow editing for legacy plugins

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
@@ -179,7 +179,7 @@ const templateToConfiguration = (template: HogFunctionTemplateType): HogFunction
         hog: template.hog,
         icon_url: template.icon_url,
         inputs: getInputs(template.inputs_schema),
-        enabled: template.type !== 'broadcast',
+        enabled: true,
     }
 }
 


### PR DESCRIPTION
## Problem

Right now broadcast functions can be created from template as disabled with no way to change. This changes default to enabled: true for broadcasts and allows toggling in the UI
<img width="422" alt="Screenshot 2025-04-07 at 2 10 01 PM" src="https://github.com/user-attachments/assets/9352a5b8-717c-4849-94af-25bcbfdf6bfc" />
<img width="1416" alt="Screenshot 2025-04-07 at 2 11 58 PM" src="https://github.com/user-attachments/assets/1d482434-18e5-4751-a512-d864c56b3846" />


## Changes

- Change enabled: true for new hog function destinations (this was disabled only for broadcasts)
- Show enabled switch

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

See screenshots above