### PR TITLE
fix(hogql): dot notation breakdown fields

### DIFF
--- a/posthog/hogql_queries/insights/trends/test/test_utils.py
+++ b/posthog/hogql_queries/insights/trends/test/test_utils.py
@@ -44,10 +44,10 @@ def test_properties_chain_events():
 def test_properties_chain_warehouse_props():
     p1 = get_properties_chain(
         breakdown_type=BreakdownType.DATA_WAREHOUSE_PERSON_PROPERTY,
-        breakdown_field="some_table.field",
+        breakdown_field="some.table.field",
         group_type_index=None,
     )
-    assert p1 == ["person", "some_table", "field"]
+    assert p1 == ["person", "some.table", "field"]
 
     p2 = get_properties_chain(
         breakdown_type=BreakdownType.DATA_WAREHOUSE_PERSON_PROPERTY,

--- a/posthog/hogql_queries/insights/trends/utils.py
+++ b/posthog/hogql_queries/insights/trends/utils.py
@@ -29,6 +29,7 @@ def get_properties_chain(
         return [*breakdown_field.split(".")]
 
     if breakdown_type == "data_warehouse_person_property":
-        return ["person", *breakdown_field.split(".")]
+        parts = breakdown_field.rsplit(".", maxsplit=1)
+        return ["person", *parts]
 
     return ["properties", breakdown_field]


### PR DESCRIPTION
## Problem

- after #30947, breakdown fields will fail when tables are joined

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- only pop the last element to keep the rest of the table name intact

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
