### PR TITLE
feat: add activity time comparisons

### DIFF
--- a/posthog/temporal/session_recordings/compare_recording_events_workflow.py
+++ b/posthog/temporal/session_recordings/compare_recording_events_workflow.py
@@ -17,6 +17,7 @@ from posthog.models import Team
 from posthog.temporal.session_recordings.queries import get_session_metadata
 from posthog.temporal.session_recordings.snapshot_utils import fetch_v1_snapshots, fetch_v2_snapshots
 from posthog.temporal.session_recordings.session_comparer import count_events_per_window
+from posthog.temporal.session_recordings.segmentation import compute_active_milliseconds
 
 
 @dataclasses.dataclass(frozen=True)
@@ -421,6 +422,75 @@ async def compare_recording_snapshots_activity(inputs: CompareRecordingSnapshots
                 "v2_total_duplicates": sum(count - 1 for count in v2_events.values() if count > 1),
                 "events_with_different_counts": {k: (v1, v2) for k, (v1, v2) in common_events.items() if v1 != v2},
             },
+        )
+
+        # Compare active milliseconds
+        v1_computed_active_ms, v2_computed_active_ms = compute_active_milliseconds(v1_snapshots)
+        v1_computed_active_ms_v2, v2_computed_active_ms_v2 = compute_active_milliseconds(v2_snapshots)
+
+        # Calculate percentage differences
+        def safe_percentage_diff(a: int, b: int) -> float:
+            if a == 0 and b == 0:
+                return 0.0
+            if a == 0:
+                return 100.0
+            return ((b - a) / a) * 100
+
+        await logger.ainfo(
+            "Active milliseconds comparison",
+            v1_snapshot_computed_v1_alg=v1_computed_active_ms,
+            v2_snapshot_computed_v1_alg=v2_computed_active_ms,
+            v1_snapshot_computed_v2_alg=v1_computed_active_ms_v2,
+            v2_snapshot_computed_v2_alg=v2_computed_active_ms_v2,
+            # Compare v1 vs v2 algorithms on v1 snapshots
+            v1_snapshots_alg_difference=v1_computed_active_ms_v2 - v1_computed_active_ms,
+            v1_snapshots_alg_difference_percentage=safe_percentage_diff(
+                v1_computed_active_ms, v1_computed_active_ms_v2
+            ),
+            # Compare v1 vs v2 algorithms on v2 snapshots
+            v2_snapshots_alg_difference=v2_computed_active_ms_v2 - v2_computed_active_ms,
+            v2_snapshots_alg_difference_percentage=safe_percentage_diff(
+                v2_computed_active_ms, v2_computed_active_ms_v2
+            ),
+            v1_metadata_value=v1_metadata["active_milliseconds"],
+            v2_metadata_value=v2_metadata["active_milliseconds"],
+            snapshot_difference_v1_alg=v2_computed_active_ms - v1_computed_active_ms,
+            snapshot_difference_percentage_v1_alg=safe_percentage_diff(v1_computed_active_ms, v2_computed_active_ms),
+            snapshot_difference_v2_alg=v2_computed_active_ms_v2 - v1_computed_active_ms_v2,
+            snapshot_difference_percentage_v2_alg=safe_percentage_diff(
+                v1_computed_active_ms_v2, v2_computed_active_ms_v2
+            ),
+            metadata_difference=v2_metadata["active_milliseconds"] - v1_metadata["active_milliseconds"],
+            metadata_difference_percentage=safe_percentage_diff(
+                v1_metadata["active_milliseconds"], v2_metadata["active_milliseconds"]
+            ),
+            v1_computed_vs_metadata_difference_v1_alg=v1_computed_active_ms - v1_metadata["active_milliseconds"],
+            v1_computed_vs_metadata_percentage_v1_alg=safe_percentage_diff(
+                v1_metadata["active_milliseconds"], v1_computed_active_ms
+            ),
+            v2_computed_vs_metadata_difference_v1_alg=v2_computed_active_ms - v2_metadata["active_milliseconds"],
+            v2_computed_vs_metadata_percentage_v1_alg=safe_percentage_diff(
+                v2_metadata["active_milliseconds"], v2_computed_active_ms
+            ),
+            v1_computed_vs_metadata_difference_v2_alg=v1_computed_active_ms_v2 - v1_metadata["active_milliseconds"],
+            v1_computed_vs_metadata_percentage_v2_alg=safe_percentage_diff(
+                v1_metadata["active_milliseconds"], v1_computed_active_ms_v2
+            ),
+            v2_computed_vs_metadata_difference_v2_alg=v2_computed_active_ms_v2 - v2_metadata["active_milliseconds"],
+            v2_computed_vs_metadata_percentage_v2_alg=safe_percentage_diff(
+                v2_metadata["active_milliseconds"], v2_computed_active_ms_v2
+            ),
+        )
+
+        # Compare snapshot metadata
+        await logger.ainfo(
+            "Snapshot metadata comparison",
+            v1_snapshot_source=v1_metadata["snapshot_source"],
+            v2_snapshot_source=v2_metadata["snapshot_source"],
+            v1_snapshot_library=v1_metadata["snapshot_library"],
+            v2_snapshot_library=v2_metadata["snapshot_library"],
+            snapshot_source_matches=v1_metadata["snapshot_source"] == v2_metadata["snapshot_source"],
+            snapshot_library_matches=v1_metadata["snapshot_library"] == v2_metadata["snapshot_library"],
         )
 
         end_time = dt.datetime.now()

--- a/posthog/temporal/session_recordings/compare_sampled_recording_events_workflow.py
+++ b/posthog/temporal/session_recordings/compare_sampled_recording_events_workflow.py
@@ -84,8 +84,29 @@ async def compare_sampled_recording_events_activity(inputs: CompareSampledRecord
             recording = await sync_to_async(SessionRecording.get_or_build)(session_id=session_id, team=team)
 
             # Get v1 and v2 snapshots using the shared utility functions
-            v1_snapshots = await asyncio.to_thread(fetch_v1_snapshots, recording)
-            v2_snapshots = await asyncio.to_thread(fetch_v2_snapshots, recording)
+            try:
+                v1_snapshots = await asyncio.to_thread(fetch_v1_snapshots, recording)
+            except Exception as e:
+                await logger.awarn(
+                    "Skipping session due to error when fetching v1 snapshots",
+                    session_id=session_id,
+                    team_id=team_id,
+                    error=str(e),
+                    error_type=type(e).__name__,
+                )
+                continue
+
+            try:
+                v2_snapshots = await asyncio.to_thread(fetch_v2_snapshots, recording)
+            except Exception as e:
+                await logger.awarn(
+                    "Skipping session due to error when fetching v2 snapshots",
+                    session_id=session_id,
+                    team_id=team_id,
+                    error=str(e),
+                    error_type=type(e).__name__,
+                )
+                continue
 
             # Convert snapshots to dictionaries for counting duplicates
             v1_events: dict[str, int] = {}

--- a/posthog/temporal/session_recordings/compare_sampled_recording_events_workflow.py
+++ b/posthog/temporal/session_recordings/compare_sampled_recording_events_workflow.py
@@ -28,6 +28,7 @@ from posthog.temporal.session_recordings.session_comparer import (
 )
 from posthog.temporal.session_recordings.queries import get_session_metadata
 from posthog.temporal.session_recordings.snapshot_utils import fetch_v1_snapshots, fetch_v2_snapshots
+from posthog.temporal.session_recordings.segmentation import compute_active_milliseconds
 
 
 @dataclasses.dataclass(frozen=True)
@@ -352,6 +353,81 @@ async def compare_sampled_recording_events_activity(inputs: CompareSampledRecord
                     "v2_total_duplicates": sum(count - 1 for count in v2_events.values() if count > 1),
                     "events_with_different_counts": {k: (v1, v2) for k, (v1, v2) in common_events.items() if v1 != v2},
                 },
+            )
+
+            # Compare snapshot metadata
+            await logger.ainfo(
+                "Snapshot metadata comparison",
+                session_id=session_id,
+                team_id=team_id,
+                v1_snapshot_source=v1_metadata["snapshot_source"],
+                v2_snapshot_source=v2_metadata["snapshot_source"],
+                v1_snapshot_library=v1_metadata["snapshot_library"],
+                v2_snapshot_library=v2_metadata["snapshot_library"],
+                snapshot_source_matches=v1_metadata["snapshot_source"] == v2_metadata["snapshot_source"],
+                snapshot_library_matches=v1_metadata["snapshot_library"] == v2_metadata["snapshot_library"],
+            )
+
+            # Compare active milliseconds
+            v1_computed_active_ms, v2_computed_active_ms = compute_active_milliseconds(v1_snapshots)
+            v1_computed_active_ms_v2, v2_computed_active_ms_v2 = compute_active_milliseconds(v2_snapshots)
+
+            # Calculate percentage differences
+            def safe_percentage_diff(a: int, b: int) -> float:
+                if a == 0 and b == 0:
+                    return 0.0
+                if a == 0:
+                    return 100.0
+                return ((b - a) / a) * 100
+
+            await logger.ainfo(
+                "Active milliseconds comparison",
+                session_id=session_id,
+                team_id=team_id,
+                v1_snapshot_computed_v1_alg=v1_computed_active_ms,
+                v2_snapshot_computed_v1_alg=v2_computed_active_ms,
+                v1_snapshot_computed_v2_alg=v1_computed_active_ms_v2,
+                v2_snapshot_computed_v2_alg=v2_computed_active_ms_v2,
+                # Compare v1 vs v2 algorithms on v1 snapshots
+                v1_snapshots_alg_difference=v1_computed_active_ms_v2 - v1_computed_active_ms,
+                v1_snapshots_alg_difference_percentage=safe_percentage_diff(
+                    v1_computed_active_ms, v1_computed_active_ms_v2
+                ),
+                # Compare v1 vs v2 algorithms on v2 snapshots
+                v2_snapshots_alg_difference=v2_computed_active_ms_v2 - v2_computed_active_ms,
+                v2_snapshots_alg_difference_percentage=safe_percentage_diff(
+                    v2_computed_active_ms, v2_computed_active_ms_v2
+                ),
+                v1_metadata_value=v1_metadata["active_milliseconds"],
+                v2_metadata_value=v2_metadata["active_milliseconds"],
+                snapshot_difference_v1_alg=v2_computed_active_ms - v1_computed_active_ms,
+                snapshot_difference_percentage_v1_alg=safe_percentage_diff(
+                    v1_computed_active_ms, v2_computed_active_ms
+                ),
+                snapshot_difference_v2_alg=v2_computed_active_ms_v2 - v1_computed_active_ms_v2,
+                snapshot_difference_percentage_v2_alg=safe_percentage_diff(
+                    v1_computed_active_ms_v2, v2_computed_active_ms_v2
+                ),
+                metadata_difference=v2_metadata["active_milliseconds"] - v1_metadata["active_milliseconds"],
+                metadata_difference_percentage=safe_percentage_diff(
+                    v1_metadata["active_milliseconds"], v2_metadata["active_milliseconds"]
+                ),
+                v1_computed_vs_metadata_difference_v1_alg=v1_computed_active_ms - v1_metadata["active_milliseconds"],
+                v1_computed_vs_metadata_percentage_v1_alg=safe_percentage_diff(
+                    v1_metadata["active_milliseconds"], v1_computed_active_ms
+                ),
+                v2_computed_vs_metadata_difference_v1_alg=v2_computed_active_ms - v2_metadata["active_milliseconds"],
+                v2_computed_vs_metadata_percentage_v1_alg=safe_percentage_diff(
+                    v2_metadata["active_milliseconds"], v2_computed_active_ms
+                ),
+                v1_computed_vs_metadata_difference_v2_alg=v1_computed_active_ms_v2 - v1_metadata["active_milliseconds"],
+                v1_computed_vs_metadata_percentage_v2_alg=safe_percentage_diff(
+                    v1_metadata["active_milliseconds"], v1_computed_active_ms_v2
+                ),
+                v2_computed_vs_metadata_difference_v2_alg=v2_computed_active_ms_v2 - v2_metadata["active_milliseconds"],
+                v2_computed_vs_metadata_percentage_v2_alg=safe_percentage_diff(
+                    v2_metadata["active_milliseconds"], v2_computed_active_ms_v2
+                ),
             )
 
             # Analyze events per window

--- a/posthog/temporal/session_recordings/queries.py
+++ b/posthog/temporal/session_recordings/queries.py
@@ -74,6 +74,9 @@ def get_session_metadata(team_id: int, session_id: str, table_name: str) -> dict
             "console_error_count": 0,
             "first_url": None,
             "all_urls": [],
+            "snapshot_source": None,
+            "snapshot_library": None,
+            "active_milliseconds": 0,
         }
 
     row = result[0]
@@ -87,4 +90,7 @@ def get_session_metadata(team_id: int, session_id: str, table_name: str) -> dict
         "event_count": row[14],  # event_count index
         "first_url": row[5],  # first_url index
         "all_urls": row[6],  # all_urls index
+        "snapshot_source": row[15],  # snapshot_source index
+        "snapshot_library": row[16],  # snapshot_library index
+        "active_milliseconds": row[10],  # active_milliseconds index
     }

--- a/posthog/temporal/session_recordings/segmentation.py
+++ b/posthog/temporal/session_recordings/segmentation.py
@@ -1,0 +1,235 @@
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Any, Optional
+
+
+class RRWebEventType(IntEnum):
+    """RRWeb event types ported from rrweb-types.ts"""
+
+    DomContentLoaded = 0
+    Load = 1
+    FullSnapshot = 2
+    IncrementalSnapshot = 3
+    Meta = 4
+    Custom = 5
+    Plugin = 6
+
+
+class RRWebEventSource(IntEnum):
+    """RRWeb event sources ported from rrweb-types.ts"""
+
+    Mutation = 0
+    MouseMove = 1
+    MouseInteraction = 2
+    Scroll = 3
+    ViewportResize = 4
+    Input = 5
+    TouchMove = 6
+    MediaInteraction = 7
+    StyleSheetRule = 8
+    CanvasMutation = 9
+    Font = 10
+    Log = 11
+    Drag = 12
+    StyleDeclaration = 13
+
+
+# V1 implementation uses raw numbers
+V1_ACTIVE_SOURCES = [1, 2, 3, 4, 5, 6, 7, 12]
+
+# V2 implementation uses enum
+V2_ACTIVE_SOURCES = [
+    RRWebEventSource.MouseMove,
+    RRWebEventSource.MouseInteraction,
+    RRWebEventSource.Scroll,
+    RRWebEventSource.ViewportResize,
+    RRWebEventSource.Input,
+    RRWebEventSource.TouchMove,
+    RRWebEventSource.MediaInteraction,
+    RRWebEventSource.Drag,
+]
+
+ACTIVITY_THRESHOLD_MS = 5000
+
+
+@dataclass
+class V2SegmentationEvent:
+    """Simplified event with just the essential information for activity tracking"""
+
+    timestamp: int
+    is_active: bool
+
+
+@dataclass
+class V2RecordingSegment:
+    """Represents a segment of recording with activity information"""
+
+    kind: str  # 'window' | 'buffer' | 'gap'
+    start_timestamp: int  # Epoch time that the segment starts
+    end_timestamp: int  # Epoch time that the segment ends
+    duration_ms: int
+    is_active: bool
+
+
+@dataclass
+class V1RecordingSegment:
+    """V1 implementation of recording segment"""
+
+    kind: str  # 'window' | 'buffer' | 'gap'
+    start_timestamp: int
+    end_timestamp: int
+    duration_ms: int
+    is_active: bool
+
+
+def is_v1_active_event(event: dict[str, Any]) -> bool:
+    """V1 implementation of active event check"""
+    return event.get("type") == 3 and (event.get("data", {}).get("source", -1) in V1_ACTIVE_SOURCES)
+
+
+def is_v2_active_event(event: dict[str, Any]) -> bool:
+    """V2 implementation of active event check"""
+    event_type = event.get("type")
+    data = event.get("data")
+    source = data.get("source") if isinstance(data, dict) else None
+
+    return event_type == RRWebEventType.IncrementalSnapshot and source in V2_ACTIVE_SOURCES
+
+
+def to_v2_segmentation_event(event: dict[str, Any]) -> V2SegmentationEvent:
+    """Converts an RRWeb event to a simplified V2SegmentationEvent"""
+    data = event.get("data", {})
+    if not isinstance(data, dict) or "timestamp" not in data:
+        raise ValueError("Invalid event data - missing timestamp")
+    return V2SegmentationEvent(timestamp=data["timestamp"], is_active=is_v2_active_event(event["data"]))
+
+
+def create_v1_segments(snapshots: list[dict[str, Any]]) -> list[V1RecordingSegment]:
+    """V1 implementation of segment creation"""
+    segments: list[V1RecordingSegment] = []
+    active_segment: Optional[V1RecordingSegment] = None
+    last_active_event_timestamp = 0
+
+    for snapshot in snapshots:
+        event_is_active = is_v1_active_event(snapshot["data"])
+        if not isinstance(snapshot.get("data"), dict) or "timestamp" not in snapshot["data"]:
+            continue
+        timestamp = snapshot["data"]["timestamp"]
+
+        # When do we create a new segment?
+        # 1. If we don't have one yet
+        is_new_segment = active_segment is None
+
+        # 2. If it is currently inactive but a new "active" event comes in
+        if event_is_active and not (active_segment and active_segment.is_active):
+            is_new_segment = True
+
+        # 3. If it is currently active but no new active event has been seen for the activity threshold
+        if (
+            active_segment
+            and active_segment.is_active
+            and last_active_event_timestamp + ACTIVITY_THRESHOLD_MS < timestamp
+        ):
+            is_new_segment = True
+
+        # NOTE: We have to make sure that we set this _after_ we use it
+        last_active_event_timestamp = timestamp if event_is_active else last_active_event_timestamp
+
+        if is_new_segment:
+            if active_segment:
+                segments.append(active_segment)
+
+            active_segment = V1RecordingSegment(
+                kind="window",
+                start_timestamp=timestamp,
+                end_timestamp=timestamp,
+                duration_ms=0,
+                is_active=event_is_active,
+            )
+        elif active_segment:
+            active_segment.end_timestamp = timestamp
+            active_segment.duration_ms = active_segment.end_timestamp - active_segment.start_timestamp
+
+    if active_segment:
+        segments.append(active_segment)
+
+    return segments
+
+
+def create_v2_segments_from_events(segmentation_events: list[V2SegmentationEvent]) -> list[V2RecordingSegment]:
+    """V2 implementation of segment creation"""
+    sorted_events = sorted(segmentation_events, key=lambda x: x.timestamp)
+    segments: list[V2RecordingSegment] = []
+    active_segment: Optional[V2RecordingSegment] = None
+    last_active_event_timestamp = 0
+
+    for event in sorted_events:
+        # When do we create a new segment?
+        # 1. If we don't have one yet
+        is_new_segment = active_segment is None
+
+        # 2. If it is currently inactive but a new "active" event comes in
+        if event.is_active and not (active_segment and active_segment.is_active):
+            is_new_segment = True
+
+        # 3. If it is currently active but no new active event has been seen for the activity threshold
+        if (
+            active_segment
+            and active_segment.is_active
+            and last_active_event_timestamp + ACTIVITY_THRESHOLD_MS < event.timestamp
+        ):
+            is_new_segment = True
+
+        # NOTE: We have to make sure that we set this _after_ we use it
+        if event.is_active:
+            last_active_event_timestamp = event.timestamp
+
+        if is_new_segment:
+            if active_segment:
+                segments.append(active_segment)
+
+            active_segment = V2RecordingSegment(
+                kind="window",
+                start_timestamp=event.timestamp,
+                end_timestamp=event.timestamp,
+                duration_ms=0,
+                is_active=event.is_active,
+            )
+        elif active_segment:
+            active_segment.end_timestamp = event.timestamp
+            active_segment.duration_ms = active_segment.end_timestamp - active_segment.start_timestamp
+
+    if active_segment:
+        segments.append(active_segment)
+
+    return segments
+
+
+def v2_active_milliseconds_from_events(segmentation_events: list[V2SegmentationEvent]) -> int:
+    """V2 implementation: Calculates the total active time in milliseconds from a list of segmentation events"""
+    segments = create_v2_segments_from_events(segmentation_events)
+    return v2_active_milliseconds_from_segments(segments)
+
+
+def v2_active_milliseconds_from_segments(segments: list[V2RecordingSegment]) -> int:
+    """V2 implementation: Calculates total active milliseconds from segments"""
+    return sum(max(1, segment.duration_ms) if segment.is_active else 0 for segment in segments)
+
+
+def v1_active_milliseconds(snapshots: list[dict[str, Any]]) -> int:
+    """V1 implementation: Compute active milliseconds from a list of snapshots"""
+    segments = create_v1_segments(snapshots)
+    return sum(max(1, segment.duration_ms) if segment.is_active else 0 for segment in segments)
+
+
+def v2_active_milliseconds(snapshots: list[dict[str, Any]]) -> int:
+    """V2 implementation: Compute active milliseconds from a list of snapshots"""
+    segmentation_events = [to_v2_segmentation_event(event) for event in snapshots]
+    return v2_active_milliseconds_from_events(segmentation_events)
+
+
+def compute_active_milliseconds(snapshots: list[dict[str, Any]]) -> tuple[int, int]:
+    """Compute active milliseconds using both v1 and v2 implementations"""
+    v1_ms = v1_active_milliseconds(snapshots)
+    v2_ms = v2_active_milliseconds(snapshots)
+    return v1_ms, v2_ms


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We saw differences in active time for v1 and v2 sessions, we don't know how big the differences are and if that's an issue with the rewritten algorithm.

## Changes

Adds comparisons for everything segmentation related.

Adds error handling when fetching snapshots, as we saw a lot of v1 failures in the comparison tasks.

## Does this work well for both Cloud and self-hosted?

N/A

## How did you test this code?

Tested locally.