### PR TITLE
chore(replay): Rate limit persisting recordings

### DIFF
--- a/ee/session_recordings/persistence_tasks.py
+++ b/ee/session_recordings/persistence_tasks.py
@@ -28,18 +28,12 @@ REPLAY_NEEDS_PERSISTENCE_V2_COUNTER = Counter(
 )
 
 
-@shared_task(
-    ignore_result=True,
-    queue=CeleryQueue.SESSION_REPLAY_PERSISTENCE.value,
-)
+@shared_task(ignore_result=True, queue=CeleryQueue.SESSION_REPLAY_PERSISTENCE.value, rate_limit="10/m")
 def persist_single_recording(id: str, team_id: int) -> None:
     persist_recording(id, team_id)
 
 
-@shared_task(
-    ignore_result=True,
-    queue=CeleryQueue.SESSION_REPLAY_PERSISTENCE.value,
-)
+@shared_task(ignore_result=True, queue=CeleryQueue.SESSION_REPLAY_PERSISTENCE.value, rate_limit="10/m")
 def persist_single_recording_v2(id: str, team_id: int) -> None:
     persist_recording_v2(id, team_id)
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
This job is super spiky, causing simultaneousqueryerrors.
<img width="1798" alt="image" src="https://github.com/user-attachments/assets/1507a2ed-a107-49b3-a5b4-96487291c9df" />


We're averaging 70k of these calls/day (between v1 and v2). `70000/(60*60)=20` whichs means we need to average 20 queries per minute to clear the backlog. I've set the rate limit to 10 per worker and we have 10 workers, so thats 100 queries/minute.
<img width="1446" alt="image" src="https://github.com/user-attachments/assets/12937d80-1c65-423d-b051-7b1f5ff31b53" />

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
