### PR TITLE
fix: Insight variables url load first

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -76,6 +76,7 @@ export interface InsightCardProps extends Resizeable {
     className?: string
     style?: React.CSSProperties
     children?: React.ReactNode
+    noCache?: boolean
 }
 
 function InsightCardInternal(
@@ -107,6 +108,7 @@ function InsightCardInternal(
         doNotLoad,
         variablesOverride,
         children,
+        noCache,
         ...divProps
     }: InsightCardProps,
     ref: React.Ref<HTMLDivElement>
@@ -176,7 +178,7 @@ function InsightCardInternal(
                         <div className="InsightCard__viz">
                             <Query
                                 query={insight.query}
-                                cachedResults={insight}
+                                cachedResults={noCache ? undefined : insight}
                                 context={{
                                     insightProps: insightLogicProps,
                                 }}

--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
@@ -42,7 +42,7 @@ export const VariablesForDashboard = (): JSX.Element => {
                         key={n.variable.id}
                         variable={n.variable}
                         showEditingUI={false}
-                        onChange={overrideVariableValue}
+                        onChange={(variableId, value, isNull) => overrideVariableValue(variableId, value, isNull, true)}
                         variableOverridesAreSet={false}
                         insightsUsingVariable={n.insights}
                     />

--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
@@ -36,7 +36,7 @@ export const VariablesForDashboard = (): JSX.Element => {
 
     return (
         <>
-            <div className="flex gap-4 flex-wrap px-px mt-4">
+            <div className="flex gap-4 flex-wrap px-px mt-4 mb-2">
                 {dashboardVariables.map((n) => (
                     <VariableComponent
                         key={n.variable.id}
@@ -108,7 +108,7 @@ const VariableInput = ({
         }
 
         if (variable.type === 'Boolean') {
-            return val ? 'true' : 'false'
+            return val === true || val === 'true' ? 'true' : 'false'
         }
 
         if (variable.type === 'Date' && !val) {

--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/variableDataLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/variableDataLogic.ts
@@ -1,5 +1,5 @@
 import { lemonToast } from '@posthog/lemon-ui'
-import { kea, path } from 'kea'
+import { events, kea, path } from 'kea'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 
@@ -14,7 +14,6 @@ export const variableDataLogic = kea<variableDataLogicType>([
             {
                 getVariables: async () => {
                     const insights = await api.insightVariables.list()
-
                     return insights.results
                 },
                 deleteVariable: async (variableId: string) => {
@@ -28,5 +27,10 @@ export const variableDataLogic = kea<variableDataLogicType>([
                 },
             },
         ],
+    })),
+    events(({ actions }) => ({
+        afterMount: () => {
+            actions.getVariables()
+        },
     })),
 ])

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -30,6 +30,7 @@ export function DashboardItems(): JSX.Element {
         temporaryVariables,
         temporaryBreakdownColors,
         dataColorThemeId,
+        noCache,
     } = useValues(dashboardLogic)
     const {
         updateLayouts,
@@ -159,6 +160,7 @@ export function DashboardItems(): JSX.Element {
                                     // :HACKY: The two props below aren't actually used in the component, but are needed to trigger a re-render
                                     breakdownColorOverride={temporaryBreakdownColors}
                                     dataColorThemeId={dataColorThemeId}
+                                    noCache={noCache}
                                     {...commonTileProps}
                                     // NOTE: ReactGridLayout additionally injects its resize handles as `children`!
                                 />


### PR DESCRIPTION
## Problem

- query variables in dashboard URL cause the dashboard to reset

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- if query vars are in URL, keep loading state active until results returned and don't use cache so there's no flickering

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
