### PR TITLE
feat(flags): roll new flags to 1% of cloud customers

### DIFF
--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -897,5 +897,13 @@ describe('lib/utils', () => {
                 })
             ).toBe(false)
         })
+        it('returns false for our hashed API key when explicitly excluded', () => {
+            expect(
+                shouldEnablePreviewFlagsV2('sTMFPsFhdP1Ssg', {
+                    rolloutPercentage: 100,
+                    excludedHashes: new Set(['3a4a1aa4']),
+                })
+            ).toBe(false)
+        })
     })
 })

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -878,19 +878,20 @@ describe('lib/utils', () => {
 
     describe('shouldEnablePreviewFlagsV2', () => {
         it('returns true for anything if the rollout percentage is 100', () => {
-            expect(
-                shouldEnablePreviewFlagsV2('test', { rolloutPercentage: 100, includedHashes: new Set(['1234567890']) })
-            ).toBe(true)
+            const result = shouldEnablePreviewFlagsV2('test', {
+                rolloutPercentage: 100,
+            })
+            expect(result).toBe(true)
         })
         it('returns true for our hashed API key', () => {
             expect(
                 shouldEnablePreviewFlagsV2('sTMFPsFhdP1Ssg', {
                     rolloutPercentage: 1,
-                    includedHashes: new Set(['3a4a1aa4']),
+                    includedHashes: new Set(['593cb24f9928bab39ec383c06c908481880d5099']),
                 })
             ).toBe(true)
         })
-        it('returns false for our hashed API key when not passed it', () => {
+        it('returns false for our hashed API key when not passed in and the percentage rollout is too small', () => {
             expect(
                 shouldEnablePreviewFlagsV2('sTMFPsFhdP1Ssg', {
                     rolloutPercentage: 1,
@@ -901,7 +902,7 @@ describe('lib/utils', () => {
             expect(
                 shouldEnablePreviewFlagsV2('sTMFPsFhdP1Ssg', {
                     rolloutPercentage: 100,
-                    excludedHashes: new Set(['3a4a1aa4']),
+                    excludedHashes: new Set(['593cb24f9928bab39ec383c06c908481880d5099']),
                 })
             ).toBe(false)
         })

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -46,6 +46,7 @@ import {
     roundToDecimal,
     selectorOperatorMap,
     shortTimeZone,
+    shouldEnablePreviewFlagsV2,
     stringOperatorMap,
     toParams,
     wordPluralize,
@@ -873,5 +874,28 @@ describe('lib/utils', () => {
         expect(shortTimeZone('America/Phoenix')).toEqual('MST')
         expect(shortTimeZone('Europe/Moscow')).toEqual('UTC+3')
         expect(shortTimeZone('Asia/Tokyo')).toEqual('UTC+9')
+    })
+
+    describe('shouldEnablePreviewFlagsV2', () => {
+        it('returns true for anything if the rollout percentage is 100', () => {
+            expect(
+                shouldEnablePreviewFlagsV2('test', { rolloutPercentage: 100, includedHashes: new Set(['1234567890']) })
+            ).toBe(true)
+        })
+        it('returns true for our hashed API key', () => {
+            expect(
+                shouldEnablePreviewFlagsV2('sTMFPsFhdP1Ssg', {
+                    rolloutPercentage: 1,
+                    includedHashes: new Set(['3a4a1aa4']),
+                })
+            ).toBe(true)
+        })
+        it('returns false for our hashed API key when not passed it', () => {
+            expect(
+                shouldEnablePreviewFlagsV2('sTMFPsFhdP1Ssg', {
+                    rolloutPercentage: 1,
+                })
+            ).toBe(false)
+        })
     })
 })

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/react'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { shouldEnablePreviewFlagsV2 } from 'lib/utils'
 import posthog, { CaptureResult, PostHogConfig } from 'posthog-js'
 
 interface WindowWithCypressCaptures extends Window {
@@ -25,6 +26,11 @@ const configWithSentry = (config: Partial<PostHogConfig>): Partial<PostHogConfig
 
 export function loadPostHogJS(): void {
     if (window.JS_POSTHOG_API_KEY) {
+        const PREVIEW_FLAGS_V2_CONFIG = {
+            rolloutPercentage: 1,
+            includedHashes: new Set(['3a4a1aa4']),
+        }
+
         posthog.init(
             window.JS_POSTHOG_API_KEY,
             configWithSentry({
@@ -84,6 +90,7 @@ export function loadPostHogJS(): void {
                 capture_performance: { web_vitals: true },
                 person_profiles: 'always',
                 __preview_remote_config: true,
+                __preview_flags_v2: shouldEnablePreviewFlagsV2(window.JS_POSTHOG_API_KEY, PREVIEW_FLAGS_V2_CONFIG),
             })
         )
     } else {

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -28,7 +28,7 @@ export function loadPostHogJS(): void {
     if (window.JS_POSTHOG_API_KEY) {
         const PREVIEW_FLAGS_V2_CONFIG = {
             rolloutPercentage: 1,
-            includedHashes: new Set(['3a4a1aa4']),
+            includedHashes: new Set(['593cb24f9928bab39ec383c06c908481880d5099']),
         }
 
         posthog.init(


### PR DESCRIPTION
## Problem

we're scaling the new `/flags` service and we want to do it intentionally.  For starters, I want to start rolling out traffic to our customers on the `us.posthog.com` cloud instance – this way, if there's funky behavior, it just affects our customers, not our customers' customers.  

## Changes

The way I'm doing this is to basically hash the feature flag keys and then compare those values with a rollout percentage.  This way we can guarantee that the same API keys see the same rollout value without hard-coding anything.

This rollout function also takes in Sets that can contain hashed values to explicitly include or exclude, which override the rollout percentage.  The idea here is that if want to roll specific customers on or off, we can easily do that.  I've done it for our public API key, for example (this isn't just an example though, I want to turn this on for us)

## Does this work well for both Cloud and self-hosted?

should work the same for both

## How did you test this code?

wrote tests for hashing function, and then 
