### PR TITLE
[Support SUPERDAY] Add 'Report a bug' button to SidePanelSupport.tsx

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
@@ -1,4 +1,4 @@
-import { IconFeatures, IconHelmet, IconMap } from '@posthog/icons'
+import { IconBug, IconFeatures, IconHelmet, IconMap } from '@posthog/icons'
 import { LemonButton, Link } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { SupportForm } from 'lib/components/Support/SupportForm'
@@ -421,6 +421,17 @@ export function SidePanelSupport(): JSX.Element {
                                             targetBlank
                                         >
                                             Request a feature
+                                        </LemonButton>
+                                    </li>
+                                    <li>
+                                        <LemonButton
+                                            type="secondary"
+                                            status="alt"
+                                            to="https://github.com/PostHog/posthog/issues/new?&labels=bug&template=bug_report.yml"
+                                            icon={<IconBug />}
+                                            targetBlank
+                                        >
+                                            Report a bug
                                         </LemonButton>
                                     </li>
                                 </ul>


### PR DESCRIPTION
## Problem

We want our users to be able to quickly report bugs to us.

## Changes

I've added a 'Report a bug' button to the bottom of the Sidepanel. This button automatically opens the `bug_report.yml` template and applies a `bug` label to the issue:

![image](https://github.com/user-attachments/assets/e2ae0149-967f-4f23-a4ee-eb6691e541a7)


## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

I ran into issues when trying to set up the repo in a GitHub Codespace. Instead, I did the next best thing, which was to recreate my code changes directly in the HTML. The SVG for the icon was [copied from our Storybook](https://storybook.posthog.net/?path=/story/posthog-3000-icons--alphabetical).

The code should still be tested locally. Having said that, the button looked right and behaved correctly in my "mockup":

![image](https://github.com/user-attachments/assets/91f47c83-e1a2-4db1-8cb2-8b7bf8bacfab)

Tagging @abigailbramble for review.