### PR TITLE
chore(plugin-server): normalize token and event-key based event dropping behavior in…

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -128,7 +128,6 @@ export function getDefaultConfig(): PluginsServerConfig {
         CLOUD_DEPLOYMENT: null,
         EXTERNAL_REQUEST_TIMEOUT_MS: 10 * 1000, // 10 seconds
         DROP_EVENTS_BY_TOKEN_DISTINCT_ID: '',
-        DROP_EVENTS_BY_TOKEN: '',
         SKIP_PERSONS_PROCESSING_BY_TOKEN_DISTINCT_ID: '',
         PIPELINE_STEP_STALLED_LOG_TIMEOUT: 30,
         RELOAD_PLUGIN_JITTER_MAX_MS: 60000,

--- a/plugin-server/src/ingestion/ingestion-consumer.test.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.test.ts
@@ -364,8 +364,8 @@ describe('IngestionConsumer', () => {
                 })
 
                 it('should drop all events for team with only token listed to be dropped', async () => {
-                    const any_distinct_id = 'any_distinct_id'
-                    const other_distinct_id = 'other_distinct_id'
+                    const any_distinct_id = 'any_distinct_id_DEBUG'
+                    const other_distinct_id = 'other_distinct_id_DEBUG'
                     const messages = createKafkaMessages([
                         createEvent({
                             distinct_id: any_distinct_id,

--- a/plugin-server/src/ingestion/ingestion-consumer.test.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.test.ts
@@ -349,15 +349,15 @@ describe('IngestionConsumer', () => {
                     expectDropLogs([[team.api_token, distinct_id_to_drop]])
                 })
 
-                it('should not drop events for team with event key to drop when distinct_id differs', async () => {
-                    const any_distinct_id = 'any_distinct_id'
+                it('should not drop all events for team with event key listed when distinct_id differs in event', async () => {
+                    const unlisted_distinct_id = 'team1_distinct_id_NOT_to_drop'
                     const messages = createKafkaMessages([
                         createEvent({
                             token: team.api_token,
-                            distinct_id: any_distinct_id,
+                            distinct_id: unlisted_distinct_id,
                         }),
                     ])
-                    addMessageHeaders(messages[0], team.api_token, any_distinct_id)
+                    addMessageHeaders(messages[0], team.api_token, unlisted_distinct_id)
                     await ingester.handleKafkaBatch(messages)
                     expect(getProducedKafkaMessagesForTopic('clickhouse_events_json_test')).not.toHaveLength(0)
                     expectDropLogs([])

--- a/plugin-server/src/ingestion/ingestion-consumer.test.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.test.ts
@@ -284,55 +284,6 @@ describe('IngestionConsumer', () => {
                 }
             }
 
-            describe('with DROP_EVENTS_BY_TOKEN', () => {
-                beforeEach(async () => {
-                    hub.DROP_EVENTS_BY_TOKEN = `${team.api_token},phc_other`
-                    ingester = new IngestionConsumer(hub)
-                    await ingester.start()
-                })
-
-                it('should drop events with matching token', async () => {
-                    const messages = createKafkaMessages([createEvent({}), createEvent({})])
-                    addMessageHeaders(messages[0], team.api_token)
-                    await ingester.handleKafkaBatch(messages)
-                    expect(getProducedKafkaMessagesForTopic('clickhouse_events_json_test')).toHaveLength(0)
-                    expectDropLogs([
-                        [team.api_token, 'user-1'],
-                        [team.api_token, 'user-1'],
-                    ])
-                })
-
-                it('should not drop events for a different team token', async () => {
-                    const messages = createKafkaMessages([createEvent({ token: team2.api_token })])
-                    addMessageHeaders(messages[0], team2.api_token)
-                    await ingester.handleKafkaBatch(messages)
-                    expect(getProducedKafkaMessagesForTopic('clickhouse_events_json_test')).not.toHaveLength(0)
-                    expectDropLogs([])
-                })
-
-                it('should only drop events in batch matching', async () => {
-                    const messages = createKafkaMessages([
-                        createEvent({ token: team.api_token }),
-                        createEvent({ token: team2.api_token, distinct_id: 'team2-distinct-id' }),
-                        createEvent({ token: team.api_token }),
-                    ])
-                    addMessageHeaders(messages[0], team.api_token)
-                    addMessageHeaders(messages[1], team2.api_token)
-                    addMessageHeaders(messages[2], team.api_token)
-                    await ingester.handleKafkaBatch(messages)
-                    const eventsMessages = getProducedKafkaMessagesForTopic('clickhouse_events_json_test')
-                    expect(eventsMessages).toHaveLength(1)
-                    expect(eventsMessages[0].value).toMatchObject({
-                        team_id: team2.id,
-                        distinct_id: 'team2-distinct-id',
-                    })
-                    expectDropLogs([
-                        [team.api_token, kind === 'headers' ? undefined : 'user-1'],
-                        [team.api_token, kind === 'headers' ? undefined : 'user-1'],
-                    ])
-                })
-            })
-
             describe('with DROP_EVENTS_BY_TOKEN_DISTINCT_ID', () => {
                 beforeEach(async () => {
                     hub.DROP_EVENTS_BY_TOKEN_DISTINCT_ID = `${team.api_token}:distinct-id-to-ignore,phc_other:distinct-id-to-ignore`

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -544,8 +544,13 @@ export class IngestionConsumer {
     }
 
     private shouldDropEvent(token?: string, distinctId?: string) {
-        if (distinctId === 'any_distinct_id_DEBUG' || distinctId == 'other_distinct_id_DEBUG') {
-            console.log(`ELI DEBUG: TEST BY TOKEN RESULT: ${token && this.tokenDistinctIdsToDrop.includes(token)}`)
+        if (distinctId === 'any_user' || distinctId == 'other_user') {
+            console.log(`ELI DEBUG: HUB LIST: ${this.hub.DROP_EVENTS_BY_TOKEN_DISTINCT_ID}`)
+            console.log(
+                `ELI DEBUG: TEST BY TOKEN RESULT (${distinctId}): ${
+                    token && this.tokenDistinctIdsToDrop.includes(token)
+                }`
+            )
         }
         return (
             (token && this.tokenDistinctIdsToDrop.includes(token)) ||

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -94,7 +94,6 @@ export class IngestionConsumer {
     public hogTransformer: HogTransformerService
     private overflowRateLimiter: MemoryRateLimiter
     private ingestionWarningLimiter: MemoryRateLimiter
-    private tokensToDrop: string[] = []
     private tokenDistinctIdsToDrop: string[] = []
     private tokenDistinctIdsToSkipPersons: string[] = []
     private tokenDistinctIdsToForceOverflow: string[] = []
@@ -116,7 +115,6 @@ export class IngestionConsumer {
         this.topic = overrides.INGESTION_CONSUMER_CONSUME_TOPIC ?? hub.INGESTION_CONSUMER_CONSUME_TOPIC
         this.overflowTopic = overrides.INGESTION_CONSUMER_OVERFLOW_TOPIC ?? hub.INGESTION_CONSUMER_OVERFLOW_TOPIC
         this.dlqTopic = overrides.INGESTION_CONSUMER_DLQ_TOPIC ?? hub.INGESTION_CONSUMER_DLQ_TOPIC
-        this.tokensToDrop = hub.DROP_EVENTS_BY_TOKEN.split(',').filter((x) => !!x)
         this.tokenDistinctIdsToDrop = hub.DROP_EVENTS_BY_TOKEN_DISTINCT_ID.split(',').filter((x) => !!x)
         this.tokenDistinctIdsToSkipPersons = hub.SKIP_PERSONS_PROCESSING_BY_TOKEN_DISTINCT_ID.split(',').filter(
             (x) => !!x
@@ -547,7 +545,7 @@ export class IngestionConsumer {
 
     private shouldDropEvent(token?: string, distinctId?: string) {
         return (
-            (token && this.tokensToDrop.includes(token)) ||
+            (token && this.tokenDistinctIdsToDrop.includes(token)) ||
             (token && distinctId && this.tokenDistinctIdsToDrop.includes(`${token}:${distinctId}`))
         )
     }

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -544,14 +544,6 @@ export class IngestionConsumer {
     }
 
     private shouldDropEvent(token?: string, distinctId?: string) {
-        if (distinctId === 'any_user' || distinctId == 'other_user') {
-            console.log(`ELI DEBUG: HUB LIST: ${this.hub.DROP_EVENTS_BY_TOKEN_DISTINCT_ID}`)
-            console.log(
-                `ELI DEBUG: TEST BY TOKEN RESULT (${distinctId}): ${
-                    token && this.tokenDistinctIdsToDrop.includes(token)
-                }`
-            )
-        }
         return (
             (token && this.tokenDistinctIdsToDrop.includes(token)) ||
             (token && distinctId && this.tokenDistinctIdsToDrop.includes(`${token}:${distinctId}`))

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -544,6 +544,9 @@ export class IngestionConsumer {
     }
 
     private shouldDropEvent(token?: string, distinctId?: string) {
+        if (distinctId === 'any_distinct_id_DEBUG' || distinctId == 'other_distinct_id_DEBUG') {
+            console.log(`ELI DEBUG: TEST BY TOKEN RESULT: ${token && this.tokenDistinctIdsToDrop.includes(token)}`)
+        }
         return (
             (token && this.tokenDistinctIdsToDrop.includes(token)) ||
             (token && distinctId && this.tokenDistinctIdsToDrop.includes(`${token}:${distinctId}`))

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -248,7 +248,6 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
     CLOUD_DEPLOYMENT: string | null
     EXTERNAL_REQUEST_TIMEOUT_MS: number
     DROP_EVENTS_BY_TOKEN_DISTINCT_ID: string
-    DROP_EVENTS_BY_TOKEN: string
     SKIP_PERSONS_PROCESSING_BY_TOKEN_DISTINCT_ID: string
     RELOAD_PLUGIN_JITTER_MAX_MS: number
     RUSTY_HOOK_FOR_TEAMS: string


### PR DESCRIPTION
## Problem
We need more uniform tools across ingestion pipeline services to opt certain teams and or events out of the ingest pipeline so maintainers can make rapid adjustments prior to remediation during incidents.

## Changes
`plugin-server` changes to normalize `token` and `token:distinct_id` CSV env var as config for dropping and rerouting events conditionally.

🎗️ Will require a matching `charts` change to shift preexisting settings to the new var and format.

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally and in CI
