### PR TITLE
chore(data-warehouse): Run temporal workers for data warehouse locally

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -21,6 +21,12 @@ procs:
         # added a sleep to give the docker stuff time to start
         shell: 'bin/check_kafka_clickhouse_up && bin/check_temporal_up && python manage.py start_temporal_worker --task-queue batch-exports-task-queue --metrics-port 8002'
 
+    temporal-worker-data-warehouse:
+        shell: 'bin/check_kafka_clickhouse_up && bin/check_temporal_up && python manage.py start_temporal_worker --task-queue data-warehouse-task-queue --metrics-port 8003'
+
+    temporal-worker-data-warehouse-compaction:
+        shell: 'bin/check_kafka_clickhouse_up && bin/check_temporal_up && python manage.py start_temporal_worker --task-queue data-warehouse-compaction-task-queue --metrics-port 8004'
+
     docker-compose:
         # docker-compose makes sure the stack is up, and then follows its logs - but doesn't tear down on exit for speed
         shell: 'docker compose -f docker-compose.dev.yml up --pull always -d && docker compose -f docker-compose.dev.yml logs --tail=0 -f'


### PR DESCRIPTION
## Problem

At the moment the data warehouse Temporal workers don't run in mprocs.

## Changes

Add Temporal workers listening on `data-warehouse-task-queue` and  `data-warehouse-compaction-task-queue` task queues (annoyingly it seems a worker can only listen to a single queue)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Should do

## How did you test this code?

Ran things locally
