### PR TITLE
fix(data-warehouse): Fix missing kea logic key in ElapsedTime

### DIFF
--- a/frontend/src/queries/nodes/DataNode/ElapsedTime.tsx
+++ b/frontend/src/queries/nodes/DataNode/ElapsedTime.tsx
@@ -1,6 +1,7 @@
 import { IconDatabaseBolt } from '@posthog/icons'
 import clsx from 'clsx'
 import { useValues } from 'kea'
+import { router } from 'kea-router'
 import { Popover } from 'lib/lemon-ui/Popover'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { useState } from 'react'
@@ -80,7 +81,8 @@ export function ElapsedTime({ showTimings }: { showTimings?: boolean }): JSX.Ele
         useValues(dataNodeLogic)
     const [, setTick] = useState(0)
 
-    const { editingView } = useValues(multitabEditorLogic)
+    const codeEditorKey = `hogQLQueryEditor/${router.values.location.pathname}`
+    const { editingView } = useValues(multitabEditorLogic({ key: codeEditorKey }))
     const { dataWarehouseSavedQueryMapById } = useValues(dataWarehouseViewsLogic)
     const savedQuery = editingView ? dataWarehouseSavedQueryMapById[editingView.id] : null
     const isAlreadyMaterialized = !!savedQuery?.last_run_at


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

There is currently an error raised when navigating to certain scenes: `Error: [KEA] Undefined key for logic "data-warehouse.editor.multitabEditorLogic"`

This appears to have been introduced in https://github.com/PostHog/posthog/pull/31029

## Changes

Add the missing key prop.

I took this from [another example in our codebase](https://github.com/PostHog/posthog/blob/6257f3d391593a8a08526402b5b4fd1fe167c419/frontend/src/scenes/data-warehouse/editor/EditorScene.tsx#L62-L63) but am not sure if this is correct so some eyes on this would be much appreciated.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Tested locally by viewing one of the scenes that was previously raising the error
