### PR TITLE
chore(plugin-server): comment removed to create a deployment for plugin-server

### DIFF
--- a/plugin-server/src/cdp/hog-transformations/transformation-functions.ts
+++ b/plugin-server/src/cdp/hog-transformations/transformation-functions.ts
@@ -9,7 +9,7 @@ function cleanNullValuesInternal(value: unknown, depth: number): unknown {
         return null
     }
 
-    // Handle arrays
+    // Handles arrays
     if (Array.isArray(value)) {
         return value.map((item) => cleanNullValuesInternal(item, depth + 1)).filter((item) => item !== null)
     }


### PR DESCRIPTION
## Problem

Looking to test some service deployments we moved over to being managed via ArgoCD so creating a deployment by changing some comment in the code

## Changes

A single comment was changed to create a deployment

## How did you test this code?

No behavioural changes
