### PR TITLE
fix(trends): Fixed trends breakdowns by dwh tables

### DIFF
--- a/posthog/warehouse/models/util.py
+++ b/posthog/warehouse/models/util.py
@@ -21,9 +21,17 @@ if TYPE_CHECKING:
 def get_view_or_table_by_name(team, name) -> Union["DataWarehouseSavedQuery", "DataWarehouseTable", None]:
     from posthog.warehouse.models import DataWarehouseSavedQuery, DataWarehouseTable
 
+    table_name = name
+    if "." in name:
+        chain = name.split(".")
+        if len(chain) == 2:
+            table_name = f"{chain[0]}_{chain[1]}"
+        elif len(chain) == 3:
+            table_name = f"{chain[1]}_{chain[0]}_{chain[2]}"
+
     table: DataWarehouseSavedQuery | DataWarehouseTable | None = (
         DataWarehouseTable.objects.filter(Q(deleted__isnull=True) | Q(deleted=False))
-        .filter(team=team, name=name)
+        .filter(team=team, name=table_name)
         .first()
     )
     if table is None:


### PR DESCRIPTION
## Problem
- https://posthog.slack.com/archives/C019RAX2XBN/p1744743070125149
- Trends breakdowns on dwh tables by dwh fields are broken because they look up the `DataWarehouseTable` by name

## Changes
- Temp fix this by reversing the dot notation name logic
- This is such a bad fix and so I'm gonna do a proper conversion tomorrow for all the dot notation stuff and finally convert everything over

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
- Tested locally