### PR TITLE
feat: experiment defaults to a fixed relative MDE.

### DIFF
--- a/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeCalculatorLogic.tsx
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeCalculatorLogic.tsx
@@ -3,7 +3,7 @@ import { loaders } from 'kea-loaders'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { EXPERIMENT_DEFAULT_DURATION } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
-import { experimentLogic } from 'scenes/experiments/experimentLogic'
+import { DEFAULT_MDE, experimentLogic } from 'scenes/experiments/experimentLogic'
 
 import { performQuery } from '~/queries/query'
 import {
@@ -23,11 +23,9 @@ import {
     Experiment,
     ExperimentMetricMathType,
     FunnelVizType,
-    InsightType,
     PropertyMathType,
 } from '~/types'
 
-import { getMinimumDetectableEffect } from '../utils'
 import type { runningTimeCalculatorLogicType } from './runningTimeCalculatorLogicType'
 
 export const TIMEFRAME_HISTORICAL_DATA_DAYS = 14
@@ -207,15 +205,9 @@ export const runningTimeCalculatorLogic = kea<runningTimeCalculatorLogicType>([
         ],
         eventOrAction: ['click' as string, { setEventOrAction: (_, { value }) => value }],
         minimumDetectableEffect: [
-            30 as number,
+            DEFAULT_MDE as number,
             {
                 setMinimumDetectableEffect: (_, { value }) => value,
-                loadMetricResultSuccess: (state: number, { metricResult }) => {
-                    if (metricResult && typeof metricResult.suggestedMde === 'number') {
-                        return metricResult.suggestedMde
-                    }
-                    return state
-                },
             },
         ],
         conversionRateInputType: [
@@ -271,15 +263,6 @@ export const runningTimeCalculatorLogic = kea<runningTimeCalculatorLogicType>([
                     return {
                         uniqueUsers: result?.results?.[0]?.count ?? null,
                         automaticConversionRateDecimal: automaticConversionRateDecimal,
-                        suggestedMde: getMinimumDetectableEffect(
-                            InsightType.FUNNELS,
-                            {
-                                averageTime: 0,
-                                stepRate: 0,
-                                totalRate: automaticConversionRateDecimal ?? 0,
-                            },
-                            []
-                        ),
                     }
                 }
 

--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -235,12 +235,12 @@ describe('experimentLogic', () => {
     describe('selector values', () => {
         it('given an mde, calculates correct sample size', async () => {
             await expectLogic(logic).toMatchValues({
-                minimumDetectableEffect: 1,
+                minimumDetectableEffect: 30,
             })
 
-            expect(logic.values.minimumSampleSizePerVariant(20)).toEqual(25600)
+            expect(logic.values.minimumSampleSizePerVariant(20)).toEqual(29)
 
-            expect(logic.values.minimumSampleSizePerVariant(40)).toEqual(38400)
+            expect(logic.values.minimumSampleSizePerVariant(40)).toEqual(43)
 
             expect(logic.values.minimumSampleSizePerVariant(0)).toEqual(0)
         })
@@ -258,11 +258,11 @@ describe('experimentLogic', () => {
 
         it('given control count data, calculates correct running time', async () => {
             // 1000 count over 14 days
-            expect(logic.values.recommendedExposureForCountData(1000)).toEqual(2251.2)
+            expect(logic.values.recommendedExposureForCountData(1000)).toEqual(2.8)
 
             // 10,000 entrants over 14 days
             // 10x entrants, so 1/10th running time
-            expect(logic.values.recommendedExposureForCountData(10000)).toEqual(225.1)
+            expect(logic.values.recommendedExposureForCountData(10000)).toEqual(0.3)
 
             // 0 entrants over 14 days, so infinite running time
             expect(logic.values.recommendedExposureForCountData(0)).toEqual(Infinity)

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -73,12 +73,7 @@ import { experimentsLogic } from './experimentsLogic'
 import { holdoutsLogic } from './holdoutsLogic'
 import { SharedMetric } from './SharedMetrics/sharedMetricLogic'
 import { sharedMetricsLogic } from './SharedMetrics/sharedMetricsLogic'
-import {
-    featureFlagEligibleForExperiment,
-    getMinimumDetectableEffect,
-    percentageDistribution,
-    transformFiltersForWinningVariant,
-} from './utils'
+import { featureFlagEligibleForExperiment, percentageDistribution, transformFiltersForWinningVariant } from './utils'
 
 const NEW_EXPERIMENT: Experiment = {
     id: 'new',
@@ -102,6 +97,8 @@ const NEW_EXPERIMENT: Experiment = {
     updated_at: null,
     holdout_id: null,
 }
+
+export const DEFAULT_MDE = 30
 
 export interface ExperimentLogicProps {
     experimentId?: Experiment['id']
@@ -1518,14 +1515,9 @@ export const experimentLogic = kea<experimentLogicType>([
             },
         ],
         minimumDetectableEffect: [
-            (s) => [s.experiment, s.getInsightType, s.conversionMetrics, s.trendResults, s.firstPrimaryMetric],
-            (newExperiment, getInsightType, conversionMetrics, trendResults, firstPrimaryMetric): number => {
-                return (
-                    newExperiment?.parameters?.minimum_detectable_effect ||
-                    // :KLUDGE: extracted the method due to difficulties with logic tests
-                    getMinimumDetectableEffect(getInsightType(firstPrimaryMetric), conversionMetrics, trendResults) ||
-                    0
-                )
+            (s) => [s.experiment],
+            (newExperiment): number => {
+                return newExperiment?.parameters?.minimum_detectable_effect ?? DEFAULT_MDE
             },
         ],
         minimumSampleSizePerVariant: [

--- a/frontend/src/scenes/experiments/utils.test.ts
+++ b/frontend/src/scenes/experiments/utils.test.ts
@@ -19,11 +19,9 @@ import {
 } from '~/queries/schema/schema-general'
 import {
     ChartDisplayType,
-    EntityType,
     ExperimentMetricMathType,
     FeatureFlagFilters,
     FeatureFlagType,
-    InsightType,
     PropertyFilterType,
     PropertyMathType,
     PropertyOperator,
@@ -35,7 +33,6 @@ import {
     featureFlagEligibleForExperiment,
     filterToExposureConfig,
     filterToMetricConfig,
-    getMinimumDetectableEffect,
     getViewRecordingFilters,
     metricToFilter,
     metricToQuery,
@@ -67,96 +64,6 @@ describe('utils', () => {
             expect(percentageDistribution(19)).toEqual([6, 6, 6, 6, 6, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5])
             expect(percentageDistribution(20)).toEqual([5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5])
         })
-    })
-
-    it('Funnel experiment returns correct MDE', async () => {
-        const metricType = InsightType.FUNNELS
-        const trendResults = [
-            {
-                action: {
-                    id: '$pageview',
-                    type: 'events' as EntityType,
-                    order: 0,
-                    name: '$pageview',
-                    custom_name: null,
-                    math: 'total',
-                    math_group_type_index: null,
-                },
-                aggregated_value: 0,
-                label: '$pageview',
-                count: 0,
-                data: [],
-                labels: [],
-                days: [],
-            },
-        ]
-
-        let conversionMetrics = { averageTime: 0, stepRate: 0, totalRate: 0 }
-        expect(getMinimumDetectableEffect(metricType, conversionMetrics, trendResults)).toEqual(1)
-        conversionMetrics = { averageTime: 0, stepRate: 0, totalRate: 1 }
-        expect(getMinimumDetectableEffect(metricType, conversionMetrics, trendResults)).toEqual(1)
-
-        conversionMetrics = { averageTime: 0, stepRate: 0, totalRate: 0.01 }
-        expect(getMinimumDetectableEffect(metricType, conversionMetrics, trendResults)).toEqual(1)
-        conversionMetrics = { averageTime: 0, stepRate: 0, totalRate: 0.99 }
-        expect(getMinimumDetectableEffect(metricType, conversionMetrics, trendResults)).toEqual(1)
-
-        conversionMetrics = { averageTime: 0, stepRate: 0, totalRate: 0.1 }
-        expect(getMinimumDetectableEffect(metricType, conversionMetrics, trendResults)).toEqual(5)
-        conversionMetrics = { averageTime: 0, stepRate: 0, totalRate: 0.9 }
-        expect(getMinimumDetectableEffect(metricType, conversionMetrics, trendResults)).toEqual(5)
-
-        conversionMetrics = { averageTime: 0, stepRate: 0, totalRate: 0.3 }
-        expect(getMinimumDetectableEffect(metricType, conversionMetrics, trendResults)).toEqual(3)
-        conversionMetrics = { averageTime: 0, stepRate: 0, totalRate: 0.7 }
-        expect(getMinimumDetectableEffect(metricType, conversionMetrics, trendResults)).toEqual(3)
-
-        conversionMetrics = { averageTime: 0, stepRate: 0, totalRate: 0.2 }
-        expect(getMinimumDetectableEffect(metricType, conversionMetrics, trendResults)).toEqual(4)
-        conversionMetrics = { averageTime: 0, stepRate: 0, totalRate: 0.8 }
-        expect(getMinimumDetectableEffect(metricType, conversionMetrics, trendResults)).toEqual(4)
-
-        conversionMetrics = { averageTime: 0, stepRate: 0, totalRate: 0.5 }
-        expect(getMinimumDetectableEffect(metricType, conversionMetrics, trendResults)).toEqual(5)
-    })
-
-    it('Trend experiment returns correct MDE', async () => {
-        const metricType = InsightType.TRENDS
-        const conversionMetrics = { averageTime: 0, stepRate: 0, totalRate: 0 }
-        const trendResults = [
-            {
-                action: {
-                    id: '$pageview',
-                    type: 'events' as EntityType,
-                    order: 0,
-                    name: '$pageview',
-                    custom_name: null,
-                    math: 'total',
-                    math_group_type_index: null,
-                },
-                aggregated_value: 0,
-                label: '$pageview',
-                count: 0,
-                data: [],
-                labels: [],
-                days: [],
-            },
-        ]
-
-        trendResults[0].count = 0
-        expect(getMinimumDetectableEffect(metricType, conversionMetrics, trendResults)).toEqual(100)
-
-        trendResults[0].count = 200
-        expect(getMinimumDetectableEffect(metricType, conversionMetrics, trendResults)).toEqual(100)
-
-        trendResults[0].count = 201
-        expect(getMinimumDetectableEffect(metricType, conversionMetrics, trendResults)).toEqual(20)
-
-        trendResults[0].count = 1001
-        expect(getMinimumDetectableEffect(metricType, conversionMetrics, trendResults)).toEqual(5)
-
-        trendResults[0].count = 20000
-        expect(getMinimumDetectableEffect(metricType, conversionMetrics, trendResults)).toEqual(5)
     })
 
     it('transforms filters for a winning variant', async () => {

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -29,13 +29,10 @@ import {
     FeatureFlagType,
     FilterType,
     FunnelConversionWindowTimeUnit,
-    FunnelTimeConversionMetrics,
     FunnelVizType,
-    InsightType,
     PropertyFilterType,
     PropertyOperator,
     type QueryBasedInsightModel,
-    TrendResult,
     UniversalFiltersGroupValue,
 } from '~/types'
 
@@ -56,64 +53,6 @@ export function percentageDistribution(variantCount: number): number[] {
         percentages[i] += 1
     }
     return percentages
-}
-
-export function getMinimumDetectableEffect(
-    metricType: InsightType,
-    conversionMetrics: FunnelTimeConversionMetrics,
-    trendResults: TrendResult[]
-): number | null {
-    if (metricType === InsightType.FUNNELS) {
-        // FUNNELS
-        // Given current CR, find a realistic target CR increase and return MDE based on it
-        if (!conversionMetrics) {
-            return null
-        }
-
-        let currentConversionRate = conversionMetrics.totalRate * 100
-        // 40% should have the same MDE as 60% -> perform a flip above 50%
-        if (currentConversionRate > 50) {
-            currentConversionRate = 100 - currentConversionRate
-        }
-
-        // Multiplication would result in 0; return MDE = 1
-        if (currentConversionRate === 0) {
-            return 1
-        }
-
-        // CR = 50% requires a high running time
-        // CR = 1% or 99% requires a low running time
-        const midpointDistance = Math.abs(50 - currentConversionRate)
-
-        let targetConversionRateIncrease
-        if (midpointDistance <= 20) {
-            targetConversionRateIncrease = 0.1
-        } else if (midpointDistance <= 35) {
-            targetConversionRateIncrease = 0.2
-        } else {
-            targetConversionRateIncrease = 0.5
-        }
-
-        const targetConversionRate = Math.round(currentConversionRate * (1 + targetConversionRateIncrease))
-        const mde = Math.ceil(targetConversionRate - currentConversionRate)
-
-        return mde || 30
-    }
-
-    // TRENDS
-    // Given current count of the Trend metric, what percentage increase are we targeting?
-    if (trendResults[0]?.count === undefined) {
-        return null
-    }
-
-    const baselineCount = trendResults[0].count
-
-    if (baselineCount <= 200) {
-        return 100
-    } else if (baselineCount <= 1000) {
-        return 20
-    }
-    return 5
 }
 
 export function transformFiltersForWinningVariant(


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Following up on this comment from #30792

> Just a side note for later: I think we can get rid of this whole function actually. It think this calculation tries to estimate an absolute MDE, but we should just default to 30% relative MDE. So no need for this logic. But that's another PR.
https://github.com/PostHog/posthog/pull/30792#discussion_r2030835700

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We are removing `getMinimumDetectableEffect`, their tests and all usages in favor of a constant we'll use as default.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

```bash
pnpm --filter=@posthog/frontend jest frontend/src/scenes/experiments/experimentLogic.test.ts
```

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
