### PR TITLE
chore: set tags on exceptions as properties

### DIFF
--- a/posthog/api/monitoring.py
+++ b/posthog/api/monitoring.py
@@ -1,8 +1,8 @@
 from enum import StrEnum
 from prometheus_client import Counter
-from sentry_sdk import set_tag
 from collections.abc import Callable
 from functools import wraps
+from posthog.clickhouse.query_tagging import tag_queries
 
 
 class Feature(StrEnum):
@@ -37,7 +37,7 @@ def monitor(*, feature: Feature | None, endpoint: str, method: str) -> Callable:
             API_REQUESTS_COUNTER.labels(endpoint=endpoint, method=method).inc()
 
             if feature:
-                set_tag("feature", feature.value)
+                tag_queries(feature=feature.value)
             try:
                 return func(*args, **kwargs)
             except Exception:

--- a/posthog/api/monitoring.py
+++ b/posthog/api/monitoring.py
@@ -28,7 +28,7 @@ API_REQUESTS_ERROR_COUNTER = Counter(
 def monitor(*, feature: Feature | None, endpoint: str, method: str) -> Callable:
     """
     Decorator to increment the API requests counter
-    Sets sentry tags for the endpoint and method
+    Tags endpoints and methods with the feature name
     """
 
     def decorator(func: Callable) -> Callable:

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -138,7 +138,6 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
     )
     @monitor(feature=Feature.QUERY, endpoint="query", method="POST")
     def create(self, request: Request, *args, **kwargs) -> Response:
-        # raise Exception("This is a test exception")
         data = self.get_model(request.data, QueryRequest)
         with suppress(Exception):
             request_id = structlog.get_context(logger).get("request_id")

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -10,7 +10,7 @@ from rest_framework.exceptions import APIException, NotFound
 
 from posthog import celery, redis
 from posthog.clickhouse.client.async_task_chain import add_task_to_on_commit
-from posthog.clickhouse.query_tagging import tag_queries, get_query_tags
+from posthog.clickhouse.query_tagging import tag_queries
 from posthog.errors import CHQueryErrorTooManySimultaneousQueries, ExposedCHQueryError
 from posthog.hogql.constants import LimitContext
 from posthog.hogql.errors import ExposedHogQLError
@@ -213,7 +213,7 @@ def execute_process_query(
             # We can only expose the error message if it's a known safe error OR if the user is PostHog staff
             query_status.error_message = str(err)
         logger.exception("Error processing query async", team_id=team_id, query_id=query_id, exc_info=True)
-        capture_exception(err, properties=get_query_tags())
+        capture_exception(err)
         # Do not raise here, the task itself did its job and we cannot recover
     finally:
         query_status.end_time = datetime.datetime.now(datetime.UTC)

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -162,8 +162,8 @@ def execute_process_query(
     user = None
     if user_id:
         user = User.objects.only("email", "is_staff").get(pk=user_id)
-        tag_queries(user_email=user.email)
         is_staff_user = user.is_staff
+        tag_queries(user_email=user.email)
 
     query_status = manager.get_query_status()
 

--- a/posthog/exceptions.py
+++ b/posthog/exceptions.py
@@ -64,7 +64,7 @@ def exception_reporting(exception: Exception, context: ExceptionContext) -> Opti
     if not isinstance(exception, APIException):
         tags = get_query_tags()
         logger.exception(exception, path=context["request"].path, **tags)
-        return capture_exception(exception, properties=tags)
+        return capture_exception(exception)
     return None
 
 

--- a/posthog/exceptions.py
+++ b/posthog/exceptions.py
@@ -6,6 +6,7 @@ from django.http.response import JsonResponse
 from rest_framework import status
 from rest_framework.exceptions import APIException
 from posthog.exceptions_capture import capture_exception
+from posthog.clickhouse.query_tagging import get_query_tags
 
 from posthog.cloud_utils import is_cloud
 
@@ -61,8 +62,9 @@ def exception_reporting(exception: Exception, context: ExceptionContext) -> Opti
     Used through drf-exceptions-hog
     """
     if not isinstance(exception, APIException):
-        logger.exception(exception, path=context["request"].path)
-        return capture_exception(exception)
+        tags = get_query_tags()
+        logger.exception(exception, path=context["request"].path, **tags)
+        return capture_exception(exception, properties=tags)
     return None
 
 

--- a/posthog/exceptions_capture.py
+++ b/posthog/exceptions_capture.py
@@ -1,10 +1,18 @@
-def capture_exception(error=None, properties=None):
+from posthog.clickhouse.query_tagging import get_query_tags
+
+
+def capture_exception(error=None, additional_properties=None):
     from posthoganalytics import api_key, capture_exception as posthog_capture_exception
     import structlog
 
     logger = structlog.get_logger(__name__)
 
     logger.exception(error)
+
+    properties = get_query_tags()
+
+    if additional_properties:
+        properties.update(additional_properties)
 
     if api_key:
         posthog_capture_exception(error, properties=properties)

--- a/posthog/models/file_system/file_system_mixin.py
+++ b/posthog/models/file_system/file_system_mixin.py
@@ -1,11 +1,11 @@
 # posthog/models/file_system/file_system_mixin.py
 
 import dataclasses
-import posthoganalytics
 from django.db.models import Exists, OuterRef, CharField, Model, F, Q, QuerySet
 from django.db.models.functions import Cast
 from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
+from posthog.exceptions_capture import capture_exception
 from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
@@ -97,7 +97,7 @@ class FileSystemSyncMixin(Model):
                     )
             except Exception as e:
                 # Don't raise exceptions in signals
-                posthoganalytics.capture_exception(e, properties=dataclasses.asdict(fs_data))
+                capture_exception(e, additional_properties=dataclasses.asdict(fs_data))
 
         @receiver(post_delete, sender=cls)
         def _file_system_post_delete(sender, instance: FileSystemSyncMixin, **kwargs):
@@ -109,4 +109,4 @@ class FileSystemSyncMixin(Model):
                 delete_file(team=team, file_type=fs_data.type, ref=fs_data.ref)
             except Exception as e:
                 # Don't raise exceptions in signals
-                posthoganalytics.capture_exception(e, properties=dataclasses.asdict(fs_data))
+                capture_exception(e, additional_properties=dataclasses.asdict(fs_data))

--- a/posthog/rbac/migrations/rbac_team_migration.py
+++ b/posthog/rbac/migrations/rbac_team_migration.py
@@ -83,12 +83,12 @@ def rbac_team_access_control_migration(organization_id: int):
                 except Exception as e:
                     error_message = f"Failed to migrate team {team.id}"
                     logger.exception(error_message, exc_info=e)
-                    capture_exception(e, properties={"team_id": team.id, "organization_id": organization_id})
+                    capture_exception(e, additional_properties={"team_id": team.id, "organization_id": organization_id})
                     raise
 
         logger.info("Finished RBAC team migrations", organization_id=organization_id)
     except Exception as e:
         error_message = f"Failed to complete RBAC migration for organization {organization_id}"
         logger.exception(error_message, exc_info=e)
-        capture_exception(e, properties={"organization_id": organization_id})
+        capture_exception(e, additional_properties={"organization_id": organization_id})
         raise

--- a/posthog/rbac/migrations/rbac_team_migration.py
+++ b/posthog/rbac/migrations/rbac_team_migration.py
@@ -67,7 +67,7 @@ def rbac_team_access_control_migration(organization_id: int):
                             logger.exception(error_message, exc_info=e)
                             capture_exception(
                                 e,
-                                properties={
+                                additional_properties={
                                     "team_id": team.id,
                                     "organization_id": organization_id,
                                     "team_membership_id": team_membership.id,

--- a/posthog/session_recordings/realtime_snapshots.py
+++ b/posthog/session_recordings/realtime_snapshots.py
@@ -53,7 +53,7 @@ def publish_subscription(team_id: str, session_id: str) -> None:
     except Exception as e:
         capture_exception(
             e,
-            properties={
+            additional_properties={
                 "team_id": team_id,
                 "session_id": session_id,
                 "operation": "publish_realtime_subscription",
@@ -107,7 +107,7 @@ def get_realtime_snapshots(team_id: str, session_id: str, attempt_count=0) -> Op
         # very broad capture to see if there are any unexpected errors
         capture_exception(
             e,
-            properties={
+            additional_properties={
                 "attempt_count": attempt_count,
                 "operation": "get_realtime_snapshots",
                 "team_id": team_id,

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -72,6 +72,7 @@ from openai.types.chat import (
 from posthog.session_recordings.utils import clean_prompt_whitespace
 from posthog.session_recordings.session_recording_v2_service import list_blocks
 from posthog.storage.session_recording_v2_object_storage import BlockFetchError
+from posthog.exceptions_capture import capture_exception
 
 SNAPSHOTS_BY_PERSONAL_API_KEY_COUNTER = Counter(
     "snapshots_personal_api_key_counter",
@@ -369,7 +370,7 @@ def clean_referer_url(current_url: str | None) -> str:
         path = re.sub("/", "-", path)
         return path or "unknown"
     except Exception as e:
-        posthoganalytics.capture_exception(e, distinct_id="clean_referer_url", properties={"current_url": current_url})
+        capture_exception(e, additional_properties={"current_url": current_url, "function_name": "clean_referer_url"})
         return "unknown"
 
 

--- a/posthog/tasks/alerts/checks.py
+++ b/posthog/tasks/alerts/checks.py
@@ -96,7 +96,7 @@ def alerts_backlog_task() -> None:
         capture_ph_event(
             ANIRUDH_DISTINCT_ID,
             "alert check backlog",
-            properties={
+            additional_properties={
                 "calculation_interval": AlertCalculationInterval.DAILY,
                 "backlog": daily_alerts_breaching_sla,
             },
@@ -105,7 +105,7 @@ def alerts_backlog_task() -> None:
         capture_ph_event(
             ANIRUDH_DISTINCT_ID,
             "alert check backlog",
-            properties={
+            additional_properties={
                 "calculation_interval": AlertCalculationInterval.HOURLY,
                 "backlog": hourly_alerts_breaching_sla,
             },

--- a/posthog/tasks/alerts/checks.py
+++ b/posthog/tasks/alerts/checks.py
@@ -265,7 +265,7 @@ def check_alert(alert_id: str, capture_ph_event: Callable = lambda *args, **kwar
         logger.exception(AlertCheckException(err))
         capture_exception(
             AlertCheckException(err),
-            properties={
+            additional_properties={
                 "alert_configuration_id": alert_id,
             },
         )

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -1,7 +1,6 @@
 import time
 from typing import Optional
 from uuid import UUID
-import posthoganalytics
 
 import requests
 from celery import shared_task
@@ -22,6 +21,7 @@ from posthog.ph_client import get_ph_client
 from posthog.redis import get_client
 from posthog.settings import CLICKHOUSE_CLUSTER
 from posthog.tasks.utils import CeleryQueue
+from posthog.exceptions_capture import capture_exception
 
 logger = get_logger(__name__)
 
@@ -908,7 +908,7 @@ def ee_count_items_in_playlists() -> None:
             enqueue_recordings_that_match_playlist_filters,
         )
     except ImportError as ie:
-        posthoganalytics.capture_exception(ie, properties={"posthog_feature": "session_replay_playlist_counters"})
+        capture_exception(ie, additional_properties={"posthog_feature": "session_replay_playlist_counters"})
         logger.exception("Failed to import task to count items in playlists", error=ie)
     else:
         enqueue_recordings_that_match_playlist_filters()

--- a/posthog/temporal/common/posthog_client.py
+++ b/posthog/temporal/common/posthog_client.py
@@ -52,7 +52,7 @@ class _PostHogClientActivityInboundInterceptor(ActivityInboundInterceptor):
             await _add_inputs_to_properties(properties, input, "activity")
             if api_key:
                 try:
-                    capture_exception(e, properties=properties)
+                    capture_exception(e, additional_properties=properties)
                 except Exception as capture_error:
                     await logger.awarning("Failed to capture exception", exc_info=capture_error)
             raise
@@ -77,7 +77,7 @@ class _PostHogClientWorkflowInterceptor(WorkflowInboundInterceptor):
             if api_key and not workflow.unsafe.is_replaying():
                 with workflow.unsafe.sandbox_unrestricted():
                     try:
-                        capture_exception(e, properties=properties)
+                        capture_exception(e, additional_properties=properties)
                     except Exception as capture_error:
                         await logger.awarning("Failed to capture exception", exc_info=capture_error)
             raise

--- a/posthog/temporal/common/posthog_client.py
+++ b/posthog/temporal/common/posthog_client.py
@@ -28,7 +28,7 @@ async def _add_inputs_to_properties(
         await logger.awarning(
             "Failed to add inputs to properties for class %s", type(input.args[0]).__name__, exc_info=e
         )
-        capture_exception(e)
+        capture_exception(e, properties=properties)
 
 
 class _PostHogClientActivityInboundInterceptor(ActivityInboundInterceptor):
@@ -52,7 +52,7 @@ class _PostHogClientActivityInboundInterceptor(ActivityInboundInterceptor):
             await _add_inputs_to_properties(properties, input, "activity")
             if api_key:
                 try:
-                    capture_exception(e, additional_properties=properties)
+                    capture_exception(e, properties=properties)
                 except Exception as capture_error:
                     await logger.awarning("Failed to capture exception", exc_info=capture_error)
             raise
@@ -77,7 +77,7 @@ class _PostHogClientWorkflowInterceptor(WorkflowInboundInterceptor):
             if api_key and not workflow.unsafe.is_replaying():
                 with workflow.unsafe.sandbox_unrestricted():
                     try:
-                        capture_exception(e, additional_properties=properties)
+                        capture_exception(e, properties=properties)
                     except Exception as capture_error:
                         await logger.awarning("Failed to capture exception", exc_info=capture_error)
             raise


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Precursor to https://github.com/PostHog/posthog/pull/31338

We weren't tagging a lot of issues with the relevant properties which made it really difficult to find exceptions in PostHog

## Changes

- We apply a bunch of tags in a thread safe manner already
- Adding them to the exceptions manually in the `exception_reporting` handler