### PR TITLE
fix(dashboards): fix duplicating dashboard text tile

### DIFF
--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -363,6 +363,7 @@ class DashboardSerializer(DashboardBasicSerializer):
     @staticmethod
     def _update_tiles(instance: Dashboard, tile_data: dict, user: User) -> None:
         tile_data.pop("is_cached", None)  # read only field
+        tile_data.pop("order", None)  # read only field
 
         if tile_data.get("text", None):
             text_json: dict = tile_data.get("text", {})


### PR DESCRIPTION
## Problem

Duplicating a text tile on a dashboard fails https://posthog.slack.com/archives/C0368RPHLQH/p1744809904641539

## Changes

We added the `"order"` field to the dashboard tile model [here](https://github.com/PostHog/posthog/pull/31021/files#diff-18f54c55e41c79153d8172c6c81178e3cc6c502dfaf2bfb2539bb7593539ccb1R84). When duplicating text tiles, this field gets sent back to the backend, which unexpectedly causes dashboard tile updates to fail. I’ve fixed it by excluding `"order"` from the payload, just like we do with other read-only fields.

## How did you test this code?

Tried manually