### PR TITLE
fix(error): Fix visit issue button for unmerged issues

### DIFF
--- a/posthog/api/error_tracking.py
+++ b/posthog/api/error_tracking.py
@@ -115,10 +115,11 @@ class ErrorTrackingIssueViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, view
             record = fingerprint_queryset.filter(fingerprint=fingerprint).first()
 
             if record:
-                if not record.issue_id == self.request.GET.get("pk"):
+                if not str(record.issue_id) == self.kwargs.get("pk"):
                     return JsonResponse({"issue_id": record.issue_id}, status=status.HTTP_308_PERMANENT_REDIRECT)
 
-                serializer = self.get_serializer(record.issue)
+                issue_with_first_seen = ErrorTrackingIssue.objects.with_first_seen().get(id=record.issue_id)
+                serializer = self.get_serializer(issue_with_first_seen)
                 return Response(serializer.data)
 
         return super().retrieve(request, *args, **kwargs)

--- a/posthog/api/test/test_error_tracking.py
+++ b/posthog/api/test/test_error_tracking.py
@@ -75,6 +75,16 @@ class TestErrorTracking(APIBaseTest):
         assert response.status_code == 308
         assert response.json() == {"issue_id": str(merged_issue.id)}
 
+    def test_issue_fingerprint_does_not_redirect_when_not_merged(self):
+        issue = self.create_issue(fingerprints=["fingerprint"])
+
+        # with fingerprint hint
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/error_tracking/issue/{issue.id}?fingerprint=fingerprint",
+        )
+        assert response.status_code == 200
+        assert response.json().get("id") == str(issue.id)
+
     @freeze_time("2025-01-01")
     def test_issue_fetch(self):
         issue = self.create_issue(["fingerprint"])


### PR DESCRIPTION
## Problem

Originally raised [on Slack](https://posthog.slack.com/archives/C07AA937K9A/p1744196748636189) and had a bit of time to investigate this afternoon as I was curious - when clicking the visit issue link for unmerged issues the page wouldn't load the issue. The problem was we were erroneously returning a 308 permanent redirect.

## Changes

Don't return a 308 if it's an unmerged issue.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Tested locally that:
- When clicking visit issue:
	- The redirect works correctly still for merged issues
	- Unmerged issues load properly
- Also added a test to test the before/after