### PR TITLE
feat(revenue-analytics): Introduce basic Revenue Analytics setup page + queries

### DIFF
--- a/frontend/src/layout/navigation-3000/navigationLogic.tsx
+++ b/frontend/src/layout/navigation-3000/navigationLogic.tsx
@@ -523,6 +523,16 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
                                           : undefined,
                               }
                             : null,
+
+                        featureFlags[FEATURE_FLAGS.REVENUE_ANALYTICS]
+                            ? {
+                                  identifier: Scene.RevenueAnalytics,
+                                  label: 'Revenue analytics',
+                                  icon: <IconPiggyBank />,
+                                  to: urls.revenueAnalytics(),
+                                  tag: 'beta' as const,
+                              }
+                            : null,
                         {
                             identifier: Scene.Replay,
                             label: 'Session replay',
@@ -641,15 +651,6 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
                                   icon: <IconMegaphone />,
                                   to: urls.messagingBroadcasts(),
                                   tag: 'alpha' as const,
-                              }
-                            : null,
-                        featureFlags[FEATURE_FLAGS.REVENUE_ANALYTICS]
-                            ? {
-                                  identifier: Scene.RevenueAnalytics,
-                                  label: 'Revenue analytics',
-                                  icon: <IconPiggyBank />,
-                                  to: urls.revenueAnalytics(),
-                                  tag: 'beta' as const,
                               }
                             : null,
                     ].filter(isNotNil) as NavbarItem[],

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -363,6 +363,15 @@
                     "$ref": "#/definitions/HogQLAutocomplete"
                 },
                 {
+                    "$ref": "#/definitions/RevenueAnalyticsOverviewQuery"
+                },
+                {
+                    "$ref": "#/definitions/RevenueAnalyticsGrowthRateQuery"
+                },
+                {
+                    "$ref": "#/definitions/RevenueAnalyticsChurnRateQuery"
+                },
+                {
                     "$ref": "#/definitions/WebOverviewQuery"
                 },
                 {
@@ -3665,6 +3674,200 @@
             ],
             "type": "object"
         },
+        "CachedRevenueAnalyticsChurnRateQueryResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "cache_key": {
+                    "type": "string"
+                },
+                "cache_target_age": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "calculation_trigger": {
+                    "description": "What triggered the calculation of the query, leave empty if user/immediate",
+                    "type": "string"
+                },
+                "error": {
+                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                    "type": "string"
+                },
+                "hogql": {
+                    "description": "Generated HogQL query.",
+                    "type": "string"
+                },
+                "is_cached": {
+                    "type": "boolean"
+                },
+                "last_refresh": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "next_allowed_client_refresh": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "query_status": {
+                    "$ref": "#/definitions/QueryStatus",
+                    "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "results": {},
+                "timezone": {
+                    "type": "string"
+                },
+                "timings": {
+                    "description": "Measured timings for different parts of the query generation process",
+                    "items": {
+                        "$ref": "#/definitions/QueryTiming"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "cache_key",
+                "is_cached",
+                "last_refresh",
+                "next_allowed_client_refresh",
+                "results",
+                "timezone"
+            ],
+            "type": "object"
+        },
+        "CachedRevenueAnalyticsGrowthRateQueryResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "cache_key": {
+                    "type": "string"
+                },
+                "cache_target_age": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "calculation_trigger": {
+                    "description": "What triggered the calculation of the query, leave empty if user/immediate",
+                    "type": "string"
+                },
+                "error": {
+                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                    "type": "string"
+                },
+                "hogql": {
+                    "description": "Generated HogQL query.",
+                    "type": "string"
+                },
+                "is_cached": {
+                    "type": "boolean"
+                },
+                "last_refresh": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "next_allowed_client_refresh": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "query_status": {
+                    "$ref": "#/definitions/QueryStatus",
+                    "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "results": {},
+                "timezone": {
+                    "type": "string"
+                },
+                "timings": {
+                    "description": "Measured timings for different parts of the query generation process",
+                    "items": {
+                        "$ref": "#/definitions/QueryTiming"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "cache_key",
+                "is_cached",
+                "last_refresh",
+                "next_allowed_client_refresh",
+                "results",
+                "timezone"
+            ],
+            "type": "object"
+        },
+        "CachedRevenueAnalyticsOverviewQueryResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "cache_key": {
+                    "type": "string"
+                },
+                "cache_target_age": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "calculation_trigger": {
+                    "description": "What triggered the calculation of the query, leave empty if user/immediate",
+                    "type": "string"
+                },
+                "error": {
+                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                    "type": "string"
+                },
+                "hogql": {
+                    "description": "Generated HogQL query.",
+                    "type": "string"
+                },
+                "is_cached": {
+                    "type": "boolean"
+                },
+                "last_refresh": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "next_allowed_client_refresh": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "query_status": {
+                    "$ref": "#/definitions/QueryStatus",
+                    "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "results": {
+                    "items": {
+                        "$ref": "#/definitions/RevenueAnalyticsOverviewItem"
+                    },
+                    "type": "array"
+                },
+                "timezone": {
+                    "type": "string"
+                },
+                "timings": {
+                    "description": "Measured timings for different parts of the query generation process",
+                    "items": {
+                        "$ref": "#/definitions/QueryTiming"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "cache_key",
+                "is_cached",
+                "last_refresh",
+                "next_allowed_client_refresh",
+                "results",
+                "timezone"
+            ],
+            "type": "object"
+        },
         "CachedRevenueExampleDataWarehouseTablesQueryResponse": {
             "additionalProperties": false,
             "properties": {
@@ -5970,6 +6173,104 @@
                         {
                             "additionalProperties": false,
                             "properties": {
+                                "error": {
+                                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                                    "type": "string"
+                                },
+                                "hogql": {
+                                    "description": "Generated HogQL query.",
+                                    "type": "string"
+                                },
+                                "modifiers": {
+                                    "$ref": "#/definitions/HogQLQueryModifiers",
+                                    "description": "Modifiers used when performing the query"
+                                },
+                                "query_status": {
+                                    "$ref": "#/definitions/QueryStatus",
+                                    "description": "Query status indicates whether next to the provided data, a query is still running."
+                                },
+                                "results": {
+                                    "items": {
+                                        "$ref": "#/definitions/RevenueAnalyticsOverviewItem"
+                                    },
+                                    "type": "array"
+                                },
+                                "timings": {
+                                    "description": "Measured timings for different parts of the query generation process",
+                                    "items": {
+                                        "$ref": "#/definitions/QueryTiming"
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "required": ["results"],
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "error": {
+                                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                                    "type": "string"
+                                },
+                                "hogql": {
+                                    "description": "Generated HogQL query.",
+                                    "type": "string"
+                                },
+                                "modifiers": {
+                                    "$ref": "#/definitions/HogQLQueryModifiers",
+                                    "description": "Modifiers used when performing the query"
+                                },
+                                "query_status": {
+                                    "$ref": "#/definitions/QueryStatus",
+                                    "description": "Query status indicates whether next to the provided data, a query is still running."
+                                },
+                                "results": {},
+                                "timings": {
+                                    "description": "Measured timings for different parts of the query generation process",
+                                    "items": {
+                                        "$ref": "#/definitions/QueryTiming"
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "required": ["results"],
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "error": {
+                                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                                    "type": "string"
+                                },
+                                "hogql": {
+                                    "description": "Generated HogQL query.",
+                                    "type": "string"
+                                },
+                                "modifiers": {
+                                    "$ref": "#/definitions/HogQLQueryModifiers",
+                                    "description": "Modifiers used when performing the query"
+                                },
+                                "query_status": {
+                                    "$ref": "#/definitions/QueryStatus",
+                                    "description": "Query status indicates whether next to the provided data, a query is still running."
+                                },
+                                "results": {},
+                                "timings": {
+                                    "description": "Measured timings for different parts of the query generation process",
+                                    "items": {
+                                        "$ref": "#/definitions/QueryTiming"
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "required": ["results"],
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
                                 "columns": {
                                     "items": {},
                                     "type": "array"
@@ -6417,6 +6718,15 @@
                             "$ref": "#/definitions/SessionAttributionExplorerQuery"
                         },
                         {
+                            "$ref": "#/definitions/RevenueAnalyticsOverviewQuery"
+                        },
+                        {
+                            "$ref": "#/definitions/RevenueAnalyticsGrowthRateQuery"
+                        },
+                        {
+                            "$ref": "#/definitions/RevenueAnalyticsChurnRateQuery"
+                        },
+                        {
                             "$ref": "#/definitions/RevenueExampleEventsQuery"
                         },
                         {
@@ -6699,6 +7009,32 @@
             "required": ["name", "hogql_value", "type", "schema_valid"],
             "type": "object"
         },
+        "DatabaseSchemaManagedViewTable": {
+            "additionalProperties": false,
+            "properties": {
+                "fields": {
+                    "additionalProperties": {
+                        "$ref": "#/definitions/DatabaseSchemaField"
+                    },
+                    "type": "object"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "query": {
+                    "$ref": "#/definitions/HogQLQuery"
+                },
+                "type": {
+                    "const": "managed_view",
+                    "type": "string"
+                }
+            },
+            "required": ["fields", "id", "name", "query", "type"],
+            "type": "object"
+        },
         "DatabaseSchemaMaterializedViewTable": {
             "additionalProperties": false,
             "properties": {
@@ -6844,6 +7180,9 @@
                     "$ref": "#/definitions/DatabaseSchemaViewTable"
                 },
                 {
+                    "$ref": "#/definitions/DatabaseSchemaManagedViewTable"
+                },
+                {
                     "$ref": "#/definitions/DatabaseSchemaBatchExportTable"
                 },
                 {
@@ -6867,7 +7206,7 @@
                     "type": "string"
                 },
                 "type": {
-                    "enum": ["posthog", "data_warehouse", "view", "batch_export", "materialized_view"],
+                    "enum": ["posthog", "data_warehouse", "view", "batch_export", "materialized_view", "managed_view"],
                     "type": "string"
                 }
             },
@@ -11290,6 +11629,9 @@
                 "WebGoalsQuery",
                 "WebVitalsQuery",
                 "WebVitalsPathBreakdownQuery",
+                "RevenueAnalyticsOverviewQuery",
+                "RevenueAnalyticsGrowthRateQuery",
+                "RevenueAnalyticsChurnRateQuery",
                 "ExperimentMetric",
                 "ExperimentQuery",
                 "ExperimentExposureQuery",
@@ -13002,6 +13344,104 @@
                     "type": "object"
                 },
                 {
+                    "additionalProperties": false,
+                    "properties": {
+                        "error": {
+                            "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                            "type": "string"
+                        },
+                        "hogql": {
+                            "description": "Generated HogQL query.",
+                            "type": "string"
+                        },
+                        "modifiers": {
+                            "$ref": "#/definitions/HogQLQueryModifiers",
+                            "description": "Modifiers used when performing the query"
+                        },
+                        "query_status": {
+                            "$ref": "#/definitions/QueryStatus",
+                            "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "results": {
+                            "items": {
+                                "$ref": "#/definitions/RevenueAnalyticsOverviewItem"
+                            },
+                            "type": "array"
+                        },
+                        "timings": {
+                            "description": "Measured timings for different parts of the query generation process",
+                            "items": {
+                                "$ref": "#/definitions/QueryTiming"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": ["results"],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "error": {
+                            "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                            "type": "string"
+                        },
+                        "hogql": {
+                            "description": "Generated HogQL query.",
+                            "type": "string"
+                        },
+                        "modifiers": {
+                            "$ref": "#/definitions/HogQLQueryModifiers",
+                            "description": "Modifiers used when performing the query"
+                        },
+                        "query_status": {
+                            "$ref": "#/definitions/QueryStatus",
+                            "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "results": {},
+                        "timings": {
+                            "description": "Measured timings for different parts of the query generation process",
+                            "items": {
+                                "$ref": "#/definitions/QueryTiming"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": ["results"],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "error": {
+                            "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                            "type": "string"
+                        },
+                        "hogql": {
+                            "description": "Generated HogQL query.",
+                            "type": "string"
+                        },
+                        "modifiers": {
+                            "$ref": "#/definitions/HogQLQueryModifiers",
+                            "description": "Modifiers used when performing the query"
+                        },
+                        "query_status": {
+                            "$ref": "#/definitions/QueryStatus",
+                            "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "results": {},
+                        "timings": {
+                            "description": "Measured timings for different parts of the query generation process",
+                            "items": {
+                                "$ref": "#/definitions/QueryTiming"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": ["results"],
+                    "type": "object"
+                },
+                {
                     "properties": {},
                     "type": "object"
                 },
@@ -13542,6 +13982,104 @@
                         },
                         "types": {
                             "items": {},
+                            "type": "array"
+                        }
+                    },
+                    "required": ["results"],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "error": {
+                            "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                            "type": "string"
+                        },
+                        "hogql": {
+                            "description": "Generated HogQL query.",
+                            "type": "string"
+                        },
+                        "modifiers": {
+                            "$ref": "#/definitions/HogQLQueryModifiers",
+                            "description": "Modifiers used when performing the query"
+                        },
+                        "query_status": {
+                            "$ref": "#/definitions/QueryStatus",
+                            "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "results": {
+                            "items": {
+                                "$ref": "#/definitions/RevenueAnalyticsOverviewItem"
+                            },
+                            "type": "array"
+                        },
+                        "timings": {
+                            "description": "Measured timings for different parts of the query generation process",
+                            "items": {
+                                "$ref": "#/definitions/QueryTiming"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": ["results"],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "error": {
+                            "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                            "type": "string"
+                        },
+                        "hogql": {
+                            "description": "Generated HogQL query.",
+                            "type": "string"
+                        },
+                        "modifiers": {
+                            "$ref": "#/definitions/HogQLQueryModifiers",
+                            "description": "Modifiers used when performing the query"
+                        },
+                        "query_status": {
+                            "$ref": "#/definitions/QueryStatus",
+                            "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "results": {},
+                        "timings": {
+                            "description": "Measured timings for different parts of the query generation process",
+                            "items": {
+                                "$ref": "#/definitions/QueryTiming"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": ["results"],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "error": {
+                            "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                            "type": "string"
+                        },
+                        "hogql": {
+                            "description": "Generated HogQL query.",
+                            "type": "string"
+                        },
+                        "modifiers": {
+                            "$ref": "#/definitions/HogQLQueryModifiers",
+                            "description": "Modifiers used when performing the query"
+                        },
+                        "query_status": {
+                            "$ref": "#/definitions/QueryStatus",
+                            "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "results": {},
+                        "timings": {
+                            "description": "Measured timings for different parts of the query generation process",
+                            "items": {
+                                "$ref": "#/definitions/QueryTiming"
+                            },
                             "type": "array"
                         }
                     },
@@ -14464,6 +15002,15 @@
                     "$ref": "#/definitions/WebVitalsPathBreakdownQuery"
                 },
                 {
+                    "$ref": "#/definitions/RevenueAnalyticsOverviewQuery"
+                },
+                {
+                    "$ref": "#/definitions/RevenueAnalyticsGrowthRateQuery"
+                },
+                {
+                    "$ref": "#/definitions/RevenueAnalyticsChurnRateQuery"
+                },
+                {
                     "$ref": "#/definitions/DataVisualizationNode"
                 },
                 {
@@ -15158,6 +15705,244 @@
                 }
             },
             "required": ["count"],
+            "type": "object"
+        },
+        "RevenueAnalyticsBaseQuery<RevenueAnalyticsChurnRateQueryResponse>": {
+            "additionalProperties": false,
+            "properties": {
+                "dateRange": {
+                    "$ref": "#/definitions/DateRange"
+                },
+                "kind": {
+                    "$ref": "#/definitions/NodeKind"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "response": {
+                    "$ref": "#/definitions/RevenueAnalyticsChurnRateQueryResponse"
+                }
+            },
+            "required": ["kind"],
+            "type": "object"
+        },
+        "RevenueAnalyticsBaseQuery<RevenueAnalyticsGrowthRateQueryResponse>": {
+            "additionalProperties": false,
+            "properties": {
+                "dateRange": {
+                    "$ref": "#/definitions/DateRange"
+                },
+                "kind": {
+                    "$ref": "#/definitions/NodeKind"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "response": {
+                    "$ref": "#/definitions/RevenueAnalyticsGrowthRateQueryResponse"
+                }
+            },
+            "required": ["kind"],
+            "type": "object"
+        },
+        "RevenueAnalyticsBaseQuery<RevenueAnalyticsOverviewQueryResponse>": {
+            "additionalProperties": false,
+            "properties": {
+                "dateRange": {
+                    "$ref": "#/definitions/DateRange"
+                },
+                "kind": {
+                    "$ref": "#/definitions/NodeKind"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "response": {
+                    "$ref": "#/definitions/RevenueAnalyticsOverviewQueryResponse"
+                }
+            },
+            "required": ["kind"],
+            "type": "object"
+        },
+        "RevenueAnalyticsChurnRateQuery": {
+            "additionalProperties": false,
+            "properties": {
+                "dateRange": {
+                    "$ref": "#/definitions/DateRange"
+                },
+                "kind": {
+                    "const": "RevenueAnalyticsChurnRateQuery",
+                    "type": "string"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "response": {
+                    "$ref": "#/definitions/RevenueAnalyticsChurnRateQueryResponse"
+                }
+            },
+            "required": ["kind"],
+            "type": "object"
+        },
+        "RevenueAnalyticsChurnRateQueryResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "error": {
+                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                    "type": "string"
+                },
+                "hogql": {
+                    "description": "Generated HogQL query.",
+                    "type": "string"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "query_status": {
+                    "$ref": "#/definitions/QueryStatus",
+                    "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "results": {},
+                "timings": {
+                    "description": "Measured timings for different parts of the query generation process",
+                    "items": {
+                        "$ref": "#/definitions/QueryTiming"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["results"],
+            "type": "object"
+        },
+        "RevenueAnalyticsGrowthRateQuery": {
+            "additionalProperties": false,
+            "properties": {
+                "dateRange": {
+                    "$ref": "#/definitions/DateRange"
+                },
+                "kind": {
+                    "const": "RevenueAnalyticsGrowthRateQuery",
+                    "type": "string"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "response": {
+                    "$ref": "#/definitions/RevenueAnalyticsGrowthRateQueryResponse"
+                }
+            },
+            "required": ["kind"],
+            "type": "object"
+        },
+        "RevenueAnalyticsGrowthRateQueryResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "error": {
+                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                    "type": "string"
+                },
+                "hogql": {
+                    "description": "Generated HogQL query.",
+                    "type": "string"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "query_status": {
+                    "$ref": "#/definitions/QueryStatus",
+                    "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "results": {},
+                "timings": {
+                    "description": "Measured timings for different parts of the query generation process",
+                    "items": {
+                        "$ref": "#/definitions/QueryTiming"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["results"],
+            "type": "object"
+        },
+        "RevenueAnalyticsOverviewItem": {
+            "additionalProperties": false,
+            "properties": {
+                "key": {
+                    "$ref": "#/definitions/RevenueAnalyticsOverviewItemKey"
+                },
+                "value": {
+                    "type": "number"
+                }
+            },
+            "required": ["key"],
+            "type": "object"
+        },
+        "RevenueAnalyticsOverviewItemKey": {
+            "enum": ["MRR", "ARR", "Customer Count", "New customers", "Churned customers"],
+            "type": "string"
+        },
+        "RevenueAnalyticsOverviewQuery": {
+            "additionalProperties": false,
+            "properties": {
+                "dateRange": {
+                    "$ref": "#/definitions/DateRange"
+                },
+                "kind": {
+                    "const": "RevenueAnalyticsOverviewQuery",
+                    "type": "string"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "response": {
+                    "$ref": "#/definitions/RevenueAnalyticsOverviewQueryResponse"
+                }
+            },
+            "required": ["kind"],
+            "type": "object"
+        },
+        "RevenueAnalyticsOverviewQueryResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "error": {
+                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                    "type": "string"
+                },
+                "hogql": {
+                    "description": "Generated HogQL query.",
+                    "type": "string"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "query_status": {
+                    "$ref": "#/definitions/QueryStatus",
+                    "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "results": {
+                    "items": {
+                        "$ref": "#/definitions/RevenueAnalyticsOverviewItem"
+                    },
+                    "type": "array"
+                },
+                "timings": {
+                    "description": "Measured timings for different parts of the query generation process",
+                    "items": {
+                        "$ref": "#/definitions/QueryTiming"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["results"],
             "type": "object"
         },
         "RevenueCurrencyPropertyConfig": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -105,6 +105,11 @@ export enum NodeKind {
     WebVitalsQuery = 'WebVitalsQuery',
     WebVitalsPathBreakdownQuery = 'WebVitalsPathBreakdownQuery',
 
+    // Revenue analytics queries
+    RevenueAnalyticsOverviewQuery = 'RevenueAnalyticsOverviewQuery',
+    RevenueAnalyticsGrowthRateQuery = 'RevenueAnalyticsGrowthRateQuery',
+    RevenueAnalyticsChurnRateQuery = 'RevenueAnalyticsChurnRateQuery',
+
     // Experiment queries
     ExperimentMetric = 'ExperimentMetric',
     ExperimentQuery = 'ExperimentQuery',
@@ -140,6 +145,9 @@ export type AnyDataNode =
     | HogQLQuery
     | HogQLMetadata
     | HogQLAutocomplete
+    | RevenueAnalyticsOverviewQuery
+    | RevenueAnalyticsGrowthRateQuery
+    | RevenueAnalyticsChurnRateQuery
     | WebOverviewQuery
     | WebStatsTableQuery
     | WebExternalClicksTableQuery
@@ -191,6 +199,11 @@ export type QuerySchema =
     | WebGoalsQuery
     | WebVitalsQuery
     | WebVitalsPathBreakdownQuery
+
+    // Revenue analytics
+    | RevenueAnalyticsOverviewQuery
+    | RevenueAnalyticsGrowthRateQuery
+    | RevenueAnalyticsChurnRateQuery
 
     // Interface nodes
     | DataVisualizationNode
@@ -689,6 +702,9 @@ export interface DataTableNode
                     | WebVitalsQuery
                     | WebVitalsPathBreakdownQuery
                     | SessionAttributionExplorerQuery
+                    | RevenueAnalyticsOverviewQuery
+                    | RevenueAnalyticsGrowthRateQuery
+                    | RevenueAnalyticsChurnRateQuery
                     | RevenueExampleEventsQuery
                     | RevenueExampleDataWarehouseTablesQuery
                     | ErrorTrackingQuery
@@ -715,6 +731,9 @@ export interface DataTableNode
         | WebVitalsQuery
         | WebVitalsPathBreakdownQuery
         | SessionAttributionExplorerQuery
+        | RevenueAnalyticsOverviewQuery
+        | RevenueAnalyticsGrowthRateQuery
+        | RevenueAnalyticsChurnRateQuery
         | RevenueExampleEventsQuery
         | RevenueExampleDataWarehouseTablesQuery
         | ErrorTrackingQuery
@@ -1796,6 +1815,44 @@ export interface RevenueExampleDataWarehouseTablesQueryResponse extends Analytic
 export type CachedRevenueExampleDataWarehouseTablesQueryResponse =
     CachedQueryResponse<RevenueExampleDataWarehouseTablesQueryResponse>
 
+/*
+ * Revenue Analytics Queries
+ */
+export interface RevenueAnalyticsBaseQuery<R extends Record<string, any>> extends DataNode<R> {
+    dateRange?: DateRange
+}
+
+export interface RevenueAnalyticsOverviewQuery
+    extends RevenueAnalyticsBaseQuery<RevenueAnalyticsOverviewQueryResponse> {
+    kind: NodeKind.RevenueAnalyticsOverviewQuery
+}
+
+export type RevenueAnalyticsOverviewItemKey = 'MRR' | 'ARR' | 'Customer Count' | 'New customers' | 'Churned customers'
+export interface RevenueAnalyticsOverviewItem {
+    key: RevenueAnalyticsOverviewItemKey
+    value?: number
+}
+
+export interface RevenueAnalyticsOverviewQueryResponse
+    extends AnalyticsQueryResponseBase<RevenueAnalyticsOverviewItem[]> {}
+export type CachedRevenueAnalyticsOverviewQueryResponse = CachedQueryResponse<RevenueAnalyticsOverviewQueryResponse>
+
+export interface RevenueAnalyticsGrowthRateQuery
+    extends RevenueAnalyticsBaseQuery<RevenueAnalyticsGrowthRateQueryResponse> {
+    kind: NodeKind.RevenueAnalyticsGrowthRateQuery
+}
+
+export interface RevenueAnalyticsGrowthRateQueryResponse extends AnalyticsQueryResponseBase<unknown> {}
+export type CachedRevenueAnalyticsGrowthRateQueryResponse = CachedQueryResponse<RevenueAnalyticsGrowthRateQueryResponse>
+
+export interface RevenueAnalyticsChurnRateQuery
+    extends RevenueAnalyticsBaseQuery<RevenueAnalyticsChurnRateQueryResponse> {
+    kind: NodeKind.RevenueAnalyticsChurnRateQuery
+}
+
+export interface RevenueAnalyticsChurnRateQueryResponse extends AnalyticsQueryResponseBase<unknown> {}
+export type CachedRevenueAnalyticsChurnRateQueryResponse = CachedQueryResponse<RevenueAnalyticsChurnRateQueryResponse>
+
 export interface ErrorTrackingQuery extends DataNode<ErrorTrackingQueryResponse> {
     kind: NodeKind.ErrorTrackingQuery
     issueId?: ErrorTrackingIssue['id']
@@ -2264,7 +2321,7 @@ export interface DatabaseSchemaField {
 }
 
 export interface DatabaseSchemaTableCommon {
-    type: 'posthog' | 'data_warehouse' | 'view' | 'batch_export' | 'materialized_view'
+    type: 'posthog' | 'data_warehouse' | 'view' | 'batch_export' | 'materialized_view' | 'managed_view'
     id: string
     name: string
     fields: Record<string, DatabaseSchemaField>
@@ -2272,6 +2329,11 @@ export interface DatabaseSchemaTableCommon {
 
 export interface DatabaseSchemaViewTable extends DatabaseSchemaTableCommon {
     type: 'view'
+    query: HogQLQuery
+}
+
+export interface DatabaseSchemaManagedViewTable extends DatabaseSchemaTableCommon {
+    type: 'managed_view'
     query: HogQLQuery
 }
 
@@ -2302,6 +2364,7 @@ export type DatabaseSchemaTable =
     | DatabaseSchemaPostHogTable
     | DatabaseSchemaDataWarehouseTable
     | DatabaseSchemaViewTable
+    | DatabaseSchemaManagedViewTable
     | DatabaseSchemaBatchExportTable
     | DatabaseSchemaMaterializedViewTable
 

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -38,6 +38,9 @@ import {
     QueryStatusResponse,
     ResultCustomizationBy,
     RetentionQuery,
+    RevenueAnalyticsChurnRateQuery,
+    RevenueAnalyticsGrowthRateQuery,
+    RevenueAnalyticsOverviewQuery,
     RevenueExampleDataWarehouseTablesQuery,
     RevenueExampleEventsQuery,
     SavedInsightNode,
@@ -141,6 +144,24 @@ export function isHogQLASTQuery(node?: Record<string, any> | null): node is HogQ
 
 export function isHogQLMetadata(node?: Record<string, any> | null): node is HogQLMetadata {
     return node?.kind === NodeKind.HogQLMetadata
+}
+
+export function isRevenueAnalyticsOverviewQuery(
+    node?: Record<string, any> | null
+): node is RevenueAnalyticsOverviewQuery {
+    return node?.kind === NodeKind.RevenueAnalyticsOverviewQuery
+}
+
+export function isRevenueAnalyticsGrowthRateQuery(
+    node?: Record<string, any> | null
+): node is RevenueAnalyticsGrowthRateQuery {
+    return node?.kind === NodeKind.RevenueAnalyticsGrowthRateQuery
+}
+
+export function isRevenueAnalyticsChurnRateQuery(
+    node?: Record<string, any> | null
+): node is RevenueAnalyticsChurnRateQuery {
+    return node?.kind === NodeKind.RevenueAnalyticsChurnRateQuery
 }
 
 export function isWebOverviewQuery(node?: Record<string, any> | null): node is WebOverviewQuery {

--- a/frontend/src/scenes/data-warehouse/external/forms/DataWarehouseIntegrationChoice.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/DataWarehouseIntegrationChoice.tsx
@@ -18,7 +18,7 @@ export function DataWarehouseIntegrationChoice({
         <IntegrationChoice
             {...props}
             integration={sourceConfig.name.toLowerCase()}
-            redirectUrl={`${urls.pipelineNodeNew(PipelineStage.Source)}?kind=${sourceConfig.name.toLowerCase()}`}
+            redirectUrl={urls.pipelineNodeNew(PipelineStage.Source, { kind: sourceConfig.name.toLowerCase() })}
         />
     )
 }

--- a/frontend/src/scenes/data-warehouse/external/forms/SchemaForm.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/SchemaForm.tsx
@@ -5,6 +5,8 @@ import { dayjs } from 'lib/dayjs'
 import { syncAnchorIntervalToHumanReadable } from 'scenes/data-warehouse/utils'
 import { teamLogic } from 'scenes/teamLogic'
 
+import { ExternalDataSourceSyncSchema } from '~/types'
+
 import { sourceWizardLogic } from '../../new/sourceWizardLogic'
 import { SyncMethodForm } from './SyncMethodForm'
 
@@ -13,6 +15,14 @@ export default function SchemaForm(): JSX.Element {
         useActions(sourceWizardLogic)
     const { databaseSchema, isProjectTime } = useValues(sourceWizardLogic)
     const { currentTeam } = useValues(teamLogic)
+
+    const onClickCheckbox = (schema: ExternalDataSourceSyncSchema, checked: boolean): void => {
+        if (schema.sync_type === null) {
+            openSyncMethodModal(schema)
+            return
+        }
+        toggleSchemaShouldSync(schema, checked)
+    }
 
     return (
         <>
@@ -25,17 +35,11 @@ export default function SchemaForm(): JSX.Element {
                             {
                                 width: 0,
                                 key: 'enabled',
-                                render: (_, schema) => {
+                                render: function RenderEnabled(_, schema) {
                                     return (
                                         <LemonCheckbox
                                             checked={schema.should_sync}
-                                            onChange={(checked) => {
-                                                if (schema.sync_type === null) {
-                                                    openSyncMethodModal(schema)
-                                                    return
-                                                }
-                                                toggleSchemaShouldSync(schema, checked)
-                                            }}
+                                            onChange={(checked) => onClickCheckbox(schema, checked)}
                                         />
                                     )
                                 },
@@ -44,14 +48,21 @@ export default function SchemaForm(): JSX.Element {
                                 title: 'Table',
                                 key: 'table',
                                 render: function RenderTable(_, schema) {
-                                    return <span className="font-mono">{schema.table}</span>
+                                    return (
+                                        <span
+                                            className="font-mono cursor-pointer"
+                                            onClick={() => onClickCheckbox(schema, !schema.should_sync)}
+                                        >
+                                            {schema.table}
+                                        </span>
+                                    )
                                 },
                             },
                             {
                                 title: 'Rows',
                                 key: 'rows',
                                 isHidden: !databaseSchema.some((schema) => schema.rows),
-                                render: (_, schema) => {
+                                render: function RenderRows(_, schema) {
                                     return schema.rows != null ? schema.rows : 'Unknown'
                                 },
                             },
@@ -73,7 +84,7 @@ export default function SchemaForm(): JSX.Element {
                                 key: 'sync_time_of_day',
                                 tooltip:
                                     'Time of day in which the first sync will run. The sync interval will be offset from the anchor time. This will not apply to sync intervals one hour or less.',
-                                render: function RenderSyncTimeOfDayLocal(_, schema) {
+                                render: function RenderSyncTimeOfDay(_, schema) {
                                     const utcTime = schema.sync_time_of_day || '00:00:00'
                                     const localTime = isProjectTime
                                         ? dayjs
@@ -116,7 +127,7 @@ export default function SchemaForm(): JSX.Element {
                                 align: 'right',
                                 tooltip:
                                     'Full refresh will refresh the full table on every sync, whereas incremental will only sync new and updated rows since the last sync',
-                                render: (_, schema) => {
+                                render: function RenderSyncType(_, schema) {
                                     if (!schema.sync_type) {
                                         return (
                                             <div className="justify-end flex">

--- a/frontend/src/scenes/data-warehouse/external/forms/SyncMethodForm.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/SyncMethodForm.tsx
@@ -51,15 +51,17 @@ const getSaveDisabledReason = (
 }
 
 export const SyncMethodForm = ({ schema, onClose, onSave, saveButtonIsLoading }: SyncMethodFormProps): JSX.Element => {
-    const [radioValue, setRadioValue] = useState(schema.sync_type ?? undefined)
+    const incrementalSyncSupported = getIncrementalSyncSupported(schema)
+
+    const [radioValue, setRadioValue] = useState(
+        schema.sync_type ?? (incrementalSyncSupported ? 'incremental' : undefined)
+    )
     const [incrementalFieldValue, setIncrementalFieldValue] = useState(schema.incremental_field ?? null)
 
     useEffect(() => {
-        setRadioValue(schema.sync_type ?? undefined)
+        setRadioValue(schema.sync_type ?? (incrementalSyncSupported ? 'incremental' : undefined))
         setIncrementalFieldValue(schema.incremental_field ?? null)
     }, [schema.table])
-
-    const incrementalSyncSupported = getIncrementalSyncSupported(schema)
 
     return (
         <>

--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -27,23 +27,25 @@ import { dataWarehouseSettingsLogic } from '../settings/dataWarehouseSettingsLog
 import { dataWarehouseTableLogic } from './dataWarehouseTableLogic'
 import type { sourceWizardLogicType } from './sourceWizardLogicType'
 
-const Caption = (): JSX.Element => (
+const StripeCaption = (): JSX.Element => (
     <>
         Enter your Stripe credentials to automatically pull your Stripe data into the PostHog Data warehouse.
         <br />
         You can find your account ID{' '}
-        <Link to="https://dashboard.stripe.com/settings/user" target="_blank">
+        <Link to="https://dashboard.stripe.com/settings/account" target="_blank">
             in your Stripe dashboard
         </Link>
         , and create a secret key{' '}
-        <Link to="https://dashboard.stripe.com/apikeys" target="_blank">
+        <Link to="https://dashboard.stripe.com/apikeys/create" target="_blank">
             here
         </Link>
         .
         <br />
-        Currently, read permissions are required for the following resources:
         <br />
-        Account, Invoice, Customer, Subscription, Product, Price, BalanceTransaction, Charge.
+        Currently, <strong>read permissions are required</strong> for the following resources:
+        <br />
+        <code>Account</code>, <code>Invoice</code>, <code>Customer</code>, <code>Subscription</code>,{' '}
+        <code>Product</code>, <code>Price</code>, <code>BalanceTransaction</code>, and <code>Charge</code>.
     </>
 )
 
@@ -53,7 +55,7 @@ export const getHubspotRedirectUri = (): string =>
 export const SOURCE_DETAILS: Record<ExternalDataSourceType, SourceConfig> = {
     Stripe: {
         name: 'Stripe',
-        caption: <Caption />,
+        caption: <StripeCaption />,
         fields: [
             {
                 name: 'stripe_account_id',

--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -48,7 +48,7 @@ const Caption = (): JSX.Element => (
 )
 
 export const getHubspotRedirectUri = (): string =>
-    `${window.location.origin}${urls.pipelineNodeNew(PipelineStage.Source)}?kind=hubspot`
+    `${window.location.origin}${urls.pipelineNodeNew(PipelineStage.Source, { kind: 'hubspot' })}`
 
 export const SOURCE_DETAILS: Record<ExternalDataSourceType, SourceConfig> = {
     Stripe: {
@@ -795,7 +795,7 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
     actions({
         selectConnector: (connector: SourceConfig | null) => ({ connector }),
         toggleManualLinkFormVisible: (visible: boolean) => ({ visible }),
-        handleRedirect: (kind: string, searchParams: any) => ({ kind, searchParams }),
+        handleRedirect: (kind: string, searchParams?: any) => ({ kind, searchParams }),
         onClear: true,
         onBack: true,
         onNext: true,
@@ -1207,7 +1207,7 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
                     actions.updateSource({
                         source_type: 'Hubspot',
                         payload: {
-                            code: searchParams.code,
+                            code: searchParams?.code,
                             redirect_uri: getHubspotRedirectUri(),
                         },
                     })
@@ -1216,6 +1216,12 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
                 case 'salesforce': {
                     actions.updateSource({
                         source_type: 'Salesforce',
+                    })
+                    break
+                }
+                case 'stripe': {
+                    actions.updateSource({
+                        source_type: 'Stripe',
                     })
                     break
                 }
@@ -1271,7 +1277,12 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
             }
             if (searchParams.kind == 'salesforce') {
                 actions.selectConnector(SOURCE_DETAILS['Salesforce'])
-                actions.handleRedirect(searchParams.kind, {})
+                actions.handleRedirect(searchParams.kind)
+                actions.setStep(2)
+            }
+            if (searchParams.kind == 'stripe') {
+                actions.selectConnector(SOURCE_DETAILS['Stripe'])
+                actions.handleRedirect(searchParams.kind)
                 actions.setStep(2)
             }
         },

--- a/frontend/src/scenes/pipeline/Pipeline.stories.tsx
+++ b/frontend/src/scenes/pipeline/Pipeline.stories.tsx
@@ -199,7 +199,7 @@ export function PipelineNodeNewDestinationWithoutDataPipelines(): JSX.Element {
 
 export function PipelineNodeNewSequenceTimer(): JSX.Element {
     useEffect(() => {
-        router.actions.push(urls.pipelineNodeNew(PipelineStage.Transformation, eventSequenceTimerPluginId))
+        router.actions.push(urls.pipelineNodeNew(PipelineStage.Transformation, { id: eventSequenceTimerPluginId }))
     }, [])
     return <App />
 }
@@ -207,21 +207,21 @@ export function PipelineNodeNewSequenceTimer(): JSX.Element {
 export function PipelineNodeNewBigQuery(): JSX.Element {
     useAvailableFeatures([AvailableFeature.DATA_PIPELINES])
     useEffect(() => {
-        router.actions.push(urls.pipelineNodeNew(PipelineStage.Destination, 'BigQuery'))
+        router.actions.push(urls.pipelineNodeNew(PipelineStage.Destination, { id: 'BigQuery' }))
     }, [])
     return <App />
 }
 
 export function PipelineNodeNewBigQueryWithoutPipelines(): JSX.Element {
     useEffect(() => {
-        router.actions.push(urls.pipelineNodeNew(PipelineStage.Destination, 'BigQuery'))
+        router.actions.push(urls.pipelineNodeNew(PipelineStage.Destination, { id: 'BigQuery' }))
     }, [])
     return <App />
 }
 
 export function PipelineNodeNewHogFunction(): JSX.Element {
     useEffect(() => {
-        router.actions.push(urls.pipelineNodeNew(PipelineStage.Destination, 'hog-template-slack'))
+        router.actions.push(urls.pipelineNodeNew(PipelineStage.Destination, { id: 'hog-template-slack' }))
     }, [])
     return <App />
 }

--- a/frontend/src/scenes/pipeline/PipelineNodeNew.tsx
+++ b/frontend/src/scenes/pipeline/PipelineNodeNew.tsx
@@ -31,7 +31,7 @@ const paramsToProps = ({
     searchParams: { kind } = {},
 }: {
     params: { stage?: string; id?: string }
-    searchParams: { kind?: string }
+    searchParams?: { kind?: string }
 }): PipelineNodeNewLogicProps => {
     const numericId = id && /^\d+$/.test(id) ? parseInt(id) : undefined
     const pluginId = numericId && !isNaN(numericId) ? numericId : null

--- a/frontend/src/scenes/pipeline/PipelineNodeNew.tsx
+++ b/frontend/src/scenes/pipeline/PipelineNodeNew.tsx
@@ -27,9 +27,11 @@ import { PipelineBackend } from './types'
 import { RenderApp } from './utils'
 
 const paramsToProps = ({
-    params: { stage, id },
+    params: { stage, id } = {},
+    searchParams: { kind } = {},
 }: {
     params: { stage?: string; id?: string }
+    searchParams: { kind?: string }
 }): PipelineNodeNewLogicProps => {
     const numericId = id && /^\d+$/.test(id) ? parseInt(id) : undefined
     const pluginId = numericId && !isNaN(numericId) ? numericId : null
@@ -41,6 +43,7 @@ const paramsToProps = ({
         pluginId,
         batchExportDestination,
         hogFunctionId,
+        kind: kind ?? null,
     }
 }
 
@@ -161,7 +164,7 @@ function NodeOptionsTable({
                         render: function RenderName(_, target) {
                             return (
                                 <LemonTableLink
-                                    to={urls.pipelineNodeNew(stage, target.id)}
+                                    to={urls.pipelineNodeNew(stage, { id: target.id })}
                                     title={target.name}
                                     description={target.description}
                                 />
@@ -179,7 +182,7 @@ function NodeOptionsTable({
                                     data-attr={`new-${stage}-${target.id}`}
                                     icon={<IconPlusSmall />}
                                     // Preserve hash params to pass config in
-                                    to={combineUrl(urls.pipelineNodeNew(stage, target.id), {}, hashParams).url}
+                                    to={combineUrl(urls.pipelineNodeNew(stage, { id: target.id }), {}, hashParams).url}
                                 >
                                     Create
                                 </LemonButton>

--- a/frontend/src/scenes/pipeline/destinations/newDestinationsLogic.tsx
+++ b/frontend/src/scenes/pipeline/destinations/newDestinationsLogic.tsx
@@ -90,10 +90,9 @@ export const newDestinationsLogic = kea<newDestinationsLogicType>([
                             description: hogFunction.description,
                             backend: PipelineBackend.HogFunction as const,
                             url: combineUrl(
-                                urls.pipelineNodeNew(
-                                    hogFunctionTypeToPipelineStage(hogFunction.type),
-                                    `hog-${hogFunction.id}`
-                                ),
+                                urls.pipelineNodeNew(hogFunctionTypeToPipelineStage(hogFunction.type), {
+                                    id: `hog-${hogFunction.id}`,
+                                }),
                                 {},
                                 hashParams
                             ).url,
@@ -105,7 +104,7 @@ export const newDestinationsLogic = kea<newDestinationsLogicType>([
                         name: humanizeBatchExportName(service),
                         description: `${service} batch export`,
                         backend: PipelineBackend.BatchExport as const,
-                        url: urls.pipelineNodeNew(PipelineStage.Destination, `${service}`),
+                        url: urls.pipelineNodeNew(PipelineStage.Destination, { id: service }),
                         free: false,
                     })),
                 ]

--- a/frontend/src/scenes/pipeline/hogfunctions/urls.ts
+++ b/frontend/src/scenes/pipeline/hogfunctions/urls.ts
@@ -7,7 +7,7 @@ export function hogFunctionNewUrl(type: HogFunctionTypeType, template?: string):
         ? urls.messagingBroadcastNew()
         : type === 'internal_destination' && template?.includes('error-tracking')
         ? urls.errorTrackingAlert(template)
-        : urls.pipelineNodeNew(hogFunctionTypeToPipelineStage(type), template ? `hog-${template}` : undefined)
+        : urls.pipelineNodeNew(hogFunctionTypeToPipelineStage(type), { id: template ? `hog-${template}` : undefined })
 }
 
 export function hogFunctionUrl(

--- a/frontend/src/scenes/pipeline/pipelineNodeNewLogic.tsx
+++ b/frontend/src/scenes/pipeline/pipelineNodeNewLogic.tsx
@@ -22,6 +22,7 @@ export interface PipelineNodeNewLogicProps {
     pluginId: number | null
     batchExportDestination: string | null
     hogFunctionId: string | null
+    kind: string | null
 }
 
 export const pipelineNodeNewLogic = kea<pipelineNodeNewLogicType>([
@@ -45,23 +46,33 @@ export const pipelineNodeNewLogic = kea<pipelineNodeNewLogicType>([
     selectors(() => ({
         loading: [(s) => [s.pluginsLoading], (pluginsLoading) => pluginsLoading],
         breadcrumbs: [
-            (_, p) => [p.stage, p.pluginId, p.batchExportDestination],
-            (stage, pluginId, batchDestination): Breadcrumb[] => [
-                {
-                    key: Scene.Pipeline,
-                    name: 'Data pipeline',
-                    path: urls.pipeline(),
-                },
-                {
-                    key: stage || 'unknown',
-                    name: stage ? capitalizeFirstLetter(NODE_STAGE_TO_PIPELINE_TAB[stage] || '') : 'Unknown',
-                    path: urls.pipeline(stage ? NODE_STAGE_TO_PIPELINE_TAB[stage] : undefined),
-                },
-                {
-                    key: pluginId || batchDestination || 'Unknown',
-                    name: pluginId ? 'New' : batchDestination ? `New ${batchDestination} destination` : 'New',
-                },
-            ],
+            (_, p) => [p.stage, p.pluginId, p.kind, p.batchExportDestination],
+            (stage, pluginId, kind, batchDestination): Breadcrumb[] => {
+                const parsedStage = stage ? stage.replace('-', ' ') : null
+
+                return [
+                    {
+                        key: Scene.Pipeline,
+                        name: 'Data pipeline',
+                        path: urls.pipeline(),
+                    },
+                    {
+                        key: stage || 'unknown',
+                        name: stage ? capitalizeFirstLetter(NODE_STAGE_TO_PIPELINE_TAB[stage] || '') : 'Unknown',
+                        path: urls.pipeline(stage ? NODE_STAGE_TO_PIPELINE_TAB[stage] : undefined),
+                    },
+                    {
+                        key: pluginId || batchDestination || 'Unknown',
+                        name: kind
+                            ? `New ${capitalizeFirstLetter(kind)} source`
+                            : pluginId
+                            ? 'New'
+                            : batchDestination
+                            ? `New ${batchDestination} destination`
+                            : `New ${parsedStage}`.trim(),
+                    },
+                ]
+            },
         ],
     })),
 ])

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -12,6 +12,7 @@ import {
     IconLifecycle,
     IconPerson,
     IconPieChart,
+    IconPiggyBank,
     IconPlusSmall,
     IconRetention,
     IconStar,
@@ -251,6 +252,24 @@ export const QUERY_TYPES_METADATA: Record<NodeKind, InsightTypeMetadata> = {
         name: 'Database Schema',
         description: 'Introspect the PostHog database schema.',
         icon: IconHogQL,
+        inMenu: true,
+    },
+    [NodeKind.RevenueAnalyticsOverviewQuery]: {
+        name: 'Revenue Analytics Overview',
+        description: 'View revenue analytics overview.',
+        icon: IconPiggyBank,
+        inMenu: true,
+    },
+    [NodeKind.RevenueAnalyticsGrowthRateQuery]: {
+        name: 'Revenue Analytics Growth Rate',
+        description: 'View revenue analytics growth rate.',
+        icon: IconPiggyBank,
+        inMenu: true,
+    },
+    [NodeKind.RevenueAnalyticsChurnRateQuery]: {
+        name: 'Revenue Analytics Churn Rate',
+        description: 'View revenue analytics churn rate.',
+        icon: IconPiggyBank,
         inMenu: true,
     },
     [NodeKind.WebOverviewQuery]: {

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -584,7 +584,7 @@ export const routes: Record<string, [Scene | string, string]> = {
     [urls.personByUUID('*', false)]: [Scene.Person, 'personByUUID'],
     [urls.persons()]: [Scene.PersonsManagement, 'persons'],
     [urls.pipelineNodeNew(':stage')]: [Scene.PipelineNodeNew, 'pipelineNodeNew'],
-    [urls.pipelineNodeNew(':stage', ':id')]: [Scene.PipelineNodeNew, 'pipelineNodeNewWithId'],
+    [urls.pipelineNodeNew(':stage', { id: ':id' })]: [Scene.PipelineNodeNew, 'pipelineNodeNewWithId'],
     [urls.pipeline(':tab')]: [Scene.Pipeline, 'pipeline'],
     [urls.pipelineNode(':stage', ':id', ':nodeTab')]: [Scene.PipelineNode, 'pipelineNode'],
     [urls.pipelineNode(':stage', ':id')]: [Scene.PipelineNode, 'pipelineNodeWithId'],

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -41,8 +41,20 @@ export const urls = {
     ingestionWarnings: (): string => '/data-management/ingestion-warnings',
     revenueSettings: (): string => '/data-management/revenue',
 
-    pipelineNodeNew: (stage: PipelineStage | ':stage', id?: string | number): string => {
-        return `/pipeline/new/${stage}${id ? `/${id}` : ''}`
+    pipelineNodeNew: (
+        stage: PipelineStage | ':stage',
+        { id, kind }: { id?: string | number; kind?: string } = {}
+    ): string => {
+        let base = `/pipeline/new/${stage}`
+        if (id) {
+            base += `/${id}`
+        }
+
+        if (kind) {
+            return `${base}?kind=${kind}`
+        }
+
+        return base
     },
     pipeline: (tab?: PipelineTab | ':tab'): string => `/pipeline/${tab ? tab : PipelineTab.Overview}`,
     /** @param id 'new' for new, uuid for batch exports and numbers for plugins */

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -635,7 +635,12 @@ class SerializedField:
     chain: Optional[list[str | int]] = None
 
 
-DatabaseSchemaTable: TypeAlias = DatabaseSchemaPostHogTable | DatabaseSchemaDataWarehouseTable | DatabaseSchemaViewTable
+DatabaseSchemaTable: TypeAlias = (
+    DatabaseSchemaPostHogTable
+    | DatabaseSchemaDataWarehouseTable
+    | DatabaseSchemaViewTable
+    | DatabaseSchemaManagedViewTable
+)
 
 
 def serialize_database(
@@ -687,11 +692,6 @@ def serialize_database(
         .all()
         if warehouse_table_names
         else []
-    )
-
-    # Fetch all views in a single query
-    all_views = (
-        DataWarehouseSavedQuery.objects.exclude(deleted=True).filter(team_id=context.team_id).all() if views else []
     )
 
     # Process warehouse tables
@@ -759,6 +759,11 @@ def serialize_database(
             schema=schema,
             source=source,
         )
+
+    # Fetch all views in a single query
+    all_views = (
+        DataWarehouseSavedQuery.objects.exclude(deleted=True).filter(team_id=context.team_id).all() if views else []
+    )
 
     # Process views using prefetched data
     views_dict = {view.name: view for view in all_views}

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -377,6 +377,45 @@ def get_query_runner(
             limit_context=limit_context,
         )
 
+    if kind == "RevenueAnalyticsOverviewQuery":
+        from products.revenue_analytics.backend.hogql_queries.revenue_analytics_overview_query_runner import (
+            RevenueAnalyticsOverviewQueryRunner,
+        )
+
+        return RevenueAnalyticsOverviewQueryRunner(
+            query=query,
+            team=team,
+            timings=timings,
+            modifiers=modifiers,
+            limit_context=limit_context,
+        )
+
+    if kind == "RevenueAnalyticsGrowthRateQuery":
+        from products.revenue_analytics.backend.hogql_queries.revenue_analytics_growth_rate_query_runner import (
+            RevenueAnalyticsGrowthRateQueryRunner,
+        )
+
+        return RevenueAnalyticsGrowthRateQueryRunner(
+            query=query,
+            team=team,
+            timings=timings,
+            modifiers=modifiers,
+            limit_context=limit_context,
+        )
+
+    if kind == "RevenueAnalyticsChurnRateQuery":
+        from products.revenue_analytics.backend.hogql_queries.revenue_analytics_churn_rate_query_runner import (
+            RevenueAnalyticsChurnRateQueryRunner,
+        )
+
+        return RevenueAnalyticsChurnRateQueryRunner(
+            query=query,
+            team=team,
+            timings=timings,
+            modifiers=modifiers,
+            limit_context=limit_context,
+        )
+
     if kind == "RevenueExampleEventsQuery":
         from products.revenue_analytics.backend.hogql_queries.revenue_example_events_query_runner import (
             RevenueExampleEventsQueryRunner,

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -768,6 +768,7 @@ class Type1(StrEnum):
     VIEW = "view"
     BATCH_EXPORT = "batch_export"
     MATERIALIZED_VIEW = "materialized_view"
+    MANAGED_VIEW = "managed_view"
 
 
 class DatabaseSerializedFieldType(StrEnum):
@@ -1411,6 +1412,9 @@ class NodeKind(StrEnum):
     WEB_GOALS_QUERY = "WebGoalsQuery"
     WEB_VITALS_QUERY = "WebVitalsQuery"
     WEB_VITALS_PATH_BREAKDOWN_QUERY = "WebVitalsPathBreakdownQuery"
+    REVENUE_ANALYTICS_OVERVIEW_QUERY = "RevenueAnalyticsOverviewQuery"
+    REVENUE_ANALYTICS_GROWTH_RATE_QUERY = "RevenueAnalyticsGrowthRateQuery"
+    REVENUE_ANALYTICS_CHURN_RATE_QUERY = "RevenueAnalyticsChurnRateQuery"
     EXPERIMENT_METRIC = "ExperimentMetric"
     EXPERIMENT_QUERY = "ExperimentQuery"
     EXPERIMENT_EXPOSURE_QUERY = "ExperimentExposureQuery"
@@ -1567,7 +1571,7 @@ class QueryResponseAlternative17(BaseModel):
     total_exposures: dict[str, float]
 
 
-class QueryResponseAlternative47(BaseModel):
+class QueryResponseAlternative53(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -1686,6 +1690,14 @@ class RetentionPeriod(StrEnum):
 class RetentionType(StrEnum):
     RETENTION_RECURRING = "retention_recurring"
     RETENTION_FIRST_TIME = "retention_first_time"
+
+
+class RevenueAnalyticsOverviewItemKey(StrEnum):
+    MRR = "MRR"
+    ARR = "ARR"
+    CUSTOMER_COUNT = "Customer Count"
+    NEW_CUSTOMERS = "New customers"
+    CHURNED_CUSTOMERS = "Churned customers"
 
 
 class RevenueCurrencyPropertyConfig(BaseModel):
@@ -3021,6 +3033,77 @@ class RetentionValue(BaseModel):
     )
     count: int
     label: Optional[str] = None
+
+
+class RevenueAnalyticsChurnRateQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    error: Optional[str] = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    query_status: Optional[QueryStatus] = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    results: Any
+    timings: Optional[list[QueryTiming]] = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+
+
+class RevenueAnalyticsGrowthRateQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    error: Optional[str] = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    query_status: Optional[QueryStatus] = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    results: Any
+    timings: Optional[list[QueryTiming]] = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+
+
+class RevenueAnalyticsOverviewItem(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    key: RevenueAnalyticsOverviewItemKey
+    value: Optional[float] = None
+
+
+class RevenueAnalyticsOverviewQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    error: Optional[str] = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    query_status: Optional[QueryStatus] = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    results: list[RevenueAnalyticsOverviewItem]
+    timings: Optional[list[QueryTiming]] = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
 
 
 class RevenueExampleDataWarehouseTablesQueryResponse(BaseModel):
@@ -4406,6 +4489,96 @@ class CachedPathsQueryResponse(BaseModel):
     )
 
 
+class CachedRevenueAnalyticsChurnRateQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    cache_key: str
+    cache_target_age: Optional[datetime] = None
+    calculation_trigger: Optional[str] = Field(
+        default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
+    )
+    error: Optional[str] = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
+    is_cached: bool
+    last_refresh: datetime
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    next_allowed_client_refresh: datetime
+    query_status: Optional[QueryStatus] = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    results: Any
+    timezone: str
+    timings: Optional[list[QueryTiming]] = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+
+
+class CachedRevenueAnalyticsGrowthRateQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    cache_key: str
+    cache_target_age: Optional[datetime] = None
+    calculation_trigger: Optional[str] = Field(
+        default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
+    )
+    error: Optional[str] = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
+    is_cached: bool
+    last_refresh: datetime
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    next_allowed_client_refresh: datetime
+    query_status: Optional[QueryStatus] = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    results: Any
+    timezone: str
+    timings: Optional[list[QueryTiming]] = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+
+
+class CachedRevenueAnalyticsOverviewQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    cache_key: str
+    cache_target_age: Optional[datetime] = None
+    calculation_trigger: Optional[str] = Field(
+        default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
+    )
+    error: Optional[str] = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
+    is_cached: bool
+    last_refresh: datetime
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    next_allowed_client_refresh: datetime
+    query_status: Optional[QueryStatus] = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    results: list[RevenueAnalyticsOverviewItem]
+    timezone: str
+    timings: Optional[list[QueryTiming]] = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+
+
 class CachedRevenueExampleDataWarehouseTablesQueryResponse(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -5094,7 +5267,75 @@ class Response9(BaseModel):
     types: Optional[list] = None
 
 
-class Response15(BaseModel):
+class Response10(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    error: Optional[str] = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    query_status: Optional[QueryStatus] = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    results: list[RevenueAnalyticsOverviewItem]
+    timings: Optional[list[QueryTiming]] = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+
+
+class Response11(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    error: Optional[str] = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    query_status: Optional[QueryStatus] = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    results: Any
+    timings: Optional[list[QueryTiming]] = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+
+
+class Response13(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    columns: Optional[list] = None
+    error: Optional[str] = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hasMore: Optional[bool] = None
+    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
+    limit: Optional[int] = None
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    offset: Optional[int] = None
+    query_status: Optional[QueryStatus] = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    results: Any
+    timings: Optional[list[QueryTiming]] = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+    types: Optional[list] = None
+
+
+class Response18(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -6291,6 +6532,48 @@ class QueryResponseAlternative23(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    error: Optional[str] = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    query_status: Optional[QueryStatus] = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    results: list[RevenueAnalyticsOverviewItem]
+    timings: Optional[list[QueryTiming]] = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+
+
+class QueryResponseAlternative24(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    error: Optional[str] = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    query_status: Optional[QueryStatus] = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    results: Any
+    timings: Optional[list[QueryTiming]] = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+
+
+class QueryResponseAlternative26(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
     columns: list
     error: Optional[str] = Field(
         default=None,
@@ -6313,7 +6596,7 @@ class QueryResponseAlternative23(BaseModel):
     types: list[str]
 
 
-class QueryResponseAlternative24(BaseModel):
+class QueryResponseAlternative27(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -6340,7 +6623,7 @@ class QueryResponseAlternative24(BaseModel):
     types: list[str]
 
 
-class QueryResponseAlternative25(BaseModel):
+class QueryResponseAlternative28(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -6367,7 +6650,7 @@ class QueryResponseAlternative25(BaseModel):
     types: list[str]
 
 
-class QueryResponseAlternative26(BaseModel):
+class QueryResponseAlternative29(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -6397,7 +6680,7 @@ class QueryResponseAlternative26(BaseModel):
     types: Optional[list] = Field(default=None, description="Types of returned columns")
 
 
-class QueryResponseAlternative27(BaseModel):
+class QueryResponseAlternative30(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -6421,7 +6704,7 @@ class QueryResponseAlternative27(BaseModel):
     )
 
 
-class QueryResponseAlternative28(BaseModel):
+class QueryResponseAlternative31(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -6448,7 +6731,7 @@ class QueryResponseAlternative28(BaseModel):
     types: Optional[list] = None
 
 
-class QueryResponseAlternative31(BaseModel):
+class QueryResponseAlternative34(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -6469,7 +6752,7 @@ class QueryResponseAlternative31(BaseModel):
     )
 
 
-class QueryResponseAlternative32(BaseModel):
+class QueryResponseAlternative35(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -6495,7 +6778,75 @@ class QueryResponseAlternative32(BaseModel):
     types: Optional[list] = None
 
 
-class QueryResponseAlternative35(BaseModel):
+class QueryResponseAlternative36(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    error: Optional[str] = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    query_status: Optional[QueryStatus] = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    results: list[RevenueAnalyticsOverviewItem]
+    timings: Optional[list[QueryTiming]] = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+
+
+class QueryResponseAlternative37(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    error: Optional[str] = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    query_status: Optional[QueryStatus] = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    results: Any
+    timings: Optional[list[QueryTiming]] = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+
+
+class QueryResponseAlternative39(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    columns: Optional[list] = None
+    error: Optional[str] = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hasMore: Optional[bool] = None
+    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
+    limit: Optional[int] = None
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    offset: Optional[int] = None
+    query_status: Optional[QueryStatus] = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    results: Any
+    timings: Optional[list[QueryTiming]] = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+    types: Optional[list] = None
+
+
+class QueryResponseAlternative41(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -6520,7 +6871,7 @@ class QueryResponseAlternative35(BaseModel):
     )
 
 
-class QueryResponseAlternative38(BaseModel):
+class QueryResponseAlternative44(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -6545,7 +6896,7 @@ class QueryResponseAlternative38(BaseModel):
     )
 
 
-class QueryResponseAlternative39(BaseModel):
+class QueryResponseAlternative45(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -6567,7 +6918,7 @@ class QueryResponseAlternative39(BaseModel):
     )
 
 
-class QueryResponseAlternative40(BaseModel):
+class QueryResponseAlternative46(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -6589,7 +6940,7 @@ class QueryResponseAlternative40(BaseModel):
     )
 
 
-class QueryResponseAlternative42(BaseModel):
+class QueryResponseAlternative48(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -6610,7 +6961,7 @@ class QueryResponseAlternative42(BaseModel):
     )
 
 
-class QueryResponseAlternative43(BaseModel):
+class QueryResponseAlternative49(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -6631,7 +6982,7 @@ class QueryResponseAlternative43(BaseModel):
     )
 
 
-class QueryResponseAlternative45(BaseModel):
+class QueryResponseAlternative51(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -6657,7 +7008,7 @@ class QueryResponseAlternative45(BaseModel):
     types: Optional[list] = None
 
 
-class QueryResponseAlternative48(BaseModel):
+class QueryResponseAlternative54(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -6678,7 +7029,7 @@ class QueryResponseAlternative48(BaseModel):
     )
 
 
-class QueryResponseAlternative49(BaseModel):
+class QueryResponseAlternative55(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -6699,7 +7050,7 @@ class QueryResponseAlternative49(BaseModel):
     )
 
 
-class QueryResponseAlternative50(BaseModel):
+class QueryResponseAlternative56(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -6720,7 +7071,7 @@ class QueryResponseAlternative50(BaseModel):
     )
 
 
-class QueryResponseAlternative51(BaseModel):
+class QueryResponseAlternative57(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -6745,7 +7096,7 @@ class QueryResponseAlternative51(BaseModel):
     )
 
 
-class QueryResponseAlternative52(BaseModel):
+class QueryResponseAlternative58(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -6855,6 +7206,78 @@ class RetentionResult(BaseModel):
     date: datetime
     label: str
     values: list[RetentionValue]
+
+
+class RevenueAnalyticsBaseQueryRevenueAnalyticsChurnRateQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    dateRange: Optional[DateRange] = None
+    kind: NodeKind
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    response: Optional[RevenueAnalyticsChurnRateQueryResponse] = None
+
+
+class RevenueAnalyticsBaseQueryRevenueAnalyticsGrowthRateQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    dateRange: Optional[DateRange] = None
+    kind: NodeKind
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    response: Optional[RevenueAnalyticsGrowthRateQueryResponse] = None
+
+
+class RevenueAnalyticsBaseQueryRevenueAnalyticsOverviewQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    dateRange: Optional[DateRange] = None
+    kind: NodeKind
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    response: Optional[RevenueAnalyticsOverviewQueryResponse] = None
+
+
+class RevenueAnalyticsChurnRateQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    dateRange: Optional[DateRange] = None
+    kind: Literal["RevenueAnalyticsChurnRateQuery"] = "RevenueAnalyticsChurnRateQuery"
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    response: Optional[RevenueAnalyticsChurnRateQueryResponse] = None
+
+
+class RevenueAnalyticsGrowthRateQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    dateRange: Optional[DateRange] = None
+    kind: Literal["RevenueAnalyticsGrowthRateQuery"] = "RevenueAnalyticsGrowthRateQuery"
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    response: Optional[RevenueAnalyticsGrowthRateQueryResponse] = None
+
+
+class RevenueAnalyticsOverviewQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    dateRange: Optional[DateRange] = None
+    kind: Literal["RevenueAnalyticsOverviewQuery"] = "RevenueAnalyticsOverviewQuery"
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    response: Optional[RevenueAnalyticsOverviewQueryResponse] = None
 
 
 class RevenueExampleDataWarehouseTablesQuery(BaseModel):
@@ -7447,7 +7870,7 @@ class Response3(BaseModel):
     types: Optional[list] = Field(default=None, description="Types of returned columns")
 
 
-class Response12(BaseModel):
+class Response15(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -7636,7 +8059,7 @@ class PropertyGroupFilter(BaseModel):
     values: list[PropertyGroupFilterValue]
 
 
-class QueryResponseAlternative41(BaseModel):
+class QueryResponseAlternative47(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -7944,7 +8367,7 @@ class CachedExperimentTrendsQueryResponse(BaseModel):
     variants: list[ExperimentVariantTrendsBaseStats]
 
 
-class Response14(BaseModel):
+class Response17(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -7970,6 +8393,17 @@ class DataVisualizationNode(BaseModel):
     kind: Literal["DataVisualizationNode"] = "DataVisualizationNode"
     source: HogQLQuery
     tableSettings: Optional[TableSettings] = None
+
+
+class DatabaseSchemaManagedViewTable(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    fields: dict[str, DatabaseSchemaField]
+    id: str
+    name: str
+    query: HogQLQuery
+    type: Literal["managed_view"] = "managed_view"
 
 
 class DatabaseSchemaMaterializedViewTable(BaseModel):
@@ -8452,7 +8886,7 @@ class QueryResponseAlternative16(BaseModel):
     variants: Union[list[ExperimentVariantTrendsBaseStats], list[ExperimentVariantFunnelsBaseStats]]
 
 
-class QueryResponseAlternative36(BaseModel):
+class QueryResponseAlternative42(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -8468,7 +8902,7 @@ class QueryResponseAlternative36(BaseModel):
     variants: list[ExperimentVariantFunnelsBaseStats]
 
 
-class QueryResponseAlternative37(BaseModel):
+class QueryResponseAlternative43(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -8599,7 +9033,7 @@ class CachedExperimentQueryResponse(BaseModel):
     variants: Union[list[ExperimentVariantTrendsBaseStats], list[ExperimentVariantFunnelsBaseStats]]
 
 
-class Response13(BaseModel):
+class Response16(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -8752,7 +9186,7 @@ class PathsQuery(BaseModel):
     samplingFactor: Optional[float] = Field(default=None, description="Sampling rate")
 
 
-class QueryResponseAlternative46(BaseModel):
+class QueryResponseAlternative52(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -8762,6 +9196,7 @@ class QueryResponseAlternative46(BaseModel):
             DatabaseSchemaPostHogTable,
             DatabaseSchemaDataWarehouseTable,
             DatabaseSchemaViewTable,
+            DatabaseSchemaManagedViewTable,
             DatabaseSchemaBatchExportTable,
             DatabaseSchemaMaterializedViewTable,
         ],
@@ -8790,32 +9225,37 @@ class QueryResponseAlternative(
             QueryResponseAlternative18,
             QueryResponseAlternative19,
             QueryResponseAlternative22,
-            Any,
             QueryResponseAlternative23,
             QueryResponseAlternative24,
-            QueryResponseAlternative25,
+            Any,
             QueryResponseAlternative26,
             QueryResponseAlternative27,
             QueryResponseAlternative28,
+            QueryResponseAlternative29,
+            QueryResponseAlternative30,
             QueryResponseAlternative31,
-            QueryResponseAlternative32,
+            QueryResponseAlternative34,
             QueryResponseAlternative35,
             QueryResponseAlternative36,
             QueryResponseAlternative37,
-            QueryResponseAlternative38,
             QueryResponseAlternative39,
-            QueryResponseAlternative40,
             QueryResponseAlternative41,
             QueryResponseAlternative42,
             QueryResponseAlternative43,
+            QueryResponseAlternative44,
             QueryResponseAlternative45,
             QueryResponseAlternative46,
             QueryResponseAlternative47,
             QueryResponseAlternative48,
             QueryResponseAlternative49,
-            QueryResponseAlternative50,
             QueryResponseAlternative51,
             QueryResponseAlternative52,
+            QueryResponseAlternative53,
+            QueryResponseAlternative54,
+            QueryResponseAlternative55,
+            QueryResponseAlternative56,
+            QueryResponseAlternative57,
+            QueryResponseAlternative58,
         ]
     ]
 ):
@@ -8839,32 +9279,37 @@ class QueryResponseAlternative(
         QueryResponseAlternative18,
         QueryResponseAlternative19,
         QueryResponseAlternative22,
-        Any,
         QueryResponseAlternative23,
         QueryResponseAlternative24,
-        QueryResponseAlternative25,
+        Any,
         QueryResponseAlternative26,
         QueryResponseAlternative27,
         QueryResponseAlternative28,
+        QueryResponseAlternative29,
+        QueryResponseAlternative30,
         QueryResponseAlternative31,
-        QueryResponseAlternative32,
+        QueryResponseAlternative34,
         QueryResponseAlternative35,
         QueryResponseAlternative36,
         QueryResponseAlternative37,
-        QueryResponseAlternative38,
         QueryResponseAlternative39,
-        QueryResponseAlternative40,
         QueryResponseAlternative41,
         QueryResponseAlternative42,
         QueryResponseAlternative43,
+        QueryResponseAlternative44,
         QueryResponseAlternative45,
         QueryResponseAlternative46,
         QueryResponseAlternative47,
         QueryResponseAlternative48,
         QueryResponseAlternative49,
-        QueryResponseAlternative50,
         QueryResponseAlternative51,
         QueryResponseAlternative52,
+        QueryResponseAlternative53,
+        QueryResponseAlternative54,
+        QueryResponseAlternative55,
+        QueryResponseAlternative56,
+        QueryResponseAlternative57,
+        QueryResponseAlternative58,
     ]
 
 
@@ -8878,6 +9323,7 @@ class DatabaseSchemaQueryResponse(BaseModel):
             DatabaseSchemaPostHogTable,
             DatabaseSchemaDataWarehouseTable,
             DatabaseSchemaViewTable,
+            DatabaseSchemaManagedViewTable,
             DatabaseSchemaBatchExportTable,
             DatabaseSchemaMaterializedViewTable,
         ],
@@ -9212,10 +9658,13 @@ class DataTableNode(BaseModel):
             Response5,
             Response8,
             Response9,
-            Response12,
+            Response10,
+            Response11,
             Response13,
-            Response14,
             Response15,
+            Response16,
+            Response17,
+            Response18,
         ]
     ] = None
     showActions: Optional[bool] = Field(default=None, description="Show the kebab menu at the end of the row")
@@ -9258,6 +9707,9 @@ class DataTableNode(BaseModel):
         WebVitalsQuery,
         WebVitalsPathBreakdownQuery,
         SessionAttributionExplorerQuery,
+        RevenueAnalyticsOverviewQuery,
+        RevenueAnalyticsGrowthRateQuery,
+        RevenueAnalyticsChurnRateQuery,
         RevenueExampleEventsQuery,
         RevenueExampleDataWarehouseTablesQuery,
         ErrorTrackingQuery,
@@ -9296,6 +9748,9 @@ class HogQLAutocomplete(BaseModel):
             HogQLQuery,
             HogQLMetadata,
             HogQLAutocomplete,
+            RevenueAnalyticsOverviewQuery,
+            RevenueAnalyticsGrowthRateQuery,
+            RevenueAnalyticsChurnRateQuery,
             WebOverviewQuery,
             WebStatsTableQuery,
             WebExternalClicksTableQuery,
@@ -9347,6 +9802,9 @@ class HogQLMetadata(BaseModel):
             HogQLQuery,
             HogQLMetadata,
             HogQLAutocomplete,
+            RevenueAnalyticsOverviewQuery,
+            RevenueAnalyticsGrowthRateQuery,
+            RevenueAnalyticsChurnRateQuery,
             WebOverviewQuery,
             WebStatsTableQuery,
             WebExternalClicksTableQuery,
@@ -9410,6 +9868,9 @@ class QueryRequest(BaseModel):
         WebGoalsQuery,
         WebVitalsQuery,
         WebVitalsPathBreakdownQuery,
+        RevenueAnalyticsOverviewQuery,
+        RevenueAnalyticsGrowthRateQuery,
+        RevenueAnalyticsChurnRateQuery,
         DataVisualizationNode,
         DataTableNode,
         SavedInsightNode,
@@ -9486,6 +9947,9 @@ class QuerySchemaRoot(
             WebGoalsQuery,
             WebVitalsQuery,
             WebVitalsPathBreakdownQuery,
+            RevenueAnalyticsOverviewQuery,
+            RevenueAnalyticsGrowthRateQuery,
+            RevenueAnalyticsChurnRateQuery,
             DataVisualizationNode,
             DataTableNode,
             SavedInsightNode,
@@ -9536,6 +10000,9 @@ class QuerySchemaRoot(
         WebGoalsQuery,
         WebVitalsQuery,
         WebVitalsPathBreakdownQuery,
+        RevenueAnalyticsOverviewQuery,
+        RevenueAnalyticsGrowthRateQuery,
+        RevenueAnalyticsChurnRateQuery,
         DataVisualizationNode,
         DataTableNode,
         SavedInsightNode,

--- a/products/early_access_features/frontend/InstructionsModal.tsx
+++ b/products/early_access_features/frontend/InstructionsModal.tsx
@@ -28,10 +28,9 @@ export function InstructionsModal({ onClose, visible, flag }: InstructionsModalP
                         <div>
                             Give your users a{' '}
                             <Link
-                                to={urls.pipelineNodeNew(
-                                    PipelineStage.SiteApp,
-                                    preflight?.region === Region.EU ? 332 : 574
-                                )}
+                                to={urls.pipelineNodeNew(PipelineStage.SiteApp, {
+                                    id: preflight?.region === Region.EU ? 332 : 574,
+                                })}
                             >
                                 prebuilt widget
                             </Link>{' '}

--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_churn_rate_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_churn_rate_query_runner.py
@@ -1,0 +1,36 @@
+from posthog.hogql import ast
+from posthog.hogql.query import execute_hogql_query
+from posthog.schema import (
+    CachedRevenueAnalyticsChurnRateQueryResponse,
+    RevenueAnalyticsChurnRateQueryResponse,
+    RevenueAnalyticsChurnRateQuery,
+)
+
+from .revenue_analytics_query_runner import RevenueAnalyticsQueryRunner
+
+
+class RevenueAnalyticsChurnRateQueryRunner(RevenueAnalyticsQueryRunner):
+    query: RevenueAnalyticsChurnRateQuery
+    response: RevenueAnalyticsChurnRateQueryResponse
+    cached_response: CachedRevenueAnalyticsChurnRateQueryResponse
+
+    def to_query(self) -> ast.SelectQuery:
+        return ast.SelectQuery.empty()
+
+    def calculate(self):
+        response = execute_hogql_query(
+            query_type="revenue_analytics_churn_rate_query",
+            query=self.to_query(),
+            team=self.team,
+            timings=self.timings,
+            modifiers=self.modifiers,
+            limit_context=self.limit_context,
+        )
+
+        assert response.results
+
+        return RevenueAnalyticsChurnRateQueryResponse(
+            columns=response.columns,
+            results=response.results,
+            modifiers=self.modifiers,
+        )

--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_churn_rate_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_churn_rate_query_runner.py
@@ -30,7 +30,6 @@ class RevenueAnalyticsChurnRateQueryRunner(RevenueAnalyticsQueryRunner):
         assert response.results
 
         return RevenueAnalyticsChurnRateQueryResponse(
-            columns=response.columns,
             results=response.results,
             modifiers=self.modifiers,
         )

--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_growth_rate_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_growth_rate_query_runner.py
@@ -30,7 +30,6 @@ class RevenueAnalyticsGrowthRateQueryRunner(RevenueAnalyticsQueryRunner):
         assert response.results
 
         return RevenueAnalyticsGrowthRateQueryResponse(
-            columns=response.columns,
             results=response.results,
             modifiers=self.modifiers,
         )

--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_growth_rate_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_growth_rate_query_runner.py
@@ -1,0 +1,36 @@
+from posthog.hogql import ast
+from posthog.hogql.query import execute_hogql_query
+from posthog.schema import (
+    CachedRevenueAnalyticsGrowthRateQueryResponse,
+    RevenueAnalyticsGrowthRateQueryResponse,
+    RevenueAnalyticsGrowthRateQuery,
+)
+
+from .revenue_analytics_query_runner import RevenueAnalyticsQueryRunner
+
+
+class RevenueAnalyticsGrowthRateQueryRunner(RevenueAnalyticsQueryRunner):
+    query: RevenueAnalyticsGrowthRateQuery
+    response: RevenueAnalyticsGrowthRateQueryResponse
+    cached_response: CachedRevenueAnalyticsGrowthRateQueryResponse
+
+    def to_query(self) -> ast.SelectQuery:
+        return ast.SelectQuery.empty()
+
+    def calculate(self):
+        response = execute_hogql_query(
+            query_type="revenue_analytics_growth_rate_query",
+            query=self.to_query(),
+            team=self.team,
+            timings=self.timings,
+            modifiers=self.modifiers,
+            limit_context=self.limit_context,
+        )
+
+        assert response.results
+
+        return RevenueAnalyticsGrowthRateQueryResponse(
+            columns=response.columns,
+            results=response.results,
+            modifiers=self.modifiers,
+        )

--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_overview_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_overview_query_runner.py
@@ -1,0 +1,36 @@
+from posthog.hogql import ast
+from posthog.hogql.query import execute_hogql_query
+from posthog.schema import (
+    CachedRevenueAnalyticsOverviewQueryResponse,
+    RevenueAnalyticsOverviewQueryResponse,
+    RevenueAnalyticsOverviewQuery,
+)
+
+from .revenue_analytics_query_runner import RevenueAnalyticsQueryRunner
+
+
+class RevenueAnalyticsOverviewQueryRunner(RevenueAnalyticsQueryRunner):
+    query: RevenueAnalyticsOverviewQuery
+    response: RevenueAnalyticsOverviewQueryResponse
+    cached_response: CachedRevenueAnalyticsOverviewQueryResponse
+
+    def to_query(self) -> ast.SelectQuery:
+        return ast.SelectQuery.empty()
+
+    def calculate(self):
+        response = execute_hogql_query(
+            query_type="revenue_analytics_overview_query",
+            query=self.to_query(),
+            team=self.team,
+            timings=self.timings,
+            modifiers=self.modifiers,
+            limit_context=self.limit_context,
+        )
+
+        assert response.results
+
+        return RevenueAnalyticsOverviewQueryResponse(
+            columns=response.columns,
+            results=response.results,
+            modifiers=self.modifiers,
+        )

--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_overview_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_overview_query_runner.py
@@ -30,7 +30,6 @@ class RevenueAnalyticsOverviewQueryRunner(RevenueAnalyticsQueryRunner):
         assert response.results
 
         return RevenueAnalyticsOverviewQueryResponse(
-            columns=response.columns,
             results=response.results,
             modifiers=self.modifiers,
         )

--- a/products/revenue_analytics/backend/hogql_queries/revenue_analytics_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_analytics_query_runner.py
@@ -1,0 +1,6 @@
+from posthog.hogql_queries.query_runner import QueryRunner
+
+
+# Base class, empty for now but might include some helpers in the future
+class RevenueAnalyticsQueryRunner(QueryRunner):
+    pass

--- a/products/revenue_analytics/backend/hogql_queries/revenue_example_data_warehouse_tables_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_example_data_warehouse_tables_query_runner.py
@@ -3,7 +3,6 @@ from typing import cast, Union
 from posthog.hogql import ast
 from posthog.hogql.constants import LimitContext
 from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
-from posthog.hogql_queries.query_runner import QueryRunner
 from posthog.hogql.database.database import create_hogql_database, Database
 from posthog.hogql.hogql import HogQLContext
 from posthog.schema import (
@@ -12,9 +11,10 @@ from posthog.schema import (
     CachedRevenueExampleDataWarehouseTablesQueryResponse,
 )
 from ..models import RevenueAnalyticsRevenueView
+from .revenue_analytics_query_runner import RevenueAnalyticsQueryRunner
 
 
-class RevenueExampleDataWarehouseTablesQueryRunner(QueryRunner):
+class RevenueExampleDataWarehouseTablesQueryRunner(RevenueAnalyticsQueryRunner):
     query: RevenueExampleDataWarehouseTablesQuery
     response: RevenueExampleDataWarehouseTablesQueryResponse
     cached_response: CachedRevenueExampleDataWarehouseTablesQueryResponse

--- a/products/revenue_analytics/backend/hogql_queries/revenue_example_events_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_example_events_query_runner.py
@@ -4,7 +4,6 @@ from posthog.hogql import ast
 from posthog.hogql.ast import CompareOperationOp
 from posthog.hogql.constants import LimitContext
 from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
-from posthog.hogql_queries.query_runner import QueryRunner
 from posthog.hogql.database.schema.exchange_rate import (
     DEFAULT_CURRENCY,
     revenue_expression_for_events,
@@ -17,8 +16,10 @@ from posthog.schema import (
     CachedRevenueExampleEventsQueryResponse,
 )
 
+from .revenue_analytics_query_runner import RevenueAnalyticsQueryRunner
 
-class RevenueExampleEventsQueryRunner(QueryRunner):
+
+class RevenueExampleEventsQueryRunner(RevenueAnalyticsQueryRunner):
     query: RevenueExampleEventsQuery
     response: RevenueExampleEventsQueryResponse
     cached_response: CachedRevenueExampleEventsQueryResponse

--- a/products/revenue_analytics/backend/models.py
+++ b/products/revenue_analytics/backend/models.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     pass
 
 STRIPE_DATA_WAREHOUSE_CHARGE_IDENTIFIER = "Charge"
+STRIPE_CHARGE_SUCCEEDED_STATUS = "succeeded"
 
 # Stripe represents most currencies with integer amounts multiplied by 100,
 # since most currencies have its smallest unit as 1/100 of their base unit
@@ -58,8 +59,6 @@ FIELDS: dict[str, FieldOrTable] = {
     "currency": StringDatabaseField(name="currency"),
     "amount": DecimalDatabaseField(name="amount"),
 }
-
-STRIPE_CHARGE_SUCCEEDED_STATUS = "succeeded"
 
 
 class RevenueAnalyticsRevenueView(SavedQuery):

--- a/products/revenue_analytics/frontend/RevenueAnalyticsScene.tsx
+++ b/products/revenue_analytics/frontend/RevenueAnalyticsScene.tsx
@@ -1,11 +1,20 @@
+import { IconPlus } from '@posthog/icons'
+import { LemonButton, Link } from '@posthog/lemon-ui'
+import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
+import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
+import { userLogic } from 'scenes/userLogic'
 
 import { PipelineStage, ProductKey } from '~/types'
 
 import { revenueAnalyticsLogic } from './revenueAnalyticsLogic'
+import { GrossRevenueTile } from './tiles/GrossRevenueTile'
+import { OverviewTile } from './tiles/OverviewTile'
+import { RevenueChurnTile } from './tiles/RevenueChurnTile'
+import { RevenueGrowthRateTile } from './tiles/RevenueGrowthRateTile'
 
 export const scene: SceneExport = {
     component: RevenueAnalyticsScene,
@@ -13,17 +22,76 @@ export const scene: SceneExport = {
 }
 
 export function RevenueAnalyticsScene(): JSX.Element {
+    const { hasRevenueTables } = useValues(revenueAnalyticsLogic)
+    const { updateHasSeenProductIntroFor } = useActions(userLogic)
+
     return (
         <>
             <ProductIntroduction
-                isEmpty // TODO: Compute whether people need to enable this or not
+                isEmpty={!hasRevenueTables}
                 productName="Revenue Analytics"
                 productKey={ProductKey.REVENUE_ANALYTICS}
-                thingName="revenue" // TODO: Doesn't make sense, this is temporary
+                titleOverride="Connect your first revenue source"
+                thingName="revenue" // Not used because we're overriding the title, but required prop
                 description="Track and analyze your revenue metrics to understand your business performance and growth."
-                docsURL="https://posthog.com/docs/revenue-analytics"
-                action={() => router.actions.push(urls.pipelineNodeNew(PipelineStage.Source, { kind: 'stripe' }))}
+                actionElementOverride={
+                    <div className="flex flex-col gap-1">
+                        <LemonButton
+                            type="primary"
+                            icon={<IconPlus />}
+                            onClick={() => {
+                                updateHasSeenProductIntroFor(ProductKey.REVENUE_ANALYTICS, true)
+                                router.actions.push(urls.pipelineNodeNew(PipelineStage.Source, { kind: 'stripe' }))
+                            }}
+                            data-attr="create-revenue-source"
+                        >
+                            Connect revenue source
+                        </LemonButton>
+                        <span className="text-xs text-muted-alt">
+                            Only Stripe is supported currently. <br />
+                            <Link
+                                target="_blank"
+                                to="https://github.com/PostHog/posthog/issues/new?assignees=&labels=enhancement,feature/revenue-analytics%2C+feature&projects=&template=feature_request.yml&title=New%20revenue%20source:%20%3Cinsert%20source%3E"
+                            >
+                                Request more revenue integrations.
+                            </Link>
+                        </span>
+                    </div>
+                }
             />
+
+            {hasRevenueTables && (
+                <div className="flex flex-col gap-2">
+                    <RevenueAnalyticsFilters />
+                    <RevenueAnalyticsTables />
+                </div>
+            )}
         </>
+    )
+}
+
+// Currently only date filter, might need to add more filters and in that case we'll want this to be sticky
+const RevenueAnalyticsFilters = (): JSX.Element => {
+    const {
+        dateFilter: { dateTo, dateFrom },
+    } = useValues(revenueAnalyticsLogic)
+    const { setDates } = useActions(revenueAnalyticsLogic)
+
+    return (
+        <div className="flex flex-row">
+            <DateFilter dateFrom={dateFrom} dateTo={dateTo} onChange={setDates} />
+        </div>
+    )
+}
+
+const RevenueAnalyticsTables = (): JSX.Element => {
+    return (
+        <div className="flex flex-col gap-4">
+            <OverviewTile />
+
+            <GrossRevenueTile />
+            <RevenueGrowthRateTile />
+            <RevenueChurnTile />
+        </div>
     )
 }

--- a/products/revenue_analytics/frontend/RevenueAnalyticsScene.tsx
+++ b/products/revenue_analytics/frontend/RevenueAnalyticsScene.tsx
@@ -1,11 +1,9 @@
-import { LemonButton } from '@posthog/lemon-ui'
 import { router } from 'kea-router'
-import { PageHeader } from 'lib/components/PageHeader'
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
-import { ProductKey } from '~/types'
+import { PipelineStage, ProductKey } from '~/types'
 
 import { revenueAnalyticsLogic } from './revenueAnalyticsLogic'
 
@@ -17,7 +15,6 @@ export const scene: SceneExport = {
 export function RevenueAnalyticsScene(): JSX.Element {
     return (
         <>
-            <PageHeader buttons={<LemonButton type="primary">CREATE SOMETHING TODO</LemonButton>} delimited />
             <ProductIntroduction
                 isEmpty // TODO: Compute whether people need to enable this or not
                 productName="Revenue Analytics"
@@ -25,7 +22,7 @@ export function RevenueAnalyticsScene(): JSX.Element {
                 thingName="revenue" // TODO: Doesn't make sense, this is temporary
                 description="Track and analyze your revenue metrics to understand your business performance and growth."
                 docsURL="https://posthog.com/docs/revenue-analytics"
-                action={() => router.actions.push(urls.revenueAnalytics())} // TODO: Doesn't make sense, this is temporary
+                action={() => router.actions.push(urls.pipelineNodeNew(PipelineStage.Source, { kind: 'stripe' }))}
             />
         </>
     )

--- a/products/revenue_analytics/frontend/revenueAnalyticsLogic.ts
+++ b/products/revenue_analytics/frontend/revenueAnalyticsLogic.ts
@@ -1,12 +1,94 @@
-import { kea, path, selectors } from 'kea'
+import { actions, connect, kea, path, reducers, selectors } from 'kea'
+import { getDefaultInterval, updateDatesWithInterval } from 'lib/utils'
+import { getCurrencySymbol } from 'lib/utils/geography/currency'
+import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
+import { dataWarehouseSceneLogic } from 'scenes/data-warehouse/settings/dataWarehouseSceneLogic'
 import { urls } from 'scenes/urls'
 
-import { Breadcrumb } from '~/types'
+import { NodeKind, QuerySchema } from '~/queries/schema/schema-general'
+import { Breadcrumb, ChartDisplayType, InsightLogicProps, IntervalType, PropertyMathType } from '~/types'
 
 import type { revenueAnalyticsLogicType } from './revenueAnalyticsLogicType'
+import { revenueEventsSettingsLogic } from './settings/revenueEventsSettingsLogic'
+
+export enum RevenueAnalyticsQuery {
+    OVERVIEW,
+    GROSS_REVENUE,
+    REVENUE_GROWTH_RATE,
+    REVENUE_CHURN,
+}
+
+export const REVENUE_ANALYTICS_DATA_COLLECTION_NODE_ID = 'revenue-analytics'
+
+// Type needs to look like this to be able to apss this to
+export const buildDashboardItemId = (queryType: RevenueAnalyticsQuery): InsightLogicProps['dashboardItemId'] => {
+    return `new-AdHoc.revenue-analytics.${queryType}`
+}
+
+const INITIAL_DATE_FROM = '-30d' as string | null
+const INITIAL_DATE_TO = null as string | null
+const INITIAL_INTERVAL = getDefaultInterval(INITIAL_DATE_FROM, INITIAL_DATE_TO)
+
+const teamId = window.POSTHOG_APP_CONTEXT?.current_team?.id
+const persistConfig = { persist: true, prefix: `${teamId}__` }
 
 export const revenueAnalyticsLogic = kea<revenueAnalyticsLogicType>([
     path(['products', 'revenueAnalytics', 'frontend', 'revenueAnalyticsLogic']),
+    connect(() => ({
+        values: [
+            dataWarehouseSceneLogic,
+            ['dataWarehouseTablesBySourceType'],
+            databaseTableListLogic,
+            ['managedViews'],
+            revenueEventsSettingsLogic,
+            ['baseCurrency'],
+        ],
+    })),
+    actions({
+        setDates: (dateFrom: string | null, dateTo: string | null) => ({ dateFrom, dateTo }),
+        setInterval: (interval: IntervalType) => ({ interval }),
+        setDatesAndInterval: (dateFrom: string | null, dateTo: string | null, interval: IntervalType) => ({
+            dateFrom,
+            dateTo,
+            interval,
+        }),
+    }),
+    reducers({
+        dateFilter: [
+            {
+                dateFrom: INITIAL_DATE_FROM,
+                dateTo: INITIAL_DATE_TO,
+                interval: INITIAL_INTERVAL,
+            },
+            persistConfig,
+            {
+                setDates: (_, { dateTo, dateFrom }) => ({
+                    dateTo,
+                    dateFrom,
+                    interval: getDefaultInterval(dateFrom, dateTo),
+                }),
+                setInterval: ({ dateFrom: oldDateFrom, dateTo: oldDateTo }, { interval }) => {
+                    const { dateFrom, dateTo } = updateDatesWithInterval(interval, oldDateFrom, oldDateTo)
+                    return {
+                        dateTo,
+                        dateFrom,
+                        interval,
+                    }
+                },
+                setDatesAndInterval: (_, { dateTo, dateFrom, interval }) => {
+                    if (!dateFrom && !dateTo) {
+                        dateFrom = INITIAL_DATE_FROM
+                        dateTo = INITIAL_DATE_TO
+                    }
+                    return {
+                        dateTo,
+                        dateFrom,
+                        interval: interval || getDefaultInterval(dateFrom, dateTo),
+                    }
+                },
+            },
+        ],
+    }),
     selectors({
         breadcrumbs: [
             () => [],
@@ -17,6 +99,66 @@ export const revenueAnalyticsLogic = kea<revenueAnalyticsLogicType>([
                     path: urls.revenueAnalytics(),
                 },
             ],
+        ],
+
+        hasRevenueTables: [
+            (s) => [s.dataWarehouseTablesBySourceType],
+            (dataWarehouseTablesBySourceType): boolean => Boolean(dataWarehouseTablesBySourceType['Stripe']?.length),
+        ],
+
+        queries: [
+            (s) => [s.dateFilter, s.managedViews, s.baseCurrency],
+            (dateFilter, managedViews, baseCurrency): Record<RevenueAnalyticsQuery, QuerySchema> => {
+                const { dateFrom, dateTo, interval } = dateFilter
+                const dateRange = { date_from: dateFrom, date_to: dateTo }
+
+                return {
+                    [RevenueAnalyticsQuery.OVERVIEW]: {
+                        kind: NodeKind.RevenueAnalyticsOverviewQuery,
+                        dateRange,
+                    },
+                    [RevenueAnalyticsQuery.GROSS_REVENUE]: {
+                        kind: NodeKind.InsightVizNode,
+                        embedded: false,
+                        hidePersonsModal: true,
+                        hideTooltipOnScroll: true,
+                        source: {
+                            kind: NodeKind.TrendsQuery,
+                            series: managedViews.map((view) => ({
+                                kind: NodeKind.DataWarehouseNode,
+                                id: view.name,
+                                name: view.name,
+                                custom_name:
+                                    managedViews.length > 1 ? `Gross revenue for ${view.name}` : 'Gross revenue',
+                                id_field: 'id',
+                                timestamp_field: 'timestamp',
+                                distinct_id_field: 'id',
+                                table_name: view.name,
+                                math: PropertyMathType.Sum,
+                                math_property: 'amount',
+                            })),
+                            interval,
+                            dateRange,
+                            trendsFilter: {
+                                display:
+                                    managedViews.length > 1
+                                        ? ChartDisplayType.ActionsAreaGraph
+                                        : ChartDisplayType.ActionsLineGraph,
+                                aggregationAxisFormat: 'numeric',
+                                aggregationAxisPrefix: getCurrencySymbol(baseCurrency).symbol,
+                            },
+                        },
+                    },
+                    [RevenueAnalyticsQuery.REVENUE_GROWTH_RATE]: {
+                        kind: NodeKind.RevenueAnalyticsGrowthRateQuery,
+                        dateRange,
+                    },
+                    [RevenueAnalyticsQuery.REVENUE_CHURN]: {
+                        kind: NodeKind.RevenueAnalyticsChurnRateQuery,
+                        dateRange,
+                    },
+                }
+            },
         ],
     }),
 ])

--- a/products/revenue_analytics/frontend/tiles/GrossRevenueTile.tsx
+++ b/products/revenue_analytics/frontend/tiles/GrossRevenueTile.tsx
@@ -1,0 +1,39 @@
+import { useValues } from 'kea'
+import { useMemo } from 'react'
+
+import { Query } from '~/queries/Query/Query'
+import { InsightVizNode } from '~/queries/schema/schema-general'
+import { InsightLogicProps } from '~/types'
+
+import {
+    buildDashboardItemId,
+    REVENUE_ANALYTICS_DATA_COLLECTION_NODE_ID,
+    revenueAnalyticsLogic,
+    RevenueAnalyticsQuery,
+} from '../revenueAnalyticsLogic'
+
+const QUERY_ID = RevenueAnalyticsQuery.GROSS_REVENUE
+const INSIGHT_PROPS: InsightLogicProps<InsightVizNode> = {
+    dashboardItemId: buildDashboardItemId(QUERY_ID),
+    loadPriority: QUERY_ID,
+    dataNodeCollectionId: REVENUE_ANALYTICS_DATA_COLLECTION_NODE_ID,
+}
+
+export const GrossRevenueTile = (): JSX.Element => {
+    const { queries } = useValues(revenueAnalyticsLogic)
+    const query = queries[QUERY_ID]
+
+    const context = useMemo(() => ({ insightProps: { ...INSIGHT_PROPS, query } }), [query])
+
+    return (
+        <div className="flex flex-col gap-1">
+            <h3 className="text-lg font-semibold">Gross Revenue</h3>
+            <p className="text-sm text-gray-500">
+                Gross revenue is the total amount of revenue generated from all sources, including all products and
+                services.
+            </p>
+
+            <Query query={query} readOnly context={context} />
+        </div>
+    )
+}

--- a/products/revenue_analytics/frontend/tiles/OverviewTile.tsx
+++ b/products/revenue_analytics/frontend/tiles/OverviewTile.tsx
@@ -1,4 +1,8 @@
 import { useValues } from 'kea'
+import { useMemo } from 'react'
+
+import { InsightVizNode } from '~/queries/schema/schema-general'
+import { InsightLogicProps } from '~/types'
 
 import {
     buildDashboardItemId,
@@ -8,27 +12,17 @@ import {
 } from '../revenueAnalyticsLogic'
 
 const QUERY_ID = RevenueAnalyticsQuery.OVERVIEW
-const QUERY_CONTEXT = {
-    insightProps: {
-        dashboardItemId: buildDashboardItemId(QUERY_ID),
-        loadPriority: QUERY_ID,
-        dataNodeCollectionId: REVENUE_ANALYTICS_DATA_COLLECTION_NODE_ID,
-    },
+const INSIGHT_PROPS: InsightLogicProps<InsightVizNode> = {
+    dashboardItemId: buildDashboardItemId(QUERY_ID),
+    loadPriority: QUERY_ID,
+    dataNodeCollectionId: REVENUE_ANALYTICS_DATA_COLLECTION_NODE_ID,
 }
 
 export const OverviewTile = (): JSX.Element => {
     const { queries } = useValues(revenueAnalyticsLogic)
     const query = queries[QUERY_ID]
 
-    return (
-        <div className="flex flex-col gap-1">
-            TODO: {JSON.stringify({ query, context: QUERY_CONTEXT })}
-            {/* <h3 className="text-lg font-semibold">Overview</h3>
-        <p className="text-sm text-gray-500">
-            Overview of your revenue data.
-        </p>
+    const context = useMemo(() => ({ insightProps: { ...INSIGHT_PROPS, query } }), [query])
 
-        <Query query={query} readOnly context={context} /> */}
-        </div>
-    )
+    return <div className="flex flex-col gap-1">TODO: {JSON.stringify({ query, context })}</div>
 }

--- a/products/revenue_analytics/frontend/tiles/OverviewTile.tsx
+++ b/products/revenue_analytics/frontend/tiles/OverviewTile.tsx
@@ -1,0 +1,34 @@
+import { useValues } from 'kea'
+
+import {
+    buildDashboardItemId,
+    REVENUE_ANALYTICS_DATA_COLLECTION_NODE_ID,
+    revenueAnalyticsLogic,
+    RevenueAnalyticsQuery,
+} from '../revenueAnalyticsLogic'
+
+const QUERY_ID = RevenueAnalyticsQuery.OVERVIEW
+const QUERY_CONTEXT = {
+    insightProps: {
+        dashboardItemId: buildDashboardItemId(QUERY_ID),
+        loadPriority: QUERY_ID,
+        dataNodeCollectionId: REVENUE_ANALYTICS_DATA_COLLECTION_NODE_ID,
+    },
+}
+
+export const OverviewTile = (): JSX.Element => {
+    const { queries } = useValues(revenueAnalyticsLogic)
+    const query = queries[QUERY_ID]
+
+    return (
+        <div className="flex flex-col gap-1">
+            TODO: {JSON.stringify({ query, context: QUERY_CONTEXT })}
+            {/* <h3 className="text-lg font-semibold">Overview</h3>
+        <p className="text-sm text-gray-500">
+            Overview of your revenue data.
+        </p>
+
+        <Query query={query} readOnly context={context} /> */}
+        </div>
+    )
+}

--- a/products/revenue_analytics/frontend/tiles/RevenueChurnTile.tsx
+++ b/products/revenue_analytics/frontend/tiles/RevenueChurnTile.tsx
@@ -1,4 +1,8 @@
 import { useValues } from 'kea'
+import { useMemo } from 'react'
+
+import { InsightVizNode } from '~/queries/schema/schema-general'
+import { InsightLogicProps } from '~/types'
 
 import {
     buildDashboardItemId,
@@ -8,27 +12,17 @@ import {
 } from '../revenueAnalyticsLogic'
 
 const QUERY_ID = RevenueAnalyticsQuery.REVENUE_CHURN
-const QUERY_CONTEXT = {
-    insightProps: {
-        dashboardItemId: buildDashboardItemId(QUERY_ID),
-        loadPriority: QUERY_ID,
-        dataNodeCollectionId: REVENUE_ANALYTICS_DATA_COLLECTION_NODE_ID,
-    },
+const INSIGHT_PROPS: InsightLogicProps<InsightVizNode> = {
+    dashboardItemId: buildDashboardItemId(QUERY_ID),
+    loadPriority: QUERY_ID,
+    dataNodeCollectionId: REVENUE_ANALYTICS_DATA_COLLECTION_NODE_ID,
 }
 
 export const RevenueChurnTile = (): JSX.Element => {
     const { queries } = useValues(revenueAnalyticsLogic)
     const query = queries[QUERY_ID]
 
-    return (
-        <div className="flex flex-col gap-1">
-            TODO: {JSON.stringify({ query, context: QUERY_CONTEXT })}
-            {/* <h3 className="text-lg font-semibold">Revenue Churn</h3>
-        <p className="text-sm text-gray-500">
-            Revenue churn is the percentage of revenue that is lost to churn.
-        </p>
+    const context = useMemo(() => ({ insightProps: { ...INSIGHT_PROPS, query } }), [query])
 
-        <Query query={query} readOnly context={context} /> */}
-        </div>
-    )
+    return <div className="flex flex-col gap-1">TODO: {JSON.stringify({ query, context })}</div>
 }

--- a/products/revenue_analytics/frontend/tiles/RevenueChurnTile.tsx
+++ b/products/revenue_analytics/frontend/tiles/RevenueChurnTile.tsx
@@ -1,0 +1,34 @@
+import { useValues } from 'kea'
+
+import {
+    buildDashboardItemId,
+    REVENUE_ANALYTICS_DATA_COLLECTION_NODE_ID,
+    revenueAnalyticsLogic,
+    RevenueAnalyticsQuery,
+} from '../revenueAnalyticsLogic'
+
+const QUERY_ID = RevenueAnalyticsQuery.REVENUE_CHURN
+const QUERY_CONTEXT = {
+    insightProps: {
+        dashboardItemId: buildDashboardItemId(QUERY_ID),
+        loadPriority: QUERY_ID,
+        dataNodeCollectionId: REVENUE_ANALYTICS_DATA_COLLECTION_NODE_ID,
+    },
+}
+
+export const RevenueChurnTile = (): JSX.Element => {
+    const { queries } = useValues(revenueAnalyticsLogic)
+    const query = queries[QUERY_ID]
+
+    return (
+        <div className="flex flex-col gap-1">
+            TODO: {JSON.stringify({ query, context: QUERY_CONTEXT })}
+            {/* <h3 className="text-lg font-semibold">Revenue Churn</h3>
+        <p className="text-sm text-gray-500">
+            Revenue churn is the percentage of revenue that is lost to churn.
+        </p>
+
+        <Query query={query} readOnly context={context} /> */}
+        </div>
+    )
+}

--- a/products/revenue_analytics/frontend/tiles/RevenueGrowthRateTile.tsx
+++ b/products/revenue_analytics/frontend/tiles/RevenueGrowthRateTile.tsx
@@ -1,4 +1,8 @@
 import { useValues } from 'kea'
+import { useMemo } from 'react'
+
+import { InsightVizNode } from '~/queries/schema/schema-general'
+import { InsightLogicProps } from '~/types'
 
 import {
     buildDashboardItemId,
@@ -8,27 +12,17 @@ import {
 } from '../revenueAnalyticsLogic'
 
 const QUERY_ID = RevenueAnalyticsQuery.REVENUE_GROWTH_RATE
-const QUERY_CONTEXT = {
-    insightProps: {
-        dashboardItemId: buildDashboardItemId(QUERY_ID),
-        loadPriority: QUERY_ID,
-        dataNodeCollectionId: REVENUE_ANALYTICS_DATA_COLLECTION_NODE_ID,
-    },
+const INSIGHT_PROPS: InsightLogicProps<InsightVizNode> = {
+    dashboardItemId: buildDashboardItemId(QUERY_ID),
+    loadPriority: QUERY_ID,
+    dataNodeCollectionId: REVENUE_ANALYTICS_DATA_COLLECTION_NODE_ID,
 }
 
 export const RevenueGrowthRateTile = (): JSX.Element => {
     const { queries } = useValues(revenueAnalyticsLogic)
     const query = queries[QUERY_ID]
 
-    return (
-        <div className="flex flex-col gap-1">
-            TODO: {JSON.stringify({ query, context: QUERY_CONTEXT })}
-            {/* <h3 className="text-lg font-semibold">Revenue Growth Rate</h3>
-        <p className="text-sm text-gray-500">
-            Revenue growth rate is the percentage change in revenue from one period to another.
-        </p>
+    const context = useMemo(() => ({ insightProps: { ...INSIGHT_PROPS, query } }), [query])
 
-        <Query query={query} readOnly context={context} /> */}
-        </div>
-    )
+    return <div className="flex flex-col gap-1">TODO: {JSON.stringify({ query, context })}</div>
 }

--- a/products/revenue_analytics/frontend/tiles/RevenueGrowthRateTile.tsx
+++ b/products/revenue_analytics/frontend/tiles/RevenueGrowthRateTile.tsx
@@ -1,0 +1,34 @@
+import { useValues } from 'kea'
+
+import {
+    buildDashboardItemId,
+    REVENUE_ANALYTICS_DATA_COLLECTION_NODE_ID,
+    revenueAnalyticsLogic,
+    RevenueAnalyticsQuery,
+} from '../revenueAnalyticsLogic'
+
+const QUERY_ID = RevenueAnalyticsQuery.REVENUE_GROWTH_RATE
+const QUERY_CONTEXT = {
+    insightProps: {
+        dashboardItemId: buildDashboardItemId(QUERY_ID),
+        loadPriority: QUERY_ID,
+        dataNodeCollectionId: REVENUE_ANALYTICS_DATA_COLLECTION_NODE_ID,
+    },
+}
+
+export const RevenueGrowthRateTile = (): JSX.Element => {
+    const { queries } = useValues(revenueAnalyticsLogic)
+    const query = queries[QUERY_ID]
+
+    return (
+        <div className="flex flex-col gap-1">
+            TODO: {JSON.stringify({ query, context: QUERY_CONTEXT })}
+            {/* <h3 className="text-lg font-semibold">Revenue Growth Rate</h3>
+        <p className="text-sm text-gray-500">
+            Revenue growth rate is the percentage change in revenue from one period to another.
+        </p>
+
+        <Query query={query} readOnly context={context} /> */}
+        </div>
+    )
+}


### PR DESCRIPTION
We're now rendering a slightly improved "empty" state for Revenue Analytics - still ways to go.
We've also now got the initial query runners, these are all we need for an initial Beta release next week.

There's also some other improvements in this PR, all stuff that I need before launch, you can check commit by commit

- Improve Stripe setup
  - Improving description
  - Fixing broken links
  - Make "incremental" selected by default
  - Allow table name to be clicked rather than forcing a click on the checkbox
- Improve InsightLabel alignment
- Support redirection to Stripe setup

![image](https://github.com/user-attachments/assets/a4a1639e-99de-473a-9585-4d27b46c30c9)

