### PR TITLE
chore: decrease the rate of session replay task to offloed offline cluster 

### DIFF
--- a/ee/session_recordings/playlist_counters/recordings_that_match_playlist_filters.py
+++ b/ee/session_recordings/playlist_counters/recordings_that_match_playlist_filters.py
@@ -284,7 +284,7 @@ def convert_filters_to_recordings_query(playlist: SessionRecordingPlaylist) -> R
     ignore_result=True,
     queue=CeleryQueue.SESSION_REPLAY_GENERAL.value,
     # limit how many run per worker instance - if we have 10 workers, this will run 600 times per hour
-    rate_limit="180/h",
+    rate_limit="120/h",
     expires=TASK_EXPIRATION_TIME,
     autoretry_for=(CHQueryErrorTooManySimultaneousQueries,),
     # will retry twice, once after 120 seconds (with jitter)


### PR DESCRIPTION
## Problem

count_recordings_that_match_playlist_filters executes for over 82000 minutes daily, averaging 52 queries at any given moment

## Changes

lower rate from 180 -> 120/h
we need to optimize it, then revert

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

...
