### PR TITLE
chore(data-warehouse): Show a lemon toast of errors

### DIFF
--- a/frontend/src/scenes/data-warehouse/new/dataWarehouseTableLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/dataWarehouseTableLogic.tsx
@@ -125,10 +125,14 @@ export const dataWarehouseTableLogic = kea<dataWarehouseTableLogicType>([
                 }
             },
             submit: async (tablePayload) => {
-                if (props.id && props.id !== 'new') {
-                    actions.updateTable(tablePayload)
-                } else {
-                    actions.createTable(tablePayload)
+                try {
+                    if (props.id && props.id !== 'new') {
+                        actions.updateTable(tablePayload)
+                    } else {
+                        actions.createTable(tablePayload)
+                    }
+                } catch (e: any) {
+                    lemonToast.error(e.data?.message ?? e.message)
                 }
             },
         },


### PR DESCRIPTION
## Problem
- When creating a new source, if the credentials are wrong we return an error to the client, but users only get a lemonToast with `Non-OK response` instead of the actual error

## Changes
- Show a lemon toast with the actual error message
