### PR TITLE
feat(sql-editor): Store the response of the query and show it when opening the editor

### DIFF
--- a/frontend/src/lib/components/TZLabel/index.tsx
+++ b/frontend/src/lib/components/TZLabel/index.tsx
@@ -111,11 +111,17 @@ const TZLabelRaw = forwardRef<HTMLElement, TZLabelProps>(function TZLabelRaw(
 
     useEffect(() => {
         // NOTE: This is an optimization to make sure we don't needlessly re-render the component every second.
-        const interval = setInterval(() => {
+        const run = (): void => {
             if (format() !== formattedContent) {
                 setFormattedContent(format())
             }
-        }, 1000)
+        }
+
+        const interval = setInterval(run, 1000)
+
+        // Run immediately and dont wait 1000ms
+        run()
+
         return () => clearInterval(interval)
     }, [parsedTime, format])
 

--- a/frontend/src/queries/nodes/DataNode/LoadNext.tsx
+++ b/frontend/src/queries/nodes/DataNode/LoadNext.tsx
@@ -1,4 +1,5 @@
 import { useActions, useValues } from 'kea'
+import { TZLabel } from 'lib/components/TZLabel'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { useMemo } from 'react'
 
@@ -67,8 +68,10 @@ export function LoadNext({ query }: LoadNextProps): JSX.Element {
     )
 }
 
-export function LoadPreviewText(): JSX.Element {
-    const { response, hasMoreData, responseLoading } = useValues(dataNodeLogic)
+export function LoadPreviewText({ localResponse }: { localResponse?: Record<string, any> | null }): JSX.Element {
+    const { response: dataNodeResponse, hasMoreData, responseLoading } = useValues(dataNodeLogic)
+
+    const response = dataNodeResponse ?? localResponse
 
     if (responseLoading) {
         return <div />
@@ -78,10 +81,21 @@ export function LoadPreviewText(): JSX.Element {
     const isSingleEntry = resultCount === 1
     const showFirstPrefix = hasMoreData && resultCount > 1
 
+    const lastRefreshTimeUtc: string | null | undefined =
+        response && 'last_refresh' in response ? response['last_refresh'] : null
+
     return (
         <>
-            Showing {showFirstPrefix ? 'first ' : ' '}
-            {isSingleEntry ? 'one' : resultCount} {isSingleEntry ? 'entry' : 'entries'}
+            <span>
+                Showing {showFirstPrefix ? 'first ' : ' '}
+                {isSingleEntry ? 'one' : resultCount} {isSingleEntry ? 'entry' : 'entries'}
+            </span>
+            {lastRefreshTimeUtc && (
+                <>
+                    <span className="ml-2 mr-2">|</span>
+                    <TZLabel noStyles time={lastRefreshTimeUtc} />
+                </>
+            )}
         </>
     )
 }

--- a/frontend/src/scenes/data-warehouse/editor/EditorScene.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/EditorScene.tsx
@@ -65,7 +65,7 @@ export function EditorScene(): JSX.Element {
     })
 
     const { queryInput, sourceQuery, dataLogicKey } = useValues(logic)
-    const { setSourceQuery } = useActions(logic)
+    const { setSourceQuery, setResponse } = useActions(logic)
 
     const dataVisualizationLogicProps: DataVisualizationLogicProps = {
         key: dataLogicKey,
@@ -87,6 +87,9 @@ export function EditorScene(): JSX.Element {
         dataNodeCollectionId: dataLogicKey,
         variablesOverride: undefined,
         autoLoad: false,
+        onData: (data) => {
+            setResponse(data ?? null)
+        },
     }
 
     const { loadData } = useActions(dataNodeLogic(dataNodeLogicProps))

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -175,13 +175,28 @@ export function OutputPane(): JSX.Element {
     const { activeTab } = useValues(outputPaneLogic)
     const { setActiveTab } = useActions(outputPaneLogic)
 
-    const { sourceQuery, exportContext, editorKey, editingInsight, updateInsightButtonEnabled, showLegacyFilters } =
-        useValues(multitabEditorLogic)
+    const {
+        sourceQuery,
+        exportContext,
+        editorKey,
+        editingInsight,
+        updateInsightButtonEnabled,
+        showLegacyFilters,
+        localStorageResponse,
+    } = useValues(multitabEditorLogic)
     const { saveAsInsight, updateInsight, setSourceQuery, runQuery } = useActions(multitabEditorLogic)
     const { isDarkModeOn } = useValues(themeLogic)
-    const { response, responseLoading, responseError, queryId, pollResponse } = useValues(dataNodeLogic)
+    const {
+        response: dataNodeResponse,
+        responseLoading,
+        responseError,
+        queryId,
+        pollResponse,
+    } = useValues(dataNodeLogic)
     const { queryCancelled } = useValues(dataVisualizationLogic)
     const { toggleChartSettingsPanel } = useActions(dataVisualizationLogic)
+
+    const response = dataNodeResponse ?? localStorageResponse
 
     const [progressCache, setProgressCache] = useState<Record<string, number>>({})
 
@@ -421,7 +436,9 @@ export function OutputPane(): JSX.Element {
                 />
             </div>
             <div className="flex justify-between px-2 border-t">
-                <div>{response && !responseError ? <LoadPreviewText /> : <></>}</div>
+                <div>
+                    {response && !responseError ? <LoadPreviewText localResponse={localStorageResponse} /> : <></>}
+                </div>
                 <ElapsedTime />
             </div>
             <RowDetailsModal

--- a/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
@@ -28,7 +28,7 @@ import {
 } from '~/types'
 
 import { dataWarehouseViewsLogic } from '../saved_queries/dataWarehouseViewsLogic'
-import { DATAWAREHOUSE_EDITOR_ITEM_ID } from '../utils'
+import { DATAWAREHOUSE_EDITOR_ITEM_ID, sizeOfInBytes } from '../utils'
 import type { multitabEditorLogicType } from './multitabEditorLogicType'
 import { outputPaneLogic, OutputTab } from './outputPaneLogic'
 import { ViewEmptyState } from './ViewLoadingState'
@@ -73,6 +73,7 @@ export interface QueryTab {
     name: string
     sourceQuery?: DataVisualizationNode
     insight?: QueryBasedInsightModel
+    response?: Record<string, any>
 }
 
 export const multitabEditorLogic = kea<multitabEditorLogicType>([
@@ -93,7 +94,7 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
             ['setActiveTab'],
         ],
     })),
-    actions({
+    actions(({ values }) => ({
         setQueryInput: (queryInput: string) => ({ queryInput }),
         updateState: (skipBreakpoint?: boolean) => ({ skipBreakpoint }),
         runQuery: (queryOverride?: string, switchTab?: boolean) => ({
@@ -130,7 +131,8 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
         editInsight: (query: string, insight: QueryBasedInsightModel) => ({ query, insight }),
         updateQueryTabState: (skipBreakpoint?: boolean) => ({ skipBreakpoint }),
         setLastRunQuery: (lastRunQuery: DataVisualizationNode | null) => ({ lastRunQuery }),
-    }),
+        setResponse: (response: Record<string, any> | null) => ({ response, currentTab: values.activeModelUri }),
+    })),
     propsChanged(({ actions, props }, oldProps) => {
         if (!oldProps.monaco && !oldProps.editor && props.monaco && props.editor) {
             actions.initialize()
@@ -336,6 +338,7 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
                         insight: uri.path === tab.uri.path ? insight : tab.insight,
                         sourceQuery: uri.path === tab.uri.path ? insight?.query : tab.insight?.query,
                         name: tab.name,
+                        response: tab.response,
                     }
                 })
                 actions.setLocalState(editorModelsStateKey(props.key), JSON.stringify(queries))
@@ -454,6 +457,7 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
                         path: tab.uri.path.split('/').pop(),
                         view: tab.view,
                         insight: tab.insight,
+                        response: tab.response,
                     }
                 })
                 actions.setLocalState(editorModelsStateKey(props.key), JSON.stringify(queries))
@@ -498,6 +502,7 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
                             insight: model.insight,
                             name: model.name,
                             sourceQuery: existingTab?.sourceQuery,
+                            response: model.response,
                         })
                         mountedCodeEditorLogic && initModel(newModel, mountedCodeEditorLogic)
                     }
@@ -528,6 +533,7 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
                             name: activeView?.name || activeInsight?.name || activeTab.name,
                             insight: activeInsight,
                             sourceQuery: activeTab.sourceQuery,
+                            response: activeTab.response,
                         })
                     }
                 } else if (newModels.length) {
@@ -537,6 +543,7 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
                         sourceQuery: newModels[0].sourceQuery,
                         view: newModels[0].view,
                         insight: newModels[0].insight,
+                        response: newModels[0].response,
                     })
                 }
             } else {
@@ -563,6 +570,7 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
                     name: model.view?.name || model.name,
                     view: model.view,
                     insight: model.insight,
+                    response: model.response,
                 }
             })
             actions.setLocalState(editorModelsStateKey(props.key), JSON.stringify(queries))
@@ -775,6 +783,21 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
                 console.error(e)
             }
         },
+        setResponse: ({ response, currentTab }) => {
+            if (!currentTab || !response) {
+                return
+            }
+
+            const responseInBytes = sizeOfInBytes(response)
+
+            // Store in local storage if the response is less than 1 MB
+            if (responseInBytes <= 1024 * 1024) {
+                actions.updateTab({
+                    ...currentTab,
+                    response,
+                })
+            }
+        },
     })),
     subscriptions(({ props, actions, values }) => ({
         activeModelUri: (activeModelUri) => {
@@ -876,6 +899,12 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
                         doNotLoad: true,
                     })
                 )
+            },
+        ],
+        localStorageResponse: [
+            (s) => [s.activeModelUri],
+            (activeModelUri) => {
+                return activeModelUri?.response
             },
         ],
     }),

--- a/frontend/src/scenes/data-warehouse/utils.ts
+++ b/frontend/src/scenes/data-warehouse/utils.ts
@@ -69,7 +69,7 @@ const typeSizes = {
     number: () => 8,
     string: (item: string) => 2 * item.length,
     object: (item: Record<any, any>) =>
-        !item ? 0 : Object.keys(item).reduce((total, key) => sizeOfInBytes(key) + sizeOfInBytes(item[key]) + total, 0),
+        !item ? 0 : Array.isArray(item) ? item.reduce((total, element) => sizeOfInBytes(element) + total, 0) : Object.keys(item).reduce((total, key) => sizeOfInBytes(key) + sizeOfInBytes(item[key]) + total, 0),
     function: () => 0,
     symbol: () => 0,
     bigint: () => 0,

--- a/frontend/src/scenes/data-warehouse/utils.ts
+++ b/frontend/src/scenes/data-warehouse/utils.ts
@@ -76,5 +76,5 @@ const typeSizes = {
 }
 
 export const sizeOfInBytes = (value: any): number => {
-    return typeSizes[typeof value](value)
+    return (typeSizes[typeof value] || (() => 0))(value)
 }

--- a/frontend/src/scenes/data-warehouse/utils.ts
+++ b/frontend/src/scenes/data-warehouse/utils.ts
@@ -69,7 +69,11 @@ const typeSizes = {
     number: () => 8,
     string: (item: string) => 2 * item.length,
     object: (item: Record<any, any>) =>
-        !item ? 0 : Array.isArray(item) ? item.reduce((total, element) => sizeOfInBytes(element) + total, 0) : Object.keys(item).reduce((total, key) => sizeOfInBytes(key) + sizeOfInBytes(item[key]) + total, 0),
+        !item
+            ? 0
+            : Array.isArray(item)
+            ? item.reduce((total, element) => sizeOfInBytes(element) + total, 0)
+            : Object.keys(item).reduce((total, key) => sizeOfInBytes(key) + sizeOfInBytes(item[key]) + total, 0),
     function: () => 0,
     symbol: () => 0,
     bigint: () => 0,

--- a/frontend/src/scenes/data-warehouse/utils.ts
+++ b/frontend/src/scenes/data-warehouse/utils.ts
@@ -62,3 +62,19 @@ function humanTimeFormatter(hours: number, minutes: number): string {
     const displayHours = hours % 12 || 12 // Convert 0 to 12 for 12 AM
     return `${displayHours}:${minutes.toString().padStart(2, '0')} ${period}`
 }
+
+const typeSizes = {
+    undefined: () => 0,
+    boolean: () => 4,
+    number: () => 8,
+    string: (item: string) => 2 * item.length,
+    object: (item: Record<any, any>) =>
+        !item ? 0 : Object.keys(item).reduce((total, key) => sizeOfInBytes(key) + sizeOfInBytes(item[key]) + total, 0),
+    function: () => 0,
+    symbol: () => 0,
+    bigint: () => 0,
+}
+
+export const sizeOfInBytes = (value: any): number => {
+    return typeSizes[typeof value](value)
+}


### PR DESCRIPTION
## Problem
- Reloading the SQL editor forces you to re-run queries to view the results
- I also don't know how old the results of this query are 

## Changes
- Store the `response` object in local storage with the query tab, but only if the response is under 1MB (soft limits of Chrome are around 16MB)
- When loading the editor, use the stored `response` object if the `dataNode` response is nullish
- Also display when the query was calculated in the info bar at the bottom 

https://github.com/user-attachments/assets/fd5421b9-1112-4b51-b4e8-52cac76ba692


## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
See vid