### PR TITLE
fix(perf): make persorted events table the default for activity log

### DIFF
--- a/frontend/src/scenes/activity/explore/defaults.ts
+++ b/frontend/src/scenes/activity/explore/defaults.ts
@@ -11,6 +11,9 @@ export const getDefaultEventsSceneQuery = (properties?: AnyPropertyFilter[]): Da
         orderBy: ['timestamp DESC'],
         after: '-24h',
         ...(properties ? { properties } : {}),
+        modifiers: {
+            usePresortedEventsTable: true,
+        },
     },
     propertiesViaUrl: true,
     showSavedQueries: true,

--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -224,7 +224,7 @@ class EventsQueryRunner(QueryRunner):
                     and not has_any_aggregation
                 ):
                     inner_query = parse_select(
-                        "SELECT timestamp, event, cityHash64(distinct_id) as did, cityHash64(uuid) as uuid FROM events"
+                        "SELECT timestamp, event, cityHash64(distinct_id), cityHash64(uuid) FROM events"
                     )
                     assert isinstance(inner_query, ast.SelectQuery)
                     inner_query.where = where

--- a/posthog/hogql_queries/test/__snapshots__/test_events_query_runner.ambr
+++ b/posthog/hogql_queries/test/__snapshots__/test_events_query_runner.ambr
@@ -142,7 +142,7 @@
   SELECT tuple(events.uuid, events.event, events.properties, toTimeZone(events.timestamp, 'UTC'), events.team_id, events.distinct_id, events.elements_chain, toTimeZone(events.created_at, 'UTC')) AS `tuple(uuid, event, properties, toTimeZone(timestamp, 'UTC'), team_id, distinct_id, elements_chain, toTimeZone(created_at, 'UTC'))`
   FROM events
   WHERE and(equals(events.team_id, 99999), in(tuple(toTimeZone(events.timestamp, 'UTC'), events.event, cityHash64(events.distinct_id), cityHash64(events.uuid)),
-                                                (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.event AS event, cityHash64(events.distinct_id) AS did, cityHash64(events.uuid) AS uuid
+                                                (SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp, events.event AS event, cityHash64(events.distinct_id) AS `cityHash64(distinct_id)`, cityHash64(events.uuid) AS `cityHash64(uuid)`
                                                  FROM events
                                                  WHERE and(equals(events.team_id, 99999), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'some_prop'), ''), 'null'), '^"|"$', ''), 'a'), 0), equals(events.event, '$pageview'), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2021-01-21 00:00:05.000000', 6, 'UTC')), greater(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')))
                                                  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC


### PR DESCRIPTION
## Problem

The presorted events table broke custom SQL filters for UUID, which are frequently used for support/debugging use cases. See https://github.com/PostHog/posthog/pull/31371.

## Changes

This is because the unused alias `uuid` would shadow the actual field. I've now removed the aliases.

## How did you test this code?

Tried locally