### PR TITLE
fix: make sure quota limiting fields are set

### DIFF
--- a/ee/billing/test/test_quota_limiting.py
+++ b/ee/billing/test/test_quota_limiting.py
@@ -327,7 +327,7 @@ class TestQuotaLimiting(BaseTest):
 
             self.organization.refresh_from_db()
             assert self.organization.usage == {
-                "events": {"usage": 99, "limit": 100, "todays_usage": 10},
+                "events": {"usage": 99, "limit": 100, "todays_usage": 10, "quota_limited_until": 1612137599},
                 "exceptions": {"usage": 10, "limit": 100, "todays_usage": 0},
                 "recordings": {"usage": 1, "limit": 100, "todays_usage": 0},
                 "rows_synced": {"usage": 5, "limit": 100, "todays_usage": 0},


### PR DESCRIPTION
## Changes

We are not explicitly setting the quota limiting fields on the organization usage, and it looks like there is an error from that. 

This adds quote a few db calls so we may want to improve the efficiency here somehow. 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

It doesn't have an impact.

## How did you test this code?

Will add tests
