### PR TITLE
fix(batch-exports): Refresh list of backfills after creation

### DIFF
--- a/frontend/src/scenes/pipeline/batchExportBackfillModalLogic.tsx
+++ b/frontend/src/scenes/pipeline/batchExportBackfillModalLogic.tsx
@@ -107,7 +107,6 @@ export const batchExportBackfillModalLogic = kea<batchExportBackfillModalLogicTy
                     }
                 }
 
-                await new Promise((resolve) => setTimeout(resolve, 1000))
                 await api.batchExports
                     .createBackfill(props.id, {
                         start_at: earliest_backfill ? null : start_at?.toISOString() ?? null,

--- a/frontend/src/scenes/pipeline/batchExportBackfillsLogic.tsx
+++ b/frontend/src/scenes/pipeline/batchExportBackfillsLogic.tsx
@@ -111,6 +111,11 @@ export const batchExportBackfillsLogic = kea<batchExportBackfillsLogicType>([
                 lemonToast.error('Failed to cancel backfill. Please try again.')
             }
         },
+        submitBackfillFormSuccess: () => {
+            setTimeout(() => {
+                actions.loadBackfills()
+            }, 1000)
+        },
     })),
     afterMount(({ actions }) => {
         actions.loadBackfills()


### PR DESCRIPTION
## Problem

At the moment after you create a new backfill you need to refresh in order to view it.

## Changes

Refresh the list of backfills after creating a new one.

I also remove a 1 second wait before submitting the API request on backfill creation. I'm not sure if there was a reason this was there before but it seems to work without it (git blame has my name on it but I moved this code from another file originally)


https://github.com/user-attachments/assets/934c2ef5-feeb-44f5-8669-20fb5cd34a63


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Tested locally
