### PR TITLE
chore: check get_available_feature in tests

### DIFF
--- a/posthog/api/sharing.py
+++ b/posthog/api/sharing.py
@@ -20,6 +20,7 @@ from posthog.api.exports import ExportedAssetSerializer
 from posthog.api.insight import InsightSerializer
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.clickhouse.client.async_task_chain import task_chain_context
+from posthog.constants import AvailableFeature
 from posthog.models import SessionRecording, SharingConfiguration, Team, InsightViewed
 from posthog.models.activity_logging.activity_log import Change, Detail, log_activity
 from posthog.models.dashboard import Dashboard
@@ -311,7 +312,9 @@ class SharingViewerPageViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSe
         else:
             raise NotFound()
 
-        if "whitelabel" in request.GET and resource.team.organization.is_feature_available("white_labelling"):
+        if "whitelabel" in request.GET and resource.team.organization.is_feature_available(
+            AvailableFeature.WHITE_LABELLING
+        ):
             exported_data.update({"whitelabel": True})
         if "noHeader" in request.GET:
             exported_data.update({"noHeader": True})


### PR DESCRIPTION
## Problem

fix some old debt

## Changes

add get_available_feature to tests, use proper AvailableFeature enum

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Yes.