### PR TITLE
chore(flags): remove the conditions that didn't actually make sense

### DIFF
--- a/cypress/support/decide.ts
+++ b/cypress/support/decide.ts
@@ -18,7 +18,7 @@ export const setupFeatureFlags = (overrides: Record<string, any> = {}): void => 
         })
     )
 
-    cy.intercept('**/decide/*', (req) =>
+    cy.intercept('**/flags/*', (req) =>
         req.reply(
             decideResponse({
                 ...overrides,

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -46,7 +46,6 @@ import {
     roundToDecimal,
     selectorOperatorMap,
     shortTimeZone,
-    shouldEnablePreviewFlagsV2,
     stringOperatorMap,
     toParams,
     wordPluralize,
@@ -874,37 +873,5 @@ describe('lib/utils', () => {
         expect(shortTimeZone('America/Phoenix')).toEqual('MST')
         expect(shortTimeZone('Europe/Moscow')).toEqual('UTC+3')
         expect(shortTimeZone('Asia/Tokyo')).toEqual('UTC+9')
-    })
-
-    describe('shouldEnablePreviewFlagsV2', () => {
-        it('returns true for anything if the rollout percentage is 100', () => {
-            const result = shouldEnablePreviewFlagsV2('test', {
-                rolloutPercentage: 100,
-            })
-            expect(result).toBe(true)
-        })
-        it('returns true for our hashed API key', () => {
-            expect(
-                shouldEnablePreviewFlagsV2('sTMFPsFhdP1Ssg', {
-                    rolloutPercentage: 1,
-                    includedHashes: new Set(['593cb24f9928bab39ec383c06c908481880d5099']),
-                })
-            ).toBe(true)
-        })
-        it('returns false for our hashed API key when not passed in and the percentage rollout is too small', () => {
-            expect(
-                shouldEnablePreviewFlagsV2('sTMFPsFhdP1Ssg', {
-                    rolloutPercentage: 1,
-                })
-            ).toBe(false)
-        })
-        it('returns false for our hashed API key when explicitly excluded', () => {
-            expect(
-                shouldEnablePreviewFlagsV2('sTMFPsFhdP1Ssg', {
-                    rolloutPercentage: 100,
-                    excludedHashes: new Set(['593cb24f9928bab39ec383c06c908481880d5099']),
-                })
-            ).toBe(false)
-        })
     })
 })

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/react'
-import crypto from 'crypto'
 import equal from 'fast-deep-equal'
 import { tagColors } from 'lib/colors'
 import { WEBHOOK_SERVICES } from 'lib/constants'
@@ -2042,27 +2041,4 @@ export const getJSHeapMemory = (): {
         }
     }
     return {}
-}
-
-interface PreviewFlagsV2Config {
-    rolloutPercentage: number
-    includedHashes?: Set<string>
-    excludedHashes?: Set<string>
-}
-
-export function shouldEnablePreviewFlagsV2(apiKey: string, config: PreviewFlagsV2Config): boolean {
-    const hashHex = crypto.createHash('sha1').update(`preview_flags_v2.${apiKey}`).digest('hex')
-
-    // Check explicit includes/excludes first
-    if (config.includedHashes && config.includedHashes.has(hashHex)) {
-        return true
-    }
-    if (config.excludedHashes && config.excludedHashes.has(hashHex)) {
-        return false
-    }
-
-    // For all other keys, use percentage rollout
-    // Use first 8 characters of hash for percentage calculation to avoid floating point precision issues
-    const normalizedHash = parseInt(hashHex.slice(0, 8), 16) / 0xffffffff
-    return normalizedHash <= config.rolloutPercentage / 100
 }

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -1,6 +1,5 @@
 import * as Sentry from '@sentry/react'
 import { FEATURE_FLAGS } from 'lib/constants'
-import { shouldEnablePreviewFlagsV2 } from 'lib/utils'
 import posthog, { CaptureResult, PostHogConfig } from 'posthog-js'
 
 interface WindowWithCypressCaptures extends Window {
@@ -26,11 +25,6 @@ const configWithSentry = (config: Partial<PostHogConfig>): Partial<PostHogConfig
 
 export function loadPostHogJS(): void {
     if (window.JS_POSTHOG_API_KEY) {
-        const PREVIEW_FLAGS_V2_CONFIG = {
-            rolloutPercentage: 20,
-            includedHashes: new Set(['593cb24f9928bab39ec383c06c908481880d5099']),
-        }
-
         posthog.init(
             window.JS_POSTHOG_API_KEY,
             configWithSentry({
@@ -90,7 +84,7 @@ export function loadPostHogJS(): void {
                 capture_performance: { web_vitals: true },
                 person_profiles: 'always',
                 __preview_remote_config: true,
-                __preview_flags_v2: shouldEnablePreviewFlagsV2(window.JS_POSTHOG_API_KEY, PREVIEW_FLAGS_V2_CONFIG),
+                __preview_flags_v2: true,
             })
         )
     } else {

--- a/playwright/e2e/signup.spec.ts
+++ b/playwright/e2e/signup.spec.ts
@@ -186,7 +186,7 @@ test.describe('Signup', () => {
 
     test('Shows redirect notice if redirecting for maintenance', async ({ page }) => {
         // Equivalent to setupFeatureFlags in Playwright
-        await page.route('**/decide/*', async (route) => {
+        await page.route('**/flags/*', async (route) => {
             const response = {
                 config: {
                     enable_collect_everything: true,

--- a/playwright/utils/mockApi.ts
+++ b/playwright/utils/mockApi.ts
@@ -35,7 +35,7 @@ export const mockFeatureFlags = async (page: Page, overrides: Record<string, any
         await route.continue()
     })
 
-    await page.route('**/decide/*', async (route) => {
+    await page.route('**/flags/*', async (route) => {
         await route.fulfill({
             status: 200,
             body: JSON.stringify({


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

SO I'm a fool and it turns out that when I made [this PR](https://github.com/PostHog/posthog/pull/31020), I actually rolled out _all_ instances of `us.posthog.com` to use new flags – i.e., if someone were to log into their PostHog account, the feature flags used BY PostHog FOR PostHog would be loaded by `/flags` instead of decide.  I thought I gated the percentage but turns out I rolled it everywhere.  Ooops but not oops because it worked, so yay.

As you can see, when I trying bumping up the percentage by 20x, nothing changed about the traffic: 

<img width="1392" alt="image" src="https://github.com/user-attachments/assets/5e04d69c-284b-482d-a6df-5302c972c4c3" />


Anyway, this PR just removes all the extra stuff and commits to using on `/flags` for our cloud instance.