### PR TITLE
feat: Retry ClickHouse Dagster jobs on CANNOT_SCHEDULE_TASK error

### DIFF
--- a/dags/common.py
+++ b/dags/common.py
@@ -44,6 +44,7 @@ class ClickhouseClusterResource(dagster.ConfigurableResource):
                                 ErrorCodes.NETWORK_ERROR,
                                 ErrorCodes.TOO_MANY_SIMULTANEOUS_QUERIES,
                                 ErrorCodes.NOT_ENOUGH_SPACE,
+                                439,  # CANNOT_SCHEDULE_TASK: "Cannot schedule a task: cannot allocate thread"
                             )
                         )
                         # queries that exceed memory limits can be retried if they were killed due to total server


### PR DESCRIPTION
## Problem

Sometimes the servers are so overloaded we see the CANNOT_SCHEDULE_TASK error, e.g. https://dagster.prod-us.posthog.dev/runs/991962d4-b2c0-4243-b7f5-1d33b1a5c1a4

## Changes

Retry on `CANNOT_SCHEDULE_TASK` error.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

-