### PR TITLE
fix: Prevent materialization job from failing when some shards require more work than others

### DIFF
--- a/dags/materialized_columns.py
+++ b/dags/materialized_columns.py
@@ -137,8 +137,8 @@ class MaterializationConfig(dagster.Config):
                 commands.add(f"MATERIALIZE INDEX {index} IN PARTITION %(partition)s")
 
             if commands:
-                mutations[partition].append(
-                    AlterTableMutationRunner(self.table, commands, parameters={"partition": partition})
+                mutations[partition] = AlterTableMutationRunner(
+                    self.table, commands, parameters={"partition": partition}
                 )
 
         return mutations

--- a/dags/materialized_columns.py
+++ b/dags/materialized_columns.py
@@ -13,12 +13,10 @@ from dags.common import JobOwners
 from posthog import settings
 from posthog.clickhouse.cluster import AlterTableMutationRunner, ClickhouseCluster, HostInfo
 
-K = TypeVar("K")
-V = TypeVar("V")
-
 
 K1 = TypeVar("K1")
 K2 = TypeVar("K2")
+V = TypeVar("V")
 
 
 def join_mappings(mappings: Mapping[K1, Mapping[K2, V]]) -> Mapping[K2, Mapping[K1, V]]:

--- a/dags/materialized_columns.py
+++ b/dags/materialized_columns.py
@@ -1,7 +1,7 @@
 import datetime
 import itertools
 from collections import defaultdict
-from collections.abc import Iterable, Iterator, Mapping, Sequence
+from collections.abc import Iterator, Mapping
 from typing import ClassVar, TypeVar, cast
 
 import dagster
@@ -17,21 +17,26 @@ K = TypeVar("K")
 V = TypeVar("V")
 
 
-def zip_values(mapping: Mapping[K, Iterable[V]]) -> Iterator[Mapping[K, V]]:
-    """
-    Takes a mapping that contains values of sequences if identical lengths, returns an iterator of dictionaries for each
-    index in the sequence, with keys for each value taken from the input mapping.
-    """
-    keys, values = [], []
-    for key, value in mapping.items():
-        keys.append(key)
-        values.append(value)
+K1 = TypeVar("K1")
+K2 = TypeVar("K2")
 
-    if len({len(value) for value in values}) > 1:
-        raise ValueError("expected all value sequences to be of the same length")
 
-    for chunk in zip(*values):
-        yield dict(zip(keys, chunk))
+def join_mappings(mappings: Mapping[K1, Mapping[K2, V]]) -> Mapping[K2, Mapping[K1, V]]:
+    outer_keys = set()
+    for inner_mapping in mappings.values():
+        outer_keys.update(inner_mapping.keys())
+
+    result = {}
+    for outer_key in outer_keys:
+        result[outer_key] = {}
+        for inner_key, inner_mapping in mappings.items():
+            if outer_key in inner_mapping:
+                result[outer_key][inner_key] = inner_mapping[outer_key]
+
+    return result
+
+
+PartitionId = str
 
 
 class PartitionRange(dagster.Config):
@@ -47,7 +52,7 @@ class PartitionRange(dagster.Config):
         while (date := date_lower + relativedelta(months=next(seq))) <= date_upper:
             yield date
 
-    def iter_ids(self) -> Iterator[str]:
+    def iter_ids(self) -> Iterator[PartitionId]:
         for date in self.iter_dates():
             yield date.strftime(self.FORMAT)
 
@@ -74,7 +79,7 @@ class MaterializationConfig(dagster.Config):
     indexes: list[str]
     partitions: PartitionRange  # TODO: make optional for non-partitioned tables
 
-    def get_mutations_to_run(self, client: Client) -> Sequence[AlterTableMutationRunner]:
+    def get_mutations_to_run(self, client: Client) -> Mapping[PartitionId, AlterTableMutationRunner]:
         # The primary key column(s) should exist in all parts, so we can determine what parts (and partitions) do not
         # have the target column materialized by finding parts where the key column exists but the target column does
         # not.
@@ -120,9 +125,9 @@ class MaterializationConfig(dagster.Config):
             for [partition] in results:
                 columns_remaining_by_partition[partition].add(column)
 
-        mutations = []
+        mutations = {}
 
-        for partition in reversed([*self.partitions.iter_ids()]):
+        for partition in self.partitions.iter_ids():
             commands = set()
 
             for column in columns_remaining_by_partition[partition]:
@@ -134,7 +139,9 @@ class MaterializationConfig(dagster.Config):
                 commands.add(f"MATERIALIZE INDEX {index} IN PARTITION %(partition)s")
 
             if commands:
-                mutations.append(AlterTableMutationRunner(self.table, commands, parameters={"partition": partition}))
+                mutations[partition].append(
+                    AlterTableMutationRunner(self.table, commands, parameters={"partition": partition})
+                )
 
         return mutations
 
@@ -165,8 +172,9 @@ def run_materialize_mutations(
         cluster.map_one_host_per_shard(config.get_mutations_to_run).result()
     )
 
-    for mutations in zip_values(mutations_to_run_by_shard):
-        shard_waiters = _convert_hostinfo_keys_to_shard_num(cluster.map_any_host_in_shards(mutations).result())
+    shard_mutations_to_run_by_partition = join_mappings(mutations_to_run_by_shard)
+    for _partition, shard_mutations in shard_mutations_to_run_by_partition.items():  # TODO: sort
+        shard_waiters = _convert_hostinfo_keys_to_shard_num(cluster.map_any_host_in_shards(shard_mutations).result())
         cluster.map_all_hosts_in_shards(shard_waiters).result()
 
 

--- a/dags/materialized_columns.py
+++ b/dags/materialized_columns.py
@@ -173,9 +173,11 @@ def run_materialize_mutations(
     )
 
     shard_mutations_to_run_by_partition = join_mappings(mutations_to_run_by_shard)
-    for _partition, shard_mutations in shard_mutations_to_run_by_partition.items():  # TODO: sort
+    for partition_id, shard_mutations in sorted(shard_mutations_to_run_by_partition.items(), reverse=True):
+        context.log.info("Starting %s materializations for partition %r...", len(shard_mutations), partition_id)
         shard_waiters = _convert_hostinfo_keys_to_shard_num(cluster.map_any_host_in_shards(shard_mutations).result())
         cluster.map_all_hosts_in_shards(shard_waiters).result()
+        context.log.info("Completed materializations for partition %r!", partition_id)
 
 
 @dagster.job(tags={"owner": JobOwners.TEAM_CLICKHOUSE.value})

--- a/dags/tests/test_materialized_columns.py
+++ b/dags/tests/test_materialized_columns.py
@@ -100,7 +100,7 @@ def test_sharded_table_job(cluster: ClickhouseCluster):
             ).result()
             for _shard_host, shard_mutations in remaining_partitions_by_shard.items():
                 assert len(shard_mutations) == 3
-                for mutation in shard_mutations:
+                for mutation in shard_mutations.values():
                     # mutations should only be for the column
                     assert all("MATERIALIZE COLUMN" in command for command in mutation.commands)
 
@@ -121,7 +121,7 @@ def test_sharded_table_job(cluster: ClickhouseCluster):
                 materialize_column_config.get_mutations_to_run
             ).result()
             for _shard_host, shard_mutations in remaining_partitions_by_shard.items():
-                assert shard_mutations == []
+                assert shard_mutations == {}
 
             # XXX: if ee.* not importable, this text should have been xfailed by the materialize context manager
             from ee.clickhouse.materialized_columns.columns import get_minmax_index_name
@@ -138,7 +138,7 @@ def test_sharded_table_job(cluster: ClickhouseCluster):
             ).result()
             for _shard_host, shard_mutations in remaining_partitions_by_shard.items():
                 assert len(shard_mutations) == 3
-                for mutation in shard_mutations:
+                for mutation in shard_mutations.values():
                     # skip the column (as it has been materialized), but materialize the index
                     assert all("MATERIALIZE INDEX" in command for command in mutation.commands)
 

--- a/dags/tests/test_materialized_columns.py
+++ b/dags/tests/test_materialized_columns.py
@@ -14,20 +14,22 @@ from dags.materialized_columns import (
     PartitionRange,
     materialize_column,
     run_materialize_mutations,
-    zip_values,
+    join_mappings,
 )
 from posthog.clickhouse.cluster import ClickhouseCluster, Query
 from posthog.test.base import materialized
 
 
-def test_zip_values():
-    assert [*zip_values({1: ["a", "b"], 2: ["c", "d"]})] == [
-        {1: "a", 2: "c"},
-        {1: "b", 2: "d"},
-    ]
+def test_join_mappings():
+    assert join_mappings({}) == {}
 
-    with pytest.raises(ValueError):
-        next(zip_values({1: ["a"], 2: ["c", "d"]}))
+    assert join_mappings({1: {"a": 1}}) == {"a": {1: 1}}
+
+    # overlapping keys
+    assert join_mappings({1: {"a": 1}, 2: {"a": 2}}) == {"a": {1: 1, 2: 2}}
+
+    # non-overlapping keys
+    assert join_mappings({1: {"a": 1}, 2: {"b": 2}}) == {"a": {1: 1}, "b": {2: 2}}
 
 
 def test_partition_range_validation():


### PR DESCRIPTION
## Problem

If column is materialized in only a subset of shards within a partition, this task was failing.

## Changes

Updates implementation to accommodate the situation where some shards require materialization mutations for a partition and others do not.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Updated existing tests - it's not really feasible to write an integration test for this because our CI ClickHouse only has a single shard, but the updated unit tests should cover the non-overlapping keys (in our case, partition IDs) case that we have been seeing. Existing integration tests and type checks should ensure it runs correctly overall