### PR TITLE
fix: update product intent activation last checked at time

### DIFF
--- a/posthog/models/product_intent/product_intent.py
+++ b/posthog/models/product_intent/product_intent.py
@@ -170,6 +170,14 @@ class ProductIntent(UUIDModel, RootTeamMixin):
         return self.team.ingested_event
 
     def check_and_update_activation(self, skip_reporting: bool = False) -> bool:
+        # If the intent is already activated, we don't need to check again
+        if self.activated_at:
+            return True
+
+        # Update the last activation check time
+        self.activation_last_checked_at = datetime.now(tz=UTC)
+        self.save()
+
         activation_checks = {
             "data_warehouse": self.has_activated_data_warehouse,
             "experiments": self.has_activated_experiments,
@@ -186,6 +194,7 @@ class ProductIntent(UUIDModel, RootTeamMixin):
             if not skip_reporting:
                 self.report_activation(self.product_type)
             return True
+
         return False
 
     def report_activation(self, product_key: str) -> None:


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Looks like this `activation_last_checked_at` field was never being set

## Changes

Set this so that we can debug product intents that aren't being activated properly - and avoid rechecking them unnecessarily.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added tests
