### PR TITLE
fix(source-update): `switch-group` source update

### DIFF
--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -1373,7 +1373,8 @@ export const getErrorsForFields = (
         errorsObj: Record<string, any>
     ): void => {
         if (field.type === 'switch-group') {
-            if (valueObj[field.name]?.['enabled']) {
+            // handle string value coming down from the backend for an update
+            if (valueObj[field.name]?.['enabled'] && valueObj[field.name]?.['enabled'] !== 'False') {
                 errorsObj[field.name] = {}
                 field.fields.forEach((f) => validateField(f, valueObj[field.name], errorsObj[field.name]))
             }


### PR DESCRIPTION
Cannot update sources sometimes, not obvious at all why, silently fails...

## Problem

Our backend is sometimes communicating in pythonic strings that are really booleans and thus we crashed into some sneaky issues where form fields that were not rendered and should be not needed are blocking form submission.

MySQL example
```
{
    "enabled": "False",
    "host": "",
    "port": "",
    "auth_type": {
        "selection": "password",
        "username": "",
        "password": "",
        "passphrase": "",
        "private_key": ""
    }
}
```


## Changes
Look for "False" explicitly for now, perhaps a better long term fix is to correctly type our backend.

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Switch-Group no longer blocks nested form submission if set to false.
