### PR TITLE
fix(bi): Fixed tabels not scrolling

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
@@ -198,7 +198,11 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
     }
 
     return (
-        <div className="DataVisualization flex flex-1 gap-2 h-full">
+        <div
+            className={clsx('DataVisualization flex flex-1 gap-2', {
+                'h-full': visualizationType !== ChartDisplayType.ActionsTable,
+            })}
+        >
             {!readOnly && showEditingUI && (
                 <div className="max-sm:hidden max-w-xs">
                     <DatabaseTableTreeWithItems inline />


### PR DESCRIPTION
## Problem
- DataViz tables no longer can scroll 😱 
- https://posthog.slack.com/archives/C019RAX2XBN/p1744299091619839

## Changes
- Remove the `h-full` class I added yday, but only for tables

