### PR TITLE
feat: api queries whitelist setting

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -151,6 +151,7 @@ services:
             CLICKHOUSE_DATABASE: 'posthog'
             CLICKHOUSE_SECURE: 'false'
             CLICKHOUSE_VERIFY: 'false'
+            API_QUERIES_PER_TEAM: '{"1": 7}'
             KAFKA_HOSTS: 'kafka'
             REDIS_URL: 'redis://redis:6379/'
             PGHOST: db

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -111,10 +111,8 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
     def get_throttles(self):
         if self.action == "draft_sql":
             return [AIBurstRateThrottle(), AISustainedRateThrottle()]
-        if (
-            self.team_id in settings.API_QUERIES_PER_TEAM
-            or settings.API_QUERIES_ENABLED
-            and self.check_team_api_queries_concurrency()
+        if self.team_id in settings.API_QUERIES_PER_TEAM or (
+            settings.API_QUERIES_ENABLED and self.check_team_api_queries_concurrency()
         ):
             return [APIQueriesBurstThrottle(), APIQueriesSustainedThrottle()]
         if query := self.request.data.get("query"):

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -49,10 +49,11 @@ from posthog.models.user import User
 from posthog.rate_limit import (
     AIBurstRateThrottle,
     AISustainedRateThrottle,
+    APIQueriesBurstThrottle,
+    APIQueriesSustainedThrottle,
     ClickHouseBurstRateThrottle,
     ClickHouseSustainedRateThrottle,
     HogQLQueryThrottle,
-    APIQueriesThrottle,
 )
 from posthog.schema import (
     QueryRequest,
@@ -110,8 +111,12 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
     def get_throttles(self):
         if self.action == "draft_sql":
             return [AIBurstRateThrottle(), AISustainedRateThrottle()]
-        if settings.API_QUERIES_ENABLED and self.check_team_api_queries_concurrency():
-            return [APIQueriesThrottle()]
+        if (
+            self.team_id in settings.API_QUERIES_PER_TEAM
+            or settings.API_QUERIES_ENABLED
+            and self.check_team_api_queries_concurrency()
+        ):
+            return [APIQueriesBurstThrottle(), APIQueriesSustainedThrottle()]
         if query := self.request.data.get("query"):
             if isinstance(query, dict) and query.get("kind") == "HogQLQuery":
                 return [HogQLQueryThrottle()]

--- a/posthog/clickhouse/client/limit.py
+++ b/posthog/clickhouse/client/limit.py
@@ -108,7 +108,7 @@ class RateLimit:
         max_concurrency = self.max_concurrency
         in_beta = team_id in settings.API_QUERIES_PER_TEAM
         if in_beta:
-            max_concurrency = settings.API_QUERIES_PER_TEAM.get(team_id)
+            max_concurrency = settings.API_QUERIES_PER_TEAM[team_id]  # type: ignore
         elif "limit" in kwargs:
             max_concurrency = kwargs.get("limit") or max_concurrency
         # Atomically check, remove expired if limit hit, and add the new task

--- a/posthog/clickhouse/client/limit.py
+++ b/posthog/clickhouse/client/limit.py
@@ -102,9 +102,15 @@ class RateLimit:
         task_name = self.get_task_name(*args, **kwargs)
         running_tasks_key = self.get_task_key(*args, **kwargs) if self.get_task_key else task_name
         task_id = self.get_task_id(*args, **kwargs)
+        team_id: Optional[int] = kwargs.get("team_id", None)
         current_time = self.get_time()
 
-        max_concurrency = kwargs.get("limit") or self.max_concurrency
+        max_concurrency = self.max_concurrency
+        in_beta = team_id in settings.API_QUERIES_PER_TEAM
+        if in_beta:
+            max_concurrency = settings.API_QUERIES_PER_TEAM.get(team_id)
+        elif "limit" in kwargs:
+            max_concurrency = kwargs.get("limit") or max_concurrency
         # Atomically check, remove expired if limit hit, and add the new task
         if (
             self.redis_client.eval(lua_script, 1, running_tasks_key, current_time, task_id, max_concurrency, self.ttl)
@@ -112,18 +118,18 @@ class RateLimit:
         ):
             from posthog.rate_limit import team_is_allowed_to_bypass_throttle
 
-            bypass = team_is_allowed_to_bypass_throttle(kwargs.get("team_id", None))
+            bypass = team_is_allowed_to_bypass_throttle(team_id)
             result = "allow" if bypass else "block"
 
             CONCURRENT_QUERY_LIMIT_EXCEEDED_COUNTER.labels(
                 task_name=task_name,
-                team_id=str(kwargs.get("team_id", "")),
+                team_id=str(team_id),
                 limit=max_concurrency,
                 limit_name=self.limit_name,
                 result=result,
             ).inc()
 
-            if not self.bypass_all and not bypass:
+            if (not self.bypass_all or in_beta) and not bypass:
                 raise ConcurrencyLimitExceeded(
                     f"Exceeded maximum concurrency limit: {max_concurrency} for key: {task_name} and task: {task_id}"
                 )

--- a/posthog/clickhouse/client/limit.py
+++ b/posthog/clickhouse/client/limit.py
@@ -129,7 +129,7 @@ class RateLimit:
                 result=result,
             ).inc()
 
-            if (not self.bypass_all or in_beta) and not bypass:
+            if (not self.bypass_all or in_beta) and not bypass:  # team in beta cannot skip limits
                 raise ConcurrencyLimitExceeded(
                     f"Exceeded maximum concurrency limit: {max_concurrency} for key: {task_name} and task: {task_id}"
                 )

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -339,8 +339,13 @@ class HogQLQueryThrottle(PersonalApiKeyRateThrottle):
     rate = "120/hour"
 
 
-class APIQueriesThrottle(PersonalApiKeyRateThrottle):
-    scope = "query"
+class APIQueriesBurstThrottle(PersonalApiKeyRateThrottle):
+    scope = "api_queries_burst"
+    rate = "120/minute"
+
+
+class APIQueriesSustainedThrottle(PersonalApiKeyRateThrottle):
+    scope = "api_queries_sustained"
     rate = "1200/hour"
 
 

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -112,7 +112,6 @@ if read_host:
 if JOB_QUEUE_GRAPHILE_URL:
     DATABASES["graphile"] = dj_database_url.config(default=JOB_QUEUE_GRAPHILE_URL, conn_max_age=600)
 
-
 # Opt-in to using the read replica
 # Models using this will likely see better query latency, and better performance.
 # Immediately reading after writing may not return consistent data if done in <100ms
@@ -122,7 +121,6 @@ if JOB_QUEUE_GRAPHILE_URL:
 # Database routers route models!
 replica_opt_in = os.environ.get("READ_REPLICA_OPT_IN", "")
 READ_REPLICA_OPT_IN: list[str] = get_list(replica_opt_in)
-
 
 # Xdist Settings
 # When running concurrent tests, PYTEST_XDIST_WORKER gets set to "gw0" ... "gwN"
@@ -179,6 +177,12 @@ try:
 except Exception:
     CLICKHOUSE_PER_TEAM_SETTINGS = {}
 
+try:
+    as_json = json.loads(os.getenv("API_QUERIES_PER_TEAM", {}))
+    API_QUERIES_PER_TEAM: dict[int, int] = {int(k): int(v) for k, v in as_json.items()}
+except Exception:
+    API_QUERIES_PER_TEAM: dict[int, int] = {}
+
 _clickhouse_http_protocol = "http://"
 _clickhouse_http_port = "8123"
 if CLICKHOUSE_SECURE:
@@ -195,7 +199,6 @@ if TEST or DEBUG or os.getenv("CLICKHOUSE_OFFLINE_CLUSTER_HOST", None) is None:
     # When testing, there is no offline cluster.
     # Also in EU, there is no offline cluster.
     CLICKHOUSE_OFFLINE_HTTP_URL = CLICKHOUSE_HTTP_URL
-
 
 READONLY_CLICKHOUSE_USER: str | None = os.getenv("READONLY_CLICKHOUSE_USER", None)
 READONLY_CLICKHOUSE_PASSWORD: str | None = os.getenv("READONLY_CLICKHOUSE_PASSWORD", None)
@@ -299,7 +302,6 @@ if get_from_env("POSTHOG_SESSION_RECORDING_REDIS_HOST", ""):
         os.getenv("POSTHOG_SESSION_RECORDING_REDIS_PORT", "6379"),
     )
 
-
 if not REDIS_URL:
     raise ImproperlyConfigured(
         "Env var REDIS_URL or POSTHOG_REDIS_HOST is absolutely required to run this software.\n"
@@ -325,7 +327,6 @@ REDIS_READER_URL = os.getenv("REDIS_READER_URL", None)
 # pubsub channel, pushed to when plugin configs change.
 # We should move away to a different communication channel and remove this.
 PLUGINS_RELOAD_REDIS_URL = os.getenv("PLUGINS_RELOAD_REDIS_URL", REDIS_URL)
-
 
 CDP_API_URL = get_from_env("CDP_API_URL", "")
 

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -1,5 +1,6 @@
 import json
 import os
+from contextlib import suppress
 from urllib.parse import urlparse
 
 import dj_database_url
@@ -177,11 +178,11 @@ try:
 except Exception:
     CLICKHOUSE_PER_TEAM_SETTINGS = {}
 
-try:
+API_QUERIES_PER_TEAM: dict[int, int] = {}
+with suppress(Exception):
     as_json = json.loads(os.getenv("API_QUERIES_PER_TEAM", "{}"))
-    API_QUERIES_PER_TEAM: dict[int, int] = {int(k): int(v) for k, v in as_json.items()}
-except Exception:
-    API_QUERIES_PER_TEAM: dict[int, int] = {}
+    API_QUERIES_PER_TEAM = {int(k): int(v) for k, v in as_json.items()}
+
 
 _clickhouse_http_protocol = "http://"
 _clickhouse_http_port = "8123"

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -178,7 +178,7 @@ except Exception:
     CLICKHOUSE_PER_TEAM_SETTINGS = {}
 
 try:
-    as_json = json.loads(os.getenv("API_QUERIES_PER_TEAM", {}))
+    as_json = json.loads(os.getenv("API_QUERIES_PER_TEAM", "{}"))
     API_QUERIES_PER_TEAM: dict[int, int] = {int(k): int(v) for k, v in as_json.items()}
 except Exception:
     API_QUERIES_PER_TEAM: dict[int, int] = {}


### PR DESCRIPTION
## Problem

Control manually teams in API Queries beta.

## Changes

Add env API_QUERIES_PER_TEAM enabling to put teams in beta and manually set concurrency limit for them.

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Most has tests + manual tests, modified the local docker setup