### PR TITLE
feat: Display revenue views in data warehouse sidebar

### DIFF
--- a/frontend/src/scenes/data-management/database/databaseTableListLogic.ts
+++ b/frontend/src/scenes/data-management/database/databaseTableListLogic.ts
@@ -165,13 +165,11 @@ export const databaseTableListLogic = kea<databaseTableListLogicType>([
                 views,
                 managedViews
             ): Record<string, DatabaseSchemaViewTable | DatabaseSchemaManagedViewTable> => {
-                if (!database || !database.tables) {
+                if (!database?.tables) {
                     return {}
                 }
 
-                const allViews = [...views, ...managedViews]
-
-                return allViews.reduce((acc, cur) => {
+                return [...views, ...managedViews].reduce((acc, cur) => {
                     acc[cur.name] = database.tables[cur.name] as
                         | DatabaseSchemaViewTable
                         | DatabaseSchemaManagedViewTable
@@ -180,18 +178,12 @@ export const databaseTableListLogic = kea<databaseTableListLogicType>([
             },
         ],
         viewsMapById: [
-            (s) => [s.database],
-            (database): Record<string, DatabaseSchemaViewTable> => {
-                if (!database || !database.tables) {
-                    return {}
-                }
-
-                return Object.values(database.tables)
-                    .filter((n): n is DatabaseSchemaViewTable => n.type === 'view')
-                    .reduce((acc, cur) => {
-                        acc[cur.id] = database.tables[cur.name] as DatabaseSchemaViewTable
-                        return acc
-                    }, {} as Record<string, DatabaseSchemaViewTable>)
+            (s) => [s.viewsMap],
+            (viewsMap): Record<string, DatabaseSchemaViewTable | DatabaseSchemaManagedViewTable> => {
+                return Object.values(viewsMap).reduce((acc, cur) => {
+                    acc[cur.id] = cur
+                    return acc
+                }, {} as Record<string, DatabaseSchemaViewTable | DatabaseSchemaManagedViewTable>)
             },
         ],
     }),

--- a/frontend/src/scenes/data-warehouse/editor/editorSceneLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/editorSceneLogic.tsx
@@ -17,7 +17,11 @@ import { urls } from 'scenes/urls'
 import { navigation3000Logic } from '~/layout/navigation-3000/navigationLogic'
 import { FuseSearchMatch } from '~/layout/navigation-3000/sidebars/utils'
 import { BasicListItem, ExtendedListItem, ListItemAccordion, SidebarCategory } from '~/layout/navigation-3000/types'
-import { DatabaseSchemaDataWarehouseTable, DatabaseSchemaTable } from '~/queries/schema/schema-general'
+import {
+    DatabaseSchemaDataWarehouseTable,
+    DatabaseSchemaManagedViewTable,
+    DatabaseSchemaTable,
+} from '~/queries/schema/schema-general'
 import { DataWarehouseSavedQuery, PipelineStage, ProductKey } from '~/types'
 
 import { dataWarehouseViewsLogic } from '../saved_queries/dataWarehouseViewsLogic'
@@ -27,19 +31,23 @@ import type { editorSceneLogicType } from './editorSceneLogicType'
 import { multitabEditorLogic } from './multitabEditorLogic'
 import { queryDatabaseLogic } from './sidebar/queryDatabaseLogic'
 
-const dataWarehouseTablesfuse = new Fuse<DatabaseSchemaDataWarehouseTable | DatabaseSchemaTable>([], {
+const FUSE_OPTIONS: Fuse.IFuseOptions<any> = {
     keys: [{ name: 'name', weight: 2 }],
     threshold: 0.3,
     ignoreLocation: true,
     includeMatches: true,
-})
+}
 
-const savedQueriesfuse = new Fuse<DataWarehouseSavedQuery>([], {
-    keys: [{ name: 'name', weight: 2 }],
-    threshold: 0.3,
-    ignoreLocation: true,
-    includeMatches: true,
-})
+const dataWarehouseTablesfuse = new Fuse<DatabaseSchemaDataWarehouseTable | DatabaseSchemaTable>([], FUSE_OPTIONS)
+const savedQueriesFuse = new Fuse<DataWarehouseSavedQuery>([], FUSE_OPTIONS)
+const managedViewsFuse = new Fuse<DatabaseSchemaManagedViewTable>([], FUSE_OPTIONS)
+
+const checkIsSavedQuery = (
+    view: DataWarehouseSavedQuery | DatabaseSchemaManagedViewTable
+): view is DataWarehouseSavedQuery => 'last_run_at' in view
+const checkIsManagedView = (
+    view: DataWarehouseSavedQuery | DatabaseSchemaManagedViewTable
+): view is DatabaseSchemaManagedViewTable => 'type' in view && view.type === 'managed_view'
 
 export const editorSceneLogic = kea<editorSceneLogicType>([
     path(['data-warehouse', 'editor', 'editorSceneLogic']),
@@ -50,7 +58,15 @@ export const editorSceneLogic = kea<editorSceneLogicType>([
             dataWarehouseViewsLogic,
             ['dataWarehouseSavedQueries', 'dataWarehouseSavedQueryMapById', 'initialDataWarehouseSavedQueryLoading'],
             databaseTableListLogic,
-            ['posthogTables', 'dataWarehouseTables', 'allTables', 'databaseLoading', 'views', 'viewsMapById'],
+            [
+                'posthogTables',
+                'dataWarehouseTables',
+                'allTables',
+                'databaseLoading',
+                'views',
+                'viewsMapById',
+                'managedViews',
+            ],
         ],
         actions: [
             queryDatabaseLogic,
@@ -96,7 +112,7 @@ export const editorSceneLogic = kea<editorSceneLogicType>([
     selectors(({ actions }) => ({
         contents: [
             (s) => [
-                s.relevantSavedQueries,
+                s.relevantViews,
                 s.initialDataWarehouseSavedQueryLoading,
                 s.relevantDataWarehouseTables,
                 s.dataWarehouseTablesBySourceType,
@@ -104,7 +120,7 @@ export const editorSceneLogic = kea<editorSceneLogicType>([
                 navigation3000Logic.selectors.searchTerm,
             ],
             (
-                relevantSavedQueries,
+                relevantViews,
                 initialDataWarehouseSavedQueryLoading,
                 relevantDataWarehouseTables,
                 dataWarehouseTablesBySourceType,
@@ -197,67 +213,89 @@ export const editorSceneLogic = kea<editorSceneLogicType>([
                     key: 'data-warehouse-views',
                     noun: ['view', 'views'],
                     loading: initialDataWarehouseSavedQueryLoading,
-                    items: relevantSavedQueries.map(([savedQuery, matches]) => ({
-                        key: savedQuery.id,
-                        name: savedQuery.name,
-                        url: '',
-                        icon: savedQuery.last_run_at ? (
-                            <Tooltip title="Materialized view">
-                                <IconDatabase />
-                            </Tooltip>
-                        ) : (
-                            <Tooltip title="View">
-                                <IconDocument />
-                            </Tooltip>
-                        ),
-                        searchMatch: matches
-                            ? {
-                                  matchingFields: matches.map((match) => match.key),
-                                  nameHighlightRanges: matches.find((match) => match.key === 'name')?.indices,
-                              }
-                            : null,
-                        onClick: () => {
-                            multitabEditorLogic({
-                                key: `hogQLQueryEditor/${router.values.location.pathname}`,
-                            }).actions.editView(savedQuery.query.query, savedQuery)
-                        },
-                        menuItems: [
-                            {
-                                label: 'Open schema',
-                                onClick: () => {
-                                    actions.selectSchema(savedQuery)
-                                },
-                            },
-                            {
-                                label: 'Edit view definition',
-                                onClick: () => {
-                                    multitabEditorLogic({
-                                        key: `hogQLQueryEditor/${router.values.location.pathname}`,
-                                    }).actions.editView(savedQuery.query.query, savedQuery)
-                                },
-                            },
-                            {
-                                label: 'Add join',
-                                onClick: () => {
-                                    actions.selectSourceTable(savedQuery.name)
-                                    actions.toggleJoinTableModal()
-                                },
-                            },
-                            {
-                                label: 'Delete',
-                                status: 'danger',
-                                onClick: () => {
-                                    actions.deleteDataWarehouseSavedQuery(savedQuery.id)
-                                },
-                            },
-                            {
-                                label: 'Copy view name',
-                                onClick: () => {
-                                    void copyToClipboard(savedQuery.name)
-                                },
-                            },
-                        ],
-                    })),
+                    items: [
+                        ...relevantViews.map(([view, matches]) => {
+                            const isSavedQuery = checkIsSavedQuery(view)
+                            const isManagedView = checkIsManagedView(view)
+
+                            const onClick = (): void => {
+                                isManagedView
+                                    ? multitabEditorLogic({
+                                          key: `hogQLQueryEditor/${router.values.location.pathname}`,
+                                      }).actions.createTab(`SELECT * FROM ${view.name}`)
+                                    : isSavedQuery
+                                    ? multitabEditorLogic({
+                                          key: `hogQLQueryEditor/${router.values.location.pathname}`,
+                                      }).actions.editView(view.query.query, view)
+                                    : null
+                            }
+
+                            const savedViewMenuItems = isSavedQuery
+                                ? [
+                                      {
+                                          label: 'Edit view definition',
+                                          onClick: () => {
+                                              multitabEditorLogic({
+                                                  key: `hogQLQueryEditor/${router.values.location.pathname}`,
+                                              }).actions.editView(view.query.query, view)
+                                          },
+                                      },
+                                      {
+                                          label: 'Add join',
+                                          onClick: () => {
+                                              actions.selectSourceTable(view.name)
+                                              actions.toggleJoinTableModal()
+                                          },
+                                      },
+                                      {
+                                          label: 'Delete',
+                                          status: 'danger',
+                                          onClick: () => {
+                                              actions.deleteDataWarehouseSavedQuery(view.id)
+                                          },
+                                      },
+                                  ]
+                                : []
+
+                            return {
+                                key: view.id,
+                                name: view.name,
+                                url: '',
+                                icon:
+                                    isSavedQuery && view.last_run_at ? (
+                                        <Tooltip title="Materialized view">
+                                            <IconDatabase />
+                                        </Tooltip>
+                                    ) : (
+                                        <Tooltip title="View">
+                                            <IconDocument />
+                                        </Tooltip>
+                                    ),
+                                searchMatch: matches
+                                    ? {
+                                          matchingFields: matches.map((match) => match.key),
+                                          nameHighlightRanges: matches.find((match) => match.key === 'name')?.indices,
+                                      }
+                                    : null,
+                                onClick,
+                                menuItems: [
+                                    {
+                                        label: 'Open schema',
+                                        onClick: () => {
+                                            actions.selectSchema(view)
+                                        },
+                                    },
+                                    ...savedViewMenuItems,
+                                    {
+                                        label: 'Copy view name',
+                                        onClick: () => {
+                                            void copyToClipboard(view.name)
+                                        },
+                                    },
+                                ],
+                            }
+                        }),
+                    ],
                 } as SidebarCategory,
             ],
         ],
@@ -409,15 +447,28 @@ export const editorSceneLogic = kea<editorSceneLogicType>([
                 return []
             },
         ],
-        relevantSavedQueries: [
-            (s) => [s.dataWarehouseSavedQueries, navigation3000Logic.selectors.searchTerm],
-            (dataWarehouseSavedQueries, searchTerm): [DataWarehouseSavedQuery, FuseSearchMatch[] | null][] => {
+        relevantViews: [
+            (s) => [s.dataWarehouseSavedQueries, s.managedViews, navigation3000Logic.selectors.searchTerm],
+            (
+                dataWarehouseSavedQueries,
+                managedViews,
+                searchTerm
+            ): [DataWarehouseSavedQuery | DatabaseSchemaManagedViewTable, FuseSearchMatch[] | null][] => {
                 if (searchTerm) {
-                    return savedQueriesfuse
-                        .search(searchTerm)
-                        .map((result) => [result.item, result.matches as FuseSearchMatch[]])
+                    return [savedQueriesFuse, managedViewsFuse].flatMap((fuse) =>
+                        fuse
+                            .search(searchTerm)
+                            .map(
+                                (result) =>
+                                    [result.item, result.matches] as [
+                                        DataWarehouseSavedQuery | DatabaseSchemaManagedViewTable,
+                                        FuseSearchMatch[]
+                                    ]
+                            )
+                    )
                 }
-                return dataWarehouseSavedQueries.map((savedQuery) => [savedQuery, null])
+
+                return [...dataWarehouseSavedQueries, ...managedViews].map((item) => [item, null])
             },
         ],
     })),
@@ -427,7 +478,10 @@ export const editorSceneLogic = kea<editorSceneLogicType>([
             dataWarehouseTablesfuse.setCollection(tables)
         },
         dataWarehouseSavedQueries: (dataWarehouseSavedQueries) => {
-            savedQueriesfuse.setCollection(dataWarehouseSavedQueries)
+            savedQueriesFuse.setCollection(dataWarehouseSavedQueries)
+        },
+        managedViews: (managedViews) => {
+            managedViewsFuse.setCollection(managedViews)
         },
     }),
 ])

--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -59,23 +59,26 @@ const EditorSidebarOverlay = (): JSX.Element => {
                             onClick={() => copy()}
                         />
                     )}
-                    <LemonMenu
-                        items={[
-                            {
-                                label: 'Add join',
-                                onClick: () => {
-                                    if (selectedSchema) {
-                                        selectSourceTable(selectedSchema.name)
-                                        toggleJoinTableModal()
-                                    }
+
+                    {selectedSchema && 'type' in selectedSchema && selectedSchema.type !== 'managed_view' && (
+                        <LemonMenu
+                            items={[
+                                {
+                                    label: 'Add join',
+                                    onClick: () => {
+                                        if (selectedSchema) {
+                                            selectSourceTable(selectedSchema.name)
+                                            toggleJoinTableModal()
+                                        }
+                                    },
                                 },
-                            },
-                        ]}
-                    >
-                        <div>
-                            <LemonButton size="small" noPadding icon={<IconEllipsis />} />
-                        </div>
-                    </LemonMenu>
+                            ]}
+                        >
+                            <div>
+                                <LemonButton size="small" noPadding icon={<IconEllipsis />} />
+                            </div>
+                        </LemonMenu>
+                    )}
                 </div>
             </header>
             <div className="overflow-y-auto flex-1">

--- a/frontend/src/scenes/data-warehouse/settings/dataWarehouseSceneLogic.ts
+++ b/frontend/src/scenes/data-warehouse/settings/dataWarehouseSceneLogic.ts
@@ -285,13 +285,17 @@ export const dataWarehouseSceneLogic = kea<dataWarehouseSceneLogicType>([
                     kind: NodeKind.HogQLQuery,
                     query: query,
                 }
+
                 const oldView = values.viewsMapById[values.editingView]
-                const newView: DatabaseSchemaViewTable & { types: string[][] } = {
-                    ...oldView,
-                    query: newViewQuery,
-                    types,
+                if (oldView.type === 'view') {
+                    // Should always be `view`, but assert at the TS level
+                    const newView: DatabaseSchemaViewTable & { types: string[][] } = {
+                        ...oldView,
+                        query: newViewQuery,
+                        types,
+                    }
+                    actions.updateDataWarehouseSavedQuery(newView)
                 }
-                actions.updateDataWarehouseSavedQuery(newView)
             }
         },
     })),


### PR DESCRIPTION
Add the required stuff to make it properly display in the sidebar + display schema when asked

There's still a small bug where `decimal` properties aren't showing up, [here's a follow-up](https://github.com/PostHog/posthog/pull/31276)

![image](https://github.com/user-attachments/assets/f3582603-b1ec-43c9-a620-0fb1df23877c)
![image](https://github.com/user-attachments/assets/a96e6a3e-ac67-45c2-92dc-845699eb9934)

