### PR TITLE
perf(data-warehouse): SQL Server DWH source without SQLAlchemy 

### DIFF
--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -367,11 +367,11 @@ export const SOURCE_DETAILS: Record<ExternalDataSourceType, SourceConfig> = {
     },
     MSSQL: {
         name: 'MSSQL',
-        label: 'Azure SQL Server',
+        label: 'Microsoft SQL Server',
         caption: (
             <>
-                Enter your MS SQL Server/Azure SQL Server credentials to automatically pull your SQL data into the
-                PostHog Data warehouse.
+                Enter your Microsoft SQL Server/Azure SQL Server credentials to automatically pull your SQL data into
+                the PostHog Data warehouse.
             </>
         ),
         fields: [

--- a/posthog/settings/data_warehouse.py
+++ b/posthog/settings/data_warehouse.py
@@ -17,3 +17,7 @@ PYARROW_DEBUG_LOGGING = get_from_env("PYARROW_DEBUG_LOGGING", False, type_cast=s
 # Temporary, using it to maintain existing teams in old  bigquery source.
 # After further testing this will be removed and all teams moved to new source.
 OLD_BIGQUERY_SOURCE_TEAM_IDS: list[str] = get_list(os.getenv("OLD_BIGQUERY_SOURCE_TEAM_IDS", ""))
+
+# Temporary, using it to maintain existing teams in old MS SQL Server source.
+# After further testing this will be removed and all teams moved to new source.
+OLD_MSSQL_SOURCE_TEAM_IDS: list[str] = get_list(os.getenv("OLD_MSSQL_SOURCE_TEAM_IDS", ""))

--- a/posthog/temporal/data_imports/pipelines/mssql/mssql.py
+++ b/posthog/temporal/data_imports/pipelines/mssql/mssql.py
@@ -43,7 +43,7 @@ def _build_query(
     if db_incremental_field_last_value is None:
         db_incremental_field_last_value = incremental_type_to_initial_value(incremental_field_type)
 
-    query = f"SELECT * FROM [{schema}].[{table_name}] WHERE [{incremental_field}] >= %(incremental_value)s ORDER BY [{incremental_field}] ASC"
+    query = f"SELECT * FROM [{schema}].[{table_name}] WHERE [{incremental_field}] > %(incremental_value)s ORDER BY [{incremental_field}] ASC"
 
     return query, {
         "incremental_value": db_incremental_field_last_value,

--- a/posthog/temporal/data_imports/pipelines/mssql/mssql.py
+++ b/posthog/temporal/data_imports/pipelines/mssql/mssql.py
@@ -199,7 +199,7 @@ def mssql_source(
             primary_keys = _get_primary_keys(cursor, schema, table_name)
             table_structure = _get_table_structure(cursor, schema, table_name)
 
-            # Falback on checking for an `id` field on the table
+            # Fallback on checking for an `id` field on the table
             if primary_keys is None:
                 if any(ts.column_name == "id" for ts in table_structure):
                     primary_keys = ["id"]

--- a/posthog/temporal/data_imports/pipelines/mssql/mssql.py
+++ b/posthog/temporal/data_imports/pipelines/mssql/mssql.py
@@ -1,0 +1,246 @@
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+import pyarrow as pa
+import pymssql
+from dlt.common.normalizers.naming.snake_case import NamingConvention
+from pymssql import Cursor
+
+from posthog.temporal.common.logger import FilteringBoundLogger
+from posthog.temporal.data_imports.pipelines.helpers import (
+    incremental_type_to_initial_value,
+)
+from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from posthog.temporal.data_imports.pipelines.pipeline.utils import (
+    DEFAULT_NUMERIC_PRECISION,
+    DEFAULT_NUMERIC_SCALE,
+    build_pyarrow_decimal_type,
+    table_from_iterator,
+)
+from posthog.temporal.data_imports.pipelines.sql_database.settings import (
+    DEFAULT_CHUNK_SIZE,
+)
+from posthog.warehouse.models import IncrementalFieldType
+
+
+def _build_query(
+    schema: str,
+    table_name: str,
+    is_incremental: bool,
+    incremental_field: str | None,
+    incremental_field_type: IncrementalFieldType | None,
+    db_incremental_field_last_value: Any | None,
+) -> tuple[str, dict[str, Any]]:
+    query = f"SELECT * FROM [{schema}].[{table_name}]"
+
+    if not is_incremental:
+        return query, {}
+
+    if incremental_field is None or incremental_field_type is None:
+        raise ValueError("incremental_field and incremental_field_type can't be None")
+
+    if db_incremental_field_last_value is None:
+        db_incremental_field_last_value = incremental_type_to_initial_value(incremental_field_type)
+
+    query = f"SELECT * FROM [{schema}].[{table_name}] WHERE [{incremental_field}] >= %(incremental_value)s ORDER BY [{incremental_field}] ASC"
+
+    return query, {
+        "incremental_value": db_incremental_field_last_value,
+    }
+
+
+def _get_primary_keys(cursor: Cursor, schema: str, table_name: str) -> list[str] | None:
+    query = """
+        SELECT c.name AS column_name
+        FROM sys.indexes i
+        JOIN sys.index_columns ic ON i.object_id = ic.object_id AND i.index_id = ic.index_id
+        JOIN sys.columns c ON ic.object_id = c.object_id AND ic.column_id = c.column_id
+        JOIN sys.tables t ON i.object_id = t.object_id
+        JOIN sys.schemas s ON t.schema_id = s.schema_id
+        WHERE i.is_primary_key = 1
+        AND s.name = %(schema)s
+        AND t.name = %(table_name)s
+        ORDER BY ic.key_ordinal"""
+
+    cursor.execute(
+        query,
+        {
+            "schema": schema,
+            "table_name": table_name,
+        },
+    )
+    rows = cursor.fetchall()
+    if not rows:
+        return None
+
+    return [row[0] for row in rows]
+
+
+@dataclass
+class TableStructureRow:
+    column_name: str
+    data_type: str
+    is_nullable: bool
+    numeric_precision: int | None
+    numeric_scale: int | None
+
+
+def _get_table_structure(cursor: Cursor, schema: str, table_name: str) -> list[TableStructureRow]:
+    query = """
+        SELECT
+            COLUMN_NAME,
+            DATA_TYPE,
+            CASE IS_NULLABLE WHEN 'YES' THEN 1 ELSE 0 END as IS_NULLABLE,
+            NUMERIC_PRECISION,
+            NUMERIC_SCALE
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = %(schema)s
+        AND TABLE_NAME = %(table_name)s
+        ORDER BY ORDINAL_POSITION"""
+
+    cursor.execute(
+        query,
+        {
+            "schema": schema,
+            "table_name": table_name,
+        },
+    )
+    rows = cursor.fetchall()
+    if not rows:
+        raise ValueError(f"Table {table_name} not found")
+    return [
+        TableStructureRow(
+            column_name=row[0],
+            data_type=row[1],
+            is_nullable=bool(row[2]),
+            numeric_precision=row[3],
+            numeric_scale=row[4],
+        )
+        for row in rows
+    ]
+
+
+def _get_arrow_schema(table_structure: list[TableStructureRow]) -> pa.Schema:
+    fields = []
+
+    for col in table_structure:
+        name = col.column_name
+        data_type = col.data_type.lower()
+
+        arrow_type: pa.DataType
+
+        # Map MS SQL type names to PyArrow types
+        # https://learn.microsoft.com/en-us/sql/t-sql/data-types/data-types-transact-sql?view=sql-server-ver16
+        match data_type:
+            case "bigint":
+                arrow_type = pa.int64()
+            case "int" | "integer":
+                arrow_type = pa.int32()
+            case "smallint":
+                arrow_type = pa.int16()
+            case "tinyint":
+                arrow_type = pa.int8()
+            case "decimal" | "numeric" | "money":
+                precision = col.numeric_precision if col.numeric_precision is not None else DEFAULT_NUMERIC_PRECISION
+                scale = col.numeric_scale if col.numeric_scale is not None else DEFAULT_NUMERIC_SCALE
+                arrow_type = build_pyarrow_decimal_type(precision, scale)
+            case "float" | "real":
+                arrow_type = pa.float64()
+            case "varchar" | "char" | "text" | "nchar" | "nvarchar" | "ntext":
+                arrow_type = pa.string()
+            case "date":
+                arrow_type = pa.date32()
+            case "datetime" | "datetime2" | "smalldatetime":
+                arrow_type = pa.timestamp("us")
+            case "time":
+                arrow_type = pa.time64("us")
+            case "bit" | "boolean" | "bool":
+                arrow_type = pa.bool_()
+            case "binary" | "varbinary" | "image":
+                arrow_type = pa.binary()
+            case "json":
+                arrow_type = pa.string()
+            case _:
+                arrow_type = pa.string()
+
+        fields.append(pa.field(name, arrow_type, nullable=col.is_nullable))
+
+    return pa.schema(fields)
+
+
+def mssql_source(
+    host: str,
+    port: int,
+    user: str,
+    password: str,
+    database: str,
+    schema: str,
+    table_names: list[str],
+    is_incremental: bool,
+    logger: FilteringBoundLogger,
+    db_incremental_field_last_value: Any | None,
+    incremental_field: str | None = None,
+    incremental_field_type: IncrementalFieldType | None = None,
+) -> SourceResponse:
+    table_name = table_names[0]
+    if not table_name:
+        raise ValueError("Table name is missing")
+
+    with pymssql.connect(
+        server=host,
+        port=str(port),
+        database=database,
+        user=user,
+        password=password,
+        login_timeout=5,
+    ) as connection:
+        with connection.cursor() as cursor:
+            primary_keys = _get_primary_keys(cursor, schema, table_name)
+            table_structure = _get_table_structure(cursor, schema, table_name)
+
+            # Falback on checking for an `id` field on the table
+            if primary_keys is None:
+                if any(ts.column_name == "id" for ts in table_structure):
+                    primary_keys = ["id"]
+
+    def get_rows() -> Iterator[Any]:
+        arrow_schema = _get_arrow_schema(table_structure)
+
+        with pymssql.connect(
+            server=host,
+            port=str(port),
+            database=database,
+            user=user,
+            password=password,
+            login_timeout=5,
+        ) as connection:
+            with connection.cursor() as cursor:
+                query, args = _build_query(
+                    schema,
+                    table_name,
+                    is_incremental,
+                    incremental_field,
+                    incremental_field_type,
+                    db_incremental_field_last_value,
+                )
+                logger.debug(f"MS SQL query: {query.format(args)}")
+
+                cursor.execute(query, args)
+
+                column_names = [column[0] for column in cursor.description or []]
+
+                while True:
+                    rows = cursor.fetchmany(DEFAULT_CHUNK_SIZE)
+                    if not rows:
+                        break
+
+                    yield table_from_iterator((dict(zip(column_names, row)) for row in rows), arrow_schema)
+
+    name = NamingConvention().normalize_identifier(table_name)
+
+    return SourceResponse(
+        name=name,
+        items=get_rows(),
+        primary_keys=primary_keys,
+    )

--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -286,7 +286,7 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
                     ):
                         source = mssql_source(
                             host=tunnel.local_bind_host,
-                            port=tunnel.local_bind_port,
+                            port=int(tunnel.local_bind_port),
                             user=user,
                             password=password,
                             database=database,

--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -192,6 +192,7 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
             ExternalDataSource.Type.MYSQL,
             ExternalDataSource.Type.MSSQL,
         ]:
+            from posthog.temporal.data_imports.pipelines.mssql.mssql import mssql_source
             from posthog.temporal.data_imports.pipelines.mysql.mysql import mysql_source
             from posthog.temporal.data_imports.pipelines.postgres.postgres import (
                 postgres_source,
@@ -279,7 +280,33 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
                             if schema.is_incremental
                             else None,
                         )
+                    elif (
+                        ExternalDataSource.Type(model.pipeline.source_type) == ExternalDataSource.Type.MSSQL
+                        and str(inputs.team_id) not in settings.OLD_MSSQL_SOURCE_TEAM_IDS
+                    ):
+                        source = mssql_source(
+                            host=tunnel.local_bind_host,
+                            port=tunnel.local_bind_port,
+                            user=user,
+                            password=password,
+                            database=database,
+                            schema=pg_schema,
+                            table_names=endpoints,
+                            is_incremental=schema.is_incremental,
+                            logger=logger,
+                            incremental_field=schema.sync_type_config.get("incremental_field")
+                            if schema.is_incremental
+                            else None,
+                            incremental_field_type=schema.sync_type_config.get("incremental_field_type")
+                            if schema.is_incremental
+                            else None,
+                            db_incremental_field_last_value=processed_incremental_last_value
+                            if schema.is_incremental
+                            else None,
+                        )
                     else:
+                        # Old MS SQL Server source
+                        # TODO: remove once all teams have been moved to new source
                         source = sql_source_for_type(
                             source_type=ExternalDataSource.Type(model.pipeline.source_type),
                             host=tunnel.local_bind_host,
@@ -354,7 +381,31 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
                     else None,
                     db_incremental_field_last_value=processed_incremental_last_value if schema.is_incremental else None,
                 )
+            elif (
+                ExternalDataSource.Type(model.pipeline.source_type) == ExternalDataSource.Type.MSSQL
+                and str(inputs.team_id) not in settings.OLD_MSSQL_SOURCE_TEAM_IDS
+            ):
+                source = mssql_source(
+                    host=host,
+                    port=port,
+                    user=user,
+                    password=password,
+                    database=database,
+                    schema=pg_schema,
+                    table_names=endpoints,
+                    is_incremental=schema.is_incremental,
+                    logger=logger,
+                    incremental_field=schema.sync_type_config.get("incremental_field")
+                    if schema.is_incremental
+                    else None,
+                    incremental_field_type=schema.sync_type_config.get("incremental_field_type")
+                    if schema.is_incremental
+                    else None,
+                    db_incremental_field_last_value=processed_incremental_last_value if schema.is_incremental else None,
+                )
             else:
+                # Old MS SQL Server source
+                # TODO: remove once all teams have been moved to new source
                 source = sql_source_for_type(
                     source_type=ExternalDataSource.Type(model.pipeline.source_type),
                     host=host,

--- a/posthog/temporal/tests/data_imports/test_mssql_source.py
+++ b/posthog/temporal/tests/data_imports/test_mssql_source.py
@@ -1,0 +1,178 @@
+"""Tests for the Microsoft SQL Server source.
+
+NOTE: These tests require a Microsoft SQL Server to be running somewhere (for example, on Azure).
+Therefore these tests will only run if the required environment variables are set.
+
+You can run these tests using:
+
+```
+OBJECT_STORAGE_ENDPOINT=http://localhost:19000 \
+    MSSQL_HOST=localhost \
+    MSSQL_USER=username \
+    MSSQL_PASSWORD=password \
+    MSSQL_DATABASE=database_name \
+    pytest posthog/temporal/tests/data_imports/test_mssql_source.py
+```
+"""
+
+import datetime as dt
+import os
+import uuid
+from collections.abc import Generator
+from typing import Any
+
+import pymssql
+import pytest
+
+from posthog.temporal.tests.data_imports.conftest import run_external_data_job_workflow
+from posthog.warehouse.models import ExternalDataSchema, ExternalDataSource
+
+pytestmark = pytest.mark.usefixtures("minio_client")
+
+REQUIRED_ENV_VARS = (
+    "MSSQL_HOST",
+    "MSSQL_USER",
+    "MSSQL_PASSWORD",
+    "MSSQL_DATABASE",
+)
+
+MSSQL_TABLE_NAME = "test_table"
+
+TEST_DATA = [
+    (1, "John Doe", "john@example.com", dt.datetime(2025, 1, 1, tzinfo=dt.UTC), 100),
+    (2, "Jane Smith", "jane@example.com", dt.datetime(2025, 1, 2, tzinfo=dt.UTC), 2000000),
+    (3, "Bob Wilson", "bob@example.com", dt.datetime(2025, 1, 3, tzinfo=dt.UTC), 3409892966),
+]
+
+
+def mssql_env_vars_are_set() -> bool:
+    if not all(env_var in os.environ for env_var in REQUIRED_ENV_VARS):
+        return False
+    return True
+
+
+SKIP_IF_MISSING_MSSQL_CREDENTIALS = pytest.mark.skipif(
+    not mssql_env_vars_are_set(),
+    reason="MSSQL required env vars are not set",
+)
+
+
+@pytest.fixture
+def mssql_config() -> dict[str, Any]:
+    return {
+        "user": os.environ["MSSQL_USER"],
+        "password": os.environ["MSSQL_PASSWORD"],
+        "database": os.environ["MSSQL_DATABASE"],
+        "schema": os.environ.get("MSSQL_SCHEMA", "dbo"),
+        "host": os.environ["MSSQL_HOST"],
+        "port": int(os.environ.get("MSSQL_PORT", 1433)),
+    }
+
+
+@pytest.fixture
+def mssql_connection(mssql_config: dict[str, Any]) -> Generator[pymssql.Connection, None, None]:
+    connection = pymssql.connect(
+        server=mssql_config["host"],
+        port=mssql_config["port"],
+        database=mssql_config["database"],
+        user=mssql_config["user"],
+        password=mssql_config["password"],
+    )
+
+    yield connection
+    connection.close()
+
+
+@pytest.fixture
+def mssql_source_table(
+    mssql_connection: pymssql.Connection, mssql_config: dict[str, Any]
+) -> Generator[pymssql.Cursor, None, None]:
+    """Create a MS SQL Server table with test data and clean it up after the test."""
+    cursor = mssql_connection.cursor()
+    full_table_name = f"[{mssql_config['schema']}].[{MSSQL_TABLE_NAME}]"
+
+    # Create test table
+    cursor.execute(f"""
+        IF NOT EXISTS (
+            SELECT *
+            FROM sys.tables t
+            JOIN sys.schemas s ON t.schema_id = s.schema_id
+            WHERE s.name = '{mssql_config['schema']}'
+            AND t.name = '{MSSQL_TABLE_NAME}'
+        )
+        BEGIN
+            CREATE TABLE {full_table_name} (
+                id INTEGER,
+                name NVARCHAR(255),
+                email NVARCHAR(255),
+                created_at DATETIME2 DEFAULT GETUTCDATE(),
+                big_int BIGINT
+            )
+        END
+    """)
+
+    # Insert test data
+    for row in TEST_DATA:
+        cursor.execute(
+            f"INSERT INTO {full_table_name} (id, name, email, created_at, big_int) VALUES (%d, %s, %s, %s, %d)", row
+        )
+    mssql_connection.commit()
+
+    yield cursor
+
+    # Cleanup
+    cursor.execute(f"DROP TABLE IF EXISTS {full_table_name}")
+    mssql_connection.commit()
+    cursor.close()
+
+
+@pytest.fixture
+def external_data_source(mssql_config: dict[str, Any], team) -> ExternalDataSource:
+    source = ExternalDataSource.objects.create(
+        source_id=str(uuid.uuid4()),
+        connection_id=str(uuid.uuid4()),
+        destination_id=str(uuid.uuid4()),
+        team=team,
+        status="running",
+        source_type="MSSQL",
+        job_inputs=mssql_config,
+    )
+    return source
+
+
+@pytest.fixture
+def external_data_schema_full_refresh(external_data_source: ExternalDataSource, team) -> ExternalDataSchema:
+    schema = ExternalDataSchema.objects.create(
+        name=MSSQL_TABLE_NAME,
+        team_id=team.pk,
+        source_id=external_data_source.pk,
+        sync_type="full_refresh",
+        sync_type_config={},
+    )
+    return schema
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+@SKIP_IF_MISSING_MSSQL_CREDENTIALS
+async def test_mssql_source_full_refresh(
+    team,
+    mssql_source_table: pymssql.Cursor,
+    external_data_source: ExternalDataSource,
+    external_data_schema_full_refresh: ExternalDataSchema,
+):
+    """Test that a full refresh sync works as expected."""
+    table_name = f"mssql_{MSSQL_TABLE_NAME}"
+    expected_num_rows = len(TEST_DATA)
+
+    res = await run_external_data_job_workflow(
+        team=team,
+        external_data_source=external_data_source,
+        external_data_schema=external_data_schema_full_refresh,
+        table_name=table_name,
+        expected_rows_synced=expected_num_rows,
+        expected_total_rows=expected_num_rows,
+        expected_columns=["id", "name", "email", "created_at", "big_int"],
+    )
+
+    assert list(res.results) == TEST_DATA

--- a/posthog/temporal/tests/data_imports/test_mssql_source.py
+++ b/posthog/temporal/tests/data_imports/test_mssql_source.py
@@ -121,7 +121,7 @@ def mssql_connection(mssql_config: dict[str, Any]) -> Generator[pymssql.Connecti
 def _insert_test_data(cursor: pymssql.Cursor, table_name: str, data: list[tuple[Any, ...]]) -> None:
     for row in data:
         cursor.execute(
-            f"INSERT INTO {table_name} (id, name, email, created_at, big_int, json_data, active, decimal_data, price, float_data) VALUES (%d, %s, %s, %s, %d, %s, %d, %s, %s, %s)",
+            f"INSERT INTO {table_name} (uid, name, email, created_at, big_int, json_data, active, decimal_data, price, float_data) VALUES (%d, %s, %s, %s, %d, %s, %d, %s, %s, %s)",
             row,
         )
     cursor.connection.commit()
@@ -146,7 +146,7 @@ def mssql_source_table(
             )
             BEGIN
                 CREATE TABLE {full_table_name} (
-                    id INTEGER,
+                    uid INTEGER PRIMARY KEY,
                     name NVARCHAR(255),
                     email NVARCHAR(255),
                     created_at DATETIME2 DEFAULT GETUTCDATE(),
@@ -197,22 +197,6 @@ def external_data_schema_full_refresh(external_data_source: ExternalDataSource, 
     return schema
 
 
-@pytest.fixture
-def external_data_schema_incremental(external_data_source: ExternalDataSource, team) -> ExternalDataSchema:
-    schema = ExternalDataSchema.objects.create(
-        name=MSSQL_TABLE_NAME,
-        team_id=team.pk,
-        source_id=external_data_source.pk,
-        sync_type="incremental",
-        sync_type_config={
-            "incremental_field": "id",
-            "incremental_field_type": "integer",
-            "incremental_field_last_value": None,
-        },
-    )
-    return schema
-
-
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 @SKIP_IF_MISSING_MSSQL_CREDENTIALS
@@ -234,7 +218,7 @@ async def test_mssql_source_full_refresh(
         expected_rows_synced=expected_num_rows,
         expected_total_rows=expected_num_rows,
         expected_columns=[
-            "id",
+            "uid",
             "name",
             "email",
             "created_at",
@@ -248,6 +232,22 @@ async def test_mssql_source_full_refresh(
     )
 
     assert list(res.results) == TEST_DATA
+
+
+@pytest.fixture
+def external_data_schema_incremental(external_data_source: ExternalDataSource, team) -> ExternalDataSchema:
+    schema = ExternalDataSchema.objects.create(
+        name=MSSQL_TABLE_NAME,
+        team_id=team.pk,
+        source_id=external_data_source.pk,
+        sync_type="incremental",
+        sync_type_config={
+            "incremental_field": "uid",
+            "incremental_field_type": "integer",
+            "incremental_field_last_value": None,
+        },
+    )
+    return schema
 
 
 @pytest.mark.django_db(transaction=True)
@@ -271,7 +271,7 @@ async def test_mssql_source_incremental(
         expected_rows_synced=expected_num_rows,
         expected_total_rows=expected_num_rows,
         expected_columns=[
-            "id",
+            "uid",
             "name",
             "email",
             "created_at",
@@ -313,7 +313,108 @@ async def test_mssql_source_incremental(
         expected_rows_synced=len(NEW_TEST_DATA),
         expected_total_rows=expected_total_num_rows,
         expected_columns=[
-            "id",
+            "uid",
+            "name",
+            "email",
+            "created_at",
+            "big_int",
+            "json_data",
+            "active",
+            "decimal_data",
+            "price",
+            "float_data",
+        ],
+    )
+
+    # Compare sorted results as rows may have been shuffled around, but we only care the data is there,
+    # not in which order.
+    assert sorted(res.results, key=operator.itemgetter(0)) == sorted(
+        TEST_DATA + NEW_TEST_DATA, key=operator.itemgetter(0)
+    )
+
+
+@pytest.fixture
+def external_data_schema_incremental_using_created_at_column(
+    external_data_source: ExternalDataSource, team
+) -> ExternalDataSchema:
+    schema = ExternalDataSchema.objects.create(
+        name=MSSQL_TABLE_NAME,
+        team_id=team.pk,
+        source_id=external_data_source.pk,
+        sync_type="incremental",
+        sync_type_config={
+            "incremental_field": "created_at",
+            "incremental_field_type": "datetime",
+            "incremental_field_last_value": None,
+        },
+    )
+    return schema
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+@SKIP_IF_MISSING_MSSQL_CREDENTIALS
+async def test_mssql_source_incremental_using_created_at_column(
+    team,
+    mssql_source_table: pymssql.Cursor,
+    external_data_source: ExternalDataSource,
+    external_data_schema_incremental_using_created_at_column: ExternalDataSchema,
+):
+    """Test that a full refresh sync works as expected."""
+    table_name = f"mssql_{MSSQL_TABLE_NAME}"
+    expected_num_rows = len(TEST_DATA)
+
+    res = await run_external_data_job_workflow(
+        team=team,
+        external_data_source=external_data_source,
+        external_data_schema=external_data_schema_incremental_using_created_at_column,
+        table_name=table_name,
+        expected_rows_synced=expected_num_rows,
+        expected_total_rows=expected_num_rows,
+        expected_columns=[
+            "uid",
+            "name",
+            "email",
+            "created_at",
+            "big_int",
+            "json_data",
+            "active",
+            "decimal_data",
+            "price",
+            "float_data",
+        ],
+    )
+
+    assert list(res.results) == TEST_DATA
+
+    # insert new data to be synced on next incremental run
+    NEW_TEST_DATA = [
+        (
+            4,
+            "Mo Doe",
+            "mo@example.com",
+            dt.datetime(2025, 1, 4, tzinfo=pytz.UTC),
+            999999999,
+            '{"key":null}',
+            True,
+            Decimal("1300.33"),
+            Decimal("199.99"),
+            17678785.0,
+        ),
+    ]
+
+    _insert_test_data(cursor=mssql_source_table, table_name=MSSQL_TABLE_NAME, data=NEW_TEST_DATA)
+    expected_total_num_rows = expected_num_rows + len(NEW_TEST_DATA)
+
+    res = await run_external_data_job_workflow(
+        team=team,
+        external_data_source=external_data_source,
+        external_data_schema=external_data_schema_incremental_using_created_at_column,
+        table_name=table_name,
+        expected_rows_synced=len(NEW_TEST_DATA),
+        expected_total_rows=expected_total_num_rows,
+        expected_columns=[
+            "uid",
             "name",
             "email",
             "created_at",

--- a/posthog/temporal/tests/data_imports/test_mssql_source.py
+++ b/posthog/temporal/tests/data_imports/test_mssql_source.py
@@ -259,7 +259,7 @@ async def test_mssql_source_incremental(
     external_data_source: ExternalDataSource,
     external_data_schema_incremental: ExternalDataSchema,
 ):
-    """Test that a full refresh sync works as expected."""
+    """Test that an incremental sync works as expected."""
     table_name = f"mssql_{MSSQL_TABLE_NAME}"
     expected_num_rows = len(TEST_DATA)
 

--- a/posthog/temporal/tests/data_imports/test_mssql_source.py
+++ b/posthog/temporal/tests/data_imports/test_mssql_source.py
@@ -360,7 +360,7 @@ async def test_mssql_source_incremental_using_created_at_column(
     external_data_source: ExternalDataSource,
     external_data_schema_incremental_using_created_at_column: ExternalDataSchema,
 ):
-    """Test that a full refresh sync works as expected."""
+    """Test that an incremental sync works as expected when using the `created_at` column as the incremental field."""
     table_name = f"mssql_{MSSQL_TABLE_NAME}"
     expected_num_rows = len(TEST_DATA)
 


### PR DESCRIPTION
## Problem

Rewrite the Microsoft SQL Server source to not use SQLAlchemy, in order to be improve memory efficiency.

## Changes

- Create our own MS SQL source using `pymssql`
- Following similar pattern to existing DB sources (Postgres, MySQL)
- Have kept it simple for now (no partitioning for example) while we roll this out to all teams
- Rollout will be controlled via `OLD_MSSQL_SOURCE_TEAM_IDS` env var
    - Will add this to charts repo before deploying this to ensure primary users of MSSQL source continue to use the old source, then can start migrating these over gradually to ensure any unforeseen errors are ironed out as we discover them

## Does this work well for both Cloud and self-hosted?

Should do

## How did you test this code?

Added new tests for MS SQL source. These will only run if required env vars are provided. I tested myself by spinning up an Azure SQL Server DB.
