### PR TITLE
feat(capture): add config to optionally retain partition keys when routing to overflow

### DIFF
--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -35,6 +35,9 @@ pub struct Config {
     #[envconfig(default = "false")]
     pub overflow_enabled: bool,
 
+    #[envconfig(default = "false")]
+    pub overflow_preserve_partition_locality: bool,
+
     #[envconfig(default = "100")]
     pub overflow_per_second_limit: NonZeroU32,
 

--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -51,13 +51,16 @@ async fn create_sink(
                     config.overflow_per_second_limit,
                     config.overflow_burst_limit,
                     config.ingestion_force_overflow_by_token_distinct_id.clone(),
+                    config.overflow_preserve_partition_locality,
                 );
+
                 if config.export_prometheus {
                     let partition = partition.clone();
                     tokio::spawn(async move {
                         partition.report_metrics().await;
                     });
                 }
+
                 {
                     // Ensure that the rate limiter state does not grow unbounded
                     let partition = partition.clone();

--- a/rust/capture/tests/common.rs
+++ b/rust/capture/tests/common.rs
@@ -35,6 +35,7 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     address: SocketAddr::from_str("127.0.0.1:0").unwrap(),
     redis_url: "redis://localhost:6379/".to_string(),
     overflow_enabled: false,
+    overflow_preserve_partition_locality: false,
     overflow_burst_limit: NonZeroU32::new(5).unwrap(),
     overflow_per_second_limit: NonZeroU32::new(10).unwrap(),
     ingestion_force_overflow_by_token_distinct_id: None,

--- a/rust/capture/tests/events.rs
+++ b/rust/capture/tests/events.rs
@@ -454,7 +454,7 @@ async fn it_overflows_events_on_specified_keys_preserving_locality() -> Result<(
     let res = server.capture_events(batch_3.to_string()).await;
     assert_eq!(StatusCode::OK, res.status());
 
-    // main toppic results
+    // main topic results
     assert_eq!(
         topic.next_message_key()?.unwrap(),
         format!("{}:{}", token2, distinct_id1)
@@ -479,17 +479,17 @@ async fn it_overflows_events_on_specified_keys_preserving_locality() -> Result<(
     // Expected events should be in overflow topic, but should
     // retain original partition keys, so fetch-by-key works here
     assert_eq!(
-        topic.next_message_key()?.unwrap(),
+        overflow_topic.next_message_key()?.unwrap(),
         format!("{}:{}", token1, distinct_id1)
     );
 
     assert_eq!(
-        topic.next_message_key()?.unwrap(),
+        overflow_topic.next_message_key()?.unwrap(),
         format!("{}:{}", token1, distinct_id2)
     );
 
     assert_eq!(
-        topic.next_message_key()?.unwrap(),
+        overflow_topic.next_message_key()?.unwrap(),
         format!("{}:{}", token2, distinct_id2)
     );
 

--- a/rust/capture/tests/events.rs
+++ b/rust/capture/tests/events.rs
@@ -334,7 +334,7 @@ async fn it_overflows_events_on_specified_keys() -> Result<()> {
 
     topic.assert_empty();
 
-    // Third event should be in overflow topic, but has no
+    // Expected events should be in overflow topic, but have no
     // message key as overflow events are round-robined
     assert_json_include!(
         actual: overflow_topic.next_event()?,
@@ -358,6 +358,139 @@ async fn it_overflows_events_on_specified_keys() -> Result<()> {
             "token": token2,
             "distinct_id": distinct_id2,
         })
+    );
+
+    overflow_topic.assert_empty();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn it_overflows_events_on_specified_keys_preserving_locality() -> Result<()> {
+    setup_tracing();
+
+    // token only will be limited by candidate list
+    let token1 = String::from("token1");
+    let distinct_id1 = String::from("user1");
+
+    // token:distinct_id will be limited by candidate list
+    let token2 = String::from("token2");
+    let distinct_id2 = String::from("user2");
+    let key2 = format!("{}:{}", token2, distinct_id2);
+
+    // won't be limited other than by burst/rate-limits
+    let token3 = String::from("token3");
+    let distinct_id3 = String::from("user3");
+
+    let topic = EphemeralTopic::new().await;
+    let overflow_topic = EphemeralTopic::new().await;
+
+    let mut config = DEFAULT_CONFIG.clone();
+    // this is the candidate list of tokens/event keys to reroute on sight
+    config.ingestion_force_overflow_by_token_distinct_id = Some(format!("{},{}", token1, key2));
+    config.kafka.kafka_hosts = "localhost:9092".to_string();
+    config.kafka.kafka_producer_linger_ms = 0; // Send messages immediately
+    config.kafka.kafka_message_timeout_ms = 10000; // 10s timeout
+    config.kafka.kafka_producer_max_retries = 3;
+    config.kafka.kafka_topic = topic.topic_name().to_string();
+    config.kafka.kafka_overflow_topic = overflow_topic.topic_name().to_string();
+    config.overflow_enabled = true;
+    config.overflow_preserve_partition_locality = true;
+    config.overflow_burst_limit = NonZeroU32::new(10).unwrap();
+    config.overflow_per_second_limit = NonZeroU32::new(10).unwrap();
+
+    let server = ServerHandle::for_config(config).await;
+
+    let batch_1 = json!([
+    // all events with token1 should be in overflow
+    {
+        "token": token1,
+        "event": "event1",
+        "distinct_id": distinct_id1,
+    },
+    {
+        "token": token1,
+        "event": "event2",
+        "distinct_id": distinct_id2,
+    }]);
+
+    let batch_2 = json!([
+    // only events with token2:distinct_id2 should be in overflow
+    {
+        "token": token2,
+        "event": "event3",
+        "distinct_id": distinct_id2,
+    },
+    {
+        "token": token2,
+        "event": "event4",
+        "distinct_id": distinct_id1,
+    }]);
+
+    let batch_3 = json!([
+    // all events for token3 and token3:distinct_id3 should be in main topic
+    {
+        "token": token3,
+        "event": "event5",
+        "distinct_id": distinct_id1,
+    },
+    {
+        "token": token3,
+        "event": "event6",
+        "distinct_id": distinct_id2,
+    },
+    {
+        "token": token3,
+        "event": "event7",
+        "distinct_id": distinct_id3,
+    }]);
+
+    let res = server.capture_events(batch_1.to_string()).await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    let res = server.capture_events(batch_2.to_string()).await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    let res = server.capture_events(batch_3.to_string()).await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    // main toppic results
+    assert_eq!(
+        topic.next_message_key()?.unwrap(),
+        format!("{}:{}", token2, distinct_id1)
+    );
+    assert_eq!(
+        topic.next_message_key()?.unwrap(),
+        format!("{}:{}", token3, distinct_id1)
+    );
+
+    assert_eq!(
+        topic.next_message_key()?.unwrap(),
+        format!("{}:{}", token3, distinct_id2)
+    );
+
+    assert_eq!(
+        topic.next_message_key()?.unwrap(),
+        format!("{}:{}", token3, distinct_id3)
+    );
+
+    topic.assert_empty();
+
+    // Expected events should be in overflow topic, but should
+    // retain original partition keys, so fetch-by-key works here
+    assert_eq!(
+        topic.next_message_key()?.unwrap(),
+        format!("{}:{}", token1, distinct_id1)
+    );
+
+    assert_eq!(
+        topic.next_message_key()?.unwrap(),
+        format!("{}:{}", token1, distinct_id2)
+    );
+
+    assert_eq!(
+        topic.next_message_key()?.unwrap(),
+        format!("{}:{}", token2, distinct_id2)
     );
 
     overflow_topic.assert_empty();
@@ -479,7 +612,7 @@ async fn it_reroutes_to_historical_on_specified_keys() -> Result<()> {
 
     topic.assert_empty();
 
-    // Third event should be in historical topic
+    // Expected events should be in historical topic
     assert_json_include!(
         actual: historical_topic.next_event()?,
         expected: json!({
@@ -587,7 +720,7 @@ async fn it_reroutes_to_historical_on_event_timestamp() -> Result<()> {
 
     topic.assert_empty();
 
-    // Third event should be in historical topic
+    // Expected events should be in historical topic
     assert_json_include!(
         actual: historical_topic.next_event()?,
         expected: json!({
@@ -656,7 +789,7 @@ async fn it_overflows_events_on_burst() -> Result<()> {
     topic.assert_empty();
 
     // Third event should be in overflow topic, but has no
-    // message key as overflow events are round-robined
+    // message key as overflow locality is off for this test
     assert_json_include!(
         actual: overflow_topic.next_event()?,
         expected: json!({


### PR DESCRIPTION
## Problem

Normally, when routing a team's events to overflow ingestion we remove the partition key, along with some guarantees about QoS (ordering etc.)

However, when the root problem that caused us to reroute the team's events involves delayed persons processing, distributing them without a partition key can spread out the resulting person -> distinct_id DB traffic in a way that can degrade performance more in overflow than it would in the main ingest pipeline.

[The plugin-server already has optional handling for this](https://github.com/PostHog/posthog/blob/d5fd693f7592ac604a034e5862ef4d620770aa55/plugin-server/src/config/config.ts#L83). As a starting place, let's push this handling upstream into `capture-rs` as we've been doing for our other ingestion defense mechanisms.

## Changes

* Adds configuration to `capture-rs`, and logic to the `OverflowLimiter` and Kafka sink to control partition keys during overflow routing
* Adds new unit tests to exercise the new behavior 

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally and in CI
