### PR TITLE
chore(devex): new tab and copy link address added in tree menus

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -91,6 +91,30 @@ export function ProjectTree(): JSX.Element {
 
         return (
             <>
+                {item.record?.path && item.record?.type !== 'folder' && item.record?.href ? (
+                    <>
+                        <MenuItem
+                            asChild
+                            onClick={(e) => {
+                                e.stopPropagation()
+                                window.open(item.record?.href, '_blank')
+                            }}
+                        >
+                            <ButtonPrimitive menuItem>Open link in new tab</ButtonPrimitive>
+                        </MenuItem>
+                        <MenuItem
+                            asChild
+                            onClick={(e) => {
+                                e.stopPropagation()
+                                void navigator.clipboard.writeText(document.location.origin + item.record?.href)
+                            }}
+                        >
+                            <ButtonPrimitive menuItem>Copy link address</ButtonPrimitive>
+                        </MenuItem>
+
+                        <MenuSeparator />
+                    </>
+                ) : null}
                 {item.record?.path ? (
                     <MenuItem
                         asChild


### PR DESCRIPTION
## Problem
When we hijack the browser context menu, users expect some browsers features when dealing with links

![2025-04-17 12 25 16](https://github.com/user-attachments/assets/8ca13743-dada-40c4-9ac2-28bdeab3f556)


## Changes
* [For tree items with and `href`]: Add menu item "Open link in new tab"
* [For tree items with and `href`]: Add menu item "Copy link address" => `http://localhost:8010/feature_flags/15`

## Does this work well for both Cloud and self-hosted?
Good question

## How did you test this code?
Locally, pretty basic 
