### PR TITLE
feat: Retry ClickHouse Dagster jobs on socket timeout error

### DIFF
--- a/dags/common.py
+++ b/dags/common.py
@@ -44,6 +44,7 @@ class ClickhouseClusterResource(dagster.ConfigurableResource):
                                 ErrorCodes.NETWORK_ERROR,
                                 ErrorCodes.TOO_MANY_SIMULTANEOUS_QUERIES,
                                 ErrorCodes.NOT_ENOUGH_SPACE,
+                                ErrorCodes.SOCKET_TIMEOUT,
                                 439,  # CANNOT_SCHEDULE_TASK: "Cannot schedule a task: cannot allocate thread"
                             )
                         )


### PR DESCRIPTION
## Problem

Another class of retryable error:

https://dagster.prod-eu.posthog.dev/runs/a2fde891-859b-439d-9eb3-2148e6311608
https://dagster.prod-eu.posthog.dev/runs/01eba5af-099f-4c74-8700-0303207f02e6

## Changes

Retry when encountering this error

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

-