### PR TITLE
chore: count more about elements chain serialization

### DIFF
--- a/posthog/api/element.py
+++ b/posthog/api/element.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from prometheus_client import Counter, Histogram
+from prometheus_client import Histogram
 from rest_framework import request, response, serializers, viewsets
 from posthog.api.utils import ServerTimingsGathered, action
 from rest_framework.exceptions import ValidationError
@@ -30,7 +30,7 @@ ELEMENT_STATS_SERIALIZE_TIME_HISTOGRAM = Histogram(
     "How long does it take to serialize element stats?",
 )
 
-DISTINCT_CHAIN_IN_RESPONSE_COUNTER = Counter(
+DISTINCT_CHAIN_IN_RESPONSE_HISTOGRAM = Histogram(
     "element_stats_distinct_chain_in_response",
     "How many distinct chains are in the response?",
 )
@@ -149,7 +149,7 @@ class ElementViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                     }
                     serialized_elements.append(element_data)
 
-            DISTINCT_CHAIN_IN_RESPONSE_COUNTER.set(len(distinct_chains))
+            DISTINCT_CHAIN_IN_RESPONSE_HISTOGRAM.set(len(distinct_chains))
 
             has_next = len(result) == limit + 1
             next_url = format_query_params_absolute_url(request, offset + limit) if has_next else None

--- a/posthog/api/element.py
+++ b/posthog/api/element.py
@@ -33,6 +33,8 @@ ELEMENT_STATS_SERIALIZE_TIME_HISTOGRAM = Histogram(
 DISTINCT_CHAIN_IN_RESPONSE_HISTOGRAM = Histogram(
     "element_stats_distinct_chain_in_response",
     "How many distinct chains are in the response?",
+    # default page is 10_000
+    buckets=(1, 10, 100, 1000, 2000, 4000, 6000, 8000, 10000),
 )
 
 
@@ -149,7 +151,7 @@ class ElementViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                     }
                     serialized_elements.append(element_data)
 
-            DISTINCT_CHAIN_IN_RESPONSE_HISTOGRAM.set(len(distinct_chains))
+            DISTINCT_CHAIN_IN_RESPONSE_HISTOGRAM.observe(len(distinct_chains))
 
             has_next = len(result) == limit + 1
             next_url = format_query_params_absolute_url(request, offset + limit) if has_next else None

--- a/posthog/models/element/element.py
+++ b/posthog/models/element/element.py
@@ -1,5 +1,4 @@
 import re
-from functools import lru_cache
 
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
@@ -58,7 +57,6 @@ def elements_to_string(elements: list[Element]) -> str:
     return ";".join(ret)
 
 
-@lru_cache(maxsize=5000)
 def chain_to_elements(chain: str) -> list[Element]:
     """
     Converts an elements chain string into a list of Element objects.


### PR DESCRIPTION
follow up to https://github.com/PostHog/posthog/pull/31090

serialization is taking a long time, adding a cache had no impact

this winds that back and alters how we count the items we have so we can try and understand what is happening