### PR TITLE
fix: Plugin Server - Node Error

### DIFF
--- a/plugin-server/src/server.ts
+++ b/plugin-server/src/server.ts
@@ -42,7 +42,7 @@ import { delay } from './utils/utils'
 import { teardownPlugins } from './worker/plugins/teardown'
 import { initPlugins as _initPlugins } from './worker/tasks'
 
-const { version } = require('../../package.json')
+const { version } = require('../package.json')
 
 CompressionCodecs[CompressionTypes.Snappy] = SnappyCodec
 CompressionCodecs[CompressionTypes.LZ4] = new LZ4().codec

--- a/plugin-server/src/server.ts
+++ b/plugin-server/src/server.ts
@@ -284,22 +284,16 @@ export class PluginServer {
             // These are used by the preflight checks in the Django app to determine if
             // the plugin-server is running.
             schedule.scheduleJob('*/5 * * * * *', async () => {
-                await this.hub?.db.redisSet(
+                await hub.db.redisSet(
                     '@posthog-plugin-server/ping',
                     new Date().toISOString(),
                     'preflightSchedules',
                     60,
                     { jsonSerialize: false }
                 )
-                await this.hub?.db.redisSet(
-                    '@posthog-plugin-server/version',
-                    version,
-                    'preflightSchedules',
-                    undefined,
-                    {
-                        jsonSerialize: false,
-                    }
-                )
+                await hub.db.redisSet('@posthog-plugin-server/version', version, 'preflightSchedules', undefined, {
+                    jsonSerialize: false,
+                })
             })
 
             pluginServerStartupTimeMs.inc(Date.now() - startupTimer.valueOf())


### PR DESCRIPTION
## Problem

Stuck at the validation screen post a fresh install via the curl command for self hosted posthog. 
For more info see: https://github.com/PostHog/posthog/issues/29706

It seems that server initialization was refactored in https://github.com/PostHog/posthog/pull/29425, and they may have forgotten to include the preflight check ping that was previously here [‎plugin-server/src/main/pluginsServer.ts](https://github.com/PostHog/posthog/commit/5821ba14ece1aba4f2a7f4799cbaa87dfb87a526#diff-817bc42d0008d9b475bf2736d21dcfd35bfad26a11b97340e8917b1eee5b58a6)

## Changes

Restore the health redis ping logic.

<table>
  <tr>
    <td>Before</td>
    <td>After</td>
   </tr> 
   <tr>
      <td><img width="508" alt="image" src="https://github.com/user-attachments/assets/a423a33a-bba8-4fb5-a4d4-d11c5a28ac1d" /></td>
      <td><img width="530" alt="image" src="https://github.com/user-attachments/assets/c925be0c-290a-4ef9-8375-ae7e9e346b96" /></td>
  </tr>
</table>

## Does this work well for both Cloud and self-hosted?
Not sure, I only tested locally with Flox

## How did you test this code?
Flox local dev

