### PR TITLE
chore(batch-exports): Increase jitter to 1/4th of interval

### DIFF
--- a/posthog/batch_exports/models.py
+++ b/posthog/batch_exports/models.py
@@ -250,7 +250,7 @@ class BatchExport(UUIDModel):
 
     @property
     def interval_time_delta(self) -> timedelta:
-        """Return a datetime.timedelta that corresponds to this BatchExport's interval."""
+        """Return a datetime.timedelta that corresponds to this batch export's interval."""
         if self.interval == "hour":
             return timedelta(hours=1)
         elif self.interval == "day":
@@ -261,6 +261,28 @@ class BatchExport(UUIDModel):
             _, value, unit = self.interval.split(" ")
             kwargs = {unit: int(value)}
             return timedelta(**kwargs)
+        raise ValueError(f"Invalid interval: '{self.interval}'")
+
+    @property
+    def jitter(self) -> timedelta:
+        """Return jitter for this batch export based on interval.
+
+        We always want the start jitter to be less than the frequency, as
+        otherwise a batch export run could start after it's batch period has
+        elapsed. But there is margin to tweak this under that upper limit.
+
+        So, the values set here are quite arbitrary and are adjusted based on
+        how other systems react to batch exports load.
+        """
+        if self.interval == "hour":
+            return timedelta(minutes=15)
+        elif self.interval == "day":
+            return timedelta(hours=1)
+        elif self.interval == "week":
+            return timedelta(days=1)
+        elif self.interval.startswith("every"):
+            # 5 minute batch exports = 1.25 minutes of jitter
+            return self.interval_time_delta / 4
         raise ValueError(f"Invalid interval: '{self.interval}'")
 
 

--- a/posthog/batch_exports/models.py
+++ b/posthog/batch_exports/models.py
@@ -281,8 +281,12 @@ class BatchExport(UUIDModel):
         elif self.interval == "week":
             return timedelta(days=1)
         elif self.interval.startswith("every"):
-            # 5 minute batch exports = 1.25 minutes of jitter
-            return self.interval_time_delta / 4
+            # This yields 1 minute for 5 minute batch exports, which is the only
+            # "every" interval in use currently.
+            # In the future, we can extend this to have different handling for
+            # different "every" intervals.
+            return self.interval_time_delta / 5
+
         raise ValueError(f"Invalid interval: '{self.interval}'")
 
 

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -695,7 +695,7 @@ def sync_batch_export(batch_export: BatchExport, created: bool):
             start_at=batch_export.start_at,
             end_at=batch_export.end_at,
             intervals=[ScheduleIntervalSpec(every=batch_export.interval_time_delta)],
-            jitter=max(dt.timedelta(minutes=1), (batch_export.interval_time_delta / 6)),
+            jitter=max(dt.timedelta(minutes=15), (batch_export.interval_time_delta / 4)),
             time_zone_name=batch_export.team.timezone,
         ),
         state=state,

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -695,7 +695,7 @@ def sync_batch_export(batch_export: BatchExport, created: bool):
             start_at=batch_export.start_at,
             end_at=batch_export.end_at,
             intervals=[ScheduleIntervalSpec(every=batch_export.interval_time_delta)],
-            jitter=max(dt.timedelta(minutes=15), (batch_export.interval_time_delta / 4)),
+            jitter=max(dt.timedelta(minutes=1), (batch_export.interval_time_delta / 4)),
             time_zone_name=batch_export.team.timezone,
         ),
         state=state,

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -695,7 +695,7 @@ def sync_batch_export(batch_export: BatchExport, created: bool):
             start_at=batch_export.start_at,
             end_at=batch_export.end_at,
             intervals=[ScheduleIntervalSpec(every=batch_export.interval_time_delta)],
-            jitter=max(dt.timedelta(minutes=1), (batch_export.interval_time_delta / 4)),
+            jitter=batch_export.jitter,
             time_zone_name=batch_export.team.timezone,
         ),
         state=state,


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We had a max jitter of 1 minute. increase that to 15 minutes (for hourly exports).

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
