### PR TITLE
fix(web-analytics): Switch to using timezone offset rather than parsin timezone

### DIFF
--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -579,11 +579,8 @@ GROUP BY session_id, breakdown_value
             case WebStatsBreakdown.LANGUAGE:
                 return ast.Field(chain=["properties", "$browser_language"])
             case WebStatsBreakdown.TIMEZONE:
-                # Get the difference between the UNIX timestamp at UTC and the UNIX timestamp at the event's timezone
-                # Value is in milliseconds, turn it to hours, works even for fractional timezone offsets (I'm looking at you, Australia)
-                return parse_expr(
-                    "if(or(isNull(properties.$timezone), empty(properties.$timezone), properties.$timezone == 'Etc/Unknown'), NULL, (toUnixTimestamp64Milli(parseDateTimeBestEffort(assumeNotNull(toString(timestamp, properties.$timezone)))) - toUnixTimestamp64Milli(parseDateTimeBestEffort(assumeNotNull(toString(timestamp, 'UTC'))))) / 3600000)"
-                )
+                # Value is in minutes, turn it to hours, works even for fractional timezone offsets (I'm looking at you, Australia)
+                return parse_expr("toFloat(properties.$timezone_offset) / 60")
             case _:
                 raise NotImplementedError("Breakdown not implemented")
 

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
@@ -3968,7 +3968,7 @@
   FROM
     (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
             count() AS filtered_pageview_count,
-            if(or(isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone'), ''), 'null'), '^"|"$', '')), empty(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone'), ''), 'null'), '^"|"$', '')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone'), ''), 'null'), '^"|"$', ''), 'Etc/Unknown'), 0)), NULL, divide(minus(toUnixTimestamp64Milli(parseDateTime64BestEffortOrNull(assumeNotNull(toString(toTimeZone(events.timestamp, 'UTC'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone'), ''), 'null'), '^"|"$', ''))), 6, 'UTC')), toUnixTimestamp64Milli(parseDateTime64BestEffortOrNull(assumeNotNull(toString(toTimeZone(events.timestamp, 'UTC'), 'UTC')), 6, 'UTC'))), 3600000)) AS breakdown_value,
+            divide(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone_offset'), ''), 'null'), '^"|"$', ''), 'Float64'), 60) AS breakdown_value,
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
@@ -4087,6 +4087,183 @@
     (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
             count() AS filtered_pageview_count,
             if(or(isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone'), ''), 'null'), '^"|"$', '')), empty(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone'), ''), 'null'), '^"|"$', '')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone'), ''), 'null'), '^"|"$', ''), 'Etc/Unknown'), 0)), NULL, divide(minus(toUnixTimestamp64Milli(parseDateTime64BestEffortOrNull(assumeNotNull(toString(toTimeZone(events.timestamp, 'UTC'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone'), ''), 'null'), '^"|"$', ''))), 6, 'UTC')), toUnixTimestamp64Milli(parseDateTime64BestEffortOrNull(assumeNotNull(toString(toTimeZone(events.timestamp, 'UTC'), 'UTC')), 6, 'UTC'))), 3600000)) AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-07-30 00:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2025-01-29 23:59:59', 'UTC')), toIntervalDay(3))))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-07-30 00:00:00', 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-01-29 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.1
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            divide(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone_offset'), ''), 'null'), '^"|"$', ''), 'Float64'), 60) AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-07-30 00:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2025-01-29 23:59:59', 'UTC')), toIntervalDay(3))))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-07-30 00:00:00', 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-01-29 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.2
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.3
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            divide(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone_offset'), ''), 'null'), '^"|"$', ''), 'Float64'), 60) AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-07-30 00:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2025-01-29 23:59:59', 'UTC')), toIntervalDay(3))))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-07-30 00:00:00', 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2025-01-29 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.4
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone_offset.5
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            divide(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone_offset'), ''), 'null'), '^"|"$', ''), 'Float64'), 60) AS breakdown_value,
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp

--- a/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
@@ -1199,27 +1199,31 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
         before_date = "2024-07-14"
         after_date = "2024-07-16"
 
-        for idx, (distinct_id, before_session_id, after_session_id) in enumerate(
+        for idx, (timezone_offset, before_session_id, after_session_id) in enumerate(
             [
-                ("UTC", str(uuid7(before_date)), str(uuid7(after_date))),
-                ("Asia/Calcutta", str(uuid7(before_date)), str(uuid7(after_date))),
-                ("America/New_York", str(uuid7(before_date)), str(uuid7(after_date))),
-                ("America/Sao_Paulo", str(uuid7(before_date)), str(uuid7(after_date))),
+                (0, str(uuid7(before_date)), str(uuid7(after_date))),  # UTC
+                (330, str(uuid7(before_date)), str(uuid7(after_date))),  # Calcutta UTC+5:30
+                (-240, str(uuid7(before_date)), str(uuid7(after_date))),  # New York UTC-4
+                (-180, str(uuid7(before_date)), str(uuid7(after_date))),  # Brasilia UTC-3
             ]
         ):
             _create_person(
                 team_id=self.team.pk,
-                distinct_ids=[distinct_id],
-                properties={"name": before_session_id, "email": f"{distinct_id}@example.com"},
+                distinct_ids=[timezone_offset],
+                properties={"name": before_session_id, "email": f"{timezone_offset}@example.com"},
             )
 
             # Always one event in the before_date
             _create_event(
                 team=self.team,
                 event="$pageview",
-                distinct_id=distinct_id,
+                distinct_id=timezone_offset,
                 timestamp=before_date,
-                properties={"$session_id": before_session_id, "$pathname": f"/path/landing", "$timezone": distinct_id},
+                properties={
+                    "$session_id": before_session_id,
+                    "$pathname": f"/path/landing",
+                    "$timezone_offset": timezone_offset,
+                },
             )
 
             # Several events in the actual range
@@ -1227,9 +1231,13 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
                 _create_event(
                     team=self.team,
                     event="$pageview",
-                    distinct_id=distinct_id,
+                    distinct_id=timezone_offset,
                     timestamp=after_date,
-                    properties={"$session_id": after_session_id, "$pathname": f"/path{i}", "$timezone": distinct_id},
+                    properties={
+                        "$session_id": after_session_id,
+                        "$pathname": f"/path{i}",
+                        "$timezone_offset": timezone_offset,
+                    },
                 )
 
         results = self._run_web_stats_table_query(
@@ -1246,50 +1254,19 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
             [0, (1, None), (1, None), ""],
         ]
 
-    def test_timezone_filter_dst_change(self):
-        did = "id"
-        sid = str(uuid7("2019-02-17"))
-
-        _create_person(
-            team_id=self.team.pk,
-            distinct_ids=[did],
-            properties={"name": sid, "email": f"test@example.com"},
-        )
-
-        # Cross daylight savings time change in Brazil
-        for i in range(6):
-            _create_event(
-                team=self.team,
-                event="$pageview",
-                distinct_id=did,
-                timestamp=f"2019-02-17 0{i}:00:00",
-                properties={"$session_id": sid, "$pathname": f"/path1", "$timezone": "America/Sao_Paulo"},
-            )
-
-        results = self._run_web_stats_table_query(
-            "all",
-            None,
-            breakdown_by=WebStatsBreakdown.TIMEZONE,
-        ).results
-
-        # Change from UTC-2 to UTC-3 in the middle of the night
-        assert results == [
-            [-3.0, (1.0, None), (4.0, None), ""],
-            [-2.0, (1.0, None), (2.0, None), ""],
-        ]
-
-    def test_timezone_filter_with_invalid_timezone(self):
+    def test_timezone_filter_with_invalid_timezone_offset(self):
         date = "2024-07-30"
 
         for idx, (distinct_id, session_id) in enumerate(
             [
-                ("UTC", str(uuid7(date))),
+                (None, str(uuid7(date))),
                 ("Timezone_not_exists", str(uuid7(date))),
+                ("", str(uuid7(date))),
             ]
         ):
             _create_person(
                 team_id=self.team.pk,
-                distinct_ids=[distinct_id],
+                distinct_ids=[str(distinct_id)],
                 properties={"name": session_id, "email": f"{distinct_id}@example.com"},
             )
 
@@ -1297,72 +1274,18 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
                 _create_event(
                     team=self.team,
                     event="$pageview",
-                    distinct_id=distinct_id,
+                    distinct_id=str(distinct_id),
                     timestamp=date,
-                    properties={"$session_id": session_id, "$pathname": f"/path{i}", "$timezone": distinct_id},
+                    properties={"$session_id": session_id, "$pathname": f"/path{i}", "$timezone_offset": distinct_id},
                 )
 
-        with self.assertRaisesRegex(Exception, "Cannot load time zone"):
-            self._run_web_stats_table_query(
+            results = self._run_web_stats_table_query(
                 "all",
                 None,
                 breakdown_by=WebStatsBreakdown.TIMEZONE,
-            )
+            ).results
 
-    def test_timezone_filter_with_empty_timezone(self):
-        did = "id"
-        sid = str(uuid7("2019-02-17"))
-
-        _create_person(
-            team_id=self.team.pk,
-            distinct_ids=[did],
-            properties={"name": sid, "email": f"test@example.com"},
-        )
-
-        # Key not exists
-        _create_event(
-            team=self.team,
-            event="$pageview",
-            distinct_id=did,
-            timestamp=f"2019-02-17 00:00:00",
-            properties={"$session_id": sid, "$pathname": f"/path1"},
-        )
-
-        # Key exists, it's null
-        _create_event(
-            team=self.team,
-            event="$pageview",
-            distinct_id=did,
-            timestamp=f"2019-02-17 00:00:00",
-            properties={"$session_id": sid, "$pathname": f"/path1", "$timezone": None},
-        )
-
-        # Key exists, it's empty string
-        _create_event(
-            team=self.team,
-            event="$pageview",
-            distinct_id=did,
-            timestamp=f"2019-02-17 00:00:00",
-            properties={"$session_id": sid, "$pathname": f"/path1", "$timezone": ""},
-        )
-
-        # Key exists, it's set to the invalid 'Etc/Unknown' timezone
-        _create_event(
-            team=self.team,
-            event="$pageview",
-            distinct_id=did,
-            timestamp=f"2019-02-17 00:00:00",
-            properties={"$session_id": sid, "$pathname": f"/path1", "$timezone": "Etc/Unknown"},
-        )
-
-        results = self._run_web_stats_table_query(
-            "all",
-            None,
-            breakdown_by=WebStatsBreakdown.TIMEZONE,
-        ).results
-
-        # Don't crash, treat all of them null
-        assert results == []
+            assert results == []
 
     def test_conversion_goal_no_conversions(self):
         s1 = str(uuid7("2023-12-01"))


### PR DESCRIPTION
## Problem

See zendesk: https://posthoghelp.zendesk.com/agent/tickets/28733 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/31196)

We use the $timezone property in the timezone query, and try to get clickhouse to parse it to compute the offset.

Sadly this often fails, and clickhouse doesn't provide a way to return null for rows with an invalid timezone. This means the whole query will fail once you have one event in your data with an invalid timezone.



## Changes
Instead, use $timezone_offset. This property wasn't available when the original query was written.

Yes

## How did you test this code?
Updated the tests
