### PR TITLE
fix(experiments): set math on default (initial) mean metric

### DIFF
--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -332,6 +332,7 @@ export function getDefaultCountMetric(): ExperimentMetric {
         source: {
             kind: NodeKind.EventsNode,
             event: '$pageview',
+            math: ExperimentMetricMathType.TotalCount,
         },
     }
 }


### PR DESCRIPTION
## Problem
Currently, `math` is not set (`undefined`) on the default new mean metric. If users just leave it without changing the math type, it's left out of the metric when saved. It works fine in the experiment evaluation, as we do default to `total`. But in the MDE currently, it does not behave well when `math` is undefined. It`s really no reason to leave it undefined. We should be explicit when we can.

## Changes
Set `math` on the initial default count metric.

I have not looked closely on what it would take to make it required. The thing is that we extend the `EntityNode` where it is optional. We can work around that I guess, with some type script type fun, but for now I just want this to work. Will pick that up later. 

## How did you test this code?
* created an experiment and added a metric with out changing anything and verified that `math` was stored
* tested the MDE calculator with the defualt metric and it works fine now
