### PR TITLE
feat(clickhouse): adds breadcrumbs column to events table

### DIFF
--- a/posthog/clickhouse/kafka_engine.py
+++ b/posthog/clickhouse/kafka_engine.py
@@ -26,8 +26,7 @@ SELECT generateUUIDv4()
 KAFKA_COLUMNS = """
 , _timestamp DateTime
 , _offset UInt64
-, header_names Array(String)
-, header_values Array(String)
+, consumer_breadcrumbs Array(String)
 """
 
 # Use this with new tables, old one didn't include partition

--- a/posthog/clickhouse/kafka_engine.py
+++ b/posthog/clickhouse/kafka_engine.py
@@ -26,7 +26,6 @@ SELECT generateUUIDv4()
 KAFKA_COLUMNS = """
 , _timestamp DateTime
 , _offset UInt64
-, consumer_breadcrumbs Array(String)
 """
 
 # Use this with new tables, old one didn't include partition

--- a/posthog/clickhouse/kafka_engine.py
+++ b/posthog/clickhouse/kafka_engine.py
@@ -26,6 +26,8 @@ SELECT generateUUIDv4()
 KAFKA_COLUMNS = """
 , _timestamp DateTime
 , _offset UInt64
+, header_names Array(String)
+, header_values Array(String)
 """
 
 # Use this with new tables, old one didn't include partition

--- a/posthog/clickhouse/migrations/0113_add_kafka_consumer_breadcrumbs.py
+++ b/posthog/clickhouse/migrations/0113_add_kafka_consumer_breadcrumbs.py
@@ -1,0 +1,67 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions, NodeRole
+from posthog.clickhouse.cluster import ON_CLUSTER_CLAUSE
+from posthog.models.event.sql import (
+    EVENTS_TABLE_JSON_MV_SQL,
+    KAFKA_EVENTS_TABLE_JSON_SQL,
+)
+
+ALTER_EVENTS_TABLE_ADD_BREADCRUMBS_COLUMN = """
+ALTER TABLE {table_name} {on_cluster_clause}
+    ADD COLUMN IF NOT EXISTS _kafka_consumer_breadcrumbs Nullable(String)
+"""
+
+# DROP KAFKA TABLE
+DROP_KAFKA_EVENTS_TABLE_JSON_TEMPLATE = """
+    DROP TABLE IF EXISTS kafka_events_json {on_cluster_clause}
+"""
+
+# DROP MATERIALIZED VIEW
+DROP_EVENTS_TABLE_JSON_MV_TEMPLATE = """
+    DROP TABLE IF EXISTS events_json_mv {on_cluster_clause}
+"""
+
+
+def DROP_KAFKA_EVENTS_TABLE_JSON(on_cluster=True):
+    return DROP_KAFKA_EVENTS_TABLE_JSON_TEMPLATE.format(on_cluster_clause=ON_CLUSTER_CLAUSE(on_cluster))
+
+
+def DROP_EVENTS_TABLE_JSON_MV(on_cluster=True):
+    return DROP_EVENTS_TABLE_JSON_MV_TEMPLATE.format(on_cluster_clause=ON_CLUSTER_CLAUSE(on_cluster))
+
+
+def ADD_BREADRUMBS_COLUMNS_DISTRIBUTED_EVENTS_TABLE_SQL(on_cluster=True):
+    return ALTER_EVENTS_TABLE_ADD_BREADCRUMBS_COLUMN.format(
+        table_name="events", on_cluster_clause=ON_CLUSTER_CLAUSE(on_cluster)
+    )
+
+
+def ADD_BREADRUMBS_COLUMNS_WRITABLE_EVENTS_TABLE_SQL(on_cluster=True):
+    return ALTER_EVENTS_TABLE_ADD_BREADCRUMBS_COLUMN.format(
+        table_name="writable_events", on_cluster_clause=ON_CLUSTER_CLAUSE(on_cluster)
+    )
+
+
+def ADD_BREADRUMBS_COLUMNS_SHARDED_EVENTS_TABLE_SQL(on_cluster=True):
+    return ALTER_EVENTS_TABLE_ADD_BREADCRUMBS_COLUMN.format(
+        table_name="sharded_events", on_cluster_clause=ON_CLUSTER_CLAUSE(on_cluster)
+    )
+
+
+operations = [
+    # First drop the materialized view
+    run_sql_with_exceptions(DROP_EVENTS_TABLE_JSON_MV, NodeRole.WRITE),
+    run_sql_with_exceptions(DROP_KAFKA_EVENTS_TABLE_JSON, NodeRole.WRITE),
+    # add missing columns to all tables in correct order
+    # first the sharded tables
+    run_sql_with_exceptions(ADD_BREADRUMBS_COLUMNS_SHARDED_EVENTS_TABLE_SQL()),
+    # second, add missing columns to writable table
+    run_sql_with_exceptions(ADD_BREADRUMBS_COLUMNS_WRITABLE_EVENTS_TABLE_SQL()),
+    # third,add missing columns to distributed table
+    run_sql_with_exceptions(
+        ADD_BREADRUMBS_COLUMNS_DISTRIBUTED_EVENTS_TABLE_SQL(on_cluster=False), node_role=NodeRole.COORDINATOR
+    ),
+    # recreate the kafka table
+    run_sql_with_exceptions(KAFKA_EVENTS_TABLE_JSON_SQL()),
+    # recreate the materialized view
+    run_sql_with_exceptions(EVENTS_TABLE_JSON_MV_SQL()),
+]

--- a/posthog/clickhouse/migrations/0113_add_kafka_consumer_breadcrumbs.py
+++ b/posthog/clickhouse/migrations/0113_add_kafka_consumer_breadcrumbs.py
@@ -7,8 +7,7 @@ from posthog.models.event.sql import (
 
 ALTER_EVENTS_TABLE_ADD_BREADCRUMBS_COLUMN = """
 ALTER TABLE {table_name} {on_cluster_clause}
-    ADD COLUMN IF NOT EXISTS header_names Array(String),
-    ADD COLUMN IF NOT EXISTS header_values Array(String)
+    ADD COLUMN IF NOT EXISTS consumer_breadcrumbs Array(String)
 """
 
 # DROP KAFKA TABLE

--- a/posthog/clickhouse/migrations/0113_add_kafka_consumer_breadcrumbs.py
+++ b/posthog/clickhouse/migrations/0113_add_kafka_consumer_breadcrumbs.py
@@ -7,7 +7,8 @@ from posthog.models.event.sql import (
 
 ALTER_EVENTS_TABLE_ADD_BREADCRUMBS_COLUMN = """
 ALTER TABLE {table_name} {on_cluster_clause}
-    ADD COLUMN IF NOT EXISTS _kafka_consumer_breadcrumbs Nullable(String)
+    ADD COLUMN IF NOT EXISTS header_names Array(String),
+    ADD COLUMN IF NOT EXISTS header_values Array(String)
 """
 
 # DROP KAFKA TABLE

--- a/posthog/clickhouse/migrations/0113_add_kafka_consumer_breadcrumbs.py
+++ b/posthog/clickhouse/migrations/0113_add_kafka_consumer_breadcrumbs.py
@@ -49,9 +49,9 @@ def ADD_BREADCRUMBS_COLUMNS_SHARDED_EVENTS_TABLE_SQL(on_cluster=True):
 
 operations = [
     # First drop the materialized view
-    run_sql_with_exceptions(DROP_EVENTS_TABLE_JSON_MV, NodeRole.WRITE),
+    run_sql_with_exceptions(DROP_EVENTS_TABLE_JSON_MV()),
     # then drop the kafka table
-    run_sql_with_exceptions(DROP_KAFKA_EVENTS_TABLE_JSON, NodeRole.WRITE),
+    run_sql_with_exceptions(DROP_KAFKA_EVENTS_TABLE_JSON()),
     # add missing columns to all tables in correct order
     # first the sharded tables
     run_sql_with_exceptions(ADD_BREADCRUMBS_COLUMNS_SHARDED_EVENTS_TABLE_SQL()),

--- a/posthog/clickhouse/migrations/0113_add_kafka_consumer_breadcrumbs.py
+++ b/posthog/clickhouse/migrations/0113_add_kafka_consumer_breadcrumbs.py
@@ -29,19 +29,19 @@ def DROP_EVENTS_TABLE_JSON_MV(on_cluster=True):
     return DROP_EVENTS_TABLE_JSON_MV_TEMPLATE.format(on_cluster_clause=ON_CLUSTER_CLAUSE(on_cluster))
 
 
-def ADD_BREADRUMBS_COLUMNS_DISTRIBUTED_EVENTS_TABLE_SQL(on_cluster=True):
+def ADD_BREADCRUMBS_COLUMNS_DISTRIBUTED_EVENTS_TABLE_SQL(on_cluster=True):
     return ALTER_EVENTS_TABLE_ADD_BREADCRUMBS_COLUMN.format(
         table_name="events", on_cluster_clause=ON_CLUSTER_CLAUSE(on_cluster)
     )
 
 
-def ADD_BREADRUMBS_COLUMNS_WRITABLE_EVENTS_TABLE_SQL(on_cluster=True):
+def ADD_BREADCRUMBS_COLUMNS_WRITABLE_EVENTS_TABLE_SQL(on_cluster=True):
     return ALTER_EVENTS_TABLE_ADD_BREADCRUMBS_COLUMN.format(
         table_name="writable_events", on_cluster_clause=ON_CLUSTER_CLAUSE(on_cluster)
     )
 
 
-def ADD_BREADRUMBS_COLUMNS_SHARDED_EVENTS_TABLE_SQL(on_cluster=True):
+def ADD_BREADCRUMBS_COLUMNS_SHARDED_EVENTS_TABLE_SQL(on_cluster=True):
     return ALTER_EVENTS_TABLE_ADD_BREADCRUMBS_COLUMN.format(
         table_name="sharded_events", on_cluster_clause=ON_CLUSTER_CLAUSE(on_cluster)
     )
@@ -50,15 +50,16 @@ def ADD_BREADRUMBS_COLUMNS_SHARDED_EVENTS_TABLE_SQL(on_cluster=True):
 operations = [
     # First drop the materialized view
     run_sql_with_exceptions(DROP_EVENTS_TABLE_JSON_MV, NodeRole.WRITE),
+    # then drop the kafka table
     run_sql_with_exceptions(DROP_KAFKA_EVENTS_TABLE_JSON, NodeRole.WRITE),
     # add missing columns to all tables in correct order
     # first the sharded tables
-    run_sql_with_exceptions(ADD_BREADRUMBS_COLUMNS_SHARDED_EVENTS_TABLE_SQL()),
+    run_sql_with_exceptions(ADD_BREADCRUMBS_COLUMNS_SHARDED_EVENTS_TABLE_SQL()),
     # second, add missing columns to writable table
-    run_sql_with_exceptions(ADD_BREADRUMBS_COLUMNS_WRITABLE_EVENTS_TABLE_SQL()),
+    run_sql_with_exceptions(ADD_BREADCRUMBS_COLUMNS_WRITABLE_EVENTS_TABLE_SQL()),
     # third,add missing columns to distributed table
     run_sql_with_exceptions(
-        ADD_BREADRUMBS_COLUMNS_DISTRIBUTED_EVENTS_TABLE_SQL(on_cluster=False), node_role=NodeRole.COORDINATOR
+        ADD_BREADCRUMBS_COLUMNS_DISTRIBUTED_EVENTS_TABLE_SQL(on_cluster=False), node_role=NodeRole.COORDINATOR
     ),
     # recreate the kafka table
     run_sql_with_exceptions(KAFKA_EVENTS_TABLE_JSON_SQL()),

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -27,7 +27,7 @@
       group4_created_at DateTime64,
       person_mode Enum8('full' = 0, 'propertyless' = 1, 'force_upgrade' = 2)
       
-      , _headers Array(Tuple(String, String))
+      
       
   ) ENGINE = Kafka('kafka:9092', 'clickhouse_events_json_test', 'group1', 'JSONEachRow')
   
@@ -143,7 +143,7 @@
       group4_created_at DateTime64,
       person_mode Enum8('full' = 0, 'propertyless' = 1, 'force_upgrade' = 2)
       
-      , _headers Array(Tuple(String, String))
+      
       
   ) ENGINE = Kafka('test.kafka.broker:9092', 'clickhouse_events_json_test', 'group1', 'JSONEachRow')
   
@@ -868,7 +868,13 @@
   person_mode,
   _timestamp,
   _offset,
-  arrayFirst(x -> x.1 = 'kafka-consumer-breadcrumb', _headers).2 as _kafka_consumer_breadcrumbs
+  arrayMap(
+      i -> _headers.value[i],
+      arrayFilter(
+          i -> _headers.name[i] = 'kafka-consumer-breadcrumbs',
+          arrayEnumerate(_headers.name)
+      )
+  ) as consumer_breadcrumbs
   FROM posthog_test.kafka_events_json
   
   '''
@@ -1203,7 +1209,7 @@
       group4_created_at DateTime64,
       person_mode Enum8('full' = 0, 'propertyless' = 1, 'force_upgrade' = 2)
       
-      , _headers Array(Tuple(String, String))
+      
       
   ) ENGINE = Kafka('kafka:9092', 'clickhouse_events_json_test', 'group1', 'JSONEachRow')
   
@@ -2696,7 +2702,7 @@
       
   , _timestamp DateTime
   , _offset UInt64
-  , inserted_at Nullable(DateTime64(6, 'UTC')) DEFAULT NOW64(), _kafka_consumer_breadcrumbs Nullable(String)
+  , inserted_at Nullable(DateTime64(6, 'UTC')) DEFAULT NOW64(), consumer_breadcrumbs Array(String)
       
       , INDEX kafka_timestamp_minmax_sharded_events _timestamp TYPE minmax GRANULARITY 3
       
@@ -3979,7 +3985,7 @@
       
   , _timestamp DateTime
   , _offset UInt64
-  , inserted_at Nullable(DateTime64(6, 'UTC')) DEFAULT NOW64(), _kafka_consumer_breadcrumbs Nullable(String)
+  , inserted_at Nullable(DateTime64(6, 'UTC')) DEFAULT NOW64(), consumer_breadcrumbs Array(String)
       
       , INDEX kafka_timestamp_minmax_sharded_events _timestamp TYPE minmax GRANULARITY 3
       

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -27,7 +27,7 @@
       group4_created_at DateTime64,
       person_mode Enum8('full' = 0, 'propertyless' = 1, 'force_upgrade' = 2)
       
-      
+      , _headers Array(Tuple(String, String))
       
   ) ENGINE = Kafka('kafka:9092', 'clickhouse_events_json_test', 'group1', 'JSONEachRow')
   
@@ -143,7 +143,7 @@
       group4_created_at DateTime64,
       person_mode Enum8('full' = 0, 'propertyless' = 1, 'force_upgrade' = 2)
       
-      
+      , _headers Array(Tuple(String, String))
       
   ) ENGINE = Kafka('test.kafka.broker:9092', 'clickhouse_events_json_test', 'group1', 'JSONEachRow')
   
@@ -867,7 +867,8 @@
   group4_created_at,
   person_mode,
   _timestamp,
-  _offset
+  _offset,
+  arrayFirst(x -> x.1 = 'kafka-consumer-breadcrumb', _headers).2 as _kafka_consumer_breadcrumbs
   FROM posthog_test.kafka_events_json
   
   '''
@@ -1202,7 +1203,7 @@
       group4_created_at DateTime64,
       person_mode Enum8('full' = 0, 'propertyless' = 1, 'force_upgrade' = 2)
       
-      
+      , _headers Array(Tuple(String, String))
       
   ) ENGINE = Kafka('kafka:9092', 'clickhouse_events_json_test', 'group1', 'JSONEachRow')
   
@@ -2695,7 +2696,7 @@
       
   , _timestamp DateTime
   , _offset UInt64
-  , inserted_at Nullable(DateTime64(6, 'UTC')) DEFAULT NOW64()
+  , inserted_at Nullable(DateTime64(6, 'UTC')) DEFAULT NOW64(), _kafka_consumer_breadcrumbs Nullable(String)
       
       , INDEX kafka_timestamp_minmax_sharded_events _timestamp TYPE minmax GRANULARITY 3
       
@@ -3978,7 +3979,7 @@
       
   , _timestamp DateTime
   , _offset UInt64
-  , inserted_at Nullable(DateTime64(6, 'UTC')) DEFAULT NOW64()
+  , inserted_at Nullable(DateTime64(6, 'UTC')) DEFAULT NOW64(), _kafka_consumer_breadcrumbs Nullable(String)
       
       , INDEX kafka_timestamp_minmax_sharded_events _timestamp TYPE minmax GRANULARITY 3
       

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -211,7 +211,7 @@ group4_created_at,
 person_mode,
 _timestamp,
 _offset,
-arrayFirst(x -> x.1 = 'kafka-consumer-breadcrumb', _headers).2 as _kafka_consumer_breadcrumbs
+CAST(arrayFirst(x -> x.1 = 'kafka-consumer-breadcrumb', _headers).2 AS Nullable(String)) as _kafka_consumer_breadcrumbs
 FROM {database}.kafka_events_json
 """.format(
         target_table=WRITABLE_EVENTS_DATA_TABLE(),

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -212,8 +212,13 @@ group4_created_at,
 person_mode,
 _timestamp,
 _offset,
-_headers.name as header_names,
-_headers.value as header_values
+arrayMap(
+    i -> _headers.value[i],
+    arrayFilter(
+        i -> _headers.name[i] = 'kafka-consumer-breadcrumbs',
+        arrayEnumerate(_headers.name)
+    )
+) as consumer_breadcrumbs
 FROM {database}.kafka_events_json
 """.format(
         target_table=WRITABLE_EVENTS_DATA_TABLE(),

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -176,7 +176,7 @@ def KAFKA_EVENTS_TABLE_JSON_SQL():
         table_name="kafka_events_json",
         on_cluster_clause=ON_CLUSTER_CLAUSE(),
         engine=kafka_engine(topic=KAFKA_EVENTS_JSON),
-        extra_fields=", _headers Array(Tuple(String, String))",  # NICKS TODOD: do we want to make this string a constatn?
+        extra_fields=", _headers Array(Tuple(String, String))",
         materialized_columns="",
         indexes="",
     )

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -49,6 +49,7 @@ DROP_DISTRIBUTED_EVENTS_TABLE_SQL = f"DROP TABLE IF EXISTS events {ON_CLUSTER_CL
 
 INSERTED_AT_COLUMN = ", inserted_at Nullable(DateTime64(6, 'UTC')) DEFAULT NOW64()"
 INSERTED_AT_NOT_NULLABLE_COLUMN = ", inserted_at DateTime64(6, 'UTC') DEFAULT NOW64()"
+KAFKA_CONSUMER_BREADCRUMBS_COLUMN = ", _kafka_consumer_breadcrumbs Nullable(String)"
 
 EVENTS_TABLE_BASE_SQL = """
 CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
@@ -137,7 +138,7 @@ ORDER BY (team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64
         table_name=EVENTS_DATA_TABLE(),
         on_cluster_clause=ON_CLUSTER_CLAUSE(),
         engine=EVENTS_DATA_TABLE_ENGINE(),
-        extra_fields=KAFKA_COLUMNS + INSERTED_AT_COLUMN,
+        extra_fields=KAFKA_COLUMNS + INSERTED_AT_COLUMN + KAFKA_CONSUMER_BREADCRUMBS_COLUMN,
         materialized_columns=EVENTS_TABLE_MATERIALIZED_COLUMNS,
         indexes=f"""
     , {index_by_kafka_timestamp(EVENTS_DATA_TABLE())}
@@ -175,7 +176,7 @@ def KAFKA_EVENTS_TABLE_JSON_SQL():
         table_name="kafka_events_json",
         on_cluster_clause=ON_CLUSTER_CLAUSE(),
         engine=kafka_engine(topic=KAFKA_EVENTS_JSON),
-        extra_fields="",
+        extra_fields=", _headers Array(Tuple(String, String))",  # NICKS TODOD: do we want to make this string a constatn?
         materialized_columns="",
         indexes="",
     )
@@ -209,7 +210,8 @@ group3_created_at,
 group4_created_at,
 person_mode,
 _timestamp,
-_offset
+_offset,
+arrayFirst(x -> x.1 = 'kafka-consumer-breadcrumb', _headers).2 as _kafka_consumer_breadcrumbs
 FROM {database}.kafka_events_json
 """.format(
         target_table=WRITABLE_EVENTS_DATA_TABLE(),


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We have no good way of finding where our events are being duplicated across the ingestion pipeline.

In related [PR](https://github.com/PostHog/posthog/pull/31201) we add an array of breadcrumbs under the 'kafka-consumer-breadcrumbs' key to the header of our kafka messages that are enqueued to the clickhouse topic.

## Changes

A data migration to include the headers as an extra field we pull in from the kafka engine table, then pass on as a top level column to the `events` table.

## Does this work well for both Cloud and self-hosted?

Doesn't have impact

## How did you test this code?

Tested this code through running the migrations locally and then watching events come in and being able to query them from the materialized view in clickhouse.
example query:
```
curl -X POST 'http://localhost:8123/' \
  -H 'Content-Type: text/plain' \
  --data 'SELECT consumer_breadcrumbs from events ORDER BY timestamp DESC limit 10' 
['[{"topic":"events_plugin_ingestion","partition":0,"offset":8,"processed_at":"2025-04-22T03:48:29.600Z","consumer_id":"clickhouse-ingestion"}]']
['[{"topic":"events_plugin_ingestion","partition":0,"offset":7,"processed_at":"2025-04-22T03:48:30.840Z","consumer_id":"clickhouse-ingestion"}]']
['[{"topic":"events_plugin_ingestion","partition":0,"offset":11,"processed_at":"2025-04-22T03:48:30.932Z","consumer_id":"clickhouse-ingestion"}]']
['[{"topic":"events_plugin_ingestion","partition":0,"offset":10,"processed_at":"2025-04-22T03:48:30.850Z","consumer_id":"clickhouse-ingestion"}]']
['[{"topic":"events_plugin_ingestion","partition":0,"offset":9,"processed_at":"2025-04-22T03:48:30.847Z","consumer_id":"clickhouse-ingestion"}]']
['[{"topic":"events_plugin_ingestion","partition":0,"offset":6,"processed_at":"2025-04-22T03:48:30.282Z","consumer_id":"clickhouse-ingestion"}]']
['[{"topic":"events_plugin_ingestion","partition":0,"offset":5,"processed_at":"2025-04-22T03:48:30.279Z","consumer_id":"clickhouse-ingestion"}]']
['[{"topic":"events_plugin_ingestion","partition":0,"offset":4,"processed_at":"2025-04-22T03:48:29.600Z","consumer_id":"clickhouse-ingestion"}]']
```