### PR TITLE
fix(batch-exports): Support all event fields in custom query

### DIFF
--- a/posthog/api/test/batch_exports/test_create.py
+++ b/posthog/api/test/batch_exports/test_create.py
@@ -259,7 +259,8 @@ SELECT
   team_id AS my_team,
   properties,
   properties.$browser AS browser,
-  properties.custom AS custom
+  properties.custom AS custom,
+  person_id
 FROM events
 """
 
@@ -329,6 +330,7 @@ def test_create_batch_export_with_custom_schema(client: HttpClient, temporal):
                 "expression": "replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_1)s), ''), 'null'), '^\"|\"$', '')",
                 "alias": "custom",
             },
+            {"alias": "person_id", "expression": "events.person_id"},
         ]
         expected_schema = {
             "fields": expected_fields,


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

When passing a custom hogql query, we were losing some node information while parsing as the dialect was set to hogql on the initial parse. Now, we set it to ClickHouse to avoid losing node precision. This allows us to support fields from lazy joins (person_id) if they are present in events.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
