### PR TITLE
fix(max): prevent rerender if props are the same

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonMarkdown/LemonMarkdown.tsx
+++ b/frontend/src/lib/lemon-ui/LemonMarkdown/LemonMarkdown.tsx
@@ -2,6 +2,7 @@ import './LemonMarkdown.scss'
 
 import clsx from 'clsx'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+import React from 'react'
 import ReactMarkdown from 'react-markdown'
 
 import { Link } from '../Link'
@@ -16,7 +17,7 @@ export interface LemonMarkdownProps {
 }
 
 /** Beautifully rendered Markdown. */
-export function LemonMarkdown({
+export const LemonMarkdown = React.memo(function LemonMarkdown({
     children,
     lowKeyHeadings = false,
     disableDocsRedirect = false,
@@ -49,4 +50,4 @@ export function LemonMarkdown({
             </ReactMarkdown>
         </div>
     )
-}
+})


### PR DESCRIPTION
## Problem

- markdown is glitchy as it rerenders everytime the thread is rendered even if content doesn't change

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- memoize the component

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
