### PR TITLE
chore: Add Revenue Analytics to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,3 +30,6 @@ posthog/hogql/database/schema/sessions_v2.py @PostHog/web-analytics
 # Paul owns testing infrastructure
 cypress/** @pauldambra
 playwright/** @pauldambra
+
+# Revenue Analytics team owns revenue analytics stuff
+products/revenue_analytics/** @PostHog/revenue-analytics


### PR DESCRIPTION
All of Revenue Analytics code is located in a single folder, which means it's pretty easy to add a rule for this team