### PR TITLE
fix(editor): editor search docs

### DIFF
--- a/products/editor/backend/api.py
+++ b/products/editor/backend/api.py
@@ -50,7 +50,7 @@ SUPPORTED_MODELS_WITH_THINKING = AnthropicConfig.SUPPORTED_MODELS_WITH_THINKING
 
 
 class LLMProxyCompletionSerializer(serializers.Serializer):
-    system = serializers.CharField()
+    system = serializers.CharField(allow_blank=True)
     messages = serializers.ListField(child=serializers.DictField())
     model = serializers.CharField()
     thinking = serializers.BooleanField(default=False, required=False)
@@ -176,7 +176,7 @@ class LLMProxyViewSet(viewsets.ViewSet):
                 | "claude-3-haiku-20240307"
             ):
                 return AnthropicProvider(model_id)
-            case "inkeep-qa":
+            case "inkeep-qa-expert":
                 return InkeepProvider(model_id)
             case _:
                 return Response({"error": "Unsupported model"}, status=400)

--- a/products/editor/backend/providers/inkeep.py
+++ b/products/editor/backend/providers/inkeep.py
@@ -10,12 +10,14 @@ logger = logging.getLogger(__name__)
 
 
 class InkeepConfig:
-    SUPPORTED_MODELS = ["inkeep-qa"]
+    SUPPORTED_MODELS = ["inkeep-qa-expert"]
 
 
 class InkeepProvider:
     def __init__(self, model_id: str):
         self.client = openai.OpenAI(base_url="https://api.inkeep.com/v1", api_key=self.get_api_key())
+        if model_id not in InkeepConfig.SUPPORTED_MODELS:
+            raise ValueError(f"Model {model_id} is not supported")
         self.model_id = model_id
 
     def validate_messages(self, messages: list[dict[str, Any]]) -> None:
@@ -32,7 +34,7 @@ class InkeepProvider:
             raise ValueError("INKEEP_API_KEY is not set in environment or settings")
         return api_key
 
-    def stream_response(self, _: str, messages: list, thinking: bool = False) -> Generator[str, None, None]:
+    def stream_response(self, system: str, messages: list, thinking: bool = False) -> Generator[str, None, None]:
         """
         Generator function that yields SSE formatted data
         """


### PR DESCRIPTION
## Problem
The `search_documentation` tool in the editor is broken, as it doesn't need a system prompt. We also use the wrong model because Inkeep's docs are not updated.

## Changes
- Allow blank `system` prompt in the API request
- Change Inkeep's model name

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
By calling the API locally.
