### PR TITLE
fix: reusing feature flag for new experiments.

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -141,9 +141,6 @@ class ExperimentSerializer(serializers.ModelSerializer):
         return value
 
     def validate_existing_feature_flag_for_experiment(self, feature_flag: FeatureFlag):
-        if feature_flag.experiment_set.exists():
-            raise ValidationError("Feature flag is already associated with an experiment.")
-
         variants = feature_flag.filters.get("multivariate", {}).get("variants", [])
 
         if len(variants) and len(variants) > 1:

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -2210,6 +2210,62 @@ class TestExperimentCRUD(APILicensedTest):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_create_multiple_experiments_with_same_feature_flag(self):
+        # Create a feature flag with proper structure for experiments
+        feature_flag = FeatureFlag.objects.create(
+            team=self.team,
+            name="Shared feature flag",
+            key="shared-feature-flag",
+            filters={
+                "multivariate": {
+                    "variants": [
+                        {"key": "control", "rollout_percentage": 50},
+                        {"key": "test", "rollout_percentage": 50},
+                    ]
+                }
+            },
+            created_by=self.user,
+        )
+
+        # Create first experiment with this feature flag
+        first_experiment_response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "First experiment",
+                "feature_flag_key": feature_flag.key,
+                "parameters": {},
+            },
+        )
+
+        self.assertEqual(first_experiment_response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(first_experiment_response.json()["feature_flag"]["id"], feature_flag.id)
+
+        # Create second experiment with the same feature flag - this would have previously failed
+        second_experiment_response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "Second experiment",
+                "feature_flag_key": feature_flag.key,
+                "parameters": {},
+            },
+        )
+
+        # Assert that the second experiment is created successfully
+        self.assertEqual(second_experiment_response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(second_experiment_response.json()["feature_flag"]["id"], feature_flag.id)
+
+        # Verify both experiments exist and point to the same feature flag
+        first_experiment_id = first_experiment_response.json()["id"]
+        second_experiment_id = second_experiment_response.json()["id"]
+
+        # Ensure both experiments exist in the database
+        first_experiment = Experiment.objects.get(id=first_experiment_id)
+        second_experiment = Experiment.objects.get(id=second_experiment_id)
+
+        # Verify both experiments use the same feature flag
+        self.assertEqual(first_experiment.feature_flag_id, feature_flag.id)
+        self.assertEqual(second_experiment.feature_flag_id, feature_flag.id)
+
 
 class TestExperimentAuxiliaryEndpoints(ClickhouseTestMixin, APILicensedTest):
     def _generate_experiment(self, start_date="2024-01-01T10:23", extra_parameters=None):

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -2031,6 +2031,62 @@ class TestExperimentCRUD(APILicensedTest):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.json()["feature_flag"]["id"], feature_flag.id)
 
+    def test_create_multiple_experiments_with_same_feature_flag(self):
+        # Create a feature flag with proper structure for experiments
+        feature_flag = FeatureFlag.objects.create(
+            team=self.team,
+            name="Shared feature flag",
+            key="shared-feature-flag",
+            filters={
+                "multivariate": {
+                    "variants": [
+                        {"key": "control", "rollout_percentage": 50},
+                        {"key": "test", "rollout_percentage": 50},
+                    ]
+                }
+            },
+            created_by=self.user,
+        )
+
+        # Create first experiment with this feature flag
+        first_experiment_response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "First experiment",
+                "feature_flag_key": feature_flag.key,
+                "parameters": {},
+            },
+        )
+
+        self.assertEqual(first_experiment_response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(first_experiment_response.json()["feature_flag"]["id"], feature_flag.id)
+
+        # Create second experiment with the same feature flag - this would have previously failed
+        second_experiment_response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "Second experiment",
+                "feature_flag_key": feature_flag.key,
+                "parameters": {},
+            },
+        )
+
+        # Assert that the second experiment is created successfully
+        self.assertEqual(second_experiment_response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(second_experiment_response.json()["feature_flag"]["id"], feature_flag.id)
+
+        # Verify both experiments exist and point to the same feature flag
+        first_experiment_id = first_experiment_response.json()["id"]
+        second_experiment_id = second_experiment_response.json()["id"]
+
+        # Ensure both experiments exist in the database
+        first_experiment = Experiment.objects.get(id=first_experiment_id)
+        second_experiment = Experiment.objects.get(id=second_experiment_id)
+
+        # Verify both experiments use the same feature flag
+        self.assertEqual(first_experiment.feature_flag_id, feature_flag.id)
+        self.assertEqual(second_experiment.feature_flag_id, feature_flag.id)
+
     def test_feature_flag_and_experiment_sync(self):
         # Create an experiment with control and test variants
         response = self.client.post(
@@ -2209,62 +2265,6 @@ class TestExperimentCRUD(APILicensedTest):
             },
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-    def test_create_multiple_experiments_with_same_feature_flag(self):
-        # Create a feature flag with proper structure for experiments
-        feature_flag = FeatureFlag.objects.create(
-            team=self.team,
-            name="Shared feature flag",
-            key="shared-feature-flag",
-            filters={
-                "multivariate": {
-                    "variants": [
-                        {"key": "control", "rollout_percentage": 50},
-                        {"key": "test", "rollout_percentage": 50},
-                    ]
-                }
-            },
-            created_by=self.user,
-        )
-
-        # Create first experiment with this feature flag
-        first_experiment_response = self.client.post(
-            f"/api/projects/{self.team.id}/experiments/",
-            {
-                "name": "First experiment",
-                "feature_flag_key": feature_flag.key,
-                "parameters": {},
-            },
-        )
-
-        self.assertEqual(first_experiment_response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(first_experiment_response.json()["feature_flag"]["id"], feature_flag.id)
-
-        # Create second experiment with the same feature flag - this would have previously failed
-        second_experiment_response = self.client.post(
-            f"/api/projects/{self.team.id}/experiments/",
-            {
-                "name": "Second experiment",
-                "feature_flag_key": feature_flag.key,
-                "parameters": {},
-            },
-        )
-
-        # Assert that the second experiment is created successfully
-        self.assertEqual(second_experiment_response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(second_experiment_response.json()["feature_flag"]["id"], feature_flag.id)
-
-        # Verify both experiments exist and point to the same feature flag
-        first_experiment_id = first_experiment_response.json()["id"]
-        second_experiment_id = second_experiment_response.json()["id"]
-
-        # Ensure both experiments exist in the database
-        first_experiment = Experiment.objects.get(id=first_experiment_id)
-        second_experiment = Experiment.objects.get(id=second_experiment_id)
-
-        # Verify both experiments use the same feature flag
-        self.assertEqual(first_experiment.feature_flag_id, feature_flag.id)
-        self.assertEqual(second_experiment.feature_flag_id, feature_flag.id)
 
 
 class TestExperimentAuxiliaryEndpoints(ClickhouseTestMixin, APILicensedTest):


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

> [!NOTE]
> This is a follow-up of #31005.

## Problem

We've removed the check in the frontend to reuse a feature flag with a new experiment, but the backend still checks for `experiment_set`.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Remove the `feature_flag.experiment_set.exists()` on the `ExperimentSerializer` validation functions. We should be on the lookout for variant consistency, and consider adding checks and warnings in the frontend.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
