### PR TITLE
chore(update-dw-sync-language): Updating dw syncing language

### DIFF
--- a/frontend/src/scenes/data-warehouse/settings/source/Schemas.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/Schemas.tsx
@@ -352,7 +352,7 @@ export const SchemaTable = ({ schemas, isLoading }: SchemaTableProps): JSX.Eleme
                                                                 }}
                                                                 status="danger"
                                                             >
-                                                                Drop table and resync
+                                                                Delete table and resync
                                                             </LemonButton>
                                                         </Tooltip>
                                                     )}

--- a/frontend/src/scenes/data-warehouse/settings/source/Schemas.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/Schemas.tsx
@@ -319,20 +319,28 @@ export const SchemaTable = ({ schemas, isLoading }: SchemaTableProps): JSX.Eleme
                                         <More
                                             overlay={
                                                 <>
-                                                    <LemonButton
-                                                        type="tertiary"
-                                                        size="xsmall"
-                                                        fullWidth
-                                                        key={`reload-data-warehouse-schema-${schema.id}`}
-                                                        id="data-warehouse-schema-reload"
-                                                        onClick={() => {
-                                                            reloadSchema(schema)
-                                                        }}
+                                                    <Tooltip
+                                                        title={
+                                                            schema.incremental
+                                                                ? 'Sync incremental data since the last run.'
+                                                                : 'Sync all data.'
+                                                        }
                                                     >
-                                                        Reload
-                                                    </LemonButton>
+                                                        <LemonButton
+                                                            type="tertiary"
+                                                            size="xsmall"
+                                                            fullWidth
+                                                            key={`reload-data-warehouse-schema-${schema.id}`}
+                                                            id="data-warehouse-schema-reload"
+                                                            onClick={() => {
+                                                                reloadSchema(schema)
+                                                            }}
+                                                        >
+                                                            Sync now
+                                                        </LemonButton>
+                                                    </Tooltip>
                                                     {schema.incremental && (
-                                                        <Tooltip title="Completely resync incrementally loaded data. Only recommended if there is an issue with data quality in previously imported data">
+                                                        <Tooltip title="Completely resync incrementally loaded data. Only recommended if there is an issue with data quality in previously imported data.">
                                                             <LemonButton
                                                                 type="tertiary"
                                                                 size="xsmall"
@@ -344,7 +352,7 @@ export const SchemaTable = ({ schemas, isLoading }: SchemaTableProps): JSX.Eleme
                                                                 }}
                                                                 status="danger"
                                                             >
-                                                                Resync
+                                                                Drop table and resync
                                                             </LemonButton>
                                                         </Tooltip>
                                                     )}


### PR DESCRIPTION
## Problem
Confusing language causes ambiguity about what to do when needing to re-sync tables.

<img width="1288" alt="image" src="https://github.com/user-attachments/assets/30b8857b-6fa1-49cb-aabf-2bb4b5308fd4" />

## Changes
- [x] Language Updates
- [ ] Update docs as well

## Does this work well for both Cloud and self-hosted?
Yes
