### PR TITLE
chore: use proper workload in sync_execute, use workload value as label

### DIFF
--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -193,6 +193,11 @@ def _make_ch_pool(*, client_settings: Mapping[str, str] | None = None, **overrid
 make_ch_pool = cache(_make_ch_pool)
 
 
+def get_default_clickhouse_workload_type():
+    global _default_workload
+    return _default_workload
+
+
 @contextmanager
 def set_default_clickhouse_workload_type(workload: Workload):
     global _default_workload

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -161,7 +161,7 @@ def sync_execute(
         "query_id": query_id,
     }
 
-    if workload == workload.DEFAULT:
+    if workload == Workload.DEFAULT:
         workload = get_default_clickhouse_workload_type()
 
     if workload == Workload.OFFLINE:

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -15,7 +15,7 @@ from django.conf import settings as app_settings
 from prometheus_client import Counter, Gauge
 from sentry_sdk import set_tag
 
-from posthog.clickhouse.client.connection import Workload, get_client_from_pool
+from posthog.clickhouse.client.connection import Workload, get_client_from_pool, get_default_clickhouse_workload_type
 from posthog.clickhouse.client.escape import substitute_params
 from posthog.clickhouse.query_tagging import get_query_tag_value, get_query_tags
 from posthog.cloud_utils import is_cloud
@@ -132,7 +132,7 @@ def sync_execute(
     if get_query_tag_value("id") == "posthog.tasks.tasks.process_query_task":
         workload = Workload.ONLINE
 
-    chargeable = get_query_tag_value("chargeable") or False
+    chargeable = get_query_tag_value("chargeable") or 0
     # Customer is paying for API
     if (
         team_id
@@ -161,6 +161,9 @@ def sync_execute(
         "query_id": query_id,
     }
 
+    if workload == workload.DEFAULT:
+        workload = get_default_clickhouse_workload_type()
+
     if workload == Workload.OFFLINE:
         # disabling hedged requests for offline queries reduces the likelihood of these queries bleeding over into the
         # online resource pool when the offline resource pool is under heavy load. this comes at the cost of higher and
@@ -182,14 +185,14 @@ def sync_execute(
         exception_type = type(err).__name__
         set_tag("clickhouse_exception_type", exception_type)
         QUERY_ERROR_COUNTER.labels(
-            exception_type=exception_type, query_type=query_type, workload=workload, chargeable=chargeable
+            exception_type=exception_type, query_type=query_type, workload=workload.value, chargeable=chargeable
         ).inc()
 
         raise err from e
     finally:
         execution_time = perf_counter() - start_time
 
-        QUERY_EXECUTION_TIME_GAUGE.labels(query_type=query_type, workload=workload, chargeable=chargeable).set(
+        QUERY_EXECUTION_TIME_GAUGE.labels(query_type=query_type, workload=workload.value, chargeable=chargeable).set(
             execution_time * 1000.0
         )
 


### PR DESCRIPTION
## Problem

default enum format is key:value, only value is enough

## Changes

change the workload label value, and make the chargeable label consistent with query_log.log_comment

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Run.