### PR TITLE
feat(propdefs-v2): inline batch writes when any batch bucket is full 

### DIFF
--- a/rust/property-defs-rs/src/v2_batch_ingestion.rs
+++ b/rust/property-defs-rs/src/v2_batch_ingestion.rs
@@ -306,6 +306,27 @@ pub async fn process_batch_v2(
                 }
             }
         }
+
+        // if any of the batches are full, execute them now
+        if handles.is_empty() {
+            continue;
+        }
+        let to_exec = handles;
+        handles = vec![];
+        for handle in to_exec {
+            match handle.await {
+                // metrics are statted in write_*_batch methods so we just log here
+                Ok(result) => match result {
+                    Ok(_) => continue,
+                    Err(db_err) => {
+                        error!("Batch write exhausted retries: {:?}", db_err);
+                    }
+                },
+                Err(join_err) => {
+                    warn!("Batch query JoinError: {:?}", join_err);
+                }
+            }
+        }
     }
 
     // ensure partial batches are flushed to Postgres too


### PR DESCRIPTION
## Problem
Seeing some problems with v2 batch writes in `prod-us` at high event volume, even using larger batches, with the internal queue backing up. I think this is a result of passing along all the batches to `tokio::spawn` before awaiting any handles to complete.

## Changes
* Inline writes of any full batches in the batching loop

Just to see how it behaves in next deploy test. Next thing to try: inline all (most?) batch writes in the main thread.

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally and in CI; once merged, in deploy test and observation
