### PR TITLE
fix(crm): Ensure UI reflects the currently selected tab

### DIFF
--- a/frontend/src/scenes/persons-management/personsManagementSceneLogic.tsx
+++ b/frontend/src/scenes/persons-management/personsManagementSceneLogic.tsx
@@ -8,6 +8,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { Cohorts } from 'scenes/cohorts/Cohorts'
 import { Groups } from 'scenes/groups/Groups'
+import { groupsSceneLogic } from 'scenes/groups/groupsSceneLogic'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
@@ -33,6 +34,7 @@ export type PersonsManagementTabs = Record<
 export const personsManagementSceneLogic = kea<personsManagementSceneLogicType>([
     path(['scenes', 'persons-management', 'personsManagementSceneLogic']),
     connect(() => ({
+        actions: [groupsSceneLogic, ['setGroupTypeIndex']],
         values: [
             groupsModel,
             ['aggregationLabel', 'groupTypes', 'groupTypesLoading', 'groupsAccessStatus'],
@@ -185,6 +187,7 @@ export const personsManagementSceneLogic = kea<personsManagementSceneLogicType>(
         if (!values.featureFlags[FEATURE_FLAGS.B2B_ANALYTICS]) {
             urlToAction[urls.groups(':key')] = ({ key }: { key: string }) => {
                 actions.setTabKey(`groups-${key}`)
+                actions.setGroupTypeIndex(parseInt(key))
             }
         }
         return urlToAction

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -261,7 +261,9 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
 
     def get_group_types(self, team: Team) -> list[dict[str, Any]]:
         return list(
-            GroupTypeMapping.objects.filter(project_id=team.project_id).values(*GROUP_TYPE_MAPPING_SERIALIZER_FIELDS)
+            GroupTypeMapping.objects.filter(project_id=team.project_id)
+            .order_by("group_type_index")
+            .values(*GROUP_TYPE_MAPPING_SERIALIZER_FIELDS)
         )
 
     def get_live_events_token(self, team: Team) -> Optional[str]:

--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -696,6 +696,7 @@
          "posthog_grouptypemapping"."default_columns"
   FROM "posthog_grouptypemapping"
   WHERE "posthog_grouptypemapping"."project_id" = 99999
+  ORDER BY "posthog_grouptypemapping"."group_type_index" ASC
   '''
 # ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down.27
@@ -4869,6 +4870,7 @@
          "posthog_grouptypemapping"."default_columns"
   FROM "posthog_grouptypemapping"
   WHERE "posthog_grouptypemapping"."project_id" = 99999
+  ORDER BY "posthog_grouptypemapping"."group_type_index" ASC
   '''
 # ---
 # name: TestDecideRemoteConfig.test_decide_doesnt_error_out_when_database_is_down.27

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -103,16 +103,21 @@ def team_api_test_factory():
             self.assertEqual(response_data["has_group_types"], False)
             self.assertEqual(response_data["group_types"], [])
 
-            # Creating a group type in the same project, but different team
             GroupTypeMapping.objects.create(
                 project=self.project, team=other_team, group_type="person", group_type_index=0
+            )
+            GroupTypeMapping.objects.create(
+                project=self.project, team=other_team, group_type="thing", group_type_index=2
+            )
+            GroupTypeMapping.objects.create(
+                project=self.project, team=other_team, group_type="place", group_type_index=1
             )
 
             response = self.client.get("/api/environments/@current/")
             response_data = response.json()
 
             self.assertEqual(response.status_code, status.HTTP_200_OK, response_data)
-            self.assertEqual(response_data["has_group_types"], True)  # Irreleveant that group type has different `team`
+            self.assertEqual(response_data["has_group_types"], True)
             self.assertEqual(
                 response_data["group_types"],
                 [
@@ -123,7 +128,23 @@ def team_api_test_factory():
                         "name_plural": None,
                         "default_columns": None,
                         "detail_dashboard": None,
-                    }
+                    },
+                    {
+                        "group_type": "place",
+                        "group_type_index": 1,
+                        "name_singular": None,
+                        "name_plural": None,
+                        "default_columns": None,
+                        "detail_dashboard": None,
+                    },
+                    {
+                        "group_type": "thing",
+                        "group_type_index": 2,
+                        "name_singular": None,
+                        "name_plural": None,
+                        "default_columns": None,
+                        "detail_dashboard": None,
+                    },
                 ],
             )
 


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/29881
Reported in https://posthoghelp.zendesk.com/agent/tickets/28873 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/33255)

## Changes

Calls `groupsSceneLogic.actions.setGroupTypeIndex()` when `personsManagementSceneLogic` is handling URLs to ensure `groupsSceneLogic` knows which group type is being rendered.

Also ensures the group types are returned in a consistent order.

**Before**

![CleanShot 2025-04-11 at 08 57 42@2x](https://github.com/user-attachments/assets/0a819fac-09fd-46c2-ade1-b491db142461)

**After**

![CleanShot 2025-04-11 at 08 57 19@2x](https://github.com/user-attachments/assets/6b434992-1814-4e0b-aba7-50f8679ff8d9)

## How did you test this code?

Refreshed the page of a non-zero index group type.