### PR TITLE
fix(project-tree): clean up deletes

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -141,27 +141,64 @@ export function ProjectTree(): JSX.Element {
                         <ButtonPrimitive menuItem>Rename</ButtonPrimitive>
                     </MenuItem>
                 ) : null}
-                {item.record?.id || item.record?.type === 'folder' ? (
+
+                {checkedItemCountNumeric > 1 && checkedItems[item.id] ? (
+                    <>
+                        <MenuItem asChild disabled={!item.record?.shortcut}>
+                            <ButtonPrimitive menuItem disabled>
+                                Delete {checkedItemsCount} item{checkedItemCountNumeric === 1 ? '' : 's'}
+                            </ButtonPrimitive>
+                        </MenuItem>
+                        <MenuItem
+                            asChild
+                            disabled={!item.record?.shortcut}
+                            onClick={(e: any) => {
+                                e.stopPropagation()
+                                if (checkedItemCountNumeric > 1 && checkedItems[item.id]) {
+                                    deleteCheckedItems()
+                                } else {
+                                    deleteItem(item.record as unknown as FileSystemEntry)
+                                }
+                            }}
+                        >
+                            <ButtonPrimitive menuItem disabled>
+                                Move {checkedItemsCount} item{checkedItemCountNumeric === 1 ? '' : 's'} to 'Unfiled'
+                            </ButtonPrimitive>
+                        </MenuItem>
+                    </>
+                ) : item.record?.shortcut ? (
                     <MenuItem
                         asChild
                         onClick={(e: any) => {
                             e.stopPropagation()
-                            if (checkedItemCountNumeric > 1 && checkedItems[item.id]) {
-                                deleteCheckedItems()
-                            } else {
-                                deleteItem(item.record as unknown as FileSystemEntry)
-                            }
+                            deleteItem(item.record as unknown as FileSystemEntry)
                         }}
                     >
-                        <ButtonPrimitive menuItem>
-                            {checkedItemCountNumeric > 1 && checkedItems[item.id]
-                                ? `Delete ${checkedItemsCount} item${checkedItemCountNumeric === 1 ? '' : 's'}`
-                                : item.record?.shortcut
-                                ? 'Remove shortcut'
-                                : "Delete and move back to 'Unfiled'"}
-                        </ButtonPrimitive>
+                        <ButtonPrimitive menuItem>Remove shortcut</ButtonPrimitive>
                     </MenuItem>
-                ) : null}
+                ) : (
+                    <>
+                        <MenuItem asChild disabled>
+                            <ButtonPrimitive menuItem disabled={!item.record?.shortcut}>
+                                {item.record?.type === 'folder' ? 'Delete folder' : 'Delete'}
+                            </ButtonPrimitive>
+                        </MenuItem>
+                        {item.record?.type === 'folder' || !item.record?.path.startsWith('Unfiled/') ? (
+                            <MenuItem
+                                asChild
+                                onClick={(e: any) => {
+                                    e.stopPropagation()
+                                    deleteItem(item.record as unknown as FileSystemEntry)
+                                }}
+                            >
+                                <ButtonPrimitive menuItem>
+                                    {item.record?.type === 'folder' ? "Move folder to 'Unfiled'" : "Move to 'Unfiled'"}
+                                </ButtonPrimitive>
+                            </MenuItem>
+                        ) : null}
+                    </>
+                )}
+
                 {item.record?.type === 'folder' || item.id?.startsWith('project-folder-empty/') ? (
                     <>
                         {!item.id?.startsWith('project-folder-empty/') ? <MenuSeparator /> : null}


### PR DESCRIPTION
## Problem

Our delete/unfile buttons are confusing.

## Changes

Show a grayed out "delete" button in addition to the "move to unfiled" buttons. I would add a `disabledReason` prop (if one was available) saying "Not yet implemented". Plus some other changes:

![2025-04-09 22 46 13](https://github.com/user-attachments/assets/78e68b41-6b8b-4317-bd0b-9aaf480422c6)

![2025-04-09 22 49 41](https://github.com/user-attachments/assets/c94bc6bf-d1b8-4378-83cd-73f8df1265b2)


## How did you test this code?

See screencast