### PR TITLE
fix(import): don't dup col names

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
@@ -13,6 +13,7 @@ from posthog.temporal.data_imports.pipelines.pipeline.utils import (
     _get_max_decimal_type,
     should_partition_table,
     table_from_py_list,
+    normalize_table_column_names,
 )
 
 
@@ -378,3 +379,22 @@ def test_should_partition_table_with_table_and_key():
 
     res = should_partition_table(delta_table, schema, source)
     assert res is True
+
+
+def test_normalize_table_column_names_prevents_collisions():
+    # Create a table with columns that would collide when normalized
+    table = pa.table({"foo___bar": ["value1"], "foo_bar": ["value2"], "another___field": ["value3"]})
+
+    normalized_table = normalize_table_column_names(table)
+
+    # First column that would collide keeps original name
+    assert "foo___bar" in normalized_table.column_names
+    # Non-colliding column gets normalized
+    assert "another_field" in normalized_table.column_names
+    # Second column that would collide keeps original name
+    assert "foo_bar" in normalized_table.column_names
+
+    # Verify the data is preserved
+    assert normalized_table.column("foo___bar").to_pylist() == ["value1"]
+    assert normalized_table.column("foo_bar").to_pylist() == ["value2"]
+    assert normalized_table.column("another_field").to_pylist() == ["value3"]

--- a/posthog/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/utils.py
@@ -285,14 +285,21 @@ def should_partition_table(
 
 
 def normalize_table_column_names(table: pa.Table) -> pa.Table:
+    used_names = set()
+
     for column_name in table.column_names:
         normalized_column_name = normalize_column_name(column_name)
+
+        if normalized_column_name in used_names or normalized_column_name in table.column_names:
+            continue
+
         if normalized_column_name != column_name:
             table = table.set_column(
                 table.schema.get_field_index(column_name),
                 normalized_column_name,
                 table.column(column_name),  # type: ignore
             )
+            used_names.add(normalized_column_name)
 
     return table
 


### PR DESCRIPTION
## Problem

- multiple columns like a__b, and a_b. Both will collapse to a_b from normalization and cause an issue

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- track repeats

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
