### PR TITLE
fix: failover personal_api_key

### DIFF
--- a/ee/clickhouse/queries/test/test_util.py
+++ b/ee/clickhouse/queries/test/test_util.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 
 from zoneinfo import ZoneInfo
 from freezegun.api import freeze_time
-from unittest.mock import patch, MagicMock
 
 from posthog.clickhouse.client import sync_execute
 from posthog.hogql.hogql import HogQLContext
@@ -11,8 +10,6 @@ from posthog.models.cohort import Cohort
 from posthog.queries.breakdown_props import _parse_breakdown_cohorts
 from posthog.queries.util import get_earliest_timestamp
 from posthog.test.base import _create_event
-from posthog.clickhouse.client import ServerException
-from posthog.clickhouse.client import Workload
 
 
 def test_get_earliest_timestamp(db, team):
@@ -66,35 +63,3 @@ def test_parse_breakdown_cohort_query(db, team):
     queries, params = _parse_breakdown_cohorts([cohort1], HogQLContext(team_id=team.pk))
     assert len(queries) == 1
     sync_execute(queries[0], params)
-
-
-@patch("posthog.clickhouse.client.execute.get_client_from_pool")
-def test_sync_execute_retries_with_online_workload_on_202(mock_get_client):
-    # Create mock clients
-    mock_client1 = MagicMock()
-    mock_client2 = MagicMock()
-
-    # First client raises 202 ServerException
-    mock_client1.__enter__.return_value.execute.side_effect = ServerException("Too many simultaneous queries", code=202)
-
-    # Second client succeeds
-    mock_client2.__enter__.return_value.execute.return_value = "success"
-
-    # Return different clients on consecutive calls
-    mock_get_client.side_effect = [mock_client1, mock_client2]
-
-    # Execute query with personal_api_key access method and offline workload
-    query = "SELECT 1"
-    tag_queries = {"access_method": "personal_api_key"}
-
-    with patch("posthog.clickhouse.client.execute.get_query_tags", return_value=tag_queries):
-        result = sync_execute(query, workload=Workload.OFFLINE)
-
-    # Verify first call was with OFFLINE workload
-    mock_get_client.assert_any_call(Workload.OFFLINE, None, False)
-
-    # Verify second call was with ONLINE workload
-    mock_get_client.assert_any_call(Workload.ONLINE, None, False)
-
-    # Verify final result
-    assert result == "success"

--- a/ee/clickhouse/queries/test/test_util.py
+++ b/ee/clickhouse/queries/test/test_util.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 
 from zoneinfo import ZoneInfo
 from freezegun.api import freeze_time
+from unittest.mock import patch, MagicMock
 
 from posthog.clickhouse.client import sync_execute
 from posthog.hogql.hogql import HogQLContext
@@ -10,6 +11,8 @@ from posthog.models.cohort import Cohort
 from posthog.queries.breakdown_props import _parse_breakdown_cohorts
 from posthog.queries.util import get_earliest_timestamp
 from posthog.test.base import _create_event
+from posthog.clickhouse.client import ServerException
+from posthog.clickhouse.client import Workload
 
 
 def test_get_earliest_timestamp(db, team):
@@ -63,3 +66,35 @@ def test_parse_breakdown_cohort_query(db, team):
     queries, params = _parse_breakdown_cohorts([cohort1], HogQLContext(team_id=team.pk))
     assert len(queries) == 1
     sync_execute(queries[0], params)
+
+
+@patch("posthog.clickhouse.client.execute.get_client_from_pool")
+def test_sync_execute_retries_with_online_workload_on_202(mock_get_client):
+    # Create mock clients
+    mock_client1 = MagicMock()
+    mock_client2 = MagicMock()
+
+    # First client raises 202 ServerException
+    mock_client1.__enter__.return_value.execute.side_effect = ServerException("Too many simultaneous queries", code=202)
+
+    # Second client succeeds
+    mock_client2.__enter__.return_value.execute.return_value = "success"
+
+    # Return different clients on consecutive calls
+    mock_get_client.side_effect = [mock_client1, mock_client2]
+
+    # Execute query with personal_api_key access method and offline workload
+    query = "SELECT 1"
+    tag_queries = {"access_method": "personal_api_key"}
+
+    with patch("posthog.clickhouse.client.execute.get_query_tags", return_value=tag_queries):
+        result = sync_execute(query, workload=Workload.OFFLINE)
+
+    # Verify first call was with OFFLINE workload
+    mock_get_client.assert_any_call(Workload.OFFLINE, None, False)
+
+    # Verify second call was with ONLINE workload
+    mock_get_client.assert_any_call(Workload.ONLINE, None, False)
+
+    # Verify final result
+    assert result == "success"

--- a/ee/clickhouse/test/test_error.py
+++ b/ee/clickhouse/test/test_error.py
@@ -37,9 +37,9 @@ from posthog.errors import wrap_query_error
         ),
         (
             ServerException("Too many simultaneous queries. Maximum: 100.", code=202),
-            "CHQueryErrorTooManySimultaneousQueries",
-            "Code: 202.\nToo many simultaneous queries. Try again later.",
-            202,
+            "ClickhouseAtCapacity",
+            "Clickhouse cluster is at capacity. Please try this query again later.",
+            None,
         ),
     ],
 )

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -19,6 +19,7 @@ from posthog.clickhouse.client.escape import substitute_params
 from posthog.clickhouse.query_tagging import tag_queries, get_query_tag_value, get_query_tags
 from posthog.cloud_utils import is_cloud
 from posthog.errors import wrap_query_error
+from posthog.exceptions import ClickhouseAtCapacity
 from posthog.settings import TEST
 from posthog.utils import generate_short_id, patchable
 
@@ -118,13 +119,11 @@ def sync_execute(
         except ModuleNotFoundError:  # when we run plugin server tests it tries to run above, ignore
             pass
 
-    if workload == Workload.DEFAULT and (
-        # When someone uses an API key, always put their query to the offline cluster
-        get_query_tag_value("access_method") == "personal_api_key"
-        or
-        # Execute all celery tasks not directly set to be online on the offline cluster
-        get_query_tag_value("kind") == "celery"
-    ):
+    is_personal_api_key = get_query_tag_value("access_method") == "personal_api_key"
+
+    # When someone uses an API key, always put their query to the offline cluster
+    # Execute all celery tasks not directly set to be online on the offline cluster
+    if workload == Workload.DEFAULT and (is_personal_api_key or get_query_tag_value("kind") == "celery"):
         workload = Workload.OFFLINE
 
     # Make sure we always have process_query_task on the online cluster
@@ -144,42 +143,53 @@ def sync_execute(
 
     start_time = perf_counter()
 
-    prepared_sql, prepared_args, tags = _prepare_query(query=query, args=args, workload=workload)
-    query_id = validated_client_query_id()
-    core_settings = {**default_settings(), **(settings or {})}
-    tags["query_settings"] = core_settings
-
-    query_type = tags.get("query_type", "Other")
-    if team_id is not None:
-        tag_queries(team_id=team_id)
-
-    settings = {
-        **core_settings,
-        "log_comment": json.dumps(tags, separators=(",", ":")),
-        "query_id": query_id,
-    }
-
-    if workload == Workload.DEFAULT:
-        workload = get_default_clickhouse_workload_type()
-
-    if workload == Workload.OFFLINE:
-        # disabling hedged requests for offline queries reduces the likelihood of these queries bleeding over into the
-        # online resource pool when the offline resource pool is under heavy load. this comes at the cost of higher and
-        # more variable latency and a higher likelihood of query failures - but offline workloads should be tolerant to
-        # these disruptions
-        settings["use_hedged_requests"] = "0"
-
     try:
-        with sync_client or get_client_from_pool(workload, team_id, readonly) as client:
-            result = client.execute(
-                prepared_sql,
-                params=prepared_args,
-                settings=settings,
-                with_column_types=with_column_types,
-                query_id=query_id,
-            )
+        repeat = False
+        while True:
+            prepared_sql, prepared_args, tags = _prepare_query(query=query, args=args, workload=workload)
+            query_id = validated_client_query_id()
+            core_settings = {**default_settings(), **(settings or {})}
+            tags["query_settings"] = core_settings
+
+            query_type = tags.get("query_type", "Other")
+            if team_id is not None:
+                tag_queries(team_id=team_id)
+
+            settings = {
+                **core_settings,
+                "log_comment": json.dumps(tags, separators=(",", ":")),
+                "query_id": query_id,
+            }
+
+            if workload == Workload.DEFAULT:
+                workload = get_default_clickhouse_workload_type()
+
+            if workload == Workload.OFFLINE:
+                # disabling hedged requests for offline queries reduces the likelihood of these queries bleeding over into the
+                # online resource pool when the offline resource pool is under heavy load. this comes at the cost of higher and
+                # more variable latency and a higher likelihood of query failures - but offline workloads should be tolerant to
+                # these disruptions
+                settings["use_hedged_requests"] = "0"
+
+            try:
+                with sync_client or get_client_from_pool(workload, team_id, readonly) as client:
+                    result = client.execute(
+                        prepared_sql,
+                        params=prepared_args,
+                        settings=settings,
+                        with_column_types=with_column_types,
+                        query_id=query_id,
+                    )
+            except Exception as e:
+                err = wrap_query_error(e)
+                if isinstance(err, ClickhouseAtCapacity) and is_personal_api_key and workload == Workload.OFFLINE:
+                    workload = Workload.ONLINE
+                    repeat = True
+                else:
+                    raise err
+            if not repeat:
+                break
     except Exception as e:
-        err = wrap_query_error(e)
         exception_type = type(err).__name__
         tag_queries(clickhouse_exception_type=exception_type)
         QUERY_ERROR_COUNTER.labels(

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -189,8 +189,7 @@ def sync_execute(
                 if isinstance(err, ClickhouseAtCapacity) and is_personal_api_key and workload == Workload.OFFLINE:
                     workload = Workload.ONLINE
                     continue
-                else:
-                    raise err from e
+                raise err from e
             break
     finally:
         execution_time = perf_counter() - start_time

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -188,6 +188,7 @@ def sync_execute(
                 ).inc()
                 if isinstance(err, ClickhouseAtCapacity) and is_personal_api_key and workload == Workload.OFFLINE:
                     workload = Workload.ONLINE
+                    settings["use_hedged_requests"] = "1"
                     continue
                 raise err from e
             break

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -144,7 +144,6 @@ def sync_execute(
     start_time = perf_counter()
 
     try:
-        repeat = False
         while True:
             prepared_sql, prepared_args, tags = _prepare_query(query=query, args=args, workload=workload)
             query_id = validated_client_query_id()
@@ -189,11 +188,10 @@ def sync_execute(
                 ).inc()
                 if isinstance(err, ClickhouseAtCapacity) and is_personal_api_key and workload == Workload.OFFLINE:
                     workload = Workload.ONLINE
-                    repeat = True
+                    continue
                 else:
                     raise err from e
-            if not repeat:
-                break
+            break
     finally:
         execution_time = perf_counter() - start_time
 

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -1,6 +1,8 @@
 import json
 from typing import Any
 
+from clickhouse_driver.errors import ServerException
+
 from posthog.clickhouse.client.async_task_chain import task_chain_context
 from posthog.clickhouse.client.connection import Workload
 import uuid
@@ -10,6 +12,7 @@ from django.db import transaction
 
 from posthog.clickhouse.client import execute_async as client
 from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.query_tagging import tag_queries
 from posthog.errors import CHQueryErrorTooManySimultaneousQueries
 from posthog.models import Organization, Team
 from posthog.models.user import User
@@ -359,11 +362,31 @@ class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):
             self.assertIn(f"/* user_id:{self.user_id} request:1 */", first_query)
 
     @patch("posthog.clickhouse.client.execute.get_client_from_pool")
-    def test_offline_workload_if_personal_api_key(self, mock_get_client):
-        from posthog.clickhouse.query_tagging import tag_queries
+    def test_offline_workload_if_personal_api_key_and_retries_online(self, mock_get_client):
+        # Create mock clients
+        mock_client1 = MagicMock()
+        mock_client2 = MagicMock()
 
-        with self.capture_select_queries():
-            tag_queries(kind="request", id="1", access_method="personal_api_key")
-            sync_execute("select 1")
+        # First client raises 202 ServerException
+        mock_client1.__enter__.return_value.execute.side_effect = ServerException("Test error", code=202)
 
-            self.assertEqual(mock_get_client.call_args[0][0], Workload.OFFLINE)
+        # Second client succeeds
+        mock_client2.__enter__.return_value.execute.return_value = "success"
+
+        # Return different clients on consecutive calls
+        mock_get_client.side_effect = [mock_client1, mock_client2]
+
+        # Execute query with personal_api_key access method
+        query = "SELECT 1"
+        # tag_queries = {"access_method": "personal_api_key"}
+        tag_queries(access_method="personal_api_key")
+        result = sync_execute(query)
+
+        # Verify first call was with OFFLINE workload
+        mock_get_client.assert_any_call(Workload.OFFLINE, None, False)
+
+        # Verify second call was with ONLINE workload
+        mock_get_client.assert_any_call(Workload.ONLINE, None, False)
+
+        # Verify final result
+        self.assertEqual(result, "success")

--- a/posthog/errors.py
+++ b/posthog/errors.py
@@ -44,7 +44,7 @@ def wrap_query_error(err: Exception) -> Exception:
     if not isinstance(err, ServerException):
         return err
 
-    if re.search(r"Too many simultaneous.", err.message):
+    if err.code == 202:
         return ClickhouseAtCapacity()
 
     # Return a 512 error for queries which would time out

--- a/posthog/errors.py
+++ b/posthog/errors.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from clickhouse_driver.errors import ServerException
 
-from posthog.exceptions import EstimatedQueryExecutionTimeTooLong, QuerySizeExceeded
+from posthog.exceptions import EstimatedQueryExecutionTimeTooLong, QuerySizeExceeded, ClickhouseAtCapacity
 
 
 class InternalCHQueryError(ServerException):
@@ -43,6 +43,9 @@ def wrap_query_error(err: Exception) -> Exception:
     "Beautifies clickhouse client errors, using custom error classes for every code"
     if not isinstance(err, ServerException):
         return err
+
+    if re.search(r"Too many simultaneous.", err.message):
+        return ClickhouseAtCapacity()
 
     # Return a 512 error for queries which would time out
     match = re.search(r"Estimated query execution time \(.* seconds\) is too long.", err.message)

--- a/posthog/exceptions.py
+++ b/posthog/exceptions.py
@@ -43,6 +43,11 @@ class Conflict(APIException):
     default_code = "conflict"
 
 
+class ClickhouseAtCapacity(APIException):
+    status_code = 500
+    default_detail = "Clickhouse cluster is at capacity. Please try this query again later."
+
+
 class EstimatedQueryExecutionTimeTooLong(APIException):
     status_code = 512  # Custom error code
     default_detail = "Estimated query execution time is too long. Try reducing its scope by changing the time range."


### PR DESCRIPTION
## Problem
Api requests are 500'ing because of cluster capacity

## Changes
Failover api requests with personal_api_key to online if offline is at max
