### PR TITLE
fix: fix v2 logs being log instead of info

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/rrweb-types.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/rrweb-types.ts
@@ -86,27 +86,7 @@ export function hrefFrom(inputEvent: SnapshotEvent): string | undefined {
 
 // Constants for log levels
 export enum ConsoleLogLevel {
-    Log = 'log',
+    Info = 'info',
     Warn = 'warn',
     Error = 'error',
-}
-
-/**
- * Checks if an event is a console event and returns its log level, or null if it's not a console event
- */
-export function getConsoleLogLevel(inputEvent: SnapshotEvent): ConsoleLogLevel | null {
-    const event = inputEvent as
-        | { type?: number; data?: { plugin?: string; payload?: { level?: ConsoleLogLevel } } }
-        | undefined
-    if (event?.type === RRWebEventType.Plugin && event?.data?.plugin === 'rrweb/console@1') {
-        const level = event?.data?.payload?.level
-        if (level === ConsoleLogLevel.Log) {
-            return ConsoleLogLevel.Log
-        } else if (level === ConsoleLogLevel.Warn) {
-            return ConsoleLogLevel.Warn
-        } else if (level === ConsoleLogLevel.Error) {
-            return ConsoleLogLevel.Error
-        }
-    }
-    return null
 }

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-console-log-recorder.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-console-log-recorder.test.ts
@@ -237,7 +237,7 @@ describe('SessionConsoleLogRecorder', () => {
                 {
                     team_id: 1,
                     message: 'First message',
-                    level: ConsoleLogLevel.Log,
+                    level: ConsoleLogLevel.Info,
                     log_source: 'session_replay',
                     log_source_id: 'test_session_id',
                     instance_id: null,
@@ -287,7 +287,7 @@ describe('SessionConsoleLogRecorder', () => {
                 {
                     team_id: 1,
                     message: 'Message with multiple strings',
-                    level: ConsoleLogLevel.Log,
+                    level: ConsoleLogLevel.Info,
                     log_source: 'session_replay',
                     log_source_id: 'test_session_id',
                     instance_id: null,
@@ -363,17 +363,17 @@ describe('SessionConsoleLogRecorder', () => {
     describe('Log level mapping', () => {
         const testCases = [
             // Info level mappings
-            { input: 'info', expected: ConsoleLogLevel.Log },
-            { input: 'log', expected: ConsoleLogLevel.Log },
-            { input: 'debug', expected: ConsoleLogLevel.Log },
-            { input: 'trace', expected: ConsoleLogLevel.Log },
-            { input: 'dir', expected: ConsoleLogLevel.Log },
-            { input: 'dirxml', expected: ConsoleLogLevel.Log },
-            { input: 'group', expected: ConsoleLogLevel.Log },
-            { input: 'groupCollapsed', expected: ConsoleLogLevel.Log },
-            { input: 'count', expected: ConsoleLogLevel.Log },
-            { input: 'timeEnd', expected: ConsoleLogLevel.Log },
-            { input: 'timeLog', expected: ConsoleLogLevel.Log },
+            { input: 'info', expected: ConsoleLogLevel.Info },
+            { input: 'log', expected: ConsoleLogLevel.Info },
+            { input: 'debug', expected: ConsoleLogLevel.Info },
+            { input: 'trace', expected: ConsoleLogLevel.Info },
+            { input: 'dir', expected: ConsoleLogLevel.Info },
+            { input: 'dirxml', expected: ConsoleLogLevel.Info },
+            { input: 'group', expected: ConsoleLogLevel.Info },
+            { input: 'groupCollapsed', expected: ConsoleLogLevel.Info },
+            { input: 'count', expected: ConsoleLogLevel.Info },
+            { input: 'timeEnd', expected: ConsoleLogLevel.Info },
+            { input: 'timeLog', expected: ConsoleLogLevel.Info },
             // Warn level mappings
             { input: 'warn', expected: ConsoleLogLevel.Warn },
             { input: 'countReset', expected: ConsoleLogLevel.Warn },
@@ -406,11 +406,11 @@ describe('SessionConsoleLogRecorder', () => {
 
         it('handles edge cases', async () => {
             const edgeCases = [
-                { level: 'unknown', expected: ConsoleLogLevel.Log },
-                { level: '', expected: ConsoleLogLevel.Log },
-                { level: undefined, expected: ConsoleLogLevel.Log },
-                { level: null, expected: ConsoleLogLevel.Log },
-                { level: 123, expected: ConsoleLogLevel.Log },
+                { level: 'unknown', expected: ConsoleLogLevel.Info },
+                { level: '', expected: ConsoleLogLevel.Info },
+                { level: undefined, expected: ConsoleLogLevel.Info },
+                { level: null, expected: ConsoleLogLevel.Info },
+                { level: 123, expected: ConsoleLogLevel.Info },
             ]
 
             for (const { level, expected } of edgeCases) {
@@ -459,7 +459,7 @@ describe('SessionConsoleLogRecorder', () => {
             expect(mockConsoleLogStore.storeSessionConsoleLogs).toHaveBeenCalledTimes(1)
             expect(mockConsoleLogStore.storeSessionConsoleLogs).toHaveBeenCalledWith([
                 expect.objectContaining({
-                    level: ConsoleLogLevel.Log,
+                    level: ConsoleLogLevel.Info,
                     message: 'Duplicate message',
                 }),
             ])
@@ -491,7 +491,7 @@ describe('SessionConsoleLogRecorder', () => {
             expect(mockConsoleLogStore.storeSessionConsoleLogs).toHaveBeenCalledTimes(1)
             expect(mockConsoleLogStore.storeSessionConsoleLogs).toHaveBeenCalledWith([
                 expect.objectContaining({
-                    level: ConsoleLogLevel.Log,
+                    level: ConsoleLogLevel.Info,
                     message: 'Same message',
                 }),
                 expect.objectContaining({
@@ -532,7 +532,7 @@ describe('SessionConsoleLogRecorder', () => {
             expect(mockConsoleLogStore.storeSessionConsoleLogs).toHaveBeenCalledTimes(1)
             expect(mockConsoleLogStore.storeSessionConsoleLogs).toHaveBeenCalledWith([
                 expect.objectContaining({
-                    level: ConsoleLogLevel.Log,
+                    level: ConsoleLogLevel.Info,
                     message: 'Duplicate message',
                 }),
             ])
@@ -584,7 +584,7 @@ describe('SessionConsoleLogRecorder', () => {
             expect(mockConsoleLogStore.storeSessionConsoleLogs).toHaveBeenCalledTimes(1)
             expect(mockConsoleLogStore.storeSessionConsoleLogs).toHaveBeenCalledWith([
                 expect.objectContaining({
-                    level: ConsoleLogLevel.Log,
+                    level: ConsoleLogLevel.Info,
                     message: 'Duplicate info',
                 }),
                 expect.objectContaining({
@@ -624,15 +624,15 @@ describe('SessionConsoleLogRecorder', () => {
             expect(mockConsoleLogStore.storeSessionConsoleLogs).toHaveBeenCalledTimes(1)
             expect(mockConsoleLogStore.storeSessionConsoleLogs).toHaveBeenCalledWith([
                 expect.objectContaining({
-                    level: ConsoleLogLevel.Log,
+                    level: ConsoleLogLevel.Info,
                     message: 'First unique message',
                 }),
                 expect.objectContaining({
-                    level: ConsoleLogLevel.Log,
+                    level: ConsoleLogLevel.Info,
                     message: 'Second unique message',
                 }),
                 expect.objectContaining({
-                    level: ConsoleLogLevel.Log,
+                    level: ConsoleLogLevel.Info,
                     message: 'Third unique message',
                 }),
             ])

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-console-log-recorder.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-console-log-recorder.ts
@@ -7,26 +7,26 @@ import { MessageWithTeam } from '../teams/types'
 import { ConsoleLogEntry, SessionConsoleLogStore } from './session-console-log-store'
 
 const levelMapping: Record<string, ConsoleLogLevel> = {
-    info: ConsoleLogLevel.Log,
-    count: ConsoleLogLevel.Log,
-    timeEnd: ConsoleLogLevel.Log,
+    info: ConsoleLogLevel.Info,
+    count: ConsoleLogLevel.Info,
+    timeEnd: ConsoleLogLevel.Info,
     warn: ConsoleLogLevel.Warn,
     countReset: ConsoleLogLevel.Warn,
     error: ConsoleLogLevel.Error,
     assert: ConsoleLogLevel.Error,
-    // really these should be 'log' but we don't want users to have to think about this
-    log: ConsoleLogLevel.Log,
-    trace: ConsoleLogLevel.Log,
-    dir: ConsoleLogLevel.Log,
-    dirxml: ConsoleLogLevel.Log,
-    group: ConsoleLogLevel.Log,
-    groupCollapsed: ConsoleLogLevel.Log,
-    debug: ConsoleLogLevel.Log,
-    timeLog: ConsoleLogLevel.Log,
+    // really these should be 'info' but we don't want users to have to think about this
+    log: ConsoleLogLevel.Info,
+    trace: ConsoleLogLevel.Info,
+    dir: ConsoleLogLevel.Info,
+    dirxml: ConsoleLogLevel.Info,
+    group: ConsoleLogLevel.Info,
+    groupCollapsed: ConsoleLogLevel.Info,
+    debug: ConsoleLogLevel.Info,
+    timeLog: ConsoleLogLevel.Info,
 }
 
 function safeLevel(level: unknown): ConsoleLogLevel {
-    return levelMapping[typeof level === 'string' ? level : 'info'] || ConsoleLogLevel.Log
+    return levelMapping[typeof level === 'string' ? level : 'info'] || ConsoleLogLevel.Info
 }
 
 function sanitizeForUTF8(input: string): string {
@@ -119,7 +119,7 @@ export class SessionConsoleLogRecorder {
                     const payload: unknown[] = Array.isArray(maybePayload) ? maybePayload : []
                     const message = payloadToSafeString(payload)
 
-                    if (level === ConsoleLogLevel.Log) {
+                    if (level === ConsoleLogLevel.Info) {
                         this.consoleLogCount++
                     } else if (level === ConsoleLogLevel.Warn) {
                         this.consoleWarnCount++

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-console-log-store.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-console-log-store.test.ts
@@ -35,7 +35,7 @@ describe('SessionConsoleLogStore', () => {
             {
                 team_id: 1,
                 message: 'Test log message',
-                level: ConsoleLogLevel.Log,
+                level: ConsoleLogLevel.Info,
                 log_source: 'session_replay',
                 log_source_id: 'session123',
                 instance_id: null,
@@ -77,7 +77,7 @@ describe('SessionConsoleLogStore', () => {
             {
                 team_id: 1,
                 message: 'Test log message',
-                level: 'log',
+                level: 'info',
                 log_source: 'session_replay',
                 log_source_id: 'session123',
                 instance_id: null,
@@ -126,7 +126,7 @@ describe('SessionConsoleLogStore', () => {
             {
                 team_id: 1,
                 message: 'Test log message',
-                level: ConsoleLogLevel.Log,
+                level: ConsoleLogLevel.Info,
                 log_source: 'session_replay',
                 log_source_id: 'session123',
                 instance_id: null,
@@ -144,7 +144,7 @@ describe('SessionConsoleLogStore', () => {
             {
                 team_id: 1,
                 message: 'Test log message 1',
-                level: ConsoleLogLevel.Log,
+                level: ConsoleLogLevel.Info,
                 log_source: 'session_replay',
                 log_source_id: 'session1',
                 instance_id: null,
@@ -154,7 +154,7 @@ describe('SessionConsoleLogStore', () => {
             {
                 team_id: 1,
                 message: 'Test log message 2',
-                level: ConsoleLogLevel.Log,
+                level: ConsoleLogLevel.Info,
                 log_source: 'session_replay',
                 log_source_id: 'session2',
                 instance_id: null,
@@ -180,7 +180,7 @@ describe('SessionConsoleLogStore', () => {
             {
                 team_id: 1,
                 message: 'Test log message',
-                level: ConsoleLogLevel.Log,
+                level: ConsoleLogLevel.Info,
                 log_source: 'session_replay',
                 log_source_id: 'session123',
                 instance_id: null,
@@ -202,7 +202,7 @@ describe('SessionConsoleLogStore', () => {
             {
                 team_id: 1,
                 message: 'Test log message',
-                level: ConsoleLogLevel.Log,
+                level: ConsoleLogLevel.Info,
                 log_source: 'session_replay',
                 log_source_id: 'session123',
                 instance_id: null,
@@ -237,7 +237,7 @@ describe('SessionConsoleLogStore', () => {
                 {
                     team_id: 1,
                     message: 'Test log message',
-                    level: ConsoleLogLevel.Log,
+                    level: ConsoleLogLevel.Info,
                     log_source: 'session_replay',
                     log_source_id: 'session123',
                     instance_id: null,
@@ -273,7 +273,7 @@ describe('SessionConsoleLogStore', () => {
                 {
                     team_id: 1,
                     message: 'Test log message',
-                    level: ConsoleLogLevel.Log,
+                    level: ConsoleLogLevel.Info,
                     log_source: 'session_replay',
                     log_source_id: 'session123',
                     instance_id: null,
@@ -305,7 +305,7 @@ describe('SessionConsoleLogStore', () => {
         const createTestLog = (id: string): ConsoleLogEntry => ({
             team_id: 1,
             message: `Test message ${id}`,
-            level: ConsoleLogLevel.Log,
+            level: ConsoleLogLevel.Info,
             log_source: 'session_replay',
             log_source_id: `session${id}`,
             instance_id: null,


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We have a bug where we're logging with log level 'log' instead of 'info' in Blobby V2. We should be logging 'info' to match the V1 behaviour.

## Changes

Updates Blobby V2 to log with level 'info'.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Updated unit tests.