### PR TITLE
fix(sql-editor): Show legacy filters when using date range directly

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
@@ -858,7 +858,10 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
         showLegacyFilters: [
             (s) => [s.sourceQuery],
             (sourceQuery) => {
-                return sourceQuery.source.query.indexOf('{filters}') !== -1
+                return (
+                    sourceQuery.source.query.indexOf('{filters}') !== -1 ||
+                    sourceQuery.source.query.indexOf('{filters.') !== -1
+                )
             },
         ],
         dataLogicKey: [


### PR DESCRIPTION
## Problem
- We dont show the legacy date range picker when using `{filters.dateRange.to}` - we only covered the `{filters}` usecase
- https://posthog.slack.com/archives/C019RAX2XBN/p1744300913811989?thread_ts=1744300701.447669&cid=C019RAX2XBN
