### PR TITLE
fix(cdp): don't add up invocation duration results

### DIFF
--- a/plugin-server/src/cdp/services/hog-watcher.service.ts
+++ b/plugin-server/src/cdp/services/hog-watcher.service.ts
@@ -25,7 +25,7 @@ export type HogWatcherFunctionState = {
 }
 
 export const hogFunctionExecutionTimeSummary = new Histogram({
-    name: 'cdp_hog_function_execution_duration_by_kind',
+    name: 'cdp_hog_watcher_timings',
     help: 'Processing time of hog function execution by kind',
     labelNames: ['kind'],
     buckets: [0, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000],

--- a/plugin-server/src/cdp/services/hog-watcher.service.ts
+++ b/plugin-server/src/cdp/services/hog-watcher.service.ts
@@ -28,7 +28,7 @@ export const hogFunctionExecutionTimeSummary = new Histogram({
     name: 'cdp_hog_function_execution_duration_by_kind',
     help: 'Processing time of hog function execution by kind',
     labelNames: ['kind'],
-    buckets: [0, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000],
+    buckets: [0, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000],
 })
 
 // TODO: Future follow up - we should swap this to an API call or something.

--- a/plugin-server/src/cdp/services/hog-watcher.service.ts
+++ b/plugin-server/src/cdp/services/hog-watcher.service.ts
@@ -28,7 +28,7 @@ export const hogFunctionExecutionTimeSummary = new Histogram({
     name: 'cdp_hog_watcher_timings',
     help: 'Processing time of hog function execution by kind',
     labelNames: ['kind'],
-    buckets: [0, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000],
+    buckets: [0, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, Infinity],
 })
 
 // TODO: Future follow up - we should swap this to an API call or something.

--- a/plugin-server/src/cdp/services/hog-watcher.service.ts
+++ b/plugin-server/src/cdp/services/hog-watcher.service.ts
@@ -143,14 +143,14 @@ export class HogWatcherService {
                 // Calculate cost based on individual timings, not the total
                 let costForTimings = 0
 
+                // Calculate cost for this individual timing
+                const lowerBound = this.hub.CDP_WATCHER_COST_TIMING_LOWER_MS
+                const upperBound = this.hub.CDP_WATCHER_COST_TIMING_UPPER_MS
+                const costTiming = this.hub.CDP_WATCHER_COST_TIMING
+
                 for (const timing of result.invocation.timings) {
                     // Record metrics for this timing entry
                     hogFunctionExecutionTimeSummary.labels(timing.kind).observe(timing.duration_ms)
-
-                    // Calculate cost for this individual timing
-                    const lowerBound = this.hub.CDP_WATCHER_COST_TIMING_LOWER_MS
-                    const upperBound = this.hub.CDP_WATCHER_COST_TIMING_UPPER_MS
-                    const costTiming = this.hub.CDP_WATCHER_COST_TIMING
                     const ratio = Math.max(timing.duration_ms - lowerBound, 0) / (upperBound - lowerBound)
 
                     // Add to the total cost for this result


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Right now we add up the invocation duration result which leads to higher cost for a hog function for e.g. this scenario 

```
result.invocation.timings = [
                { kind: 'hog', duration_ms: 100 }, // Below threshold, should have minimal cost
                { kind: 'async_function', duration_ms: 100 }, // Below threshold, should have minimal cost
                { kind: 'hog', duration_ms: 100 }, // Below threshold, should have minimal cost
            ]
```
instead of having 0 cost it has higher cost because we are not treating it as 3 individual invocations that are just about at the threshold but we are summing the durations up leading to 300ms and penalising it.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

fixes the problem and adds instrumentation per invocation kind

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- added tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
