### PR TITLE
feat(crm): Ensure group dashboard loads expected layout

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -301,6 +301,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
             allVariables: values.variables,
             isNull,
         }),
+        setLoadLayoutFromServerOnPreview: (loadLayoutFromServerOnPreview: boolean) => ({
+            loadLayoutFromServerOnPreview,
+        }),
 
         resetVariables: () => ({ variables: values.insightVariables }),
         resetDashboardFilters: () => true,
@@ -330,7 +333,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
 
                         // don't update dashboard tile layouts if we're previewing
                         // we want to retain what the user has temporarily set
-                        if (action === 'preview' && dashboard) {
+                        if (action === 'preview' && dashboard && !values.loadLayoutFromServerOnPreview) {
                             const editModeTileLayouts: Record<number, DashboardTile['layouts']> = {}
                             values.dashboard?.tiles.forEach((tile: DashboardTile<QueryBasedInsightModel>) => {
                                 editModeTileLayouts[tile.id] = tile.layouts
@@ -831,6 +834,13 @@ export const dashboardLogic = kea<dashboardLogicType>([
             null as DashboardMode | null,
             {
                 setDashboardMode: (_, { mode }) => mode,
+            },
+        ],
+        loadLayoutFromServerOnPreview: [
+            false,
+            {
+                setLoadLayoutFromServerOnPreview: (_, { loadLayoutFromServerOnPreview }) =>
+                    loadLayoutFromServerOnPreview,
             },
         ],
         autoRefresh: [

--- a/frontend/src/scenes/groups/cards/GroupDashboardCard.tsx
+++ b/frontend/src/scenes/groups/cards/GroupDashboardCard.tsx
@@ -35,7 +35,7 @@ function GroupDetailDashboard({
                 },
             ])
         }
-    }, [groupTypeDetailDashboard, groupData, groupTypeName, setProperties])
+    }, [groupTypeDetailDashboard, groupData, groupTypeName, setProperties, setLoadLayoutFromServerOnPreview])
 
     return <Dashboard id={groupTypeDetailDashboard.toString()} placement={DashboardPlacement.Group} />
 }

--- a/frontend/src/scenes/groups/cards/GroupDashboardCard.tsx
+++ b/frontend/src/scenes/groups/cards/GroupDashboardCard.tsx
@@ -18,10 +18,13 @@ function GroupDetailDashboard({
     groupData: Group
 }): JSX.Element {
     const { groupTypeName } = useValues(groupLogic)
-    const { setProperties } = useActions(dashboardLogic({ id: groupTypeDetailDashboard }))
+    const { setProperties, setLoadLayoutFromServerOnPreview } = useActions(
+        dashboardLogic({ id: groupTypeDetailDashboard })
+    )
 
     useEffect(() => {
         if (groupTypeDetailDashboard && groupData) {
+            setLoadLayoutFromServerOnPreview(true)
             setProperties([
                 {
                     type: PropertyFilterType.EventMetadata,


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/29881

## Changes

Hackily sets a `loadLayoutFromServerOnPreview` property so `loadDashboard()` uses the tile layout defined by the server, not the local version of the layout (which doesn't exist).

The underlying issue is that I'm using `setProperties()` to render the dashboard with an override:

https://github.com/PostHog/posthog/blob/f0c77584dc1eeeea06aca4007c70da2f719b0147/frontend/src/scenes/groups/cards/GroupDashboardCard.tsx#L28-L36

However, `setProperties()` ends up calling `actions.loadDashboard({ action: 'preview' })` and these client-side filters are only applied with `action == 'preview'`

https://github.com/PostHog/posthog/blob/d2fe0ed8046f2223c963cad32ee2b178c0197f93/frontend/src/scenes/dashboard/dashboardLogic.tsx#L1643-L1647

https://github.com/PostHog/posthog/blob/d2fe0ed8046f2223c963cad32ee2b178c0197f93/frontend/src/scenes/dashboard/dashboardLogic.tsx#L324-L328

I don't love it, but it also seems like the least complex solution to a complex set of code.

**Before**
Insight isn't full width but should be:

![CleanShot 2025-04-11 at 13 09 30@2x](https://github.com/user-attachments/assets/246057b8-25bc-46ad-8dff-70868320a18c)

**After**

![CleanShot 2025-04-11 at 13 08 51@2x](https://github.com/user-attachments/assets/39578264-69c0-4d03-823b-93410bd5123a)

## How did you test this code?

Manual review.