### PR TITLE
chore: Ensure dist folder exists

### DIFF
--- a/common/hogvm/typescript/package.json
+++ b/common/hogvm/typescript/package.json
@@ -12,7 +12,7 @@
         "build": "pnpm clean && pnpm build:parcel && pnpm build:cli",
         "build:parcel": "parcel build",
         "build:compile": "tsc -p tsconfig.build.json",
-        "build:cli": "cp ./src/cli.js ./dist/cli.js",
+        "build:cli": "mkdir -p ./dist && cp ./src/cli.js ./dist/cli.js",
         "compile:stl": "cd ../../.. && python3 -m common.hogvm.stl.compile",
         "check": "tsc -p tsconfig.build.json --noEmit",
         "prettier": "prettier --write src",


### PR DESCRIPTION
## Problem

I ran into this in the ./bin/start.sh script, the frontend part didn't work as this folder didn't exist when it tried to `cp`

## Changes

Make the folder

## Does this work well for both Cloud and self-hosted?

n/a

## How did you test this code?

n/a
