### PR TITLE
fix: don't open filters when click on max

### DIFF
--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFilters.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFilters.tsx
@@ -299,7 +299,7 @@ export const RecordingsUniversalFilters = ({
                     'Show recordings showing user frustration',
                     'Show recordings of people who faced bugs',
                 ]}
-                onMaxOpen={() => setIsFiltersExpanded(true)}
+                onMaxOpen={() => setIsFiltersExpanded(false)}
             >
                 <>
                     <LemonButton


### PR DESCRIPTION
No context needed