### PR TITLE
feat(data-warehouse): Allow partitioning by day

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -196,6 +196,7 @@ class PipelineNonDLT:
             partition_count = self._schema.partition_count or self._resource.partition_count
             partition_size = self._schema.partition_size or self._resource.partition_size
             partition_keys = self._schema.partitioning_keys or self._resource.primary_keys
+            partition_format = self._schema.partition_format
             if partition_count and partition_keys and partition_size:
                 # This needs to happen before _evolve_pyarrow_schema
                 pa_table, partition_mode, updated_partition_keys = append_partition_key_to_table(
@@ -204,6 +205,7 @@ class PipelineNonDLT:
                     partition_size=partition_size,
                     partition_keys=partition_keys,
                     partition_mode=self._schema.partition_mode,
+                    partition_format=partition_format,
                     logger=self._logger,
                 )
 

--- a/posthog/temporal/data_imports/pipelines/pipeline/typings.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/typings.py
@@ -20,3 +20,4 @@ class SourceResponse:
 
 
 PartitionMode = Literal["md5", "numerical", "datetime"]
+PartitionFormat = Literal["month", "day"]

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -1634,6 +1634,7 @@ async def test_partition_folders_with_uuid_id_and_created_at_with_day_format(
     assert schema.partitioning_enabled is True
     assert schema.partitioning_keys == ["created_at"]
     assert schema.partition_mode == "datetime"
+    assert schema.partition_format == "day"
     assert schema.partition_count is not None
 
 

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -1553,6 +1553,92 @@ async def test_partition_folders_with_uuid_id_and_created_at(team, postgres_conf
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
+async def test_partition_folders_with_uuid_id_and_created_at_with_day_format(
+    team, postgres_config, postgres_connection, minio_client
+):
+    await postgres_connection.execute(
+        "CREATE TABLE IF NOT EXISTS {schema}.test_partition_folders (id uuid, created_at timestamp)".format(
+            schema=postgres_config["schema"]
+        )
+    )
+
+    await postgres_connection.execute(
+        "INSERT INTO {schema}.test_partition_folders (id, created_at) VALUES ('{uuid}', '2025-01-01T12:00:00.000Z')".format(
+            schema=postgres_config["schema"], uuid=str(uuid.uuid4())
+        )
+    )
+    await postgres_connection.execute(
+        "INSERT INTO {schema}.test_partition_folders (id, created_at) VALUES ('{uuid}', '2025-01-02T12:00:00.000Z')".format(
+            schema=postgres_config["schema"], uuid=str(uuid.uuid4())
+        )
+    )
+    await postgres_connection.commit()
+
+    workflow_id, inputs = await _run(
+        team=team,
+        schema_name="test_partition_folders",
+        table_name="postgres_test_partition_folders",
+        source_type="Postgres",
+        job_inputs={
+            "host": postgres_config["host"],
+            "port": postgres_config["port"],
+            "database": postgres_config["database"],
+            "user": postgres_config["user"],
+            "password": postgres_config["password"],
+            "schema": postgres_config["schema"],
+            "ssh_tunnel_enabled": "False",
+        },
+        mock_data_response=[],
+        sync_type=ExternalDataSchema.SyncType.INCREMENTAL,
+        sync_type_config={"incremental_field": "created_at", "incremental_field_type": "timestamp"},
+        ignore_assertions=True,
+    )
+
+    # Set the parition format on the schema - this will persist after a reset_pipeline
+    schema: ExternalDataSchema = await sync_to_async(ExternalDataSchema.objects.get)(id=inputs.external_data_schema_id)
+    schema.sync_type_config["partition_format"] = "day"
+    await sync_to_async(schema.save)()
+
+    # Resync with reset_pipeline = True
+    await _execute_run(
+        str(uuid.uuid4()),
+        ExternalDataWorkflowInputs(
+            team_id=inputs.team_id,
+            external_data_source_id=inputs.external_data_source_id,
+            external_data_schema_id=inputs.external_data_schema_id,
+            reset_pipeline=True,
+        ),
+        [],
+    )
+
+    @sync_to_async
+    def get_jobs():
+        jobs = ExternalDataJob.objects.filter(
+            team_id=team.pk,
+            pipeline_id=inputs.external_data_source_id,
+        ).order_by("-created_at")
+
+        return list(jobs)
+
+    jobs = await get_jobs()
+    latest_job = jobs[0]
+    folder_path = await sync_to_async(latest_job.folder_path)()
+
+    s3_objects = await minio_client.list_objects_v2(Bucket=BUCKET_NAME, Prefix=f"{folder_path}/test_partition_folders/")
+
+    # Using datetime partition mode with created_at - formatted to the day
+    assert any(f"{PARTITION_KEY}=2025-01-01" in obj["Key"] for obj in s3_objects["Contents"])
+    assert any(f"{PARTITION_KEY}=2025-01-02" in obj["Key"] for obj in s3_objects["Contents"])
+
+    schema = await ExternalDataSchema.objects.aget(id=inputs.external_data_schema_id)
+    assert schema.partitioning_enabled is True
+    assert schema.partitioning_keys == ["created_at"]
+    assert schema.partition_mode == "datetime"
+    assert schema.partition_count is not None
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
 async def test_partition_folders_with_existing_table(team, postgres_config, postgres_connection, minio_client):
     await postgres_connection.execute(
         "CREATE TABLE IF NOT EXISTS {schema}.test_partition_folders (id integer, created_at timestamp)".format(

--- a/posthog/warehouse/models/external_data_schema.py
+++ b/posthog/warehouse/models/external_data_schema.py
@@ -15,7 +15,7 @@ import psycopg2
 from psycopg2 import sql
 import pymysql
 
-from posthog.temporal.data_imports.pipelines.pipeline.typings import PartitionMode
+from posthog.temporal.data_imports.pipelines.pipeline.typings import PartitionFormat, PartitionMode
 from posthog.warehouse.s3 import get_s3_client
 from .external_data_source import ExternalDataSource
 from posthog.warehouse.data_load.service import (
@@ -144,6 +144,14 @@ class ExternalDataSchema(CreatedMetaFields, UpdatedMetaFields, UUIDModel, Delete
     def partition_mode(self) -> PartitionMode | None:
         if self.sync_type_config:
             return self.sync_type_config.get("partition_mode", None)
+
+        return None
+
+    @property
+    def partition_format(self) -> PartitionFormat | None:
+        # This key doesn't get reset on pipeline_reset and can only be set via the DB directly right now
+        if self.sync_type_config:
+            return self.sync_type_config.get("partition_format", None)
 
         return None
 


### PR DESCRIPTION
## Problem
- Customer_1 has a table partitioned by `created_at`, but the more recent months partitions are too big and is causing our pods to OOM

## Changes
- Allow tables to be partitioned by day instead of month, so we get partitions like `["2025-04-01", "2025-04-02"]` instead of `["2025-03", "2025-04"]`
- This will allow us to load a partition without blowing up the pods memory 
- This setting will have to be set manually on the schema for the time being - setting `partition_format="day"`. The default is `month`. 
  - This setting persists through pipeline resets too

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Added a unit test