### PR TITLE
feat(capture-rs): overflow routing by token or partition key for capture-rs

### DIFF
--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -41,8 +41,8 @@ pub struct Config {
     #[envconfig(default = "1000")]
     pub overflow_burst_limit: NonZeroU32,
 
-    pub overflow_forced_keys: Option<String>, // Coma-delimited keys
-    pub dropped_keys: Option<String>, // "<token>:<distinct_id or *>,<distinct_id or *>;<token>..."
+    pub ingestion_force_overflow_by_token_distinct_id: Option<String>, // Comma-delimited keys
+    pub drop_events_by_token_distinct_id: Option<String>, // "<token>:<distinct_id or *>,<distinct_id or *>;<token>..."
 
     #[envconfig(nested = true)]
     pub kafka: KafkaConfig,
@@ -90,6 +90,8 @@ pub struct KafkaConfig {
     pub kafka_hosts: String,
     #[envconfig(default = "events_plugin_ingestion")]
     pub kafka_topic: String,
+    #[envconfig(default = "events_plugin_ingestion_overflow")]
+    pub kafka_overflow_topic: String,
     #[envconfig(default = "events_plugin_ingestion_historical")]
     pub kafka_historical_topic: String,
     #[envconfig(default = "events_plugin_ingestion")]

--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -50,7 +50,7 @@ async fn create_sink(
                 let partition = OverflowLimiter::new(
                     config.overflow_per_second_limit,
                     config.overflow_burst_limit,
-                    config.overflow_forced_keys.clone(),
+                    config.ingestion_force_overflow_by_token_distinct_id.clone(),
                 );
                 if config.export_prometheus {
                     let partition = partition.clone();
@@ -147,7 +147,7 @@ where
     .expect("failed to create billing limiter");
 
     let token_dropper = config
-        .dropped_keys
+        .drop_events_by_token_distinct_id
         .clone()
         .map(|k| TokenDropper::new(&k))
         .unwrap_or_default();

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -113,6 +113,7 @@ pub struct KafkaSink {
     producer: FutureProducer<KafkaContext>,
     partition: Option<OverflowLimiter>,
     main_topic: String,
+    overflow_topic: String,
     historical_topic: String,
     client_ingestion_warning_topic: String,
     exceptions_topic: String,
@@ -197,6 +198,7 @@ impl KafkaSink {
             producer,
             partition,
             main_topic: config.kafka_topic,
+            overflow_topic: config.kafka_overflow_topic,
             historical_topic: config.kafka_historical_topic,
             client_ingestion_warning_topic: config.kafka_client_ingestion_warning_topic,
             exceptions_topic: config.kafka_exceptions_topic,
@@ -235,9 +237,13 @@ impl KafkaSink {
                     None => false,
                     Some(partition) => partition.is_limited(&event_key),
                 };
+
                 if is_limited {
-                    (&self.main_topic, None) // Analytics overflow goes to the main topic without locality
+                    // Analytics overflow goes to the overflow topic without locality
+                    (&self.overflow_topic, None)
                 } else {
+                    // event_key is "<token>:<distinct_id>" for std events or
+                    // "<token>:<ip_addr>" for cookieless events
                     (&self.main_topic, Some(event_key.as_str()))
                 }
             }
@@ -415,6 +421,7 @@ mod tests {
             kafka_compression_codec: "none".to_string(),
             kafka_hosts: cluster.bootstrap_servers(),
             kafka_topic: "events_plugin_ingestion".to_string(),
+            kafka_overflow_topic: "events_plugin_ingestion_overflow".to_string(),
             kafka_historical_topic: "events_plugin_ingestion_historical".to_string(),
             kafka_client_ingestion_warning_topic: "events_plugin_ingestion".to_string(),
             kafka_exceptions_topic: "events_plugin_ingestion".to_string(),

--- a/rust/capture/tests/events.rs
+++ b/rust/capture/tests/events.rs
@@ -224,6 +224,147 @@ async fn it_captures_a_historical_batch() -> Result<()> {
 }
 
 #[tokio::test]
+async fn it_overflows_events_on_specified_keys() -> Result<()> {
+    setup_tracing();
+
+    // token only will be limited by candidate list
+    let token1 = String::from("token1");
+    let distinct_id1 = String::from("user1");
+
+    // token:distinct_id will be limited by candidate list
+    let token2 = String::from("token2");
+    let distinct_id2 = String::from("user2");
+    let key2 = format!("{}:{}", token2, distinct_id2);
+
+    // won't be limited other than by burst/rate-limits
+    let token3 = String::from("token3");
+    let distinct_id3 = String::from("user3");
+
+    let topic = EphemeralTopic::new().await;
+    let overflow_topic = EphemeralTopic::new().await;
+
+    let mut config = DEFAULT_CONFIG.clone();
+    // this is the candidate list of tokens/event keys to reroute on sight
+    config.ingestion_force_overflow_by_token_distinct_id = Some(format!("{},{}", token1, key2));
+    config.kafka.kafka_hosts = "localhost:9092".to_string();
+    config.kafka.kafka_producer_linger_ms = 0; // Send messages immediately
+    config.kafka.kafka_message_timeout_ms = 10000; // 10s timeout
+    config.kafka.kafka_producer_max_retries = 3;
+    config.kafka.kafka_topic = topic.topic_name().to_string();
+    config.kafka.kafka_overflow_topic = overflow_topic.topic_name().to_string();
+    config.overflow_enabled = true;
+    config.overflow_burst_limit = NonZeroU32::new(10).unwrap();
+    config.overflow_per_second_limit = NonZeroU32::new(10).unwrap();
+
+    let server = ServerHandle::for_config(config).await;
+
+    let batch_1 = json!([
+    // all events with token1 should be in overflow
+    {
+        "token": token1,
+        "event": "event1",
+        "distinct_id": distinct_id1,
+    },
+    {
+        "token": token1,
+        "event": "event2",
+        "distinct_id": distinct_id2,
+    }]);
+
+    let batch_2 = json!([
+    // only events with token2:distinct_id2 should be in overflow
+    {
+        "token": token2,
+        "event": "event3",
+        "distinct_id": distinct_id2,
+    },
+    {
+        "token": token2,
+        "event": "event4",
+        "distinct_id": distinct_id1,
+    }]);
+
+    let batch_3 = json!([
+    // all events for token3 and token3:distinct_id3 should be in main topic
+    {
+        "token": token3,
+        "event": "event5",
+        "distinct_id": distinct_id1,
+    },
+    {
+        "token": token3,
+        "event": "event6",
+        "distinct_id": distinct_id2,
+    },
+    {
+        "token": token3,
+        "event": "event7",
+        "distinct_id": distinct_id3,
+    }]);
+
+    let res = server.capture_events(batch_1.to_string()).await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    let res = server.capture_events(batch_2.to_string()).await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    let res = server.capture_events(batch_3.to_string()).await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    // main toppic results
+    assert_eq!(
+        topic.next_message_key()?.unwrap(),
+        format!("{}:{}", token2, distinct_id1)
+    );
+    assert_eq!(
+        topic.next_message_key()?.unwrap(),
+        format!("{}:{}", token3, distinct_id1)
+    );
+
+    assert_eq!(
+        topic.next_message_key()?.unwrap(),
+        format!("{}:{}", token3, distinct_id2)
+    );
+
+    assert_eq!(
+        topic.next_message_key()?.unwrap(),
+        format!("{}:{}", token3, distinct_id3)
+    );
+
+    topic.assert_empty();
+
+    // Third event should be in overflow topic, but has no
+    // message key as overflow events are round-robined
+    assert_json_include!(
+        actual: overflow_topic.next_event()?,
+        expected: json!({
+            "token": token1,
+            "distinct_id": distinct_id1,
+        })
+    );
+
+    assert_json_include!(
+        actual: overflow_topic.next_event()?,
+        expected: json!({
+            "token": token1,
+            "distinct_id": distinct_id2,
+        })
+    );
+
+    assert_json_include!(
+        actual: overflow_topic.next_event()?,
+        expected: json!({
+            "token": token2,
+            "distinct_id": distinct_id2,
+        })
+    );
+
+    overflow_topic.assert_empty();
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn it_overflows_events_on_burst() -> Result<()> {
     setup_tracing();
 

--- a/rust/capture/tests/events.rs
+++ b/rust/capture/tests/events.rs
@@ -49,10 +49,12 @@ async fn it_drops_events_if_dropper_enabled() -> Result<()> {
 
     let main_topic = EphemeralTopic::new().await;
     let histo_topic = EphemeralTopic::new().await;
+    let overflow_topic = EphemeralTopic::new().await;
     let mut config = DEFAULT_CONFIG.clone();
     config.kafka.kafka_topic = main_topic.topic_name().to_string();
     config.kafka.kafka_historical_topic = histo_topic.topic_name().to_string();
-    config.dropped_keys = Some(format!("{}:{}", token, dropped_id));
+    config.kafka.kafka_overflow_topic = overflow_topic.topic_name().to_string();
+    config.drop_events_by_token_distinct_id = Some(format!("{}:{}", token, dropped_id));
     let server = ServerHandle::for_config(config).await;
 
     let event = json!({
@@ -229,32 +231,40 @@ async fn it_overflows_events_on_burst() -> Result<()> {
     let distinct_id = random_string("id", 16);
 
     let topic = EphemeralTopic::new().await;
+    let overflow_topic = EphemeralTopic::new().await;
 
     let mut config = DEFAULT_CONFIG.clone();
+    config.kafka.kafka_hosts = "localhost:9092".to_string();
+    config.kafka.kafka_producer_linger_ms = 0; // Send messages immediately
+    config.kafka.kafka_message_timeout_ms = 10000; // 10s timeout
+    config.kafka.kafka_producer_max_retries = 3;
     config.kafka.kafka_topic = topic.topic_name().to_string();
+    config.kafka.kafka_overflow_topic = overflow_topic.topic_name().to_string();
     config.overflow_enabled = true;
     config.overflow_burst_limit = NonZeroU32::new(2).unwrap();
     config.overflow_per_second_limit = NonZeroU32::new(1).unwrap();
 
     let server = ServerHandle::for_config(config).await;
 
-    let event = json!([{
+    let events = json!([{
         "token": token,
         "event": "event1",
-        "distinct_id": distinct_id
+        "distinct_id": distinct_id,
     },{
         "token": token,
         "event": "event2",
-        "distinct_id": distinct_id
-    },{
+        "distinct_id": distinct_id,
+    },
+    {
         "token": token,
-        "event": "event3",
-        "distinct_id": distinct_id
+        "event": "event3_to_overflow",
+        "distinct_id": distinct_id,
     }]);
 
-    let res = server.capture_events(event.to_string()).await;
+    let res = server.capture_events(events.to_string()).await;
     assert_eq!(StatusCode::OK, res.status());
 
+    // First two events should go to main topic
     assert_eq!(
         topic.next_message_key()?.unwrap(),
         format!("{}:{}", token, distinct_id)
@@ -265,7 +275,19 @@ async fn it_overflows_events_on_burst() -> Result<()> {
         format!("{}:{}", token, distinct_id)
     );
 
-    assert_eq!(topic.next_message_key()?, None);
+    topic.assert_empty();
+
+    // Third event should be in overflow topic, but has no
+    // message key as overflow events are round-robined
+    assert_json_include!(
+        actual: overflow_topic.next_event()?,
+        expected: json!({
+            "token": token,
+            "distinct_id": distinct_id,
+        })
+    );
+
+    overflow_topic.assert_empty();
 
     Ok(())
 }
@@ -322,9 +344,11 @@ async fn it_skips_overflows_when_disabled() -> Result<()> {
     let distinct_id = random_string("id", 16);
 
     let topic = EphemeralTopic::new().await;
+    let overflow_topic = EphemeralTopic::new().await;
 
     let mut config = DEFAULT_CONFIG.clone();
     config.kafka.kafka_topic = topic.topic_name().to_string();
+    config.kafka.kafka_overflow_topic = overflow_topic.topic_name().to_string();
     config.overflow_enabled = false;
     config.overflow_burst_limit = NonZeroU32::new(2).unwrap();
     config.overflow_per_second_limit = NonZeroU32::new(1).unwrap();

--- a/rust/common/limiters/src/overflow.rs
+++ b/rust/common/limiters/src/overflow.rs
@@ -38,8 +38,24 @@ impl OverflowLimiter {
         }
     }
 
-    pub fn is_limited(&self, key: &String) -> bool {
-        self.forced_keys.contains(key) || self.limiter.check_key(key).is_err()
+    // event_key is the candidate partition key for the outbound event. It is either
+    // "<token>:<distinct_id>" for std events or "<token>:<ip_addr>" for cookieless.
+    // If this method returns true, the event should be rerouted to the overflow topic
+    // without a partition key, to avoid hot partitions in that pipeline.
+    pub fn is_limited(&self, event_key: &String) -> bool {
+        // is the event key in the forced_keys list?
+        let forced_key_match = self.forced_keys.contains(event_key);
+
+        // is the token (first component of the event key) in the forced_keys list?
+        let forced_token_match = match event_key.split(':').next() {
+            Some(token) => !token.is_empty() && self.forced_keys.contains(token),
+            None => false,
+        };
+
+        // should rate limiting be triggered for this event?
+        let rate_limited_key = self.limiter.check_key(event_key).is_err();
+
+        forced_key_match || forced_token_match || rate_limited_key
     }
 
     /// Reports the number of tracked keys to prometheus every 10 seconds,
@@ -82,10 +98,10 @@ mod tests {
             NonZeroU32::new(1).unwrap(),
             None,
         );
-        let token = String::from("test");
 
-        assert!(!limiter.is_limited(&token));
-        assert!(limiter.is_limited(&token));
+        let key = String::from("test:user");
+        assert!(!limiter.is_limited(&key));
+        assert!(limiter.is_limited(&key));
     }
 
     #[tokio::test]
@@ -95,33 +111,65 @@ mod tests {
             NonZeroU32::new(3).unwrap(),
             None,
         );
-        let token = String::from("test");
 
-        assert!(!limiter.is_limited(&token));
-        assert!(!limiter.is_limited(&token));
-        assert!(!limiter.is_limited(&token));
-        assert!(limiter.is_limited(&token));
+        let key = String::from("test:user");
+        assert!(!limiter.is_limited(&key));
+        assert!(!limiter.is_limited(&key));
+        assert!(!limiter.is_limited(&key));
+        assert!(limiter.is_limited(&key));
     }
 
     #[tokio::test]
     async fn forced_key() {
-        let key_one = String::from("one");
-        let key_two = String::from("two");
-        let key_three = String::from("three");
-        let forced_keys = Some(String::from("one,three"));
+        let key1 = String::from("token1:user1");
+        let key2 = String::from("token2:user2");
 
+        // replicate the above in forced_keys list
+        let forced_keys = Some(format!("{},{}", key1, key2));
         let limiter = OverflowLimiter::new(
             NonZeroU32::new(1).unwrap(),
             NonZeroU32::new(1).unwrap(),
             forced_keys,
         );
 
-        // One and three are limited from the start, two is not
-        assert!(limiter.is_limited(&key_one));
-        assert!(!limiter.is_limited(&key_two));
-        assert!(limiter.is_limited(&key_three));
+        // token1:user1 and token2:user2 are limited from the start, token3:user3 is not
+        assert!(limiter.is_limited(&key1));
+        assert!(!limiter.is_limited(&String::from("token3:user3")));
+        assert!(limiter.is_limited(&key2));
 
-        // Two is limited on the second event
-        assert!(limiter.is_limited(&key_two));
+        // token3:user3 is limited on the second event
+        assert!(limiter.is_limited(&String::from("token3:user3")));
+    }
+
+    #[tokio::test]
+    async fn test_optional_distinct_id() {
+        let token1 = "token1";
+        let dist_id1 = "user1";
+        let key1 = format!("{}:{}", token1, dist_id1);
+        let token2 = "token2";
+        let dist_id2 = "user2";
+        let key2 = format!("{}:{}", token2, dist_id2);
+        let token3 = "token3";
+        let dist_id3 = "user3";
+        let key3 = format!("{}:{}", token3, dist_id3);
+
+        let limiter = OverflowLimiter::new(
+            NonZeroU32::new(1).unwrap(),
+            NonZeroU32::new(1).unwrap(),
+            Some(format!("{},{}", token1, key2)),
+        );
+
+        // token1 is limited for all distinct_ids
+        assert!(limiter.is_limited(&key1));
+        assert!(limiter.is_limited(&format!("{}:{}", token1, "other_user")));
+        assert!(limiter.is_limited(&token1.to_string()));
+
+        // token2:user2 is limited only for that specific user
+        assert!(limiter.is_limited(&key2));
+        assert!(!limiter.is_limited(&format!("{}:{}", token2, "other_user")));
+
+        // token3 gets rate limited normally
+        assert!(!limiter.is_limited(&key3));
+        assert!(limiter.is_limited(&key3)); // Second hit is limited
     }
 }

--- a/rust/common/limiters/src/token_dropper.rs
+++ b/rust/common/limiters/src/token_dropper.rs
@@ -4,34 +4,45 @@ use tracing::warn;
 
 #[derive(Default)]
 pub struct TokenDropper {
-    to_drop: HashMap<String, Vec<String>>,
+    to_drop: HashMap<String, Option<Vec<String>>>,
 }
 
 impl TokenDropper {
-    // Takes "<token>:<distinct_id or *>,<distinct_id or *>;<token>..."
+    // Takes "token:id_1,token:id2,token" where token without id means drop all events
     pub fn new(config: &str) -> Self {
         let mut to_drop = HashMap::new();
-        for pair in config.split(';') {
-            let mut parts = pair.split(':');
+
+        for part in config.split(',') {
+            let mut parts = part.trim().split(':');
             let Some(token) = parts.next() else {
-                warn!("No distinct id's configured for pair {}", pair);
+                warn!("Invalid format in part {}", part);
                 continue;
             };
-            let Some(ids) = parts.next() else {
-                warn!("No distinct id's configured for token {}", token);
-                continue;
-            };
-            let ids = ids.split(',').map(|s| s.to_string()).collect();
-            to_drop.insert(token.to_string(), ids);
+
+            match parts.next() {
+                Some(id) => {
+                    let entry = to_drop
+                        .entry(token.to_string())
+                        .or_insert_with(|| Some(Vec::new()));
+                    if let Some(ids) = entry {
+                        ids.push(id.to_string());
+                    }
+                }
+                None => {
+                    // No distinct_id means drop all events for this token
+                    to_drop.insert(token.to_string(), None);
+                }
+            }
         }
         Self { to_drop }
     }
 
     pub fn should_drop(&self, token: &str, distinct_id: &str) -> bool {
-        self.to_drop
-            .get(token)
-            .map(|ids| ids.iter().any(|id| id == distinct_id || id == "*"))
-            .unwrap_or(false)
+        match self.to_drop.get(token) {
+            Some(None) => true, // Drop all events for this token
+            Some(Some(ids)) => ids.iter().any(|id| id == distinct_id),
+            None => false,
+        }
     }
 }
 
@@ -54,23 +65,25 @@ mod test {
 
     #[test]
     fn test_multiple_ids() {
-        let dropper = TokenDropper::new("token:id1,id2");
+        let dropper = TokenDropper::new("token:id1,token:id2");
         assert!(dropper.should_drop("token", "id1"));
         assert!(dropper.should_drop("token", "id2"));
         assert!(!dropper.should_drop("token", "id3"));
     }
 
     #[test]
-    fn test_wildcard() {
-        let dropper = TokenDropper::new("token:*");
+    fn test_drop_all_for_token() {
+        let dropper = TokenDropper::new("token");
         assert!(dropper.should_drop("token", "anything"));
     }
 
     #[test]
-    fn test_multiple_tokens() {
-        let dropper = TokenDropper::new("token1:id1;token2:id2");
+    fn test_mixed_format() {
+        let dropper = TokenDropper::new("token1:id1,token2,token3:id3");
         assert!(dropper.should_drop("token1", "id1"));
-        assert!(dropper.should_drop("token2", "id2"));
+        assert!(dropper.should_drop("token2", "anything"));
+        assert!(dropper.should_drop("token3", "id3"));
         assert!(!dropper.should_drop("token1", "id2"));
+        assert!(!dropper.should_drop("token3", "id1"));
     }
 }


### PR DESCRIPTION
## Problem
`capture-rs` has no way to conditionally route events for a particular `token` or partition key to the overflow topic. This prevents rapid response to safeguard the primary event ingest flow from misconfigured event streams or high load from a particular source.

**Env vars to point to the overflow topic must be landed in `capture-rs` deployments before this PR is landed**

## Changes
* Adds overflow topic registration to `capture-rs`
* Implements logic to detect tokens and partition keys in the event stream to be rerouted
* Adds env var handling to parse and track tokens and partition keys of interest for overflow routing

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally (new unit tests) and in CI
