### PR TITLE
fix(rust): Bump cargo-binstall version in ci-rust.yml Action

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -220,7 +220,7 @@ jobs:
     shear:
         name: Shear Rust services
         needs: changes
-        runs-on: depot-ubuntu-22.04-4
+        runs-on: depot-ubuntu-24.04
 
         defaults:
             run:

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -238,7 +238,7 @@ jobs:
 
             - name: Install cargo-binstall
               if: needs.changes.outputs.rust == 'true'
-              uses: cargo-bins/cargo-binstall@89e50159140fdba08fc64e36186a014c5c253d33 # main
+              uses: cargo-bins/cargo-binstall@acc44cb2074df76ed5fcafe8c2ef6167ad1d750d # main
 
             - name: Install cargo-shear
               if: needs.changes.outputs.rust == 'true'


### PR DESCRIPTION
## Problem
Observed missing GLIBC version errors on the `cargo shear` step in `ci-rust.yml` during CI runs.

## Changes
- Bump to latest `cargo-binstall` for bootstrapping `cargo shear`

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally + CI
