### PR TITLE
feat(navigation): Make SidePanelPaneHeader sticky

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/components/SidePanelPaneHeader.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/components/SidePanelPaneHeader.tsx
@@ -16,10 +16,10 @@ export function SidePanelPaneHeader({ children, title }: SidePanelPaneHeaderProp
 
     return (
         <header
-            className={clsx('border-b shrink-0 flex items-center justify-end gap-1', {
-                'p-1 h-10': !modalMode,
-                'pb-2 mt-2 mx-3': modalMode,
-            })}
+            className={clsx(
+                'border-b shrink-0 flex items-center justify-end gap-1',
+                !modalMode ? 'sticky top-0 z-10 bg-surface-secondary p-1 h-10' : 'pb-2 mt-2 mx-3'
+            )}
         >
             {title ? (
                 <h3

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelDocs.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelDocs.tsx
@@ -76,6 +76,7 @@ export const SidePanelDocs = (): JSX.Element => {
                         size="small"
                         value={activeMenuName ?? ''}
                         options={menuOptions.map(({ name, url }) => ({ label: name, value: url }))}
+                        className="shrink whitespace-nowrap overflow-hidden"
                     />
                 )}
 


### PR DESCRIPTION
## Problem

~~@haacked~~ @phixMe made a good point that the side panel header would be more intuitive if it were sticky. Honestly I thought it was already, but nope.

## Changes

Stickiness:

<img width="438" alt="Screenshot 2025-04-10 at 17 50 04" src="https://github.com/user-attachments/assets/69a42523-2d28-41fc-a704-cfb0114305a8" />