### PR TITLE
fix: stickiness cumulative doesn't sum to 100%

### DIFF
--- a/posthog/hogql_queries/insights/stickiness_query_runner.py
+++ b/posthog/hogql_queries/insights/stickiness_query_runner.py
@@ -283,6 +283,8 @@ class StickinessQueryRunner(QueryRunner):
 
                 data = val[0]
 
+                # Count doesn't change if we alter the data to cumulative
+                count = sum(data)
                 # Calculate cumulative values if requested
                 if (
                     self.query.stickinessFilter
@@ -295,7 +297,7 @@ class StickinessQueryRunner(QueryRunner):
                     data = cumulative_data
 
                 series_object = {
-                    "count": sum(data),
+                    "count": count,
                     "data": data,
                     "days": val[1],
                     "label": "All events" if series_label is None else series_label,

--- a/posthog/hogql_queries/insights/test/test_stickiness_query_runner.py
+++ b/posthog/hogql_queries/insights/test/test_stickiness_query_runner.py
@@ -845,6 +845,7 @@ class TestStickinessQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         # Test cumulative data
         assert result["data"] == [3, 2, 1]  # Day 1: 3 users, Day 2: 2 users for 2+ days, Day 3: 1 user for 3 days
+        assert result["count"] == 3
         assert result["labels"] == ["1 day or more", "2 days or more", "3 days or more"]
 
     def test_cumulative_stickiness_with_intervals(self):


### PR DESCRIPTION
## Problem
Cumulative stickiness should always sum to 100%

## Changes

![image](https://github.com/user-attachments/assets/586cf2c7-845b-42ac-acf7-84ba65e34395)


## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Unit and test in dev
