### PR TITLE
feat(delta-table): Run multiple merge threads

### DIFF
--- a/posthog/settings/data_warehouse.py
+++ b/posthog/settings/data_warehouse.py
@@ -21,3 +21,7 @@ OLD_BIGQUERY_SOURCE_TEAM_IDS: list[str] = get_list(os.getenv("OLD_BIGQUERY_SOURC
 # Temporary, using it to maintain existing teams in old MS SQL Server source.
 # After further testing this will be removed and all teams moved to new source.
 OLD_MSSQL_SOURCE_TEAM_IDS: list[str] = get_list(os.getenv("OLD_MSSQL_SOURCE_TEAM_IDS", ""))
+
+# Temporary, using to redirect subset of teams to concurrent delta table merging.
+# TODO: Remove after concurrent merges prove their worth (or not).
+CONCURRENT_MERGES_TEAM_IDS: list[str] = get_list(os.getenv("CONCURRENT_MERGES_TEAM_IDS", ""))

--- a/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -224,7 +224,7 @@ class DeltaTableHelper:
         delta_table: deltalake.DeltaTable,
         data: pa.Table,
         predicate_ops: list[str],
-        max_workers: int | None = None,
+        max_workers: int | None = 5,
     ) -> None:
         """Execute concurrent merges of data partitions into delta table.
 

--- a/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -63,6 +63,7 @@ class DeltaTableHelper:
                 "AWS_DEFAULT_REGION": settings.AIRBYTE_BUCKET_REGION,
                 "AWS_ALLOW_HTTP": "true",
                 "AWS_S3_ALLOW_UNSAFE_RENAME": "false",
+                "conditional_put": "etag",
             }
 
         return {
@@ -71,6 +72,7 @@ class DeltaTableHelper:
             "region_name": settings.AIRBYTE_BUCKET_REGION,
             "AWS_DEFAULT_REGION": settings.AIRBYTE_BUCKET_REGION,
             "AWS_S3_ALLOW_UNSAFE_RENAME": "false",
+            "conditional_put": "etag",
         }
 
     def _get_delta_table_uri(self) -> str:

--- a/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -258,7 +258,8 @@ class DeltaTableHelper:
                 partition_predicate_ops = predicate_ops.copy()
                 partition_predicate_ops.append(f"target.{PARTITION_KEY} = '{partition}'")
 
-                filtered_table = data.filter(pc.equal(data[PARTITION_KEY], partition))
+                expr = pc.field(PARTITION_KEY) == partition
+                filtered_table = data.filter(expr)
 
                 logger.debug(
                     "Submitting merge for partition '%s'",

--- a/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -160,7 +160,7 @@ class DeltaTableHelper:
             if use_partitioning:
                 # We are testing concurrent merges with a subset of teams.
                 # TODO: Do all merges concurrently and remove the sequential method.
-                if str(self._job.team.id) in settings.CONCURRENT_MERGES_TEAM_IDS:
+                if (str(self._job.team.id) in settings.CONCURRENT_MERGES_TEAM_IDS) or True:
                     self.merge_partitioned_delta_table(delta_table, data, predicate_ops)
 
                 else:

--- a/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -62,7 +62,7 @@ class DeltaTableHelper:
                 "region_name": settings.AIRBYTE_BUCKET_REGION,
                 "AWS_DEFAULT_REGION": settings.AIRBYTE_BUCKET_REGION,
                 "AWS_ALLOW_HTTP": "true",
-                "AWS_S3_ALLOW_UNSAFE_RENAME": "true",
+                "AWS_S3_ALLOW_UNSAFE_RENAME": "false",
             }
 
         return {
@@ -70,7 +70,7 @@ class DeltaTableHelper:
             "aws_secret_access_key": settings.AIRBYTE_BUCKET_SECRET,
             "region_name": settings.AIRBYTE_BUCKET_REGION,
             "AWS_DEFAULT_REGION": settings.AIRBYTE_BUCKET_REGION,
-            "AWS_S3_ALLOW_UNSAFE_RENAME": "true",
+            "AWS_S3_ALLOW_UNSAFE_RENAME": "false",
         }
 
     def _get_delta_table_uri(self) -> str:
@@ -187,6 +187,9 @@ class DeltaTableHelper:
                     mode=mode,
                     schema_mode=schema_mode,
                     engine="rust",
+                    storage_options={
+                        "conditional_put": "etag",
+                    },
                 )  # type: ignore
             except deltalake.exceptions.SchemaMismatchError as e:
                 logger.exception("Attempting to overwrite schema due to SchemaMismatchError", exc_info=e)
@@ -199,6 +202,9 @@ class DeltaTableHelper:
                     mode=mode,
                     schema_mode="overwrite",
                     engine="rust",
+                    storage_options={
+                        "conditional_put": "etag",
+                    },
                 )  # type: ignore
 
         delta_table = self.get_delta_table()

--- a/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -265,7 +265,7 @@ class DeltaTableHelper:
                     logger.exception("Failed to merge partition %s: %s", partition, exc)
                     raise
                 else:
-                    logger.debug("Successfully merged partition %s: %s", partition)
+                    logger.debug("Successfully merged partition %s", partition)
 
     def merge_delta_table(
         self, delta_table: deltalake.DeltaTable, data: pa.Table, predicate_ops: list[str], streamed_exc: bool = False


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

If we have too many partitions to merge, running them sequentially can be prohibitively expensive. As an alternative, we can merge partitions concurrently in separate threads, as delta lake ensures no conflicts when merging different partitions.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

* Run concurrent partitioned merges in separate threads.
* Move logging variables to logger context.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
