### PR TITLE
fix(sql-editor): Bugs and minor improvements

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -237,6 +237,8 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
             ['response', 'responseLoading', 'responseError', 'queryCancelled'],
             themeLogic,
             ['isDarkModeOn'],
+            sceneLogic,
+            ['activeScene'],
         ],
         actions: [
             dataNodeLogic({
@@ -597,11 +599,14 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
             },
         ],
         presetChartHeight: [
-            (state, props) => [props.key, state.dashboardId],
-            (key, dashboardId) => {
+            (state, props) => [props.key, state.dashboardId, state.activeScene],
+            (key, dashboardId, activeScene) => {
                 // Key for SQL editor based visiaulizations
-                const currentScene = sceneLogic.findMounted()?.values
-                const sqlEditorScene = currentScene?.activeScene === Scene.SQLEditor
+                const sqlEditorScene = activeScene === Scene.SQLEditor
+
+                if (activeScene === Scene.Insight) {
+                    return true
+                }
 
                 return !key.includes('new-SQL') && !dashboardId && !sqlEditorScene
             },

--- a/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
@@ -982,7 +982,26 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
                     }
 
                     actions.editInsight(query, insight)
-                    actions.runQuery()
+
+                    // Only run the query if the results aren't already cached locally
+                    if (insight.query?.kind === NodeKind.DataVisualizationNode && insight.query) {
+                        dataNodeLogic({
+                            key: values.dataLogicKey,
+                            query: (insight.query as DataVisualizationNode).source,
+                        }).mount()
+
+                        const response = dataNodeLogic({
+                            key: values.dataLogicKey,
+                            query: (insight.query as DataVisualizationNode).source,
+                        }).values.response
+
+                        if (!response) {
+                            actions.runQuery()
+                        }
+                    } else {
+                        actions.runQuery()
+                    }
+
                     tabAdded = true
                     router.actions.replace(router.values.location.pathname)
                 }

--- a/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
@@ -284,8 +284,11 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
         },
         editInsight: ({ query, insight }) => {
             const maybeExistingTab = values.allTabs.find((tab) => tab.insight?.short_id === insight.short_id)
+
             if (maybeExistingTab) {
-                actions.selectTab(maybeExistingTab)
+                const updatedTab = { ...maybeExistingTab, insight }
+                actions.updateTab(updatedTab)
+                actions.selectTab(updatedTab)
             } else {
                 actions.createTab(query, undefined, insight)
             }
@@ -441,29 +444,31 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
             }
         },
         _deleteTab: ({ tab: tabToRemove }) => {
-            if (props.monaco) {
-                const model = props.monaco.editor.getModel(tabToRemove.uri)
-                if (tabToRemove.uri.toString() === values.activeModelUri?.uri.toString()) {
-                    const indexOfModel = values.allTabs.findIndex(
-                        (tab) => tab.uri.toString() === tabToRemove.uri.toString()
-                    )
-                    const nextModel =
-                        values.allTabs[indexOfModel + 1] || values.allTabs[indexOfModel - 1] || values.allTabs[0] // there will always be one
-                    actions.selectTab(nextModel)
-                }
-                model?.dispose()
-                actions.removeTab(tabToRemove)
-                const queries = values.allTabs.map((tab) => {
-                    return {
-                        query: props.monaco?.editor.getModel(tab.uri)?.getValue() || '',
-                        path: tab.uri.path.split('/').pop(),
-                        view: tab.view,
-                        insight: tab.insight,
-                        response: tab.response,
-                    }
-                })
-                actions.setLocalState(editorModelsStateKey(props.key), JSON.stringify(queries))
+            if (!props.monaco) {
+                return
             }
+
+            const model = props.monaco.editor.getModel(tabToRemove.uri)
+            if (tabToRemove.uri.toString() === values.activeModelUri?.uri.toString()) {
+                const indexOfModel = values.allTabs.findIndex(
+                    (tab) => tab.uri.toString() === tabToRemove.uri.toString()
+                )
+                const nextModel =
+                    values.allTabs[indexOfModel + 1] || values.allTabs[indexOfModel - 1] || values.allTabs[0] // there will always be one
+                actions.selectTab(nextModel)
+            }
+            model?.dispose()
+            actions.removeTab(tabToRemove)
+            const queries = values.allTabs.map((tab) => {
+                return {
+                    query: props.monaco?.editor.getModel(tab.uri)?.getValue() || '',
+                    path: tab.uri.path.split('/').pop(),
+                    view: tab.view,
+                    insight: tab.insight,
+                    response: tab.response,
+                }
+            })
+            actions.setLocalState(editorModelsStateKey(props.key), JSON.stringify(queries))
         },
         setLocalState: ({ key, value }) => {
             localStorage.setItem(key, value)
@@ -706,6 +711,10 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
 
             lemonToast.info(`You're now viewing ${insight.name || insight.derived_name || name}`)
 
+            if (values.activeModelUri) {
+                actions._deleteTab(values.activeModelUri)
+            }
+
             router.actions.push(urls.insightView(insight.short_id))
         },
         updateInsight: async () => {
@@ -731,7 +740,12 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
             }
 
             lemonToast.info(`You're now viewing ${savedInsight.name || savedInsight.derived_name || name}`)
-            router.actions.push(urls.insightView(savedInsight.short_id, undefined, undefined))
+
+            if (values.activeModelUri) {
+                actions._deleteTab(values.activeModelUri)
+            }
+
+            router.actions.push(urls.insightView(savedInsight.short_id))
         },
         loadDataWarehouseSavedQueriesSuccess: ({ dataWarehouseSavedQueries }) => {
             // keep tab views up to date


### PR DESCRIPTION
## Changes
- Fixed the height of charts when viewing an insight on the insight view page (e.g. `/project/1/insights/Z1k8agnK`)
- Update the locally cached `insight` value in the editor with the newly incoming version - we sometimes have a stale insight in local storage which wasn't being updated
- After saving or creating an insight from the editor, remove the tab from the editor (this happens when we redirect out of the editor)
  - I was finding myself with a gazillion tabs open from editing insights which I no longer needed
- When loading an insight in the editor from another page where the insight had already loaded via `dataNodelLogic`, don't re-run the query, just use the cached version
  - Even better now that we show how old the query results are in the editor! 