### PR TITLE
fix: actually show the elements

### DIFF
--- a/frontend/src/toolbar/elements/elementsLogic.ts
+++ b/frontend/src/toolbar/elements/elementsLogic.ts
@@ -310,7 +310,7 @@ export const elementsLogic = kea<elementsLogicType>([
             (s) => [s.elementsToDisplayRaw],
             (elementsToDisplayRaw) => {
                 return elementsToDisplayRaw
-                    .filter(({ rect, visible }) => rect && rect.width > 0 && rect.height > 0 && visible)
+                    .filter(({ rect }) => rect && (rect.width !== 0 || rect.height !== 0))
                     .map((element) => ({
                         ...element,
                         // being able to hover over elements might rely on their original z-index


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

[This PR](https://github.com/PostHog/posthog/commit/72ec89cd4c7374f65cee7084240b5a7cd9c033cf#diff-4cf27f6f99916b8908f226b55703df042a2e32f96aa4402a60e91b8535d5b184) introduced a bug where clicking "Select Element" from the action bit of the toolbar wouldn't actually show the selectable elements.

It's looking for some sort of `visible` prop that isn't critical from what I can tell... so reverting to the former less-strict version so that the toolbar actions actually work again!

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Goes back to prior version

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

👀 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
