### PR TITLE
fix: add missing scopes to SessionRecordingPlaylistViewSet

### DIFF
--- a/posthog/session_recordings/session_recording_playlist_api.py
+++ b/posthog/session_recordings/session_recording_playlist_api.py
@@ -243,6 +243,8 @@ class SessionRecordingPlaylistSerializer(serializers.ModelSerializer):
 
 class SessionRecordingPlaylistViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelViewSet):
     scope_object = "session_recording_playlist"
+    scope_object_read_actions = ["list", "retrieve", "recordings"]
+    scope_object_write_actions = ["create", "update", "modify_recordings"]
     queryset = SessionRecordingPlaylist.objects.all()
     serializer_class = SessionRecordingPlaylistSerializer
     throttle_classes = [ClickHouseBurstRateThrottle, ClickHouseSustainedRateThrottle]


### PR DESCRIPTION
## Problem

Users are unable to get or modify recordings with the `session_recording_playlists` endpoint due to missing scopes

## Changes

Adds the scopes `recordings` and `modify_recordings` here:

```python
    scope_object_read_actions = ["list", "retrieve", "recordings"]
    scope_object_write_actions = ["create", "update", "modify_recordings"]
```

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Tested locally
