### PR TITLE
test: Add `docker-compose.base.yml` to backend tests filter

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -84,6 +84,7 @@ jobs:
                         # changes to docker-compose.dev.yml e.g. dependency
                         # version changes
                         - docker-compose.dev.yml
+                        - docker-compose.base.yml
                         - frontend/public/email/*
                         # These scripts are used in the CI
                         - bin/check_temporal_up

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -305,7 +305,6 @@ services:
                 condition: service_healthy
             elasticsearch:
                 condition: service_started
-
     temporal-admin-tools:
         environment:
             - TEMPORAL_CLI_ADDRESS=temporal:7233


### PR DESCRIPTION
## Problem

Currently backend tests are not running in CI if `docker-compose.base.yml` is updated. We use docker compose to run our tests in CI so we should run these if it is updated. An example where this was caught: https://github.com/PostHog/posthog/pull/31335

## Changes

Add `docker-compose.base.yml` to filters. We could add all the docker compose files to this pattern but some, like `docker-compose.playwright.yml` are not used for backend tests, so just kept it simple.
