### PR TITLE
feat: add recording comparison timestamp leeway

### DIFF
--- a/posthog/temporal/session_recordings/compare_recording_metadata_workflow.py
+++ b/posthog/temporal/session_recordings/compare_recording_metadata_workflow.py
@@ -20,6 +20,7 @@ def get_session_replay_events(
     started_after: dt.datetime,
     started_before: dt.datetime,
     session_length_limit_seconds: int = 172800,
+    timestamp_leeway_seconds: int = 0,
 ) -> list[tuple]:
     """Get session replay events from the specified table within the time range."""
     query = """
@@ -43,8 +44,8 @@ def get_session_replay_events(
             argMinMerge(snapshot_library) as snapshot_library
             {block_fields}
         FROM {table}
-        WHERE min_first_timestamp >= toDateTime(%(started_after)s)
-        AND max_last_timestamp <= toDateTime(%(started_before)s) + INTERVAL {session_length_limit_seconds} SECOND
+        WHERE min_first_timestamp >= toDateTime(%(started_after)s) - INTERVAL %(timestamp_leeway)s SECOND
+        AND max_last_timestamp <= toDateTime(%(started_before)s) + INTERVAL {session_length_limit_seconds} SECOND + INTERVAL %(timestamp_leeway)s SECOND
         GROUP BY
             session_id,
             team_id
@@ -72,6 +73,7 @@ def get_session_replay_events(
         {
             "started_after": started_after.strftime("%Y-%m-%d %H:%M:%S"),
             "started_before": started_before.strftime("%Y-%m-%d %H:%M:%S"),
+            "timestamp_leeway": timestamp_leeway_seconds,
         },
     )
 
@@ -103,6 +105,7 @@ class CompareRecordingMetadataActivityInputs:
     started_before: str = dataclasses.field()
     window_result_limit: int | None = dataclasses.field(default=None)
     session_length_limit_seconds: int = dataclasses.field(default=172800)  # 48h default
+    timestamp_leeway_seconds: int = dataclasses.field(default=0)  # No leeway by default
 
     @property
     def properties_to_log(self) -> dict[str, typing.Any]:
@@ -111,6 +114,7 @@ class CompareRecordingMetadataActivityInputs:
             "started_before": self.started_before,
             "window_result_limit": self.window_result_limit,
             "session_length_limit_seconds": self.session_length_limit_seconds,
+            "timestamp_leeway_seconds": self.timestamp_leeway_seconds,
         }
 
 
@@ -140,6 +144,7 @@ async def compare_recording_metadata_activity(inputs: CompareRecordingMetadataAc
                 started_after,
                 started_before,
                 inputs.session_length_limit_seconds,
+                inputs.timestamp_leeway_seconds,
             ),
             asyncio.to_thread(
                 get_session_replay_events,
@@ -147,6 +152,7 @@ async def compare_recording_metadata_activity(inputs: CompareRecordingMetadataAc
                 started_after,
                 started_before,
                 inputs.session_length_limit_seconds,
+                inputs.timestamp_leeway_seconds,
             ),
         )
 
@@ -280,6 +286,7 @@ class CompareRecordingMetadataWorkflowInputs:
     window_seconds: int = dataclasses.field(default=300)  # 5 minutes default
     window_result_limit: int | None = dataclasses.field(default=None)  # No limit by default
     session_length_limit_seconds: int = dataclasses.field(default=172800)  # 48h default
+    timestamp_leeway_seconds: int = dataclasses.field(default=0)  # No leeway by default
 
     @property
     def properties_to_log(self) -> dict[str, typing.Any]:
@@ -289,6 +296,7 @@ class CompareRecordingMetadataWorkflowInputs:
             "window_seconds": self.window_seconds,
             "window_result_limit": self.window_result_limit,
             "session_length_limit_seconds": self.session_length_limit_seconds,
+            "timestamp_leeway_seconds": self.timestamp_leeway_seconds,
         }
 
 
@@ -322,12 +330,17 @@ class CompareRecordingMetadataWorkflow(PostHogWorkflow):
         if not isinstance(session_length_limit_seconds, int) or session_length_limit_seconds <= 0:
             raise ValueError("session_length_limit_seconds must be a positive integer")
 
+        timestamp_leeway_seconds = loaded.get("timestamp_leeway_seconds", 0)
+        if not isinstance(timestamp_leeway_seconds, int) or timestamp_leeway_seconds < 0:
+            raise ValueError("timestamp_leeway_seconds must be a non-negative integer")
+
         return CompareRecordingMetadataWorkflowInputs(
             started_after=loaded["started_after"],
             started_before=loaded["started_before"],
             window_seconds=window_seconds,
             window_result_limit=window_result_limit,
             session_length_limit_seconds=session_length_limit_seconds,
+            timestamp_leeway_seconds=timestamp_leeway_seconds,
         )
 
     @staticmethod
@@ -356,11 +369,12 @@ class CompareRecordingMetadataWorkflow(PostHogWorkflow):
         logger = get_internal_logger()
         workflow_start = dt.datetime.now()
         logger.info(
-            "Starting comparison workflow for sessions between %s and %s using %d second windows%s",
+            "Starting comparison workflow for sessions between %s and %s using %d second windows%s%s",
             started_after,
             started_before,
             inputs.window_seconds,
             f" (limiting to {inputs.window_result_limit} sessions per window)" if inputs.window_result_limit else "",
+            f" (with {inputs.timestamp_leeway_seconds}s timestamp leeway)" if inputs.timestamp_leeway_seconds else "",
         )
 
         # Generate time windows
@@ -381,6 +395,7 @@ class CompareRecordingMetadataWorkflow(PostHogWorkflow):
                 started_before=window_end.isoformat(),
                 window_result_limit=inputs.window_result_limit,
                 session_length_limit_seconds=inputs.session_length_limit_seconds,
+                timestamp_leeway_seconds=inputs.timestamp_leeway_seconds,
             )
 
             await temporalio.workflow.execute_activity(


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Records in session replay events can span several rows and the rows can have different values between v1 and v2 tables even when the total is the same.

## Changes

Adds a timestamp leeway to help exclude sessions that partially fall outside of the requested window for the comparison.

## Does this work well for both Cloud and self-hosted?

N/A

## How did you test this code?

Tested locally.