### PR TITLE
feat(capture-rs): implement historical event rerouting 

### DIFF
--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -42,6 +42,7 @@ pub struct Config {
     pub overflow_burst_limit: NonZeroU32,
 
     pub ingestion_force_overflow_by_token_distinct_id: Option<String>, // Comma-delimited keys
+
     pub drop_events_by_token_distinct_id: Option<String>, // "<token>:<distinct_id or *>,<distinct_id or *>;<token>..."
 
     #[envconfig(default = "false")]
@@ -49,6 +50,8 @@ pub struct Config {
 
     #[envconfig(default = "1")]
     pub historical_rerouting_threshold_days: i64,
+
+    pub historical_tokens_keys: Option<String>, // "<token>:<distinct_id or *>,<distinct_id or *>;<token>..."
 
     #[envconfig(nested = true)]
     pub kafka: KafkaConfig,

--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -44,6 +44,12 @@ pub struct Config {
     pub ingestion_force_overflow_by_token_distinct_id: Option<String>, // Comma-delimited keys
     pub drop_events_by_token_distinct_id: Option<String>, // "<token>:<distinct_id or *>,<distinct_id or *>;<token>..."
 
+    #[envconfig(default = "false")]
+    pub enable_historical_rerouting: bool,
+
+    #[envconfig(default = "1")]
+    pub historical_rerouting_threshold_days: i64,
+
     #[envconfig(nested = true)]
     pub kafka: KafkaConfig,
 

--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -33,6 +33,13 @@ pub struct State {
     pub billing_limiter: RedisLimiter,
     pub token_dropper: Arc<TokenDropper>,
     pub event_size_limit: usize,
+    pub historical_cfg: HistoricalConfig,
+}
+
+#[derive(Clone)]
+pub struct HistoricalConfig {
+    pub enable_historical_rerouting: bool,
+    pub historical_rerouting_threshold_days: i64,
 }
 
 async fn index() -> &'static str {
@@ -55,6 +62,8 @@ pub fn router<
     capture_mode: CaptureMode,
     concurrency_limit: Option<usize>,
     event_size_limit: usize,
+    enable_historical_rerouting: bool,
+    historical_rerouting_threshold_days: i64,
 ) -> Router {
     let state = State {
         sink: Arc::new(sink),
@@ -63,6 +72,10 @@ pub fn router<
         billing_limiter,
         event_size_limit,
         token_dropper: Arc::new(token_dropper),
+        historical_cfg: HistoricalConfig {
+            enable_historical_rerouting,
+            historical_rerouting_threshold_days,
+        },
     };
 
     // Very permissive CORS policy, as old SDK versions

--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::future::ready;
 use std::sync::Arc;
 
@@ -40,6 +41,44 @@ pub struct State {
 pub struct HistoricalConfig {
     pub enable_historical_rerouting: bool,
     pub historical_rerouting_threshold_days: i64,
+    pub historical_tokens_keys: HashSet<String>,
+}
+
+impl HistoricalConfig {
+    pub fn new(
+        enable_historical_rerouting: bool,
+        historical_rerouting_threshold_days: i64,
+        tokens_keys: Option<String>,
+    ) -> Self {
+        let mut htk = HashSet::new();
+        if let Some(s) = tokens_keys {
+            for entry in s.split(",") {
+                htk.insert(entry.trim().to_string());
+            }
+        }
+
+        HistoricalConfig {
+            enable_historical_rerouting,
+            historical_rerouting_threshold_days,
+            historical_tokens_keys: htk,
+        }
+    }
+
+    // event_key is on of: "token" "token:ip_addr" or "token:distinct_id"
+    // and self.historical_tokens_keys is a set of the same. if the key
+    // matches any entry in the set, the event should be rerouted
+    pub fn should_reroute(&self, event_key: &str) -> bool {
+        // is the event key in the forced_keys list?
+        let key_match = self.historical_tokens_keys.contains(event_key);
+
+        // is the token (first component of the event key) in the forced_keys list?
+        let token_match = match event_key.split(':').next() {
+            Some(token) => !token.is_empty() && self.historical_tokens_keys.contains(token),
+            None => false,
+        };
+
+        key_match || token_match
+    }
 }
 
 async fn index() -> &'static str {
@@ -64,6 +103,7 @@ pub fn router<
     event_size_limit: usize,
     enable_historical_rerouting: bool,
     historical_rerouting_threshold_days: i64,
+    historical_tokens_keys: Option<String>,
 ) -> Router {
     let state = State {
         sink: Arc::new(sink),
@@ -72,10 +112,11 @@ pub fn router<
         billing_limiter,
         event_size_limit,
         token_dropper: Arc::new(token_dropper),
-        historical_cfg: HistoricalConfig {
+        historical_cfg: HistoricalConfig::new(
             enable_historical_rerouting,
             historical_rerouting_threshold_days,
-        },
+            historical_tokens_keys,
+        ),
     };
 
     // Very permissive CORS policy, as old SDK versions

--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -64,7 +64,7 @@ impl HistoricalConfig {
         }
     }
 
-    // event_key is on of: "token" "token:ip_addr" or "token:distinct_id"
+    // event_key is one of: "token" "token:ip_addr" or "token:distinct_id"
     // and self.historical_tokens_keys is a set of the same. if the key
     // matches any entry in the set, the event should be rerouted
     pub fn should_reroute(&self, event_key: &str) -> bool {

--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -179,6 +179,7 @@ where
         event_max_bytes,
         config.enable_historical_rerouting,
         config.historical_rerouting_threshold_days,
+        config.historical_tokens_keys,
     );
 
     // run our app with hyper

--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -177,6 +177,8 @@ where
         config.capture_mode,
         config.concurrency_limit,
         event_max_bytes,
+        config.enable_historical_rerouting,
+        config.historical_rerouting_threshold_days,
     );
 
     // run our app with hyper

--- a/rust/capture/tests/common.rs
+++ b/rust/capture/tests/common.rs
@@ -41,6 +41,7 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     drop_events_by_token_distinct_id: None,
     enable_historical_rerouting: false,
     historical_rerouting_threshold_days: 1_i64,
+    historical_tokens_keys: None,
     kafka: KafkaConfig {
         kafka_producer_linger_ms: 0, // Send messages as soon as possible
         kafka_producer_queue_mib: 10,

--- a/rust/capture/tests/common.rs
+++ b/rust/capture/tests/common.rs
@@ -39,6 +39,8 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     overflow_per_second_limit: NonZeroU32::new(10).unwrap(),
     ingestion_force_overflow_by_token_distinct_id: None,
     drop_events_by_token_distinct_id: None,
+    enable_historical_rerouting: false,
+    historical_rerouting_threshold_days: 1_i64,
     kafka: KafkaConfig {
         kafka_producer_linger_ms: 0, // Send messages as soon as possible
         kafka_producer_queue_mib: 10,

--- a/rust/capture/tests/django_compat.rs
+++ b/rust/capture/tests/django_compat.rs
@@ -117,9 +117,11 @@ async fn it_matches_django_capture_behaviour() -> anyhow::Result<()> {
         )
         .expect("failed to create billing limiter");
 
-        // for this test, shut it off entirely as we use fixture files with old timestamps
+        // disable historical rerouting for this test,
+        // since we use fixture files with old timestamps
         let enable_historical_rerouting = false;
         let historical_rerouting_threshold_days = 1_i64;
+        let historical_tokens_keys = None;
 
         let app = router(
             timesource,
@@ -134,6 +136,7 @@ async fn it_matches_django_capture_behaviour() -> anyhow::Result<()> {
             25 * 1024 * 1024,
             enable_historical_rerouting,
             historical_rerouting_threshold_days,
+            historical_tokens_keys,
         );
 
         let client = TestClient::new(app);

--- a/rust/capture/tests/django_compat.rs
+++ b/rust/capture/tests/django_compat.rs
@@ -94,12 +94,7 @@ async fn it_matches_django_capture_behaviour() -> anyhow::Result<()> {
             continue;
         }
 
-        // kludge to ensure test fixtures have up-to-date "now" timestamps
-        // so that stamp-based historical rerouting works as expected
-        //let event_now = Utc::now().to_rfc3339();
-
         let case: RequestDump = serde_json::from_str(&line_contents)?;
-        //case.now = event_now.clone();
 
         let raw_body = general_purpose::STANDARD.decode(&case.body)?;
         assert_eq!(
@@ -122,7 +117,7 @@ async fn it_matches_django_capture_behaviour() -> anyhow::Result<()> {
         )
         .expect("failed to create billing limiter");
 
-        // for this test, shut it off entirely
+        // for this test, shut it off entirely as we use fixture files with old timestamps
         let enable_historical_rerouting = false;
         let historical_rerouting_threshold_days = 1_i64;
 
@@ -187,12 +182,6 @@ async fn it_matches_django_capture_behaviour() -> anyhow::Result<()> {
 
             // Normalizing the expected event to align with known django->rust inconsistencies
             let mut expected = expected.clone();
-
-            // kludge to ensure fixtures and expected "now" values match and
-            // are too new to trigger "now" based historical rerouting
-            //if let Some(timestamp) = expected.get_mut("now") {
-            //    *timestamp = Value::from(event_now.clone());
-            //}
 
             if let Some(value) = expected.get_mut("sent_at") {
                 // Default ISO format is different between python and rust, both are valid

--- a/rust/capture/tests/events.rs
+++ b/rust/capture/tests/events.rs
@@ -550,24 +550,25 @@ async fn it_reroutes_to_historical_on_event_timestamp() -> Result<()> {
     let stale_timestamp = Utc::now().checked_sub_days(chrono::Days::new(1)).unwrap();
 
     let events = vec![
-    json!([{
-        "token": token1,
-        "event": "event1",
-        "timestamp": Utc::now().to_rfc3339(),
-        "distinct_id": distinct_id1,
-    }]),
-    json!([{
-        "token": token2,
-        "event": "event2",
-        "timestamp": stale_timestamp.to_rfc3339(),
-        "distinct_id": distinct_id2,
-    }]),
-    json!([{
-        "token": token3,
-        "event": "event3",
-        // missing stamp won't trigger historical reroute
-        "distinct_id": distinct_id3,
-    }])];
+        json!([{
+            "token": token1,
+            "event": "event1",
+            "timestamp": Utc::now().to_rfc3339(),
+            "distinct_id": distinct_id1,
+        }]),
+        json!([{
+            "token": token2,
+            "event": "event2",
+            "timestamp": stale_timestamp.to_rfc3339(),
+            "distinct_id": distinct_id2,
+        }]),
+        json!([{
+            "token": token3,
+            "event": "event3",
+            // missing stamp won't trigger historical reroute
+            "distinct_id": distinct_id3,
+        }]),
+    ];
 
     for event in events {
         let res = server.capture_events(event.to_string()).await;

--- a/rust/capture/tests/events.rs
+++ b/rust/capture/tests/events.rs
@@ -4,6 +4,7 @@ use time::Duration;
 use crate::common::*;
 use anyhow::Result;
 use assert_json_diff::assert_json_include;
+use chrono::Utc;
 use limiters::redis::QuotaResource;
 use reqwest::StatusCode;
 use serde_json::json;
@@ -360,6 +361,241 @@ async fn it_overflows_events_on_specified_keys() -> Result<()> {
     );
 
     overflow_topic.assert_empty();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn it_reroutes_to_historical_on_specified_keys() -> Result<()> {
+    setup_tracing();
+
+    // token only will be limited by candidate list
+    let token1 = String::from("token1");
+    let distinct_id1 = String::from("user1");
+
+    // token:distinct_id will be limited by candidate list
+    let token2 = String::from("token2");
+    let distinct_id2 = String::from("user2");
+    let key2 = format!("{}:{}", token2, distinct_id2);
+
+    // won't be limited other than by burst/rate-limits
+    let token3 = String::from("token3");
+    let distinct_id3 = String::from("user3");
+
+    let topic = EphemeralTopic::new().await;
+    let historical_topic = EphemeralTopic::new().await;
+
+    let mut config = DEFAULT_CONFIG.clone();
+
+    // enable historical rerouting but focus this test on token1, key2
+    config.enable_historical_rerouting = true;
+    config.historical_rerouting_threshold_days = 30_i64; // 30 days won't interfere w/test!
+    config.historical_tokens_keys = Some(format!("{},{}", token1, key2));
+
+    config.kafka.kafka_hosts = "localhost:9092".to_string();
+    config.kafka.kafka_producer_linger_ms = 0; // Send messages immediately
+    config.kafka.kafka_message_timeout_ms = 10000; // 10s timeout
+    config.kafka.kafka_producer_max_retries = 3;
+    config.kafka.kafka_topic = topic.topic_name().to_string();
+    config.kafka.kafka_historical_topic = historical_topic.topic_name().to_string();
+    config.overflow_enabled = false;
+    config.overflow_burst_limit = NonZeroU32::new(10).unwrap();
+    config.overflow_per_second_limit = NonZeroU32::new(10).unwrap();
+
+    let server = ServerHandle::for_config(config).await;
+
+    let batch_1 = json!([
+    // all events with token1 should be in overflow
+    {
+        "token": token1,
+        "event": "event1",
+        "distinct_id": distinct_id1,
+    },
+    {
+        "token": token1,
+        "event": "event2",
+        "distinct_id": distinct_id2,
+    }]);
+
+    let batch_2 = json!([
+    // only events with token2:distinct_id2 should be in overflow
+    {
+        "token": token2,
+        "event": "event3",
+        "distinct_id": distinct_id2,
+    },
+    {
+        "token": token2,
+        "event": "event4",
+        "distinct_id": distinct_id1,
+    }]);
+
+    let batch_3 = json!([
+    // all events for token3 and token3:distinct_id3 should be in main topic
+    {
+        "token": token3,
+        "event": "event5",
+        "distinct_id": distinct_id1,
+    },
+    {
+        "token": token3,
+        "event": "event6",
+        "distinct_id": distinct_id2,
+    },
+    {
+        "token": token3,
+        "event": "event7",
+        "distinct_id": distinct_id3,
+    }]);
+
+    let res = server.capture_events(batch_1.to_string()).await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    let res = server.capture_events(batch_2.to_string()).await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    let res = server.capture_events(batch_3.to_string()).await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    // main toppic results
+    assert_eq!(
+        topic.next_message_key()?.unwrap(),
+        format!("{}:{}", token2, distinct_id1)
+    );
+    assert_eq!(
+        topic.next_message_key()?.unwrap(),
+        format!("{}:{}", token3, distinct_id1)
+    );
+
+    assert_eq!(
+        topic.next_message_key()?.unwrap(),
+        format!("{}:{}", token3, distinct_id2)
+    );
+
+    assert_eq!(
+        topic.next_message_key()?.unwrap(),
+        format!("{}:{}", token3, distinct_id3)
+    );
+
+    topic.assert_empty();
+
+    // Third event should be in historical topic
+    assert_json_include!(
+        actual: historical_topic.next_event()?,
+        expected: json!({
+            "token": token1,
+            "distinct_id": distinct_id1,
+        })
+    );
+
+    assert_json_include!(
+        actual: historical_topic.next_event()?,
+        expected: json!({
+            "token": token1,
+            "distinct_id": distinct_id2,
+        })
+    );
+
+    assert_json_include!(
+        actual: historical_topic.next_event()?,
+        expected: json!({
+            "token": token2,
+            "distinct_id": distinct_id2,
+        })
+    );
+
+    historical_topic.assert_empty();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn it_reroutes_to_historical_on_event_timestamp() -> Result<()> {
+    setup_tracing();
+
+    // token only will be limited by candidate list
+    let token1 = String::from("token1");
+    let distinct_id1 = String::from("user1");
+
+    // token:distinct_id will be limited by candidate list
+    let token2 = String::from("token2");
+    let distinct_id2 = String::from("user2");
+
+    // won't be limited other than by burst/rate-limits
+    let token3 = String::from("token3");
+    let distinct_id3 = String::from("user3");
+
+    let topic = EphemeralTopic::new().await;
+    let historical_topic = EphemeralTopic::new().await;
+
+    let mut config = DEFAULT_CONFIG.clone();
+
+    // enable historical rerouting for events w/timestamp older than 1 day
+    config.enable_historical_rerouting = true;
+    config.historical_rerouting_threshold_days = 1_i64;
+    config.historical_tokens_keys = None;
+
+    config.kafka.kafka_hosts = "localhost:9092".to_string();
+    config.kafka.kafka_producer_linger_ms = 0; // Send messages immediately
+    config.kafka.kafka_message_timeout_ms = 10000; // 10s timeout
+    config.kafka.kafka_producer_max_retries = 3;
+    config.kafka.kafka_topic = topic.topic_name().to_string();
+    config.kafka.kafka_historical_topic = historical_topic.topic_name().to_string();
+    config.overflow_enabled = false;
+    config.overflow_burst_limit = NonZeroU32::new(10).unwrap();
+    config.overflow_per_second_limit = NonZeroU32::new(10).unwrap();
+
+    let server = ServerHandle::for_config(config).await;
+
+    let stale_timestamp = Utc::now().checked_sub_days(chrono::Days::new(1)).unwrap();
+
+    let events = vec![
+    json!([{
+        "token": token1,
+        "event": "event1",
+        "timestamp": Utc::now().to_rfc3339(),
+        "distinct_id": distinct_id1,
+    }]),
+    json!([{
+        "token": token2,
+        "event": "event2",
+        "timestamp": stale_timestamp.to_rfc3339(),
+        "distinct_id": distinct_id2,
+    }]),
+    json!([{
+        "token": token3,
+        "event": "event3",
+        // missing stamp won't trigger historical reroute
+        "distinct_id": distinct_id3,
+    }])];
+
+    for event in events {
+        let res = server.capture_events(event.to_string()).await;
+        assert_eq!(StatusCode::OK, res.status());
+    }
+
+    // main toppic results
+    assert_eq!(
+        topic.next_message_key()?.unwrap(),
+        format!("{}:{}", token1, distinct_id1)
+    );
+    assert_eq!(
+        topic.next_message_key()?.unwrap(),
+        format!("{}:{}", token3, distinct_id3)
+    );
+
+    topic.assert_empty();
+
+    // Third event should be in historical topic
+    assert_json_include!(
+        actual: historical_topic.next_event()?,
+        expected: json!({
+            "token": token2,
+            "distinct_id": distinct_id2,
+        })
+    );
+
+    historical_topic.assert_empty();
 
     Ok(())
 }


### PR DESCRIPTION
## Problem
We need to implement automatic rerouting of historical events older than 1 day when they are submitted by users without proper scoping to the main event pipeline. We also want to be able to conditionally route events to the historical topic when a specified token or event key is seen in the event stream.

## Changes
* Adds historical rerouting config vars to env
* Adds processing logic for timestamp based historical rerouting
* Adds processing logic for token/key based historical rerouting
* Unit tests

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally (unit tests) and CI
