### PR TITLE
fix(data-warehouse): Update data warehouse routing to use environments

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -823,7 +823,7 @@ class ApiRequest {
 
     // # Warehouse view
     public dataWarehouseSavedQueries(teamId?: TeamType['id']): ApiRequest {
-        return this.projectsDetail(teamId).addPathComponent('warehouse_saved_queries')
+        return this.environmentsDetail(teamId).addPathComponent('warehouse_saved_queries')
     }
     public dataWarehouseSavedQuery(id: DataWarehouseSavedQuery['id'], teamId?: TeamType['id']): ApiRequest {
         return this.dataWarehouseSavedQueries(teamId).addPathComponent(id)
@@ -836,14 +836,14 @@ class ApiRequest {
         offset = 0,
         teamId?: TeamType['id']
     ): ApiRequest {
-        return this.projectsDetail(teamId)
+        return this.environmentsDetail(teamId)
             .addPathComponent('data_modeling_jobs')
             .withQueryString({ saved_query_id: savedQueryId, limit: pageSize, offset })
     }
 
     // # Warehouse view link
     public dataWarehouseViewLinks(teamId?: TeamType['id']): ApiRequest {
-        return this.projectsDetail(teamId).addPathComponent('warehouse_view_link')
+        return this.environmentsDetail(teamId).addPathComponent('warehouse_view_link')
     }
     public dataWarehouseViewLink(id: DataWarehouseViewLink['id'], teamId?: TeamType['id']): ApiRequest {
         return this.dataWarehouseViewLinks(teamId).addPathComponent(id)

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -104,8 +104,8 @@ export const defaultMocks: Mocks = {
         '/api/projects/:team_id/feature_flags/:feature_flag_id/role_access': EMPTY_PAGINATED_RESPONSE,
         '/api/projects/:team_id/experiments/': EMPTY_PAGINATED_RESPONSE,
         '/api/environments/:team_id/explicit_members/': [],
-        '/api/projects/:team_id/warehouse_view_link/': EMPTY_PAGINATED_RESPONSE,
-        '/api/projects/:team_id/warehouse_saved_queries/': EMPTY_PAGINATED_RESPONSE,
+        '/api/environments/:team_id/warehouse_view_link/': EMPTY_PAGINATED_RESPONSE,
+        '/api/environments/:team_id/warehouse_saved_queries/': EMPTY_PAGINATED_RESPONSE,
         '/api/environments/:team_id/warehouse_tables/': EMPTY_PAGINATED_RESPONSE,
         '/api/organizations/@current/': (): MockSignature => [
             200,

--- a/frontend/src/scenes/data-management/database/DatabaseTable.tsx
+++ b/frontend/src/scenes/data-management/database/DatabaseTable.tsx
@@ -9,7 +9,7 @@ import { useCallback } from 'react'
 import { dataWarehouseJoinsLogic } from 'scenes/data-warehouse/external/dataWarehouseJoinsLogic'
 import { dataWarehouseSceneLogic } from 'scenes/data-warehouse/settings/dataWarehouseSceneLogic'
 import { viewLinkLogic } from 'scenes/data-warehouse/viewLinkLogic'
-import { projectLogic } from 'scenes/projectLogic'
+import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { DatabaseSchemaTable, DatabaseSerializedFieldType } from '~/queries/schema/schema-general'
@@ -46,7 +46,7 @@ const isNonEditableSchemaType = (schemaType: unknown): schemaType is NonEditable
     return typeof schemaType === 'string' && nonEditableSchemaTypes.includes(schemaType as NonEditableSchemaTypes)
 }
 const JoinsMoreMenu = ({ tableName, fieldName }: { tableName: string; fieldName: string }): JSX.Element => {
-    const { currentProjectId } = useValues(projectLogic)
+    const { currentTeamId } = useValues(teamLogic)
     const { toggleEditJoinModal } = useActions(viewLinkLogic)
     const { joins, joinsLoading } = useValues(dataWarehouseJoinsLogic)
     const { loadJoins } = useActions(dataWarehouseJoinsLogic)
@@ -68,7 +68,7 @@ const JoinsMoreMenu = ({ tableName, fieldName }: { tableName: string; fieldName:
                         fullWidth
                         onClick={() => {
                             void deleteWithUndo({
-                                endpoint: `projects/${currentProjectId}/warehouse_view_link`,
+                                endpoint: `environments/${currentTeamId}/warehouse_view_link`,
                                 object: {
                                     id: join.id,
                                     name: `${join.field_name} on ${join.source_table_name}`,

--- a/posthog/api/test/test_query.py
+++ b/posthog/api/test/test_query.py
@@ -6,14 +6,13 @@ from freezegun import freeze_time
 from rest_framework import status
 
 from posthog.api.services.query import process_query_dict
-
-
+from posthog.hogql.constants import LimitContext
 from posthog.models.insight_variable import InsightVariable
 from posthog.models.property_definition import PropertyDefinition, PropertyType
 from posthog.models.utils import UUIDT
-from posthog.hogql.constants import LimitContext
 from posthog.schema import (
     CachedEventsQueryResponse,
+    CachedHogQLQueryResponse,
     DataWarehouseNode,
     EventPropertyFilter,
     EventsQuery,
@@ -22,7 +21,6 @@ from posthog.schema import (
     HogQLQuery,
     PersonPropertyFilter,
     PropertyOperator,
-    CachedHogQLQueryResponse,
 )
 from posthog.test.base import (
     APIBaseTest,
@@ -85,7 +83,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                     "concat(event, ' ', properties.key)",
                 ]
             )
-            response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": query.dict()}).json()
+            response = self.client.post(f"/api/environments/{self.team.id}/query/", {"query": query.dict()}).json()
             self.assertEqual(
                 response,
                 response
@@ -108,7 +106,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             )
 
             query.select = ["*", "event"]
-            response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": query.dict()}).json()
+            response = self.client.post(f"/api/environments/{self.team.id}/query/", {"query": query.dict()}).json()
             self.assertEqual(response["columns"], ["*", "event"])
             self.assertIn("Tuple(", response["types"][0])
             self.assertEqual(response["types"][1], "String")
@@ -117,7 +115,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             self.assertIsInstance(response["results"][0][1], str)
 
             query.select = ["count()", "event"]
-            response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": query.dict()}).json()
+            response = self.client.post(f"/api/environments/{self.team.id}/query/", {"query": query.dict()}).json()
             self.assertEqual(
                 response,
                 response
@@ -132,7 +130,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             query.select = ["count()", "event"]
             query.where = ["event == 'sign up' or like(properties.key, '%val2')"]
             query.orderBy = ["count() DESC", "event"]
-            response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": query.dict()}).json()
+            response = self.client.post(f"/api/environments/{self.team.id}/query/", {"query": query.dict()}).json()
             self.assertEqual(
                 response,
                 response
@@ -194,19 +192,19 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 ]
             )
 
-            response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": query.dict()}).json()
+            response = self.client.post(f"/api/environments/{self.team.id}/query/", {"query": query.dict()}).json()
             self.assertEqual(len(response["results"]), 4)
 
             query.properties = [HogQLPropertyFilter(type="hogql", key="'a%sd' == 'foo'")]
-            response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": query.dict()}).json()
+            response = self.client.post(f"/api/environments/{self.team.id}/query/", {"query": query.dict()}).json()
             self.assertEqual(len(response["results"]), 0)
 
             query.properties = [HogQLPropertyFilter(type="hogql", key="'a%sd' == 'a%sd'")]
-            response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": query.dict()}).json()
+            response = self.client.post(f"/api/environments/{self.team.id}/query/", {"query": query.dict()}).json()
             self.assertEqual(len(response["results"]), 4)
 
             query.properties = [HogQLPropertyFilter(type="hogql", key="properties.key == 'test_val2'")]
-            response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": query.dict()}).json()
+            response = self.client.post(f"/api/environments/{self.team.id}/query/", {"query": query.dict()}).json()
             self.assertEqual(len(response["results"]), 2)
 
     @also_test_with_materialized_columns(event_properties=["key", "path"])
@@ -258,7 +256,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                     "concat(event, ' ', properties.key)",
                 ]
             )
-            response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": query.dict()}).json()
+            response = self.client.post(f"/api/environments/{self.team.id}/query/", {"query": query.dict()}).json()
             self.assertEqual(len(response["results"]), 4)
 
             query.properties = [
@@ -269,7 +267,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                     operator=PropertyOperator.EXACT,
                 )
             ]
-            response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": query.dict()}).json()
+            response = self.client.post(f"/api/environments/{self.team.id}/query/", {"query": query.dict()}).json()
             self.assertEqual(len(response["results"]), 1)
 
             query.properties = [
@@ -280,7 +278,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                     operator=PropertyOperator.ICONTAINS,
                 )
             ]
-            response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": query.dict()}).json()
+            response = self.client.post(f"/api/environments/{self.team.id}/query/", {"query": query.dict()}).json()
             self.assertEqual(len(response["results"]), 1)
 
     @also_test_with_materialized_columns(event_properties=["key"], person_properties=["email"])
@@ -340,14 +338,14 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                     )
                 ],
             )
-            response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": query.dict()}).json()
+            response = self.client.post(f"/api/environments/{self.team.id}/query/", {"query": query.dict()}).json()
             self.assertEqual(len(response["results"]), 2)
 
     def test_safe_clickhouse_error_passed_through(self):
         query = {"kind": "EventsQuery", "select": ["timestamp + 'string'"]}
 
         with freeze_time("2024-10-16 22:10:29.691212"):
-            response_post = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": query})
+            response_post = self.client.post(f"/api/environments/{self.team.id}/query/", {"query": query})
             self.assertEqual(response_post.status_code, status.HTTP_400_BAD_REQUEST)
 
             self.assertEqual(
@@ -366,7 +364,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
     def test_unsafe_clickhouse_error_is_swallowed(self, sqlparse_format_mock):
         query = {"kind": "EventsQuery", "select": ["timestamp"]}
 
-        response_post = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": query})
+        response_post = self.client.post(f"/api/environments/{self.team.id}/query/", {"query": query})
         self.assertEqual(response_post.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     @also_test_with_materialized_columns(event_properties=["key", "path"])
@@ -410,11 +408,11 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
 
         with freeze_time("2020-01-10 12:14:00"):
             query = EventsQuery(select=["properties.key", "count()"])
-            response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": query.dict()}).json()
+            response = self.client.post(f"/api/environments/{self.team.id}/query/", {"query": query.dict()}).json()
             self.assertEqual(len(response["results"]), 3)
 
             query.where = ["count() > 1"]
-            response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": query.dict()}).json()
+            response = self.client.post(f"/api/environments/{self.team.id}/query/", {"query": query.dict()}).json()
             self.assertEqual(len(response["results"]), 1)
 
     @snapshot_clickhouse_queries
@@ -457,7 +455,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
 
         with freeze_time("2020-01-10 12:14:00"):
             query = EventsQuery(select=["event", "person", "person -- P"])
-            response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": query.dict()}).json()
+            response = self.client.post(f"/api/environments/{self.team.id}/query/", {"query": query.dict()}).json()
             self.assertEqual(len(response["results"]), 4)
             self.assertEqual(response["results"][0][1], {"distinct_id": "4"})
             self.assertEqual(response["results"][1][1], {"distinct_id": "3"})
@@ -512,15 +510,15 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
 
         with freeze_time("2023-01-12 12:14:00"):
             query = EventsQuery(select=["event"], after="all")
-            response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": query.dict()}).json()
+            response = self.client.post(f"/api/environments/{self.team.id}/query/", {"query": query.dict()}).json()
             self.assertEqual(len(response["results"]), 4)
 
             query = EventsQuery(select=["event"], before="-1y", after="all")
-            response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": query.dict()}).json()
+            response = self.client.post(f"/api/environments/{self.team.id}/query/", {"query": query.dict()}).json()
             self.assertEqual(len(response["results"]), 3)
 
             query = EventsQuery(select=["event"], before="2022-01-01", after="-4y")
-            response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": query.dict()}).json()
+            response = self.client.post(f"/api/environments/{self.team.id}/query/", {"query": query.dict()}).json()
             self.assertEqual(len(response["results"]), 2)
 
     @also_test_with_materialized_columns(event_properties=["key"])
@@ -564,7 +562,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
 
         with freeze_time("2020-01-10 12:14:00"):
             query = HogQLQuery(query="select event, distinct_id, properties.key from events order by timestamp")
-            api_response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": query.dict()}).json()
+            api_response = self.client.post(f"/api/environments/{self.team.id}/query/", {"query": query.dict()}).json()
             response = CachedHogQLQueryResponse.model_validate(api_response)
 
             self.assertEqual(response.results and len(response.results), 4)
@@ -586,7 +584,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 "query": "SELECT event from events",
             },
         }
-        response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": query})
+        response = self.client.post(f"/api/environments/{self.team.id}/query/", {"query": query})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_query_not_supported(self):
@@ -594,7 +592,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
             "kind": "SavedInsightNode",
             "shortId": "123",
         }
-        response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": query})
+        response = self.client.post(f"/api/environments/{self.team.id}/query/", {"query": query})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json()["detail"], "Unsupported query kind: SavedInsightNode", response.content)
 
@@ -729,7 +727,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.columns, ["event"])
 
     def test_invalid_query_kind(self):
-        api_response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": {"kind": "Tomato Soup"}})
+        api_response = self.client.post(f"/api/environments/{self.team.id}/query/", {"query": {"kind": "Tomato Soup"}})
         self.assertEqual(api_response.status_code, 400)
         self.assertEqual(api_response.json()["code"], "parse_error")
         self.assertIn("1 validation error for QueryRequest", api_response.json()["detail"], api_response.content)
@@ -742,7 +740,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
     def test_funnel_query_with_data_warehouse_node_temporarily_raises(self):
         # As of September 2024, funnels don't support data warehouse tables YET, so we want a helpful error message
         api_response = self.client.post(
-            f"/api/projects/{self.team.id}/query/",
+            f"/api/environments/{self.team.id}/query/",
             {
                 "query": FunnelsQuery(
                     series=[
@@ -773,11 +771,11 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
         )
 
     def test_missing_query(self):
-        api_response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": {}})
+        api_response = self.client.post(f"/api/environments/{self.team.id}/query/", {"query": {}})
         self.assertEqual(api_response.status_code, 400)
 
     def test_missing_body(self):
-        api_response = self.client.post(f"/api/projects/{self.team.id}/query/")
+        api_response = self.client.post(f"/api/environments/{self.team.id}/query/")
         self.assertEqual(api_response.status_code, 400)
 
     @snapshot_clickhouse_queries
@@ -820,7 +818,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
 
         with freeze_time("2020-01-10 12:14:00"):
             self.client.post(
-                f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+                f"/api/environments/{self.team.id}/warehouse_saved_queries/",
                 {
                     "name": "event_view",
                     "query": {
@@ -830,7 +828,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 },
             )
             query = HogQLQuery(query="select * from event_view")
-            api_response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": query.dict()})
+            api_response = self.client.post(f"/api/environments/{self.team.id}/query/", {"query": query.dict()})
             response = CachedHogQLQueryResponse.model_validate(api_response.json())
 
             self.assertEqual(api_response.status_code, 200)
@@ -872,7 +870,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
         with freeze_time("2020-01-10 12:14:00"):
             query = HogQLQuery(query="select * from events")
             api_response = self.client.post(
-                f"/api/projects/{self.team.id}/query/", {"query": query.dict(), "refresh": "force_async"}
+                f"/api/environments/{self.team.id}/query/", {"query": query.dict(), "refresh": "force_async"}
             )
 
             self.assertEqual(api_response.status_code, 202)  # This means "Accepted" (for processing)
@@ -1019,7 +1017,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
         variable_override_value = "helloooooo"
 
         api_response = self.client.post(
-            f"/api/projects/{self.team.id}/query/",
+            f"/api/environments/{self.team.id}/query/",
             {
                 "query": {
                     "kind": "HogQLQuery",
@@ -1103,13 +1101,13 @@ class TestQueryRetrieve(APIBaseTest):
                 "results": ["result1", "result2"],
             }
         ).encode()
-        response = self.client.get(f"/api/projects/{self.team.id}/query/{self.valid_query_id}/")
+        response = self.client.get(f"/api/environments/{self.team.id}/query/{self.valid_query_id}/")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["query_status"]["complete"], True, response.content)
 
     def test_with_invalid_query_id(self):
         self.redis_client_mock.get.return_value = None
-        response = self.client.get(f"/api/projects/{self.team.id}/query/{self.invalid_query_id}/")
+        response = self.client.get(f"/api/environments/{self.team.id}/query/{self.invalid_query_id}/")
         self.assertEqual(response.status_code, 404)
 
     def test_completed_query(self):
@@ -1121,7 +1119,7 @@ class TestQueryRetrieve(APIBaseTest):
                 "results": ["result1", "result2"],
             }
         ).encode()
-        response = self.client.get(f"/api/projects/{self.team.id}/query/{self.valid_query_id}/")
+        response = self.client.get(f"/api/environments/{self.team.id}/query/{self.valid_query_id}/")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.json()["query_status"]["complete"])
 
@@ -1133,7 +1131,7 @@ class TestQueryRetrieve(APIBaseTest):
                 "complete": False,
             }
         ).encode()
-        response = self.client.get(f"/api/projects/{self.team.id}/query/{self.valid_query_id}/")
+        response = self.client.get(f"/api/environments/{self.team.id}/query/{self.valid_query_id}/")
         self.assertEqual(response.status_code, 202)
         self.assertFalse(response.json()["query_status"]["complete"])
 
@@ -1146,7 +1144,7 @@ class TestQueryRetrieve(APIBaseTest):
                 "error_message": None,
             }
         ).encode()
-        response = self.client.get(f"/api/projects/{self.team.id}/query/{self.valid_query_id}/")
+        response = self.client.get(f"/api/environments/{self.team.id}/query/{self.valid_query_id}/")
         self.assertEqual(response.status_code, 500)
         self.assertTrue(response.json()["query_status"]["error"])
 
@@ -1159,7 +1157,7 @@ class TestQueryRetrieve(APIBaseTest):
                 "error_message": "Try changing the time range",
             }
         ).encode()
-        response = self.client.get(f"/api/projects/{self.team.id}/query/{self.valid_query_id}/")
+        response = self.client.get(f"/api/environments/{self.team.id}/query/{self.valid_query_id}/")
         self.assertEqual(response.status_code, 400)
         self.assertTrue(response.json()["query_status"]["error"])
 
@@ -1172,7 +1170,7 @@ class TestQueryRetrieve(APIBaseTest):
                 "error_message": "Query failed",
             }
         ).encode()
-        response = self.client.delete(f"/api/projects/{self.team.id}/query/{self.valid_query_id}/")
+        response = self.client.delete(f"/api/environments/{self.team.id}/query/{self.valid_query_id}/")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(self.redis_client_mock.delete.call_count, 2)
 
@@ -1180,7 +1178,9 @@ class TestQueryRetrieve(APIBaseTest):
 class TestQueryDraftSql(APIBaseTest):
     @patch("posthog.hogql.ai.hit_openai", return_value=("SELECT 1", 21, 37))
     def test_draft_sql(self, hit_openai_mock):
-        response = self.client.get(f"/api/projects/{self.team.id}/query/draft_sql/", {"prompt": "I need the number 1"})
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/query/draft_sql/", {"prompt": "I need the number 1"}
+        )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"sql": "SELECT 1"})
         hit_openai_mock.assert_called_once()

--- a/posthog/hogql/test/test_metadata.py
+++ b/posthog/hogql/test/test_metadata.py
@@ -286,7 +286,7 @@ class TestMetadata(ClickhouseTestMixin, APIBaseTest):
 
     def test_valid_view_nested_view(self):
         saved_query_response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
             {
                 "name": "event_view",
                 "query": {

--- a/posthog/warehouse/api/test/test_datamodelingjob.py
+++ b/posthog/warehouse/api/test/test_datamodelingjob.py
@@ -1,7 +1,8 @@
 from django.utils import timezone
+
+from posthog.models.team.team import Team
 from posthog.test.base import APIBaseTest
 from posthog.warehouse.models.data_modeling_job import DataModelingJob
-from posthog.models.team.team import Team
 from posthog.warehouse.models.datawarehouse_saved_query import DataWarehouseSavedQuery
 
 
@@ -49,7 +50,7 @@ class TestDataModelingJob(APIBaseTest):
         )
 
     def test_list_data_modeling_jobs(self):
-        response = self.client.get(f"/api/projects/{self.team.pk}/data_modeling_jobs/")
+        response = self.client.get(f"/api/environments/{self.team.pk}/data_modeling_jobs/")
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -69,7 +70,7 @@ class TestDataModelingJob(APIBaseTest):
         self.assertEqual(first_job["error"], "Something went wrong")
 
     def test_retrieve_data_modeling_job(self):
-        response = self.client.get(f"/api/projects/{self.team.pk}/data_modeling_jobs/{self.job1.id}/")
+        response = self.client.get(f"/api/environments/{self.team.pk}/data_modeling_jobs/{self.job1.id}/")
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -86,7 +87,7 @@ class TestDataModelingJob(APIBaseTest):
         )
 
         response = self.client.get(
-            f"/api/projects/{self.team.pk}/data_modeling_jobs/?saved_query_id={self.saved_query.id}"
+            f"/api/environments/{self.team.pk}/data_modeling_jobs/?saved_query_id={self.saved_query.id}"
         )
         self.assertEqual(response.status_code, 200)
 
@@ -97,7 +98,7 @@ class TestDataModelingJob(APIBaseTest):
         self.assertNotIn(str(other_job.id), [job["id"] for job in results])
 
         response = self.client.get(
-            f"/api/projects/{self.team.pk}/data_modeling_jobs/?saved_query_id={other_saved_query.id}"
+            f"/api/environments/{self.team.pk}/data_modeling_jobs/?saved_query_id={other_saved_query.id}"
         )
         self.assertEqual(response.status_code, 200)
 
@@ -108,10 +109,10 @@ class TestDataModelingJob(APIBaseTest):
         self.assertEqual(results[0]["id"], str(other_job.id))
 
     def test_cannot_access_other_teams_jobs(self):
-        response = self.client.get(f"/api/projects/{self.team.pk}/data_modeling_jobs/{self.other_team_job.id}/")
+        response = self.client.get(f"/api/environments/{self.team.pk}/data_modeling_jobs/{self.other_team_job.id}/")
         self.assertEqual(response.status_code, 404)
 
-        response = self.client.get(f"/api/projects/{self.team.pk}/data_modeling_jobs/")
+        response = self.client.get(f"/api/environments/{self.team.pk}/data_modeling_jobs/")
         self.assertEqual(response.status_code, 200)
 
         job_ids = [job["id"] for job in response.json()["results"]]

--- a/posthog/warehouse/api/test/test_saved_query.py
+++ b/posthog/warehouse/api/test/test_saved_query.py
@@ -1,5 +1,5 @@
-from unittest.mock import patch
 import uuid
+from unittest.mock import patch
 
 from posthog.test.base import APIBaseTest
 from posthog.warehouse.models import DataWarehouseModelPath, DataWarehouseSavedQuery
@@ -8,7 +8,7 @@ from posthog.warehouse.models import DataWarehouseModelPath, DataWarehouseSavedQ
 class TestSavedQuery(APIBaseTest):
     def test_create(self):
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
             {
                 "name": "event_view",
                 "query": {
@@ -38,7 +38,7 @@ class TestSavedQuery(APIBaseTest):
     def test_create_with_types(self):
         with patch.object(DataWarehouseSavedQuery, "get_columns") as mock_get_columns:
             response = self.client.post(
-                f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+                f"/api/environments/{self.team.id}/warehouse_saved_queries/",
                 {
                     "name": "event_view",
                     "query": {
@@ -67,7 +67,7 @@ class TestSavedQuery(APIBaseTest):
 
     def test_create_name_overlap_error(self):
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
             {
                 "name": "events",
                 "query": {
@@ -84,7 +84,7 @@ class TestSavedQuery(APIBaseTest):
 
         with patch("posthog.warehouse.api.saved_query.delete_saved_query_schedule") as mock_delete_saved_query_schedule:
             response = self.client.delete(
-                f"/api/projects/{self.team.id}/warehouse_saved_queries/{saved_query.id}",
+                f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query.id}",
             )
 
             mock_delete_saved_query_schedule.assert_called()
@@ -118,7 +118,7 @@ class TestSavedQuery(APIBaseTest):
         )
 
         response = self.client.get(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
         )
 
         assert response.status_code == 200
@@ -138,14 +138,14 @@ class TestSavedQuery(APIBaseTest):
         )
 
         response = self.client.get(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/{query.id}",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/{query.id}",
         )
 
         assert response.status_code == 404
 
     def test_update_sync_frequency_with_existing_schedule(self):
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
             {
                 "name": "event_view",
                 "query": {
@@ -164,7 +164,7 @@ class TestSavedQuery(APIBaseTest):
             mock_saved_query_workflow_exists.return_value = True
 
             response = self.client.patch(
-                f"/api/projects/{self.team.id}/warehouse_saved_queries/{saved_query['id']}",
+                f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query['id']}",
                 {"sync_frequency": "24hour"},
             )
 
@@ -174,7 +174,7 @@ class TestSavedQuery(APIBaseTest):
 
     def test_update_sync_frequency_to_never(self):
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
             {
                 "name": "event_view",
                 "query": {
@@ -188,7 +188,7 @@ class TestSavedQuery(APIBaseTest):
 
         with patch("posthog.warehouse.api.saved_query.delete_saved_query_schedule") as mock_delete_saved_query_schedule:
             response = self.client.patch(
-                f"/api/projects/{self.team.id}/warehouse_saved_queries/{saved_query['id']}",
+                f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query['id']}",
                 {"sync_frequency": "never"},
             )
 
@@ -226,7 +226,7 @@ class TestSavedQuery(APIBaseTest):
 
     def test_delete_with_existing_schedule(self):
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
             {
                 "name": "event_view",
                 "query": {
@@ -240,7 +240,7 @@ class TestSavedQuery(APIBaseTest):
 
         with patch("posthog.warehouse.api.saved_query.delete_saved_query_schedule") as mock_delete_saved_query_schedule:
             response = self.client.delete(
-                f"/api/projects/{self.team.id}/warehouse_saved_queries/{saved_query['id']}",
+                f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query['id']}",
             )
 
             self.assertEqual(response.status_code, 204)
@@ -248,7 +248,7 @@ class TestSavedQuery(APIBaseTest):
 
     def test_saved_query_doesnt_exist(self):
         saved_query_1_response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
             {
                 "name": "event_view",
                 "query": {
@@ -261,7 +261,7 @@ class TestSavedQuery(APIBaseTest):
 
     def test_view_updated(self):
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
             {
                 "name": "event_view",
                 "query": {
@@ -273,7 +273,7 @@ class TestSavedQuery(APIBaseTest):
         self.assertEqual(response.status_code, 201, response.content)
         saved_query_1_response = response.json()
         saved_query_1_response = self.client.patch(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/" + saved_query_1_response["id"],
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/" + saved_query_1_response["id"],
             {
                 "query": {
                     "kind": "HogQLQuery",
@@ -302,7 +302,7 @@ class TestSavedQuery(APIBaseTest):
 
     def test_nested_view(self):
         saved_query_1_response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
             {
                 "name": "event_view",
                 "query": {
@@ -314,7 +314,7 @@ class TestSavedQuery(APIBaseTest):
         self.assertEqual(saved_query_1_response.status_code, 201, saved_query_1_response.content)
 
         saved_view_2_response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
             {
                 "name": "outer_event_view",
                 "query": {
@@ -327,7 +327,7 @@ class TestSavedQuery(APIBaseTest):
 
     def test_create_with_saved_query(self):
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
             {
                 "name": "event_view",
                 "query": {
@@ -345,7 +345,7 @@ class TestSavedQuery(APIBaseTest):
 
     def test_create_with_nested_saved_query(self):
         response_1 = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
             {
                 "name": "event_view",
                 "query": {
@@ -357,7 +357,7 @@ class TestSavedQuery(APIBaseTest):
         self.assertEqual(response_1.status_code, 201, response_1.content)
 
         response_2 = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
             {
                 "name": "event_view_2",
                 "query": {
@@ -388,7 +388,7 @@ class TestSavedQuery(APIBaseTest):
         """
 
         response_parent = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
             {
                 "name": "event_view",
                 "query": {
@@ -399,7 +399,7 @@ class TestSavedQuery(APIBaseTest):
         )
 
         response_child = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
             {
                 "name": "event_view_2",
                 "query": {
@@ -414,7 +414,7 @@ class TestSavedQuery(APIBaseTest):
 
         saved_query_parent_id = response_parent.json()["id"]
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/{saved_query_parent_id}/ancestors",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query_parent_id}/ancestors",
         )
 
         self.assertEqual(response.status_code, 200, response.content)
@@ -424,7 +424,7 @@ class TestSavedQuery(APIBaseTest):
 
         saved_query_child_id = response_child.json()["id"]
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/{saved_query_child_id}/ancestors",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query_child_id}/ancestors",
         )
 
         self.assertEqual(response.status_code, 200, response.content)
@@ -433,7 +433,7 @@ class TestSavedQuery(APIBaseTest):
         self.assertEqual(child_ancestors, sorted([saved_query_parent_id, "events", "persons"]))
 
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/{saved_query_child_id}/ancestors", {"level": 1}
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query_child_id}/ancestors", {"level": 1}
         )
 
         self.assertEqual(response.status_code, 200, response.content)
@@ -442,7 +442,7 @@ class TestSavedQuery(APIBaseTest):
         self.assertEqual(child_ancestors_level_1, [saved_query_parent_id])
 
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/{saved_query_child_id}/ancestors", {"level": 2}
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query_child_id}/ancestors", {"level": 2}
         )
         self.assertEqual(response.status_code, 200, response.content)
         child_ancestors_level_2 = response.json()["ancestors"]
@@ -450,7 +450,7 @@ class TestSavedQuery(APIBaseTest):
         self.assertEqual(child_ancestors_level_2, sorted([saved_query_parent_id, "events", "persons"]))
 
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/{saved_query_child_id}/ancestors", {"level": 10}
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query_child_id}/ancestors", {"level": 10}
         )
         self.assertEqual(response.status_code, 200, response.content)
         child_ancestors_level_10 = response.json()["ancestors"]
@@ -468,7 +468,7 @@ class TestSavedQuery(APIBaseTest):
         """
 
         response_parent = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
             {
                 "name": "event_view",
                 "query": {
@@ -479,7 +479,7 @@ class TestSavedQuery(APIBaseTest):
         )
 
         response_child = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
             {
                 "name": "event_view_2",
                 "query": {
@@ -490,7 +490,7 @@ class TestSavedQuery(APIBaseTest):
         )
 
         response_grand_child = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
             {
                 "name": "event_view_3",
                 "query": {
@@ -508,7 +508,7 @@ class TestSavedQuery(APIBaseTest):
         saved_query_child_id = response_child.json()["id"]
         saved_query_grand_child_id = response_grand_child.json()["id"]
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/{saved_query_parent_id}/descendants",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query_parent_id}/descendants",
         )
 
         self.assertEqual(response.status_code, 200, response.content)
@@ -519,7 +519,8 @@ class TestSavedQuery(APIBaseTest):
         )
 
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/{saved_query_parent_id}/descendants", {"level": 1}
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query_parent_id}/descendants",
+            {"level": 1},
         )
 
         self.assertEqual(response.status_code, 200, response.content)
@@ -530,7 +531,8 @@ class TestSavedQuery(APIBaseTest):
         )
 
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/{saved_query_parent_id}/descendants", {"level": 2}
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query_parent_id}/descendants",
+            {"level": 2},
         )
 
         self.assertEqual(response.status_code, 200, response.content)
@@ -541,7 +543,7 @@ class TestSavedQuery(APIBaseTest):
         )
 
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/{saved_query_child_id}/descendants",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query_child_id}/descendants",
         )
 
         self.assertEqual(response.status_code, 200, response.content)
@@ -549,7 +551,7 @@ class TestSavedQuery(APIBaseTest):
         self.assertEqual(child_ancestors, [saved_query_grand_child_id])
 
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/{saved_query_grand_child_id}/descendants",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query_grand_child_id}/descendants",
         )
 
         self.assertEqual(response.status_code, 200, response.content)
@@ -559,7 +561,7 @@ class TestSavedQuery(APIBaseTest):
     def test_update_without_query_change_doesnt_call_get_columns(self):
         # First create a saved query
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
             {
                 "name": "event_view",
                 "query": {
@@ -574,7 +576,7 @@ class TestSavedQuery(APIBaseTest):
         # Now update it without changing the query
         with patch.object(DataWarehouseSavedQuery, "get_columns") as mock_get_columns:
             response = self.client.patch(
-                f"/api/projects/{self.team.id}/warehouse_saved_queries/{saved_query['id']}",
+                f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query['id']}",
                 {"name": "updated_event_view"},  # Only changing the name, not the query
             )
 
@@ -588,7 +590,7 @@ class TestSavedQuery(APIBaseTest):
     def test_update_with_query_change_calls_get_columns(self):
         # First create a saved query
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
             {
                 "name": "event_view",
                 "query": {
@@ -604,7 +606,7 @@ class TestSavedQuery(APIBaseTest):
         with patch.object(DataWarehouseSavedQuery, "get_columns") as mock_get_columns:
             mock_get_columns.return_value = {}
             response = self.client.patch(
-                f"/api/projects/{self.team.id}/warehouse_saved_queries/{saved_query['id']}",
+                f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query['id']}",
                 {
                     "query": {
                         "kind": "HogQLQuery",

--- a/posthog/warehouse/api/test/test_view.py
+++ b/posthog/warehouse/api/test/test_view.py
@@ -7,7 +7,7 @@ from posthog.warehouse.models import DataWarehouseSavedQuery
 class TestView(APIBaseTest):
     def test_create(self):
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
             {
                 "name": "event_view",
                 "query": {
@@ -36,7 +36,7 @@ class TestView(APIBaseTest):
 
     def test_view_doesnt_exist(self):
         view_1_response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
             {
                 "name": "event_view",
                 "query": {
@@ -49,7 +49,7 @@ class TestView(APIBaseTest):
 
     def test_view_updated(self):
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
             {
                 "name": "event_view",
                 "query": {
@@ -61,7 +61,7 @@ class TestView(APIBaseTest):
         self.assertEqual(response.status_code, 201, response.content)
         view = response.json()
         view_1_response = self.client.patch(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/" + view["id"],
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/" + view["id"],
             {
                 "query": {
                     "kind": "HogQLQuery",
@@ -102,7 +102,7 @@ class TestView(APIBaseTest):
     @patch("posthog.tasks.warehouse.get_ph_client")
     def test_view_with_external_table(self, patch_get_columns_1, patch_get_columns_2, patch_get_ph_client):
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_tables/",
+            f"/api/environments/{self.team.id}/warehouse_tables/",
             {
                 "name": "whatever",
                 "url_pattern": "https://your-org.s3.amazonaws.com/bucket/whatever.pqt",
@@ -117,7 +117,7 @@ class TestView(APIBaseTest):
         response = response.json()
 
         view_1_response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_saved_queries/",
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
             {
                 "name": "event_view",
                 "query": {
@@ -130,6 +130,6 @@ class TestView(APIBaseTest):
 
         self.assertEqual(DataWarehouseSavedQuery.objects.all().count(), 1)
 
-        response = self.client.delete(f"/api/projects/{self.team.id}/warehouse_tables/{response['id']}")
+        response = self.client.delete(f"/api/environments/{self.team.id}/warehouse_tables/{response['id']}")
 
         self.assertEqual(DataWarehouseSavedQuery.objects.all().count(), 1)

--- a/posthog/warehouse/api/test/test_view_link.py
+++ b/posthog/warehouse/api/test/test_view_link.py
@@ -5,7 +5,7 @@ from posthog.warehouse.models import DataWarehouseJoin
 class TestViewLinkQuery(APIBaseTest):
     def test_create(self):
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_view_links/",
+            f"/api/environments/{self.team.id}/warehouse_view_links/",
             {
                 "source_table_name": "events",
                 "joining_table_name": "persons",
@@ -35,7 +35,7 @@ class TestViewLinkQuery(APIBaseTest):
 
     def test_create_with_configuration(self):
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_view_links/",
+            f"/api/environments/{self.team.id}/warehouse_view_links/",
             {
                 "source_table_name": "events",
                 "joining_table_name": "persons",
@@ -65,7 +65,7 @@ class TestViewLinkQuery(APIBaseTest):
 
     def test_create_key_error(self):
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_view_links/",
+            f"/api/environments/{self.team.id}/warehouse_view_links/",
             {
                 "source_table_name": "eventssss",
                 "joining_table_name": "persons",
@@ -78,7 +78,7 @@ class TestViewLinkQuery(APIBaseTest):
 
     def test_create_saved_query_key_error(self):
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_view_links/",
+            f"/api/environments/{self.team.id}/warehouse_view_links/",
             {
                 "source_table_name": "eventssss",
                 "joining_table_name": "persons",
@@ -91,7 +91,7 @@ class TestViewLinkQuery(APIBaseTest):
 
     def test_create_saved_query_join_key_function(self):
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_view_links/",
+            f"/api/environments/{self.team.id}/warehouse_view_links/",
             {
                 "source_table_name": "events",
                 "joining_table_name": "persons",
@@ -115,7 +115,7 @@ class TestViewLinkQuery(APIBaseTest):
         join.save()
 
         response = self.client.patch(
-            f"/api/projects/{self.team.id}/warehouse_view_links/{join.id}/",
+            f"/api/environments/{self.team.id}/warehouse_view_links/{join.id}/",
             {"configuration": {"experiments_optimized": True, "experiments_timestamp_key": "timestamp"}},
         )
         self.assertEqual(response.status_code, 200, response.content)
@@ -140,7 +140,7 @@ class TestViewLinkQuery(APIBaseTest):
 
     def test_delete(self):
         response = self.client.post(
-            f"/api/projects/{self.team.id}/warehouse_view_links/",
+            f"/api/environments/{self.team.id}/warehouse_view_links/",
             {
                 "source_table_name": "events",
                 "joining_table_name": "persons",
@@ -152,7 +152,7 @@ class TestViewLinkQuery(APIBaseTest):
         self.assertEqual(response.status_code, 201, response.content)
         view_link = response.json()
 
-        response = self.client.delete(f"/api/projects/{self.team.id}/warehouse_view_links/{view_link['id']}")
+        response = self.client.delete(f"/api/environments/{self.team.id}/warehouse_view_links/{view_link['id']}")
         self.assertEqual(response.status_code, 204, response.content)
 
         self.assertEqual(DataWarehouseJoin.objects.all().count(), 0)


### PR DESCRIPTION
## Problem

Some features of data warehouse still don't support environments, such as saved queries.

## Changes

Update the routing on the front end to route by environment rather than project.

This affects the following routes:

- `/warehouse_saved_queries`
- `/data_modeling_jobs`
- `/warehouse_view_link`

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Local testing.
Existing tests.
