### PR TITLE
fix(ingestion): correctly adds breadcrumb to header

### DIFF
--- a/plugin-server/src/ingestion/ingestion-consumer.test.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.test.ts
@@ -163,8 +163,7 @@ describe('IngestionConsumer', () => {
             }
             messages[0].headers = [
                 {
-                    key: 'kafka-consumer-breadcrumbs',
-                    value: JSON.stringify([existingBreadcrumb]),
+                    'kafka-consumer-breadcrumbs': Buffer.from(JSON.stringify([existingBreadcrumb])),
                 },
             ]
             await ingester.handleKafkaBatch(messages)
@@ -173,11 +172,14 @@ describe('IngestionConsumer', () => {
             expect(producedMessages.length).toBe(1)
 
             const headers = producedMessages[0].headers || []
-            const breadcrumbHeader = headers.find((h) => h.key === 'kafka-consumer-breadcrumbs')
+            const breadcrumbHeader = headers.find((h) => 'kafka-consumer-breadcrumbs' in h)
 
             expect(breadcrumbHeader).toBeDefined()
 
-            const parsedBreadcrumbs = parseJSON(breadcrumbHeader?.value.toString() || '')
+            const value = breadcrumbHeader?.['kafka-consumer-breadcrumbs'] as Buffer
+            expect(value).toBeInstanceOf(Buffer)
+
+            const parsedBreadcrumbs = parseJSON(value.toString())
             expect(Array.isArray(parsedBreadcrumbs)).toBe(true)
             expect(parsedBreadcrumbs.length).toBe(2)
 

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -215,9 +215,11 @@ export class IngestionConsumer {
         const existingBreadcrumbs: KafkaConsumerBreadcrumb[] = []
         if (message.headers) {
             for (const header of message.headers) {
-                if (header.key === 'kafka-consumer-breadcrumbs') {
+                if ('kafka-consumer-breadcrumbs' in header) {
                     try {
-                        const parsedValue = parseJSON(header.value.toString())
+                        const headerValue = header['kafka-consumer-breadcrumbs']
+                        const valueString = headerValue instanceof Buffer ? headerValue.toString() : headerValue
+                        const parsedValue = parseJSON(valueString)
                         if (Array.isArray(parsedValue)) {
                             const validatedBreadcrumbs = z.array(KafkaConsumerBreadcrumbSchema).safeParse(parsedValue)
                             if (validatedBreadcrumbs.success) {

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -654,8 +654,7 @@ export class IngestionConsumer {
                 const breadcrumb = this.createBreadcrumb(message)
                 const allBreadcrumbs = [...existingBreadcrumbs, breadcrumb]
                 headers.push({
-                    key: 'kafka-consumer-breadcrumbs',
-                    value: Buffer.from(JSON.stringify(allBreadcrumbs)),
+                    'kafka-consumer-breadcrumbs': Buffer.from(JSON.stringify(allBreadcrumbs)),
                 })
                 return this.kafkaOverflowProducer!.produce({
                     topic: this.overflowTopic!,

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -259,10 +259,7 @@ export class EventsProcessor {
 
     emitEvent(rawEvent: RawKafkaEvent, breadcrumbs: KafkaConsumerBreadcrumb[]): Promise<void> {
         const headers: MessageHeader[] = []
-        headers.push({
-            key: 'kafka-consumer-breadcrumbs',
-            value: Buffer.from(JSON.stringify(breadcrumbs)),
-        })
+        headers.push({ 'kafka-consumer-breadcrumbs': Buffer.from(JSON.stringify(breadcrumbs)) })
         return this.kafkaProducer
             .produce({
                 topic: this.hub.CLICKHOUSE_JSON_EVENTS_KAFKA_TOPIC,


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Quick fix, previous header values were being set incorrectly when we were adding breadcrumbs to kafka messages being emitted from the plugin-server consumers.

The result of the previous code was that we were setting 'key': 'kafka-consumer-breadcrumbs' as the header on our messages we produced from our event ingestion pipeline.

## Changes
Changes how the header value is set for plugin-server consumers as they produce messages to their topics.

## Does this work well for both Cloud and self-hosted?

## How did you test this code?
unit tests and tested locally with events generated from clicking in the posthog app
