### PR TITLE
chore(dev): uv sync in bin/start

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -55,6 +55,11 @@ procs:
             bin/check_kafka_clickhouse_up && \
             bin/start-rust-service property-defs-rs
 
+    migrate-clickhouse:
+        # These migrations are not in the `backend` service, because they typically aren't blocking for backend startup,
+        # but unfortunately they DO take 10-30 s just to check if there's any migration to run (haven't profiled why)
+        shell: 'bin/check_kafka_clickhouse_up && python manage.py migrate_clickhouse'
+
     storybook:
         shell: 'pnpm --filter=@posthog/storybook install && pnpm run storybook'
         autostart: false

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -1,12 +1,12 @@
 procs:
     backend:
-        shell: 'bin/check_kafka_clickhouse_up && python manage.py migrate && ./bin/start-backend'
+        shell: 'uv sync --active && bin/check_kafka_clickhouse_up && python manage.py migrate && ./bin/start-backend'
 
     celery-worker:
-        shell: 'bin/check_kafka_clickhouse_up && ./bin/start-celery worker'
+        shell: 'uv sync --active && bin/check_kafka_clickhouse_up && ./bin/start-celery worker'
 
     celery-beat:
-        shell: 'bin/check_kafka_clickhouse_up && ./bin/start-celery beat'
+        shell: 'uv sync --active && bin/check_kafka_clickhouse_up && ./bin/start-celery beat'
 
     plugin-server:
         shell: 'bin/check_kafka_clickhouse_up && ./bin/plugin-server'

--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -9,7 +9,7 @@
         "functional_tests": "jest --config ./jest.config.functional.js",
         "start": "pnpm start:dev",
         "start:dist": "BASE_DIR=.. node dist/index.js",
-        "start:dev": "NODE_ENV=dev BASE_DIR=.. nodemon --watch src/ --exec node -r @swc-node/register src/index.ts",
+        "start:dev": "NODE_ENV=dev BASE_DIR=.. nodemon --exitcrash --watch src/ --exec node -r @swc-node/register src/index.ts",
         "start:devNoWatch": "NODE_ENV=dev BASE_DIR=.. node -r @swc-node/register src/index.ts",
         "prestart:dev": "pnpm build:cyclotron",
         "prestart:devNoWatch": "pnpm build:cyclotron",


### PR DESCRIPTION
## Problem

It makes no sense to run `uv sync --active` manually, when it could just be part of mprocs Python services.

## Changes

You get `uv sync`, you get `uv sync`, everyone gets `uv sync`!