### PR TITLE
feat: Retry Clickhouse queries in Dagster jobs if they fail due to cluster-wide memory limits

### DIFF
--- a/dags/common.py
+++ b/dags/common.py
@@ -37,8 +37,19 @@ class ClickhouseClusterResource(dagster.ConfigurableResource):
                 delay=ExponentialBackoff(20),
                 exceptions=lambda e: (
                     isinstance(e, Error)
-                    and e.code
-                    in (ErrorCodes.NETWORK_ERROR, ErrorCodes.TOO_MANY_SIMULTANEOUS_QUERIES, ErrorCodes.NOT_ENOUGH_SPACE)
+                    and (
+                        (
+                            e.code
+                            in (  # these are typically transient errors and unrelated to the query being executed
+                                ErrorCodes.NETWORK_ERROR,
+                                ErrorCodes.TOO_MANY_SIMULTANEOUS_QUERIES,
+                                ErrorCodes.NOT_ENOUGH_SPACE,
+                            )
+                        )
+                        # queries that exceed memory limits can be retried if they were killed due to total server
+                        # memory consumption, but we should avoid retrying queries that were killed due to query limits
+                        or (e.code == ErrorCodes.MEMORY_LIMIT_EXCEEDED and "Memory limit (total) exceeded" in e.message)
+                    )
                 ),
             ),
         )


### PR DESCRIPTION
## Problem

Sometimes administrative queries fail because other queries on the server are eating all the memory, e.g. https://dagster.prod-eu.posthog.dev/runs/57d97122-b477-43e1-a4db-02570906aea7

## Changes

Retries queries if they are killed due to server-wide memory limits. Queries are not retried if they exceed single query memory limits.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

🙃 