### PR TITLE
chore: add handled property to exception events

### DIFF
--- a/rust/cymbal/src/types/mod.rs
+++ b/rust/cymbal/src/types/mod.rs
@@ -86,7 +86,10 @@ pub struct OutputErrProps {
     #[serde(flatten)]
     pub other: HashMap<String, Value>,
 
-    // Search metadata
+    // Metadata
+    #[serde(rename = "$exception_handled")]
+    pub handled: bool,
+    // Search metadata (materialized)
     #[serde(rename = "$exception_types")]
     pub types: Vec<String>,
     #[serde(rename = "$exception_values")]
@@ -191,6 +194,12 @@ impl FingerprintedErrProps {
             Some(e.exception_message.clone())
         });
 
+        let handled = self.exception_list[0]
+            .mechanism
+            .as_ref()
+            .and_then(|m| m.handled)
+            .unwrap_or(false);
+
         OutputErrProps {
             exception_list: self.exception_list,
             fingerprint: self.fingerprint,
@@ -203,6 +212,7 @@ impl FingerprintedErrProps {
             values,
             sources,
             functions,
+            handled,
         }
     }
 }

--- a/rust/cymbal/src/types/mod.rs
+++ b/rust/cymbal/src/types/mod.rs
@@ -194,9 +194,8 @@ impl FingerprintedErrProps {
             Some(e.exception_message.clone())
         });
 
-        let handled = self.exception_list[0]
-            .mechanism
-            .as_ref()
+        let handled = self.exception_list.first()
+            .and_then(|e| e.mechanism.as_ref())
             .and_then(|m| m.handled)
             .unwrap_or(false);
 

--- a/rust/cymbal/src/types/mod.rs
+++ b/rust/cymbal/src/types/mod.rs
@@ -194,7 +194,9 @@ impl FingerprintedErrProps {
             Some(e.exception_message.clone())
         });
 
-        let handled = self.exception_list.first()
+        let handled = self
+            .exception_list
+            .first()
             .and_then(|e| e.mechanism.as_ref())
             .and_then(|m| m.handled)
             .unwrap_or(false);


### PR DESCRIPTION
## Problem

Customer requested ability to filter by `handled` property. This is currently nested in the `mechanism`

## Changes

Pull handled off the first item in the exception list