### PR TITLE
fix: hide insights tooltips break shared dashboards

### DIFF
--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -356,11 +356,17 @@ export function LineGraph_({
         }
 
         // Scroll events happen on the main element due to overflow-y: scroll
+        // but we need to make sure it exists before adding the event listener,
+        // e.g: it does not exist in the shared pages
         const main = document.getElementsByTagName('main')[0]
-        main.addEventListener('scrollend', hideTooltip)
+        if (main) {
+            main.addEventListener('scrollend', hideTooltip)
+        }
 
         return () => {
-            main.removeEventListener('scrollend', hideTooltip)
+            if (main) {
+                main.removeEventListener('scrollend', hideTooltip)
+            }
         }
     }, [hideTooltipOnScroll])
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

https://posthoghelp.zendesk.com/agent/tickets/28973 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/30335)

The fix #30407 worked for web analytics and some other internal posthog pages but it is breaking the shared dashboards/insights as there is no "main" tag on those.

## Changes

Doing the correct thing and checking the tag exists before handling the event listeners. This is the only place that uses the `document.getElementsByTagName('main')[0]` snippet that is shareable outside so it sould be ok.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Kind of tested in prod. I changed the minified code to test it on the Zendesk issue.