### PR TITLE
fix: add survey_opt_in in team activity log tab

### DIFF
--- a/frontend/src/scenes/teamActivityDescriber.tsx
+++ b/frontend/src/scenes/teamActivityDescriber.tsx
@@ -542,7 +542,15 @@ const teamActionsMapping: Record<
     primary_dashboard: () => null,
     slack_incoming_webhook: () => null,
     timezone: () => null,
-    surveys_opt_in: () => null,
+    surveys_opt_in: (change): ChangeMapping | null => {
+        if (!change) {
+            return null
+        }
+
+        return {
+            description: [<>{change?.after ? 'enabled' : 'disabled'} surveys</>],
+        }
+    },
     flags_persistence_default: () => null,
     week_start_day: () => null,
     default_modifiers: () => null,


### PR DESCRIPTION
## Changes

display the `survey_opt_in` activity log entry in the team activity tab

<img width="785" alt="image" src="https://github.com/user-attachments/assets/c6801c59-1f2c-4eff-8bab-70d08703a5a1" />

## Does this work well for both Cloud and self-hosted?

yes

## How did you test this code?

no logic changes, just adding the activity. tested locally