### PR TITLE
chore(dashboards): Edit SQL insights from dashbords

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -23,6 +23,7 @@ import { useSummarizeInsight } from 'scenes/insights/summarizeInsight'
 import { urls } from 'scenes/urls'
 
 import { dashboardsModel } from '~/models/dashboardsModel'
+import { isDataVisualizationNode } from '~/queries/utils'
 import { ExporterFormat, InsightColor, QueryBasedInsightModel } from '~/types'
 
 import { InsightCardProps } from './InsightCard'
@@ -72,7 +73,7 @@ export function InsightMeta({
     showDetailsControls = true,
     moreButtons,
 }: InsightMetaProps): JSX.Element {
-    const { short_id, name, dashboards, next_allowed_client_refresh: nextAllowedClientRefresh } = insight
+    const { short_id, query, name, dashboards, next_allowed_client_refresh: nextAllowedClientRefresh } = insight
     const { insightProps } = useValues(insightLogic)
     const { exportContext } = useValues(insightDataLogic(insightProps))
     const { samplingFactor } = useValues(insightVizDataLogic(insightProps))
@@ -187,7 +188,14 @@ export function InsightMeta({
                     )}
                     <LemonDivider />
                     {editable && (
-                        <LemonButton to={urls.insightEdit(short_id)} fullWidth>
+                        <LemonButton
+                            to={
+                                isDataVisualizationNode(query)
+                                    ? urls.sqlEditor(undefined, undefined, short_id)
+                                    : urls.insightEdit(short_id)
+                            }
+                            fullWidth
+                        >
                             Edit
                         </LemonButton>
                     )}


### PR DESCRIPTION
## Changes
- Update the "edit" url when editing a dashboard tile to go direct to the SQL editor if it's a data viz node 