### PR TITLE
fix: toolbar elements visibility tracking for clickmap

### DIFF
--- a/frontend/src/lib/components/heatmaps/heatmapDataLogic.ts
+++ b/frontend/src/lib/components/heatmaps/heatmapDataLogic.ts
@@ -111,6 +111,9 @@ export const heatmapDataLogic = kea<heatmapDataLogicType>([
                     if (!values.href || !values.href.trim().length) {
                         return null
                     }
+                    if (!values.heatmapFilters.enabled) {
+                        return null
+                    }
                     await breakpoint(150)
 
                     const { date_from, date_to, filter_test_accounts } = values.commonFilters

--- a/frontend/src/toolbar/elements/elementsLogic.ts
+++ b/frontend/src/toolbar/elements/elementsLogic.ts
@@ -221,14 +221,14 @@ export const elementsLogic = kea<elementsLogicType>([
             (heatmapElements, inspectElements, actionElements, actionsListElements): ElementMap => {
                 const elementMap = new Map<HTMLElement, ElementWithMetadata>()
 
-                ;[...inspectElements, ...heatmapElements, ...actionElements, ...actionsListElements].forEach((e) => {
-                    const elementWithMetadata: ElementWithMetadata = { ...e }
-                    if (elementMap.get(e.element)) {
-                        elementMap.set(e.element, { ...elementMap.get(e.element), ...elementWithMetadata })
-                    } else {
-                        elementMap.set(e.element, elementWithMetadata)
-                    }
-                })
+                    ;[...inspectElements, ...heatmapElements, ...actionElements, ...actionsListElements].forEach((e) => {
+                        const elementWithMetadata: ElementWithMetadata = { ...e }
+                        if (elementMap.get(e.element)) {
+                            elementMap.set(e.element, { ...elementMap.get(e.element), ...elementWithMetadata })
+                        } else {
+                            elementMap.set(e.element, elementWithMetadata)
+                        }
+                    })
                 return elementMap
             },
         ],
@@ -309,15 +309,22 @@ export const elementsLogic = kea<elementsLogicType>([
         elementsToDisplay: [
             (s) => [s.elementsToDisplayRaw],
             (elementsToDisplayRaw) => {
-                return elementsToDisplayRaw
-                    .filter(({ rect }) => rect && (rect.width !== 0 || rect.height !== 0))
-                    .map((element) => ({
-                        ...element,
-                        // being able to hover over elements might rely on their original z-index
-                        // so we copy it over to the toolbar element
-                        apparentZIndex: getMaxZIndex(element.element),
-                    }))
-            },
+                const result: ElementWithMetadata[] = []
+                elementsToDisplayRaw.forEach((element) => {
+                    const { rect, visible } = element
+                    // visible when undefined is ignored
+                    if (rect && rect.width > 0 && rect.height > 0 && visible !== false) {
+                        result.push({
+                            ...element,
+                            // being able to hover over elements might rely on their original z-index
+                            // so we copy it over to the toolbar element
+                            apparentZIndex: getMaxZIndex(element.element)
+                        })
+                    }
+                })
+
+                return result
+            }
         ],
 
         labelsToDisplay: [

--- a/frontend/src/toolbar/elements/elementsLogic.ts
+++ b/frontend/src/toolbar/elements/elementsLogic.ts
@@ -221,14 +221,20 @@ export const elementsLogic = kea<elementsLogicType>([
             (heatmapElements, inspectElements, actionElements, actionsListElements): ElementMap => {
                 const elementMap = new Map<HTMLElement, ElementWithMetadata>()
 
-                    ;[...inspectElements, ...heatmapElements, ...actionElements, ...actionsListElements].forEach((e) => {
-                        const elementWithMetadata: ElementWithMetadata = { ...e }
-                        if (elementMap.get(e.element)) {
-                            elementMap.set(e.element, { ...elementMap.get(e.element), ...elementWithMetadata })
-                        } else {
-                            elementMap.set(e.element, elementWithMetadata)
-                        }
-                    })
+                const addElements = (e: ElementWithMetadata): void => {
+                    const elementWithMetadata: ElementWithMetadata = { ...e }
+                    if (elementMap.get(e.element)) {
+                        elementMap.set(e.element, { ...elementMap.get(e.element), ...elementWithMetadata })
+                    } else {
+                        elementMap.set(e.element, elementWithMetadata)
+                    }
+                }
+
+                inspectElements.forEach(addElements)
+                heatmapElements.forEach(addElements)
+                actionElements.forEach(addElements)
+                actionsListElements.forEach(addElements)
+
                 return elementMap
             },
         ],
@@ -318,13 +324,13 @@ export const elementsLogic = kea<elementsLogicType>([
                             ...element,
                             // being able to hover over elements might rely on their original z-index
                             // so we copy it over to the toolbar element
-                            apparentZIndex: getMaxZIndex(element.element)
+                            apparentZIndex: getMaxZIndex(element.element),
                         })
                     }
                 })
 
                 return result
-            }
+            },
         ],
 
         labelsToDisplay: [

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
@@ -317,7 +317,6 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
                             existing.rageclickCount += countedElement.type === '$rageclick' ? countedElement.count : 0
                             existing.deadclickCount += countedElement.type === '$dead_click' ? countedElement.count : 0
                             existing.visible = metrics.visible
-                            existing.rect = metrics.rect
                         }
                     } else {
                         normalisedElements.set(trimmedElement, {
@@ -328,7 +327,6 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
                             element: trimmedElement,
                             actionStep: elementToActionStep(trimmedElement, dataAttributes),
                             visible: metrics.visible,
-                            rect: metrics.rect,
                         })
                     }
 
@@ -406,10 +404,8 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
         },
 
         maybeLoadHeatmap: async () => {
-            if (values.heatmapEnabled) {
-                if (values.heatmapFilters.enabled && values.heatmapFilters.type) {
-                    actions.loadHeatmap()
-                }
+            if (values.heatmapEnabled && values.heatmapFilters.enabled && values.heatmapFilters.type) {
+                actions.loadHeatmap()
             }
         },
 

--- a/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapToolbarMenuLogic.ts
@@ -117,30 +117,19 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
             },
         ],
         elementMetrics: [
-            { version: 0, map: new Map<HTMLElement, { visible: boolean }>() },
+            new Map<HTMLElement, { visible: boolean }>(),
             {
                 updateElementMetrics: (state, { observedElements }) => {
-                    let hadChanges = false
-                    for (const [element, visible] of observedElements) {
-                        const current = state.map.get(element)
-                        const hasChanged = current?.visible !== visible
-
-                        if (!hasChanged) {
-                            continue
-                        }
-
-                        state.map.set(element, { visible })
-                        hadChanges = true
-                    }
-
-                    if (!hadChanges) {
+                    if (observedElements.length === 0) {
                         return state
                     }
 
-                    return {
-                        version: state.version + 1,
-                        map: new Map(Array.from(state.map.entries())),
+                    const onUpdate = new Map(Array.from(state.entries()))
+                    for (const [element, visible] of observedElements) {
+                        onUpdate.set(element, { visible })
                     }
+
+                    return onUpdate
                 },
             },
         ],
@@ -160,17 +149,17 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
                             properties: [
                                 wildcardHref === href
                                     ? {
-                                        key: '$current_url',
-                                        value: href,
-                                        operator: PropertyOperator.Exact,
-                                        type: PropertyFilterType.Event,
-                                    }
+                                          key: '$current_url',
+                                          value: href,
+                                          operator: PropertyOperator.Exact,
+                                          type: PropertyFilterType.Event,
+                                      }
                                     : {
-                                        key: '$current_url',
-                                        value: `^${wildcardHref.split('*').map(escapeRegex).join('.*')}$`,
-                                        operator: PropertyOperator.Regex,
-                                        type: PropertyFilterType.Event,
-                                    },
+                                          key: '$current_url',
+                                          value: `^${wildcardHref.split('*').map(escapeRegex).join('.*')}$`,
+                                          operator: PropertyOperator.Regex,
+                                          type: PropertyFilterType.Event,
+                                      },
                             ],
                             date_from: values.commonFilters.date_from,
                             date_to: values.commonFilters.date_to,
@@ -304,8 +293,6 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
                     return []
                 }
 
-                console.log('wat countedElements being called', elements?.length, elementMetrics.version)
-
                 cache.intersectionObserver.disconnect()
                 cache.intersectionObserver.observe(document.body)
 
@@ -317,7 +304,7 @@ export const heatmapToolbarMenuLogic = kea<heatmapToolbarMenuLogicType>([
                         continue
                     }
 
-                    const metrics = elementMetrics.map.get(trimmedElement) || {
+                    const metrics = elementMetrics.get(trimmedElement) || {
                         visible: isElementVisible(trimmedElement),
                         rect: trimmedElement.getBoundingClientRect(),
                     }


### PR DESCRIPTION
follow-up to https://github.com/PostHog/posthog/pull/31330

the `elementsToDisplayRaw` selector swaps in different sources which aren't all tracking visibility so tracking visibility in the clickmap broke other displays

this PR:

* only hides an element if it is explicitly `visible === false` (the fix here)
* and then as a fly-by
	* makes `elementsToDisplay` only loop once out of tidiness
	* calls `updateElementMetrics` only once per set of observed elements
	* does not try to track bounding box with the interaction observer
		* it gets called so much that it was causing perf issues even with relatively few elements 

![2025-04-22 15 16 55](https://github.com/user-attachments/assets/9a5cb5c0-da38-475b-9e9d-a086f591e6f2)

