### PR TITLE
fix: metric title overflow no longer hidden in small screens.

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -240,7 +240,7 @@ export function DeltaChart({
                 <div
                     // eslint-disable-next-line react/forbid-dom-props
                     style={{ height: `${chartSvgHeight}px`, borderRight: `1px solid ${COLORS.BOUNDARY_LINES}` }}
-                    className="p-2 overflow-auto"
+                    className="p-2"
                 >
                     <MetricHeader
                         metricIndex={metricIndex}


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

For example, when loading the _Experiment_ scene on a smaller viewport, the metric header collapses and is no longer visible. This happens regardless of the title's length.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We've removed an extra `overflow` on a parent element.

| Before | After |
| - | - |
| <img width="845" alt="image" src="https://github.com/user-attachments/assets/3c03e981-6c4a-4f89-a3bd-0f7d720ea323" /> | <img width="844" alt="image" src="https://github.com/user-attachments/assets/1522d160-ba5e-4695-969b-ef770595731e" /> |
| <img width="845" alt="image" src="https://github.com/user-attachments/assets/0df0ebff-2f17-4892-a456-b7f6f6d934cc" /> | <img width="809" alt="image" src="https://github.com/user-attachments/assets/10902a53-1de1-4d77-93bf-b38b0947e0eb" /> |



<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

This is a somewhat elusive CSS bug. The most reliable way to test it so far has been by reducing the viewport site and reloading the _Experiment_ page.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
