### PR TITLE
chore: remove cutoff condition for activation sidepanel

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/sidePanelLogic.tsx
@@ -69,8 +69,7 @@ export const sidePanelLogic = kea<sidePanelLogicType>([
                 if (currentTeam?.created_at) {
                     const teamCreatedAt = dayjs(currentTeam.created_at)
 
-                    // TODO: Remove cutoff date condition after 2025-03-15
-                    if (dayjs().diff(teamCreatedAt, 'day') < 30 && teamCreatedAt.isAfter(dayjs('2025-02-13'))) {
+                    if (dayjs().diff(teamCreatedAt, 'day') < 30) {
                         tabs.push(SidePanelTab.Activation)
                     }
                 }


### PR DESCRIPTION
## Problem

Activation sidepanel was using a cutoff for existing teams for first 30 days

## Changes

No longer needed, just cleans it up.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Ran locally
