### PR TITLE
fix: exposure criteria now defaults to filtering test users.

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -96,6 +96,9 @@ const NEW_EXPERIMENT: Experiment = {
     created_by: null,
     updated_at: null,
     holdout_id: null,
+    exposure_criteria: {
+        filterTestAccounts: true,
+    },
 }
 
 export const DEFAULT_MDE = 30


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We want to start pushing best practices out, and filtering test users is a sensible default for this setting.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Small update to the default experiment configuration, that get's saved when a new experiment get's created.

| <img width="860" alt="image" src="https://github.com/user-attachments/assets/8428eeda-2ff5-448b-8fcb-f2397a3d6ef1" /> |
| - |
| _Filter Out Internal and Test Users_ defaults to `true` |


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
