### PR TITLE
feat(cdp): convert tiktok to server-side mappings

### DIFF
--- a/plugin-server/src/cdp/templates/_destinations/tiktok_ads/tiktok.template.test.ts
+++ b/plugin-server/src/cdp/templates/_destinations/tiktok_ads/tiktok.template.test.ts
@@ -168,7 +168,7 @@ describe('tiktok template', () => {
         expect(response.invocation.queue).toEqual('fetch')
         expect(response.invocation.queueParameters).toMatchInlineSnapshot(`
             {
-              "body": "{"event_source":"web","event_source_id":"pixel-id","data":[{"event":"CompletePayment","event_time":1735689600,"event_id":"event-id","user":{"email":"3d4eee8538a4bbbe2ef7912f90ee494c1280f74dd7fd81232e58deb9cb9997e3","first_name":"","last_name":"","phone":"","external_id":"b5400f5d931b20e0e905cc4a009a428ce3427b3110e3a2a1cfc7e6349beabc10","ttclid":"tiktok-id"},"properties":{"content_ids":["18499-12","94839-23"],"contents":[{"price":30,"content_id":"18499-12","content_category":"merch","content_name":"Data warehouse t-shirt","brand":"PostHog"},{"price":30,"content_id":"94839-23","content_category":"merch","content_name":"Danger t-shirt","brand":"PostHog"}],"content_type":"product","currency":"USD","value":90,"num_items":2,"order_id":"3e94e72c0a7443e9b51155a3"},"page":{}}]}",
+              "body": "{"event_source":"web","event_source_id":"pixel-id","data":[{"event":"CompletePayment","event_time":1735689600,"event_id":"event-id","user":{"email":"3d4eee8538a4bbbe2ef7912f90ee494c1280f74dd7fd81232e58deb9cb9997e3","first_name":"","last_name":"","phone":"","external_id":"b5400f5d931b20e0e905cc4a009a428ce3427b3110e3a2a1cfc7e6349beabc10","ttclid":"tiktok-id"},"properties":{"content_ids":["18499-12","94839-23"],"contents":[{"price":30,"content_id":"18499-12","content_category":"merch","content_name":"Data warehouse t-shirt","brand":"PostHog"},{"price":30,"content_id":"94839-23","content_category":"merch","content_name":"Danger t-shirt","brand":"PostHog"}],"content_type":"product","currency":"USD","value":90,"num_items":3,"order_id":"3e94e72c0a7443e9b51155a3"},"page":{}}]}",
               "headers": {
                 "Access-Token": "access-token",
                 "Content-Type": "application/json",
@@ -198,6 +198,7 @@ describe('tiktok template', () => {
         ['Products Searched', 'Search'],
         ['Product Viewed', 'ViewContent'],
         ['Signed Up', 'CompleteRegistration'],
+        ['Order Placed', 'PlaceAnOrder'],
     ])('correctly maps event names: %s', async (event, expectedEvent) => {
         const responses = await tester.invoke(
             {

--- a/plugin-server/src/cdp/templates/_destinations/tiktok_ads/tiktok.template.ts
+++ b/plugin-server/src/cdp/templates/_destinations/tiktok_ads/tiktok.template.ts
@@ -1,4 +1,69 @@
+import { HogFunctionInputSchemaType } from '~/src/cdp/types'
+
 import { HogFunctionTemplate } from '../../types'
+
+const build_inputs = (multiProductEvent = false): HogFunctionInputSchemaType[] => {
+    return [
+        {
+            key: 'eventId',
+            type: 'string',
+            label: 'Event ID',
+            description: 'The ID of the event.',
+            default: '{event.uuid}',
+            secret: false,
+            required: true,
+        },
+        {
+            key: 'eventTimestamp',
+            type: 'string',
+            label: 'Event timestamp',
+            description: 'A Unix timestamp in seconds indicating when the actual event occurred.',
+            default: '{toUnixTimestamp(event.timestamp)}',
+            secret: false,
+            required: true,
+        },
+        {
+            key: 'propertyProperties',
+            type: 'dictionary',
+            label: 'Property properties',
+            description:
+                'A map that contains customer information data. See this page for options: https://business-api.tiktok.com/portal/docs?id=1771101151059969#item-link-properties%20parameters',
+            default: {
+                content_ids: multiProductEvent
+                    ? '{arrayMap(x -> x.sku, event.properties.products ?? [])}'
+                    : '{not empty(event.properties.sku) ? [event.properties.sku] : []}',
+                contents: multiProductEvent
+                    ? "{arrayMap(x -> ({'price': x.price, 'content_id': x.sku, 'content_category': x.category, 'content_name': x.name, 'brand': x.brand}), event.properties.products ?? [])}"
+                    : "{(not empty(event.properties.sku) and not empty(event.properties.price) and not empty(event.properties.category) and not empty(event.properties.name) and not empty(event.properties.brand) ? [{'price': event.properties.price, 'content_id': event.properties.sku, 'content_category': event.properties.category, 'content_name': event.properties.name, 'brand': event.properties.brand}] : [])}",
+                content_type: 'product',
+                currency: "{event.properties.currency ?? 'USD'}",
+                value: '{toFloat(event.properties.value ?? event.properties.revenue ?? event.properties.price)}',
+                num_items: multiProductEvent
+                    ? '{arrayReduce((acc, curr) -> acc + curr.quantity, event.properties.products ?? [], 0)}'
+                    : '{event.properties.quantity}',
+                search_string: '{event.properties.query}',
+                description: '',
+                order_id: '{event.properties.order_id}',
+                shop_id: '{event.properties.shop_id}',
+            },
+            secret: false,
+            required: true,
+        },
+        {
+            key: 'pageProperties',
+            type: 'dictionary',
+            label: 'Page properties',
+            description:
+                'A map that contains page information data. See this page for options: https://business-api.tiktok.com/portal/docs?id=1771101151059969#item-link-page%20parameters',
+            default: {
+                referrer: '{event.properties.$referrer}',
+                url: '{event.properties.$current_url}',
+            },
+            secret: false,
+            required: true,
+        },
+    ]
+}
 
 export const template: HogFunctionTemplate = {
     free: false,
@@ -83,47 +148,6 @@ if (res.status >= 400) {
             required: true,
         },
         {
-            key: 'eventName',
-            type: 'string',
-            label: 'Event name',
-            description: 'A standard event or custom event name.',
-            default:
-                '{' +
-                "event.event == 'Payment Info Entered' ? 'AddPaymentInfo'" +
-                ": event.event == 'Product Added' ? 'AddToCart'" +
-                ": event.event == 'Product Added to Wishlist' ? 'AddToWishlist'" +
-                ": event.event == 'Product Clicked' ? 'ClickButton'" +
-                ": event.event == 'Order Completed' ? 'CompletePayment'" +
-                ": event.event == 'Signed Up' ? 'CompleteRegistration'" +
-                ": event.event == 'Checkout Started' ? 'InitiateCheckout'" +
-                ": event.event == 'Order Completed' ? 'PlaceAnOrder'" +
-                ": event.event == 'Products Searched' ? 'Search'" +
-                ": event.event == 'Product Viewed' ? 'ViewContent'" +
-                ": event.event == '$pageview' ? 'Pageview'" +
-                ': event.event' +
-                '}',
-            secret: false,
-            required: true,
-        },
-        {
-            key: 'eventId',
-            type: 'string',
-            label: 'Event ID',
-            description: 'The ID of the event.',
-            default: '{event.uuid}',
-            secret: false,
-            required: true,
-        },
-        {
-            key: 'eventTimestamp',
-            type: 'string',
-            label: 'Event timestamp',
-            description: 'A Unix timestamp in seconds indicating when the actual event occurred.',
-            default: '{toUnixTimestamp(event.timestamp)}',
-            secret: false,
-            required: true,
-        },
-        {
             key: 'userProperties',
             type: 'dictionary',
             label: 'User properties',
@@ -150,43 +174,6 @@ if (res.status >= 400) {
             required: true,
         },
         {
-            key: 'propertyProperties',
-            type: 'dictionary',
-            label: 'Property properties',
-            description:
-                'A map that contains customer information data. See this page for options: https://business-api.tiktok.com/portal/docs?id=1771101151059969#item-link-properties%20parameters',
-            default: {
-                content_ids:
-                    "{event.event in ('Order Completed', 'Checkout Started') ? arrayMap(x -> x.sku, event.properties.products ?? []) : not empty(event.properties.sku) ? [event.properties.sku] : []}",
-                contents:
-                    "{event.event in ('Order Completed', 'Checkout Started') ? arrayMap(x -> ({'price': x.price, 'content_id': x.sku, 'content_category': x.category, 'content_name': x.name, 'brand': x.brand}), event.properties.products ?? []) : (not empty(event.properties.sku) and not empty(event.properties.price) and not empty(event.properties.category) and not empty(event.properties.name) and not empty(event.properties.brand) ? [{'price': event.properties.price, 'content_id': event.properties.sku, 'content_category': event.properties.category, 'content_name': event.properties.name, 'brand': event.properties.brand}] : [])}",
-                content_type: 'product',
-                currency: "{event.properties.currency ?? 'USD'}",
-                value: '{toFloat(event.properties.value ?? event.properties.revenue ?? event.properties.price)}',
-                num_items:
-                    "{event.event in ('Order Completed', 'Checkout Started') ? length(arrayMap(x -> x.sku, event.properties.products ?? [])) : event.properties.quantity}",
-                search_string: '{event.properties.query}',
-                description: '',
-                order_id: '{event.properties.order_id}',
-                shop_id: '{event.properties.shop_id}',
-            },
-            secret: false,
-            required: true,
-        },
-        {
-            key: 'pageProperties',
-            type: 'dictionary',
-            label: 'Page properties',
-            description:
-                'A map that contains page information data. See this page for options: https://business-api.tiktok.com/portal/docs?id=1771101151059969#item-link-page%20parameters',
-            default: {
-                referrer: '{event.properties.$referrer}',
-                url: '{event.properties.$current_url}',
-            },
-            secret: false,
-            required: true,
-        },
-        {
             key: 'testEventCode',
             type: 'string',
             label: 'Test Event Code',
@@ -197,21 +184,227 @@ if (res.status >= 400) {
             required: false,
         },
     ],
-    filters: {
-        events: [
-            { id: '$pageview', name: 'Pageview', type: 'events' },
-            { id: 'Payment Info Entered', type: 'events' },
-            { id: 'Product Added', type: 'events' },
-            { id: 'Product Added to Wishlist', type: 'events' },
-            { id: 'Product Clicked', type: 'events' },
-            { id: 'Order Completed', type: 'events' },
-            { id: 'Signed Up', type: 'events' },
-            { id: 'Checkout Started', type: 'events' },
-            { id: 'Order Completed', type: 'events' },
-            { id: 'Products Searched', type: 'events' },
-            { id: 'Product Viewed', type: 'events' },
-        ],
-        actions: [],
-        filter_test_accounts: true,
-    },
+    filters: { bytecode: ['_H', 1, 29] },
+    mapping_templates: [
+        {
+            name: 'Page Viewed',
+            include_by_default: true,
+            filters: {
+                events: [{ id: '$pageview', name: 'Pageview', type: 'events' }],
+                bytecode: ['_H', 1, 32, '$pageview', 32, 'event', 1, 1, 11, 3, 1, 4, 1],
+            },
+            inputs_schema: [
+                {
+                    key: 'eventName',
+                    type: 'string',
+                    label: 'Event name',
+                    description: 'A standard event or custom event name.',
+                    default: 'Pageview',
+                    secret: false,
+                    required: true,
+                },
+                ...build_inputs(),
+            ],
+        },
+        {
+            name: 'Payment Info Entered',
+            include_by_default: true,
+            filters: {
+                events: [{ id: 'Payment Info Entered', type: 'events' }],
+                bytecode: ['_H', 1, 32, 'Payment Info Entered', 32, 'event', 1, 1, 11, 3, 1, 4, 1],
+            },
+            inputs_schema: [
+                {
+                    key: 'eventName',
+                    type: 'string',
+                    label: 'Event name',
+                    description: 'A standard event or custom event name.',
+                    default: 'AddPaymentInfo',
+                    secret: false,
+                    required: true,
+                },
+                ...build_inputs(),
+            ],
+        },
+        {
+            name: 'Product Added',
+            include_by_default: true,
+            filters: {
+                events: [{ id: 'Product Added', type: 'events' }],
+                bytecode: ['_H', 1, 32, 'Product Added', 32, 'event', 1, 1, 11, 3, 1, 4, 1],
+            },
+            inputs_schema: [
+                {
+                    key: 'eventName',
+                    type: 'string',
+                    label: 'Event name',
+                    description: 'A standard event or custom event name.',
+                    default: 'AddToCart',
+                    secret: false,
+                    required: true,
+                },
+                ...build_inputs(),
+            ],
+        },
+        {
+            name: 'Product Added to Wishlist',
+            include_by_default: true,
+            filters: {
+                events: [{ id: 'Product Added to Wishlist', type: 'events' }],
+                bytecode: ['_H', 1, 32, 'Product Added to Wishlist', 32, 'event', 1, 1, 11, 3, 1, 4, 1],
+            },
+            inputs_schema: [
+                {
+                    key: 'eventName',
+                    type: 'string',
+                    label: 'Event name',
+                    description: 'A standard event or custom event name.',
+                    default: 'AddToWishlist',
+                    secret: false,
+                    required: true,
+                },
+                ...build_inputs(),
+            ],
+        },
+        {
+            name: 'Product Clicked',
+            include_by_default: true,
+            filters: {
+                events: [{ id: 'Product Clicked', type: 'events' }],
+                bytecode: ['_H', 1, 32, 'Product Clicked', 32, 'event', 1, 1, 11, 3, 1, 4, 1],
+            },
+            inputs_schema: [
+                {
+                    key: 'eventName',
+                    type: 'string',
+                    label: 'Event name',
+                    description: 'A standard event or custom event name.',
+                    default: 'ClickButton',
+                    secret: false,
+                    required: true,
+                },
+                ...build_inputs(),
+            ],
+        },
+        {
+            name: 'Order Placed',
+            include_by_default: true,
+            filters: {
+                events: [{ id: 'Order Placed', type: 'events' }],
+                bytecode: ['_H', 1, 32, 'Order Placed', 32, 'event', 1, 1, 11, 3, 1, 4, 1],
+            },
+            inputs_schema: [
+                {
+                    key: 'eventName',
+                    type: 'string',
+                    label: 'Event name',
+                    description: 'A standard event or custom event name.',
+                    default: 'PlaceAnOrder',
+                    secret: false,
+                    required: true,
+                },
+                ...build_inputs(true),
+            ],
+        },
+        {
+            name: 'Signed Up',
+            include_by_default: true,
+            filters: {
+                events: [{ id: 'Signed Up', type: 'events' }],
+                bytecode: ['_H', 1, 32, 'Signed Up', 32, 'event', 1, 1, 11, 3, 1, 4, 1],
+            },
+            inputs_schema: [
+                {
+                    key: 'eventName',
+                    type: 'string',
+                    label: 'Event name',
+                    description: 'A standard event or custom event name.',
+                    default: 'CompleteRegistration',
+                    secret: false,
+                    required: true,
+                },
+                ...build_inputs(),
+            ],
+        },
+        {
+            name: 'Checkout Started',
+            include_by_default: true,
+            filters: {
+                events: [{ id: 'Checkout Started', type: 'events' }],
+                bytecode: ['_H', 1, 32, 'Checkout Started', 32, 'event', 1, 1, 11, 3, 1, 4, 1],
+            },
+            inputs_schema: [
+                {
+                    key: 'eventName',
+                    type: 'string',
+                    label: 'Event name',
+                    description: 'A standard event or custom event name.',
+                    default: 'InitiateCheckout',
+                    secret: false,
+                    required: true,
+                },
+                ...build_inputs(true),
+            ],
+        },
+        {
+            name: 'Order Completed',
+            include_by_default: true,
+            filters: {
+                events: [{ id: 'Order Completed', type: 'events' }],
+                bytecode: ['_H', 1, 32, 'Order Completed', 32, 'event', 1, 1, 11, 3, 1, 4, 1],
+            },
+            inputs_schema: [
+                {
+                    key: 'eventName',
+                    type: 'string',
+                    label: 'Event name',
+                    description: 'A standard event or custom event name.',
+                    default: 'CompletePayment',
+                    secret: false,
+                    required: true,
+                },
+                ...build_inputs(true),
+            ],
+        },
+        {
+            name: 'Products Searched',
+            include_by_default: true,
+            filters: {
+                events: [{ id: 'Products Searched', type: 'events' }],
+                bytecode: ['_H', 1, 32, 'Products Searched', 32, 'event', 1, 1, 11, 3, 1, 4, 1],
+            },
+            inputs_schema: [
+                {
+                    key: 'eventName',
+                    type: 'string',
+                    label: 'Event name',
+                    description: 'A standard event or custom event name.',
+                    default: 'Search',
+                    secret: false,
+                    required: true,
+                },
+                ...build_inputs(),
+            ],
+        },
+        {
+            name: 'Product Viewed',
+            include_by_default: true,
+            filters: {
+                events: [{ id: 'Product Viewed', type: 'events' }],
+                bytecode: ['_H', 1, 32, 'Product Viewed', 32, 'event', 1, 1, 11, 3, 1, 4, 1],
+            },
+            inputs_schema: [
+                {
+                    key: 'eventName',
+                    type: 'string',
+                    label: 'Event name',
+                    description: 'A standard event or custom event name.',
+                    default: 'ViewContent',
+                    secret: false,
+                    required: true,
+                },
+                ...build_inputs(),
+            ],
+        },
+    ],
 }

--- a/posthog/cdp/templates/tiktok_ads/template_tiktok_pixel.py
+++ b/posthog/cdp/templates/tiktok_ads/template_tiktok_pixel.py
@@ -17,7 +17,7 @@ def build_inputs(multiProductEvent=False):
                 else "{[{ 'content_id': event.properties.product_id, 'price': event.properties.price, 'content_category': event.properties.category, 'content_name': event.properties.name, 'brand': event.properties.brand, 'quantity': event.properties.quantity }]}",
                 "currency": "{event.properties.currency ?? 'USD'}",
                 "value": "{toFloat(event.properties.value ?? event.properties.revenue ?? event.properties.price)}",
-                "num_items": "{length(event.properties.products ?? [])}"
+                "num_items": "{arrayReduce((acc, curr) -> acc + curr.quantity, event.properties.products ?? [], 0)}"
                 if multiProductEvent
                 else "{event.properties.quantity}",
                 "search_string": "{event.properties.query}",
@@ -283,9 +283,9 @@ export function onEvent({ inputs }) {
             ],
         ),
         HogFunctionMappingTemplate(
-            name="Place an Order",
+            name="Order Placed",
             include_by_default=True,
-            filters={"events": [{"id": "Place an Order", "type": "events"}]},
+            filters={"events": [{"id": "Order Placed", "type": "events"}]},
             inputs_schema=[
                 {
                     "key": "eventType",


### PR DESCRIPTION
## Changes

# Before
![2025-04-11 at 09 47 12](https://github.com/user-attachments/assets/460b190e-d1db-43e5-849c-f4bf0673f1d5)

# After
![2025-04-11 at 09 46 38](https://github.com/user-attachments/assets/83e21471-03de-4d0c-b0e6-44b61ad4c516)

- convert the server-side tiktok template to use mappings
- use `arrayReduce` function to calculate num_items

todos:
- [ ] merge https://github.com/PostHog/posthog/pull/31047

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
