### PR TITLE
feat(web-analytics): using unique user for aggregations column and row

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -4647,10 +4647,7 @@
                     "description": "Query status indicates whether next to the provided data, a query is still running."
                 },
                 "results": {
-                    "items": {
-                        "$ref": "#/definitions/WebActiveHoursHeatMapResult"
-                    },
-                    "type": "array"
+                    "$ref": "#/definitions/WebActiveHoursHeatMapStructuredResult"
                 },
                 "timezone": {
                     "type": "string"
@@ -6314,10 +6311,7 @@
                                     "description": "Query status indicates whether next to the provided data, a query is still running."
                                 },
                                 "results": {
-                                    "items": {
-                                        "$ref": "#/definitions/WebActiveHoursHeatMapResult"
-                                    },
-                                    "type": "array"
+                                    "$ref": "#/definitions/WebActiveHoursHeatMapStructuredResult"
                                 },
                                 "timings": {
                                     "description": "Measured timings for different parts of the query generation process",
@@ -13663,10 +13657,7 @@
                             "description": "Query status indicates whether next to the provided data, a query is still running."
                         },
                         "results": {
-                            "items": {
-                                "$ref": "#/definitions/WebActiveHoursHeatMapResult"
-                            },
-                            "type": "array"
+                            "$ref": "#/definitions/WebActiveHoursHeatMapStructuredResult"
                         },
                         "timings": {
                             "description": "Measured timings for different parts of the query generation process",
@@ -14314,10 +14305,7 @@
                             "description": "Query status indicates whether next to the provided data, a query is still running."
                         },
                         "results": {
-                            "items": {
-                                "$ref": "#/definitions/WebActiveHoursHeatMapResult"
-                            },
-                            "type": "array"
+                            "$ref": "#/definitions/WebActiveHoursHeatMapStructuredResult"
                         },
                         "timings": {
                             "description": "Measured timings for different parts of the query generation process",
@@ -18212,6 +18200,48 @@
             },
             "type": "object"
         },
+        "WebActiveHoursHeatMapDayAndHourResult": {
+            "additionalProperties": false,
+            "properties": {
+                "day": {
+                    "$ref": "#/definitions/integer"
+                },
+                "hour": {
+                    "$ref": "#/definitions/integer"
+                },
+                "total": {
+                    "$ref": "#/definitions/integer"
+                }
+            },
+            "required": ["day", "hour", "total"],
+            "type": "object"
+        },
+        "WebActiveHoursHeatMapDayResult": {
+            "additionalProperties": false,
+            "properties": {
+                "day": {
+                    "$ref": "#/definitions/integer"
+                },
+                "total": {
+                    "$ref": "#/definitions/integer"
+                }
+            },
+            "required": ["day", "total"],
+            "type": "object"
+        },
+        "WebActiveHoursHeatMapHourResult": {
+            "additionalProperties": false,
+            "properties": {
+                "hour": {
+                    "$ref": "#/definitions/integer"
+                },
+                "total": {
+                    "$ref": "#/definitions/integer"
+                }
+            },
+            "required": ["hour", "total"],
+            "type": "object"
+        },
         "WebActiveHoursHeatMapQuery": {
             "additionalProperties": false,
             "properties": {
@@ -18303,10 +18333,7 @@
                     "description": "Query status indicates whether next to the provided data, a query is still running."
                 },
                 "results": {
-                    "items": {
-                        "$ref": "#/definitions/WebActiveHoursHeatMapResult"
-                    },
-                    "type": "array"
+                    "$ref": "#/definitions/WebActiveHoursHeatMapStructuredResult"
                 },
                 "timings": {
                     "description": "Measured timings for different parts of the query generation process",
@@ -18319,20 +18346,32 @@
             "required": ["results"],
             "type": "object"
         },
-        "WebActiveHoursHeatMapResult": {
+        "WebActiveHoursHeatMapStructuredResult": {
             "additionalProperties": false,
             "properties": {
-                "day": {
-                    "$ref": "#/definitions/integer"
+                "dayAndHours": {
+                    "items": {
+                        "$ref": "#/definitions/WebActiveHoursHeatMapDayAndHourResult"
+                    },
+                    "type": "array"
                 },
-                "hour": {
-                    "$ref": "#/definitions/integer"
+                "days": {
+                    "items": {
+                        "$ref": "#/definitions/WebActiveHoursHeatMapDayResult"
+                    },
+                    "type": "array"
+                },
+                "hours": {
+                    "items": {
+                        "$ref": "#/definitions/WebActiveHoursHeatMapHourResult"
+                    },
+                    "type": "array"
                 },
                 "total": {
                     "$ref": "#/definitions/integer"
                 }
             },
-            "required": ["day", "hour", "total"],
+            "required": ["dayAndHours", "days", "hours", "total"],
             "type": "object"
         },
         "WebAnalyticsConversionGoal": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2907,14 +2907,32 @@ export interface WebActiveHoursHeatMapQuery extends WebAnalyticsQueryBase<WebAct
     kind: NodeKind.WebActiveHoursHeatMapQuery
 }
 
-export interface WebActiveHoursHeatMapQueryResponse extends AnalyticsQueryResponseBase<WebActiveHoursHeatMapResult[]> {
+export interface WebActiveHoursHeatMapQueryResponse
+    extends AnalyticsQueryResponseBase<WebActiveHoursHeatMapStructuredResult> {
     hasMore?: boolean
     limit?: integer
 }
 
-export interface WebActiveHoursHeatMapResult {
+export interface WebActiveHoursHeatMapDayAndHourResult {
     day: integer
     hour: integer
+    total: integer
+}
+
+export interface WebActiveHoursHeatMapDayResult {
+    day: integer
+    total: integer
+}
+
+export interface WebActiveHoursHeatMapHourResult {
+    hour: integer
+    total: integer
+}
+
+export interface WebActiveHoursHeatMapStructuredResult {
+    dayAndHours: WebActiveHoursHeatMapDayAndHourResult[]
+    days: WebActiveHoursHeatMapDayResult[]
+    hours: WebActiveHoursHeatMapHourResult[]
     total: integer
 }
 

--- a/frontend/src/scenes/web-analytics/EventsHeatMap/EventsHeatMap.tsx
+++ b/frontend/src/scenes/web-analytics/EventsHeatMap/EventsHeatMap.tsx
@@ -235,7 +235,7 @@ function renderAggregationCells(
                 value={xAggregations[x]}
                 maxValue={maxXAggregation}
                 backgroundColor={aggregationColor}
-                dayAndTime={`All - ${String(x).padStart(2, '0')}:00`}
+                dayAndTime={`${AllLabel} - ${String(x).padStart(2, '0')}:00`}
             />
         </td>
     ))
@@ -257,7 +257,7 @@ function renderYAggregationCell(
                 value={value}
                 maxValue={maxYAggregation}
                 backgroundColor={aggregationColor}
-                dayAndTime={`All - ${day}`}
+                dayAndTime={`${AllLabel} - ${day}`}
             />
         </td>
     )

--- a/frontend/src/scenes/web-analytics/EventsHeatMap/EventsHeatMap.tsx
+++ b/frontend/src/scenes/web-analytics/EventsHeatMap/EventsHeatMap.tsx
@@ -16,7 +16,7 @@ import {
 } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 
-import { AllLabel, DaysAbbreviated, HoursAbbreviated } from './config'
+import { AggregationLabel, DaysAbbreviated, HoursAbbreviated } from './config'
 import { HeatMapCell } from './HeatMapCell'
 
 interface EventsHeatMapProps {
@@ -98,7 +98,9 @@ export function EventsHeatMap({ query, context, cachedResults }: EventsHeatMapPr
                         {HoursAbbreviated.values.map((label, i) => (
                             <th key={i}>{label}</th>
                         ))}
-                        {yAggregations[0] !== undefined && <th className="aggregation-border">{AllLabel}</th>}
+                        {yAggregations[0] !== undefined && (
+                            <th className="aggregation-border">{AggregationLabel.All}</th>
+                        )}
                     </tr>
 
                     {/* Data rows */}
@@ -119,7 +121,9 @@ export function EventsHeatMap({ query, context, cachedResults }: EventsHeatMapPr
 
                     {/* Aggregation row */}
                     <tr className="aggregation-border">
-                        {xAggregations[0] !== undefined && <td className="EventsHeatMap__TextTab">{AllLabel}</td>}
+                        {xAggregations[0] !== undefined && (
+                            <td className="EventsHeatMap__TextTab">{AggregationLabel.All}</td>
+                        )}
                         {renderAggregationCells(
                             xAggregations,
                             maxXAggregation,
@@ -214,7 +218,7 @@ function renderOverallCell(
                 value={overallValue}
                 maxValue={overallValue}
                 backgroundColor={backgroundColorOverall}
-                dayAndTime={AllLabel}
+                dayAndTime={AggregationLabel.All}
             />
         </td>
     )
@@ -235,7 +239,7 @@ function renderAggregationCells(
                 value={xAggregations[x]}
                 maxValue={maxXAggregation}
                 backgroundColor={aggregationColor}
-                dayAndTime={`${AllLabel} - ${String(x).padStart(2, '0')}:00`}
+                dayAndTime={`${AggregationLabel.All} - ${String(x).padStart(2, '0')}:00`}
             />
         </td>
     ))
@@ -257,7 +261,7 @@ function renderYAggregationCell(
                 value={value}
                 maxValue={maxYAggregation}
                 backgroundColor={aggregationColor}
-                dayAndTime={`${AllLabel} - ${day}`}
+                dayAndTime={`${AggregationLabel.All} - ${day}`}
             />
         </td>
     )

--- a/frontend/src/scenes/web-analytics/EventsHeatMap/EventsHeatMap.tsx
+++ b/frontend/src/scenes/web-analytics/EventsHeatMap/EventsHeatMap.tsx
@@ -8,12 +8,15 @@ import { useResizeObserver } from '~/lib/hooks/useResizeObserver'
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import {
     AnyResponseType,
+    WebActiveHoursHeatMapDayAndHourResult,
+    WebActiveHoursHeatMapDayResult,
+    WebActiveHoursHeatMapHourResult,
     WebActiveHoursHeatMapQuery,
-    WebActiveHoursHeatMapResult,
+    WebActiveHoursHeatMapStructuredResult,
 } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 
-import { DaysAbbreviated, HoursAbbreviated, Sum } from './config'
+import { AllLabel, DaysAbbreviated, HoursAbbreviated } from './config'
 import { HeatMapCell } from './HeatMapCell'
 
 interface EventsHeatMapProps {
@@ -73,7 +76,7 @@ export function EventsHeatMap({ query, context, cachedResults }: EventsHeatMapPr
         })
     )
 
-    const { matrix, maxValue, xAggregations, yAggregations, maxXAggregation, maxYAggregation, overallValue } =
+    const { matrix, maxOverall, xAggregations, yAggregations, maxXAggregation, maxYAggregation, overallValue } =
         processData(response?.results ?? [])
 
     const rotatedYLabels = [
@@ -95,14 +98,14 @@ export function EventsHeatMap({ query, context, cachedResults }: EventsHeatMapPr
                         {HoursAbbreviated.values.map((label, i) => (
                             <th key={i}>{label}</th>
                         ))}
-                        {yAggregations[0] !== undefined && <th className="aggregation-border">{Sum.label}</th>}
+                        {yAggregations[0] !== undefined && <th className="aggregation-border">{AllLabel}</th>}
                     </tr>
 
                     {/* Data rows */}
                     {rotatedYLabels.map((day, yIndex) => (
                         <tr key={yIndex}>
                             <td className="EventsHeatMap__TextTab">{day}</td>
-                            {renderDataCells(matrix[yIndex], maxValue, day, showTooltip, fontSize, heatmapColor)}
+                            {renderDataCells(matrix[yIndex], maxOverall, day, showTooltip, fontSize, heatmapColor)}
                             {renderYAggregationCell(
                                 yAggregations[yIndex],
                                 maxYAggregation,
@@ -116,7 +119,7 @@ export function EventsHeatMap({ query, context, cachedResults }: EventsHeatMapPr
 
                     {/* Aggregation row */}
                     <tr className="aggregation-border">
-                        {xAggregations[0] !== undefined && <td className="EventsHeatMap__TextTab">{Sum.label}</td>}
+                        {xAggregations[0] !== undefined && <td className="EventsHeatMap__TextTab">{AllLabel}</td>}
                         {renderAggregationCells(
                             xAggregations,
                             maxXAggregation,
@@ -132,9 +135,9 @@ export function EventsHeatMap({ query, context, cachedResults }: EventsHeatMapPr
     )
 }
 
-function processData(results: WebActiveHoursHeatMapResult[]): {
+function processData(results?: WebActiveHoursHeatMapStructuredResult): {
     matrix: { [key: number]: { [key: number]: number } }
-    maxValue: number
+    maxOverall: number
     xAggregations: { [key: number]: number }
     yAggregations: { [key: number]: number }
     maxXAggregation: number
@@ -142,9 +145,7 @@ function processData(results: WebActiveHoursHeatMapResult[]): {
     overallValue: number
 } {
     const matrix: { [key: number]: { [key: number]: number } } = {}
-    let maxValue = 0
-    let maxXAggregation = 0
-    let maxYAggregation = 0
+    let maxOverall = 0
 
     // Initialize matrix
     for (let i = 0; i < DaysAbbreviated.values.length; i++) {
@@ -154,42 +155,49 @@ function processData(results: WebActiveHoursHeatMapResult[]): {
         }
     }
 
-    // Fill matrix
-    results.forEach((result) => {
-        const adjustedDay =
-            (result.day - (DaysAbbreviated.startIndex || 0) + DaysAbbreviated.values.length) %
-            DaysAbbreviated.values.length
-        matrix[adjustedDay][result.hour] = result.total
-        maxValue = Math.max(maxValue, result.total)
-    })
-
-    // Calculate aggregations
-    const xAggregations = calculateXAggregations(matrix)
-    const yAggregations = calculateYAggregations(matrix)
-    maxXAggregation = Math.max(...Object.values(xAggregations))
-    maxYAggregation = Math.max(...Object.values(yAggregations))
-
-    const allValues = Object.values(matrix).flatMap((row) => Object.values(row))
-    const overallValue = Sum.fn(allValues)
-
-    return { matrix, maxValue, xAggregations, yAggregations, maxXAggregation, maxYAggregation, overallValue }
-}
-
-function calculateXAggregations(matrix: { [key: number]: { [key: number]: number } }): { [key: number]: number } {
-    const xAggregations: { [key: number]: number } = {}
-    for (let x = 0; x < HoursAbbreviated.values.length; x++) {
-        const values = Object.values(matrix).map((day) => day[x])
-        xAggregations[x] = Sum.fn(values)
+    // Fill matrix with day-hour combinations
+    if (results?.dayAndHours) {
+        results.dayAndHours.forEach((result: WebActiveHoursHeatMapDayAndHourResult) => {
+            const adjustedDay =
+                (result.day - (DaysAbbreviated.startIndex || 0) + DaysAbbreviated.values.length) %
+                DaysAbbreviated.values.length
+            matrix[adjustedDay][result.hour] = result.total
+            maxOverall = Math.max(maxOverall, result.total)
+        })
     }
-    return xAggregations
-}
 
-function calculateYAggregations(matrix: { [key: number]: { [key: number]: number } }): { [key: number]: number } {
-    const yAggregations: { [key: number]: number } = {}
-    for (let y = 0; y < DaysAbbreviated.values.length; y++) {
-        yAggregations[y] = Sum.fn(Object.values(matrix[y]))
+    // Calculate x aggregations from hours data
+    const xAggregations: { [key: number]: number } = Array.from({ length: HoursAbbreviated.values.length }, () => 0)
+    if (results?.hours) {
+        results.hours.forEach((result: WebActiveHoursHeatMapHourResult) => {
+            xAggregations[result.hour] = result.total
+        })
     }
-    return yAggregations
+
+    // Calculate y aggregations from days data
+    const yAggregations: { [key: number]: number } = Array.from({ length: DaysAbbreviated.values.length }, () => 0)
+    if (results?.days) {
+        results.days.forEach((result: WebActiveHoursHeatMapDayResult) => {
+            const adjustedDay =
+                (result.day - (DaysAbbreviated.startIndex || 0) + DaysAbbreviated.values.length) %
+                DaysAbbreviated.values.length
+            yAggregations[adjustedDay] = result.total
+        })
+    }
+
+    const maxXAggregation = Math.max(...Object.values(xAggregations), 0)
+    const maxYAggregation = Math.max(...Object.values(yAggregations), 0)
+    const overallValue = results?.total ?? 0
+
+    return {
+        matrix,
+        maxOverall,
+        xAggregations,
+        yAggregations,
+        maxXAggregation,
+        maxYAggregation,
+        overallValue,
+    }
 }
 
 function renderOverallCell(
@@ -206,7 +214,7 @@ function renderOverallCell(
                 value={overallValue}
                 maxValue={overallValue}
                 backgroundColor={backgroundColorOverall}
-                dayAndTime={Sum.label}
+                dayAndTime={AllLabel}
             />
         </td>
     )
@@ -227,7 +235,7 @@ function renderAggregationCells(
                 value={xAggregations[x]}
                 maxValue={maxXAggregation}
                 backgroundColor={aggregationColor}
-                dayAndTime={`${Sum.label} - ${String(x).padStart(2, '0')}:00`}
+                dayAndTime={`All - ${String(x).padStart(2, '0')}:00`}
             />
         </td>
     ))
@@ -249,7 +257,7 @@ function renderYAggregationCell(
                 value={value}
                 maxValue={maxYAggregation}
                 backgroundColor={aggregationColor}
-                dayAndTime={`${Sum.label} - ${day}`}
+                dayAndTime={`All - ${day}`}
             />
         </td>
     )

--- a/frontend/src/scenes/web-analytics/EventsHeatMap/config.test.ts
+++ b/frontend/src/scenes/web-analytics/EventsHeatMap/config.test.ts
@@ -1,14 +1,6 @@
-import { DaysAbbreviated, HoursAbbreviated, Sum } from './config'
+import { DaysAbbreviated, HoursAbbreviated } from './config'
 
 describe('EventsHeatMap config', () => {
-    describe('Sum aggregation', () => {
-        it('should sum an array of numbers correctly', () => {
-            expect(Sum.fn([1, 2, 3, 4])).toBe(10)
-            expect(Sum.fn([])).toBe(0)
-            expect(Sum.fn([0, -1, 1])).toBe(0)
-        })
-    })
-
     describe('DaysAbbreviated', () => {
         it('should have correct days configuration', () => {
             // we care about the order of the days and the startIndex

--- a/frontend/src/scenes/web-analytics/EventsHeatMap/config.ts
+++ b/frontend/src/scenes/web-analytics/EventsHeatMap/config.ts
@@ -1,4 +1,6 @@
-export const AllLabel = 'All'
+export enum AggregationLabel {
+    All = 'All',
+}
 export interface AxisConfig {
     values: string[]
     startIndex?: number

--- a/frontend/src/scenes/web-analytics/EventsHeatMap/config.ts
+++ b/frontend/src/scenes/web-analytics/EventsHeatMap/config.ts
@@ -1,3 +1,4 @@
+export const AllLabel = 'All'
 export interface AxisConfig {
     values: string[]
     startIndex?: number
@@ -6,11 +7,6 @@ export interface AxisConfig {
 export interface AggregationConfig {
     label: string
     fn: (values: number[]) => number
-}
-
-export const Sum: AggregationConfig = {
-    label: 'Sum',
-    fn: (values) => values.reduce((acc, val) => acc + val, 0),
 }
 
 export const DaysAbbreviated: AxisConfig = {

--- a/posthog/hogql_queries/web_analytics/test/test_web_active_hours_heatmap_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_active_hours_heatmap_query_runner.py
@@ -65,7 +65,7 @@ class TestWebActiveHoursHeatMapQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
     def test_empty_results_when_no_data(self):
         response = self._run_web_active_hours_heatmap_query_runner("2023-12-08", "2023-12-15")
-        self.assertEqual([], response.results)
+        self.assertEqual([], response.results.dayAndHours)
 
     def test_basic_active_hours(self):
         self._create_events(
@@ -91,7 +91,7 @@ class TestWebActiveHoursHeatMapQueryRunner(ClickhouseTestMixin, APIBaseTest):
         response = self._run_web_active_hours_heatmap_query_runner("2023-12-01", "2023-12-04")
 
         # Convert results to a dict for easier testing
-        results_dict = {(r.day, r.hour): r.total for r in response.results}
+        results_dict = {(r.day, r.hour): r.total for r in response.results.dayAndHours}
 
         # Saturday (day 6) expectations
         self.assertEqual(results_dict.get((6, 10)), 2)  # Two users at 10:00
@@ -123,14 +123,14 @@ class TestWebActiveHoursHeatMapQueryRunner(ClickhouseTestMixin, APIBaseTest):
         response = self._run_web_active_hours_heatmap_query_runner(
             "2023-12-01", "2023-12-03", filter_test_accounts=False
         )
-        results_dict = {(r.day, r.hour): r.total for r in response.results}
+        results_dict = {(r.day, r.hour): r.total for r in response.results.dayAndHours}
         self.assertEqual(results_dict.get((6, 10)), 2)  # Both users
 
         # Without test accounts
         response = self._run_web_active_hours_heatmap_query_runner(
             "2023-12-01", "2023-12-03", filter_test_accounts=True
         )
-        results_dict = {(r.day, r.hour): r.total for r in response.results}
+        results_dict = {(r.day, r.hour): r.total for r in response.results.dayAndHours}
         self.assertEqual(results_dict.get((6, 10)), 1)  # Only regular user
 
     def test_all_time_range(self):
@@ -147,7 +147,7 @@ class TestWebActiveHoursHeatMapQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
 
         response = self._run_web_active_hours_heatmap_query_runner("all", "2024-01-20")
-        results_dict = {(r.day, r.hour): r.total for r in response.results}
+        results_dict = {(r.day, r.hour): r.total for r in response.results.dayAndHours}
 
         self.assertEqual(results_dict.get((6, 10)), 1)  # December visit
         self.assertEqual(results_dict.get((1, 11)), 1)  # January visit
@@ -171,6 +171,57 @@ class TestWebActiveHoursHeatMapQueryRunner(ClickhouseTestMixin, APIBaseTest):
             properties=[{"key": "$browser", "value": "Chrome"}],
         )
 
-        results_dict = {(r.day, r.hour): r.total for r in response.results}
+        results_dict = {(r.day, r.hour): r.total for r in response.results.dayAndHours}
         self.assertEqual(results_dict.get((6, 10)), 1)  # Chrome visit
         self.assertNotIn((6, 11), results_dict)  # Firefox visit filtered out
+
+    def test_aggregations(self):
+        self._create_events(
+            data=[
+                (
+                    "user1",
+                    [
+                        ("2023-12-02 10:00:00", {}),  # Saturday 10:00
+                        ("2023-12-02 11:00:00", {}),  # Saturday 11:00
+                        ("2023-12-03 10:00:00", {}),  # Sunday 10:00
+                    ],
+                ),
+                (
+                    "user2",
+                    [
+                        ("2023-12-02 10:00:00", {}),  # Saturday 10:00
+                        ("2023-12-03 15:00:00", {}),  # Sunday 15:00
+                    ],
+                ),
+            ]
+        )
+
+        response = self._run_web_active_hours_heatmap_query_runner("2023-12-01", "2023-12-04")
+
+        # Test day-hour combinations
+        day_hour_dict = {(r.day, r.hour): r.total for r in response.results.dayAndHours}
+        self.assertEqual(day_hour_dict.get((6, 10)), 2)  # Two users on Saturday at 10:00
+        self.assertEqual(day_hour_dict.get((6, 11)), 1)  # One user on Saturday at 11:00
+        self.assertEqual(day_hour_dict.get((7, 10)), 1)  # One user on Sunday at 10:00
+        self.assertEqual(day_hour_dict.get((7, 15)), 1)  # One user on Sunday at 15:00
+
+        # Test days aggregation
+        days_dict = {r.day: r.total for r in response.results.days}
+        self.assertEqual(days_dict.get(6), 2)  # Two users on Saturday
+        self.assertEqual(days_dict.get(7), 2)  # Two users on Sunday
+
+        # Test hours aggregation
+        hours_dict = {r.hour: r.total for r in response.results.hours}
+        self.assertEqual(hours_dict.get(10), 2)  # Two users at 10:00
+        self.assertEqual(hours_dict.get(11), 1)  # One user at 11:00
+        self.assertEqual(hours_dict.get(15), 1)  # One user at 15:00
+
+        # Test total users
+        self.assertEqual(response.results.total, 2)  # Two unique users overall
+
+    def test_empty_results_structure(self):
+        response = self._run_web_active_hours_heatmap_query_runner("2023-12-08", "2023-12-15")
+
+        self.assertEqual(response.results.dayAndHours, [])
+        self.assertEqual(response.results.days, [])
+        self.assertEqual(response.results.hours, [])

--- a/posthog/hogql_queries/web_analytics/web_active_hours_heatmap_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/web_active_hours_heatmap_query_runner.py
@@ -27,28 +27,20 @@ class WebActiveHoursHeatMapQueryRunner(WebAnalyticsQueryRunner):
     def to_query(self) -> ast.SelectQuery:
         query = parse_select(
             """
-            WITH (
-                SELECT
-                    uniqMap(map(concat(toString(toDayOfWeek(timestamp)), ',' ,toString(toHour(timestamp))), events.person_id)) as hoursAndDays,
-                    uniqMap(map(toHour(timestamp), events.person_id)) as hours,
-                    uniqMap(map(toDayOfWeek(timestamp), events.person_id)) as days,
-                    uniq(person_id) as total
-                FROM events
-                WHERE and(
-                    event = '$pageview',
-                    {all_properties},
-                    {current_period}
-                )
-            ) as cte
             SELECT
-                mapKeys(cte.hoursAndDays) as hoursAndDaysKeys,
-                mapValues(cte.hoursAndDays) as hoursAndDaysValues,
-                mapKeys(cte.hours) as hoursKeys,
-                mapValues(cte.hours) as hoursValues,
-                mapKeys(cte.days) as daysKeys,
-                mapValues(cte.days) as daysValues,
-                cte.total
-            FROM cte
+                mapKeys(uniqMap(map(concat(toString(toDayOfWeek(timestamp)), ',' ,toString(toHour(timestamp))), events.person_id))) as hoursAndDaysKeys,
+                mapValues(uniqMap(map(concat(toString(toDayOfWeek(timestamp)), ',' ,toString(toHour(timestamp))), events.person_id))) as hoursAndDaysValues,
+                mapKeys(uniqMap(map(toHour(timestamp), events.person_id))) as hoursKeys,
+                mapValues(uniqMap(map(toHour(timestamp), events.person_id))) as hoursValues,
+                mapKeys(uniqMap(map(toDayOfWeek(timestamp), events.person_id))) as daysKeys,
+                mapValues(uniqMap(map(toDayOfWeek(timestamp), events.person_id))) as daysValues,
+                uniq(person_id) as total
+            FROM events
+            WHERE and(
+                event = '$pageview',
+                {all_properties},
+                {current_period}
+            )
             """,
             placeholders={
                 "all_properties": self._all_properties(),

--- a/posthog/hogql_queries/web_analytics/web_active_hours_heatmap_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/web_active_hours_heatmap_query_runner.py
@@ -9,7 +9,10 @@ from posthog.schema import (
     CachedWebActiveHoursHeatMapQueryResponse,
     WebActiveHoursHeatMapQuery,
     WebActiveHoursHeatMapQueryResponse,
-    WebActiveHoursHeatMapResult,
+    WebActiveHoursHeatMapDayAndHourResult,
+    WebActiveHoursHeatMapDayResult,
+    WebActiveHoursHeatMapHourResult,
+    WebActiveHoursHeatMapStructuredResult,
 )
 
 
@@ -24,19 +27,28 @@ class WebActiveHoursHeatMapQueryRunner(WebAnalyticsQueryRunner):
     def to_query(self) -> ast.SelectQuery:
         query = parse_select(
             """
+            WITH (
+                SELECT
+                    uniqMap(map((toHour(timestamp) + toDayOfWeek(timestamp) * 1000), events.person_id)) as hoursAndDays,
+                    uniqMap(map(toHour(timestamp), events.person_id)) as hours,
+                    uniqMap(map(toDayOfWeek(timestamp), events.person_id)) as days,
+                    uniq(person_id) as total
+                FROM events
+                WHERE and(
+                    event = '$pageview',
+                    {all_properties},
+                    {current_period}
+                )
+            ) as cte
             SELECT
-                toDayOfWeek(timestamp) as day,
-                toHour(timestamp) as hour,
-                uniq(events.person_id) as total
-            FROM events
-            WHERE and(
-                event = '$pageview',
-                {all_properties},
-                {current_period},
-            )
-            GROUP BY day, hour
-            ORDER BY day, hour
-            LIMIT 168 -- 24 hours * 7 days
+                mapKeys(cte.hoursAndDays) as hoursAndDaysKeys,
+                mapValues(cte.hoursAndDays) as hoursAndDaysValues,
+                mapKeys(cte.hours) as hoursKeys,
+                mapValues(cte.hours) as hoursValues,
+                mapKeys(cte.days) as daysKeys,
+                mapValues(cte.days) as daysValues,
+                cte.total
+            FROM cte
             """,
             placeholders={
                 "all_properties": self._all_properties(),
@@ -55,15 +67,53 @@ class WebActiveHoursHeatMapQueryRunner(WebAnalyticsQueryRunner):
             timings=self.timings,
             modifiers=self.modifiers,
         )
-        results = [
-            WebActiveHoursHeatMapResult(day=int(row[0]), hour=int(row[1]), total=int(row[2]))
-            for row in response.results
-        ]
 
-        assert results is not None
+        day_and_hours: list[WebActiveHoursHeatMapDayAndHourResult] = []
+        days: list[WebActiveHoursHeatMapDayResult] = []
+        hours: list[WebActiveHoursHeatMapHourResult] = []
+
+        if not response.results or len(response.results) == 0:
+            return WebActiveHoursHeatMapQueryResponse(
+                results=WebActiveHoursHeatMapStructuredResult(
+                    dayAndHours=day_and_hours, days=days, hours=hours, total=0
+                ),
+                timings=response.timings,
+                hogql=response.hogql,
+                modifiers=self.modifiers,
+            )
+
+        row = response.results[0]
+        hours_and_days_keys = row[0]
+        hours_and_days_values = row[1]
+        hours_keys = row[2]
+        hours_values = row[3]
+        days_keys = row[4]
+        days_values = row[5]
+        totalOverall = row[6]
+        # Process day-hour combinations
+        for i in range(len(hours_and_days_keys)):
+            key = int(hours_and_days_keys[i])
+            day = key // 1000
+            hour = key % 1000
+            total = int(hours_and_days_values[i])
+            day_and_hours.append(WebActiveHoursHeatMapDayAndHourResult(day=day, hour=hour, total=total))
+
+        # Process day-only entries
+        for i in range(len(days_keys)):
+            day = int(days_keys[i])
+            total = int(days_values[i])
+            days.append(WebActiveHoursHeatMapDayResult(day=day, total=total))
+
+        # Process hour-only entries
+        for i in range(len(hours_keys)):
+            hour = int(hours_keys[i])
+            total = int(hours_values[i])
+            hours.append(WebActiveHoursHeatMapHourResult(hour=hour, total=total))
 
         return WebActiveHoursHeatMapQueryResponse(
-            results=results,
+            results=WebActiveHoursHeatMapStructuredResult(
+                dayAndHours=day_and_hours, days=days, hours=hours, total=totalOverall
+            ),
             timings=response.timings,
             hogql=response.hogql,
             modifiers=self.modifiers,

--- a/posthog/hogql_queries/web_analytics/web_active_hours_heatmap_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/web_active_hours_heatmap_query_runner.py
@@ -29,7 +29,7 @@ class WebActiveHoursHeatMapQueryRunner(WebAnalyticsQueryRunner):
             """
             WITH (
                 SELECT
-                    uniqMap(map((toHour(timestamp) + toDayOfWeek(timestamp) * 1000), events.person_id)) as hoursAndDays,
+                    uniqMap(map(concat(toString(toDayOfWeek(timestamp)), ',' ,toString(toHour(timestamp))), events.person_id)) as hoursAndDays,
                     uniqMap(map(toHour(timestamp), events.person_id)) as hours,
                     uniqMap(map(toDayOfWeek(timestamp), events.person_id)) as days,
                     uniq(person_id) as total
@@ -72,7 +72,7 @@ class WebActiveHoursHeatMapQueryRunner(WebAnalyticsQueryRunner):
         days: list[WebActiveHoursHeatMapDayResult] = []
         hours: list[WebActiveHoursHeatMapHourResult] = []
 
-        if not response.results or len(response.results) == 0:
+        if not response.results:
             return WebActiveHoursHeatMapQueryResponse(
                 results=WebActiveHoursHeatMapStructuredResult(
                     dayAndHours=day_and_hours, days=days, hours=hours, total=0
@@ -92,9 +92,8 @@ class WebActiveHoursHeatMapQueryRunner(WebAnalyticsQueryRunner):
         totalOverall = row[6]
         # Process day-hour combinations
         for i in range(len(hours_and_days_keys)):
-            key = int(hours_and_days_keys[i])
-            day = key // 1000
-            hour = key % 1000
+            key = hours_and_days_keys[i]
+            day, hour = map(int, key.split(","))
             total = int(hours_and_days_values[i])
             day_and_hours.append(WebActiveHoursHeatMapDayAndHourResult(day=day, hour=hour, total=total))
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -3550,12 +3550,38 @@ class TrendsQueryResponse(BaseModel):
     )
 
 
-class WebActiveHoursHeatMapResult(BaseModel):
+class WebActiveHoursHeatMapDayAndHourResult(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
     day: int
     hour: int
+    total: int
+
+
+class WebActiveHoursHeatMapDayResult(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    day: int
+    total: int
+
+
+class WebActiveHoursHeatMapHourResult(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    hour: int
+    total: int
+
+
+class WebActiveHoursHeatMapStructuredResult(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    dayAndHours: list[WebActiveHoursHeatMapDayAndHourResult]
+    days: list[WebActiveHoursHeatMapDayResult]
+    hours: list[WebActiveHoursHeatMapHourResult]
     total: int
 
 
@@ -4966,7 +4992,7 @@ class CachedWebActiveHoursHeatMapQueryResponse(BaseModel):
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
-    results: list[WebActiveHoursHeatMapResult]
+    results: WebActiveHoursHeatMapStructuredResult
     timezone: str
     timings: Optional[list[QueryTiming]] = Field(
         default=None, description="Measured timings for different parts of the query generation process"
@@ -5374,7 +5400,7 @@ class Response9(BaseModel):
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
-    results: list[WebActiveHoursHeatMapResult]
+    results: WebActiveHoursHeatMapStructuredResult
     timings: Optional[list[QueryTiming]] = Field(
         default=None, description="Measured timings for different parts of the query generation process"
     )
@@ -6709,7 +6735,7 @@ class QueryResponseAlternative24(BaseModel):
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
-    results: list[WebActiveHoursHeatMapResult]
+    results: WebActiveHoursHeatMapStructuredResult
     timings: Optional[list[QueryTiming]] = Field(
         default=None, description="Measured timings for different parts of the query generation process"
     )
@@ -6957,7 +6983,7 @@ class QueryResponseAlternative37(BaseModel):
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
-    results: list[WebActiveHoursHeatMapResult]
+    results: WebActiveHoursHeatMapStructuredResult
     timings: Optional[list[QueryTiming]] = Field(
         default=None, description="Measured timings for different parts of the query generation process"
     )
@@ -7660,7 +7686,7 @@ class WebActiveHoursHeatMapQueryResponse(BaseModel):
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
-    results: list[WebActiveHoursHeatMapResult]
+    results: WebActiveHoursHeatMapStructuredResult
     timings: Optional[list[QueryTiming]] = Field(
         default=None, description="Measured timings for different parts of the query generation process"
     )


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

On the before "sum" column and row we were actually doing a sum, so a same user in the column/row would count more than once.

For that I updated the query using uniqMap and also mapped the results in the UI

## Changes
Update of activity hours query and respective UI logic.

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Update tests and tested manually.

Before:
<img width="1226" alt="image" src="https://github.com/user-attachments/assets/8753d99f-59e4-40ef-8d3a-d8ec7d80b591" />

did not match global result
<img width="210" alt="image" src="https://github.com/user-attachments/assets/a290c54e-a5b9-41d1-8e12-8f5dab46020a" />

After:

<img width="1182" alt="image" src="https://github.com/user-attachments/assets/784c4f18-56c4-49c3-bc2e-859ff50b00d0" />
matches the global result

<img width="244" alt="image" src="https://github.com/user-attachments/assets/fc38b057-3d5b-454d-b4f5-981cf415b71d" />

