### PR TITLE
chore(pipeline): Dont reset job count for failed incremental syncs

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -100,7 +100,7 @@ class PipelineNonDLT:
 
         try:
             # Reset the rows_synced count - this may not be 0 if the job restarted due to a heartbeat timeout
-            if self._job.rows_synced is not None and self._job.rows_synced != 0:
+            if self._job.rows_synced is not None and self._job.rows_synced != 0 and not self._schema.is_incremental:
                 self._job.rows_synced = 0
                 self._job.save()
 

--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -103,8 +103,7 @@ class PipelineNonDLT:
             if (
                 self._job.rows_synced is not None
                 and self._job.rows_synced != 0
-                and not self._schema.is_incremental
-                and not self._reset_pipeline
+                and (not self._schema.is_incremental or self._reset_pipeline is True)
             ):
                 self._job.rows_synced = 0
                 self._job.save()

--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -103,7 +103,7 @@ class PipelineNonDLT:
             if (
                 self._job.rows_synced is not None
                 and self._job.rows_synced != 0
-                and (not self._schema.is_incremental or self._reset_pipeline is True)
+                and (not self._is_incremental or self._reset_pipeline is True)
             ):
                 self._job.rows_synced = 0
                 self._job.save()

--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -100,7 +100,12 @@ class PipelineNonDLT:
 
         try:
             # Reset the rows_synced count - this may not be 0 if the job restarted due to a heartbeat timeout
-            if self._job.rows_synced is not None and self._job.rows_synced != 0 and not self._schema.is_incremental:
+            if (
+                self._job.rows_synced is not None
+                and self._job.rows_synced != 0
+                and not self._schema.is_incremental
+                and not self._reset_pipeline
+            ):
                 self._job.rows_synced = 0
                 self._job.save()
 


### PR DESCRIPTION
## Problem
- when an incremental job fails and restarts, we reset the rows synced, making it look like the previous job synced 0 rows when actually it may have
- This logic was to protect over-charging, but this can't apply to incremental syncs

## Changes
- Only reset the rows synced count when its a full refresh sync OR we're doing a full pipeline reset
