### PR TITLE
fix: fix bad index in compare metadata workflow

### DIFF
--- a/posthog/temporal/session_recordings/compare_recording_metadata_workflow.py
+++ b/posthog/temporal/session_recordings/compare_recording_metadata_workflow.py
@@ -78,7 +78,6 @@ def get_session_replay_events(
 
 
 FIELD_NAMES = [
-    "team_id",
     "distinct_id",
     "min_first_timestamp_agg",
     "max_last_timestamp_agg",


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

The session field index offset was off by 1 in the compare metadata task causing exceptions.

## Changes

Removes the team id from the fields to check, so that the index is correct again.

## Does this work well for both Cloud and self-hosted?

N/A

## How did you test this code?

Will test on prod.