### PR TITLE
fix(cdp): allow property filters for transformations

### DIFF
--- a/frontend/src/scenes/pipeline/hogfunctions/filters/HogFunctionFilters.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/filters/HogFunctionFilters.tsx
@@ -98,7 +98,11 @@ export function HogFunctionFilters({ embedded = false }: { embedded?: boolean })
             <LemonField
                 name="filters"
                 label={useMapping ? 'Global filters' : 'Filters'}
-                info={useMapping ? 'Filters applied to all events before they reach a mapping' : null}
+                info={
+                    useMapping
+                        ? 'Filters applied to all events before they reach a mapping'
+                        : 'Filters applied to all events'
+                }
             >
                 {({ value, onChange }) => {
                     const filters = (value ?? {}) as HogFunctionFiltersType

--- a/frontend/src/scenes/pipeline/hogfunctions/filters/HogFunctionFilters.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/filters/HogFunctionFilters.tsx
@@ -110,41 +110,38 @@ export function HogFunctionFilters({ embedded = false }: { embedded?: boolean })
                                     mappings.
                                 </p>
                             )}
-                            {isTransformation && (
-                                <LemonBanner type="info">
-                                    For transformations, only event properties and SQL expressions can be used in
-                                    filters as they run during ingestion before other properties are available.
-                                </LemonBanner>
-                            )}
                             {!isTransformation && (
-                                <>
-                                    <TestAccountFilterSwitch
-                                        checked={filters?.filter_test_accounts ?? false}
-                                        onChange={(filter_test_accounts) =>
-                                            onChange({ ...filters, filter_test_accounts })
-                                        }
-                                        fullWidth
-                                    />
-                                    <PropertyFilters
-                                        propertyFilters={(filters?.properties ?? []) as AnyPropertyFilter[]}
-                                        taxonomicGroupTypes={[
-                                            TaxonomicFilterGroupType.EventProperties,
-                                            TaxonomicFilterGroupType.PersonProperties,
-                                            TaxonomicFilterGroupType.EventFeatureFlags,
-                                            TaxonomicFilterGroupType.Elements,
-                                            TaxonomicFilterGroupType.HogQLExpression,
-                                            ...groupsTaxonomicTypes,
-                                        ]}
-                                        onChange={(properties: AnyPropertyFilter[]) => {
-                                            onChange({
-                                                ...filters,
-                                                properties,
-                                            })
-                                        }}
-                                        pageKey={`HogFunctionPropertyFilters.${id}`}
-                                    />
-                                </>
+                                <TestAccountFilterSwitch
+                                    checked={filters?.filter_test_accounts ?? false}
+                                    onChange={(filter_test_accounts) => onChange({ ...filters, filter_test_accounts })}
+                                    fullWidth
+                                />
                             )}
+                            <PropertyFilters
+                                propertyFilters={(filters?.properties ?? []) as AnyPropertyFilter[]}
+                                taxonomicGroupTypes={
+                                    isTransformation
+                                        ? [
+                                              TaxonomicFilterGroupType.EventProperties,
+                                              TaxonomicFilterGroupType.HogQLExpression,
+                                          ]
+                                        : [
+                                              TaxonomicFilterGroupType.EventProperties,
+                                              TaxonomicFilterGroupType.PersonProperties,
+                                              TaxonomicFilterGroupType.EventFeatureFlags,
+                                              TaxonomicFilterGroupType.Elements,
+                                              TaxonomicFilterGroupType.HogQLExpression,
+                                              ...groupsTaxonomicTypes,
+                                          ]
+                                }
+                                onChange={(properties: AnyPropertyFilter[]) => {
+                                    onChange({
+                                        ...filters,
+                                        properties,
+                                    })
+                                }}
+                                pageKey={`HogFunctionPropertyFilters.${id}`}
+                            />
 
                             {!useMapping ? (
                                 <>


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We want to allow property-filters for hog transformations as well but restrict it to event data and hogql expressions

![Screenshot 2025-04-16 at 14 20 29](https://github.com/user-attachments/assets/1ec8e4a5-6617-41f6-a2f9-b42f63be0f4d)


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- enabled prop-filters for transformations restricted to event data and hogql expressions

![Screenshot 2025-04-16 at 14 19 39](https://github.com/user-attachments/assets/cce42f2a-189d-488e-b0ba-a5ef19fe2f05)

![Screenshot 2025-04-16 at 14 20 04](https://github.com/user-attachments/assets/d420005b-c618-4f0a-b0d1-420ccae59e1c)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- tested locally

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
