### PR TITLE
chore: run workflows in offline cluster

### DIFF
--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -36,6 +36,7 @@ from posthog.warehouse.data_load.create_table import create_table_from_saved_que
 from posthog.warehouse.models import DataWarehouseModelPath, DataWarehouseSavedQuery, DataWarehouseTable
 from posthog.warehouse.models.data_modeling_job import DataModelingJob
 from posthog.warehouse.util import database_sync_to_async
+from posthog.clickhouse.client.connection import Workload
 
 logger = structlog.get_logger()
 
@@ -497,6 +498,7 @@ def hogql_table(query: str, team: Team, table_name: str, table_columns: dlt_typi
             team,
             settings=settings,
             limit_context=LimitContext.SAVED_QUERY,
+            workload=Workload.OFFLINE,
         )
 
         if not response.columns:


### PR DESCRIPTION
## Problem

- materialization queries are run in the online clickhouse cluster. This cluster is meant for realtime traffic

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- move materialization jobs to offline cluster

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
