### PR TITLE
fix(devex): tooltip with links not using contrasting Link color

### DIFF
--- a/common/tailwind/tailwind.config.js
+++ b/common/tailwind/tailwind.config.js
@@ -6,6 +6,7 @@ const commonColors = {
     'current': 'currentColor',
     'transparent': 'transparent',
     'accent': 'var(--accent)',
+    'accent-inverted': 'var(--accent-inverted)',
     'accent-hover': 'var(--accent-hover)',
     'accent-active': 'var(--accent-active)',
     'accent-highlight-primary': 'var(--accent-highlight-primary)',

--- a/frontend/src/lib/lemon-ui/LemonButton/LemonButton.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonButton/LemonButton.stories.tsx
@@ -441,7 +441,11 @@ WithVeryLongPopoverToTheBottom.args = {
 export const WithTooltip: Story = BasicTemplate.bind({})
 WithTooltip.args = {
     ...Default.args,
-    tooltip: 'The flux capacitor will be reloaded. This might take up to 14 hours.',
+    tooltip: (
+        <>
+            This is example with a link: <Link to="https://posthog.com">Go home</Link>
+        </>
+    ),
 }
 
 export const More_ = (): JSX.Element => {

--- a/frontend/src/lib/lemon-ui/Link/Link.scss
+++ b/frontend/src/lib/lemon-ui/Link/Link.scss
@@ -34,4 +34,19 @@
             color: var(--accent-hover);
         }
     }
+
+    // Tooltips are inverted, so links are too
+    .Tooltip & {
+        color: var(--accent-inverted);
+
+        &:not(:disabled) {
+            &:hover {
+                color: var(--accent-hover-inverted);
+            }
+
+            &:active {
+                color: var(--accent-active-inverted);
+            }
+        }
+    }
 }

--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -335,6 +335,11 @@
     // Used for interactive elements and highlights, inputs, toggles, charts, etc.
     // //////////////////////////////////////////////////////////
     --accent: hsl(var(--brand-primary-hue), var(--brand-primary-saturation), var(--brand-primary-lightness));
+    --accent-inverted: hsl(
+        var(--primitive-posthog-brand-yellow-hue),
+        var(--primitive-posthog-brand-yellow-saturation),
+        var(--primitive-posthog-brand-yellow-lightness)
+    );
     --accent-hover: hsl(
         var(--brand-primary-hue),
         var(--brand-primary-saturation),

--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -345,10 +345,20 @@
         var(--brand-primary-saturation),
         calc(var(--brand-primary-lightness) + 10%)
     );
+    --accent-hover-inverted: hsl(
+        var(--primitive-posthog-brand-yellow-hue),
+        var(--primitive-posthog-brand-yellow-saturation),
+        calc(var(--primitive-posthog-brand-yellow-lightness) + 10%)
+    );
     --accent-active: hsl(
         var(--brand-primary-hue),
         var(--brand-primary-saturation),
         calc(var(--brand-primary-lightness) + 15%)
+    );
+    --accent-active-inverted: hsl(
+        var(--primitive-posthog-brand-yellow-hue),
+        var(--primitive-posthog-brand-yellow-saturation),
+        calc(var(--primitive-posthog-brand-yellow-lightness) + 15%)
     );
     --accent-highlight-primary: hsla(
         var(--brand-primary-hue),
@@ -785,15 +795,30 @@
     // Accent colors (dark mode)
     // //////////////////////////////////////////////////////////
     --accent: hsl(var(--brand-primary-hue), var(--brand-primary-saturation), var(--brand-primary-lightness));
+    --accent-inverted: hsl(
+        var(--primitive-posthog-brand-orange-hue),
+        var(--primitive-posthog-brand-orange-saturation),
+        var(--primitive-posthog-brand-orange-lightness)
+    );
     --accent-hover: hsl(
         var(--brand-primary-hue),
         var(--brand-primary-saturation),
         calc(var(--brand-primary-lightness) + 10%)
     );
+    --accent-hover-inverted: hsl(
+        var(--primitive-posthog-brand-orange-hue),
+        var(--primitive-posthog-brand-orange-saturation),
+        calc(var(--primitive-posthog-brand-orange-lightness) + 10%)
+    );
     --accent-active: hsl(
         var(--brand-primary-hue),
         var(--brand-primary-saturation),
         calc(var(--brand-primary-lightness) + 15%)
+    );
+    --accent-active-inverted: hsl(
+        var(--primitive-posthog-brand-orange-hue),
+        var(--primitive-posthog-brand-orange-saturation),
+        calc(var(--primitive-posthog-brand-orange-lightness) + 15%)
     );
 
     // Used for highlighting search results, and other subtle accent sitations


### PR DESCRIPTION
## Problem
Tooltips are dark on light mode... and light on dark...
So links inside a tooltip should follow our dark mode color scheme for light mode and vice-versa.

Before:
![2025-04-19 00 10 59](https://github.com/user-attachments/assets/611e7e2b-33e6-42ac-8cbd-f21eff0f3ed2)
After: 
![2025-04-19 00 10 16](https://github.com/user-attachments/assets/2cd7c4c6-f5a7-40d3-a180-82a5007a6fd9)


## Changes
* Introduce `accent-inverted` CSS vars and classes
* Target Links in Tooltips and invert the color (hover too)
* Update LemonButton story with tooltip to show this behaviour


## How did you test this code?
Locally, storybook