### PR TITLE
feat(web-analytics): add loading state to Active users widget

### DIFF
--- a/frontend/src/scenes/web-analytics/EventsHeatMap/EventsHeatMap.tsx
+++ b/frontend/src/scenes/web-analytics/EventsHeatMap/EventsHeatMap.tsx
@@ -1,8 +1,10 @@
 import './EventsHeatMap.scss'
 
 import { useValues } from 'kea'
+import { InsightsWrapper } from 'products/revenue_analytics/frontend/nodes/utils'
 import React, { useCallback, useEffect, useState } from 'react'
 import { dataThemeLogic } from 'scenes/dataThemeLogic'
+import { InsightLoadingState } from 'scenes/insights/EmptyStates'
 
 import { useResizeObserver } from '~/lib/hooks/useResizeObserver'
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
@@ -67,7 +69,7 @@ export function EventsHeatMap({ query, context, cachedResults }: EventsHeatMapPr
         updateSize()
     }, [elementRef, updateSize])
 
-    const { response } = useValues(
+    const { response, responseLoading, queryId } = useValues(
         dataNodeLogic({
             query,
             key: 'events-heat-map',
@@ -75,6 +77,14 @@ export function EventsHeatMap({ query, context, cachedResults }: EventsHeatMapPr
             cachedResults,
         })
     )
+
+    if (responseLoading) {
+        return (
+            <InsightsWrapper>
+                <InsightLoadingState queryId={queryId} key={queryId} insightProps={context.insightProps ?? {}} />
+            </InsightsWrapper>
+        )
+    }
 
     const { matrix, maxOverall, xAggregations, yAggregations, maxXAggregation, maxYAggregation, overallValue } =
         processData(response?.results ?? [])


### PR DESCRIPTION
This PR:
- Introduced loading state handling using InsightLoadingState and InsightsWrapper.
- Updated useValues to include responseLoading and queryId for better loading management.

> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We do not show any feedback when refetching the results for the active users components

## Changes

During fetching the query we show the loading component as every other component do

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manually

<img width="1197" alt="image" src="https://github.com/user-attachments/assets/fe3c9d3b-c0d9-4489-8ace-71ab23714414" />

