### PR TITLE
fix: cache missing tokens in lazy loader

### DIFF
--- a/plugin-server/src/utils/team-manager-lazy.test.ts
+++ b/plugin-server/src/utils/team-manager-lazy.test.ts
@@ -116,6 +116,17 @@ describe('TeamManager()', () => {
             expect(fetchTeamsSpy).toHaveBeenCalledTimes(1)
             expect(results.map((r) => r?.id)).toEqual([teamId, teamId, teamId, teamId, undefined])
         })
+
+        it('caches null results for non-existing tokens', async () => {
+            const nonExistentToken = 'non-existent-token'
+            const result1 = await teamManager.getTeamByToken(nonExistentToken)
+            expect(result1).toBeNull()
+            expect(fetchTeamsSpy).toHaveBeenCalledTimes(1)
+
+            const result2 = await teamManager.getTeamByToken(nonExistentToken)
+            expect(result2).toBeNull()
+            expect(fetchTeamsSpy).toHaveBeenCalledTimes(1)
+        })
     })
 
     describe('hasAvailableFeature()', () => {

--- a/plugin-server/src/utils/team-manager-lazy.test.ts
+++ b/plugin-server/src/utils/team-manager-lazy.test.ts
@@ -127,6 +127,27 @@ describe('TeamManager()', () => {
             expect(result2).toBeNull()
             expect(fetchTeamsSpy).toHaveBeenCalledTimes(1)
         })
+
+        it('correctly handles mix of existing and non-existing teams', async () => {
+            const nonExistentId = 9999
+            const [existingTeam, nonExistingTeam] = await Promise.all([
+                teamManager.getTeam(teamId),
+                teamManager.getTeam(nonExistentId),
+            ])
+
+            expect(existingTeam?.id).toEqual(teamId)
+            expect(nonExistingTeam).toBeNull()
+            expect(fetchTeamsSpy).toHaveBeenCalledTimes(1)
+
+            // Second fetch should use cache for both
+            const [existingTeam2, nonExistingTeam2] = await Promise.all([
+                teamManager.getTeam(teamId),
+                teamManager.getTeam(nonExistentId),
+            ])
+            expect(existingTeam2?.id).toEqual(teamId)
+            expect(nonExistingTeam2).toBeNull()
+            expect(fetchTeamsSpy).toHaveBeenCalledTimes(1)
+        })
     })
 
     describe('hasAvailableFeature()', () => {

--- a/plugin-server/src/utils/team-manager-lazy.ts
+++ b/plugin-server/src/utils/team-manager-lazy.ts
@@ -97,7 +97,7 @@ export class TeamManagerLazy {
         return null
     }
 
-    private async fetchTeams(teamIdOrTokens: string[]): Promise<Record<string, Team>> {
+    private async fetchTeams(teamIdOrTokens: string[]): Promise<Record<string, Team | null>> {
         const [teamIds, tokens] = teamIdOrTokens.reduce(
             ([teamIds, tokens], idOrToken) => {
                 // TRICKY: We are caching ids and tokens so we need to determine which is which
@@ -144,7 +144,14 @@ export class TeamManagerLazy {
             'fetch-teams-with-features'
         )
 
-        return result.rows.reduce((acc, row) => {
+        // Initialize result record with nulls for all requested IDs/tokens
+        const resultRecord: Record<string, Team | null> = {}
+        for (const idOrToken of teamIdOrTokens) {
+            resultRecord[idOrToken] = null
+        }
+
+        // Fill in actual teams where they exist
+        result.rows.forEach((row) => {
             const { available_product_features, ...teamPartial } = row
             const team = {
                 ...teamPartial,
@@ -152,10 +159,10 @@ export class TeamManagerLazy {
                 project_id: Number(teamPartial.project_id) as ProjectId,
                 available_features: available_product_features?.map((f) => f.key) || [],
             }
-            // We assign to the cache both ID and api_token as keys
-            acc[row.id] = team
-            acc[row.api_token] = team
-            return acc
-        }, {} as Record<string, Team>)
+            resultRecord[row.id] = team
+            resultRecord[row.api_token] = team
+        })
+
+        return resultRecord as Record<string, Team | null>
     }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Every time we receive an event for a non-existing token or team id, we go to Postgres, as we don't cache null values.

## Changes

Caches null values for non-existing tokens and team ids.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added a unit tests