### PR TITLE
fix(sql-editor): Dont get columns on view updates

### DIFF
--- a/posthog/warehouse/api/saved_query.py
+++ b/posthog/warehouse/api/saved_query.py
@@ -93,8 +93,8 @@ class DataWarehouseSavedQuerySerializer(serializers.ModelSerializer):
 
         view = DataWarehouseSavedQuery(**validated_data)
 
-        # The columns will be inferred from the query
         try:
+            # The columns will be inferred from the query
             client_types = self.context["request"].data.get("types", [])
             if len(client_types) == 0:
                 view.columns = view.get_columns()
@@ -145,7 +145,21 @@ class DataWarehouseSavedQuerySerializer(serializers.ModelSerializer):
             # Only update columns and status if the query has changed
             if "query" in validated_data:
                 try:
-                    view.columns = view.get_columns()
+                    # The columns will be inferred from the query
+                    client_types = self.context["request"].data.get("types", [])
+                    if len(client_types) == 0:
+                        view.columns = view.get_columns()
+                    else:
+                        columns = {
+                            str(item[0]): {
+                                "hogql": CLICKHOUSE_HOGQL_MAPPING[clean_type(str(item[1]))].__name__,
+                                "clickhouse": item[1],
+                                "valid": True,
+                            }
+                            for item in client_types
+                        }
+                        view.columns = columns
+
                     view.external_tables = view.s3_tables
                     view.status = DataWarehouseSavedQuery.Status.MODIFIED
                 except RecursionError:

--- a/posthog/warehouse/api/test/test_saved_query.py
+++ b/posthog/warehouse/api/test/test_saved_query.py
@@ -195,6 +195,35 @@ class TestSavedQuery(APIBaseTest):
             self.assertEqual(response.status_code, 200)
             mock_delete_saved_query_schedule.assert_called_once_with(saved_query["id"])
 
+    def test_update_with_types(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+            {
+                "name": "event_view",
+                "query": {
+                    "kind": "HogQLQuery",
+                    "query": "select event as event from events LIMIT 100",
+                },
+            },
+        )
+        self.assertEqual(response.status_code, 201)
+        saved_query = response.json()
+
+        with patch.object(DataWarehouseSavedQuery, "get_columns") as mock_get_columns:
+            response = self.client.patch(
+                f"/api/projects/{self.team.id}/warehouse_saved_queries/{saved_query['id']}",
+                {
+                    "name": "event_view",
+                    "query": {
+                        "kind": "HogQLQuery",
+                        "query": "select event as event from events LIMIT 100",
+                    },
+                    "types": [["event", "Nullable(String)"]],
+                },
+            )
+
+            mock_get_columns.assert_not_called()
+
     def test_delete_with_existing_schedule(self):
         response = self.client.post(
             f"/api/projects/{self.team.id}/warehouse_saved_queries/",


### PR DESCRIPTION
## Problem
- We try to run the saved query on the backend when we update a view, likely causing a timeout due to the query taking too long

## Changes
- Use the column types from the frontend

## Does this work well for both Cloud and self-hosted?
Yupp

## How did you test this code?
Added a test
