### PR TITLE
chore(experiments): add delay to story to fix flapping

### DIFF
--- a/frontend/src/scenes/experiments/Experiment.stories.tsx
+++ b/frontend/src/scenes/experiments/Experiment.stories.tsx
@@ -2386,6 +2386,10 @@ export const ExperimentV2WithThreeMetrics: StoryFn = () => {
     }, [])
     return <App />
 }
+ExperimentV2WithThreeMetrics.play = async () => {
+    // Add a small delay to ensure charts render completely
+    await new Promise((resolve) => setTimeout(resolve, 500))
+}
 
 export const ExperimentV3WithExperimentQuery: StoryFn = () => {
     useEffect(() => {
@@ -2393,10 +2397,18 @@ export const ExperimentV3WithExperimentQuery: StoryFn = () => {
     }, [])
     return <App />
 }
+ExperimentV3WithExperimentQuery.play = async () => {
+    // Add a small delay to ensure charts render completely
+    await new Promise((resolve) => setTimeout(resolve, 500))
+}
 
 export const ExperimentV3WithAsymmetricIntervals: StoryFn = () => {
     useEffect(() => {
         router.actions.push(urls.experiment(EXPERIMENT_WITH_ASYMMETRIC_INTERVALS.id))
     }, [])
     return <App />
+}
+ExperimentV3WithAsymmetricIntervals.play = async () => {
+    // Add a small delay to ensure charts render completely
+    await new Promise((resolve) => setTimeout(resolve, 500))
 }


### PR DESCRIPTION
## Problem
Sometimes (~ 1/500 times) the UI screenshot of the experiment scene is flapping and showing a blank chart.
Ref. https://posthog.slack.com/archives/C07PXH2GTGV/p1744110425773929

## Changes
Ideally, we would wait for a some fancy check to make sure the chart has rendered completely. But couldn't find a smooth/simple way, so just added a small delay for now. Not even sure this fixes it or if it's caused by some other rare race condition. But worth a try.

## How did you test this code?
* story renders fine still
