### PR TITLE
feat: Display count of persons for early access features

### DIFF
--- a/products/early_access_features/frontend/EarlyAccessFeature.tsx
+++ b/products/early_access_features/frontend/EarlyAccessFeature.tsx
@@ -439,7 +439,7 @@ interface PersonListProps {
     earlyAccessFeature: EarlyAccessFeatureType
 }
 
-function featureFlagRecordingEnrolmentFilter(
+function featureFlagRecordingEnrollmentFilter(
     earlyAccessFeature: EarlyAccessFeatureType,
     optedIn: boolean
 ): Partial<RecordingUniversalFilters> {
@@ -493,7 +493,7 @@ export function PersonList({ earlyAccessFeature }: PersonListProps): JSX.Element
                         content: (
                             <>
                                 <PersonsTableByFilter
-                                    recordingsFilters={featureFlagRecordingEnrolmentFilter(earlyAccessFeature, true)}
+                                    recordingsFilters={featureFlagRecordingEnrollmentFilter(earlyAccessFeature, true)}
                                     properties={[
                                         {
                                             key: featureEnrollmentKey,
@@ -511,7 +511,7 @@ export function PersonList({ earlyAccessFeature }: PersonListProps): JSX.Element
                         label: optedOutCount !== null ? `Opted-Out Users (${optedOutCount})` : 'Opted-Out Users',
                         content: (
                             <PersonsTableByFilter
-                                recordingsFilters={featureFlagRecordingEnrolmentFilter(earlyAccessFeature, false)}
+                                recordingsFilters={featureFlagRecordingEnrollmentFilter(earlyAccessFeature, false)}
                                 properties={[
                                     {
                                         key: featureEnrollmentKey,

--- a/products/early_access_features/frontend/EarlyAccessFeature.tsx
+++ b/products/early_access_features/frontend/EarlyAccessFeature.tsx
@@ -439,7 +439,7 @@ interface PersonListProps {
     earlyAccessFeature: EarlyAccessFeatureType
 }
 
-function featureFlagEnrolmentFilter(
+function featureFlagRecordingEnrolmentFilter(
     earlyAccessFeature: EarlyAccessFeatureType,
     optedIn: boolean
 ): Partial<RecordingUniversalFilters> {
@@ -478,10 +478,8 @@ function featureFlagEnrolmentFilter(
 }
 
 export function PersonList({ earlyAccessFeature }: PersonListProps): JSX.Element {
-    const { activeTab } = useValues(earlyAccessFeatureLogic)
+    const { activeTab, optedInCount, optedOutCount, featureEnrollmentKey } = useValues(earlyAccessFeatureLogic)
     const { setActiveTab } = useActions(earlyAccessFeatureLogic)
-
-    const key = '$feature_enrollment/' + earlyAccessFeature.feature_flag.key
 
     return (
         <>
@@ -491,14 +489,14 @@ export function PersonList({ earlyAccessFeature }: PersonListProps): JSX.Element
                 tabs={[
                     {
                         key: EarlyAccessFeatureTabs.OptedIn,
-                        label: 'Opted-In Users',
+                        label: optedInCount !== null ? `Opted-In Users (${optedInCount})` : 'Opted-In Users',
                         content: (
                             <>
                                 <PersonsTableByFilter
-                                    recordingsFilters={featureFlagEnrolmentFilter(earlyAccessFeature, true)}
+                                    recordingsFilters={featureFlagRecordingEnrolmentFilter(earlyAccessFeature, true)}
                                     properties={[
                                         {
-                                            key: key,
+                                            key: featureEnrollmentKey,
                                             type: PropertyFilterType.Person,
                                             operator: PropertyOperator.Exact,
                                             value: ['true'],
@@ -510,13 +508,13 @@ export function PersonList({ earlyAccessFeature }: PersonListProps): JSX.Element
                     },
                     {
                         key: EarlyAccessFeatureTabs.OptedOut,
-                        label: 'Opted-Out Users',
+                        label: optedOutCount !== null ? `Opted-Out Users (${optedOutCount})` : 'Opted-Out Users',
                         content: (
                             <PersonsTableByFilter
-                                recordingsFilters={featureFlagEnrolmentFilter(earlyAccessFeature, false)}
+                                recordingsFilters={featureFlagRecordingEnrolmentFilter(earlyAccessFeature, false)}
                                 properties={[
                                     {
-                                        key: key,
+                                        key: featureEnrollmentKey,
                                         type: PropertyFilterType.Person,
                                         operator: PropertyOperator.Exact,
                                         value: ['false'],

--- a/products/early_access_features/frontend/earlyAccessFeatureLogic.ts
+++ b/products/early_access_features/frontend/earlyAccessFeatureLogic.ts
@@ -94,12 +94,7 @@ export const earlyAccessFeatureLogic = kea<earlyAccessFeatureLogicType>([
                         return null
                     }
 
-                    if (values.personsCount === null) {
-                        await breakpoint(100)
-                    } else {
-                        await breakpoint(1000)
-                    }
-
+                    // :KRUDGE: Should try and get this to work with a single query in the future
                     const results = await Promise.all(
                         ['true', 'false'].map((value) =>
                             performQuery<ActorsQuery>({


### PR DESCRIPTION
## Problem

This bothered me, so I fixed it. Previously, we had to keep clicking until we had loaded *all* of the users because we could see how many had enabled access to our feature.

## Changes

Query and display the count 🤷🏻 

![image](https://github.com/user-attachments/assets/6d7e3912-116d-496a-bdd9-d054f9e3a1f3)

## Does this work well for both Cloud and self-hosted?

Yeap

## How did you test this code?

Manual