### PR TITLE
fix: isolate session recordings by team

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.ts
@@ -78,6 +78,7 @@ export class SessionBatchRecorder {
         const { partition } = message.message.metadata
         const sessionId = message.message.session_id
         const teamId = message.team.teamId
+        const teamSessionKey = `${teamId}$${sessionId}`
 
         if (!this.partitionSessions.has(partition)) {
             this.partitionSessions.set(partition, new Map())
@@ -85,7 +86,7 @@ export class SessionBatchRecorder {
         }
 
         const sessions = this.partitionSessions.get(partition)!
-        const existingRecorders = sessions.get(sessionId)
+        const existingRecorders = sessions.get(teamSessionKey)
 
         if (existingRecorders) {
             const [sessionBlockRecorder] = existingRecorders
@@ -99,13 +100,13 @@ export class SessionBatchRecorder {
                 return 0
             }
         } else {
-            sessions.set(sessionId, [
+            sessions.set(teamSessionKey, [
                 new SnappySessionRecorder(sessionId, teamId, this.batchId),
                 new SessionConsoleLogRecorder(sessionId, teamId, this.batchId, this.consoleLogStore),
             ])
         }
 
-        const [sessionBlockRecorder, consoleLogRecorder] = sessions.get(sessionId)!
+        const [sessionBlockRecorder, consoleLogRecorder] = sessions.get(teamSessionKey)!
         const bytesWritten = sessionBlockRecorder.recordMessage(message.message)
         await consoleLogRecorder.recordMessage(message)
 
@@ -121,6 +122,7 @@ export class SessionBatchRecorder {
         logger.debug('🔁', 'session_batch_recorder_recorded_message', {
             partition,
             sessionId,
+            teamId,
             bytesWritten,
             totalSize: this._size,
         })


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Currently in blobby v2 there are possible session ID collisions between teams.

## Changes

Isolates the sessions per team in the blobby v2 session batch recorder.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added a unit test.