### PR TITLE
fix(modeling): Support for subqueries when extracting parents

### DIFF
--- a/posthog/warehouse/models/modeling.py
+++ b/posthog/warehouse/models/modeling.py
@@ -125,22 +125,16 @@ def get_parents_from_model_query(model_query: str) -> set[str]:
         if join is None:
             continue
 
-        if isinstance(join.table, ast.SelectQuery):
-            if join.table.view_name is not None:
-                parents.add(join.table.view_name)
-                continue
-
-            queries.append(join.table)
-            continue
-        elif isinstance(join.table, ast.SelectSetQuery):
-            queries.extend(list(extract_select_queries(join.table)))
-
         while join is not None:
             if isinstance(join.table, ast.SelectQuery):
-                # Joining with a subquery.
-                # We should traverse the subquery down to the last one.
-                join = join.table.select_from
-                continue
+                if join.table.view_name is not None:
+                    parents.add(join.table.view_name)
+                    break
+
+                queries.append(join.table)
+                break
+            elif isinstance(join.table, ast.SelectSetQuery):
+                queries.extend(list(extract_select_queries(join.table)))
 
             parent_name = join.table.chain[0]  # type: ignore
 

--- a/posthog/warehouse/models/modeling.py
+++ b/posthog/warehouse/models/modeling.py
@@ -134,9 +134,14 @@ def get_parents_from_model_query(model_query: str) -> set[str]:
             continue
         elif isinstance(join.table, ast.SelectSetQuery):
             queries.extend(list(extract_select_queries(join.table)))
-            continue
 
         while join is not None:
+            if isinstance(join.table, ast.SelectQuery):
+                # Joining with a subquery.
+                # We should traverse the subquery down to the last one.
+                join = join.table.select_from
+                continue
+
             parent_name = join.table.chain[0]  # type: ignore
 
             if parent_name not in ctes and isinstance(parent_name, str):

--- a/posthog/warehouse/models/modeling.py
+++ b/posthog/warehouse/models/modeling.py
@@ -131,8 +131,10 @@ def get_parents_from_model_query(model_query: str) -> set[str]:
                 continue
 
             queries.append(join.table)
+            continue
         elif isinstance(join.table, ast.SelectSetQuery):
             queries.extend(list(extract_select_queries(join.table)))
+            continue
 
         while join is not None:
             parent_name = join.table.chain[0]  # type: ignore

--- a/posthog/warehouse/models/test/test_modeling.py
+++ b/posthog/warehouse/models/test/test_modeling.py
@@ -22,9 +22,23 @@ from posthog.warehouse.models.modeling import (
         ),
         ("select 1", set()),
         (
-            "select * from (select * from (select * from events))",
-            {"events"},
+            """
+            select *
+            from (
+              select 1 as id, *
+              from events
+              inner join (
+                select * from
+                (
+                  select number
+                  from numbers(10)
+                )
+              ) num on events.id = num.number
+            )
+            """,
+            {"events", "numbers"},
         ),
+        ("select * from (select * from (select * from (select * from events)))", {"events"}),
     ],
 )
 def test_get_parents_from_model_query(query: str, parents: set[str]):

--- a/posthog/warehouse/models/test/test_modeling.py
+++ b/posthog/warehouse/models/test/test_modeling.py
@@ -21,6 +21,10 @@ from posthog.warehouse.models.modeling import (
             {"events"},
         ),
         ("select 1", set()),
+        (
+            "select * from (select * from (select * from events))",
+            {"events"},
+        ),
     ],
 )
 def test_get_parents_from_model_query(query: str, parents: set[str]):


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

When a query contains a nested subquery, we should continue resolving
queries until we get to the last one in parent extraction.

We were not parsing parents correctly when encountering a join in a
subquery. Now, we will traverse the subqueries down until we reach
something that is not a subquery, and hopefully that is something we
can associate with a parent.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Also added tests for both cases.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
