### PR TITLE
fix(data-warehouse): Update frontend routing for external data sources to use environment

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -812,7 +812,7 @@ class ApiRequest {
 
     // # Warehouse
     public dataWarehouseTables(teamId?: TeamType['id']): ApiRequest {
-        return this.projectsDetail(teamId).addPathComponent('warehouse_tables')
+        return this.environmentsDetail(teamId).addPathComponent('warehouse_tables')
     }
     public dataWarehouseTable(id: DataWarehouseTable['id'], teamId?: TeamType['id']): ApiRequest {
         return this.dataWarehouseTables(teamId).addPathComponent(id)
@@ -1044,7 +1044,7 @@ class ApiRequest {
 
     // External Data Source
     public externalDataSources(teamId?: TeamType['id']): ApiRequest {
-        return this.projectsDetail(teamId).addPathComponent('external_data_sources')
+        return this.environmentsDetail(teamId).addPathComponent('external_data_sources')
     }
 
     public externalDataSource(sourceId: ExternalDataSource['id'], teamId?: TeamType['id']): ApiRequest {
@@ -1052,7 +1052,7 @@ class ApiRequest {
     }
 
     public externalDataSchemas(teamId?: TeamType['id']): ApiRequest {
-        return this.projectsDetail(teamId).addPathComponent('external_data_schemas')
+        return this.environmentsDetail(teamId).addPathComponent('external_data_schemas')
     }
 
     public externalDataSourceSchema(schemaId: ExternalDataSourceSchema['id'], teamId?: TeamType['id']): ApiRequest {

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -75,7 +75,7 @@ export const defaultMocks: Mocks = {
         '/api/environments/:team_id/hog_functions/': EMPTY_PAGINATED_RESPONSE,
         '/api/projects/:team_id/dashboard_templates': EMPTY_PAGINATED_RESPONSE,
         '/api/projects/:team_id/dashboard_templates/repository/': [],
-        '/api/projects/:team_id/external_data_sources/': EMPTY_PAGINATED_RESPONSE,
+        '/api/environments/:team_id/external_data_sources/': EMPTY_PAGINATED_RESPONSE,
         '/api/projects/:team_id/notebooks': () => {
             // this was matching on `?contains=query` but that made MSW unhappy and seems unnecessary
             return [
@@ -106,7 +106,7 @@ export const defaultMocks: Mocks = {
         '/api/environments/:team_id/explicit_members/': [],
         '/api/projects/:team_id/warehouse_view_link/': EMPTY_PAGINATED_RESPONSE,
         '/api/projects/:team_id/warehouse_saved_queries/': EMPTY_PAGINATED_RESPONSE,
-        '/api/projects/:team_id/warehouse_tables/': EMPTY_PAGINATED_RESPONSE,
+        '/api/environments/:team_id/warehouse_tables/': EMPTY_PAGINATED_RESPONSE,
         '/api/organizations/@current/': (): MockSignature => [
             200,
             { ...MOCK_DEFAULT_ORGANIZATION, available_product_features: getAvailableProductFeatures() },

--- a/posthog/warehouse/api/test/test_external_data_schema.py
+++ b/posthog/warehouse/api/test/test_external_data_schema.py
@@ -1,15 +1,17 @@
+import uuid
 from datetime import timedelta
 from unittest import mock
-import uuid
+
 import psycopg
 import pytest
-from asgiref.sync import sync_to_async
 import pytest_asyncio
+from asgiref.sync import sync_to_async
+from django.conf import settings
+
 from posthog.test.base import APIBaseTest
 from posthog.warehouse.models import DataWarehouseTable
 from posthog.warehouse.models.external_data_schema import ExternalDataSchema
 from posthog.warehouse.models.external_data_source import ExternalDataSource
-from django.conf import settings
 
 
 @pytest.fixture
@@ -64,7 +66,7 @@ class TestExternalDataSchema(APIBaseTest):
         )
 
         response = self.client.post(
-            f"/api/projects/{self.team.pk}/external_data_schemas/{schema.id}/incremental_fields",
+            f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}/incremental_fields",
         )
         payload = response.json()
 
@@ -85,7 +87,7 @@ class TestExternalDataSchema(APIBaseTest):
         )
 
         response = self.client.post(
-            f"/api/projects/{self.team.pk}/external_data_schemas/{schema.id}/incremental_fields",
+            f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}/incremental_fields",
         )
 
         assert response.status_code == 400
@@ -105,7 +107,7 @@ class TestExternalDataSchema(APIBaseTest):
         )
 
         response = self.client.post(
-            f"/api/projects/{self.team.pk}/external_data_schemas/{schema.id}/incremental_fields",
+            f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}/incremental_fields",
         )
 
         # should respond but with empty list. Example: Hubspot has not incremental fields but the response should be an empty list so that full refresh is selectable
@@ -155,7 +157,7 @@ class TestExternalDataSchema(APIBaseTest):
         )
 
         response = await sync_to_async(self.client.post)(
-            f"/api/projects/{self.team.pk}/external_data_schemas/{schema.id}/incremental_fields",
+            f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}/incremental_fields",
         )
         payload = response.json()
 
@@ -179,7 +181,7 @@ class TestExternalDataSchema(APIBaseTest):
             "posthog.warehouse.api.external_data_schema.trigger_external_data_workflow"
         ) as mock_trigger_external_data_workflow:
             response = self.client.patch(
-                f"/api/projects/{self.team.pk}/external_data_schemas/{schema.id}",
+                f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
                 data={"sync_type": "full_refresh"},
             )
 
@@ -212,7 +214,7 @@ class TestExternalDataSchema(APIBaseTest):
             mock.patch.object(DataWarehouseTable, "get_max_value_for_column", return_value=1),
         ):
             response = self.client.patch(
-                f"/api/projects/{self.team.pk}/external_data_schemas/{schema.id}",
+                f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
                 data={"sync_type": "incremental", "incremental_field": "field", "incremental_field_type": "integer"},
             )
 
@@ -250,7 +252,7 @@ class TestExternalDataSchema(APIBaseTest):
             mock_external_data_workflow_exists.return_value = True
 
             response = self.client.patch(
-                f"/api/projects/{self.team.pk}/external_data_schemas/{schema.id}",
+                f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
                 data={"should_sync": False},
             )
 
@@ -284,7 +286,7 @@ class TestExternalDataSchema(APIBaseTest):
             mock_external_data_workflow_exists.return_value = True
 
             response = self.client.patch(
-                f"/api/projects/{self.team.pk}/external_data_schemas/{schema.id}",
+                f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
                 data={"should_sync": True},
             )
 
@@ -318,7 +320,7 @@ class TestExternalDataSchema(APIBaseTest):
             mock_external_data_workflow_exists.return_value = False
 
             response = self.client.patch(
-                f"/api/projects/{self.team.pk}/external_data_schemas/{schema.id}",
+                f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
                 data={"should_sync": True},
             )
 
@@ -342,7 +344,7 @@ class TestExternalDataSchema(APIBaseTest):
         )
 
         response = self.client.patch(
-            f"/api/projects/{self.team.pk}/external_data_schemas/{schema.id}",
+            f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
             data={"should_sync": True},
         )
 
@@ -362,7 +364,7 @@ class TestExternalDataSchema(APIBaseTest):
         )
 
         response = self.client.patch(
-            f"/api/projects/{self.team.pk}/external_data_schemas/{schema.id}",
+            f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
             data={"sync_type": "blah"},
         )
 
@@ -393,7 +395,7 @@ class TestExternalDataSchema(APIBaseTest):
             mock_external_data_workflow_exists.return_value = True
 
             response = self.client.patch(
-                f"/api/projects/{self.team.pk}/external_data_schemas/{schema.id}",
+                f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
                 data={"sync_frequency": "7day"},
             )
 
@@ -429,7 +431,7 @@ class TestExternalDataSchema(APIBaseTest):
             mock_external_data_workflow_exists.return_value = True
 
             response = self.client.patch(
-                f"/api/projects/{self.team.pk}/external_data_schemas/{schema.id}",
+                f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
                 data={"sync_time_of_day": "15:30:00"},
             )
 

--- a/posthog/warehouse/api/test/test_external_data_source.py
+++ b/posthog/warehouse/api/test/test_external_data_source.py
@@ -44,7 +44,7 @@ class TestExternalDataSource(APIBaseTest):
 
     def test_create_external_data_source(self):
         response = self.client.post(
-            f"/api/projects/{self.team.pk}/external_data_sources/",
+            f"/api/environments/{self.team.pk}/external_data_sources/",
             data={
                 "source_type": "Stripe",
                 "payload": {
@@ -72,7 +72,7 @@ class TestExternalDataSource(APIBaseTest):
 
     def test_create_external_data_source_delete_on_missing_schemas(self):
         response = self.client.post(
-            f"/api/projects/{self.team.pk}/external_data_sources/",
+            f"/api/environments/{self.team.pk}/external_data_sources/",
             data={
                 "source_type": "Stripe",
                 "payload": {
@@ -87,7 +87,7 @@ class TestExternalDataSource(APIBaseTest):
 
     def test_create_external_data_source_delete_on_bad_schema(self):
         response = self.client.post(
-            f"/api/projects/{self.team.pk}/external_data_sources/",
+            f"/api/environments/{self.team.pk}/external_data_sources/",
             data={
                 "source_type": "Stripe",
                 "payload": {
@@ -106,7 +106,7 @@ class TestExternalDataSource(APIBaseTest):
         # Create no prefix
 
         response = self.client.post(
-            f"/api/projects/{self.team.pk}/external_data_sources/",
+            f"/api/environments/{self.team.pk}/external_data_sources/",
             data={
                 "source_type": "Stripe",
                 "payload": {
@@ -128,7 +128,7 @@ class TestExternalDataSource(APIBaseTest):
         # Try to create same type without prefix again
 
         response = self.client.post(
-            f"/api/projects/{self.team.pk}/external_data_sources/",
+            f"/api/environments/{self.team.pk}/external_data_sources/",
             data={
                 "source_type": "Stripe",
                 "payload": {
@@ -151,7 +151,7 @@ class TestExternalDataSource(APIBaseTest):
 
         # Create with prefix
         response = self.client.post(
-            f"/api/projects/{self.team.pk}/external_data_sources/",
+            f"/api/environments/{self.team.pk}/external_data_sources/",
             data={
                 "source_type": "Stripe",
                 "payload": {
@@ -174,7 +174,7 @@ class TestExternalDataSource(APIBaseTest):
 
         # Try to create same type with same prefix again
         response = self.client.post(
-            f"/api/projects/{self.team.pk}/external_data_sources/",
+            f"/api/environments/{self.team.pk}/external_data_sources/",
             data={
                 "source_type": "Stripe",
                 "payload": {
@@ -198,7 +198,7 @@ class TestExternalDataSource(APIBaseTest):
 
     def test_create_external_data_source_incremental(self):
         response = self.client.post(
-            f"/api/projects/{self.team.pk}/external_data_sources/",
+            f"/api/environments/{self.team.pk}/external_data_sources/",
             data={
                 "source_type": "Stripe",
                 "payload": {
@@ -261,7 +261,7 @@ class TestExternalDataSource(APIBaseTest):
 
     def test_create_external_data_source_incremental_missing_field(self):
         response = self.client.post(
-            f"/api/projects/{self.team.pk}/external_data_sources/",
+            f"/api/environments/{self.team.pk}/external_data_sources/",
             data={
                 "source_type": "Stripe",
                 "payload": {
@@ -318,7 +318,7 @@ class TestExternalDataSource(APIBaseTest):
 
     def test_create_external_data_source_incremental_missing_type(self):
         response = self.client.post(
-            f"/api/projects/{self.team.pk}/external_data_sources/",
+            f"/api/environments/{self.team.pk}/external_data_sources/",
             data={
                 "source_type": "Stripe",
                 "payload": {
@@ -379,7 +379,7 @@ class TestExternalDataSource(APIBaseTest):
             mocked_get_bigquery_schemas.return_value = {"my_schema": "something"}
 
             response = self.client.post(
-                f"/api/projects/{self.team.pk}/external_data_sources/",
+                f"/api/environments/{self.team.pk}/external_data_sources/",
                 data={
                     "source_type": "BigQuery",
                     "payload": {
@@ -417,7 +417,7 @@ class TestExternalDataSource(APIBaseTest):
     def test_create_external_data_source_missing_required_bigquery_job_input(self):
         """Test we fail source creation when missing inputs."""
         response = self.client.post(
-            f"/api/projects/{self.team.pk}/external_data_sources/",
+            f"/api/environments/{self.team.pk}/external_data_sources/",
             data={
                 "source_type": "BigQuery",
                 "payload": {
@@ -442,7 +442,7 @@ class TestExternalDataSource(APIBaseTest):
             mocked_get_bigquery_schemas.return_value = {"my_schema": "something"}
 
             response = self.client.post(
-                f"/api/projects/{self.team.pk}/external_data_sources/",
+                f"/api/environments/{self.team.pk}/external_data_sources/",
                 data={
                     "source_type": "BigQuery",
                     "payload": {
@@ -477,7 +477,7 @@ class TestExternalDataSource(APIBaseTest):
         assert source_model.job_inputs["private_key_id"] == "my_private_key_id"
 
         response = self.client.patch(
-            f"/api/projects/{self.team.pk}/external_data_sources/{str(source_model.pk)}/",
+            f"/api/environments/{self.team.pk}/external_data_sources/{str(source_model.pk)}/",
             data={
                 "job_inputs": {
                     "dataset_id": "my_new_dataset",
@@ -501,7 +501,7 @@ class TestExternalDataSource(APIBaseTest):
         self._create_external_data_source()
 
         with self.assertNumQueries(23):
-            response = self.client.get(f"/api/projects/{self.team.pk}/external_data_sources/")
+            response = self.client.get(f"/api/environments/{self.team.pk}/external_data_sources/")
         payload = response.json()
 
         self.assertEqual(response.status_code, 200)
@@ -510,7 +510,7 @@ class TestExternalDataSource(APIBaseTest):
     def test_dont_expose_job_inputs(self):
         self._create_external_data_source()
 
-        response = self.client.get(f"/api/projects/{self.team.pk}/external_data_sources/")
+        response = self.client.get(f"/api/environments/{self.team.pk}/external_data_sources/")
         payload = response.json()
         results = payload["results"]
 
@@ -524,7 +524,7 @@ class TestExternalDataSource(APIBaseTest):
         source = self._create_external_data_source()
         schema = self._create_external_data_schema(source.pk)
 
-        response = self.client.get(f"/api/projects/{self.team.pk}/external_data_sources/{source.pk}")
+        response = self.client.get(f"/api/environments/{self.team.pk}/external_data_sources/{source.pk}")
         payload = response.json()
 
         self.assertEqual(response.status_code, 200)
@@ -568,7 +568,7 @@ class TestExternalDataSource(APIBaseTest):
         source = self._create_external_data_source()
         schema = self._create_external_data_schema(source.pk)
 
-        response = self.client.delete(f"/api/projects/{self.team.pk}/external_data_sources/{source.pk}")
+        response = self.client.delete(f"/api/environments/{self.team.pk}/external_data_sources/{source.pk}")
 
         assert response.status_code == 204
 
@@ -580,7 +580,7 @@ class TestExternalDataSource(APIBaseTest):
     def test_reload_external_data_source(self, mock_trigger):
         source = self._create_external_data_source()
 
-        response = self.client.post(f"/api/projects/{self.team.pk}/external_data_sources/{source.pk}/reload/")
+        response = self.client.post(f"/api/environments/{self.team.pk}/external_data_sources/{source.pk}/reload/")
 
         source.refresh_from_db()
 
@@ -610,7 +610,7 @@ class TestExternalDataSource(APIBaseTest):
             postgres_connection.commit()
 
         response = self.client.post(
-            f"/api/projects/{self.team.pk}/external_data_sources/database_schema/",
+            f"/api/environments/{self.team.pk}/external_data_sources/database_schema/",
             data={
                 "source_type": "Postgres",
                 "host": settings.PG_HOST,
@@ -645,7 +645,7 @@ class TestExternalDataSource(APIBaseTest):
             validate_credentials_mock.return_value = True
 
             response = self.client.post(
-                f"/api/projects/{self.team.pk}/external_data_sources/database_schema/",
+                f"/api/environments/{self.team.pk}/external_data_sources/database_schema/",
                 data={
                     "source_type": "Stripe",
                     "client_secret": "blah",
@@ -662,7 +662,7 @@ class TestExternalDataSource(APIBaseTest):
             validate_credentials_mock.side_effect = Exception("Invalid API key")
 
             response = self.client.post(
-                f"/api/projects/{self.team.pk}/external_data_sources/database_schema/",
+                f"/api/environments/{self.team.pk}/external_data_sources/database_schema/",
                 data={
                     "source_type": "Stripe",
                     "stripe_secret_key": "invalid_key",
@@ -676,13 +676,15 @@ class TestExternalDataSource(APIBaseTest):
         with patch(
             "posthog.warehouse.api.external_data_source.validate_stripe_credentials"
         ) as validate_credentials_mock:
-            from posthog.temporal.data_imports.pipelines.stripe import StripePermissionError
+            from posthog.temporal.data_imports.pipelines.stripe import (
+                StripePermissionError,
+            )
 
             missing_permissions = {"Account": "Error message for Account", "Invoice": "Error message for Invoice"}
             validate_credentials_mock.side_effect = StripePermissionError(missing_permissions)
 
             response = self.client.post(
-                f"/api/projects/{self.team.pk}/external_data_sources/database_schema/",
+                f"/api/environments/{self.team.pk}/external_data_sources/database_schema/",
                 data={
                     "source_type": "Stripe",
                     "stripe_secret_key": "invalid_key",
@@ -699,7 +701,7 @@ class TestExternalDataSource(APIBaseTest):
             validate_credentials_mock.return_value = True
 
             response = self.client.post(
-                f"/api/projects/{self.team.pk}/external_data_sources/database_schema/",
+                f"/api/environments/{self.team.pk}/external_data_sources/database_schema/",
                 data={
                     "source_type": "Zendesk",
                     "subdomain": "blah",
@@ -717,7 +719,7 @@ class TestExternalDataSource(APIBaseTest):
             validate_credentials_mock.return_value = False
 
             response = self.client.post(
-                f"/api/projects/{self.team.pk}/external_data_sources/database_schema/",
+                f"/api/environments/{self.team.pk}/external_data_sources/database_schema/",
                 data={
                     "source_type": "Zendesk",
                     "subdomain": "blah",
@@ -734,7 +736,7 @@ class TestExternalDataSource(APIBaseTest):
         ) as validate_credentials_mock:
             validate_credentials_mock.return_value = True
             response = self.client.post(
-                f"/api/projects/{self.team.pk}/external_data_sources/database_schema/",
+                f"/api/environments/{self.team.pk}/external_data_sources/database_schema/",
                 data={
                     "source_type": "Stripe",
                 },
@@ -764,7 +766,7 @@ class TestExternalDataSource(APIBaseTest):
         with override_settings(CLOUD_DEPLOYMENT="US"):
             team_2 = Team.objects.create(id=2, organization=self.team.organization)
             response = self.client.post(
-                f"/api/projects/{team_2.id}/external_data_sources/database_schema/",
+                f"/api/environments/{team_2.id}/external_data_sources/database_schema/",
                 data={
                     "source_type": "Postgres",
                     "host": "172.16.0.0",
@@ -791,7 +793,7 @@ class TestExternalDataSource(APIBaseTest):
             new_team = Team.objects.create(id=984961485, name="new_team", organization=self.team.organization)
 
             response = self.client.post(
-                f"/api/projects/{new_team.pk}/external_data_sources/database_schema/",
+                f"/api/environments/{new_team.pk}/external_data_sources/database_schema/",
                 data={
                     "source_type": "Postgres",
                     "host": "172.16.0.0",
@@ -808,7 +810,7 @@ class TestExternalDataSource(APIBaseTest):
         with override_settings(CLOUD_DEPLOYMENT="EU"):
             team_1 = Team.objects.create(id=1, organization=self.team.organization)
             response = self.client.post(
-                f"/api/projects/{team_1.id}/external_data_sources/database_schema/",
+                f"/api/environments/{team_1.id}/external_data_sources/database_schema/",
                 data={
                     "source_type": "Postgres",
                     "host": "172.16.0.0",
@@ -837,7 +839,7 @@ class TestExternalDataSource(APIBaseTest):
             new_team = Team.objects.create(id=984961486, name="new_team", organization=self.team.organization)
 
             response = self.client.post(
-                f"/api/projects/{new_team.pk}/external_data_sources/database_schema/",
+                f"/api/environments/{new_team.pk}/external_data_sources/database_schema/",
                 data={
                     "source_type": "Postgres",
                     "host": "172.16.0.0",
@@ -865,7 +867,7 @@ class TestExternalDataSource(APIBaseTest):
         )
 
         response = self.client.get(
-            f"/api/projects/{self.team.pk}/external_data_sources/{source.pk}/jobs",
+            f"/api/environments/{self.team.pk}/external_data_sources/{source.pk}/jobs",
         )
 
         data = response.json()
@@ -893,7 +895,7 @@ class TestExternalDataSource(APIBaseTest):
         )
 
         response = self.client.get(
-            f"/api/projects/{self.team.pk}/external_data_sources/{source.pk}/jobs",
+            f"/api/environments/{self.team.pk}/external_data_sources/{source.pk}/jobs",
         )
 
         data = response.json()
@@ -916,7 +918,7 @@ class TestExternalDataSource(APIBaseTest):
             )
 
             response = self.client.get(
-                f"/api/projects/{self.team.pk}/external_data_sources/{source.pk}/jobs",
+                f"/api/environments/{self.team.pk}/external_data_sources/{source.pk}/jobs",
             )
 
             data = response.json()
@@ -938,7 +940,7 @@ class TestExternalDataSource(APIBaseTest):
             )
 
             response = self.client.get(
-                f"/api/projects/{self.team.pk}/external_data_sources/{source.pk}/jobs?after=2024-07-01T12:00:00.000Z",
+                f"/api/environments/{self.team.pk}/external_data_sources/{source.pk}/jobs?after=2024-07-01T12:00:00.000Z",
             )
 
             data = response.json()
@@ -960,7 +962,7 @@ class TestExternalDataSource(APIBaseTest):
             )
 
             response = self.client.get(
-                f"/api/projects/{self.team.pk}/external_data_sources/{source.pk}/jobs?before=2024-07-01T12:00:00.000Z",
+                f"/api/environments/{self.team.pk}/external_data_sources/{source.pk}/jobs?before=2024-07-01T12:00:00.000Z",
             )
 
             data = response.json()
@@ -971,7 +973,7 @@ class TestExternalDataSource(APIBaseTest):
 
     def test_trimming_payload(self):
         response = self.client.post(
-            f"/api/projects/{self.team.pk}/external_data_sources/",
+            f"/api/environments/{self.team.pk}/external_data_sources/",
             data={
                 "source_type": "Stripe",
                 "payload": {
@@ -1002,7 +1004,7 @@ class TestExternalDataSource(APIBaseTest):
 
         # Update with SSH tunnel config
         response = self.client.patch(
-            f"/api/projects/{self.team.pk}/external_data_sources/{str(source.pk)}/",
+            f"/api/environments/{self.team.pk}/external_data_sources/{str(source.pk)}/",
             data={
                 "job_inputs": {
                     "ssh-tunnel": {
@@ -1035,7 +1037,7 @@ class TestExternalDataSource(APIBaseTest):
         assert source.job_inputs["ssh_tunnel_auth_type_private_key"] == "testkey"
 
         # Test the to_representation from flattened to nested structure
-        response = self.client.get(f"/api/projects/{self.team.pk}/external_data_sources/{source.pk}")
+        response = self.client.get(f"/api/environments/{self.team.pk}/external_data_sources/{source.pk}")
 
         assert response.status_code == 200
         data = response.json()
@@ -1061,7 +1063,7 @@ class TestExternalDataSource(APIBaseTest):
 
             # Create a Snowflake source with password auth
             response = self.client.post(
-                f"/api/projects/{self.team.pk}/external_data_sources/",
+                f"/api/environments/{self.team.pk}/external_data_sources/",
                 data={
                     "prefix": "",
                     "payload": {
@@ -1112,7 +1114,7 @@ class TestExternalDataSource(APIBaseTest):
 
         # Update the source with a new auth type
         response = self.client.patch(
-            f"/api/projects/{self.team.pk}/external_data_sources/{source_model.pk}/",
+            f"/api/environments/{self.team.pk}/external_data_sources/{source_model.pk}/",
             data={
                 "job_inputs": {
                     "role": "my_role",

--- a/posthog/warehouse/api/test/test_log_entry.py
+++ b/posthog/warehouse/api/test/test_log_entry.py
@@ -1,19 +1,20 @@
 import datetime as dt
+
 import pytest
+from django.test.client import Client as TestClient
 
 from posthog.api.test.test_organization import create_organization
 from posthog.api.test.test_team import create_team
 from posthog.api.test.test_user import create_user
 from posthog.clickhouse.client import sync_execute
-from django.test.client import Client as TestClient
-from posthog.warehouse.models import (
-    ExternalDataSchema,
-    ExternalDataJob,
-    ExternalDataSource,
-    DataWarehouseTable,
-    DataWarehouseCredential,
-)
 from posthog.utils import encode_get_request_params
+from posthog.warehouse.models import (
+    DataWarehouseCredential,
+    DataWarehouseTable,
+    ExternalDataJob,
+    ExternalDataSchema,
+    ExternalDataSource,
+)
 
 
 def create_external_data_job_log_entry(
@@ -109,7 +110,7 @@ def external_data_resources(client, organization, team):
 
 def get_external_data_schema_run_log_entries(client: TestClient, team_id: int, external_data_schema_id: str, **extra):
     return client.get(
-        f"/api/projects/{team_id}/external_data_schemas/{external_data_schema_id}/logs",
+        f"/api/environments/{team_id}/external_data_schemas/{external_data_schema_id}/logs",
         data=encode_get_request_params(extra),
     )
 


### PR DESCRIPTION
## Problem

The frontend is routing requests for external data sources and data warehouse tables based on the current project, rather than the current environment. This is causing issues for customers who have enabled environments.

## Changes

Route requests based on selected environment.

I haven't changed the routing for saved queries and other parts of the SQL editor just to keep the changes minimal. I think we should probably do this in a follow up PR though.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Tested locally.

Updated unit tests.
