### PR TITLE
fix: enable temporal builds for compare metadata

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -187,7 +187,7 @@ jobs:
             - name: Check for changes that affect general purpose temporal worker
               id: check_changes_general_purpose_temporal_worker
               run: |
-                  echo "changed=$((git diff --name-only HEAD^ HEAD | grep -qE '^posthog/temporal/common|^posthog/temporal/proxy_service|^posthog/temporal/usage_reports|^posthog/management/commands/start_temporal_worker.py$|^requirements.txt$|^bin/temporal-django-worker$' && echo true) || echo false)" >> $GITHUB_OUTPUT
+                  echo "changed=$((git diff --name-only HEAD^ HEAD | grep -qE '^posthog/temporal/common|^posthog/temporal/compare_recording_metadata|^posthog/temporal/proxy_service|^posthog/temporal/usage_reports|^posthog/management/commands/start_temporal_worker.py$|^requirements.txt$|^bin/temporal-django-worker$' && echo true) || echo false)" >> $GITHUB_OUTPUT
 
             - name: Trigger General Purpose Temporal Worker Cloud deployment
               if: steps.check_changes_general_purpose_temporal_worker.outputs.changed == 'true'

--- a/posthog/temporal/compare_recording_metadata/compare_recording_metadata_workflow.py
+++ b/posthog/temporal/compare_recording_metadata/compare_recording_metadata_workflow.py
@@ -64,7 +64,9 @@ def get_session_replay_events(
     )
 
     return sync_execute(
-        query.format(table=table_name, block_fields=block_fields),
+        query.format(
+            table=table_name, block_fields=block_fields, session_length_limit_seconds=session_length_limit_seconds
+        ),
         {
             "started_after": started_after.strftime("%Y-%m-%d %H:%M:%S"),
             "started_before": started_before.strftime("%Y-%m-%d %H:%M:%S"),


### PR DESCRIPTION
## Problem

1. `compare_recording_metadata` folder changes didn't trigger deploys
2. The session duration template was rendered in a wrong way

## Changes

1. Updates the CI build to include compare recording metadata workflow
2. Fixes the query

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

N/A

## How did you test this code?

Will test on dev