### PR TITLE
fix: not all valid css selectors are valid for action matching

### DIFF
--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -12,8 +12,14 @@ global.TextEncoder = TextEncoder as any
 window.scrollTo = jest.fn()
 window.matchMedia = jest.fn(() => ({ matches: false, addListener: jest.fn(), removeListener: jest.fn() }) as any)
 
+// we use CSS.escape in the toolbar, but Jest/JSDom doesn't support it
+if (typeof (globalThis as any).CSS === 'undefined') {
+  ;(globalThis as any).CSS = {}
+}
 
-
+if (typeof (globalThis as any).CSS.escape !== 'function') {
+  ;(globalThis as any).CSS.escape = (value: string) => value
+}
 
 // Tell React Testing Library to use "data-attr" as the test ID attribute
 configure({ testIdAttribute: 'data-attr' })

--- a/frontend/src/lib/utils/cssEscape.ts
+++ b/frontend/src/lib/utils/cssEscape.ts
@@ -1,70 +1,8 @@
-/*! https://mths.be/cssescape v1.5.1 by @mathias | MIT license */
-export function cssEscape(string: string): string {
-    const length = string.length
-    let index = -1
-    let codeUnit: number
-    let result = ''
-    const firstCodeUnit = string.charCodeAt(0)
-    while (++index < length) {
-        codeUnit = string.charCodeAt(index)
-        // Note: there’s no need to special-case astral symbols, surrogate
-        // pairs, or lone surrogates.
-
-        // If the character is NULL (U+0000), then the REPLACEMENT CHARACTER
-        // (U+FFFD).
-        if (codeUnit == 0x0000) {
-            result += '\uFFFD'
-            continue
-        }
-
-        if (
-            // If the character is in the range [\1-\1F] (U+0001 to U+001F) or is
-            // U+007F, […]
-            (codeUnit >= 0x0001 && codeUnit <= 0x001f) ||
-            codeUnit == 0x007f ||
-            // If the character is the first character and is in the range [0-9]
-            // (U+0030 to U+0039), […]
-            (index == 0 && codeUnit >= 0x0030 && codeUnit <= 0x0039) ||
-            // If the character is the second character and is in the range [0-9]
-            // (U+0030 to U+0039) and the first character is a `-` (U+002D), […]
-            (index == 1 && codeUnit >= 0x0030 && codeUnit <= 0x0039 && firstCodeUnit == 0x002d)
-        ) {
-            // https://drafts.csswg.org/cssom/#escape-a-character-as-code-point
-            result += '\\' + codeUnit.toString(16) + ' '
-            continue
-        }
-
-        if (
-            // If the character is the first character and is a `-` (U+002D), and
-            // there is no second character, […]
-            index == 0 &&
-            length == 1 &&
-            codeUnit == 0x002d
-        ) {
-            result += '\\' + string.charAt(index)
-            continue
-        }
-
-        // If the character is not handled by one of the above rules and is
-        // greater than or equal to U+0080, is `-` (U+002D) or `_` (U+005F), or
-        // is in one of the ranges [0-9] (U+0030 to U+0039), [A-Z] (U+0041 to
-        // U+005A), or [a-z] (U+0061 to U+007A), […]
-        if (
-            codeUnit >= 0x0080 ||
-            codeUnit == 0x002d ||
-            codeUnit == 0x005f ||
-            (codeUnit >= 0x0030 && codeUnit <= 0x0039) ||
-            (codeUnit >= 0x0041 && codeUnit <= 0x005a) ||
-            (codeUnit >= 0x0061 && codeUnit <= 0x007a)
-        ) {
-            // the character itself
-            result += string.charAt(index)
-            continue
-        }
-
-        // Otherwise, the escaped character.
-        // https://drafts.csswg.org/cssom/#escape-a-character
-        result += '\\' + string.charAt(index)
-    }
-    return result
-}
+/*!
+ we used to use https://mths.be/cssescape v1.5.1 by @mathias | MIT license
+ but the `finder` dependency has always been using `CSS.escape` from the browser
+ and nobody has ever pointed out an error
+ cssEscape function was only for IE11 users
+ and they mustn't be using this anyway
+ */
+export const cssEscape = CSS.escape

--- a/frontend/src/toolbar/utils.test.ts
+++ b/frontend/src/toolbar/utils.test.ts
@@ -1,0 +1,34 @@
+import { slashDotDataAttrUnescape } from './utils'
+
+describe('utils', () => {
+    describe('slashDotDataAttrUnescape', () => {
+        const testCases = [
+            {
+                input: 'div[data-attr="test"]',
+                expected: 'div[data-attr="test"]',
+            },
+            {
+                input: 'div[data-attr="test\\."]',
+                expected: 'div[data-attr="test."]',
+            },
+            {
+                input: 'div[data-something="test\\.test\\.test"]',
+                expected: 'div[data-something="test.test.test"]',
+            },
+            {
+                input: '.tomato div[data-something="test\\.test\\.test"]',
+                expected: '.tomato div[data-something="test.test.test"]',
+            },
+            {
+                input: '\\.tomato div[data-something="test\\.test\\.test"]',
+                expected: '.tomato div[data-something="test.test.test"]',
+            },
+        ]
+        testCases.forEach(({ input, expected }) => {
+            it(`should unescape "${input}" to "${expected}"`, () => {
+                const result = slashDotDataAttrUnescape(input)
+                expect(result).toBe(expected)
+            })
+        })
+    })
+})

--- a/frontend/src/toolbar/utils.ts
+++ b/frontend/src/toolbar/utils.ts
@@ -41,14 +41,19 @@ export function elementToQuery(element: HTMLElement, dataAttributes: string[]): 
             continue
         }
 
-        const selector = `[${cssEscape(name)}="${cssEscape(value)}"]`
-        if (querySelectorAllDeep(selector).length == 1) {
-            return selector
+        const escapedSelector = `[${cssEscape(name)}="${cssEscape(value)}"]`
+        const unescapedSelector = `[${name}="${value}"]`
+
+        if (querySelectorAllDeep(escapedSelector).length == 1) {
+            // if we return the _valid_ escaped CSS,
+            // the action matching in PostHog might not match it
+            // because it's not really CSS matching
+            return unescapedSelector
         }
     }
 
     try {
-        return finder(element, {
+        const foundSelector = finder(element, {
             tagName: (name) => !TAGS_TO_IGNORE.includes(name),
             seedMinLength: 5, // include several selectors e.g. prefer .project-homepage > .project-header > .project-title over .project-title
             attr: (name) => {
@@ -57,6 +62,17 @@ export function elementToQuery(element: HTMLElement, dataAttributes: string[]): 
                 return name.startsWith('data-')
             },
         })
+        // KLUDGE: [data-attr="session\.recording\.preview"] is valid CSS
+        // but our action matching doesn't support it
+        // in order to avoid trying to write a general purpose CSS unescaper
+        // we just remove the backslash in this specific pattern
+        // if it matches data-attr="bla\.blah\.blah"
+        const dataAttrRegex = /data-[^="]+="([^"]+)"/
+        const dataAttrMatch = foundSelector?.match(dataAttrRegex)
+        if (dataAttrMatch) {
+            return foundSelector.replace(/(?<=data-[^="]+="[^"]*)(\\\.)+(?=[^"]*")/g, '.')
+        }
+        return foundSelector
     } catch (error) {
         console.warn('Error while trying to find a selector for element', element, error)
         return undefined

--- a/frontend/src/toolbar/utils.ts
+++ b/frontend/src/toolbar/utils.ts
@@ -62,17 +62,7 @@ export function elementToQuery(element: HTMLElement, dataAttributes: string[]): 
                 return name.startsWith('data-')
             },
         })
-        // KLUDGE: [data-attr="session\.recording\.preview"] is valid CSS
-        // but our action matching doesn't support it
-        // in order to avoid trying to write a general purpose CSS unescaper
-        // we just remove the backslash in this specific pattern
-        // if it matches data-attr="bla\.blah\.blah"
-        const dataAttrRegex = /data-[^="]+="([^"]+)"/
-        const dataAttrMatch = foundSelector?.match(dataAttrRegex)
-        if (dataAttrMatch) {
-            return foundSelector.replace(/(?<=data-[^="]+="[^"]*)(\\\.)+(?=[^"]*")/g, '.')
-        }
-        return foundSelector
+        return slashDotDataAttrUnescape(foundSelector)
     } catch (error) {
         console.warn('Error while trying to find a selector for element', element, error)
         return undefined
@@ -425,4 +415,15 @@ export function getHeatMapHue(count: number, maxCount: number): number {
         return 60
     }
     return 60 - (count / maxCount) * 40
+}
+
+/*
+ * KLUDGE: e.g. [data-attr="session\.recording\.preview"] is valid CSS
+ * but our action matching doesn't support it
+ * in order to avoid trying to write a general purpose CSS unescaper
+ * we just remove the backslash in this specific pattern
+ * if it matches data-attr="bla\.blah\.blah"
+ */
+export function slashDotDataAttrUnescape(foundSelector: string): string | undefined {
+    return foundSelector.replace(/\\./g, '.')
 }


### PR DESCRIPTION
https://posthoghelp.zendesk.com/agent/tickets/28216 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/30286)
and
https://github.com/PostHog/posthog/issues/15480

the toolbar uses the mdev/finder library to generate CSS selectors it might generate a valid CSS selector that we can't use in action matching. this is because it escapes CSS but our action matcher doesn't understand (all? some?) escaped CSS

i don't want to write a CSS unescaper targetting our action matching, that feels like a fool's game

let's just patch this case we know about