### PR TITLE
fix(cdp): GET requests should not pass body

### DIFF
--- a/plugin-server/src/cdp/services/fetch-executor.service.test.ts
+++ b/plugin-server/src/cdp/services/fetch-executor.service.test.ts
@@ -55,6 +55,7 @@ describe('FetchExecutorService', () => {
         const invocation = createInvocation({
             url: `${baseUrl}/test`,
             method: 'GET',
+            body: 'test body',
             return_queue: 'hog',
         })
 

--- a/plugin-server/src/cdp/services/fetch-executor.service.ts
+++ b/plugin-server/src/cdp/services/fetch-executor.service.ts
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon'
-import { FetchError } from 'node-fetch'
+import { FetchError, RequestInit } from 'node-fetch'
 
 import { PluginsServerConfig } from '../../types'
 import { trackedFetch } from '../../utils/fetch'
@@ -85,12 +85,16 @@ export class FetchExecutorService {
 
         try {
             const start = performance.now()
-            const fetchResponse = await trackedFetch(params.url, {
-                method: params.method,
-                body: params.body,
+            const method = params.method.toUpperCase()
+            const fetchParams: RequestInit = {
+                method,
                 headers: params.headers,
                 timeout: this.serverConfig.CDP_FETCH_TIMEOUT_MS,
-            })
+            }
+            if (!['GET', 'HEAD'].includes(method) && params.body) {
+                fetchParams.body = params.body
+            }
+            const fetchResponse = await trackedFetch(params.url, fetchParams)
 
             responseBody = await fetchResponse.text()
 


### PR DESCRIPTION
## Problem

The body value always exists because of the way the message is passed around but should only be included for non-get requests

## Changes

* Fixes that

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
