### PR TITLE
fix: sort rows by time in recording comparison

### DIFF
--- a/posthog/temporal/session_recordings/compare_recording_metadata_workflow.py
+++ b/posthog/temporal/session_recordings/compare_recording_metadata_workflow.py
@@ -43,9 +43,13 @@ def get_session_replay_events(
             argMinMerge(snapshot_source) as snapshot_source,
             argMinMerge(snapshot_library) as snapshot_library
             {block_fields}
-        FROM {table}
-        WHERE min_first_timestamp >= toDateTime(%(started_after)s) - INTERVAL %(timestamp_leeway)s SECOND
-        AND max_last_timestamp <= toDateTime(%(started_before)s) + INTERVAL {session_length_limit_seconds} SECOND + INTERVAL %(timestamp_leeway)s SECOND
+        FROM (
+            SELECT *
+            FROM {table}
+            WHERE min_first_timestamp >= toDateTime(%(started_after)s) - INTERVAL %(timestamp_leeway)s SECOND
+            AND max_last_timestamp <= toDateTime(%(started_before)s) + INTERVAL {session_length_limit_seconds} SECOND + INTERVAL %(timestamp_leeway)s SECOND
+            ORDER BY min_first_timestamp ASC
+        )
         GROUP BY
             session_id,
             team_id


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We're getting some session differences due to lack of ordering when comparing sessions with multiple rows.

## Changes

Orders the session replay events rows before aggregation.

## Does this work well for both Cloud and self-hosted?

N/A

## How did you test this code?

Tested locally.