### PR TITLE
fix(plugin-server): quick fix for int overflow in lazy loader fetchTeams

### DIFF
--- a/plugin-server/src/utils/team-manager-lazy.test.ts
+++ b/plugin-server/src/utils/team-manager-lazy.test.ts
@@ -85,6 +85,11 @@ describe('TeamManager()', () => {
             expect(result).toBeNull()
         })
 
+        it('returns null if the team ID is larger than 32-bit integer and could overflow DB col type', async () => {
+            const result = await teamManager.getTeam(12345678901234)
+            expect(result).toBeNull()
+        })
+
         it('caches the team for second lookup whether on token or id', async () => {
             const result = await teamManager.getTeam(teamId)
             expect(result?.id).toEqual(teamId)

--- a/plugin-server/src/utils/team-manager-lazy.ts
+++ b/plugin-server/src/utils/team-manager-lazy.ts
@@ -101,9 +101,11 @@ export class TeamManagerLazy {
         const [teamIds, tokens] = teamIdOrTokens.reduce(
             ([teamIds, tokens], idOrToken) => {
                 // TRICKY: We are caching ids and tokens so we need to determine which is which
-                // Fix this to be a prefix based lookup
-                if (/^\d+$/.test(idOrToken)) {
-                    teamIds.push(parseInt(idOrToken))
+                // Fix this to be a prefix based lookup. Added hack to limit to positive integer
+                // that shouldn't overflow 32-bit integer in DB column.
+                if (/^\d+{,10}$/.test(idOrToken)) {
+                    const parsed = parseInt(idOrToken)
+                    teamIds.push(parsed)
                 } else {
                     tokens.push(idOrToken)
                 }
@@ -114,7 +116,7 @@ export class TeamManagerLazy {
 
         const result = await this.postgres.query<RawTeam>(
             PostgresUse.COMMON_READ,
-            `SELECT 
+            `SELECT
                 t.id,
                 t.project_id,
                 t.uuid,

--- a/plugin-server/src/utils/team-manager-lazy.ts
+++ b/plugin-server/src/utils/team-manager-lazy.ts
@@ -105,7 +105,9 @@ export class TeamManagerLazy {
                 // that shouldn't overflow 32-bit integer in DB column.
                 if (/^\d{,10}$/.test(idOrToken)) {
                     const parsed = parseInt(idOrToken)
-                    teamIds.push(parsed)
+                    if (parsed > 0 && parsed <= 2147483647) {
+                        teamIds.push(parsed)
+                    }
                 } else {
                     tokens.push(idOrToken)
                 }

--- a/plugin-server/src/utils/team-manager-lazy.ts
+++ b/plugin-server/src/utils/team-manager-lazy.ts
@@ -103,9 +103,10 @@ export class TeamManagerLazy {
                 // TRICKY: We are caching ids and tokens so we need to determine which is which
                 // Fix this to be a prefix based lookup. Added hack to limit to positive integer
                 // that shouldn't overflow 32-bit integer in DB column.
-                if (/^\d{,10}$/.test(idOrToken)) {
+                if (/^\d{1,10}$/.test(idOrToken)) {
                     const parsed = parseInt(idOrToken)
-                    if (parsed > 0 && parsed <= 2147483647) {
+                    // TODO: stat if this happens
+                    if (!isNaN(parsed) && parsed > 0 && parsed <= 2147483647) {
                         teamIds.push(parsed)
                     }
                 } else {

--- a/plugin-server/src/utils/team-manager-lazy.ts
+++ b/plugin-server/src/utils/team-manager-lazy.ts
@@ -103,7 +103,7 @@ export class TeamManagerLazy {
                 // TRICKY: We are caching ids and tokens so we need to determine which is which
                 // Fix this to be a prefix based lookup. Added hack to limit to positive integer
                 // that shouldn't overflow 32-bit integer in DB column.
-                if (/^\d+{,10}$/.test(idOrToken)) {
+                if (/^\d{,10}$/.test(idOrToken)) {
                     const parsed = parseInt(idOrToken)
                     teamIds.push(parsed)
                 } else {


### PR DESCRIPTION
## Problem
Seeing integer overflow on bad teamIds due to loose regex check in lazy loader

## Changes
Tighted up check (temp), add test case

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally and in CI
