### PR TITLE
fix: reduce compare recording metadata query mem

### DIFF
--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -7,7 +7,7 @@ on:
 jobs:
     check-description:
         name: Check that PR has description
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
         if: github.event.pull_request.draft == false
 
         steps:

--- a/posthog/temporal/compare_recording_metadata/compare_recording_metadata_workflow.py
+++ b/posthog/temporal/compare_recording_metadata/compare_recording_metadata_workflow.py
@@ -18,14 +18,15 @@ def get_session_replay_events(
     table_name: str,
     started_after: dt.datetime,
     started_before: dt.datetime,
+    session_length_limit_seconds: int = 172800,
 ) -> list[tuple]:
     """Get session replay events from the specified table within the time range."""
     query = """
         SELECT
             session_id,
             any(distinct_id) as distinct_id,
-            min(min_first_timestamp) as min_first_timestamp,
-            max(max_last_timestamp) as max_last_timestamp,
+            min(min_first_timestamp) as min_first_timestamp_agg,
+            max(max_last_timestamp) as max_last_timestamp_agg,
             argMinMerge(first_url) as first_url,
             groupUniqArrayArray(all_urls) as all_urls,
             sum(click_count) as click_count,
@@ -41,13 +42,14 @@ def get_session_replay_events(
             argMinMerge(snapshot_source) as snapshot_source,
             argMinMerge(snapshot_library) as snapshot_library
             {block_fields}
-        FROM
-            {table}
+        FROM {table}
+        WHERE min_first_timestamp >= toDateTime(%(started_after)s)
+        AND max_last_timestamp <= toDateTime(%(started_before)s) + INTERVAL {session_length_limit_seconds} SECOND
         GROUP BY
             session_id
         HAVING
-            min_first_timestamp >= toDateTime(%(started_after)s)
-            AND min_first_timestamp <= toDateTime(%(started_before)s)
+            min_first_timestamp_agg >= toDateTime(%(started_after)s)
+            AND min_first_timestamp_agg <= toDateTime(%(started_before)s)
     """
 
     # Add block-related fields only for v2 table
@@ -72,8 +74,8 @@ def get_session_replay_events(
 
 FIELD_NAMES = [
     "distinct_id",
-    "min_first_timestamp",
-    "max_last_timestamp",
+    "min_first_timestamp_agg",
+    "max_last_timestamp_agg",
     "first_url",
     "all_urls",
     "click_count",
@@ -98,6 +100,7 @@ class CompareRecordingMetadataActivityInputs:
     started_after: str = dataclasses.field()
     started_before: str = dataclasses.field()
     window_result_limit: int | None = dataclasses.field(default=None)
+    session_length_limit_seconds: int = dataclasses.field(default=172800)  # 48h default
 
     @property
     def properties_to_log(self) -> dict[str, typing.Any]:
@@ -105,6 +108,7 @@ class CompareRecordingMetadataActivityInputs:
             "started_after": self.started_after,
             "started_before": self.started_before,
             "window_result_limit": self.window_result_limit,
+            "session_length_limit_seconds": self.session_length_limit_seconds,
         }
 
 
@@ -114,10 +118,13 @@ async def compare_recording_metadata_activity(inputs: CompareRecordingMetadataAc
     logger = get_internal_logger()
     start_time = dt.datetime.now()
     await logger.ainfo(
-        "Starting comparison activity for time range %s to %s%s",
+        "Starting comparison activity for time range %s to %s%s%s",
         inputs.started_after,
         inputs.started_before,
         f" (limiting to {inputs.window_result_limit} sessions)" if inputs.window_result_limit else "",
+        f" (session length limit: {inputs.session_length_limit_seconds}s)"
+        if inputs.session_length_limit_seconds
+        else "",
     )
 
     async with Heartbeater():
@@ -130,12 +137,14 @@ async def compare_recording_metadata_activity(inputs: CompareRecordingMetadataAc
                 "session_replay_events",
                 started_after,
                 started_before,
+                inputs.session_length_limit_seconds,
             ),
             asyncio.to_thread(
                 get_session_replay_events,
                 "session_replay_events_v2_test",
                 started_after,
                 started_before,
+                inputs.session_length_limit_seconds,
             ),
         )
 
@@ -202,6 +211,7 @@ class CompareRecordingMetadataWorkflowInputs:
     started_before: str = dataclasses.field()
     window_seconds: int = dataclasses.field(default=300)  # 5 minutes default
     window_result_limit: int | None = dataclasses.field(default=None)  # No limit by default
+    session_length_limit_seconds: int = dataclasses.field(default=172800)  # 48h default
 
     @property
     def properties_to_log(self) -> dict[str, typing.Any]:
@@ -210,6 +220,7 @@ class CompareRecordingMetadataWorkflowInputs:
             "started_before": self.started_before,
             "window_seconds": self.window_seconds,
             "window_result_limit": self.window_result_limit,
+            "session_length_limit_seconds": self.session_length_limit_seconds,
         }
 
 
@@ -231,21 +242,24 @@ class CompareRecordingMetadataWorkflow(PostHogWorkflow):
                 raise ValueError(f"Required field {field} not provided")
             loaded[field] = dt.datetime.fromisoformat(loaded[field])
 
-        # Optional window_seconds with default
         window_seconds = loaded.get("window_seconds", 300)
         if not isinstance(window_seconds, int) or window_seconds <= 0:
             raise ValueError("window_seconds must be a positive integer")
 
-        # Optional window_result_limit with default
         window_result_limit = loaded.get("window_result_limit")
         if window_result_limit is not None and not isinstance(window_result_limit, int | None):
             raise ValueError("window_result_limit must be an integer or None")
+
+        session_length_limit_seconds = loaded.get("session_length_limit_seconds", 172800)
+        if not isinstance(session_length_limit_seconds, int) or session_length_limit_seconds <= 0:
+            raise ValueError("session_length_limit_seconds must be a positive integer")
 
         return CompareRecordingMetadataWorkflowInputs(
             started_after=loaded["started_after"],
             started_before=loaded["started_before"],
             window_seconds=window_seconds,
             window_result_limit=window_result_limit,
+            session_length_limit_seconds=session_length_limit_seconds,
         )
 
     @staticmethod
@@ -298,6 +312,7 @@ class CompareRecordingMetadataWorkflow(PostHogWorkflow):
                 started_after=window_start.isoformat(),
                 started_before=window_end.isoformat(),
                 window_result_limit=inputs.window_result_limit,
+                session_length_limit_seconds=inputs.session_length_limit_seconds,
             )
 
             await temporalio.workflow.execute_activity(


### PR DESCRIPTION
## Problem

When running compare metadata task, we get memory limit exceptions even on small windows, as the query needs to scan the whole table for aggregation.

## Changes

Adds a where clause to limit the number of rows fetched for aggregation of the session replay events tables.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

N/A

## How did you test this code?

Tested the query manually
Can test on prod later