### PR TITLE
feat: list number of differing sessions by field

### DIFF
--- a/posthog/temporal/session_recordings/compare_recording_metadata_workflow.py
+++ b/posthog/temporal/session_recordings/compare_recording_metadata_workflow.py
@@ -165,6 +165,7 @@ async def compare_recording_metadata_activity(inputs: CompareRecordingMetadataAc
         all_differing_sessions_excluding_active_ms: list[tuple[str, int]] = []  # (session_id, team_id)
         differing_sessions_count = 0
         active_ms_diffs_percentage: list[float] = []
+        field_differences: dict[str, int] = {field: 0 for field in FIELD_NAMES}  # Track per-field differences
 
         for session_key in set(v1_sessions.keys()) & set(v2_sessions.keys()):
             session_id, team_id = session_key
@@ -189,6 +190,7 @@ async def compare_recording_metadata_activity(inputs: CompareRecordingMetadataAc
                 if v1_data[i] != v2_data[i]:
                     diff = {"field": field_name, "v1_value": v1_data[i], "v2_value": v2_data[i]}
                     differences.append(diff)
+                    field_differences[field_name] += 1
                     if field_name != "active_milliseconds":
                         differences_excluding_active_ms.append(diff)
 
@@ -231,6 +233,7 @@ async def compare_recording_metadata_activity(inputs: CompareRecordingMetadataAc
             total_differing_sessions=len(all_differing_sessions),
             total_differing_sessions_excluding_active_ms=len(all_differing_sessions_excluding_active_ms),
             active_ms_stats=active_ms_stats,
+            field_differences=field_differences,
             time_range={
                 "started_after": started_after.isoformat(),
                 "started_before": started_before.isoformat(),


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

I need more statistics on the differences between sessions to see what the main discrepancies are.

## Changes

Logs the number of differing sessions per field in the session replay events table.

## Does this work well for both Cloud and self-hosted?

N/A

## How did you test this code?

Tested locally.