### PR TITLE
chore(flags): scale to more flags traffic

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -27,7 +27,7 @@ const configWithSentry = (config: Partial<PostHogConfig>): Partial<PostHogConfig
 export function loadPostHogJS(): void {
     if (window.JS_POSTHOG_API_KEY) {
         const PREVIEW_FLAGS_V2_CONFIG = {
-            rolloutPercentage: 50,
+            rolloutPercentage: 20,
             includedHashes: new Set(['593cb24f9928bab39ec383c06c908481880d5099']),
         }
 

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -27,7 +27,7 @@ const configWithSentry = (config: Partial<PostHogConfig>): Partial<PostHogConfig
 export function loadPostHogJS(): void {
     if (window.JS_POSTHOG_API_KEY) {
         const PREVIEW_FLAGS_V2_CONFIG = {
-            rolloutPercentage: 1,
+            rolloutPercentage: 50,
             includedHashes: new Set(['593cb24f9928bab39ec383c06c908481880d5099']),
         }
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

- `/flags` is fast now, and we're not even touching the amount of scale we could be seeing.  So, let's 20x traffic and see what the metrics look like.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Testing in prod baby!!1!
