### PR TITLE
fix: report_status should not panic

### DIFF
--- a/rust/common/health/src/lib.rs
+++ b/rust/common/health/src/lib.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, RwLock};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use std::time::Duration;
+use tokio::runtime;
 use tokio::sync::mpsc;
 use tracing::{info, warn};
 
@@ -116,8 +117,15 @@ impl HealthHandle {
             component: self.component.clone(),
             status,
         };
-        if let Err(err) = self.sender.blocking_send(message) {
-            warn!("failed to report heath status: {}", err)
+        // Don't panic if we're called from within an async context,
+        // just spawn instead
+        if let Ok(h) = runtime::Handle::try_current() {
+            let m = self.clone();
+            h.spawn(async move { m.report_status(message.status).await });
+        } else {
+            if let Err(err) = self.sender.blocking_send(message) {
+                warn!("failed to report heath status: {}", err)
+            }
         }
     }
 }

--- a/rust/common/health/src/lib.rs
+++ b/rust/common/health/src/lib.rs
@@ -122,10 +122,8 @@ impl HealthHandle {
         if let Ok(h) = runtime::Handle::try_current() {
             let m = self.clone();
             h.spawn(async move { m.report_status(message.status).await });
-        } else {
-            if let Err(err) = self.sender.blocking_send(message) {
-                warn!("failed to report heath status: {}", err)
-            }
+        } else if let Err(err) = self.sender.blocking_send(message) {
+            warn!("failed to report heath status: {}", err)
         }
     }
 }


### PR DESCRIPTION
This is called from within e.g. rdkafka and can cause undefined behaviour if it panics, including trampling client offsets if used within a transaction. See https://posthog.slack.com/archives/C08NVB55QG3/p1744969530072619