### PR TITLE
fix(hogql): Support aliased calls in table joins

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -648,6 +648,12 @@ def create_hogql_database(
                 field = parse_expr(join.source_table_key)
                 if isinstance(field, ast.Field):
                     from_field = field.chain
+                elif (
+                    isinstance(field, ast.Alias)
+                    and isinstance(field.expr, ast.Call)
+                    and isinstance(field.expr.args[0], ast.Field)
+                ):
+                    from_field = field.expr.args[0].chain
                 elif isinstance(field, ast.Call) and isinstance(field.args[0], ast.Field):
                     from_field = field.args[0].chain
                 else:
@@ -656,6 +662,12 @@ def create_hogql_database(
                 field = parse_expr(join.joining_table_key)
                 if isinstance(field, ast.Field):
                     to_field = field.chain
+                elif (
+                    isinstance(field, ast.Alias)
+                    and isinstance(field.expr, ast.Call)
+                    and isinstance(field.expr.args[0], ast.Field)
+                ):
+                    to_field = field.expr.args[0].chain
                 elif isinstance(field, ast.Call) and isinstance(field.args[0], ast.Field):
                     to_field = field.args[0].chain
                 else:

--- a/posthog/warehouse/models/join.py
+++ b/posthog/warehouse/models/join.py
@@ -206,6 +206,10 @@ class DataWarehouseJoin(CreatedMetaFields, UUIDModel, DeletedMetaFields):
             expr.chain = [table_name, *expr.chain]
         elif isinstance(expr, ast.Call) and isinstance(expr.args[0], ast.Field):
             expr.args[0].chain = [table_name, *expr.args[0].chain]
+        elif (
+            isinstance(expr, ast.Alias) and isinstance(expr.expr, ast.Call) and isinstance(expr.expr.args[0], ast.Field)
+        ):
+            expr.expr.args[0].chain = [table_name, *expr.expr.args[0].chain]
         else:
             raise ResolutionError("Data Warehouse Join HogQL expression should be a Field or Call node")
 


### PR DESCRIPTION
## Problem
- Due to https://github.com/PostHog/posthog/pull/30689, joins that use `ast.Call` nodes no longer function correctly because the calls are now wrapped in an `ast.Alias` node
- https://posthoghelp.zendesk.com/agent/tickets/25370 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/31049)

## Changes
- Support alias nodes that have a `ast.Call(ast.Field))` expression

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
tested locally