### PR TITLE
feat(dwh): Support for patitioning mysql sources

### DIFF
--- a/posthog/temporal/tests/data_imports/test_mysql_source.py
+++ b/posthog/temporal/tests/data_imports/test_mysql_source.py
@@ -23,14 +23,19 @@ OBJECT_STORAGE_ENDPOINT=http://localhost:19000 \
 """
 
 import datetime as dt
+import operator
 import os
+import random
+import string
 import uuid
 
 import pymysql
 import pytest
 
+from posthog.temporal.data_imports.pipelines.mysql.mysql import _get_partition_settings
 from posthog.temporal.tests.data_imports.conftest import run_external_data_job_workflow
 from posthog.warehouse.models import ExternalDataSchema, ExternalDataSource
+from posthog.warehouse.types import IncrementalFieldType
 
 pytestmark = pytest.mark.usefixtures("minio_client")
 
@@ -166,3 +171,141 @@ async def test_mysql_source_full_refresh(
     )
 
     assert res.results == TEST_DATA
+
+
+@pytest.fixture
+def partition_table_name(request) -> str:
+    """Return the name of a table to test partitioning."""
+    try:
+        return request.param
+    except AttributeError:
+        return "test_partition_table"
+
+
+@pytest.fixture
+def partition_table_rows(request) -> int:
+    """Return the number of rows of a table to test partitioning."""
+    try:
+        return request.param
+    except AttributeError:
+        return 1_000
+
+
+@pytest.fixture
+def mysql_partition_table(mysql_connection, partition_table_name, partition_table_rows):
+    """Create an empty MySQL table and clean it up after the test."""
+    conn = mysql_connection
+    with conn.cursor() as cursor:
+        # Create test table
+        cursor.execute(f"""
+            CREATE TABLE {partition_table_name} (
+                id SERIAL,
+                value INT(4) UNSIGNED NOT NULL,
+                PRIMARY KEY (id)
+            )
+        """)
+
+        for _ in range(partition_table_rows):
+            value = "".join(random.choice(string.ascii_lowercase) for _ in range(10))
+            value = random.randint(0, 2**32 - 1)
+            cursor.execute(
+                f"INSERT INTO {partition_table_name} (value) VALUES ({value})",
+            )
+
+    conn.commit()
+
+    yield partition_table_name
+
+    with conn.cursor() as cursor:
+        # Cleanup
+        cursor.execute(f"DROP TABLE {partition_table_name}")
+    conn.commit()
+
+
+@SKIP_IF_MISSING_MYSQL_CREDENTIALS
+@pytest.mark.parametrize("partition_table_rows", [0], indirect=True)
+def test_get_partition_settings_with_empty_table(mysql_partition_table, mysql_connection):
+    with mysql_connection.cursor() as cursor:
+        partition_settings = _get_partition_settings(cursor, os.environ["MYSQL_DATABASE"], mysql_partition_table)
+
+    assert partition_settings is None
+
+
+@SKIP_IF_MISSING_MYSQL_CREDENTIALS
+def test_get_partition_settings_with_one_size_partition(mysql_partition_table, mysql_connection, partition_table_rows):
+    with mysql_connection.cursor() as cursor:
+        partition_settings = _get_partition_settings(
+            cursor, os.environ["MYSQL_DATABASE"], mysql_partition_table, partition_size_bytes=1
+        )
+
+    assert partition_settings is not None
+    assert partition_settings.partition_count == partition_table_rows
+    assert partition_settings.partition_size == 1
+
+
+@pytest.fixture
+def external_data_schema_incremental(external_data_source, team):
+    schema = ExternalDataSchema.objects.create(
+        name=MYSQL_TABLE_NAME,
+        team_id=team.pk,
+        source_id=external_data_source.pk,
+        sync_type="incremental",
+        sync_type_config={
+            "incremental_field": "id",
+            "incremental_field_type": IncrementalFieldType.Integer,
+            "incremental_field_last_value": None,
+        },
+    )
+    return schema
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+@SKIP_IF_MISSING_MYSQL_CREDENTIALS
+async def test_mysql_source_incremental(
+    team, mysql_source_table, external_data_source, external_data_schema_incremental, mysql_connection
+):
+    """Test that an incremental sync works as expected."""
+    table_name = f"mysql_{MYSQL_TABLE_NAME}"
+    expected_num_rows = len(TEST_DATA)
+
+    res = await run_external_data_job_workflow(
+        team=team,
+        external_data_source=external_data_source,
+        external_data_schema=external_data_schema_incremental,
+        table_name=table_name,
+        expected_rows_synced=expected_num_rows,
+        expected_total_rows=expected_num_rows,
+        expected_columns=["id", "name", "email", "created_at", "unsigned_int"],
+    )
+    assert res.results == TEST_DATA
+
+    NEW_TEST_DATA = [
+        (4, "John Doe", "john@example.com", dt.datetime(2025, 1, 1, tzinfo=dt.UTC), 100),
+        (5, "Jane Smith", "jane@example.com", dt.datetime(2025, 1, 2, tzinfo=dt.UTC), 2000000),
+        (6, "Bob Wilson", "bob@example.com", dt.datetime(2025, 1, 3, tzinfo=dt.UTC), 3409892966),
+    ]
+
+    with mysql_connection.cursor() as cursor:
+        cursor.executemany(
+            f"INSERT INTO {MYSQL_TABLE_NAME} (id, name, email, created_at, unsigned_int) VALUES (%s, %s, %s, %s, %s)",
+            NEW_TEST_DATA,
+        )
+    mysql_connection.commit()
+
+    expected_total_num_rows = expected_num_rows + len(NEW_TEST_DATA)
+    res = await run_external_data_job_workflow(
+        team=team,
+        external_data_source=external_data_source,
+        external_data_schema=external_data_schema_incremental,
+        table_name=table_name,
+        # We use a GTE, so the last id will be re-synced.
+        expected_rows_synced=expected_num_rows + 1,
+        expected_total_rows=expected_total_num_rows,
+        expected_columns=["id", "name", "email", "created_at", "unsigned_int"],
+    )
+    # Compare sorted results as rows may have been shuffled around, but we only care the data is there,
+    # not in which order.
+    assert sorted(res.results, key=operator.itemgetter(0)) == sorted(
+        TEST_DATA + NEW_TEST_DATA, key=operator.itemgetter(0)
+    )

--- a/posthog/temporal/tests/data_imports/test_mysql_source.py
+++ b/posthog/temporal/tests/data_imports/test_mysql_source.py
@@ -26,7 +26,6 @@ import datetime as dt
 import operator
 import os
 import random
-import string
 import uuid
 
 import pymysql
@@ -206,7 +205,6 @@ def mysql_partition_table(mysql_connection, partition_table_name, partition_tabl
         """)
 
         for _ in range(partition_table_rows):
-            value = "".join(random.choice(string.ascii_lowercase) for _ in range(10))
             value = random.randint(0, 2**32 - 1)
             cursor.execute(
                 f"INSERT INTO {partition_table_name} (value) VALUES ({value})",

--- a/posthog/warehouse/types.py
+++ b/posthog/warehouse/types.py
@@ -1,5 +1,5 @@
+import typing
 from enum import StrEnum
-from typing import TypedDict
 
 
 class IncrementalFieldType(StrEnum):
@@ -10,8 +10,20 @@ class IncrementalFieldType(StrEnum):
     Timestamp = "timestamp"
 
 
-class IncrementalField(TypedDict):
+class IncrementalField(typing.TypedDict):
     label: str  # Label shown in the UI
     type: IncrementalFieldType  # Field type shown in the UI
     field: str  # Actual DB field accessed
     field_type: IncrementalFieldType  # Actual DB type of the field
+
+
+class PartitionSettings(typing.NamedTuple):
+    """Settings used when partitioning data warehouse tables.
+
+    Attributes:
+        partition_count: Total number of partitions.
+        partition_size: Number of rows to include per partition.
+    """
+
+    partition_count: int
+    partition_size: int


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We do not support partitioning in mysql. Now we do, but with a caveat:
* Table statistics may not be fully accurate, some more dynamic approach to partitioning may be required.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Implemented function to obtain partition settings for mysql source.
Called function and returning partition settings on incremental syncs.
Defined a common namedtuple type to use for partition settings.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Added tests.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
