### PR TITLE
fix(experiments): implement exposure criteria label properly

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
@@ -6,11 +6,22 @@ import { useActions, useValues } from 'kea'
 import { humanFriendlyNumber } from 'lib/utils'
 import { useEffect, useRef } from 'react'
 
+import { ExperimentExposureCriteria } from '~/queries/schema/schema-general'
+
 import { experimentLogic } from '../experimentLogic'
 import { VariantTag } from './components'
 
+function getExposureCriteriaLabel(exposureCriteria: ExperimentExposureCriteria | undefined): string {
+    const exposureConfig = exposureCriteria?.exposure_config
+    if (!exposureConfig) {
+        return 'Default ($feature_flag_called)'
+    }
+
+    return `Custom (${exposureConfig.event})`
+}
+
 export function Exposures(): JSX.Element {
-    const { experimentId, exposures, exposuresLoading, exposureCriteriaLabel } = useValues(experimentLogic)
+    const { experimentId, exposures, exposuresLoading, exposureCriteria } = useValues(experimentLogic)
     const { openExposureCriteriaModal } = useActions(experimentLogic)
 
     const chartRef = useRef<Chart | null>(null)
@@ -137,7 +148,9 @@ export function Exposures(): JSX.Element {
                             <div>
                                 <h3 className="card-secondary">Exposure criteria</h3>
                                 <div className="flex items-center gap-2">
-                                    <div className="text-sm font-semibold">{exposureCriteriaLabel}</div>
+                                    <div className="text-sm font-semibold">
+                                        {getExposureCriteriaLabel(exposureCriteria)}
+                                    </div>
                                     <LemonButton
                                         icon={<IconPencil fontSize="12" />}
                                         size="xsmall"

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -2193,10 +2193,14 @@ export const experimentLogic = kea<experimentLogicType>([
             },
         ],
         exposureCriteriaLabel: [
-            () => [],
-            (): string => {
-                // TODO: Implement exposure criteria label
-                return 'Default ($feature_flag_called)'
+            (s) => [s.experiment],
+            (experiment: Experiment): string => {
+                const exposureCriteria = experiment.exposure_criteria?.exposure_config
+                if (!exposureCriteria) {
+                    return 'Default ($feature_flag_called)'
+                }
+
+                return `Custom (${exposureCriteria.event})`
             },
         ],
     }),

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -2192,15 +2192,10 @@ export const experimentLogic = kea<experimentLogicType>([
                 return true
             },
         ],
-        exposureCriteriaLabel: [
+        exposureCriteria: [
             (s) => [s.experiment],
-            (experiment: Experiment): string => {
-                const exposureCriteria = experiment.exposure_criteria?.exposure_config
-                if (!exposureCriteria) {
-                    return 'Default ($feature_flag_called)'
-                }
-
-                return `Custom (${exposureCriteria.event})`
+            (experiment: Experiment): ExperimentExposureCriteria | undefined => {
+                return experiment.exposure_criteria
             },
         ],
     }),


### PR DESCRIPTION
## Problem
The initial implementation just returned a hard coded Default ($feature_flag_called)` regardless of whether it was default or custom.

## Changes
Return `Custom (<event name>)` if a custom exposure criteria is used.

Default as before
<img width="373" alt="Screenshot 2025-04-08 at 16 28 02" src="https://github.com/user-attachments/assets/198e6eaf-033c-4f03-b47e-2de7a9cd2c3a" />

Custom like this
<img width="349" alt="Screenshot 2025-04-08 at 16 27 53" src="https://github.com/user-attachments/assets/5e2c6b1d-6eb3-461d-82ef-915b0506906a" />

## How did you test this code?
* manually tested with and without 👀 