### PR TITLE
fix(project-tree): place new notebooks in the right folder

### DIFF
--- a/frontend/src/scenes/notebooks/notebookSceneLogic.ts
+++ b/frontend/src/scenes/notebooks/notebookSceneLogic.ts
@@ -50,7 +50,7 @@ export const notebookSceneLogic = kea<notebookSceneLogicType>([
 
         projectTreeRef: [
             () => [(_, props: NotebookSceneLogicProps) => props.shortId],
-            (shortId): ProjectTreeRef => ({ type: 'notebook', ref: String(shortId) }),
+            (shortId): ProjectTreeRef | null => (shortId === 'new' ? null : { type: 'notebook', ref: String(shortId) }),
         ],
 
         [SIDE_PANEL_CONTEXT_KEY]: [


### PR DESCRIPTION
## Problem

For some reason I'm able to create "new notebook" in a folder locally, but not in production.

## Changes

I think trying to load a notebook with the "new" path is messing this up. Remove loading it.

## How did you test this code?

Couldn't get it to fail locally, so I'm not 100% sure if this fixes it, but at the worse case this avoids one extra API call to fetch the tree item with the ID "new".