### PR TITLE
fix: dont call survey stats for new surveys

### DIFF
--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -337,7 +337,7 @@ export const surveyLogic = kea<surveyLogicType>([
         },
         surveyUserStats: {
             loadSurveyUserStats: async (): Promise<SurveyStats | null> => {
-                if (props.id === NEW_SURVEY.id) {
+                if (props.id === NEW_SURVEY.id || values.survey.start_date === null) {
                     return null
                 }
                 const survey: Survey = values.survey as Survey

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -336,7 +336,10 @@ export const surveyLogic = kea<surveyLogicType>([
             },
         },
         surveyUserStats: {
-            loadSurveyUserStats: async (): Promise<SurveyStats> => {
+            loadSurveyUserStats: async (): Promise<SurveyStats | null> => {
+                if (props.id === NEW_SURVEY.id) {
+                    return null
+                }
                 const survey: Survey = values.survey as Survey
                 const startDate = getSurveyStartDateForQuery(survey)
                 const endDate = getSurveyEndDateForQuery(survey)


### PR DESCRIPTION
- **fix: dont call survey stats for new surveys**
- **fix: dont call survey stats if survey is new or not launched**

## Problem

[full context](https://posthog.slack.com/archives/C07QD3LT8U9/p1744145976320499)

dont call survey stats endpoint for a new / not launched survey, otherwise this error happens:

![image](https://github.com/user-attachments/assets/ecdb0d0f-af3e-49d9-963c-65e3524c1919)

## Changes

only call it for launched and not new surveys

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
