### PR TITLE
chore(flags): add some more metrics and logging for group type matching errors

### DIFF
--- a/rust/feature-flags/src/flags/flag_group_type_mapping.rs
+++ b/rust/feature-flags/src/flags/flag_group_type_mapping.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use common_metrics::inc;
 use common_types::ProjectId;
 use sqlx::FromRow;
+use tracing::error;
 
 use crate::{api::errors::FlagError, metrics::consts::FLAG_EVALUATION_ERROR_COUNTER};
 
@@ -54,6 +55,10 @@ impl GroupTypeMappingCache {
 
         if mapping.is_empty() {
             let reason = "no_group_type_mappings";
+            error!(
+                "No group type mappings found for project {}",
+                self.project_id
+            );
             inc(
                 FLAG_EVALUATION_ERROR_COUNTER,
                 &[("reason".to_string(), reason.to_string())],

--- a/rust/feature-flags/src/metrics/consts.rs
+++ b/rust/feature-flags/src/metrics/consts.rs
@@ -22,7 +22,8 @@ pub const FLAG_HASH_KEY_PROCESSING_TIME: &str = "flags_hash_key_processing_time"
 pub const FLAG_LOCAL_PROPERTY_OVERRIDE_MATCH_TIME: &str =
     "flags_local_property_override_match_time";
 pub const FLAG_DB_PROPERTIES_FETCH_TIME: &str = "flags_properties_db_fetch_time";
-pub const FLAG_GROUP_FETCH_TIME: &str = "flags_groups_cache_fetch_time";
+pub const FLAG_GROUP_DB_FETCH_TIME: &str = "flags_groups_db_fetch_time"; // this is how long it takes to fetch the group type mappings from the DB
+pub const FLAG_GROUP_CACHE_FETCH_TIME: &str = "flags_groups_cache_fetch_time"; // this is how long it takes to fetch the group type mappings from the cache
 pub const FLAG_GET_MATCH_TIME: &str = "flags_get_match_time";
 pub const FLAG_EVALUATE_ALL_CONDITIONS_TIME: &str = "flags_evaluate_all_conditions_time";
 pub const FLAG_PERSON_QUERY_TIME: &str = "flags_person_query_time";


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

I'm investigating some edge case errors with the new flags service and I've noticed a recent spike in getting group type mappings for a given project ID

<img width="840" alt="image" src="https://github.com/user-attachments/assets/0e2fb1ff-9ad4-482a-aec9-0ede56c52e7d" />

This doesn't necessarily mean we'll fail to evaluate flags (we do set `errorWhileComputingFlags` to true, but we don't exit early) – if the team in question doesn't have any flags with group targeting, all of the flags will evaluate just fine, but I want to see why this error is happening.  It might have some clues on how to fix it.

I also added a timer for that fetch operation, since I want to see how long that query takes generally.