### PR TITLE
fix(capture-rs): more defensive key/token parsing in reroute lists and inputs

### DIFF
--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -52,7 +52,7 @@ impl HistoricalConfig {
     ) -> Self {
         let mut htk = HashSet::new();
         if let Some(s) = tokens_keys {
-            for entry in s.split(",") {
+            for entry in s.split(",").filter(|s| !s.trim().is_empty()) {
                 htk.insert(entry.trim().to_string());
             }
         }
@@ -68,6 +68,10 @@ impl HistoricalConfig {
     // and self.historical_tokens_keys is a set of the same. if the key
     // matches any entry in the set, the event should be rerouted
     pub fn should_reroute(&self, event_key: &str) -> bool {
+        if event_key.is_empty() {
+            return false;
+        }
+
         // is the event key in the forced_keys list?
         let key_match = self.historical_tokens_keys.contains(event_key);
 
@@ -234,4 +238,38 @@ pub fn router<
     } else {
         router
     }
+}
+
+#[test]
+fn test_historical_config_handles_tokens_key_routing_correctly() {
+    let inputs = Some(String::from("token1,token2:user2,")); // 3 entries including empty string!
+    let hcfg = HistoricalConfig::new(true, 100, inputs);
+
+    // event key not in list passes
+    let key = "token3:user3";
+    assert!(!hcfg.should_reroute(key));
+
+    // token not in list passes
+    let key = "token4";
+    assert!(!hcfg.should_reroute(key));
+
+    // full event key in list should always be rerouted
+    let key = "token2:user2";
+    assert!(hcfg.should_reroute(key));
+
+    // event key with token 2 but different suffix should not be rerouted
+    let key = "token2:user7";
+    assert!(!hcfg.should_reroute(key));
+
+    // anything having to do with token1 should be rerouted
+    let key = "token1:user1";
+    assert!(hcfg.should_reroute(key));
+    let key = "token1:user2";
+    assert!(hcfg.should_reroute(key));
+    let key = "token1";
+    assert!(hcfg.should_reroute(key));
+
+    // empty event key/token should not be rerouted, fails open
+    let key = "";
+    assert!(!hcfg.should_reroute(key));
 }

--- a/rust/common/limiters/src/overflow.rs
+++ b/rust/common/limiters/src/overflow.rs
@@ -35,7 +35,11 @@ impl OverflowLimiter {
 
         let keys_to_reroute: HashSet<String> = match keys_to_reroute {
             None => HashSet::new(),
-            Some(values) => values.split(',').map(String::from).collect(),
+            Some(values) => values
+                .split(',')
+                .map(String::from)
+                .filter(|s| !s.is_empty())
+                .collect(),
         };
 
         OverflowLimiter {
@@ -50,13 +54,22 @@ impl OverflowLimiter {
     // If this method returns true, the event should be rerouted to the overflow topic
     // without a partition key, to avoid hot partitions in that pipeline.
     pub fn is_limited(&self, event_key: &String) -> bool {
+        if event_key.is_empty() {
+            return false;
+        }
         // is the event key in the forced_keys list?
         let forced_key_match = self.keys_to_reroute.contains(event_key);
 
         // is the token (first component of the event key) in the forced_keys list?
-        let forced_token_match = match event_key.split(':').next() {
-            Some(token) => !token.is_empty() && self.keys_to_reroute.contains(token),
-            None => false,
+        let forced_token_match = {
+            let parts = event_key
+                .split(':')
+                .filter(|s| !s.trim().is_empty())
+                .collect::<Vec<&str>>();
+            match parts.first() {
+                Some(token) => !token.is_empty() && self.keys_to_reroute.contains(*token),
+                None => false,
+            }
         };
 
         // should rate limiting be triggered for this event?
@@ -119,6 +132,38 @@ mod tests {
         let key = String::from("test:user");
         assert!(!limiter.is_limited(&key));
         assert!(limiter.is_limited(&key));
+    }
+
+    #[tokio::test]
+    async fn empty_entry_in_event_key_csv() {
+        let limiter = OverflowLimiter::new(
+            NonZeroU32::new(10).unwrap(),
+            NonZeroU32::new(10).unwrap(),
+            Some(String::from("token1,token2:user2,")), // 3 strings, last is ""
+            false,
+        );
+
+        // limiter should behave as normal even when an empty string entry
+        // slipped through the env var to OverflowLimiter::new
+        let key = String::from("token3:user3");
+        assert!(!limiter.is_limited(&key));
+        assert!(!limiter.is_limited(&key));
+        assert!(!limiter.is_limited(&key));
+
+        let key = String::from("token3");
+        assert!(!limiter.is_limited(&key));
+        assert!(!limiter.is_limited(&key));
+        assert!(!limiter.is_limited(&key));
+
+        let key = String::from("token1");
+        assert!(limiter.is_limited(&key));
+
+        let key = String::from("token2:user2");
+        assert!(limiter.is_limited(&key));
+
+        // empty *incoming* event key doesn't trigger limiter in error
+        let empty_key = String::from("");
+        assert!(!limiter.is_limited(&empty_key))
     }
 
     #[tokio::test]

--- a/rust/common/limiters/src/overflow.rs
+++ b/rust/common/limiters/src/overflow.rs
@@ -61,15 +61,9 @@ impl OverflowLimiter {
         let forced_key_match = self.keys_to_reroute.contains(event_key);
 
         // is the token (first component of the event key) in the forced_keys list?
-        let forced_token_match = {
-            let parts = event_key
-                .split(':')
-                .filter(|s| !s.trim().is_empty())
-                .collect::<Vec<&str>>();
-            match parts.first() {
-                Some(token) => !token.is_empty() && self.keys_to_reroute.contains(*token),
-                None => false,
-            }
+        let forced_token_match = match event_key.split(':').find(|s| !s.trim().is_empty()) {
+            Some(token) => self.keys_to_reroute.contains(token),
+            None => false,
         };
 
         // should rate limiting be triggered for this event?


### PR DESCRIPTION
## Problem
If someone accidentally left a stray comma in one of our CSV-formatted env vars, that could go badly for new token/key based routing logic in `capture-rs`

## Changes
Check for all this on filter construction from env inputs and per-eval event inputs. New unit tests for all of the above.

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally and in CI (+new tests)
