### PR TITLE
feat(early-access): Add concept stage warning notice

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -56,6 +56,7 @@ import {
     AvailableFeature,
     DashboardPlacement,
     DashboardType,
+    EarlyAccessFeatureStage,
     FeatureFlagGroupType,
     FeatureFlagType,
     NotebookNodeType,
@@ -115,6 +116,8 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
         setActiveTab,
     } = useActions(featureFlagLogic)
 
+    const { earlyAccessFeaturesList } = useValues(featureFlagLogic)
+
     const { tags } = useValues(tagsModel)
     const { hasAvailableFeature } = useValues(userLogic)
 
@@ -143,6 +146,8 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
     if (accessDeniedToFeatureFlag) {
         return <AccessDenied object="feature flag" />
     }
+
+    const earlyAccessFeature = earlyAccessFeaturesList?.find((f: any) => f.flagKey === featureFlag.key)
 
     const tabs = [
         {
@@ -621,6 +626,17 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                                 </>
                             }
                         />
+                        {earlyAccessFeature && earlyAccessFeature.stage === EarlyAccessFeatureStage.Concept && (
+                            <LemonBanner type="info">
+                                This feature flag is assigned to an early access feature in the{' '}
+                                <LemonTag type="default" className="uppercase">
+                                    Concept
+                                </LemonTag>{' '}
+                                stage. All users who register interest will be assigned this feature flag. Gate your
+                                code behind a different feature flag if you'd like to keep it hidden, and then switch
+                                your code to this feature flag when you're ready to release to your early access users.
+                            </LemonBanner>
+                        )}
                         <LemonTabs
                             activeKey={activeTab}
                             onChange={(tab) => tab !== activeTab && setActiveTab(tab)}

--- a/products/early_access_features/frontend/EarlyAccessFeature.tsx
+++ b/products/early_access_features/frontend/EarlyAccessFeature.tsx
@@ -253,7 +253,8 @@ export function EarlyAccessFeature({ id }: { id?: string } = {}): JSX.Element {
                                 Concept
                             </LemonTag>{' '}
                             stage assigns the feature flag to the user. Gate your code behind a different feature flag
-                            if you don't want them to access it.
+                            if you'd like to keep it hidden, and then switch your code to this feature flag when you're
+                            ready to release to your early access users.
                         </LemonBanner>
                     )}
                     <div className="flex flex-wrap items-start gap-4">

--- a/products/early_access_features/frontend/EarlyAccessFeature.tsx
+++ b/products/early_access_features/frontend/EarlyAccessFeature.tsx
@@ -1,5 +1,6 @@
 import { IconFlag, IconQuestion, IconX } from '@posthog/icons'
 import {
+    LemonBanner,
     LemonButton,
     LemonDivider,
     LemonInput,
@@ -245,6 +246,16 @@ export function EarlyAccessFeature({ id }: { id?: string } = {}): JSX.Element {
                         </LemonField>
                     )}
 
+                    {earlyAccessFeature.stage === EarlyAccessFeatureStage.Concept && !isEditingFeature && (
+                        <LemonBanner type="info">
+                            The{' '}
+                            <LemonTag type="default" className="uppercase">
+                                Concept
+                            </LemonTag>{' '}
+                            stage assigns the feature flag to the user. Gate your code behind a different feature flag
+                            if you don't want them to access it.
+                        </LemonBanner>
+                    )}
                     <div className="flex flex-wrap items-start gap-4">
                         <div className="flex-1 min-w-[20rem]">
                             {'feature_flag' in earlyAccessFeature ? (


### PR DESCRIPTION
See https://github.com/PostHog/posthog.com/pull/11240
See https://posthog.slack.com/archives/C08JLPPRA3B/p1744144727545839

## Changes

Adds a notice to let users know the feature flag will still be assigned during concept stage:

![CleanShot 2025-04-09 at 05 33 02@2x](https://github.com/user-attachments/assets/6531d151-c5e0-4583-8d1b-96e1aebb8aad)

## How did you test this code?

I switched an early access feature to 'Concept' stage and verified the banner appeared.

I then edited the early access feature to 'Beta' and verified the banner no longer appeared.