### PR TITLE
refactor: skip message counts in v2 comparison

### DIFF
--- a/posthog/temporal/session_recordings/compare_recording_metadata_workflow.py
+++ b/posthog/temporal/session_recordings/compare_recording_metadata_workflow.py
@@ -38,7 +38,6 @@ def get_session_replay_events(
             sum(console_log_count) as console_log_count,
             sum(console_warn_count) as console_warn_count,
             sum(console_error_count) as console_error_count,
-            sum(message_count) as message_count,
             sum(event_count) as event_count,
             argMinMerge(snapshot_source) as snapshot_source,
             argMinMerge(snapshot_library) as snapshot_library
@@ -90,7 +89,6 @@ FIELD_NAMES = [
     "console_log_count",
     "console_warn_count",
     "console_error_count",
-    "message_count",
     "event_count",
     "snapshot_source",
     "snapshot_library",


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We're comparing the `message_count` field between v1 and v2 sessions, which doesn't say much about the contents of the session.

## Changes

Removes the comparison from the temporal task.

## Does this work well for both Cloud and self-hosted?

N/A

## How did you test this code?

Will check results on prod.