### PR TITLE
feat(crm): Add a few more insights to the group overview

### DIFF
--- a/frontend/src/scenes/groups/cards/GroupDashboardCard.tsx
+++ b/frontend/src/scenes/groups/cards/GroupDashboardCard.tsx
@@ -59,7 +59,7 @@ export function GroupDashboardCard(): JSX.Element {
         <div className="flex flex-col gap-4">
             <div className="grid grid-cols-2 gap-2">
                 <QueryCard
-                    title="Top pageviews by path"
+                    title="Top paths"
                     description={`Shows the most popular pages viewed by this ${groupTypeName} in the last 30 days`}
                     query={
                         {

--- a/frontend/src/scenes/groups/cards/GroupDashboardCard.tsx
+++ b/frontend/src/scenes/groups/cards/GroupDashboardCard.tsx
@@ -224,9 +224,9 @@ export function GroupDashboardCard(): JSX.Element {
                     description={`Shows the number of users from this ${groupTypeName} who returned seven days after their first visit`}
                     query={
                         {
-                            kind: 'InsightVizNode',
+                            kind: NodeKind.InsightVizNode,
                             source: {
-                                kind: 'RetentionQuery',
+                                kind: NodeKind.RetentionQuery,
                                 retentionFilter: {
                                     period: 'Day',
                                     targetEntity: {

--- a/frontend/src/scenes/groups/cards/GroupDashboardCard.tsx
+++ b/frontend/src/scenes/groups/cards/GroupDashboardCard.tsx
@@ -57,37 +57,168 @@ export function GroupDashboardCard(): JSX.Element {
 
     return (
         <div className="flex flex-col gap-4">
-            <QueryCard
-                title="Weekly active users"
-                description={`Shows the number of unique users from this ${groupTypeName} in the last 90 days`}
-                query={
-                    {
-                        kind: NodeKind.InsightVizNode,
-                        source: {
-                            kind: NodeKind.TrendsQuery,
-                            interval: 'week',
-                            dateRange: {
-                                date_from: '-90d',
-                            },
-                            series: [
-                                {
-                                    kind: NodeKind.EventsNode,
-                                    math: 'dau',
-                                    event: null,
-                                    properties: [
+            <div className="grid grid-cols-2 gap-2">
+                <QueryCard
+                    title="Top pageviews by path"
+                    description={`Shows the most popular pages viewed by this ${groupTypeName} in the last 30 days`}
+                    query={
+                        {
+                            kind: NodeKind.InsightVizNode,
+                            source: {
+                                kind: NodeKind.TrendsQuery,
+                                series: [
+                                    {
+                                        kind: NodeKind.EventsNode,
+                                        event: '$pageview',
+                                        name: '$pageview',
+                                        properties: [
+                                            {
+                                                key: '$pathname',
+                                                value: ['/'],
+                                                operator: 'is_not',
+                                                type: 'event',
+                                            },
+                                            {
+                                                key: `$group_${groupData.group_type_index}`,
+                                                value: groupData.group_key,
+                                                operator: PropertyOperator.Exact,
+                                            },
+                                        ],
+                                        math: 'unique_session',
+                                    },
+                                ],
+                                trendsFilter: {
+                                    display: 'ActionsBarValue',
+                                },
+                                breakdownFilter: {
+                                    breakdowns: [
                                         {
-                                            key: `$group_${groupData.group_type_index}`,
-                                            value: groupData.group_key,
-                                            operator: PropertyOperator.Exact,
+                                            property: '$pathname',
+                                            type: 'event',
+                                            normalize_url: true,
                                         },
                                     ],
                                 },
-                            ],
-                        },
-                    } as Node
-                }
-                context={{ refresh: 'force_blocking' }}
-            />
+                                dateRange: {
+                                    date_from: '-30d',
+                                    date_to: null,
+                                    explicitDate: false,
+                                },
+                                interval: 'day',
+                            },
+                            full: true,
+                        } as Node
+                    }
+                    context={{ refresh: 'force_blocking' }}
+                />
+                <QueryCard
+                    title="Weekly active users"
+                    description={`Shows the number of unique users from this ${groupTypeName} in the last 90 days`}
+                    query={
+                        {
+                            kind: NodeKind.InsightVizNode,
+                            source: {
+                                kind: NodeKind.TrendsQuery,
+                                interval: 'week',
+                                dateRange: {
+                                    date_from: '-90d',
+                                },
+                                series: [
+                                    {
+                                        kind: NodeKind.EventsNode,
+                                        math: 'dau',
+                                        event: null,
+                                        properties: [
+                                            {
+                                                key: `$group_${groupData.group_type_index}`,
+                                                value: groupData.group_key,
+                                                operator: PropertyOperator.Exact,
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        } as Node
+                    }
+                    context={{ refresh: 'force_blocking' }}
+                />
+                <QueryCard
+                    title="Monthly active users"
+                    description={`Shows the number of unique users from this ${groupTypeName} in the last year`}
+                    query={
+                        {
+                            kind: NodeKind.InsightVizNode,
+                            source: {
+                                kind: NodeKind.TrendsQuery,
+                                interval: 'month',
+                                dateRange: {
+                                    date_from: '-365d',
+                                },
+                                series: [
+                                    {
+                                        kind: NodeKind.EventsNode,
+                                        math: 'dau',
+                                        event: null,
+                                        properties: [
+                                            {
+                                                key: `$group_${groupData.group_type_index}`,
+                                                value: groupData.group_key,
+                                                operator: PropertyOperator.Exact,
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        } as Node
+                    }
+                    context={{ refresh: 'force_blocking' }}
+                />
+                <QueryCard
+                    title="Retained users"
+                    description={`Shows the number of users from this ${groupTypeName} who returned seven days after their first visit`}
+                    query={
+                        {
+                            kind: 'InsightVizNode',
+                            source: {
+                                kind: 'RetentionQuery',
+                                retentionFilter: {
+                                    period: 'Day',
+                                    targetEntity: {
+                                        id: '$pageview',
+                                        name: '$pageview',
+                                        type: 'events',
+                                    },
+                                    retentionType: 'retention_first_time',
+                                    totalIntervals: 8,
+                                    returningEntity: {
+                                        id: '$pageview',
+                                        name: '$pageview',
+                                        type: 'events',
+                                    },
+                                    meanRetentionCalculation: 'simple',
+                                },
+                                properties: {
+                                    type: 'AND',
+                                    values: [
+                                        {
+                                            type: 'AND',
+                                            values: [
+                                                {
+                                                    type: 'hogql',
+                                                    key: `$group_${groupData.group_type_index}='${groupData.group_key}'`,
+                                                    value: null,
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            },
+                            full: true,
+                        } as Node
+                    }
+                    context={{ refresh: 'force_blocking' }}
+                />
+            </div>
             <div className="flex justify-end">
                 <LemonButton
                     type="secondary"

--- a/frontend/src/scenes/groups/cards/GroupDashboardCard.tsx
+++ b/frontend/src/scenes/groups/cards/GroupDashboardCard.tsx
@@ -112,6 +112,52 @@ export function GroupDashboardCard(): JSX.Element {
                     context={{ refresh: 'force_blocking' }}
                 />
                 <QueryCard
+                    title="Top events"
+                    description={`Shows the most popular events by this ${groupTypeName} in the last 30 days`}
+                    query={
+                        {
+                            kind: NodeKind.InsightVizNode,
+                            source: {
+                                kind: NodeKind.TrendsQuery,
+                                series: [
+                                    {
+                                        kind: NodeKind.EventsNode,
+                                        event: null,
+                                        name: 'All events',
+                                        properties: [
+                                            {
+                                                key: `$group_${groupData.group_type_index}`,
+                                                value: groupData.group_key,
+                                                operator: PropertyOperator.Exact,
+                                            },
+                                        ],
+                                        math: 'total',
+                                    },
+                                ],
+                                trendsFilter: {
+                                    display: 'ActionsBarValue',
+                                },
+                                breakdownFilter: {
+                                    breakdowns: [
+                                        {
+                                            property: 'event',
+                                            type: 'event_metadata',
+                                        },
+                                    ],
+                                },
+                                dateRange: {
+                                    date_from: '-30d',
+                                    date_to: null,
+                                    explicitDate: false,
+                                },
+                                interval: 'day',
+                            },
+                            full: true,
+                        } as Node
+                    }
+                    context={{ refresh: 'force_blocking' }}
+                />
+                <QueryCard
                     title="Weekly active users"
                     description={`Shows the number of unique users from this ${groupTypeName} in the last 90 days`}
                     query={

--- a/posthog/api/test/dashboards/test_dashboard_duplication.py
+++ b/posthog/api/test/dashboards/test_dashboard_duplication.py
@@ -42,17 +42,21 @@ class TestDashboardDuplication(APIBaseTest, QueryMatchingTest):
             },
         ).json()
 
-        assert len(duplicated_dashboard["tiles"]) == 2
-        # always makes new tiles
-        assert [tile["id"] for tile in duplicated_dashboard["tiles"]] != self.tile_ids
-        # makes new children
-        assert self.original_child_ids != self._tile_child_ids_from(duplicated_dashboard)
+        # Get only the tiles that match our original dashboard's tiles
+        original_tile_ids = set(self.tile_ids)
+        duplicated_tiles = [tile for tile in duplicated_dashboard["tiles"] if tile["id"] not in original_tile_ids]
 
-        assert [tile["color"] for tile in duplicated_dashboard["tiles"]] == [
+        assert len(duplicated_tiles) == 2
+        # always makes new tiles
+        assert [tile["id"] for tile in duplicated_tiles] != self.tile_ids
+        # makes new children
+        assert sorted(self.original_child_ids) != sorted(self._tile_child_ids_from({"tiles": duplicated_tiles}))
+
+        assert [tile["color"] for tile in duplicated_tiles] == [
             self.tile_color,
             self.tile_color,
         ]
-        assert [tile["layouts"] for tile in duplicated_dashboard["tiles"]] == [
+        assert [tile["layouts"] for tile in duplicated_tiles] == [
             self.tile_layout,
             self.tile_layout,
         ]
@@ -67,17 +71,21 @@ class TestDashboardDuplication(APIBaseTest, QueryMatchingTest):
             },
         ).json()
 
-        assert len(duplicated_dashboard["tiles"]) == 2
-        # always makes new tiles
-        assert [tile["id"] for tile in duplicated_dashboard["tiles"]] != self.tile_ids
-        # uses existing children
-        assert self.original_child_ids == self._tile_child_ids_from(duplicated_dashboard)
+        # Get only the tiles that match our original dashboard's tiles
+        original_tile_ids = set(self.tile_ids)
+        duplicated_tiles = [tile for tile in duplicated_dashboard["tiles"] if tile["id"] not in original_tile_ids]
 
-        assert [tile["color"] for tile in duplicated_dashboard["tiles"]] == [
+        assert len(duplicated_tiles) == 2
+        # always makes new tiles
+        assert [tile["id"] for tile in duplicated_tiles] != self.tile_ids
+        # uses existing children
+        assert sorted(self.original_child_ids) == sorted(self._tile_child_ids_from({"tiles": duplicated_tiles}))
+
+        assert [tile["color"] for tile in duplicated_tiles] == [
             self.tile_color,
             self.tile_color,
         ]
-        assert [tile["layouts"] for tile in duplicated_dashboard["tiles"]] == [
+        assert [tile["layouts"] for tile in duplicated_tiles] == [
             self.tile_layout,
             self.tile_layout,
         ]

--- a/posthog/helpers/dashboard_templates.py
+++ b/posthog/helpers/dashboard_templates.py
@@ -844,6 +844,7 @@ def create_group_type_mapping_detail_dashboard(group_type_mapping, user) -> Dash
 
     for index, configuration in enumerate(configurations):
         x = 6 if index % 2 == 1 else 0
+        y = 5 * (index // 2)
         insight = Insight.objects.create(
             team=dashboard.team,
             name=str(configuration["name"]),
@@ -855,7 +856,7 @@ def create_group_type_mapping_detail_dashboard(group_type_mapping, user) -> Dash
             insight=insight,
             dashboard=dashboard,
             layouts={
-                "sm": {"h": 5, "w": 6, "x": x, "y": 0, "minH": 1, "minW": 1},
+                "sm": {"h": 5, "w": 6, "x": x, "y": y, "minH": 1, "minW": 1},
                 "xs": {"h": 5, "w": 1, "x": 0, "y": 0, "minH": 1, "minW": 1},
             },
             color=None,
@@ -866,7 +867,7 @@ def create_group_type_mapping_detail_dashboard(group_type_mapping, user) -> Dash
                 "i": str(tile.id),
                 "w": 6,
                 "x": x,
-                "y": 0,
+                "y": y,
                 "minH": 1,
                 "minW": 1,
             },

--- a/posthog/helpers/dashboard_templates.py
+++ b/posthog/helpers/dashboard_templates.py
@@ -828,8 +828,8 @@ def create_group_type_mapping_detail_dashboard(group_type_mapping, user) -> Dash
         x = 6 if index % 2 == 1 else 0
         insight = Insight.objects.create(
             team=dashboard.team,
-            name=configuration["name"],
-            description=configuration["description"],
+            name=str(configuration["name"]),
+            description=str(configuration["description"]),
             is_sample=True,
             query=configuration["query"],
         )

--- a/posthog/helpers/dashboard_templates.py
+++ b/posthog/helpers/dashboard_templates.py
@@ -705,58 +705,157 @@ def create_group_type_mapping_detail_dashboard(group_type_mapping, user) -> Dash
         creation_mode="template",
     )
 
-    insight = Insight.objects.create(
-        team=dashboard.team,
-        name="Weekly active users",
-        description=f"Shows the number of unique users from this {singular} in the last 90 days",
-        is_sample=True,
-        query={
-            "kind": "InsightVizNode",
-            "source": {
-                "dateRange": {"date_from": "-90d", "explicitDate": False},
-                "filterTestAccounts": False,
-                "interval": "week",
-                "kind": "TrendsQuery",
-                "properties": [],
-                "series": [{"event": None, "kind": "EventsNode", "math": "dau"}],
-                "trendsFilter": {
-                    "aggregationAxisFormat": "numeric",
-                    "display": "ActionsLineGraph",
-                    "showAlertThresholdLines": False,
-                    "showLegend": False,
-                    "showPercentStackView": False,
-                    "showValuesOnSeries": False,
-                    "smoothingIntervals": 1,
-                    "yAxisScaleType": "linear",
+    configurations = [
+        {
+            "name": "Top pageviews by path",
+            "description": f"Shows the most popular pages viewed by this {singular} in the last 30 days",
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [
+                        {
+                            "kind": "EventsNode",
+                            "event": "$pageview",
+                            "name": "$pageview",
+                            "properties": [
+                                {
+                                    "key": "$pathname",
+                                    "value": ["/"],
+                                    "operator": "is_not",
+                                    "type": "event",
+                                },
+                            ],
+                            "math": "unique_session",
+                        },
+                    ],
+                    "trendsFilter": {
+                        "display": "ActionsBarValue",
+                    },
+                    "breakdownFilter": {
+                        "breakdown": "$pathname",
+                        "breakdown_type": "event",
+                    },
+                    "dateRange": {
+                        "date_from": "-30d",
+                        "date_to": None,
+                        "explicitDate": False,
+                    },
+                    "interval": "day",
+                },
+                "full": True,
+            },
+        },
+        {
+            "name": "Weekly active users",
+            "description": f"Shows the number of unique users from this {singular} in the last 90 days",
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "dateRange": {"date_from": "-90d", "explicitDate": False},
+                    "filterTestAccounts": False,
+                    "interval": "week",
+                    "kind": "TrendsQuery",
+                    "properties": [],
+                    "series": [{"event": None, "kind": "EventsNode", "math": "dau"}],
+                    "trendsFilter": {
+                        "aggregationAxisFormat": "numeric",
+                        "display": "ActionsLineGraph",
+                        "showAlertThresholdLines": False,
+                        "showLegend": False,
+                        "showPercentStackView": False,
+                        "showValuesOnSeries": False,
+                        "smoothingIntervals": 1,
+                        "yAxisScaleType": "linear",
+                    },
                 },
             },
         },
-    )
-    tile = DashboardTile.objects.create(
-        insight=insight,
-        dashboard=dashboard,
-        layouts={
-            "sm": {"h": 5, "w": 12, "x": 0, "y": 0, "minH": 1, "minW": 1, "moved": False, "static": False},
-            "xs": {"h": 5, "w": 1, "x": 0, "y": 0, "minH": 1, "minW": 1},
+        {
+            "name": "Monthly active users",
+            "description": f"Shows the number of unique users from this {singular} in the last year",
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "dateRange": {"date_from": "-365d", "explicitDate": False},
+                    "filterTestAccounts": False,
+                    "interval": "month",
+                    "kind": "TrendsQuery",
+                    "properties": [],
+                    "series": [{"event": None, "kind": "EventsNode", "math": "dau"}],
+                    "trendsFilter": {
+                        "aggregationAxisFormat": "numeric",
+                        "display": "ActionsLineGraph",
+                        "showAlertThresholdLines": False,
+                        "showLegend": False,
+                        "showPercentStackView": False,
+                        "showValuesOnSeries": False,
+                        "smoothingIntervals": 1,
+                        "yAxisScaleType": "linear",
+                    },
+                },
+            },
         },
-        color=None,
-    )
-    tile.layouts = {
-        "sm": {
-            "h": 5,
-            "i": str(tile.id),
-            "w": 12,
-            "x": 0,
-            "y": 0,
-            "minH": 1,
-            "minW": 1,
-            "moved": False,
-            "static": False,
+        {
+            "name": "Retained users",
+            "description": f"Shows the number of users from this {singular} who returned seven days after their first visit",
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "RetentionQuery",
+                    "retentionFilter": {
+                        "period": "Day",
+                        "targetEntity": {
+                            "id": "$pageview",
+                            "name": "$pageview",
+                            "type": "events",
+                        },
+                        "retentionType": "retention_first_time",
+                        "totalIntervals": 8,
+                        "returningEntity": {
+                            "id": "$pageview",
+                            "name": "$pageview",
+                            "type": "events",
+                        },
+                        "meanRetentionCalculation": "simple",
+                    },
+                },
+            },
         },
-        "xs": {"h": 5, "i": str(tile.id), "w": 1, "x": 0, "y": 0, "minH": 1, "minW": 1},
-    }
-    tile.last_refresh = None
-    tile.save()
+    ]
+
+    for index, configuration in enumerate(configurations):
+        x = 6 if index % 2 == 1 else 0
+        insight = Insight.objects.create(
+            team=dashboard.team,
+            name=configuration["name"],
+            description=configuration["description"],
+            is_sample=True,
+            query=configuration["query"],
+        )
+        tile = DashboardTile.objects.create(
+            insight=insight,
+            dashboard=dashboard,
+            layouts={
+                "sm": {"h": 5, "w": 6, "x": x, "y": 0, "minH": 1, "minW": 1},
+                "xs": {"h": 5, "w": 1, "x": 0, "y": 0, "minH": 1, "minW": 1},
+            },
+            color=None,
+        )
+        tile.layouts = {
+            "sm": {
+                "h": 5,
+                "i": str(tile.id),
+                "w": 6,
+                "x": x,
+                "y": 0,
+                "minH": 1,
+                "minW": 1,
+            },
+            "xs": {"h": 5, "i": str(tile.id), "w": 1, "x": 0, "y": 0, "minH": 1, "minW": 1},
+        }
+        tile.last_refresh = None
+        tile.save()
 
     return dashboard
 

--- a/posthog/helpers/dashboard_templates.py
+++ b/posthog/helpers/dashboard_templates.py
@@ -707,7 +707,7 @@ def create_group_type_mapping_detail_dashboard(group_type_mapping, user) -> Dash
 
     configurations = [
         {
-            "name": "Top pageviews by path",
+            "name": "Top paths",
             "description": f"Shows the most popular pages viewed by this {singular} in the last 30 days",
             "query": {
                 "kind": "InsightVizNode",

--- a/posthog/helpers/dashboard_templates.py
+++ b/posthog/helpers/dashboard_templates.py
@@ -747,6 +747,24 @@ def create_group_type_mapping_detail_dashboard(group_type_mapping, user) -> Dash
             },
         },
         {
+            "name": "Top events",
+            "description": f"Shows the most popular events by this {singular} in the last 30 days",
+            "query": {
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [
+                        {"kind": "EventsNode", "event": None, "name": "All events", "properties": [], "math": "total"}
+                    ],
+                    "trendsFilter": {"display": "ActionsBarValue"},
+                    "breakdownFilter": {"breakdowns": [{"property": "event", "type": "event_metadata"}]},
+                    "dateRange": {"date_from": "-30d", "date_to": None, "explicitDate": False},
+                    "interval": "day",
+                },
+                "full": True,
+            },
+        },
+        {
             "name": "Weekly active users",
             "description": f"Shows the number of unique users from this {singular} in the last 90 days",
             "query": {


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/29881

## Changes

Adds Top Paths, Top Events, Monthly Active Users, and Retained Users to the group overview:

![CleanShot 2025-04-17 at 14 57 24@2x](https://github.com/user-attachments/assets/e95d7ed9-3b8d-4d43-a6dc-b9d7241860f3)

## How did you test this code?

I viewed the page and then tested creating a dashboard.