### PR TITLE
fix: visible toolbar heatmap info tooltip

### DIFF
--- a/frontend/src/toolbar/elements/Elements.tsx
+++ b/frontend/src/toolbar/elements/Elements.tsx
@@ -16,6 +16,7 @@ import { toolbarLogic } from '../bar/toolbarLogic'
 import { ScrollDepth } from './ScrollDepth'
 
 export function Elements(): JSX.Element {
+    const { visibleMenu: activeToolbarMode } = useValues(toolbarLogic)
     const {
         heatmapElements,
         elementsToDisplay,
@@ -59,7 +60,7 @@ export function Elements(): JSX.Element {
                 }}
             >
                 <ScrollDepth />
-                <HeatmapCanvas />
+                {activeToolbarMode === 'heatmap' && <HeatmapCanvas />}
                 {highlightElementMeta?.rect ? <FocusRect rect={highlightElementMeta.rect} /> : null}
 
                 {elementsToDisplay.map(({ rect, element, apparentZIndex }, index) => {


### PR DESCRIPTION
we've separated the display of the heatmap from the active mode of the toolbar now that it is also used in the in-app browser

but that means the tooltip zero state will show when we hold down shift while the toolbar is open 🫠 

so, we just don't render the heatmap canvas in the toolbar at all - even empty - if the mode isn't active