### PR TITLE
fix(err): remove redundant 24h label on sparkline

### DIFF
--- a/frontend/src/scenes/error-tracking/errorTrackingSceneLogic.ts
+++ b/frontend/src/scenes/error-tracking/errorTrackingSceneLogic.ts
@@ -115,12 +115,7 @@ export const errorTrackingSceneLogic = kea<errorTrackingSceneLogicType>([
             (dateRange) => {
                 const customLabel = generateDateRangeLabel(dateRange)
                 return match(dateRange.date_from)
-                    .with('-24h', () => [
-                        {
-                            value: 'day',
-                            label: '24h',
-                        },
-                    ])
+                    .with('-24h', () => [])
                     .otherwise(() => [
                         {
                             value: 'custom',

--- a/frontend/src/scenes/error-tracking/errorTrackingSceneLogic.ts
+++ b/frontend/src/scenes/error-tracking/errorTrackingSceneLogic.ts
@@ -4,6 +4,7 @@ import { actionToUrl, router, urlToAction } from 'kea-router'
 import { subscriptions } from 'kea-subscriptions'
 import { objectsEqual } from 'lib/utils'
 import { Params } from 'scenes/sceneTypes'
+import { match } from 'ts-pattern'
 
 import { DataTableNode, ErrorTrackingQuery } from '~/queries/schema/schema-general'
 
@@ -113,16 +114,26 @@ export const errorTrackingSceneLogic = kea<errorTrackingSceneLogicType>([
             (state) => [state.dateRange],
             (dateRange) => {
                 const customLabel = generateDateRangeLabel(dateRange)
-                return [
-                    {
-                        value: 'custom',
-                        label: customLabel,
-                    },
-                    {
-                        value: 'day',
-                        label: '24h',
-                    },
-                ] as { value: SparklineSelectedPeriod; label: string }[]
+                return match(dateRange.date_from)
+                    .with('-24h', () => [
+                        {
+                            value: 'day',
+                            label: '24h',
+                        },
+                    ])
+                    .otherwise(() => [
+                        {
+                            value: 'custom',
+                            label: customLabel,
+                        },
+                        {
+                            value: 'day',
+                            label: '24h',
+                        },
+                    ]) as {
+                    value: SparklineSelectedPeriod
+                    label: string
+                }[]
             },
         ],
     })),


### PR DESCRIPTION
## Problem

<img width="289" alt="image" src="https://github.com/user-attachments/assets/b01a40ba-95fe-453a-97ea-bdec6ba9867c" />

## Changes

When last 24h period is selected remove segmented button 

<img width="289" alt="image" src="https://github.com/user-attachments/assets/dd8f4c9d-e944-4424-bc65-5377478ae5c6" />

