### PR TITLE
chore(persons): Support separate persons DB in django

### DIFF
--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -2876,11 +2876,11 @@ class TestDecide(BaseTest, QueryMatchingTest):
             created_by=self.user,
         )
 
-        response = self._post_decide(api_version=3, distinct_id="example_id_1", assert_num_queries=5)
+        response = self._post_decide(api_version=3, distinct_id="example_id_1", assert_num_queries=2)
         self.assertEqual(response.json()["featureFlags"], {})
         self.assertEqual(response.json()["errorsWhileComputingFlags"], True)
 
-        response = self._post_decide(api_version=3, distinct_id="another_id", assert_num_queries=5)
+        response = self._post_decide(api_version=3, distinct_id="another_id", assert_num_queries=2)
         self.assertEqual(response.json()["featureFlags"], {})
         self.assertEqual(response.json()["errorsWhileComputingFlags"], True)
 

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -2876,11 +2876,11 @@ class TestDecide(BaseTest, QueryMatchingTest):
             created_by=self.user,
         )
 
-        response = self._post_decide(api_version=3, distinct_id="example_id_1", assert_num_queries=2)
+        response = self._post_decide(api_version=3, distinct_id="example_id_1", assert_num_queries=1)
         self.assertEqual(response.json()["featureFlags"], {})
         self.assertEqual(response.json()["errorsWhileComputingFlags"], True)
 
-        response = self._post_decide(api_version=3, distinct_id="another_id", assert_num_queries=2)
+        response = self._post_decide(api_version=3, distinct_id="another_id", assert_num_queries=1)
         self.assertEqual(response.json()["featureFlags"], {})
         self.assertEqual(response.json()["errorsWhileComputingFlags"], True)
 

--- a/posthog/hogql_queries/actor_strategies.py
+++ b/posthog/hogql_queries/actor_strategies.py
@@ -56,8 +56,7 @@ class PersonStrategy(ActorStrategy):
         if order_by:
             persons_query += f" ORDER BY {order_by}"
 
-        # Use 'persons_db_writer' if it's configured, otherwise fallback to default connection
-        conn = connections["persons_db_writer"] if "persons_db_writer" in connections else connection
+        conn = connections["persons_db_reader"] if "persons_db_reader" in connections else connection
 
         with conn.cursor() as cursor:
             cursor.execute(

--- a/posthog/hogql_queries/actor_strategies.py
+++ b/posthog/hogql_queries/actor_strategies.py
@@ -1,6 +1,7 @@
 from typing import cast, Literal, Optional
 
 from django.db import connection
+from django.db import connections
 
 from posthog.hogql import ast
 from posthog.hogql.property import property_to_expr
@@ -54,7 +55,11 @@ class PersonStrategy(ActorStrategy):
             AND posthog_person.team_id = %(team_id)s"""
         if order_by:
             persons_query += f" ORDER BY {order_by}"
-        with connection.cursor() as cursor:
+
+        # Use 'persons_db_writer' if it's configured, otherwise fallback to default connection
+        conn = connections["persons_db_writer"] if "persons_db_writer" in connections else connection
+
+        with conn.cursor() as cursor:
             cursor.execute(
                 persons_query,
                 {"uuids": list(actor_ids), "team_id": self.team.pk},

--- a/posthog/management/commands/delete_persons.py
+++ b/posthog/management/commands/delete_persons.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.db import connection
+from django.db import connection, connections
 import structlog
 from django.core.management.base import BaseCommand
 
@@ -76,7 +76,8 @@ def run(options):
     WHERE id IN (SELECT id FROM to_delete);
     """
 
-    with connection.cursor() as cursor:
+    conn = connections["persons_db_writer"] if "persons_db_writer" in connections else connection
+    with conn.cursor() as cursor:
         prepared_person_distinct_ids_query = cursor.mogrify(
             delete_query_person_distinct_ids, {"team_id": team_id, "limit": batch_size, "person_ids": person_ids}
         )
@@ -110,7 +111,8 @@ def run(options):
 
     for i in range(0, batches):
         logger.info(f"Deleting batch {i + 1} of {batches} ({batch_size} rows)")
-        with connection.cursor() as cursor:
+        conn = connections["persons_db_writer"] if "persons_db_writer" in connections else connection
+        with conn.cursor() as cursor:
             cursor.execute(
                 delete_query_person_distinct_ids, {"team_id": team_id, "limit": batch_size, "person_ids": person_ids}
             )

--- a/posthog/management/commands/delete_persons.py
+++ b/posthog/management/commands/delete_persons.py
@@ -111,7 +111,6 @@ def run(options):
 
     for i in range(0, batches):
         logger.info(f"Deleting batch {i + 1} of {batches} ({batch_size} rows)")
-        conn = connections["persons_db_writer"] if "persons_db_writer" in connections else connection
         with conn.cursor() as cursor:
             cursor.execute(
                 delete_query_person_distinct_ids, {"team_id": team_id, "limit": batch_size, "person_ids": person_ids}

--- a/posthog/models/feature_flag/flag_matching.py
+++ b/posthog/models/feature_flag/flag_matching.py
@@ -12,6 +12,7 @@ from django.db.models.expressions import ExpressionWrapper, RawSQL
 from django.db.models.fields import BooleanField
 from django.db.models import Q, Func, F, CharField, Expression
 from django.db.models.query import QuerySet
+from django.db import connections
 from sentry_sdk.api import start_span
 from posthog.metrics import LABEL_TEAM_ID
 
@@ -68,6 +69,17 @@ FLAG_CACHE_HIT_COUNTER = Counter(
 
 ENTITY_EXISTS_PREFIX = "flag_entity_exists_"
 PERSON_KEY = "person"
+
+# Define which database to use for persons only.
+# This is temporary while we migrate persons to its own database.
+# It'll use `replica` until we set the PERSONS_DB_WRITER_URL env var
+DATABASE_FOR_PERSONS = (
+    "persons_db_writer"
+    if "persons_db_writer" in connections
+    else "replica"
+    if "replica" in connections and "decide" in settings.READ_REPLICA_OPT_IN
+    else "default"
+)  # Fallback if persons DB not configured
 
 
 class FeatureFlagMatchReason(StrEnum):
@@ -501,182 +513,179 @@ class FeatureFlagMatcher:
         try:
             # Some extra wiggle room here for timeouts because this depends on the number of flags as well,
             # and not just the database query.
-            with execute_with_timeout(FLAG_MATCHING_QUERY_TIMEOUT_MS * 2, DATABASE_FOR_FLAG_MATCHING):
-                with start_span(op="query_conditions"):
-                    all_conditions: dict = {}
-                    person_query: QuerySet = Person.objects.db_manager(DATABASE_FOR_FLAG_MATCHING).filter(
-                        team_id=self.team_id,
-                        persondistinctid__distinct_id=self.distinct_id,
-                        persondistinctid__team_id=self.team_id,
-                    )
-                    basic_group_query: QuerySet = Group.objects.db_manager(DATABASE_FOR_FLAG_MATCHING).filter(
-                        team_id=self.team_id
-                    )
-                    group_query_per_group_type_mapping: dict[GroupTypeIndex, tuple[QuerySet, list[str]]] = {}
-                    # :TRICKY: Create a queryset for each group type that uniquely identifies a group, based on the groups passed in.
-                    # If no groups for a group type are passed in, we can skip querying for that group type,
-                    # since the result will always be `false`.
-                    for group_type, group_key in self.groups.items():
-                        group_type_index = self.cache.group_types_to_indexes.get(group_type)
-                        if group_type_index is not None:
-                            # a tuple of querySet and field names
-                            group_query_per_group_type_mapping[group_type_index] = (
-                                basic_group_query.filter(group_type_index=group_type_index, group_key=group_key),
-                                [],
-                            )
-
-                    person_fields: list[str] = []
-
-                    for existence_condition_key in self.has_pure_is_not_conditions:
-                        if existence_condition_key == PERSON_KEY:
-                            person_exists = person_query.exists()
-                            all_conditions[f"{ENTITY_EXISTS_PREFIX}{PERSON_KEY}"] = person_exists
-                        else:
-                            if existence_condition_key not in group_query_per_group_type_mapping:
-                                continue
-
-                            group_query, _ = group_query_per_group_type_mapping[
-                                cast(GroupTypeIndex, existence_condition_key)
-                            ]
-                            group_exists = group_query.exists()
-                            all_conditions[f"{ENTITY_EXISTS_PREFIX}{existence_condition_key}"] = group_exists
-
-                    def condition_eval(key, condition):
-                        expr = None
-                        annotate_query = True
-                        nonlocal person_query
-
-                        property_list = Filter(data=condition).property_groups.flat
-                        properties_with_math_operators = get_all_properties_with_math_operators(
-                            property_list, self.cohorts_cache, self.project_id
+            with start_span(op="query_conditions"):
+                all_conditions: dict = {}
+                person_query: QuerySet = Person.objects.db_manager(DATABASE_FOR_PERSONS).filter(
+                    team_id=self.team_id,
+                    persondistinctid__distinct_id=self.distinct_id,
+                    persondistinctid__team_id=self.team_id,
+                )
+                basic_group_query: QuerySet = Group.objects.db_manager(DATABASE_FOR_FLAG_MATCHING).filter(
+                    team_id=self.team_id
+                )
+                group_query_per_group_type_mapping: dict[GroupTypeIndex, tuple[QuerySet, list[str]]] = {}
+                # :TRICKY: Create a queryset for each group type that uniquely identifies a group, based on the groups passed in.
+                # If no groups for a group type are passed in, we can skip querying for that group type,
+                # since the result will always be `false`.
+                for group_type, group_key in self.groups.items():
+                    group_type_index = self.cache.group_types_to_indexes.get(group_type)
+                    if group_type_index is not None:
+                        # a tuple of querySet and field names
+                        group_query_per_group_type_mapping[group_type_index] = (
+                            basic_group_query.filter(group_type_index=group_type_index, group_key=group_key),
+                            [],
                         )
 
-                        if len(condition.get("properties", {})) > 0:
-                            # Feature Flags don't support OR filtering yet
-                            target_properties = self.property_value_overrides
-                            if feature_flag.aggregation_group_type_index is not None:
-                                if feature_flag.aggregation_group_type_index not in self.cache.group_type_index_to_name:
-                                    target_properties = {}
-                                else:
-                                    target_properties = self.group_property_value_overrides.get(
-                                        self.cache.group_type_index_to_name[feature_flag.aggregation_group_type_index],
-                                        {},
-                                    )
+                person_fields: list[str] = []
 
-                            expr = properties_to_Q(
-                                self.project_id,
-                                property_list,
-                                override_property_values=target_properties,
-                                cohorts_cache=self.cohorts_cache,
-                                using_database=DATABASE_FOR_FLAG_MATCHING,
-                            )
+                for existence_condition_key in self.has_pure_is_not_conditions:
+                    if existence_condition_key == PERSON_KEY:
+                        person_exists = person_query.exists()
+                        all_conditions[f"{ENTITY_EXISTS_PREFIX}{PERSON_KEY}"] = person_exists
+                    else:
+                        if existence_condition_key not in group_query_per_group_type_mapping:
+                            continue
 
-                            # TRICKY: Due to property overrides for cohorts, we sometimes shortcircuit the condition check.
-                            # In that case, the expression is either an explicit True or explicit False, or multiple conditions.
-                            # We can skip going to the database in explicit True|False conditions. This is important
-                            # as it allows resolving flags correctly for non-ingested persons.
-                            # However, this doesn't work for the multiple condition case (when expr has multiple Q objects),
-                            # but it's better than nothing.
-                            # TODO: A proper fix would be to handle cohorts with property overrides before we get to this point.
-                            # Unskip test test_complex_cohort_filter_with_override_properties when we fix this.
-                            if expr == Q(pk__isnull=False):
-                                all_conditions[key] = True
-                                annotate_query = False
-                            elif expr == Q(pk__isnull=True):
-                                all_conditions[key] = False
-                                annotate_query = False
+                        group_query, _ = group_query_per_group_type_mapping[
+                            cast(GroupTypeIndex, existence_condition_key)
+                        ]
+                        group_exists = group_query.exists()
+                        all_conditions[f"{ENTITY_EXISTS_PREFIX}{existence_condition_key}"] = group_exists
 
-                        if annotate_query:
-                            if feature_flag.aggregation_group_type_index is None:
-                                # :TRICKY: Flag matching depends on type of property when doing >, <, >=, <= comparisons.
-                                # This requires a generated field to query in Q objects, which sadly don't allow inlining fields,
-                                # hence we need to annotate the query here, even though these annotations are used much deeper,
-                                # in properties_to_q, in empty_or_null_with_value_q
-                                # These need to come in before the expr so they're available to use inside the expr.
-                                # Same holds for the group queries below.
-                                type_property_annotations = _get_property_type_annotations(
-                                    properties_with_math_operators
-                                )
-                                person_query = person_query.annotate(
-                                    **type_property_annotations,
-                                    **{
-                                        key: ExpressionWrapper(
-                                            cast(Expression, expr if expr else RawSQL("true", [])),
-                                            output_field=BooleanField(),
-                                        ),
-                                    },
-                                )
-                                person_fields.append(key)
+                def condition_eval(key, condition):
+                    expr = None
+                    annotate_query = True
+                    nonlocal person_query
+
+                    property_list = Filter(data=condition).property_groups.flat
+                    properties_with_math_operators = get_all_properties_with_math_operators(
+                        property_list, self.cohorts_cache, self.project_id
+                    )
+
+                    if len(condition.get("properties", {})) > 0:
+                        # Feature Flags don't support OR filtering yet
+                        target_properties = self.property_value_overrides
+                        if feature_flag.aggregation_group_type_index is not None:
+                            if feature_flag.aggregation_group_type_index not in self.cache.group_type_index_to_name:
+                                target_properties = {}
                             else:
-                                if feature_flag.aggregation_group_type_index not in group_query_per_group_type_mapping:
-                                    # ignore flags that didn't have the right groups passed in
-                                    return
-                                (
-                                    group_query,
-                                    group_fields,
-                                ) = group_query_per_group_type_mapping[feature_flag.aggregation_group_type_index]
-                                type_property_annotations = _get_property_type_annotations(
-                                    properties_with_math_operators
-                                )
-                                group_query = group_query.annotate(
-                                    **type_property_annotations,
-                                    **{
-                                        key: ExpressionWrapper(
-                                            cast(Expression, expr if expr else RawSQL("true", [])),
-                                            output_field=BooleanField(),
-                                        ),
-                                    },
-                                )
-                                group_fields.append(key)
-                                group_query_per_group_type_mapping[feature_flag.aggregation_group_type_index] = (
-                                    group_query,
-                                    group_fields,
+                                target_properties = self.group_property_value_overrides.get(
+                                    self.cache.group_type_index_to_name[feature_flag.aggregation_group_type_index],
+                                    {},
                                 )
 
-                    # only fetch all cohorts if not passed in any cached cohorts
-                    if not self.cohorts_cache and any(feature_flag.uses_cohorts for feature_flag in self.feature_flags):
-                        all_cohorts = {
-                            cohort.pk: cohort
-                            for cohort in Cohort.objects.db_manager(DATABASE_FOR_FLAG_MATCHING).filter(
-                                team__project_id=self.project_id, deleted=False
+                        expr = properties_to_Q(
+                            self.project_id,
+                            property_list,
+                            override_property_values=target_properties,
+                            cohorts_cache=self.cohorts_cache,
+                            using_database=DATABASE_FOR_FLAG_MATCHING,
+                        )
+
+                        # TRICKY: Due to property overrides for cohorts, we sometimes shortcircuit the condition check.
+                        # In that case, the expression is either an explicit True or explicit False, or multiple conditions.
+                        # We can skip going to the database in explicit True|False conditions. This is important
+                        # as it allows resolving flags correctly for non-ingested persons.
+                        # However, this doesn't work for the multiple condition case (when expr has multiple Q objects),
+                        # but it's better than nothing.
+                        # TODO: A proper fix would be to handle cohorts with property overrides before we get to this point.
+                        # Unskip test test_complex_cohort_filter_with_override_properties when we fix this.
+                        if expr == Q(pk__isnull=False):
+                            all_conditions[key] = True
+                            annotate_query = False
+                        elif expr == Q(pk__isnull=True):
+                            all_conditions[key] = False
+                            annotate_query = False
+
+                    if annotate_query:
+                        if feature_flag.aggregation_group_type_index is None:
+                            # :TRICKY: Flag matching depends on type of property when doing >, <, >=, <= comparisons.
+                            # This requires a generated field to query in Q objects, which sadly don't allow inlining fields,
+                            # hence we need to annotate the query here, even though these annotations are used much deeper,
+                            # in properties_to_q, in empty_or_null_with_value_q
+                            # These need to come in before the expr so they're available to use inside the expr.
+                            # Same holds for the group queries below.
+                            type_property_annotations = _get_property_type_annotations(properties_with_math_operators)
+                            person_query = person_query.annotate(
+                                **type_property_annotations,
+                                **{
+                                    key: ExpressionWrapper(
+                                        cast(Expression, expr if expr else RawSQL("true", [])),
+                                        output_field=BooleanField(),
+                                    ),
+                                },
                             )
-                        }
-                        self.cohorts_cache.update(all_cohorts)
-                    # release conditions
-                    for feature_flag in self.feature_flags:
-                        # super release conditions
-                        if feature_flag.super_conditions and len(feature_flag.super_conditions) > 0:
-                            condition = feature_flag.super_conditions[0]
-                            prop_key = (condition.get("properties") or [{}])[0].get("key")
-                            if prop_key:
-                                key = f"flag_{feature_flag.pk}_super_condition"
-                                condition_eval(key, condition)
+                            person_fields.append(key)
+                        else:
+                            if feature_flag.aggregation_group_type_index not in group_query_per_group_type_mapping:
+                                # ignore flags that didn't have the right groups passed in
+                                return
+                            (
+                                group_query,
+                                group_fields,
+                            ) = group_query_per_group_type_mapping[feature_flag.aggregation_group_type_index]
+                            type_property_annotations = _get_property_type_annotations(properties_with_math_operators)
+                            group_query = group_query.annotate(
+                                **type_property_annotations,
+                                **{
+                                    key: ExpressionWrapper(
+                                        cast(Expression, expr if expr else RawSQL("true", [])),
+                                        output_field=BooleanField(),
+                                    ),
+                                },
+                            )
+                            group_fields.append(key)
+                            group_query_per_group_type_mapping[feature_flag.aggregation_group_type_index] = (
+                                group_query,
+                                group_fields,
+                            )
 
-                                is_set_key = f"flag_{feature_flag.pk}_super_condition_is_set"
-                                is_set_condition = {
-                                    "properties": [
-                                        {
-                                            "key": prop_key,
-                                            "operator": "is_set",
-                                        }
-                                    ]
-                                }
-                                condition_eval(is_set_key, is_set_condition)
+                # only fetch all cohorts if not passed in any cached cohorts
+                if not self.cohorts_cache and any(feature_flag.uses_cohorts for feature_flag in self.feature_flags):
+                    all_cohorts = {
+                        cohort.pk: cohort
+                        for cohort in Cohort.objects.db_manager(DATABASE_FOR_FLAG_MATCHING).filter(
+                            team__project_id=self.project_id, deleted=False
+                        )
+                    }
+                    self.cohorts_cache.update(all_cohorts)
+                # release conditions
+                for feature_flag in self.feature_flags:
+                    # super release conditions
+                    if feature_flag.super_conditions and len(feature_flag.super_conditions) > 0:
+                        condition = feature_flag.super_conditions[0]
+                        prop_key = (condition.get("properties") or [{}])[0].get("key")
+                        if prop_key:
+                            key = f"flag_{feature_flag.pk}_super_condition"
+                            condition_eval(key, condition)
 
-                        with start_span(
-                            op="parse_feature_flag_conditions",
-                            description=f"feature_flag={feature_flag.pk} key={feature_flag.key}",
-                        ):
-                            for index, condition in enumerate(feature_flag.conditions):
-                                key = f"flag_{feature_flag.pk}_condition_{index}"
-                                condition_eval(key, condition)
+                            is_set_key = f"flag_{feature_flag.pk}_super_condition_is_set"
+                            is_set_condition = {
+                                "properties": [
+                                    {
+                                        "key": prop_key,
+                                        "operator": "is_set",
+                                    }
+                                ]
+                            }
+                            condition_eval(is_set_key, is_set_condition)
 
-                    if len(person_fields) > 0:
-                        with start_span(op="execute_person_query"):
+                    with start_span(
+                        op="parse_feature_flag_conditions",
+                        description=f"feature_flag={feature_flag.pk} key={feature_flag.key}",
+                    ):
+                        for index, condition in enumerate(feature_flag.conditions):
+                            key = f"flag_{feature_flag.pk}_condition_{index}"
+                            condition_eval(key, condition)
+
+                if len(person_fields) > 0:
+                    with start_span(op="execute_person_query"):
+                        with execute_with_timeout(FLAG_MATCHING_QUERY_TIMEOUT_MS * 2, DATABASE_FOR_PERSONS):
                             person_query = person_query.values(*person_fields)
                             if len(person_query) > 0:
                                 all_conditions = {**all_conditions, **person_query[0]}
 
+                with execute_with_timeout(FLAG_MATCHING_QUERY_TIMEOUT_MS * 2, DATABASE_FOR_FLAG_MATCHING):
                     for (
                         group_query,
                         group_fields,
@@ -690,7 +699,7 @@ class FeatureFlagMatcher:
                                         len(group_query) == 1
                                     ), f"Expected 1 group query result, got {len(group_query)}"
                                     all_conditions = {**all_conditions, **group_query[0]}
-                    return all_conditions
+                return all_conditions
         except DatabaseError as e:
             logger.exception("query_conditions database error", error=str(e), exc_info=True)
             self.failed_to_fetch_conditions = True

--- a/posthog/models/feature_flag/flag_matching.py
+++ b/posthog/models/feature_flag/flag_matching.py
@@ -74,8 +74,8 @@ PERSON_KEY = "person"
 # This is temporary while we migrate persons to its own database.
 # It'll use `replica` until we set the PERSONS_DB_WRITER_URL env var
 DATABASE_FOR_PERSONS = (
-    "persons_db_writer"
-    if "persons_db_writer" in connections
+    "persons_db_reader"
+    if "persons_db_reader" in connections
     else "replica"
     if "replica" in connections and "decide" in settings.READ_REPLICA_OPT_IN
     else "default"

--- a/posthog/models/feature_flag/flag_matching.py
+++ b/posthog/models/feature_flag/flag_matching.py
@@ -685,20 +685,21 @@ class FeatureFlagMatcher:
                             if len(person_query) > 0:
                                 all_conditions = {**all_conditions, **person_query[0]}
 
-                with execute_with_timeout(FLAG_MATCHING_QUERY_TIMEOUT_MS * 2, DATABASE_FOR_FLAG_MATCHING):
-                    for (
-                        group_query,
-                        group_fields,
-                    ) in group_query_per_group_type_mapping.values():
-                        # Only query the group if there's a field to query
-                        if len(group_fields) > 0:
-                            with start_span(op="execute_group_query"):
-                                group_query = group_query.values(*group_fields)
-                                if len(group_query) > 0:
-                                    assert (
-                                        len(group_query) == 1
-                                    ), f"Expected 1 group query result, got {len(group_query)}"
-                                    all_conditions = {**all_conditions, **group_query[0]}
+                if len(group_query_per_group_type_mapping) > 0:
+                    with execute_with_timeout(FLAG_MATCHING_QUERY_TIMEOUT_MS * 2, DATABASE_FOR_FLAG_MATCHING):
+                        for (
+                            group_query,
+                            group_fields,
+                        ) in group_query_per_group_type_mapping.values():
+                            # Only query the group if there's a field to query
+                            if len(group_fields) > 0:
+                                with start_span(op="execute_group_query"):
+                                    group_query = group_query.values(*group_fields)
+                                    if len(group_query) > 0:
+                                        assert (
+                                            len(group_query) == 1
+                                        ), f"Expected 1 group query result, got {len(group_query)}"
+                                        all_conditions = {**all_conditions, **group_query[0]}
                 return all_conditions
         except DatabaseError as e:
             logger.exception("query_conditions database error", error=str(e), exc_info=True)

--- a/posthog/models/person/person.py
+++ b/posthog/models/person/person.py
@@ -1,7 +1,6 @@
 from typing import Any, Optional
 
-from django.conf import settings
-from django.db import models, transaction
+from django.db import models, transaction, connections
 from django.db.models import F, Q
 
 from posthog.models.utils import UUIDT
@@ -11,7 +10,12 @@ from .missing_person import uuidFromDistinctId
 
 MAX_LIMIT_DISTINCT_IDS = 2500
 
-READ_DB_FOR_PERSONS = "replica" if "replica" in settings.DATABASES else "default"
+if "persons_db_reader" in connections:
+    READ_DB_FOR_PERSONS = "persons_db_reader"
+elif "replica" in connections:
+    READ_DB_FOR_PERSONS = "replica"
+else:
+    READ_DB_FOR_PERSONS = "default"
 
 
 class PersonManager(models.Manager):

--- a/posthog/person_db_router.py
+++ b/posthog/person_db_router.py
@@ -23,7 +23,7 @@ class PersonDBRouter:
         """
         Attempts to read person models go to persons_db_writer.
         """
-        if self.is_persons_table(model._meta.db_table or model._meta.model_name):
+        if self.is_persons_model(model._meta.model_name):
             return "persons_db_writer"
         return None  # Allow default db selection
 
@@ -31,7 +31,7 @@ class PersonDBRouter:
         """
         Attempts to write person models go to persons_db_writer.
         """
-        if self.is_persons_table(model._meta.db_table or model._meta.model_name):
+        if self.is_persons_model(model._meta.model_name):
             return "persons_db_writer"
         return None  # Allow default db selection
 
@@ -70,7 +70,11 @@ class PersonDBRouter:
         Make sure the person models only appear in the 'persons_db'
         database. All other models migrate normally on 'default'.
         """
-        is_person_model = self.is_persons_table(model_name or "")
+        if model_name is None:
+            # App-level migrations should only run on the default database
+            return db != "persons_db_writer"
+
+        is_person_model = self.is_persons_model(model_name)
 
         if db == "persons_db_writer":
             # If the target db is persons_db_writer, only allow migration if it's a person model
@@ -80,7 +84,6 @@ class PersonDBRouter:
             # if it's *not* a person model.
             return not is_person_model
 
-    def is_persons_table(self, table_name):
-        # Implement the logic to determine if a table belongs to the persons_db
-        # This is a placeholder and should be replaced with the actual implementation
-        return table_name in self.PERSONS_DB_MODELS
+    def is_persons_model(self, model_name):
+        # Check if the model name belongs to the persons_db models
+        return model_name in self.PERSONS_DB_MODELS

--- a/posthog/person_db_router.py
+++ b/posthog/person_db_router.py
@@ -1,0 +1,86 @@
+# posthog/person_db_router.py
+class PersonDBRouter:
+    """
+    A router to control all database operations on models in the persons database.
+    """
+
+    # Set of models (lowercase) that should live in the persons_db
+    # Add other models from the plan here as needed.
+    PERSONS_DB_MODELS = {
+        "person",
+        "persondistinctid",
+        "personlessdistinctid",  # Assuming app_label 'posthog'
+        "personoverridemapping",  # Assuming app_label 'posthog'
+        "personoverride",  # Assuming app_label 'posthog'
+        "pendingpersonoverride",  # Assuming app_label 'posthog'
+        "flatpersonoverride",  # Assuming app_label 'posthog'
+        "featureflaghashkeyoverride",  # Assuming app_label 'posthog'
+        "cohortpeople",  # Assuming app_label 'posthog'
+    }
+    PERSONS_APP_LABEL = "posthog"  # Assuming all models are in the 'posthog' app
+
+    def db_for_read(self, model, **hints):
+        """
+        Attempts to read person models go to persons_db_writer.
+        """
+        if self.is_persons_table(model._meta.db_table or model._meta.model_name):
+            return "persons_db_writer"
+        return None  # Allow default db selection
+
+    def db_for_write(self, model, **hints):
+        """
+        Attempts to write person models go to persons_db_writer.
+        """
+        if self.is_persons_table(model._meta.db_table or model._meta.model_name):
+            return "persons_db_writer"
+        return None  # Allow default db selection
+
+    def allow_relation(self, obj1, obj2, **hints):
+        """
+        Allow relations if a model in PERSONS_DB_MODELS is involved.
+        Relations between two models that are both in PERSONS_DB_MODELS are allowed.
+        Relations between two models that are *not* in PERSONS_DB_MODELS are allowed.
+        Relations between a model in PERSONS_DB_MODELS and a model not in it are DISALLOWED
+        by default, as Django doesn't support cross-database relations natively.
+        You might need to adjust this based on specific foreign keys (e.g., Person -> Team).
+        """
+        obj1_in_persons_db = (
+            obj1._meta.app_label == self.PERSONS_APP_LABEL and obj1._meta.model_name in self.PERSONS_DB_MODELS
+        )
+        obj2_in_persons_db = (
+            obj2._meta.app_label == self.PERSONS_APP_LABEL and obj2._meta.model_name in self.PERSONS_DB_MODELS
+        )
+
+        if obj1_in_persons_db and obj2_in_persons_db:
+            # Both models are in persons_db, allow relation there
+            return True
+        elif not obj1_in_persons_db and not obj2_in_persons_db:
+            # Neither model is in persons_db, allow relation on default db
+            return None  # Allow default behavior (usually True on 'default' db)
+        else:
+            # One model is in persons_db, the other is not. Disallow by default.
+            # You might need specific logic here for allowed cross-db FKs.
+            # For example, if obj1 is Person and obj2 is Team, you might want to return True
+            # if the foreign key constraint is removed or handled appropriately.
+            # For now, returning False prevents potential issues.
+            return False
+
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
+        """
+        Make sure the person models only appear in the 'persons_db'
+        database. All other models migrate normally on 'default'.
+        """
+        is_person_model = self.is_persons_table(model_name or "")
+
+        if db == "persons_db_writer":
+            # If the target db is persons_db_writer, only allow migration if it's a person model
+            return is_person_model
+        else:
+            # Otherwise (e.g., target db is 'default'), only allow migration
+            # if it's *not* a person model.
+            return not is_person_model
+
+    def is_persons_table(self, table_name):
+        # Implement the logic to determine if a table belongs to the persons_db
+        # This is a placeholder and should be replaced with the actual implementation
+        return table_name in self.PERSONS_DB_MODELS

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -106,13 +106,24 @@ else:
         f'The environment vars "DATABASE_URL" or "POSTHOG_DB_NAME" are absolutely required to run this software'
     )
 
+DATABASE_ROUTERS: list[str] = []
+
 # Configure the database which will be used as a read replica.
 # This should have all the same config as our main writer DB, just use a different host.
 # Our database router will point here.
 read_host = os.getenv("POSTHOG_POSTGRES_READ_HOST")
 if read_host:
     DATABASES["replica"] = postgres_config(read_host)
-    DATABASE_ROUTERS = ["posthog.dbrouter.ReplicaRouter"]
+    DATABASE_ROUTERS.append("posthog.dbrouter.ReplicaRouter")
+
+# Add the persons_db_writer database configuration using PERSONS_DB_WRITER_URL
+if os.getenv("PERSONS_DB_WRITER_URL"):
+    DATABASES["persons_db_writer"] = dj_database_url.config(default=os.getenv("PERSONS_DB_WRITER_URL"), conn_max_age=0)
+
+    if DISABLE_SERVER_SIDE_CURSORS:
+        DATABASES["persons_db_writer"]["DISABLE_SERVER_SIDE_CURSORS"] = True
+
+    DATABASE_ROUTERS.insert(0, "posthog.person_db_router.PersonDBRouter")
 
 if JOB_QUEUE_GRAPHILE_URL:
     DATABASES["graphile"] = dj_database_url.config(default=JOB_QUEUE_GRAPHILE_URL, conn_max_age=600)

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -120,8 +120,12 @@ if read_host:
 if os.getenv("PERSONS_DB_WRITER_URL"):
     DATABASES["persons_db_writer"] = dj_database_url.config(default=os.getenv("PERSONS_DB_WRITER_URL"), conn_max_age=0)
 
+    # Fall back to the writer URL if no reader URL is set
+    persons_reader_url = os.getenv("PERSONS_DB_READER_URL") or os.getenv("PERSONS_DB_WRITER_URL")
+    DATABASES["persons_db_reader"] = dj_database_url.config(default=persons_reader_url, conn_max_age=0)
     if DISABLE_SERVER_SIDE_CURSORS:
         DATABASES["persons_db_writer"]["DISABLE_SERVER_SIDE_CURSORS"] = True
+        DATABASES["persons_db_reader"]["DISABLE_SERVER_SIDE_CURSORS"] = True
 
     DATABASE_ROUTERS.insert(0, "posthog.person_db_router.PersonDBRouter")
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

#27654 needs to be merged first

We want to support a separate persons DB.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

This PR should be a no-op until we set `PERSONS_DB_WRITER_URL`, at which point we'll use that database instead.

This PR fixes the logic for everything Django. We'll still need to update `plugin-server` and `rust/feature-flags` to use these env vars.

If you want to test this locally (when asked, password is `posthog`):
```bash
python manage.py migrate

psql -p 5432 -h 0.0.0.0 -U posthog -c "CREATE DATABASE persons_db;"

# Dump the tables with proper schema names
pg_dump -p 5432 -h 0.0.0.0 -U posthog -d posthog \
  -t posthog_person -t posthog_persondistinctid \
  -t posthog_personlessdistinctid -t posthog_personoverridemapping \
  -t posthog_personoverride -t posthog_pendingpersonoverride \
  -t posthog_flatpersonoverride -t posthog_featureflaghashkeyoverride \
  -t posthog_cohortpeople --no-owner -f persons_tables.sql

# Restore to the new database
psql -p 5432 -h 0.0.0.0 -U posthog -d persons_db -f persons_tables.sql
```

And if you're really brave:
```sql
psql -p 5432 -h 0.0.0.0 -U posthog -d posthog -c "
BEGIN;
  TRUNCATE TABLE 
    posthog_person,
    posthog_persondistinctid,
    posthog_personlessdistinctid,
    posthog_personoverridemapping,
    posthog_personoverride,
    posthog_pendingpersonoverride,
    posthog_flatpersonoverride,
    posthog_featureflaghashkeyoverride,
    posthog_cohortpeople
  CASCADE;
COMMIT;
"
```

Then do 
```bash
export PERSONS_DB_WRITER_URL=postgres://posthog:posthog@0.0.0.0:5432/persons_db
```

and run `bin/start-backend`
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
