### PR TITLE
fix(hogql): Fix extended person properties

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -501,6 +501,7 @@ def create_hogql_database(
                             last_group = new_group
 
                     joined_table_chain = ".".join(table_chain)
+                    s3_table.name = joined_table_chain
                     warehouse_tables_dot_notation_mapping[joined_table_chain] = table.name
 
     # For every Stripe source, let's generate its own revenue view

--- a/posthog/warehouse/api/view_link.py
+++ b/posthog/warehouse/api/view_link.py
@@ -29,6 +29,35 @@ class ViewLinkSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ["id", "created_by", "created_at"]
 
+    def to_representation(self, instance):
+        view = super().to_representation(instance)
+
+        view["source_table_name"] = self.get_source_table_name(instance)
+        view["joining_table_name"] = self.get_joining_table_name(instance)
+
+        return view
+
+    def get_source_table_name(self, join: DataWarehouseJoin) -> str:
+        team_id = self.context["team_id"]
+        database = create_hogql_database(team_id)
+        if not database.has_table(join.source_table_name):
+            return join.source_table_name
+
+        table = database.get_table(join.source_table_name)
+
+        return table.to_printed_hogql().replace("`", "")
+
+    def get_joining_table_name(self, join: DataWarehouseJoin) -> str:
+        team_id = self.context["team_id"]
+        database = create_hogql_database(team_id)
+
+        if not database.has_table(join.joining_table_name):
+            return join.joining_table_name
+
+        table = database.get_table(join.joining_table_name)
+
+        return table.to_printed_hogql().replace("`", "")
+
     def create(self, validated_data):
         validated_data["team_id"] = self.context["team_id"]
         validated_data["created_by"] = self.context["request"].user


### PR DESCRIPTION
## Problem
The gift that keeps on giving...

- because we now only return the dot-notated tables to the client, it means we can't find the corresponding table for table joins when populating "extended person properties" in the taxonomy UI

## Changes
- Override the source/joined table names from the views and convert them to the dot notated version if it exists, otherwise return it as-is

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally + unit tests