### PR TITLE
feat(propdefs): override team_id & project_id if inbound raw Event includes root_team_id

### DIFF
--- a/rust/property-defs-rs/src/api/v1/query.rs
+++ b/rust/property-defs-rs/src/api/v1/query.rs
@@ -32,7 +32,7 @@ impl Manager {
     pub fn count_query<'args, 'builder: 'args>(
         &self,
         qb: &'builder mut QueryBuilder<'args, Postgres>,
-        project_id: i32,
+        team_id: i32,
         params: &'args Params,
     ) -> Query<'args, Postgres, PgArguments> {
         /* The original Django query formulation we're duplicating
@@ -41,7 +41,7 @@ impl Manager {
         SELECT count(*) as full_count
         FROM {self.table}
         {self._join_on_event_property()}
-        WHERE coalesce({self.property_definition_table}.project_id, {self.property_definition_table}.team_id) = %(project_id)s
+        WHERE coalesce({self.property_definition_table}.project_id, {self.property_definition_table}.team_id) = %(team_id)s
             AND type = %(type)s
             AND coalesce(group_type_index, -1) = %(group_type_index)s
             {self.excluded_properties_filter}
@@ -63,13 +63,13 @@ impl Manager {
         self.gen_from_clause(qb, params.use_enterprise_taxonomy);
         self.conditionally_join_event_properties(
             qb,
-            project_id,
+            team_id,
             params.parent_type,
             &params.event_names,
         );
 
         // begin the WHERE clause
-        self.init_where_clause(qb, project_id);
+        self.init_where_clause(qb, team_id);
         self.where_property_type(qb, params.parent_type);
         qb.push(format!(
             "AND COALESCE({}.\"group_type_index\", -1) = ",
@@ -97,7 +97,7 @@ impl Manager {
 
         // NOTE: event_name_filter from orig Django query doesn't appear to be applied anywhere atm
 
-        // NOTE: count query is global per project_id, so no LIMIT/OFFSET handling is applied
+        // NOTE: count query is global per team_id, so no LIMIT/OFFSET handling is applied
 
         qb.build()
     }
@@ -105,7 +105,7 @@ impl Manager {
     pub fn property_definitions_query<'args, 'builder: 'args>(
         &self,
         qb: &'builder mut QueryBuilder<'args, Postgres>,
-        project_id: i32,
+        team_id: i32,
         params: &'args Params,
     ) -> Query<'args, Postgres, PgArguments> {
         /* The original Django query we're duplicating
@@ -114,7 +114,7 @@ impl Manager {
         SELECT {self.property_definition_fields}, {self.event_property_field} AS is_seen_on_filtered_events
         FROM {self.table}
         {self._join_on_event_property()}
-        WHERE coalesce({self.property_definition_table}.project_id, {self.property_definition_table}.team_id) = %(project_id)s
+        WHERE coalesce({self.property_definition_table}.project_id, {self.property_definition_table}.team_id) = %(team_id)s
             AND type = %(type)s
             AND coalesce(group_type_index, -1) = %(group_type_index)s
             {self.excluded_properties_filter}
@@ -151,13 +151,13 @@ impl Manager {
         self.gen_from_clause(qb, params.use_enterprise_taxonomy);
         self.conditionally_join_event_properties(
             qb,
-            project_id,
+            team_id,
             params.parent_type,
             &params.event_names,
         );
 
         // begin the WHERE clause
-        self.init_where_clause(qb, project_id);
+        self.init_where_clause(qb, team_id);
         self.where_property_type(qb, params.parent_type);
         qb.push(format!(
             " AND COALESCE({}.\"group_type_index\", -1) = ",
@@ -245,7 +245,7 @@ impl Manager {
     fn conditionally_join_event_properties<'args>(
         &self,
         qb: &mut QueryBuilder<'args, Postgres>,
-        project_id: i32,
+        team_id: i32,
         parent_type: PropertyParentType,
         event_names: &'args [String],
     ) {
@@ -261,7 +261,7 @@ impl Manager {
                 " (SELECT DISTINCT property FROM {0} WHERE COALESCE(project_id, team_id) = ",
                 EVENT_PROPERTY_TABLE
             ));
-            qb.push_bind(project_id);
+            qb.push_bind(team_id);
             qb.push(" ");
 
             // conditionally apply filter if event_names list was supplied
@@ -279,12 +279,12 @@ impl Manager {
         }
     }
 
-    fn init_where_clause(&self, qb: &mut QueryBuilder<Postgres>, project_id: i32) {
+    fn init_where_clause(&self, qb: &mut QueryBuilder<Postgres>, team_id: i32) {
         qb.push(format!(
             "WHERE COALESCE({0}.\"project_id\", {0}.\"team_id\") = ",
             PROPERTY_DEFS_TABLE
         ));
-        qb.push_bind(project_id);
+        qb.push(team_id);
         qb.push(" ");
     }
 

--- a/rust/property-defs-rs/src/api/v1/query.rs
+++ b/rust/property-defs-rs/src/api/v1/query.rs
@@ -284,7 +284,7 @@ impl Manager {
             "WHERE COALESCE({0}.\"project_id\", {0}.\"team_id\") = ",
             PROPERTY_DEFS_TABLE
         ));
-        qb.push(team_id);
+        qb.push_bind(team_id);
         qb.push(" ");
     }
 

--- a/rust/property-defs-rs/src/api/v1/routing.rs
+++ b/rust/property-defs-rs/src/api/v1/routing.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 pub fn apply_routes(parent: Router, app_ctx: Arc<AppContext>) -> Router {
     let api_router = Router::new()
         .route(
-            "/projects/:project_id/property_definitions",
+            "/projects/:team_id/property_definitions",
             get(project_property_definitions_handler),
         )
         .with_state(app_ctx);
@@ -33,28 +33,25 @@ pub fn apply_routes(parent: Router, app_ctx: Arc<AppContext>) -> Router {
 
 async fn project_property_definitions_handler(
     State(app_ctx): State<Arc<AppContext>>,
-    Path(project_id): Path<i32>,
+    Path(team_id): Path<i32>,
     Query(params): Query<HashMap<String, String>>,
 ) -> Result<Json<PropertyDefinitionResponse>, ApiError> {
     // parse and validate request's query params
     let params = parse_request(params);
     params.valid()?;
-    debug!(
-        "Request for project_id({}) w/params: {:?}",
-        project_id, &params
-    );
+    debug!("Request for team_id({}) w/params: {:?}", team_id, &params);
 
     let qmgr: &Manager = &app_ctx.query_manager;
 
     // construct the count query
     let mut count_bldr = QueryBuilder::<Postgres>::new("");
-    let count_query = qmgr.count_query(&mut count_bldr, project_id, &params);
+    let count_query = qmgr.count_query(&mut count_bldr, team_id, &params);
     let count_dbg: String = count_query.sql().into();
     debug!("Count query: {:?}", &count_dbg);
 
     // construct the property definitions query
     let mut props_bldr = QueryBuilder::<Postgres>::new("");
-    let props_query = qmgr.property_definitions_query(&mut props_bldr, project_id, &params);
+    let props_query = qmgr.property_definitions_query(&mut props_bldr, team_id, &params);
     let props_dbg: String = props_query.sql().into();
     debug!("Prop defs query: {:?}", &props_dbg);
 


### PR DESCRIPTION
## Problem
New environments handling has replaced `project_id` with a notion of parent ("root") team ID which controls the global property def type classifications and other settings for all child teams.

We need the `property-defs-rs` service to become `root_team_id` aware as part of the transition.
⚠️ **DO NOT MERGE** until environments prep work is completed ⚠️ 


## Changes
* Write path: ensure incoming `Event`s override `team_id` and `project_id` when decomposed into `Update`s whenever `Event#root_team_id` is present
* Read path: rely on `team_id` in the property defs API where project_id was needed

_TODO_: remove uses of `COALESCE` on `project_id`, falling back to `team_id`, relying on (overridden) `team_id` in all `property-defs-rs` SQL

## Does this work well for both Cloud and self-hosted?
Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Locally and in CI; coordinated w/ @benjackwhite 's ongoing environments work
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
