### PR TITLE
feat: Use dot notation for revenue views

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -406,11 +406,11 @@ def create_hogql_database(
                 .prefetch_related(Prefetch("schemas", queryset=ExternalDataSchema.objects.prefetch_related("table")))
             )
 
-        for stripe_source in stripe_sources:
-            with timings.measure(f"for_schema_source_{stripe_source.prefix or stripe_source.id}"):
+        with timings.measure("for_schema_source"):
+            for stripe_source in stripe_sources:
                 view = RevenueAnalyticsRevenueView.for_schema_source(stripe_source)
                 if view is not None:
-                    views[f"stripe_{stripe_source.prefix or stripe_source.id}_revenue"] = view
+                    views[view.name] = view
 
     def define_mappings(store: dict[str, Table], get_table: Callable):
         if "id" not in store[warehouse_modifier.table_name].fields.keys():

--- a/posthog/warehouse/test/utils.py
+++ b/posthog/warehouse/test/utils.py
@@ -63,7 +63,7 @@ def create_data_warehouse_table_from_csv(
             connection_id="connection_id",
             status=ExternalDataSource.Status.COMPLETED,
             source_type=ExternalDataSource.Type.STRIPE,
-            prefix=source_prefix or "posthog_test_",
+            prefix=source_prefix or "posthog_test",
         )
 
     if credential is None:

--- a/products/revenue_analytics/backend/hogql_queries/revenue_example_data_warehouse_tables_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_example_data_warehouse_tables_query_runner.py
@@ -47,18 +47,14 @@ class RevenueExampleDataWarehouseTablesQueryRunner(QueryRunner):
                     ast.SelectQuery(
                         select=[
                             ast.Alias(alias="view_name", expr=ast.Constant(value=view_name)),
-                            ast.Alias(alias="distinct_id", expr=ast.Field(chain=[view_name, "id"])),
-                            ast.Alias(
-                                alias="original_revenue", expr=ast.Field(chain=[view_name, "adjusted_original_amount"])
-                            ),
-                            ast.Alias(
-                                alias="original_currency", expr=ast.Field(chain=[view_name, "original_currency"])
-                            ),
-                            ast.Alias(alias="revenue", expr=ast.Field(chain=[view_name, "amount"])),
-                            ast.Alias(alias="currency", expr=ast.Field(chain=[view_name, "currency"])),
+                            ast.Alias(alias="distinct_id", expr=ast.Field(chain=["id"])),
+                            ast.Alias(alias="original_revenue", expr=ast.Field(chain=["adjusted_original_amount"])),
+                            ast.Alias(alias="original_currency", expr=ast.Field(chain=["original_currency"])),
+                            ast.Alias(alias="revenue", expr=ast.Field(chain=["amount"])),
+                            ast.Alias(alias="currency", expr=ast.Field(chain=["currency"])),
                         ],
                         select_from=ast.JoinExpr(table=ast.Field(chain=[view_name])),
-                        order_by=[ast.OrderExpr(expr=ast.Field(chain=[view_name, "timestamp"]), order="DESC")],
+                        order_by=[ast.OrderExpr(expr=ast.Field(chain=["timestamp"]), order="DESC")],
                     )
                 )
 

--- a/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_example_data_warehouse_tables_query_runner.ambr
+++ b/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_example_data_warehouse_tables_query_runner.ambr
@@ -1,12 +1,12 @@
 # serializer version: 1
 # name: TestRevenueExampleDataWarehouseTablesQueryRunner.test_database_query
   '''
-  SELECT 'stripe_posthog_test__revenue' AS view_name,
-         stripe_posthog_test__revenue.id AS distinct_id,
-         stripe_posthog_test__revenue.adjusted_original_amount AS original_revenue,
-         stripe_posthog_test__revenue.original_currency AS original_currency,
-         stripe_posthog_test__revenue.amount AS revenue,
-         stripe_posthog_test__revenue.currency AS currency
+  SELECT 'stripe.posthog_test.revenue_view' AS view_name,
+         `stripe.posthog_test.revenue_view`.id AS distinct_id,
+         `stripe.posthog_test.revenue_view`.adjusted_original_amount AS original_revenue,
+         `stripe.posthog_test.revenue_view`.original_currency AS original_currency,
+         `stripe.posthog_test.revenue_view`.amount AS revenue,
+         `stripe.posthog_test.revenue_view`.currency AS currency
   FROM
     (SELECT stripe_charge.id AS id,
             parseDateTime64BestEffortOrNull(toString(stripe_charge.created), 6, 'UTC') AS timestamp,
@@ -19,8 +19,8 @@
               'GBP' AS currency,
               if(equals(original_currency, currency), toDecimal64(adjusted_original_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(adjusted_original_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', original_currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', currency, toDate(ifNull(timestamp, toDateTime(0, 'UTC'))), toDecimal64(0, 10))))) AS amount
      FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.revenue.stripe_charges/stripe_charge/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` String, `paid` Int8, `amount` Int64, `object` String, `source` String, `status` String, `created` DateTime, `invoice` String, `outcome` String, `captured` Int8, `currency` String, `customer` String, `disputed` Int8, `livemode` Int8, `metadata` String, `refunded` Int8, `description` String, `receipt_url` String, `failure_code` String, `fraud_details` String, `radar_options` String, `receipt_email` String, `payment_intent` String, `payment_method` String, `amount_captured` Int64, `amount_refunded` Int64, `billing_details` String, `failure_message` String, `balance_transaction` String, `statement_descriptor` String, `payment_method_details` String, `calculated_statement_descriptor` String') AS stripe_charge
-     WHERE equals(stripe_charge.status, 'succeeded')) AS stripe_posthog_test__revenue
-  ORDER BY stripe_posthog_test__revenue.timestamp DESC
+     WHERE equals(stripe_charge.status, 'succeeded')) AS `stripe.posthog_test.revenue_view`
+  ORDER BY `stripe.posthog_test.revenue_view`.timestamp DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,

--- a/products/revenue_analytics/backend/hogql_queries/test/test_models.py
+++ b/products/revenue_analytics/backend/hogql_queries/test/test_models.py
@@ -64,3 +64,39 @@ class TestRevenueAnalyticsModels(BaseTest):
 
         view = RevenueAnalyticsRevenueView.for_schema_source(self.source)
         self.assertIsNone(view)
+
+    def test_revenue_view_prefix(self):
+        """Test that RevenueAnalyticsRevenueView handles prefix correctly"""
+        self.source.prefix = "prefix"
+        self.source.save()
+
+        view = RevenueAnalyticsRevenueView.for_schema_source(self.source)
+        self.assertIsNotNone(view)
+        self.assertEqual(view.name, "stripe.prefix.revenue_view")
+
+    def test_revenue_view_no_prefix(self):
+        """Test that RevenueAnalyticsRevenueView handles no prefix correctly"""
+        self.source.prefix = None
+        self.source.save()
+
+        view = RevenueAnalyticsRevenueView.for_schema_source(self.source)
+        self.assertIsNotNone(view)
+        self.assertEqual(view.name, "stripe.revenue_view")
+
+    def test_revenue_view_prefix_with_underscores(self):
+        """Test that RevenueAnalyticsRevenueView handles prefix with underscores correctly"""
+        self.source.prefix = "prefix_with_underscores_"
+        self.source.save()
+
+        view = RevenueAnalyticsRevenueView.for_schema_source(self.source)
+        self.assertIsNotNone(view)
+        self.assertEqual(view.name, "stripe.prefix_with_underscores.revenue_view")
+
+    def test_revenue_view_prefix_with_empty_string(self):
+        """Test that RevenueAnalyticsRevenueView handles prefix with underscores and periods correctly"""
+        self.source.prefix = ""
+        self.source.save()
+
+        view = RevenueAnalyticsRevenueView.for_schema_source(self.source)
+        self.assertIsNotNone(view)
+        self.assertEqual(view.name, "stripe.revenue_view")

--- a/products/revenue_analytics/backend/models.py
+++ b/products/revenue_analytics/backend/models.py
@@ -194,7 +194,7 @@ class RevenueAnalyticsRevenueView(SavedQuery):
             ),
         )
 
-        if source.prefix is None:
+        if not source.prefix:
             name = f"stripe.revenue_view"
         else:
             prefix = source.prefix.strip("_")

--- a/products/revenue_analytics/backend/models.py
+++ b/products/revenue_analytics/backend/models.py
@@ -194,9 +194,15 @@ class RevenueAnalyticsRevenueView(SavedQuery):
             ),
         )
 
+        if source.prefix is None:
+            name = f"stripe.revenue_view"
+        else:
+            prefix = source.prefix.strip("_")
+            name = f"stripe.{prefix}.revenue_view"
+
         return RevenueAnalyticsRevenueView(
             id=str(table.id),
-            name=f"stripe_{source.prefix or source.id}_revenue",
+            name=name,
             query=query.to_hogql(),
             fields=FIELDS,
         )


### PR DESCRIPTION
Following https://github.com/PostHog/posthog/pull/30947/files let's also make the revenue views use dot notation. This will make them fit slightly better.