### PR TITLE
feat: populate $captured_at timestamp on events

### DIFF
--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -231,6 +231,9 @@ export function normalizeEvent<T extends PipelineEvent | PluginEvent>(event: T):
     if (event.sent_at) {
         properties['$sent_at'] = event.sent_at
     }
+    if (event.now) {
+        properties['$captured_at'] = event.now
+    }
 
     event.properties = properties
     return event


### PR DESCRIPTION

> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
$sent_at can be set with user controlled data

set $captured_at to the capture server's timestamp so we can know for sure when the event was captured

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?
n/a

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
