### PR TITLE
chore: hard refresh on materialization

### DIFF
--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -394,6 +394,7 @@ async def materialize_model(
         pipeline_name=f"materialize_model_{model_label}",
         destination=destination,
         dataset_name=f"team_{team.pk}_model_{model_label}",
+        refresh="drop_sources",
     )
 
     try:


### PR DESCRIPTION
## Problem

- we want a complete refresh each time we materialize a view
- right now it's loading metadata from the destination which is possibly corrupted

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- complete refresh

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
