### PR TITLE
fix: correct default host for nextjs in onboarding

### DIFF
--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/next-js.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/next-js.tsx
@@ -41,7 +41,7 @@ export default function App({ Component, pageProps }: AppProps) {
 
   useEffect(() => {
     posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY as string, {
-      api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
+      api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || '${apiHostOrigin()}',
       ${
           isPersonProfilesDisabled
               ? ``
@@ -113,7 +113,7 @@ import { PostHogProvider as PHProvider } from 'posthog-js/react'
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY as string, {
-      api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
+      api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || '${apiHostOrigin()}',
       ${
           isPersonProfilesDisabled
               ? ``


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

The default host should be based off the current origin, it was defaulting to the US host

## Changes

Use the current origin to determine the host.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Ran locally
