### PR TITLE
feat: delete events from person without deleting the person

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -1,22 +1,15 @@
+import builtins
 import json
-from posthog.models.person.missing_person import MissingPerson
-from posthog.renderers import SafeJSONRenderer
-from datetime import datetime
-from typing import (  # noqa: UP035
-    Any,
-    List,
-    Optional,
-    TypeVar,
-    Union,
-    cast,
-)
 from collections.abc import Callable
+from datetime import datetime
+from typing import Any, List, Optional, TypeVar, Union, cast  # noqa: UP035
 
 from django.db.models import Prefetch
 from django.shortcuts import get_object_or_404
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiExample, OpenApiParameter
-from posthog.api.utils import action
+from loginas.utils import is_impersonated_session
+from prometheus_client import Counter
 from rest_framework import request, response, serializers, viewsets
 from rest_framework.exceptions import MethodNotAllowed, NotFound, ValidationError
 from rest_framework.pagination import LimitOffsetPagination
@@ -29,17 +22,18 @@ from statshog.defaults.django import statsd
 from posthog.api.capture import capture_internal
 from posthog.api.documentation import PersonPropertiesSerializer, extend_schema
 from posthog.api.routing import TeamAndOrgViewSetMixin
-from posthog.api.utils import format_paginated_url, get_pk_or_uuid, get_target_entity
-from posthog.constants import (
-    INSIGHT_FUNNELS,
-    LIMIT,
-    OFFSET,
-    FunnelVizType,
+from posthog.api.utils import (
+    action,
+    format_paginated_url,
+    get_pk_or_uuid,
+    get_target_entity,
 )
-from posthog.hogql.constants import CSV_EXPORT_LIMIT
+from posthog.constants import INSIGHT_FUNNELS, LIMIT, OFFSET, FunnelVizType
 from posthog.decorators import cached_by_filters
+from posthog.hogql.constants import CSV_EXPORT_LIMIT
 from posthog.logging.timing import timed
-from posthog.models import Cohort, Filter, Person, User, Team
+from posthog.metrics import LABEL_TEAM_ID
+from posthog.models import Cohort, Filter, Person, Team, User
 from posthog.models.activity_logging.activity_log import (
     Change,
     Detail,
@@ -54,11 +48,9 @@ from posthog.models.filters.path_filter import PathFilter
 from posthog.models.filters.properties_timeline_filter import PropertiesTimelineFilter
 from posthog.models.filters.retention_filter import RetentionFilter
 from posthog.models.filters.stickiness_filter import StickinessFilter
+from posthog.models.person.missing_person import MissingPerson
 from posthog.models.person.util import delete_person
-from posthog.queries.actor_base_query import (
-    ActorBaseQuery,
-    get_serialized_people,
-)
+from posthog.queries.actor_base_query import ActorBaseQuery, get_serialized_people
 from posthog.queries.funnels import ClickhouseFunnelActors, ClickhouseFunnelTrendsActors
 from posthog.queries.funnels.funnel_strict_persons import ClickhouseFunnelStrictActors
 from posthog.queries.funnels.funnel_unordered_persons import (
@@ -76,6 +68,7 @@ from posthog.rate_limit import (
     ClickHouseBurstRateThrottle,
     ClickHouseSustainedRateThrottle,
 )
+from posthog.renderers import SafeJSONRenderer
 from posthog.settings import EE_AVAILABLE
 from posthog.tasks.split_person import split_person
 from posthog.utils import (
@@ -83,10 +76,6 @@ from posthog.utils import (
     format_query_params_absolute_url,
     is_anonymous_id,
 )
-from prometheus_client import Counter
-from posthog.metrics import LABEL_TEAM_ID
-from loginas.utils import is_impersonated_session
-import builtins
 
 DEFAULT_PAGE_LIMIT = 100
 # Sync with .../lib/constants.tsx and .../ingestion/hooks.ts
@@ -257,7 +246,6 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             raise ValidationError(
                 f"The ID provided does not look like a personID. If you are using a distinctId, please use /persons?distinct_id={person_id} instead."
             )
-
         return get_object_or_404(queryset)
 
     @extend_schema(
@@ -376,17 +364,7 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             )
             # Once the person is deleted, queue deletion of associated data, if that was requested
             if "delete_events" in request.GET:
-                AsyncDeletion.objects.bulk_create(
-                    [
-                        AsyncDeletion(
-                            deletion_type=DeletionType.Person,
-                            team_id=self.team_id,
-                            key=str(person.uuid),
-                            created_by=cast(User, self.request.user),
-                        )
-                    ],
-                    ignore_conflicts=True,
-                )
+                self._queue_event_deletion(person)
             return response.Response(status=202)
         except Person.DoesNotExist:
             raise NotFound(detail="Person not found.")
@@ -442,17 +420,7 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             )
             # Once the person is deleted, queue deletion of associated data, if that was requested
             if request.data.get("delete_events"):
-                AsyncDeletion.objects.bulk_create(
-                    [
-                        AsyncDeletion(
-                            deletion_type=DeletionType.Person,
-                            team_id=self.team_id,
-                            key=str(person.uuid),
-                            created_by=cast(User, self.request.user),
-                        )
-                    ],
-                    ignore_conflicts=True,
-                )
+                self._queue_event_deletion(person)
         return response.Response(status=202)
 
     @action(methods=["GET"], detail=False, required_scopes=["person:read"])
@@ -862,6 +830,36 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         people = self.stickiness_class().people(target_entity, filter, team, request)
         next_url = paginated_result(request, len(people), filter.offset, filter.limit)
         return response.Response({"results": [{"people": people, "count": len(people)}], "next": next_url})
+
+    def _queue_event_deletion(self, person: Person) -> None:
+        """Helper to queue deletion of all events for a person."""
+        AsyncDeletion.objects.bulk_create(
+            [
+                AsyncDeletion(
+                    deletion_type=DeletionType.Person,
+                    team_id=self.team_id,
+                    key=str(person.uuid),
+                    created_by=cast(User, self.request.user),
+                )
+            ],
+            ignore_conflicts=True,
+        )
+
+    @extend_schema(
+        description="Queue deletion of all events associated with this person. The task runs during non-peak hours.",
+    )
+    @action(methods=["POST"], detail=True, required_scopes=["person:write"])
+    def delete_events(self, request: request.Request, pk=None, **kwargs) -> response.Response:
+        """
+        Queue deletion of all events for a person without deleting the person record itself.
+        The deletion task runs during non-peak hours.
+        """
+        try:
+            person = self.get_object()
+            self._queue_event_deletion(person)
+            return response.Response(status=202)
+        except Person.DoesNotExist:
+            raise NotFound(detail="Person not found.")
 
 
 def paginated_result(


### PR DESCRIPTION
## Problem

Sometimes customers need to delete their customers' events (due to data deletion request) but keep the person around so they can re-use the same distinct ID.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Makes a new API endpoint on the person model that just deletes events associated with a person but doesn't delete the person itself.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

No idea if it will work for self-hosted but probs not that important

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Added tests.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
