### PR TITLE
feat: Spread partitioning for personless overflow

### DIFF
--- a/plugin-server/src/ingestion/__snapshots__/ingestion-consumer.test.ts.snap
+++ b/plugin-server/src/ingestion/__snapshots__/ingestion-consumer.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`IngestionConsumer error handling should handle explicitly non retriable errors by sending to DLQ 1`] = `
 [
   {
-    "key": null,
+    "key": "THIS IS NOT A TOKEN FOR TEAM 2:user-1",
     "topic": "events_plugin_ingestion_dlq_test",
     "value": {
       "data": "{"distinct_id":"user-1","uuid":"<REPLACED-UUID-0>","token":"THIS IS NOT A TOKEN FOR TEAM 2","ip":"127.0.0.1","site_url":"us.posthog.com","now":"2025-01-01T00:00:00.000Z","event":"$pageview","properties":{"$current_url":"http://localhost:8000"}}",
@@ -20,7 +20,7 @@ exports[`IngestionConsumer error handling should handle explicitly non retriable
 exports[`IngestionConsumer general overflow force overflow should force events with matching token to overflow: force overflow messages 1`] = `
 [
   {
-    "key": null,
+    "key": "THIS IS NOT A TOKEN FOR TEAM 2:team1-user",
     "topic": "events_plugin_ingestion_overflow_test",
     "value": {
       "data": "{"distinct_id":"team1-user","uuid":"<REPLACED-UUID-0>","token":"THIS IS NOT A TOKEN FOR TEAM 2","ip":"127.0.0.1","site_url":"us.posthog.com","now":"2025-01-01T00:00:00.000Z","event":"$pageview","properties":{"$current_url":"http://localhost:8000"}}",

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -244,7 +244,13 @@ export class IngestionConsumer {
                         logger.warn('🪣', `Local overflow detection triggered on key ${eventKey}`)
                     }
 
-                    void this.scheduleWork(this.emitToOverflow([message], shouldForceOverflow ? true : undefined))
+                    // NOTE: If we are forcing to overflow we typically want to keep the partition key
+                    // If the event is marked for skipping persons however locality doesn't matter so we would rather have the higher throughput
+                    // of random partitioning.
+                    const preserveLocality =
+                        shouldForceOverflow && !this.shouldSkipPerson(event.token, event.distinct_id) ? true : undefined
+
+                    void this.scheduleWork(this.emitToOverflow([message], preserveLocality))
                     continue
                 }
 


### PR DESCRIPTION
## Problem

We don't want to keep hot partition issues for overflow if we don't do person processing for some data

## Changes

* Fixes it 

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
