### PR TITLE
feat(cdp): customer io merging for distinct ids on identify

### DIFF
--- a/posthog/cdp/templates/customerio/template_customerio.py
+++ b/posthog/cdp/templates/customerio/template_customerio.py
@@ -75,8 +75,8 @@ if (res.status >= 400) {
 
 // Handle profile merging for identify events
 if (inputs.enable_profile_merging and action == 'identify' and not empty(event.properties.$anon_distinct_id)) {
-    let primaryId := inputs.primaryId
-    let secondaryId := inputs.secondaryId
+    let primaryId := event.distinct_id
+    let secondaryId := event.properties.$anon_distinct_id
 
     if (not empty(primaryId) and not empty(secondaryId)) {
         let mergeRes := fetch(f'https://{inputs.host}/api/v2/entity', {
@@ -216,26 +216,8 @@ if (inputs.enable_profile_merging and action == 'identify' and not empty(event.p
             "key": "enable_profile_merging",
             "type": "boolean",
             "label": "Enable profile merging",
-            "description": "When enabled, will merge profiles in Customer.io on identify events. This is particularly useful when using distinct_id as the identifier, as it can create many duplicate profiles in Customer.io that need to be merged.",
+            "description": "Only useful when using 'ID' as your identifier type with distinct_id as the value. When enabled, merges anonymous profiles into identified profiles in Customer.io during identify events.",
             "default": False,
-            "secret": False,
-            "required": False,
-        },
-        {
-            "key": "primaryId",
-            "type": "string",
-            "label": "Primary ID",
-            "description": "The primary ID to use when merging profiles. This is typically the new/permanent ID after identification.",
-            "default": "{event.distinct_id}",
-            "secret": False,
-            "required": False,
-        },
-        {
-            "key": "secondaryId",
-            "type": "string",
-            "label": "Secondary ID",
-            "description": "The secondary ID to merge into the primary ID. This is typically the old anonymous ID before identification.",
-            "default": "{event.properties.$anon_distinct_id}",
             "secret": False,
             "required": False,
         },
@@ -318,8 +300,6 @@ class TemplateCustomerioMigrator(HogFunctionTemplateMigrator):
             "include_all_properties": {"value": True},
             "attributes": {"value": {}},
             "enable_profile_merging": {"value": False},
-            "primaryId": {"value": "{event.distinct_id}"},
-            "secondaryId": {"value": "{event.properties.$anon_distinct_id}"},
         }
 
         return hf

--- a/posthog/cdp/templates/customerio/template_customerio.py
+++ b/posthog/cdp/templates/customerio/template_customerio.py
@@ -75,6 +75,10 @@ if (res.status >= 400) {
 
 // Handle profile merging for identify events
 if (inputs.enable_profile_merging and action == 'identify' and not empty(event.properties.$anon_distinct_id)) {
+    // Check if using the correct identifier type and value
+    if (inputs.identifier_key != 'id') {
+        throw Error(f'Profile merging is only supported when using "ID" as the identifier type. Current identifier type is "{inputs.identifier_key}". Either change your identifier type to "ID" or disable profile merging.')
+    }
     let primaryId := event.distinct_id
     let secondaryId := event.properties.$anon_distinct_id
 
@@ -216,7 +220,7 @@ if (inputs.enable_profile_merging and action == 'identify' and not empty(event.p
             "key": "enable_profile_merging",
             "type": "boolean",
             "label": "Enable profile merging",
-            "description": "Only useful when using 'ID' as your identifier type with distinct_id as the value. When enabled, merges anonymous profiles into identified profiles in Customer.io during identify events.",
+            "description": "Only useful when using 'ID' as your identifier type with event.distinct_id as the identifier value. When enabled, merges anonymous profiles into identified profiles in Customer.io during identify events.",
             "default": False,
             "secret": False,
             "required": False,


### PR DESCRIPTION
## Problem

In PostHog, when a user first visits your site, they get an anonymous distinct ID. When they later sign up or log in and you call `.identify()` with their real user ID, PostHog merges both identities under one profile.

However, when these events sync to Customer.io using the default configuration:
1. First, a profile is created in Customer.io with the anonymous ID
2. Later, a second separate profile is created with the real user ID
3. The profiles remain disconnected in Customer.io, even though they're merged in PostHog

this goes for configurations that use `ID` as identifier and chose `{event.distinct_id}` as identifier value.

## Changes

You can enable automatic profile merging with the built-in toggle:

1. Go to your Customer.io destination in PostHog
2. Enable the "Enable profile merging" toggle in the configuration
3. Make sure you're using "Id" as the identifier key and `{event.distinct_id}` as the identifier value

This option will automatically merge profiles in Customer.io when an `$identify` event occurs in PostHog, connecting anonymous users with their identified profiles. We use the `$anon_distinct_id` property available in `$identify` events to merge the old anonymous profile with the new identified profile in Customer.io.

## How did you test this code?

- added tests