### PR TITLE
chore: update globs in React rules for broader file matching

### DIFF
--- a/.cursor/rules/react-typescript.mdc
+++ b/.cursor/rules/react-typescript.mdc
@@ -1,6 +1,6 @@
 ---
 description: Rules for writing frontend code at PostHog (mostly React + Typescript with Kea)
-globs: frontend/*.tsx, frontend/*.ts
+globs: frontend/**/*.ts,frontend/**/*.tsx,products/**/*.ts,products/**/*.tsx
 alwaysApply: false
 ---
 


### PR DESCRIPTION
Globs for React were not including any files since we were missing  `**` in the glob. They were also not including the TS/TSX files in the `products` folder.