### PR TITLE
chore(batch-exports): Create command to update batch exports schedules

### DIFF
--- a/posthog/management/commands/test/test_update_batch_export_schedules.py
+++ b/posthog/management/commands/test/test_update_batch_export_schedules.py
@@ -129,6 +129,6 @@ def test_update_batch_export_schedules(timezone, paused, batch_export, temporal)
     schedule = describe_schedule(temporal, str(batch_export.id))
     assert schedule.schedule.spec.time_zone_name == timezone
     # Check that the jitter was reset
-    assert schedule.schedule.spec.jitter == dt.timedelta(minutes=10)
+    assert schedule.schedule.spec.jitter == dt.timedelta(minutes=15)
     # Ensure the schedule state was preserved
     assert schedule.schedule.state.paused == paused

--- a/posthog/management/commands/test/test_update_batch_export_schedules.py
+++ b/posthog/management/commands/test/test_update_batch_export_schedules.py
@@ -1,0 +1,134 @@
+import datetime as dt
+import logging
+
+import pytest
+from asgiref.sync import async_to_sync
+from django.core.management import call_command
+from temporalio.client import Client as TemporalClient
+from temporalio.service import RPCError
+
+from posthog.api.test.test_organization import create_organization
+from posthog.api.test.test_team import create_team
+from posthog.batch_exports.service import pause_batch_export, sync_batch_export
+from posthog.models import BatchExport, BatchExportDestination
+from posthog.temporal.common.client import sync_connect
+from posthog.temporal.common.schedule import update_schedule
+
+pytestmark = [
+    pytest.mark.django_db,
+]
+
+
+@pytest.fixture
+def timezone(request):
+    try:
+        return request.param
+    except AttributeError:
+        return "UTC"
+
+
+@pytest.fixture
+def organization():
+    return create_organization("test")
+
+
+@pytest.fixture
+def team(organization, timezone):
+    return create_team(organization=organization, timezone=timezone)
+
+
+@pytest.fixture
+def batch_export(team):
+    destination_data = {
+        "type": "S3",
+        "config": {
+            "bucket_name": "my-production-s3-bucket",
+            "region": "us-east-1",
+            "prefix": "posthog-events/",
+            "aws_access_key_id": "abc123",
+            "aws_secret_access_key": "secret",
+            "invalid_key": "invalid_value",
+        },
+    }
+
+    batch_export_data = {
+        "name": "my-production-s3-bucket-destination",
+        "interval": "hour",
+    }
+
+    destination = BatchExportDestination(**destination_data)
+    batch_export = BatchExport(team=team, destination=destination, **batch_export_data)
+
+    sync_batch_export(batch_export, created=True)
+
+    destination.save()
+    batch_export.save()
+    return batch_export
+
+
+@async_to_sync
+async def delete_temporal_schedule(temporal: TemporalClient, schedule_id: str):
+    """Delete a Temporal Schedule with the given id."""
+    handle = temporal.get_schedule_handle(schedule_id)
+    await handle.delete()
+
+
+def cleanup_temporal_schedules(temporal: TemporalClient):
+    """Clean up any Temporal Schedules created during the test."""
+    for schedule in BatchExport.objects.all():
+        try:
+            delete_temporal_schedule(temporal, str(schedule.id))
+        except RPCError:
+            # Assume this is fine as we are tearing down, but don't fail silently.
+            logging.warn("Schedule %s has already been deleted, ignoring.", schedule.id)
+            continue
+
+
+@async_to_sync
+async def describe_schedule(temporal: TemporalClient, schedule_id: str):
+    """Return the description of a Temporal Schedule with the given id."""
+    handle = temporal.get_schedule_handle(schedule_id)
+    temporal_schedule = await handle.describe()
+    return temporal_schedule
+
+
+@pytest.fixture
+def temporal():
+    """Return a TemporalClient instance."""
+    client = sync_connect()
+    yield client
+    cleanup_temporal_schedules(client)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "timezone",
+    ["US/Pacific", "UTC"],
+)
+@pytest.mark.parametrize("paused", (True, False))
+def test_update_batch_export_schedules(timezone, paused, batch_export, temporal):
+    """Test the update_batch_export_schedules command updates the schedule for a batch export."""
+
+    # Manually update the schedule so we can check that the command updates it
+    schedule = describe_schedule(temporal, str(batch_export.id))
+    new_schedule = schedule.schedule
+    new_schedule.spec.jitter = dt.timedelta(hours=6)
+    update_schedule(temporal, str(batch_export.id), new_schedule, keep_tz=True)
+    schedule = describe_schedule(temporal, str(batch_export.id))
+    assert schedule.schedule.spec.jitter == dt.timedelta(hours=6)
+
+    if paused is True:
+        pause_batch_export(temporal, str(batch_export.id))
+
+    call_command(
+        "update_batch_export_schedules",
+        f"--batch-export-id={batch_export.id}",
+    )
+
+    # Check that the schedule was updated
+    schedule = describe_schedule(temporal, str(batch_export.id))
+    assert schedule.schedule.spec.time_zone_name == timezone
+    # Check that the jitter was reset
+    assert schedule.schedule.spec.jitter == dt.timedelta(minutes=10)
+    # Ensure the schedule state was preserved
+    assert schedule.schedule.state.paused == paused

--- a/posthog/management/commands/update_batch_export_schedules.py
+++ b/posthog/management/commands/update_batch_export_schedules.py
@@ -1,0 +1,48 @@
+import datetime as dt
+import logging
+
+from django.core.management.base import BaseCommand, CommandError
+
+from posthog.batch_exports.service import sync_batch_export
+from posthog.models import BatchExport
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+class Command(BaseCommand):
+    help = "Updates the Temporal schedule for a batch export"
+
+    def add_arguments(self, parser):
+        # TODO - add a way to update all batch exports
+        parser.add_argument("--batch-export-id", default=None, type=str, help="Batch export ID to update")
+
+    def handle(self, **options):
+        batch_export_id = options["batch_export_id"]
+        # verbose = options["verbosity"] > 1
+
+        if not batch_export_id:
+            raise CommandError("Batch export ID is required")
+
+        # TODO - run in a loop once we support multiple batch exports
+        try:
+            batch_export: BatchExport = BatchExport.objects.get(id=batch_export_id, deleted=False)
+        except BatchExport.DoesNotExist:
+            raise CommandError("Batch export not found")
+        except BatchExport.MultipleObjectsReturned:
+            raise CommandError("More than one existing batch export found (this should never happen)!")
+
+        display("Updating batch export schedule...", batch_export_id=batch_export.id)
+
+        sync_batch_export(batch_export, created=False)
+
+        display("Batch export schedule updated")
+
+
+def display(message, **kwargs):
+    print(message)  # noqa: T201
+    for key, value in kwargs.items():
+        if isinstance(value, dt.datetime):
+            value = value.strftime("%Y-%m-%d %H:%M:%S")
+        print(f"  {key} = {value}")  # noqa: T201
+    print()  # noqa: T201


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

When we make changes to the batch export schedules (for example, adjusting the jitter), these are not reflected in Temporal unless the batch export itself is updated.

## Changes

Create a command to update the schedule in Temporal for a given batch export ID. This is just an initial test. If successful we should add a way to apply this to multiple (or all) batch exports in bulk.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added unit tests.

Also tested locally by updating the schedule of a batch export. Verified the batch export inputs were unchanged and the schedule jitter was updated.
