### PR TITLE
chore(crm): Few navigation tweaks

### DIFF
--- a/frontend/src/layout/navigation-3000/navigationLogic.tsx
+++ b/frontend/src/layout/navigation-3000/navigationLogic.tsx
@@ -500,7 +500,7 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
                                   label: 'B2B analytics',
                                   icon: <IconGroups />,
                                   to: urls.groups(0),
-                                  tag: 'beta' as const,
+                                  tag: 'alpha' as const,
                                   sideAction:
                                       groupTypes.size > 1 && !showGroupsIntroductionPage
                                           ? {

--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -458,6 +458,9 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
                                                                             onClickInside={() => {
                                                                                 setVisibleSideAction('')
                                                                             }}
+                                                                            onClickOutside={() => {
+                                                                                setVisibleSideAction('')
+                                                                            }}
                                                                         >
                                                                             <ButtonPrimitive
                                                                                 sideActionRight

--- a/frontend/src/scenes/persons-management/personsManagementSceneLogic.tsx
+++ b/frontend/src/scenes/persons-management/personsManagementSceneLogic.tsx
@@ -1,4 +1,4 @@
-import { LemonButton } from '@posthog/lemon-ui'
+import { LemonButton, LemonTag } from '@posthog/lemon-ui'
 import { actions, connect, kea, path, reducers, selectors } from 'kea'
 import { actionToUrl, router, urlToAction } from 'kea-router'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -20,7 +20,7 @@ import { Persons } from './tabs/Persons'
 export type PersonsManagementTab = {
     key: string
     url: string
-    label: string
+    label: string | JSX.Element
     content: any
     buttons?: any
 }
@@ -77,7 +77,23 @@ export const personsManagementSceneLogic = kea<personsManagementSceneLogicType>(
                             </LemonButton>
                         ),
                     },
-                    ...(featureFlags[FEATURE_FLAGS.B2B_ANALYTICS] ? [] : groupTabs),
+                    ...(featureFlags[FEATURE_FLAGS.B2B_ANALYTICS]
+                        ? [
+                              {
+                                  key: 'groups',
+                                  label: (
+                                      <div className="flex items-center gap-1">
+                                          <span>Groups → B2B analytics</span>
+                                          <LemonTag type="completion" size="small">
+                                              alpha
+                                          </LemonTag>
+                                      </div>
+                                  ),
+                                  url: urls.groups(0),
+                                  content: null,
+                              },
+                          ]
+                        : groupTabs),
                 ]
             },
         ],


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/29881
Follow up from https://github.com/PostHog/posthog/pull/30930

## Changes

* B2B analytics is in alpha, not beta.
* Closes popover when clicking outside.
* Adds a hokey nav item for those who might be used to the location of groups:

![CleanShot 2025-04-08 at 12 09 22@2x](https://github.com/user-attachments/assets/0215a0c5-5eca-4d89-ba09-033630cd8051)

## How did you test this code?

Visual review.