### PR TITLE
fix: Geoip test ip changed

### DIFF
--- a/plugin-server/src/cdp/hog-transformations/__snapshots__/hog-transformer.service.test.ts.snap
+++ b/plugin-server/src/cdp/hog-transformations/__snapshots__/hog-transformer.service.test.ts.snap
@@ -36,7 +36,7 @@ exports[`HogTransformer transformEvent should execute multiple transformations a
       "level": "info",
       "log_source": "hog_function",
       "log_source_id": "<REPLACED-UUID-0>",
-      "message": "geoip location data for ip:, {"city_name":"Karlstad","country_name":"Sweden","country_code":"SE","continent_name":"Europe","continent_code":"EU","postal_code":"652 30","latitude":59.3784,"longitude":13.5123,"accuracy_radius":20,"time_zone":"Europe/Stockholm","subdivision_1_code":"S","subdivision_1_name":"Värmland County"}",
+      "message": "geoip location data for ip:, {"city_name":"Lidköping","country_name":"Sweden","country_code":"SE","continent_name":"Europe","continent_code":"EU","postal_code":"531 97","latitude":58.5019,"longitude":13.1585,"accuracy_radius":100,"time_zone":"Europe/Stockholm","subdivision_1_code":"O","subdivision_1_name":"Västra Götaland County"}",
       "team_id": 2,
       "timestamp": "2025-01-01 00:00:00.001",
     },


### PR DESCRIPTION
## Problem

Geoip info changed for the lookup so tests are failing

## Changes

* For now just update it - long term we should find a stable ip to map with

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
