### PR TITLE
fix: pin cargo-shear version

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -242,7 +242,7 @@ jobs:
 
             - name: Install cargo-shear
               if: needs.changes.outputs.rust == 'true'
-              run: cargo binstall --no-confirm cargo-shear
+              run: cargo binstall --no-confirm cargo-shear@1.1.12
 
             - run: cargo shear
               if: needs.changes.outputs.rust == 'true'


### PR DESCRIPTION
Latest release builds with ubuntu latest, which broke our 22.04 based CI