### PR TITLE
chore(flags): clean up unused metrics

### DIFF
--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -1009,8 +1009,8 @@ impl FeatureFlagMatcher {
         } else {
             match self.get_person_properties_from_cache() {
                 Ok(props) => Ok(props),
-                Err(FlagError::PersonNotFound) => Ok(HashMap::new()),
-                Err(FlagError::PropertiesNotInCache) => Ok(HashMap::new()),
+                Err(FlagError::PersonNotFound) => Ok(HashMap::new()), // NB: if we can't find a person associated with the distinct ID, we return an empty HashMap
+                Err(FlagError::PropertiesNotInCache) => Ok(HashMap::new()), // NB: if we can't find the properties in the cache, we return an empty HashMap
                 Err(e) => Err(e),
             }
         }

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -15,8 +15,6 @@ pub const PROPERTY_CACHE_HITS_COUNTER: &str = "flags_property_cache_hits_total";
 pub const PROPERTY_CACHE_MISSES_COUNTER: &str = "flags_property_cache_misses_total";
 pub const DB_PERSON_AND_GROUP_PROPERTIES_READS_COUNTER: &str =
     "flags_db_person_and_group_properties_reads_total";
-pub const DB_PERSON_PROPERTIES_READS_COUNTER: &str = "flags_db_person_properties_reads_total";
-pub const DB_GROUP_PROPERTIES_READS_COUNTER: &str = "flags_db_group_properties_reads_total";
 
 // Timing metrics
 pub const FLAG_EVALUATION_TIME: &str = "flags_evaluation_time";
@@ -27,7 +25,6 @@ pub const FLAG_DB_PROPERTIES_FETCH_TIME: &str = "flags_properties_db_fetch_time"
 pub const FLAG_GROUP_FETCH_TIME: &str = "flags_groups_cache_fetch_time";
 pub const FLAG_GET_MATCH_TIME: &str = "flags_get_match_time";
 pub const FLAG_EVALUATE_ALL_CONDITIONS_TIME: &str = "flags_evaluate_all_conditions_time";
-pub const FLAG_STATIC_COHORT_DB_EVALUATION_TIME: &str = "flags_static_cohort_db_fetch_time";
 pub const FLAG_PERSON_QUERY_TIME: &str = "flags_person_query_time";
 pub const FLAG_PERSON_PROCESSING_TIME: &str = "flags_person_processing_time";
 pub const FLAG_COHORT_QUERY_TIME: &str = "flags_cohort_query_time";


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Was putting this dashboard together: https://grafana.prod-us.posthog.dev/d/eehu20mrbkbuof/new-feature-flags?var-reason=$__all&var-team_id=$__all&from=now-6h&to=now&timezone=utc&var-query0=&editIndex=2&var-timing_quartile=0.95 and realized that there were a few metrics in the app code that I didn't care about AND wasn't even tracking.  So I axed it.

Added a comment back in, too (since I didn't mean to delete it).