### PR TITLE
fix: remove funnel trends incorrect heuristic

### DIFF
--- a/posthog/hogql_queries/insights/funnels/funnel_trends_udf.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_trends_udf.py
@@ -48,9 +48,6 @@ class FunnelTrendsUDF(FunnelUDFMixin, FunnelTrends):
                 """
         return ""
 
-    def udf_event_array_filter(self):
-        return self._udf_event_array_filter(1, 4, 5)
-
     # This is the function that calls the UDF
     # This is used by both the query itself and the actors query
     def _inner_aggregation_query(self):

--- a/posthog/hogql_queries/insights/funnels/funnel_trends_udf.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_trends_udf.py
@@ -114,7 +114,7 @@ class FunnelTrendsUDF(FunnelUDFMixin, FunnelTrends):
                     '{breakdown_attribution_string}',
                     '{self.context.funnelsFilter.funnelOrderType}',
                     {self._prop_vals()},
-                    {self.udf_event_array_filter()}
+                    events_array
                 )) as af_tuple,
                 toTimeZone(toDateTime(_toUInt64(af_tuple.1)), '{self.context.team.timezone}') as entrance_period_start,
                 af_tuple.2 as success_bool,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_actors_udf.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_actors_udf.ambr
@@ -10,11 +10,7 @@
             actor_id AS id
      FROM
        (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), toUInt64(toDateTime(toStartOfDay(timestamp), 'UTC')), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
-               arrayJoin(aggregate_funnel_array_trends_v6(0, 2, 3, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.5), 1), 0), ifNull(equals(x.5, x_before.5), isNull(x.5)
-                                                                                                                                                                                                          and isNull(x_before.5)), ifNull(equals(x.5, x_after.5), isNull(x.5)
-                                                                                                                                                                                                                                          and isNull(x_after.5)), ifNull(equals(x.4, x_before.4), isNull(x.4)
-                                                                                                                                                                                                                                                                         and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
-                                                                                                                                                                                                                                                                                                         and isNull(x_after.4)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               arrayJoin(aggregate_funnel_array_trends_v6(0, 2, 3, 1209600, 'first_touch', 'ordered', [[]], events_array)) AS af_tuple,
                toTimeZone(toDateTime(toUInt64(af_tuple.1), 'UTC'), 'UTC') AS entrance_period_start,
                af_tuple.2 AS success_bool,
                af_tuple.3 AS breakdown,
@@ -85,11 +81,7 @@
             actor_id AS id
      FROM
        (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), toUInt64(toDateTime(toStartOfDay(timestamp), 'UTC')), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
-               arrayJoin(aggregate_funnel_array_trends_v6(0, 3, 3, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.5), 1), 0), ifNull(equals(x.5, x_before.5), isNull(x.5)
-                                                                                                                                                                                                          and isNull(x_before.5)), ifNull(equals(x.5, x_after.5), isNull(x.5)
-                                                                                                                                                                                                                                          and isNull(x_after.5)), ifNull(equals(x.4, x_before.4), isNull(x.4)
-                                                                                                                                                                                                                                                                         and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
-                                                                                                                                                                                                                                                                                                         and isNull(x_after.4)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               arrayJoin(aggregate_funnel_array_trends_v6(0, 3, 3, 1209600, 'first_touch', 'ordered', [[]], events_array)) AS af_tuple,
                toTimeZone(toDateTime(toUInt64(af_tuple.1), 'UTC'), 'UTC') AS entrance_period_start,
                af_tuple.2 AS success_bool,
                af_tuple.3 AS breakdown,
@@ -160,11 +152,7 @@
             actor_id AS id
      FROM
        (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), toUInt64(toDateTime(toStartOfDay(timestamp), 'UTC')), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
-               arrayJoin(aggregate_funnel_array_trends_v6(0, 3, 3, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.5), 1), 0), ifNull(equals(x.5, x_before.5), isNull(x.5)
-                                                                                                                                                                                                          and isNull(x_before.5)), ifNull(equals(x.5, x_after.5), isNull(x.5)
-                                                                                                                                                                                                                                          and isNull(x_after.5)), ifNull(equals(x.4, x_before.4), isNull(x.4)
-                                                                                                                                                                                                                                                                         and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
-                                                                                                                                                                                                                                                                                                         and isNull(x_after.4)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+               arrayJoin(aggregate_funnel_array_trends_v6(0, 3, 3, 1209600, 'first_touch', 'ordered', [[]], events_array)) AS af_tuple,
                toTimeZone(toDateTime(toUInt64(af_tuple.1), 'UTC'), 'UTC') AS entrance_period_start,
                af_tuple.2 AS success_bool,
                af_tuple.3 AS breakdown,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_udf.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_udf.ambr
@@ -8,11 +8,7 @@
          data.breakdown AS prop
   FROM
     (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), toUInt64(toDateTime(toStartOfDay(timestamp), 'UTC')), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
-            arrayJoin(aggregate_funnel_array_trends_v6(0, 3, 3, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.5), 1), 0), ifNull(equals(x.5, x_before.5), isNull(x.5)
-                                                                                                                                                                                                       and isNull(x_before.5)), ifNull(equals(x.5, x_after.5), isNull(x.5)
-                                                                                                                                                                                                                                       and isNull(x_after.5)), ifNull(equals(x.4, x_before.4), isNull(x.4)
-                                                                                                                                                                                                                                                                      and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
-                                                                                                                                                                                                                                                                                                      and isNull(x_after.4)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+            arrayJoin(aggregate_funnel_array_trends_v6(0, 3, 3, 1209600, 'first_touch', 'ordered', [[]], events_array)) AS af_tuple,
             toTimeZone(toDateTime(toUInt64(af_tuple.1), 'UTC'), 'UTC') AS entrance_period_start,
             af_tuple.2 AS success_bool,
             af_tuple.3 AS breakdown,
@@ -62,11 +58,7 @@
          data.breakdown AS prop
   FROM
     (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), toUInt64(toDateTime(toStartOfDay(timestamp), 'US/Pacific')), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
-            arrayJoin(aggregate_funnel_array_trends_v6(0, 3, 3, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.5), 1), 0), ifNull(equals(x.5, x_before.5), isNull(x.5)
-                                                                                                                                                                                                       and isNull(x_before.5)), ifNull(equals(x.5, x_after.5), isNull(x.5)
-                                                                                                                                                                                                                                       and isNull(x_after.5)), ifNull(equals(x.4, x_before.4), isNull(x.4)
-                                                                                                                                                                                                                                                                      and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
-                                                                                                                                                                                                                                                                                                      and isNull(x_after.4)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+            arrayJoin(aggregate_funnel_array_trends_v6(0, 3, 3, 1209600, 'first_touch', 'ordered', [[]], events_array)) AS af_tuple,
             toTimeZone(toDateTime(toUInt64(af_tuple.1), 'US/Pacific'), 'US/Pacific') AS entrance_period_start,
             af_tuple.2 AS success_bool,
             af_tuple.3 AS breakdown,
@@ -116,11 +108,7 @@
          data.breakdown AS prop
   FROM
     (SELECT arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), toUInt64(toDateTime(toStartOfWeek(timestamp, 0), 'UTC')), uuid, [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))) AS events_array,
-            arrayJoin(aggregate_funnel_array_trends_v6(0, 3, 3, 1209600, 'first_touch', 'ordered', [[]], arrayFilter((x, x_before, x_after) -> not(and(ifNull(lessOrEquals(length(x.5), 1), 0), ifNull(equals(x.5, x_before.5), isNull(x.5)
-                                                                                                                                                                                                       and isNull(x_before.5)), ifNull(equals(x.5, x_after.5), isNull(x.5)
-                                                                                                                                                                                                                                       and isNull(x_after.5)), ifNull(equals(x.4, x_before.4), isNull(x.4)
-                                                                                                                                                                                                                                                                      and isNull(x_before.4)), ifNull(equals(x.4, x_after.4), isNull(x.4)
-                                                                                                                                                                                                                                                                                                      and isNull(x_after.4)), ifNull(greater(x.1, x_before.1), 0), ifNull(less(x.1, x_after.1), 0))), events_array, arrayRotateRight(events_array, 1), arrayRotateLeft(events_array, 1)))) AS af_tuple,
+            arrayJoin(aggregate_funnel_array_trends_v6(0, 3, 3, 1209600, 'first_touch', 'ordered', [[]], events_array)) AS af_tuple,
             toTimeZone(toDateTime(toUInt64(af_tuple.1), 'UTC'), 'UTC') AS entrance_period_start,
             af_tuple.2 AS success_bool,
             af_tuple.3 AS breakdown,

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_trends_udf.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_trends_udf.py
@@ -2,10 +2,7 @@ import datetime
 from typing import cast
 from unittest.mock import patch, Mock
 
-from hogql_parser import parse_expr
 from posthog.constants import INSIGHT_FUNNELS, TRENDS_LINEAR, FunnelOrderType
-from posthog.hogql.constants import HogQLGlobalSettings, MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY
-from posthog.hogql.query import execute_hogql_query
 from posthog.hogql_queries.insights.funnels.funnels_query_runner import FunnelsQueryRunner
 from posthog.hogql_queries.insights.funnels.test.test_funnel_trends import BaseTestFunnelTrends
 from posthog.hogql_queries.legacy_compatibility.filter_to_query import filter_to_query
@@ -30,52 +27,6 @@ from posthog.test.test_journeys import journeys_for
 )
 class TestFunnelTrendsUDF(BaseTestFunnelTrends):
     __test__ = True
-
-    def test_redundant_event_filtering(self):
-        filters = {
-            "insight": INSIGHT_FUNNELS,
-            "date_from": "-14d",
-            "funnel_viz_type": "trends",
-            "interval": "day",
-            "events": [
-                {"id": "$pageview", "order": 1},
-                {"id": "insight viewed", "order": 2},
-            ],
-        }
-
-        _create_person(
-            distinct_ids=["many_other_events"],
-            team_id=self.team.pk,
-            properties={"test": "okay"},
-        )
-        now = datetime.datetime.now()
-        for i in range(10):
-            _create_event(
-                team=self.team,
-                event="$pageview",
-                distinct_id="many_other_events",
-                timestamp=now - datetime.timedelta(days=11 + i),
-            )
-
-        query = cast(FunnelsQuery, filter_to_query(filters))
-        runner = FunnelsQueryRunner(query=query, team=self.team)
-        inner_aggregation_query = runner.funnel_class._inner_aggregation_query()
-        inner_aggregation_query.select.append(
-            parse_expr(f"{runner.funnel_class.udf_event_array_filter()} AS filtered_array")
-        )
-        inner_aggregation_query.having = None
-        response = execute_hogql_query(
-            query_type="FunnelsQuery",
-            query=inner_aggregation_query,
-            team=self.team,
-            settings=HogQLGlobalSettings(
-                # Make sure funnel queries never OOM
-                max_bytes_before_external_group_by=MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY,
-                allow_experimental_analyzer=True,
-            ),
-        )
-        # Make sure the events have been condensed down to two
-        self.assertEqual(2, len(response.results[0][-1]))
 
     def test_assert_udf_flag_is_working(self):
         filters = {

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_unordered.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_unordered.py
@@ -1870,6 +1870,77 @@ class BaseTestFunnelUnorderedSteps(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(trend_results[7]["reached_to_step_count"], 1)
         self.assertEqual(trend_results[7]["conversion_rate"], 20)
 
+    def test_unordered_trend_second_step(self):
+        # Test unordered trend with 5 users doing event 3 with different frequencies
+        # User 1: does event 3 all 8 days
+        # User 2: does event 3 4 of the 8 days
+        # User 3: does event 3 2 of the 8 days
+        # User 4: does event 3 1 of the 8 days
+        # User 5: never does event 3
+        # All users do events 1 and 2 once at the end of the funnel window
+
+        start_date = datetime(2024, 3, 1, 10, 0)
+
+        _create_person(distinct_ids=["user_1"], team_id=self.team.pk)
+        _create_person(distinct_ids=["user_2"], team_id=self.team.pk)
+        _create_person(distinct_ids=["user_3"], team_id=self.team.pk)
+        _create_person(distinct_ids=["user_4"], team_id=self.team.pk)
+        _create_person(distinct_ids=["user_5"], team_id=self.team.pk)
+
+        # Both users do event 3 all 8 days
+        # Both users do events 1 once at the end of the funnel window (day 7)
+        for distinct_id in ("user_1", "user_2"):
+            for i in range(8):
+                _create_event(
+                    team=self.team,
+                    event="event 3",
+                    distinct_id=distinct_id,
+                    timestamp=start_date + timedelta(days=i),
+                )
+            _create_event(
+                team=self.team,
+                event="event 1",
+                distinct_id=distinct_id,
+                timestamp=start_date + timedelta(days=7, hours=1),
+            )
+        # User 2 does event 2 once on the last day
+        _create_event(
+            team=self.team,
+            event="event 2",
+            distinct_id="user_2",
+            timestamp=start_date + timedelta(days=7, hours=2),
+        )
+
+        # Define a 3-step funnel with unordered events
+        filters = {
+            "events": [
+                {"id": "event 1", "type": "events", "order": 0},
+                {"id": "event 2", "type": "events", "order": 1},
+                {"id": "event 3", "type": "events", "order": 2},
+            ],
+            "insight": INSIGHT_FUNNELS,
+            "funnel_viz_type": "trends",
+            "funnel_order_type": "unordered",
+            "funnel_window_days": 8,
+            "date_from": "2024-03-01",
+            "date_to": "2024-03-08",
+            "display": "ActionsLineGraph",
+        }
+
+        # Run the funnel trend query
+        query = cast(FunnelsQuery, filter_to_query(filters))
+        query.funnelsFilter.funnelFromStep = 1
+        query.funnelsFilter.funnelToStep = 2
+        trend_results = FunnelsQueryRunner(query=query, team=self.team, just_summarize=True).calculate().results
+
+        # We should get 8 days of results
+        self.assertEqual(len(trend_results), 8)
+
+        for trend_result in trend_results:
+            self.assertEqual(trend_result["reached_from_step_count"], 2)
+            self.assertEqual(trend_result["reached_to_step_count"], 1)
+            self.assertEqual(trend_result["conversion_rate"], 50)
+
 
 class TestFunnelUnorderedStepsBreakdown(BaseTestFunnelUnorderedStepsBreakdown):
     __test__ = True

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_unordered.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_unordered.py
@@ -1742,12 +1742,11 @@ class BaseTestFunnelUnorderedSteps(ClickhouseTestMixin, APIBaseTest):
 
         start_date = datetime(2024, 3, 1, 10, 0)
 
-        # Create all 5 users
-        person1 = _create_person(distinct_ids=["user_1"], team_id=self.team.pk)
-        person2 = _create_person(distinct_ids=["user_2"], team_id=self.team.pk)
-        person3 = _create_person(distinct_ids=["user_3"], team_id=self.team.pk)
-        person4 = _create_person(distinct_ids=["user_4"], team_id=self.team.pk)
-        person5 = _create_person(distinct_ids=["user_5"], team_id=self.team.pk)
+        _create_person(distinct_ids=["user_1"], team_id=self.team.pk)
+        _create_person(distinct_ids=["user_2"], team_id=self.team.pk)
+        _create_person(distinct_ids=["user_3"], team_id=self.team.pk)
+        _create_person(distinct_ids=["user_4"], team_id=self.team.pk)
+        _create_person(distinct_ids=["user_5"], team_id=self.team.pk)
 
         # User 1: does event 3 all 8 days
         for i in range(8):
@@ -1830,49 +1829,42 @@ class BaseTestFunnelUnorderedSteps(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(trend_results[0]["conversion_rate"], 100)
 
         # Day 1 (2024-03-02): User 1 does event 3, all 5 users will do events 1 and 2
-        # So conversion is 1/5 = 20%
         self.assertEqual(trend_results[1]["timestamp"].strftime("%Y-%m-%d"), "2024-03-02")
         self.assertEqual(trend_results[1]["reached_from_step_count"], 1)
         self.assertEqual(trend_results[1]["reached_to_step_count"], 1)
         self.assertEqual(trend_results[1]["conversion_rate"], 100)
 
         # Day 2 (2024-03-03): User 1 and User 2 do event 3, all 5 users will do events 1 and 2
-        # So conversion is 2/5 = 40%
         self.assertEqual(trend_results[2]["timestamp"].strftime("%Y-%m-%d"), "2024-03-03")
         self.assertEqual(trend_results[2]["reached_from_step_count"], 2)
         self.assertEqual(trend_results[2]["reached_to_step_count"], 2)
         self.assertEqual(trend_results[2]["conversion_rate"], 100)
 
         # Day 3 (2024-03-04): User 1 does event 3, all 5 users will do events 1 and 2
-        # So conversion is 1/5 = 20%
         self.assertEqual(trend_results[3]["timestamp"].strftime("%Y-%m-%d"), "2024-03-04")
         self.assertEqual(trend_results[3]["reached_from_step_count"], 1)
         self.assertEqual(trend_results[3]["reached_to_step_count"], 1)
         self.assertEqual(trend_results[3]["conversion_rate"], 100)
 
         # Day 4 (2024-03-05): Users 1, 2, and 3 do event 3, all 5 users will do events 1 and 2
-        # So conversion is 3/5 = 60%
         self.assertEqual(trend_results[4]["timestamp"].strftime("%Y-%m-%d"), "2024-03-05")
         self.assertEqual(trend_results[4]["reached_from_step_count"], 3)
         self.assertEqual(trend_results[4]["reached_to_step_count"], 3)
         self.assertEqual(trend_results[4]["conversion_rate"], 100)
 
         # Day 5 (2024-03-06): User 1 does event 3, all 5 users will do events 1 and 2
-        # So conversion is 1/5 = 20%
         self.assertEqual(trend_results[5]["timestamp"].strftime("%Y-%m-%d"), "2024-03-06")
         self.assertEqual(trend_results[5]["reached_from_step_count"], 1)
         self.assertEqual(trend_results[5]["reached_to_step_count"], 1)
         self.assertEqual(trend_results[5]["conversion_rate"], 100)
 
         # Day 6 (2024-03-07): Users 1 and 2 do event 3, all 5 users will do events 1 and 2
-        # So conversion is 2/5 = 40%
         self.assertEqual(trend_results[6]["timestamp"].strftime("%Y-%m-%d"), "2024-03-07")
         self.assertEqual(trend_results[6]["reached_from_step_count"], 2)
         self.assertEqual(trend_results[6]["reached_to_step_count"], 2)
         self.assertEqual(trend_results[6]["conversion_rate"], 100)
 
         # Day 7 (2024-03-08): User 1 does event 3, all 5 users do events 1 and 2
-        # So conversion is 1/5 = 20%
         self.assertEqual(trend_results[7]["timestamp"].strftime("%Y-%m-%d"), "2024-03-08")
         self.assertEqual(trend_results[7]["reached_from_step_count"], 5)
         self.assertEqual(trend_results[7]["reached_to_step_count"], 1)

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_unordered.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_unordered.py
@@ -1871,21 +1871,12 @@ class BaseTestFunnelUnorderedSteps(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(trend_results[7]["conversion_rate"], 20)
 
     def test_unordered_trend_second_step(self):
-        # Test unordered trend with 5 users doing event 3 with different frequencies
-        # User 1: does event 3 all 8 days
-        # User 2: does event 3 4 of the 8 days
-        # User 3: does event 3 2 of the 8 days
-        # User 4: does event 3 1 of the 8 days
-        # User 5: never does event 3
-        # All users do events 1 and 2 once at the end of the funnel window
+        # Test unordered trend not starting at the first step
 
         start_date = datetime(2024, 3, 1, 10, 0)
 
         _create_person(distinct_ids=["user_1"], team_id=self.team.pk)
         _create_person(distinct_ids=["user_2"], team_id=self.team.pk)
-        _create_person(distinct_ids=["user_3"], team_id=self.team.pk)
-        _create_person(distinct_ids=["user_4"], team_id=self.team.pk)
-        _create_person(distinct_ids=["user_5"], team_id=self.team.pk)
 
         # Both users do event 3 all 8 days
         # Both users do events 1 once at the end of the funnel window (day 7)

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_unordered.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_unordered.py
@@ -1913,6 +1913,8 @@ class BaseTestFunnelUnorderedSteps(ClickhouseTestMixin, APIBaseTest):
             "funnel_viz_type": "trends",
             "funnel_order_type": "unordered",
             "funnel_window_days": 8,
+            "funnel_from_step": 1,
+            "funnel_to_step": 2,
             "date_from": "2024-03-01",
             "date_to": "2024-03-08",
             "display": "ActionsLineGraph",
@@ -1920,8 +1922,6 @@ class BaseTestFunnelUnorderedSteps(ClickhouseTestMixin, APIBaseTest):
 
         # Run the funnel trend query
         query = cast(FunnelsQuery, filter_to_query(filters))
-        query.funnelsFilter.funnelFromStep = 1
-        query.funnelsFilter.funnelToStep = 2
         trend_results = FunnelsQueryRunner(query=query, team=self.team, just_summarize=True).calculate().results
 
         # We should get 8 days of results

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_unordered.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_unordered.py
@@ -1825,51 +1825,51 @@ class BaseTestFunnelUnorderedSteps(ClickhouseTestMixin, APIBaseTest):
         # Day 0 (2024-03-01): 4 users do event 3, all 5 users will do events 1 and 2
         # So conversion is 4/5 = 80%
         self.assertEqual(trend_results[0]["timestamp"].strftime("%Y-%m-%d"), "2024-03-01")
-        self.assertEqual(trend_results[0]["reached_from_step_count"], 5)
+        self.assertEqual(trend_results[0]["reached_from_step_count"], 4)
         self.assertEqual(trend_results[0]["reached_to_step_count"], 4)
-        self.assertEqual(trend_results[0]["conversion_rate"], 80)
+        self.assertEqual(trend_results[0]["conversion_rate"], 100)
 
         # Day 1 (2024-03-02): User 1 does event 3, all 5 users will do events 1 and 2
         # So conversion is 1/5 = 20%
         self.assertEqual(trend_results[1]["timestamp"].strftime("%Y-%m-%d"), "2024-03-02")
-        self.assertEqual(trend_results[1]["reached_from_step_count"], 5)
+        self.assertEqual(trend_results[1]["reached_from_step_count"], 1)
         self.assertEqual(trend_results[1]["reached_to_step_count"], 1)
-        self.assertEqual(trend_results[1]["conversion_rate"], 20)
+        self.assertEqual(trend_results[1]["conversion_rate"], 100)
 
         # Day 2 (2024-03-03): User 1 and User 2 do event 3, all 5 users will do events 1 and 2
         # So conversion is 2/5 = 40%
         self.assertEqual(trend_results[2]["timestamp"].strftime("%Y-%m-%d"), "2024-03-03")
-        self.assertEqual(trend_results[2]["reached_from_step_count"], 5)
+        self.assertEqual(trend_results[2]["reached_from_step_count"], 2)
         self.assertEqual(trend_results[2]["reached_to_step_count"], 2)
-        self.assertEqual(trend_results[2]["conversion_rate"], 40)
+        self.assertEqual(trend_results[2]["conversion_rate"], 100)
 
         # Day 3 (2024-03-04): User 1 does event 3, all 5 users will do events 1 and 2
         # So conversion is 1/5 = 20%
         self.assertEqual(trend_results[3]["timestamp"].strftime("%Y-%m-%d"), "2024-03-04")
-        self.assertEqual(trend_results[3]["reached_from_step_count"], 5)
+        self.assertEqual(trend_results[3]["reached_from_step_count"], 1)
         self.assertEqual(trend_results[3]["reached_to_step_count"], 1)
-        self.assertEqual(trend_results[3]["conversion_rate"], 20)
+        self.assertEqual(trend_results[3]["conversion_rate"], 100)
 
         # Day 4 (2024-03-05): Users 1, 2, and 3 do event 3, all 5 users will do events 1 and 2
         # So conversion is 3/5 = 60%
         self.assertEqual(trend_results[4]["timestamp"].strftime("%Y-%m-%d"), "2024-03-05")
-        self.assertEqual(trend_results[4]["reached_from_step_count"], 5)
+        self.assertEqual(trend_results[4]["reached_from_step_count"], 3)
         self.assertEqual(trend_results[4]["reached_to_step_count"], 3)
-        self.assertEqual(trend_results[4]["conversion_rate"], 60)
+        self.assertEqual(trend_results[4]["conversion_rate"], 100)
 
         # Day 5 (2024-03-06): User 1 does event 3, all 5 users will do events 1 and 2
         # So conversion is 1/5 = 20%
         self.assertEqual(trend_results[5]["timestamp"].strftime("%Y-%m-%d"), "2024-03-06")
-        self.assertEqual(trend_results[5]["reached_from_step_count"], 5)
+        self.assertEqual(trend_results[5]["reached_from_step_count"], 1)
         self.assertEqual(trend_results[5]["reached_to_step_count"], 1)
-        self.assertEqual(trend_results[5]["conversion_rate"], 20)
+        self.assertEqual(trend_results[5]["conversion_rate"], 100)
 
         # Day 6 (2024-03-07): Users 1 and 2 do event 3, all 5 users will do events 1 and 2
         # So conversion is 2/5 = 40%
         self.assertEqual(trend_results[6]["timestamp"].strftime("%Y-%m-%d"), "2024-03-07")
-        self.assertEqual(trend_results[6]["reached_from_step_count"], 5)
+        self.assertEqual(trend_results[6]["reached_from_step_count"], 2)
         self.assertEqual(trend_results[6]["reached_to_step_count"], 2)
-        self.assertEqual(trend_results[6]["conversion_rate"], 40)
+        self.assertEqual(trend_results[6]["conversion_rate"], 100)
 
         # Day 7 (2024-03-08): User 1 does event 3, all 5 users do events 1 and 2
         # So conversion is 1/5 = 20%
@@ -1877,18 +1877,6 @@ class BaseTestFunnelUnorderedSteps(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(trend_results[7]["reached_from_step_count"], 5)
         self.assertEqual(trend_results[7]["reached_to_step_count"], 1)
         self.assertEqual(trend_results[7]["conversion_rate"], 20)
-
-        # Verify overall funnel results to confirm all steps
-        filters.pop("funnel_viz_type")
-        query = cast(FunnelsQuery, filter_to_query(filters))
-        funnel_results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
-
-        # All 5 users completed step 1 and step 2
-        self.assertEqual(funnel_results[0]["count"], 5)  # Completed step 1
-        self.assertEqual(funnel_results[1]["count"], 5)  # Completed step 2
-
-        # Only 4 users ever did event 3
-        self.assertEqual(funnel_results[2]["count"], 4)  # Completed step 3
 
 
 class TestFunnelUnorderedStepsBreakdown(BaseTestFunnelUnorderedStepsBreakdown):


### PR DESCRIPTION
## Problem
Event filtering heuristic breaks for trends that have multiple first steps in a row that fall in different intervals. This is especially bad in unordered trends, because any event can be the first event.
Reported here: https://posthog.slack.com/archives/C045L1VEG87/p1744047732992239

## Changes
Remove the event filtering for trends

## How did you test this code?
Wrote a test for it.
