### PR TITLE
fix(project-tree): search folder select

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
@@ -627,6 +627,7 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                     checkedItems,
                     root: 'project',
                     searchTerm: searchResults.searchTerm,
+                    disableFolderSelect: true,
                 })
                 if (searchResults.hasMore) {
                     if (searchResultsLoading) {

--- a/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
@@ -15,6 +15,7 @@ export interface ConvertProps {
     checkedItems: Record<string, boolean>
     root: string
     searchTerm?: string
+    disableFolderSelect?: boolean
 }
 
 export function wrapWithShortutIcon(item: FileSystemImport | FileSystemEntry, icon: JSX.Element): JSX.Element {
@@ -36,6 +37,7 @@ export function convertFileSystemEntryToTreeDataItem({
     checkedItems,
     root,
     searchTerm,
+    disableFolderSelect,
 }: ConvertProps): TreeDataItem[] {
     // The top-level nodes for our project tree
     const rootNodes: TreeDataItem[] = []
@@ -66,6 +68,9 @@ export function convertFileSystemEntryToTreeDataItem({
                 record: { type: 'folder', id: null, path: fullPath },
                 children: [],
                 checked: checkedItems[id],
+            }
+            if (disableFolderSelect) {
+                folderNode.disableSelect = true
             }
             allFolderNodes.push(folderNode)
             nodes.push(folderNode)
@@ -137,7 +142,11 @@ export function convertFileSystemEntryToTreeDataItem({
                 }
             },
         }
-        if (checkedItems[nodeId]) {
+        if (disableFolderSelect) {
+            if (item.type === 'folder') {
+                node.disableSelect = true
+            }
+        } else if (checkedItems[nodeId]) {
             markIndeterminateFolders(joinPath(splitPath(item.path).slice(0, -1)))
         }
 

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTreeUtils.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTreeUtils.tsx
@@ -107,11 +107,12 @@ export const TreeNodeDisplayCheckbox = ({
             <div className={ICON_CLASSES}>
                 <LemonCheckbox
                     className={cn('size-5 ml-[2px]', {
-                        'opacity-50': item.disableSelect,
+                        // Hide the checkbox if the item is disabled from being checked
+                        hidden: item.disableSelect || item.record?.type === 'folder',
                     })}
                     checked={isChecked ?? false}
-                    disabledReason={item.disableSelect ? 'Selecting folders is disabled while searching' : undefined}
                     onChange={(checked) => {
+                        // Just in case
                         if (item.disableSelect) {
                             return
                         }
@@ -150,7 +151,12 @@ export const TreeNodeDisplayIcon = ({
     }
 
     return (
-        <div className="flex gap-1 relative [&_svg]:size-4 group-hover/lemon-tree-icon-wrapper:opacity-0">
+        <div
+            className={cn('flex gap-1 relative [&_svg]:size-4', {
+                // Don't hide the icon on hover if the item is disabled from being checked
+                'group-hover/lemon-tree-icon-wrapper:opacity-0': !item.disableSelect,
+            })}
+        >
             {isFolder && (
                 <div
                     className={cn(

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTreeUtils.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTreeUtils.tsx
@@ -106,9 +106,15 @@ export const TreeNodeDisplayCheckbox = ({
         >
             <div className={ICON_CLASSES}>
                 <LemonCheckbox
-                    className="size-5 ml-[2px]"
+                    className={cn('size-5 ml-[2px]', {
+                        'opacity-50': item.disableSelect,
+                    })}
                     checked={isChecked ?? false}
+                    disabledReason={item.disableSelect ? 'Selecting folders is disabled while searching' : undefined}
                     onChange={(checked) => {
+                        if (item.disableSelect) {
+                            return
+                        }
                         handleCheckedChange?.(checked)
                     }}
                 />


### PR DESCRIPTION
## Problem

Selecting folders when searching is unintuitive. We will select the entire folder with all items:


![2025-04-10 00 07 49](https://github.com/user-attachments/assets/0f4a6a02-3a18-4f7f-a0d2-79df1c546bb1)

[Updated] with lemon tree using new prop:
![2025-04-10 13 06 02](https://github.com/user-attachments/assets/c3fe8b50-493a-4733-ba0b-36185ea86c8b)

## Changes

The easiest solution is to only allow selecting files from within the search results.

This PR adds `disableSelect: true` for folders in search results, not allowing users to select folder when searching. ~~However lemon tree doesn't respect this prop on tree items, so the checkboxes remain visible. Adam: can you look at it and bring this over the line?~~

## How did you test this code?

~~WIP~~