### PR TITLE
feat(data-warehouse): Add scopes for reading google drive files from bigquery

### DIFF
--- a/posthog/temporal/data_imports/pipelines/bigquery/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/bigquery/__init__.py
@@ -21,7 +21,7 @@ def bigquery_client(project_id: str, private_key: str, private_key_id: str, clie
             "client_email": client_email,
             "project_id": project_id,
         },
-        scopes=["https://www.googleapis.com/auth/cloud-platform"],
+        scopes=["https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/cloud-platform"],
     )
     client = bigquery.Client(
         project=project_id,

--- a/posthog/temporal/data_imports/pipelines/bigquery/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/bigquery/__init__.py
@@ -26,9 +26,6 @@ def bigquery_client(project_id: str, private_key: str, private_key_id: str, clie
     client = bigquery.Client(
         project=project_id,
         credentials=credentials,
-        client_options={
-            "scopes": ["https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/cloud-platform"]
-        },
     )
 
     try:

--- a/posthog/temporal/data_imports/pipelines/bigquery/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/bigquery/__init__.py
@@ -26,6 +26,9 @@ def bigquery_client(project_id: str, private_key: str, private_key_id: str, clie
     client = bigquery.Client(
         project=project_id,
         credentials=credentials,
+        client_options={
+            "scopes": ["https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/cloud-platform"]
+        },
     )
 
     try:

--- a/posthog/temporal/data_imports/pipelines/bigquery/source.py
+++ b/posthog/temporal/data_imports/pipelines/bigquery/source.py
@@ -29,10 +29,15 @@ def bigquery_storage_read_client(
             "client_email": client_email,
             "project_id": project_id,
         },
-        scopes=["https://www.googleapis.com/auth/cloud-platform"],
+        scopes=["https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/cloud-platform"],
     )
 
-    client = bigquery_storage.BigQueryReadClient(credentials=credentials)
+    client = bigquery_storage.BigQueryReadClient(
+        credentials=credentials,
+        client_options={
+            "scopes": ["https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/cloud-platform"]
+        },
+    )
 
     yield client
 
@@ -149,7 +154,7 @@ def bigquery_source(
 
                 bq_table = bq_client.get_table(destination_table)
 
-            elif bq_table.table_type in ("VIEW", "MATERIALIZED_VIEW"):
+            elif bq_table.table_type in ("VIEW", "MATERIALIZED_VIEW", "EXTERNAL"):
                 # BigQuery storage API does not support reading directly from views or
                 # materialized views. So, similarly to incremental runs, we must copy the
                 # results to a temporary table first. In the case of an incremental sync,

--- a/posthog/temporal/data_imports/pipelines/bigquery/source.py
+++ b/posthog/temporal/data_imports/pipelines/bigquery/source.py
@@ -34,9 +34,6 @@ def bigquery_storage_read_client(
 
     client = bigquery_storage.BigQueryReadClient(
         credentials=credentials,
-        client_options={
-            "scopes": ["https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/cloud-platform"]
-        },
     )
 
     yield client


### PR DESCRIPTION
## Problem
- We have a user that's using the google drive integration for bigquery - a table backed by a google sheet
- [support ticket link](https://posthoghelp.zendesk.com/agent/tickets/29122)

## Changes
- Based on [this](https://github.com/googleapis/google-cloud-python/issues/15196#issuecomment-2132441383), we have to add these particular scopes to our client
- From my (lack of) understanding, adding these scopes just means we _can_ request google drive content, but it won't affect anyone who don't have google drive backed tables (cc @tomasfarias maybe you can help confirm this?)
  - Tested this: syncing a normal table worked fine

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Tested locally

<img width="1236" alt="image" src="https://github.com/user-attachments/assets/43419147-96b9-496a-a978-1fb1056311c5" />
