### PR TITLE
chore(plugin-server): adds env var to allow forcing to overflow by token and distinct_id

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -79,7 +79,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         INGESTION_CONCURRENCY: 10,
         INGESTION_BATCH_SIZE: 500,
         INGESTION_OVERFLOW_ENABLED: false,
-        INGESTION_FORCE_OVERFLOW_TOKENS: '',
+        INGESTION_FORCE_OVERFLOW_TOKEN_BY_DISTINCT_ID: '',
         INGESTION_OVERFLOW_PRESERVE_PARTITION_LOCALITY: false,
         PLUGINS_DEFAULT_LOG_LEVEL: isTestEnv() ? PluginLogLevel.Full : PluginLogLevel.Log,
         LOG_LEVEL: isTestEnv() ? LogLevel.Warn : LogLevel.Info,

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -79,7 +79,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         INGESTION_CONCURRENCY: 10,
         INGESTION_BATCH_SIZE: 500,
         INGESTION_OVERFLOW_ENABLED: false,
-        INGESTION_FORCE_OVERFLOW_TOKEN_BY_DISTINCT_ID: '',
+        INGESTION_FORCE_OVERFLOW_BY_TOKEN_DISTINCT_ID: '',
         INGESTION_OVERFLOW_PRESERVE_PARTITION_LOCALITY: false,
         PLUGINS_DEFAULT_LOG_LEVEL: isTestEnv() ? PluginLogLevel.Full : PluginLogLevel.Log,
         LOG_LEVEL: isTestEnv() ? LogLevel.Warn : LogLevel.Info,

--- a/plugin-server/src/ingestion/__snapshots__/ingestion-consumer.test.ts.snap
+++ b/plugin-server/src/ingestion/__snapshots__/ingestion-consumer.test.ts.snap
@@ -17,23 +17,6 @@ exports[`IngestionConsumer error handling should handle explicitly non retriable
 ]
 `;
 
-exports[`IngestionConsumer general overflow force overflow should force events with matching token to overflow: force overflow messages 1`] = `
-[
-  {
-    "key": "THIS IS NOT A TOKEN FOR TEAM 2:team1-user",
-    "topic": "events_plugin_ingestion_overflow_test",
-    "value": {
-      "data": "{"distinct_id":"team1-user","uuid":"<REPLACED-UUID-0>","token":"THIS IS NOT A TOKEN FOR TEAM 2","ip":"127.0.0.1","site_url":"us.posthog.com","now":"2025-01-01T00:00:00.000Z","event":"$pageview","properties":{"$current_url":"http://localhost:8000"}}",
-      "distinct_id": "team1-user",
-      "ip": "127.0.0.1",
-      "now": "2025-01-01T00:00:00.000Z",
-      "token": "THIS IS NOT A TOKEN FOR TEAM 2",
-      "uuid": "<REPLACED-UUID-0>",
-    },
-  },
-]
-`;
-
 exports[`IngestionConsumer general overflow force overflow should force events with matching token:distinct_id to overflow: force overflow messages 1`] = `
 [
   {

--- a/plugin-server/src/ingestion/__snapshots__/ingestion-consumer.test.ts.snap
+++ b/plugin-server/src/ingestion/__snapshots__/ingestion-consumer.test.ts.snap
@@ -34,6 +34,52 @@ exports[`IngestionConsumer general overflow force overflow should force events w
 ]
 `;
 
+exports[`IngestionConsumer general overflow force overflow should force events with matching token:distinct_id to overflow: force overflow messages 1`] = `
+[
+  {
+    "key": "THIS IS NOT A TOKEN FOR TEAM 2:team1-user",
+    "topic": "events_plugin_ingestion_overflow_test",
+    "value": {
+      "data": "{"distinct_id":"team1-user","uuid":"<REPLACED-UUID-0>","token":"THIS IS NOT A TOKEN FOR TEAM 2","ip":"127.0.0.1","site_url":"us.posthog.com","now":"2025-01-01T00:00:00.000Z","event":"$pageview","properties":{"$current_url":"http://localhost:8000"}}",
+      "distinct_id": "team1-user",
+      "ip": "127.0.0.1",
+      "now": "2025-01-01T00:00:00.000Z",
+      "token": "THIS IS NOT A TOKEN FOR TEAM 2",
+      "uuid": "<REPLACED-UUID-0>",
+    },
+  },
+]
+`;
+
+exports[`IngestionConsumer general overflow force overflow should handle multiple token:distinct_id pairs in force overflow setting: force overflow messages multiple pairs 1`] = `
+[
+  {
+    "key": "THIS IS NOT A TOKEN FOR TEAM 2:user1",
+    "topic": "events_plugin_ingestion_overflow_test",
+    "value": {
+      "data": "{"distinct_id":"user1","uuid":"<REPLACED-UUID-0>","token":"THIS IS NOT A TOKEN FOR TEAM 2","ip":"127.0.0.1","site_url":"us.posthog.com","now":"2025-01-01T00:00:00.000Z","event":"$pageview","properties":{"$current_url":"http://localhost:8000"}}",
+      "distinct_id": "user1",
+      "ip": "127.0.0.1",
+      "now": "2025-01-01T00:00:00.000Z",
+      "token": "THIS IS NOT A TOKEN FOR TEAM 2",
+      "uuid": "<REPLACED-UUID-0>",
+    },
+  },
+  {
+    "key": "<REPLACED-UUID-1>:user2",
+    "topic": "events_plugin_ingestion_overflow_test",
+    "value": {
+      "data": "{"distinct_id":"user2","uuid":"<REPLACED-UUID-2>","token":"<REPLACED-UUID-1>","ip":"127.0.0.1","site_url":"us.posthog.com","now":"2025-01-01T00:00:00.000Z","event":"$pageview","properties":{"$current_url":"http://localhost:8000"}}",
+      "distinct_id": "user2",
+      "ip": "127.0.0.1",
+      "now": "2025-01-01T00:00:00.000Z",
+      "token": "<REPLACED-UUID-1>",
+      "uuid": "<REPLACED-UUID-2>",
+    },
+  },
+]
+`;
+
 exports[`IngestionConsumer general overflow should allow some events to pass 1`] = `
 [
   {

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -79,6 +79,7 @@ export class IngestionConsumer {
     private tokenDistinctIdsToDrop: string[] = []
     private tokenDistinctIdsToSkipPersons: string[] = []
     private tokensToForceOverflow: string[] = []
+    private tokenDistinctIdsToForceOverflow: string[] = []
 
     constructor(
         private hub: Hub,
@@ -103,7 +104,9 @@ export class IngestionConsumer {
         this.tokenDistinctIdsToSkipPersons = hub.SKIP_PERSONS_PROCESSING_BY_TOKEN_DISTINCT_ID.split(',').filter(
             (x) => !!x
         )
-        this.tokensToForceOverflow = hub.INGESTION_FORCE_OVERFLOW_TOKENS.split(',').filter((x) => !!x)
+        this.tokenDistinctIdsToForceOverflow = hub.INGESTION_FORCE_OVERFLOW_BY_TOKEN_DISTINCT_ID.split(',').filter(
+            (x) => !!x
+        )
         this.testingTopic = overrides.INGESTION_CONSUMER_TESTING_TOPIC ?? hub.INGESTION_CONSUMER_TESTING_TOPIC
 
         this.name = `ingestion-consumer-${this.topic}`
@@ -226,7 +229,7 @@ export class IngestionConsumer {
 
                 const eventKey = `${event.token}:${event.distinct_id}`
                 // Check if this token is in the force overflow list
-                const shouldForceOverflow = event.token && this.tokensToForceOverflow.includes(event.token)
+                const shouldForceOverflow = this.shouldForceOverflow(event.token, event.distinct_id)
 
                 // Check the rate limiter and emit to overflow if necessary
                 const isBelowRateLimit = this.overflowRateLimiter.consume(eventKey, 1, message.timestamp)
@@ -466,6 +469,11 @@ export class IngestionConsumer {
             (token && distinctId && this.tokenDistinctIdsToSkipPersons.includes(`${token}:${distinctId}`))
         )
     }
+
+    private shouldForceOverflow(token?: string, distinctId?: string) {
+        return token && distinctId && this.tokenDistinctIdsToForceOverflow.includes(`${token}:${distinctId}`)
+    }
+
     private overflowEnabled() {
         return (
             !!this.hub.INGESTION_CONSUMER_OVERFLOW_TOPIC &&

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -78,7 +78,6 @@ export class IngestionConsumer {
     private tokensToDrop: string[] = []
     private tokenDistinctIdsToDrop: string[] = []
     private tokenDistinctIdsToSkipPersons: string[] = []
-    private tokensToForceOverflow: string[] = []
     private tokenDistinctIdsToForceOverflow: string[] = []
 
     constructor(

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -227,7 +227,7 @@ export class IngestionConsumer {
                 }
 
                 const eventKey = `${event.token}:${event.distinct_id}`
-                // Check if this token is in the force overflow list
+                // Check if this token or token:distnict_id is in the force overflow list
                 const shouldForceOverflow = this.shouldForceOverflow(event.token, event.distinct_id)
 
                 // Check the rate limiter and emit to overflow if necessary
@@ -470,7 +470,10 @@ export class IngestionConsumer {
     }
 
     private shouldForceOverflow(token?: string, distinctId?: string) {
-        return token && distinctId && this.tokenDistinctIdsToForceOverflow.includes(`${token}:${distinctId}`)
+        return (
+            (token && this.tokenDistinctIdsToForceOverflow.includes(token)) ||
+            (token && distinctId && this.tokenDistinctIdsToForceOverflow.includes(`${token}:${distinctId}`))
+        )
     }
 
     private overflowEnabled() {

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -135,7 +135,7 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
     INGESTION_CONCURRENCY: number // number of parallel event ingestion queues per batch
     INGESTION_BATCH_SIZE: number // kafka consumer batch size
     INGESTION_OVERFLOW_ENABLED: boolean // whether or not overflow rerouting is enabled (only used by analytics-ingestion)
-    INGESTION_FORCE_OVERFLOW_BY_TOKEN_DISTINCT_ID: string // comma-separated list of token:distinct_id combo to always route to overflow
+    INGESTION_FORCE_OVERFLOW_BY_TOKEN_DISTINCT_ID: string // comma-separated list of either tokens or token:distinct_id combinations to force events to route to overflow
     INGESTION_OVERFLOW_PRESERVE_PARTITION_LOCALITY: boolean // whether or not Kafka message keys should be preserved or discarded when messages are rerouted to overflow
     TASK_TIMEOUT: number // how many seconds until tasks are timed out
     DATABASE_URL: string // Postgres database URL

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -135,7 +135,7 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
     INGESTION_CONCURRENCY: number // number of parallel event ingestion queues per batch
     INGESTION_BATCH_SIZE: number // kafka consumer batch size
     INGESTION_OVERFLOW_ENABLED: boolean // whether or not overflow rerouting is enabled (only used by analytics-ingestion)
-    INGESTION_FORCE_OVERFLOW_TOKENS: string // comma-separated list of tokens to always route to overflow
+    INGESTION_FORCE_OVERFLOW_BY_TOKEN_DISTINCT_ID: string // comma-separated list of token:distinct_id combo to always route to overflow
     INGESTION_OVERFLOW_PRESERVE_PARTITION_LOCALITY: boolean // whether or not Kafka message keys should be preserved or discarded when messages are rerouted to overflow
     TASK_TIMEOUT: number // how many seconds until tasks are timed out
     DATABASE_URL: string // Postgres database URL


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Ingestion pipeline would like to be able to force events from a particular token:distinct_id into the overflow topic to avoid particular partitions from getting hammered

Before we could only force to overflow via a team's token. We'd like to force overflow using the token:distinct_id combo, because we partition based on the distinct_id and we are trying to avoid hot partitions.
<!-- Closes #ISSUE_ID -->

## Changes

Environment Variable name was changed. Behaviour of that environment variable was changed to include token:distinct_id rather than just a token.

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Unit tests were added to test this code.
