### PR TITLE
feat(project-tree): improve deletes

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -139,7 +139,7 @@ export function ProjectTree(): JSX.Element {
                         <ButtonPrimitive menuItem>Rename</ButtonPrimitive>
                     </MenuItem>
                 ) : null}
-                {item.record?.created_at ? (
+                {item.record?.created_at || item.record?.type === 'folder' ? (
                     <MenuItem
                         asChild
                         onClick={(e: any) => {

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
@@ -789,7 +789,7 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
             }
             if (toCheck.length > 0 || toDelete.size > 0) {
                 actions.setCheckedItems({
-                    ...(toDelete.length === 0
+                    ...(toDelete.size === 0
                         ? checkedItems
                         : Object.fromEntries(Object.entries(checkedItems).filter((kv) => !toDelete.has(kv[0])))),
                     ...Object.fromEntries(toCheck.map((item) => [item, true])),

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
@@ -923,6 +923,7 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                     item = items[0]
                 } else {
                     lemonToast.error(`Could not find filesystem entry for ${item.path}. Can't delete.`)
+                    return
                 }
             }
             actions.queueAction({ type: item.type === 'folder' ? 'prepare-delete' : 'delete', item, path: item.path })

--- a/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
@@ -106,7 +106,7 @@ export function convertFileSystemEntryToTreeDataItem({
                 node.record?.path === item.path && node.record?.type === 'folder'
             const existingFolder = currentLevel.find(folderMatch)
             if (existingFolder) {
-                if (existingFolder.id) {
+                if (existingFolder.record?.id) {
                     continue
                 } else {
                     // We have a folder without an id, but the incoming one has an id. Remove the current one

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -398,6 +398,9 @@ class ApiRequest {
     public fileSystemCount(id: NonNullable<FileSystemEntry['id']>, projectId?: ProjectType['id']): ApiRequest {
         return this.fileSystem(projectId).addPathComponent(id).addPathComponent('count')
     }
+    public fileSystemCountByPath(path: string, projectId?: ProjectType['id']): ApiRequest {
+        return this.fileSystem(projectId).addPathComponent('count_by_path').withQueryString({ path })
+    }
 
     // # Plugins
     public plugins(orgId?: OrganizationType['id']): ApiRequest {
@@ -1252,6 +1255,7 @@ const api = {
     fileSystem: {
         async list({
             parent,
+            path,
             depth,
             limit,
             offset,
@@ -1261,6 +1265,7 @@ const api = {
             type__startswith,
         }: {
             parent?: string
+            path?: string
             depth?: number
             limit?: number
             offset?: number
@@ -1271,7 +1276,7 @@ const api = {
         }): Promise<CountedPaginatedResponse<FileSystemEntry>> {
             return await new ApiRequest()
                 .fileSystem()
-                .withQueryString({ parent, depth, limit, offset, search, ref, type, type__startswith })
+                .withQueryString({ parent, path, depth, limit, offset, search, ref, type, type__startswith })
                 .get()
         },
         async unfiled(type?: string): Promise<CountedPaginatedResponse<FileSystemEntry>> {
@@ -1294,6 +1299,9 @@ const api = {
         },
         async count(id: NonNullable<FileSystemEntry['id']>): Promise<FileSystemCount> {
             return await new ApiRequest().fileSystemCount(id).create()
+        },
+        async countByPath(path: string): Promise<FileSystemCount> {
+            return await new ApiRequest().fileSystemCountByPath(path).create()
         },
     },
 

--- a/posthog/api/file_system.py
+++ b/posthog/api/file_system.py
@@ -120,6 +120,7 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         depth_param = self.request.query_params.get("depth")
         parent_param = self.request.query_params.get("parent")
+        path_param = self.request.query_params.get("path")
         type_param = self.request.query_params.get("type")
         type__startswith_param = self.request.query_params.get("type__startswith")
         ref_param = self.request.query_params.get("ref")
@@ -134,6 +135,8 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         if self.action == "list":
             queryset = queryset.order_by("path")
 
+        if path_param:
+            queryset = queryset.filter(path=path_param)
         if parent_param:
             queryset = queryset.filter(path__startswith=f"{parent_param}/")
         if type_param:
@@ -260,6 +263,13 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         if instance.type != "folder":
             return Response({"detail": "Count can only be called on folders"}, status=status.HTTP_400_BAD_REQUEST)
         count = FileSystem.objects.filter(team=self.team, path__startswith=f"{instance.path}/").count()
+        return Response({"count": count}, status=status.HTTP_200_OK)
+
+    @action(methods=["POST"], detail=False)
+    def count_by_path(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """Get count of all files in a folder."""
+        path_param = self.request.query_params.get("path")
+        count = FileSystem.objects.filter(team=self.team, path__startswith=f"{path_param}/").count()
         return Response({"count": count}, status=status.HTTP_200_OK)
 
 

--- a/posthog/api/file_system.py
+++ b/posthog/api/file_system.py
@@ -269,6 +269,8 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     def count_by_path(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """Get count of all files in a folder."""
         path_param = self.request.query_params.get("path")
+        if not path_param:
+            return Response({"detail": "path parameter is required"}, status=status.HTTP_400_BAD_REQUEST)
         count = FileSystem.objects.filter(team=self.team, path__startswith=f"{path_param}/").count()
         return Response({"count": count}, status=status.HTTP_200_OK)
 

--- a/posthog/api/test/test_file_system.py
+++ b/posthog/api/test/test_file_system.py
@@ -422,7 +422,7 @@ class TestFileSystemAPI(APIBaseTest):
         self.assertEqual(data["count"], 1)
         self.assertEqual(data["results"][0]["path"], "Deep/Nested/Path")
 
-    def test_list_by_parent(self):
+    def test_list_by_parent_and_path(self):
         """
         Verify that passing ?parent=SomeFolder returns only items whose path starts with "SomeFolder/".
         """
@@ -442,6 +442,12 @@ class TestFileSystemAPI(APIBaseTest):
         self.assertIn("SomeFolder/SubFolder/File2", paths)
         self.assertNotIn("RootItem", paths)
         self.assertNotIn("AnotherFolder/File3", paths)
+
+        # Filter by ?parent=SomeFolder
+        response = self.client.get(f"/api/projects/{self.team.id}/file_system/?path=SomeFolder/File1")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["count"], 1, data["results"])
 
     def test_list_by_parent_and_depth(self):
         """
@@ -528,8 +534,13 @@ class TestFileSystemAPI(APIBaseTest):
         FileSystem.objects.create(team=self.team, path="OldFolder/File1", type="doc", created_by=self.user)
         FileSystem.objects.create(team=self.team, path="OldFolder/File2", type="doc", created_by=self.user)
 
-        # Move the folder
+        # Count the folder by id
         response = self.client.post(f"/api/projects/{self.team.id}/file_system/{folder.pk}/count")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        self.assertEqual(response.json()["count"], 2)
+
+        # Count the folder by path
+        response = self.client.post(f"/api/projects/{self.team.id}/file_system/count_by_path?path=OldFolder")
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
         self.assertEqual(response.json()["count"], 2)
 


### PR DESCRIPTION
## Problem

- You couldn't delete the folder you were in when the tree loaded (loading Unfiled/Cohorts/AAA --> can't delete Unfiled/Cohorts)
- Deleted items weren't removed from checked items causing it to say "2 selected" until cleared

## Changes

Fixes those issues. Adds an endpoint to count items by path.

## How did you test this code?

Backend tests