### PR TITLE
fix: delay invite task completion to after onboarding completed

### DIFF
--- a/frontend/src/scenes/settings/organization/inviteLogic.ts
+++ b/frontend/src/scenes/settings/organization/inviteLogic.ts
@@ -162,7 +162,10 @@ export const inviteLogic = kea<inviteLogicType>([
             }
 
             if (inviteCount > 0) {
-                activationLogic.findMounted()?.actions?.markTaskAsCompleted(ActivationTask.InviteTeamMember)
+                // We want to avoid this updating the team before the onboarding is finished
+                setTimeout(() => {
+                    activationLogic.findMounted()?.actions?.markTaskAsCompleted(ActivationTask.InviteTeamMember)
+                }, 1000)
             }
         },
     })),


### PR DESCRIPTION
## Problem

When a user invites someone and submits onboarding they need to click twice.

## Changes

Tried to get to the bottom of why this is happening for a while, for some reason the update to mark the onboarding task as completed conflicts with the update to complete onboarding, and the loader in kea overwrites the team as having not completed onboarding.

After a while trying to fix that, just added a timeout to fix the race condition.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Ran it locally
