### PR TITLE
feat: Dedicated cyclotron images

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -159,11 +159,20 @@ jobs:
                       values:
                           image:
                               sha: '${{ needs.build.outputs.capture_digest }}'
+                    # NOTE: Will be removed once moved to the separate cyclotron images
                     - release: cyclotron
                       values:
                           fetch_image:
                               sha: '${{ needs.build.outputs.cyclotron-fetch_digest }}'
                           janitor_image:
+                              sha: '${{ needs.build.outputs.cyclotron-janitor_digest }}'
+                    - release: cyclotron-fetch
+                      values:
+                          image:
+                              sha: '${{ needs.build.outputs.cyclotron-fetch_digest }}'
+                    - release: cyclotron-janitor
+                      values:
+                          image:
                               sha: '${{ needs.build.outputs.cyclotron-janitor_digest }}'
                     - release: property-defs-rs
                       values:


### PR DESCRIPTION
## Problem

I'm attempting to move cyclotron to our nicer posthog-rust chart and to do that i need separate state file entries https://github.com/PostHog/charts/pull/4243

## Changes

* Does that

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
