### PR TITLE
fix(rust): Bump sccache to v0.0.9 in ci-rust.yml Action

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -64,7 +64,7 @@ jobs:
 
             - name: Install sccache
               if: needs.changes.outputs.rust == 'true'
-              uses: mozilla-actions/sccache-action@2e7f9ec7921547d4b46598398ca573513895d0bd # v0.0.4
+              uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
             - name: Configure sccache
               if: needs.changes.outputs.rust == 'true'
@@ -116,7 +116,7 @@ jobs:
 
             - name: Install sccache
               if: needs.changes.outputs.rust == 'true'
-              uses: mozilla-actions/sccache-action@2e7f9ec7921547d4b46598398ca573513895d0bd # v0.0.4
+              uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
             - name: Configure sccache
               if: needs.changes.outputs.rust == 'true'
@@ -197,7 +197,7 @@ jobs:
 
             - name: Install sccache
               if: needs.changes.outputs.rust == 'true'
-              uses: mozilla-actions/sccache-action@2e7f9ec7921547d4b46598398ca573513895d0bd # v0.0.4
+              uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
             - name: Configure sccache
               if: needs.changes.outputs.rust == 'true'


### PR DESCRIPTION
## Problem
Seeing build cache fails in Rust CI today ([link](https://github.com/PostHog/posthog/actions/runs/14579692942/job/40903445411)) figured I'd upgrade the Action while looking into this in more detail, its quite out of date

## Changes
Upgrade sccache Action version in `ci-rust.yml`

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
CI 