### PR TITLE
fix: inverted modifiers for actors queries

### DIFF
--- a/posthog/hogql_queries/actors_query_runner.py
+++ b/posthog/hogql_queries/actors_query_runner.py
@@ -38,6 +38,7 @@ class ActorsQueryRunner(QueryRunner):
 
         if self.query.source:
             self.source_query_runner = get_query_runner(self.query.source, self.team, self.timings, self.limit_context)
+            self.modifiers = self.source_query_runner.modifiers
 
         self.strategy = self.determine_strategy()
         self.calculating = False

--- a/posthog/hogql_queries/insights/insight_actors_query_runner.py
+++ b/posthog/hogql_queries/insights/insight_actors_query_runner.py
@@ -1,5 +1,4 @@
-from typing import cast, Optional
-
+from typing import cast, Optional, Any
 
 from posthog.hogql import ast
 from posthog.hogql.constants import HogQLGlobalSettings, LimitContext
@@ -36,17 +35,21 @@ class InsightActorsQueryRunner(QueryRunner):
 
     def __init__(
         self,
-        query: InsightActorsQueryNode,
+        query: InsightActorsQueryNode | dict[str, Any],
         team: Team,
         timings: Optional[HogQLTimings] = None,
         modifiers: Optional[HogQLQueryModifiers] = None,
         limit_context: Optional[LimitContext] = None,
         query_id: Optional[str] = None,
     ):
-        if modifiers is None:
-            modifiers = query.source.modifiers if hasattr(query.source, "modifiers") else None
         super().__init__(
-            query, team=team, timings=timings, modifiers=modifiers, limit_context=limit_context, query_id=query_id
+            query,
+            team=team,
+            timings=timings,
+            modifiers=modifiers,
+            limit_context=limit_context,
+            query_id=query_id,
+            extract_modifiers=lambda query: query.source.modifiers if hasattr(query.source, "modifiers") else None,
         )
 
     @cached_property

--- a/posthog/hogql_queries/insights/insight_actors_query_runner.py
+++ b/posthog/hogql_queries/insights/insight_actors_query_runner.py
@@ -1,8 +1,10 @@
 from typing import cast, Optional
 
+
 from posthog.hogql import ast
-from posthog.hogql.constants import HogQLGlobalSettings
+from posthog.hogql.constants import HogQLGlobalSettings, LimitContext
 from posthog.hogql.query import execute_hogql_query
+from posthog.hogql.timings import HogQLTimings
 from posthog.hogql_queries.insights.funnels.funnel_correlation_query_runner import FunnelCorrelationQueryRunner
 from posthog.hogql_queries.insights.funnels.funnels_query_runner import FunnelsQueryRunner
 from posthog.hogql_queries.insights.lifecycle_query_runner import LifecycleQueryRunner
@@ -11,6 +13,7 @@ from posthog.hogql_queries.insights.retention_query_runner import RetentionQuery
 from posthog.hogql_queries.insights.stickiness_query_runner import StickinessQueryRunner
 from posthog.hogql_queries.insights.trends.trends_query_runner import TrendsQueryRunner
 from posthog.hogql_queries.query_runner import QueryRunner, get_query_runner
+from posthog.models import Team
 from posthog.models.filters.mixins.utils import cached_property
 from posthog.schema import (
     FunnelCorrelationActorsQuery,
@@ -23,12 +26,28 @@ from posthog.schema import (
     FunnelsQuery,
     LifecycleQuery,
     StickinessActorsQuery,
+    HogQLQueryModifiers,
 )
 from posthog.types import InsightActorsQueryNode
 
 
 class InsightActorsQueryRunner(QueryRunner):
     query: InsightActorsQueryNode
+
+    def __init__(
+        self,
+        query: InsightActorsQueryNode,
+        team: Team,
+        timings: Optional[HogQLTimings] = None,
+        modifiers: Optional[HogQLQueryModifiers] = None,
+        limit_context: Optional[LimitContext] = None,
+        query_id: Optional[str] = None,
+    ):
+        if modifiers is None:
+            modifiers = query.source.modifiers if hasattr(query.source, "modifiers") else None
+        super().__init__(
+            query, team=team, timings=timings, modifiers=modifiers, limit_context=limit_context, query_id=query_id
+        )
 
     @cached_property
     def source_runner(self) -> QueryRunner:

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -630,12 +630,11 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         modifiers: Optional[HogQLQueryModifiers] = None,
         limit_context: Optional[LimitContext] = None,
         query_id: Optional[str] = None,
+        extract_modifiers=lambda query: (query.modifiers if hasattr(query, "modifiers") else None),
     ):
         self.team = team
         self.timings = timings or HogQLTimings()
         self.limit_context = limit_context or LimitContext.QUERY
-        _modifiers = modifiers or (query.modifiers if hasattr(query, "modifiers") else None)
-        self.modifiers = create_default_modifiers_for_team(team, _modifiers)
         self.query_id = query_id
 
         if not self.is_query_node(query):
@@ -651,6 +650,9 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             else:
                 query = self.query_type.model_validate(query)
                 assert isinstance(query, self.query_type)
+
+        _modifiers = modifiers or extract_modifiers(query)
+        self.modifiers = create_default_modifiers_for_team(team, _modifiers)
         self.query = query
 
     @property

--- a/posthog/hogql_queries/test/test_actors_query_runner.py
+++ b/posthog/hogql_queries/test/test_actors_query_runner.py
@@ -25,6 +25,10 @@ from posthog.schema import (
     IntervalType,
     InsightActorsQuery,
     TrendsQuery,
+    FunnelsQuery,
+    HogQLQueryModifiers,
+    FunnelsActorsQuery,
+    PersonsOnEventsMode,
 )
 from posthog.test.base import (
     APIBaseTest,
@@ -35,6 +39,8 @@ from posthog.test.base import (
 )
 from freezegun import freeze_time
 from django.test import override_settings
+from unittest.mock import patch
+from posthog.hogql.query import execute_hogql_query
 
 
 class TestActorsQueryRunner(ClickhouseTestMixin, APIBaseTest):
@@ -505,3 +511,28 @@ class TestActorsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         group = response.results[1][0]
         assert group["id"] == "org2"
         assert set(group.keys()) == {"id", "group_type_index"}
+
+    @patch("posthog.hogql_queries.insights.paginators.execute_hogql_query", wraps=execute_hogql_query)
+    def test_funnel_source_with_poe_mode(self, spy_execute_hogql_query):
+        self.team.modifiers = {
+            **(self.team.modifiers or {}),
+            "personsOnEventsMode": PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS,
+        }
+        self.team.save()
+
+        self.random_uuid = self._create_random_persons()
+        funnel_query = FunnelsQuery(
+            series=[
+                EventsNode(event="clicky-1"),
+                EventsNode(event="clicky-2"),
+            ],
+            modifiers=HogQLQueryModifiers(personsOnEventsMode=PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED),
+        )
+
+        runner = self._create_runner(ActorsQuery(source=FunnelsActorsQuery(funnelStep=1, source=funnel_query)))
+
+        runner.calculate()
+
+        # Verify that execute_hogql_query was called with the correct modifiers
+        called_modifiers: HogQLQueryModifiers = spy_execute_hogql_query.call_args[1]["modifiers"]
+        self.assertEqual(called_modifiers.personsOnEventsMode, PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED)


### PR DESCRIPTION
## Problem
Actors queries are not respecting modifiers that come from the source query. This is important to do in order for the actors query modal results to be the same as the charts themselves.

## Changes
Pull up modifiers in the case of InsightActorsQueries.

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Wrote a test.
