### PR TITLE
fix(data-warehouse): Remove new lines from clickhouse types

### DIFF
--- a/posthog/warehouse/models/util.py
+++ b/posthog/warehouse/models/util.py
@@ -53,6 +53,9 @@ def remove_named_tuples(type):
 
 
 def clean_type(column_type: str) -> str:
+    # Replace newline characters followed by empty space
+    column_type = re.sub(r"\n\s+", "", column_type)
+
     if column_type.startswith("Nullable("):
         column_type = column_type.replace("Nullable(", "")[:-1]
 


### PR DESCRIPTION
## Problem
- When getting the types of a S3 file via clickhouse, clickhouse sometimes adds in newlines to deeply nested Array/Tuple objects, like so:
  - `Array(Tuple(\n    rolesInGroup Array(Nullable(Int64)),\n    group Nullable(String),\n    version Nullable(Int64)))`
- This breaks our logic for pulling out what the true type of the field is

## Changes
- Strip out newlines and following whitespace before parsing the clickhouse type

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Tested problimatic parquet file locally
