### PR TITLE
refactor: Use `ast.SelectQuery` to build revenue analytics query

### DIFF
--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -1290,7 +1290,7 @@ class _Printer(Visitor):
 
             args = [self.visit(arg) for arg in node.args]
 
-            if self.dialect in ("hogql", "clickhouse"):
+            if self.dialect == "clickhouse":
                 if node.name == "hogql_lookupDomainType":
                     return f"coalesce(dictGetOrNull('channel_definition_dict', 'domain_type', (coalesce({args[0]}, ''), 'source')), dictGetOrNull('channel_definition_dict', 'domain_type', (cutToFirstSignificantSubdomain(coalesce({args[0]}, '')), 'source')))"
                 elif node.name == "hogql_lookupPaidSourceType":
@@ -1317,7 +1317,9 @@ class _Printer(Visitor):
                 params_part = f"({', '.join(params)})" if params is not None else ""
                 args_part = f"({', '.join(args)})"
                 return f"{relevant_clickhouse_name}{params_part}{args_part}"
-            raise QueryError(f"Unexpected unresolved HogQL function '{node.name}(...)'")
+
+            # If hogql dialect, just keep it as is
+            return f"{node.name}({', '.join(args)})"
         else:
             close_matches = get_close_matches(node.name, ALL_EXPOSED_FUNCTION_NAMES, 1)
             if len(close_matches) > 0:

--- a/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_example_data_warehouse_tables_query_runner.ambr
+++ b/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_example_data_warehouse_tables_query_runner.ambr
@@ -10,15 +10,16 @@
   FROM
     (SELECT stripe_charge.id AS id,
             parseDateTime64BestEffortOrNull(toString(stripe_charge.created), 6, 'UTC') AS timestamp,
-            accurateCastOrNull(stripe_charge.amount, 'Decimal64(10)') AS original_amount,
+            accurateCastOrNull(stripe_charge.amount_captured, 'Decimal64(10)') AS original_amount,
             upper(stripe_charge.currency) AS original_currency,
             in(original_currency,
-               tuple('BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF')) AS currency_is_zero_decimal,
+               ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS currency_is_zero_decimal,
               if(currency_is_zero_decimal, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS amount_decimal_divider,
               divideDecimal(original_amount, amount_decimal_divider) AS adjusted_original_amount,
               'GBP' AS currency,
               if(equals(original_currency, currency), toDecimal64(adjusted_original_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(adjusted_original_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))) AS amount
-     FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue.stripe_charges/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `paid` Int8, `amount` Int64, `object` String, `source` String, `status` String, `created` DateTime, `invoice` String, `outcome` String, `captured` Int8, `currency` String, `customer` String, `disputed` Int8, `livemode` Int8, `metadata` String, `refunded` Int8, `description` String, `receipt_url` String, `failure_code` String, `fraud_details` String, `radar_options` String, `receipt_email` String, `payment_intent` String, `payment_method` String, `amount_captured` Int64, `amount_refunded` Int64, `billing_details` String, `failure_message` String, `balance_transaction` String, `statement_descriptor` String, `payment_method_details` String, `calculated_statement_descriptor` String') AS stripe_charge) AS stripe_posthog_test__revenue
+     FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue.stripe_charges/stripe_charge/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `paid` Int8, `amount` Int64, `object` String, `source` String, `status` String, `created` DateTime, `invoice` String, `outcome` String, `captured` Int8, `currency` String, `customer` String, `disputed` Int8, `livemode` Int8, `metadata` String, `refunded` Int8, `description` String, `receipt_url` String, `failure_code` String, `fraud_details` String, `radar_options` String, `receipt_email` String, `payment_intent` String, `payment_method` String, `amount_captured` Int64, `amount_refunded` Int64, `billing_details` String, `failure_message` String, `balance_transaction` String, `statement_descriptor` String, `payment_method_details` String, `calculated_statement_descriptor` String') AS stripe_charge
+     WHERE equals(stripe_charge.status, 'succeeded')) AS stripe_posthog_test__revenue
   ORDER BY stripe_posthog_test__revenue.timestamp DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,

--- a/products/revenue_analytics/backend/hogql_queries/test/test_revenue_example_data_warehouse_tables_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/test/test_revenue_example_data_warehouse_tables_query_runner.py
@@ -118,13 +118,13 @@ class TestRevenueExampleDataWarehouseTablesQueryRunner(ClickhouseTestMixin, APIB
         response = self._run_revenue_example_external_tables_query()
         results = response.results
 
-        assert len(results) == len(self.csv_df)  # Same amount os rows inside the CSV
+        # Not all rows in the CSV have a status of "succeeded", let's filter them out here
+        assert len(results) == len(self.csv_df[self.csv_df["status"] == "succeeded"])
 
         # Proper conversions for some of the rows
         assert results[0][2:] == (Decimal("220"), "EUR", Decimal("182.247167654"), "GBP")
-        assert results[1][2:] == (Decimal("90"), "USD", Decimal("71.73"), "GBP")
-        assert results[2][2:] == (Decimal("180"), "GBP", Decimal("180"), "GBP")
+        assert results[1][2:] == (Decimal("180"), "GBP", Decimal("180"), "GBP")
 
         # Test JPY where there are no decimals, and an input of 500 implies 500 Yen
         # rather than the above where we had 22000 for 220 EUR (and etc.)
-        assert results[4][2:] == (Decimal("500"), "JPY", Decimal("2.5438762801"), "GBP")
+        assert results[3][2:] == (Decimal("500"), "JPY", Decimal("2.5438762801"), "GBP")

--- a/products/revenue_analytics/backend/models.py
+++ b/products/revenue_analytics/backend/models.py
@@ -1,5 +1,6 @@
 from typing import cast, Optional
 
+from posthog.hogql import ast
 from posthog.warehouse.models.external_data_source import ExternalDataSource
 from posthog.warehouse.models.table import DataWarehouseTable
 from posthog.warehouse.models.external_data_schema import ExternalDataSchema
@@ -13,7 +14,7 @@ from posthog.hogql.database.models import (
     StringDatabaseField,
     FieldOrTable,
 )
-from posthog.hogql.database.schema.exchange_rate import DEFAULT_CURRENCY
+from posthog.hogql.database.schema.exchange_rate import DEFAULT_CURRENCY, convert_currency_call
 
 
 from typing import TYPE_CHECKING
@@ -27,36 +28,38 @@ STRIPE_DATA_WAREHOUSE_CHARGE_IDENTIFIER = "Charge"
 # since most currencies have its smallest unit as 1/100 of their base unit
 # It just so happens that some currencies don't have that concept, so they're listed here
 # https://docs.stripe.com/currencies#zero-decimal
-ZERO_DECIMAL_CURRENCIES_IN_STRIPE: list[CurrencyCode] = [
-    CurrencyCode.BIF,
-    CurrencyCode.CLP,
-    CurrencyCode.DJF,
-    CurrencyCode.GNF,
-    CurrencyCode.JPY,
-    CurrencyCode.KMF,
-    CurrencyCode.KRW,
-    CurrencyCode.MGA,
-    CurrencyCode.PYG,
-    CurrencyCode.RWF,
-    CurrencyCode.UGX,
-    CurrencyCode.VND,
-    CurrencyCode.VUV,
-    CurrencyCode.XAF,
-    CurrencyCode.XOF,
-    CurrencyCode.XPF,
+ZERO_DECIMAL_CURRENCIES_IN_STRIPE: list[str] = [
+    CurrencyCode.BIF.value,
+    CurrencyCode.CLP.value,
+    CurrencyCode.DJF.value,
+    CurrencyCode.GNF.value,
+    CurrencyCode.JPY.value,
+    CurrencyCode.KMF.value,
+    CurrencyCode.KRW.value,
+    CurrencyCode.MGA.value,
+    CurrencyCode.PYG.value,
+    CurrencyCode.RWF.value,
+    CurrencyCode.UGX.value,
+    CurrencyCode.VND.value,
+    CurrencyCode.VUV.value,
+    CurrencyCode.XAF.value,
+    CurrencyCode.XOF.value,
+    CurrencyCode.XPF.value,
 ]
 
 FIELDS: dict[str, FieldOrTable] = {
     "id": StringDatabaseField(name="id"),
     "timestamp": DateTimeDatabaseField(name="timestamp"),
-    "original_amount": DecimalDatabaseField(name="original_amount", hidden=True),
-    "original_currency": StringDatabaseField(name="original_currency", hidden=True),
-    "currency_is_zero_decimal": BooleanDatabaseField(name="currency_is_zero_decimal", hidden=True),
-    "amount_decimal_divider": DecimalDatabaseField(name="amount_decimal_divider", hidden=True),
-    "adjusted_original_amount": DecimalDatabaseField(name="adjusted_original_amount", hidden=True),
+    "original_amount": DecimalDatabaseField(name="original_amount"),
+    "original_currency": StringDatabaseField(name="original_currency"),
+    "currency_is_zero_decimal": BooleanDatabaseField(name="currency_is_zero_decimal"),
+    "amount_decimal_divider": DecimalDatabaseField(name="amount_decimal_divider"),
+    "adjusted_original_amount": DecimalDatabaseField(name="adjusted_original_amount"),
     "currency": StringDatabaseField(name="currency"),
     "amount": DecimalDatabaseField(name="amount"),
 }
+
+STRIPE_CHARGE_SUCCEEDED_STATUS = "succeeded"
 
 
 class RevenueAnalyticsRevenueView(SavedQuery):
@@ -88,27 +91,112 @@ class RevenueAnalyticsRevenueView(SavedQuery):
         team = table.team
         revenue_config = team.revenue_config
 
-        zero_decimal_currencies = ", ".join([f"'{currency.value}'" for currency in ZERO_DECIMAL_CURRENCIES_IN_STRIPE])
         base_currency = (revenue_config.baseCurrency or DEFAULT_CURRENCY).value
 
-        query = f"""
-    SELECT
-        id AS id,
-        created_at AS timestamp,
-        toDecimal(amount, {EXCHANGE_RATE_DECIMAL_PRECISION}) AS original_amount,
-        upper(currency) AS original_currency,
-        original_currency IN ({zero_decimal_currencies}) AS currency_is_zero_decimal,
-        if(currency_is_zero_decimal, toDecimal(1, {EXCHANGE_RATE_DECIMAL_PRECISION}), toDecimal(100, {EXCHANGE_RATE_DECIMAL_PRECISION})) AS amount_decimal_divider,
-        divideDecimal(original_amount, amount_decimal_divider) AS adjusted_original_amount,
-        '{base_currency}' AS currency,
-        convertCurrency(original_currency, currency, adjusted_original_amount, _toDate(ifNull(timestamp, toDateTime(0)))) AS amount
-    FROM
-        {table.name}
-"""
+        # Even though we need a string query for the view,
+        # using an ast allows us to comment what each field means, and
+        # avoid manual interpolation of constants, leaving that to the HogQL printer
+        query = ast.SelectQuery(
+            select=[
+                # Base fields to allow insights to work (need `distinct_id` AND `timestamp` fields)
+                ast.Alias(alias="id", expr=ast.Field(chain=["id"])),
+                ast.Alias(alias="timestamp", expr=ast.Field(chain=["created_at"])),
+                # Compute the original amount in the original currency
+                # by looking at the captured amount, effectively ignoring refunded value
+                ast.Alias(
+                    alias="original_amount",
+                    expr=ast.Call(
+                        name="toDecimal",
+                        args=[
+                            ast.Field(chain=["amount_captured"]),
+                            ast.Constant(value=EXCHANGE_RATE_DECIMAL_PRECISION),
+                        ],
+                    ),
+                ),
+                # Compute the original currency, converting to uppercase to match the currency code in the `exchange_rate` table
+                ast.Alias(
+                    alias="original_currency",
+                    expr=ast.Call(name="upper", args=[ast.Field(chain=["currency"])]),
+                ),
+                # Compute whether the original currency is a zero-decimal currency
+                # by comparing it against a list of zero-decimal currencies
+                ast.Alias(
+                    alias="currency_is_zero_decimal",
+                    expr=ast.Call(
+                        name="in",
+                        args=[
+                            ast.Field(chain=["original_currency"]),
+                            ast.Constant(value=ZERO_DECIMAL_CURRENCIES_IN_STRIPE),
+                        ],
+                    ),
+                ),
+                # Compute the amount decimal divider, which is 1 for zero-decimal currencies and 100 for others
+                # This is used to convert the original amount to the adjusted amount
+                ast.Alias(
+                    alias="amount_decimal_divider",
+                    expr=ast.Call(
+                        name="if",
+                        args=[
+                            ast.Field(chain=["currency_is_zero_decimal"]),
+                            ast.Call(
+                                name="toDecimal",
+                                args=[ast.Constant(value=1), ast.Constant(value=EXCHANGE_RATE_DECIMAL_PRECISION)],
+                            ),
+                            ast.Call(
+                                name="toDecimal",
+                                args=[ast.Constant(value=100), ast.Constant(value=EXCHANGE_RATE_DECIMAL_PRECISION)],
+                            ),
+                        ],
+                    ),
+                ),
+                # Compute the adjusted original amount, which is the original amount divided by the amount decimal divider
+                ast.Alias(
+                    alias="adjusted_original_amount",
+                    expr=ast.Call(
+                        name="divideDecimal",
+                        args=[
+                            ast.Field(chain=["original_amount"]),
+                            ast.Field(chain=["amount_decimal_divider"]),
+                        ],
+                    ),
+                ),
+                # Expose the base/converted currency, which is the base currency from the team's revenue config
+                ast.Alias(alias="currency", expr=ast.Constant(value=base_currency)),
+                # Convert the adjusted original amount to the base currency
+                ast.Alias(
+                    alias="amount",
+                    expr=convert_currency_call(
+                        amount=ast.Field(chain=["adjusted_original_amount"]),
+                        currency_from=ast.Field(chain=["original_currency"]),
+                        currency_to=ast.Field(chain=["currency"]),
+                        timestamp=ast.Call(
+                            name="_toDate",
+                            args=[
+                                ast.Call(
+                                    name="ifNull",
+                                    args=[
+                                        ast.Field(chain=["timestamp"]),
+                                        ast.Call(name="toDateTime", args=[ast.Constant(value=0)]),
+                                    ],
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            ],
+            # Simple query, simply refer to the `stripe_charge` table
+            select_from=ast.JoinExpr(table=ast.Field(chain=[table.name])),
+            # Only include succeeded charges because they're the ones that represent revenue
+            where=ast.CompareOperation(
+                left=ast.Field(chain=["status"]),
+                right=ast.Constant(value=STRIPE_CHARGE_SUCCEEDED_STATUS),
+                op=ast.CompareOperationOp.Eq,
+            ),
+        )
 
         return RevenueAnalyticsRevenueView(
             id=str(table.id),
             name=f"stripe_{source.prefix or source.id}_revenue",
-            query=query,
+            query=query.to_hogql(),
             fields=FIELDS,
         )


### PR DESCRIPTION
Even though we need a string query for the view, using an ast allows us to comment what each field means, and avoid manual interpolation of constants, leaving that to the HogQL printer

We had to tweak the printer slightly because of an old bug, but it all works pretty well without it - apparently.