### PR TITLE
fix: add a cache to elements chain conversion

### DIFF
--- a/posthog/api/element.py
+++ b/posthog/api/element.py
@@ -142,7 +142,7 @@ class ElementViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
             elements_response.headers["Server-Timing"] = timer.to_header_string()
             elements_response.headers["Cache-Control"] = "public, max-age=30"  # Cache for 30 seconds
-
+            elements_response.headers["Vary"] = "Accept, Accept-Encoding, Query-String"
             return elements_response
 
     def _events_filter(self, request) -> tuple[Literal["$autocapture", "$rageclick", "$dead_click"], ...]:

--- a/posthog/api/element.py
+++ b/posthog/api/element.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from typing import Literal
 
 from prometheus_client import Histogram
@@ -35,6 +36,11 @@ class ElementSerializer(serializers.ModelSerializer):
             "attributes",
             "order",
         ]
+
+
+@lru_cache(maxsize=10000)
+def serialise_elements_chain(elements_chain: str) -> list[dict]:
+    return [ElementSerializer(element).data for element in chain_to_elements(elements_chain)]
 
 
 class ElementViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
@@ -118,7 +124,7 @@ class ElementViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                         "count": elements[1],
                         "hash": None,
                         "type": elements[2],
-                        "elements": [ElementSerializer(element).data for element in chain_to_elements(elements[0])],
+                        "elements": serialise_elements_chain(elements[0]),
                     }
                     for elements in result[:limit]
                 ]

--- a/posthog/api/element.py
+++ b/posthog/api/element.py
@@ -38,7 +38,7 @@ class ElementSerializer(serializers.ModelSerializer):
         ]
 
 
-@lru_cache(maxsize=10000)
+@lru_cache(maxsize=5000)
 def serialise_elements_chain(elements_chain: str) -> list[dict]:
     return [ElementSerializer(element).data for element in chain_to_elements(elements_chain)]
 

--- a/posthog/api/element.py
+++ b/posthog/api/element.py
@@ -141,6 +141,8 @@ class ElementViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             )
 
             elements_response.headers["Server-Timing"] = timer.to_header_string()
+            elements_response.headers["Cache-Control"] = "public, max-age=30"  # Cache for 30 seconds
+
             return elements_response
 
     def _events_filter(self, request) -> tuple[Literal["$autocapture", "$rageclick", "$dead_click"], ...]:

--- a/posthog/models/element/element.py
+++ b/posthog/models/element/element.py
@@ -58,7 +58,7 @@ def elements_to_string(elements: list[Element]) -> str:
     return ";".join(ret)
 
 
-@lru_cache(maxsize=10000)
+@lru_cache(maxsize=5000)
 def chain_to_elements(chain: str) -> list[Element]:
     """
     Converts an elements chain string into a list of Element objects.

--- a/posthog/models/element/element.py
+++ b/posthog/models/element/element.py
@@ -1,4 +1,5 @@
 import re
+from functools import lru_cache
 
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
@@ -57,7 +58,15 @@ def elements_to_string(elements: list[Element]) -> str:
     return ";".join(ret)
 
 
+@lru_cache(maxsize=10000)
 def chain_to_elements(chain: str) -> list[Element]:
+    """
+    Converts an elements chain string into a list of Element objects.
+    Since for example in the elements API this could be called on a large list
+    which has a limited number of unique elements_chains,
+    we have a limited LRU in-memory cache
+    conversion is completely deterministic, so can be cached indefinitely
+    """
     elements = []
     for idx, el_string in enumerate(re.findall(split_chain_regex, chain)):
         el_string_split = re.findall(split_class_attributes, el_string)[0]


### PR DESCRIPTION
<img width="963" alt="Screenshot 2025-04-10 at 19 47 42" src="https://github.com/user-attachments/assets/a79df6be-09a4-428c-b62a-4014da3b5d3e" />

added timing to the stages in the elements API

in that API we load many rows from the events table 
grouped by elements chain
so the number of elements chains is normally (if not theoretically) less than the number of rows
we then convert the elements chain for every row

since the conversion is entirely deterministic we can have an in-memory LRU cache of conversions