### PR TITLE
fix(hogql): check for deleted cohort in hogql filter

### DIFF
--- a/posthog/hogql/transforms/in_cohort.py
+++ b/posthog/hogql/transforms/in_cohort.py
@@ -95,7 +95,7 @@ class MultipleInCohortResolver(TraversingVisitor):
 
             if (isinstance(arg.value, int) or isinstance(arg.value, float)) and not isinstance(arg.value, bool):
                 int_cohorts = Cohort.objects.filter(
-                    id=int(arg.value), team__project_id=self.context.project_id
+                    id=int(arg.value), team__project_id=self.context.project_id, deleted=False
                 ).values_list("id", "is_static", "version")
                 if len(int_cohorts) == 1:
                     if node.op == ast.CompareOperationOp.NotInCohort:
@@ -310,9 +310,9 @@ class InCohortResolver(TraversingVisitor):
                 raise QueryError(f"Could not find cohort with ID {arg.value}", node=arg)
 
             if isinstance(arg.value, str):
-                cohorts2 = Cohort.objects.filter(name=arg.value, team__project_id=self.context.project_id).values_list(
-                    "id", "is_static", "version"
-                )
+                cohorts2 = Cohort.objects.filter(
+                    name=arg.value, team__project_id=self.context.project_id, deleted=False
+                ).values_list("id", "is_static", "version")
                 if len(cohorts2) == 1:
                     self.context.add_notice(
                         start=arg.start,

--- a/posthog/hogql/transforms/test/__snapshots__/test_in_cohort.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_in_cohort.ambr
@@ -71,6 +71,30 @@
   LIMIT 100
   '''
 # ---
+# name: TestInCohort.test_in_cohort_deleted
+  '''
+  -- ClickHouse
+  
+  SELECT events.event AS event 
+  FROM events LEFT JOIN (
+  SELECT person_static_cohort.person_id AS person_id, 1 AS matched 
+  FROM person_static_cohort 
+  WHERE and(equals(person_static_cohort.team_id, 99999), equals(person_static_cohort.cohort_id, XX))) AS in_cohort__XX ON equals(in_cohort__XX.person_id, events.person_id) 
+  WHERE and(equals(events.team_id, 99999), ifNull(equals(in_cohort__XX.matched, 1), 0)) 
+  LIMIT 100 
+  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1, format_csv_allow_double_quotes=0, max_ast_elements=4000000, max_expanded_ast_elements=4000000, max_bytes_before_external_group_by=0, transform_null_in=1
+  
+  -- HogQL
+  
+  SELECT event 
+  FROM events LEFT JOIN (
+  SELECT person_id, 1 AS matched 
+  FROM static_cohort_people 
+  WHERE equals(cohort_id, XX)) AS in_cohort__XX ON equals(in_cohort__XX.person_id, person_id) 
+  WHERE equals(in_cohort__XX.matched, 1) 
+  LIMIT 100
+  '''
+# ---
 # name: TestInCohort.test_in_cohort_dynamic
   '''
   -- ClickHouse


### PR DESCRIPTION
## Problem

- when you filter for cohort in hogql, we consider deleted cohorts which causes unexpected dup issues

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- don't consider deleted

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
