### PR TITLE
feat(propdefs): Stricter classification of DateTime values

### DIFF
--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -362,7 +362,7 @@ pub fn detect_property_type(key: &str, value: &Value) -> Option<PropertyValueTyp
             } else {
                 Some(PropertyValueType::String)
             }
-        }
+        },
 
         Value::Number(_) => Some(PropertyValueType::Numeric),
 

--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -362,7 +362,7 @@ pub fn detect_property_type(key: &str, value: &Value) -> Option<PropertyValueTyp
             } else {
                 Some(PropertyValueType::String)
             }
-        },
+        }
 
         Value::Number(_) => Some(PropertyValueType::Numeric),
 

--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -362,18 +362,12 @@ pub fn detect_property_type(key: &str, value: &Value) -> Option<PropertyValueTyp
             } else {
                 Some(PropertyValueType::String)
             }
-        }
-        Value::Number(n) => {
-            // this is a more rigorous threshold to ensure we don't misclassify
-            // larger numerical values easily. It mimics (roughly) the old TS service
-            // classification but still may be too aggressive. TBD
-            if is_likely_unix_timestamp(n) {
-                Some(PropertyValueType::DateTime)
-            } else {
-                Some(PropertyValueType::Numeric)
-            }
-        }
+        },
+
+        Value::Number(_) => Some(PropertyValueType::Numeric),
+
         Value::Bool(_) => Some(PropertyValueType::Boolean),
+
         _ => None,
     }
 }

--- a/rust/property-defs-rs/tests/types.rs
+++ b/rust/property-defs-rs/tests/types.rs
@@ -337,17 +337,20 @@ fn test_property_timestamp_rejections() {
         Some(PropertyValueType::Numeric)
     );
 
-    // without a keyword in the property key, these older
-    // UNIX timestamp values will be classified as a number
+    // without a keyword in the property key, even recent, valid
+    // UNIX timestamp values will be classified as Numeric
     assert_eq!(
         detect_property_type(
             "hedgehogs_enumerated",
-            &Value::Number(serde_json::Number::from(1639400730))
+            &Value::Number(Number::from(Utc::now().timestamp_millis() as u64 / 1000u64))
         ),
         Some(PropertyValueType::Numeric)
     );
     assert_eq!(
-        detect_property_type("not_a_thyme", &Value::Number(Number::from(1639400730))),
+        detect_property_type(
+            "thyme_stamp",
+            &Value::Number(Number::from(Utc::now().timestamp_millis() as u64 / 1000u64))
+        ),
         Some(PropertyValueType::Numeric)
     );
 


### PR DESCRIPTION
## Problem
We don't want to accidentally classify large numerical values as `DateTime` if they happen to match a UNIX timestamp in the last 6 month window.

## Changes
Restrict numerical valued `DateTime` classifications to be _both_ a valid UNIX timestamp in the last 6 months _and_ include one of the "timestamp keywords" in the property name.

All other numerical valued props will be classified as `Numeric`

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally and in CI
