### PR TITLE
fix(dashboards): remove react warning for props on dom elements

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -109,6 +109,8 @@ function InsightCardInternal(
         variablesOverride,
         children,
         noCache,
+        breakdownColorOverride: _breakdownColorOverride,
+        dataColorThemeId: _dataColorThemeId,
         ...divProps
     }: InsightCardProps,
     ref: React.Ref<HTMLDivElement>


### PR DESCRIPTION
## Problem

<img width="2170" alt="Screenshot 2025-04-22 at 09 58 42" src="https://github.com/user-attachments/assets/29bb3037-2d26-42b3-acd5-14aac46a811b" />

## Changed

Removes unused props from `divProps`, so they are not destructured onto a dom element.

## How did you test this code?

👀 