### PR TITLE
revert(perf): make persorted events table the default for activity log

### DIFF
--- a/frontend/src/scenes/activity/explore/defaults.ts
+++ b/frontend/src/scenes/activity/explore/defaults.ts
@@ -11,9 +11,6 @@ export const getDefaultEventsSceneQuery = (properties?: AnyPropertyFilter[]): Da
         orderBy: ['timestamp DESC'],
         after: '-24h',
         ...(properties ? { properties } : {}),
-        modifiers: {
-            usePresortedEventsTable: true,
-        },
     },
     propertiesViaUrl: true,
     showSavedQueries: true,


### PR DESCRIPTION
Reverts PostHog/posthog#31192

See https://posthog.slack.com/archives/C045L1VEG87/p1744967734903229