### PR TITLE
feat(project-tree): shift+click select

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -120,7 +120,7 @@ export function ProjectTree(): JSX.Element {
                         asChild
                         onClick={(e) => {
                             e.stopPropagation()
-                            onItemChecked(item.id, !checkedItems[item.id])
+                            onItemChecked(item.id, !checkedItems[item.id], false)
                         }}
                     >
                         <ButtonPrimitive menuItem>{checkedItems[item.id] ? 'Deselect' : 'Select'}</ButtonPrimitive>

--- a/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
@@ -81,7 +81,7 @@ export const getDefaultTreeNew = (): FileSystemImport[] =>
             type: 'hog_function/site_app',
             href: () => urls.pipelineNodeNew(PipelineStage.SiteApp),
         },
-    ].sort((a, b) => a.path.localeCompare(b.path))
+    ].sort((a, b) => a.path.localeCompare(b.path, undefined, { sensitivity: 'accent' }))
 
 export const getDefaultTreeExplore = (groupNodes: FileSystemImport[]): FileSystemImport[] =>
     [
@@ -170,4 +170,4 @@ export const getDefaultTreeExplore = (groupNodes: FileSystemImport[]): FileSyste
             href: () => urls.heatmaps(),
             flag: FEATURE_FLAGS.HEATMAPS_UI,
         },
-    ].sort((a, b) => a.path.localeCompare(b.path))
+    ].sort((a, b) => a.path.localeCompare(b.path, undefined, { sensitivity: 'accent' }))

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
@@ -690,12 +690,14 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                             id: `search-loading/`,
                             name: 'Loading...',
                             icon: <Spinner />,
+                            disableSelect: true,
                         })
                     } else {
                         results.push({
                             id: `search-load-more/${searchResults.searchTerm}`,
                             name: 'Load more...',
                             icon: <IconPlus />,
+                            disableSelect: true,
                             onClick: () =>
                                 projectTreeLogic.actions.loadSearchResults(
                                     searchResults.searchTerm,

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
@@ -948,10 +948,13 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
             if (shift && lastCheckedItem) {
                 const prevIdx = shownItems.findIndex((it) => itemKey(it) === lastCheckedItem.id)
                 const currIdx = shownItems.findIndex((it) => it.id === clickedItem.id)
-                const [start, end] = [Math.min(prevIdx, currIdx), Math.max(prevIdx, currIdx)]
-
-                for (let i = start; i <= end; i++) {
-                    applyToItem(shownItems[i])
+                if (prevIdx !== -1 && currIdx === -1) {
+                    const [start, end] = [Math.min(prevIdx, currIdx), Math.max(prevIdx, currIdx)]
+                    for (let i = start; i <= end; i++) {
+                        applyToItem(shownItems[i])
+                    }
+                } else if (currIdx !== -1) {
+                    applyToItem(shownItems[currIdx])
                 }
             } else {
                 applyToItem(clickedItem)

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
@@ -845,9 +845,6 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
         movedItem: () => {
             actions.checkSelectedFolders()
         },
-        linkedItem: () => {
-            actions.checkSelectedFolders()
-        },
         checkSelectedFolders: () => {
             // Select items added into folders that are selected
             const checkedItems = values.checkedItems
@@ -871,6 +868,9 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                         }
                     } else {
                         checkingFolder = null
+                        if (item.type === 'folder' && checkedItems[`project-folder/${item.path}`]) {
+                            checkingFolder = item.path
+                        }
                     }
                 }
             }

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
@@ -267,7 +267,14 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                     for (const result of results.slice(-1 * lastCount)) {
                         const folder = joinPath(splitPath(result.path).slice(0, -1))
                         if (newState[folder]) {
-                            newState[folder] = [...newState[folder], result]
+                            const existingItem = newState[folder].find((item) => item.id === result.id)
+                            if (existingItem) {
+                                newState[folder] = newState[folder].map((file) =>
+                                    file.id === result.id ? result : file
+                                )
+                            } else {
+                                newState[folder] = [...newState[folder], result]
+                            }
                         } else {
                             newState[folder] = [result]
                         }

--- a/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
@@ -195,7 +195,7 @@ export function convertFileSystemEntryToTreeDataItem({
             if (b.record?.type === 'folder' && a.record?.type !== 'folder') {
                 return 1
             }
-            return String(a.name).localeCompare(String(b.name))
+            return String(a.name).localeCompare(String(b.name), undefined, { sensitivity: 'accent' })
         })
         for (const node of nodes) {
             if (node.children) {

--- a/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
@@ -18,6 +18,20 @@ export interface ConvertProps {
     disableFolderSelect?: boolean
 }
 
+export function sortFilesAndFolders(a: FileSystemEntry, b: FileSystemEntry): number {
+    const parentA = a.path.substring(0, a.path.lastIndexOf('/'))
+    const parentB = b.path.substring(0, b.path.lastIndexOf('/'))
+    if (parentA === parentB) {
+        if (a.type === 'folder' && b.type !== 'folder') {
+            return -1
+        }
+        if (b.type === 'folder' && a.type !== 'folder') {
+            return 1
+        }
+    }
+    return a.path.localeCompare(b.path, undefined, { sensitivity: 'accent' })
+}
+
 export function wrapWithShortutIcon(item: FileSystemImport | FileSystemEntry, icon: JSX.Element): JSX.Element {
     if (item.shortcut) {
         return (

--- a/frontend/src/lib/lemon-ui/LemonCheckbox/LemonCheckbox.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCheckbox/LemonCheckbox.tsx
@@ -1,7 +1,7 @@
 import './LemonCheckbox.scss'
 
 import clsx from 'clsx'
-import { useEffect, useMemo, useState } from 'react'
+import { ChangeEvent, useEffect, useMemo, useState } from 'react'
 
 import { Tooltip } from '../Tooltip'
 
@@ -12,7 +12,7 @@ export interface LemonCheckboxProps {
     disabled?: boolean
     /** Like plain `disabled`, except we enforce a reason to be shown in the tooltip. */
     disabledReason?: string | null | false
-    onChange?: (value: boolean) => void
+    onChange?: (value: boolean, event: ChangeEvent<HTMLInputElement>) => void
     label?: string | JSX.Element
     id?: string
     className?: string
@@ -71,6 +71,13 @@ export function LemonCheckbox({
         }
     }, [checked, indeterminate])
 
+    // Prevent text selection when clicking on the area between the checkbox and the label
+    const stopShiftSelection = (e: React.MouseEvent): void => {
+        if (e.shiftKey && e.button === 0) {
+            e.preventDefault()
+        }
+    }
+
     return (
         <Tooltip title={disabledReason ? <i>{disabledReason}</i> : null} placement="top-start">
             <span
@@ -85,6 +92,7 @@ export function LemonCheckbox({
                     className
                 )}
                 data-attr={dataAttr}
+                onMouseDownCapture={stopShiftSelection}
             >
                 <input
                     className="LemonCheckbox__input"
@@ -94,7 +102,7 @@ export function LemonCheckbox({
                     onChange={(e) => {
                         // NOTE: We only want to setLocalChecked if the component is not controlled externally
                         checked === undefined && setLocalChecked(e.target.checked)
-                        onChange?.(e.target.checked)
+                        onChange?.(e.target.checked, e)
                     }}
                     id={id}
                     disabled={disabled}

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -110,7 +110,7 @@ type LemonTreeBaseProps = Omit<HTMLAttributes<HTMLDivElement>, 'onDragEnd'> & {
     /** Whether the item is unapplied */
     isItemUnapplied?: (item: TreeDataItem) => boolean
     /** The function to call when the item is checked. */
-    onItemChecked?: (id: string, checked: boolean) => void
+    onItemChecked?: (id: string, checked: boolean, shift: boolean) => void
     /** Count of checked items */
     checkedItemCount?: number
     /** The render function for the item. */

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTreeUtils.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTreeUtils.tsx
@@ -17,7 +17,7 @@ type TreeNodeDisplayIconWrapperProps = {
     defaultOffset: number
     multiSelectionOffset: number
     checkedItemCount?: number
-    onItemChecked?: (id: string, checked: boolean) => void
+    onItemChecked?: (id: string, checked: boolean, shift: boolean) => void
 }
 
 export const TreeNodeDisplayIconWrapper = ({
@@ -49,8 +49,8 @@ export const TreeNodeDisplayIconWrapper = ({
             >
                 <TreeNodeDisplayCheckbox
                     item={item}
-                    handleCheckedChange={(checked) => {
-                        onItemChecked?.(item.id, checked)
+                    handleCheckedChange={(checked, shift) => {
+                        onItemChecked?.(item.id, checked, shift)
                     }}
                     className={cn('absolute z-2', {
                         // Apply hidden class only when hovering the (conditional)group and there are no checked items
@@ -91,7 +91,7 @@ export const TreeNodeDisplayIconWrapper = ({
 type TreeNodeDisplayCheckboxProps = {
     item: TreeDataItem
     style?: CSSProperties
-    handleCheckedChange?: (checked: boolean) => void
+    handleCheckedChange?: (checked: boolean, shift: boolean) => void
     className?: string
 }
 
@@ -117,12 +117,19 @@ export const TreeNodeDisplayCheckbox = ({
                         hidden: item.disableSelect && item.record?.type === 'folder',
                     })}
                     checked={isChecked ?? false}
-                    onChange={(checked) => {
+                    onChange={(checked, event) => {
                         // Just in case
                         if (item.disableSelect) {
                             return
                         }
-                        handleCheckedChange?.(checked)
+                        let shift = false
+                        if (event.nativeEvent && 'shiftKey' in event.nativeEvent) {
+                            shift = !!(event.nativeEvent as PointerEvent).shiftKey
+                            if (shift) {
+                                event.stopPropagation()
+                            }
+                        }
+                        handleCheckedChange?.(checked, shift)
                     }}
                 />
             </div>

--- a/posthog/api/file_system.py
+++ b/posthog/api/file_system.py
@@ -93,7 +93,7 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     serializer_class = FileSystemSerializer
     filter_backends = [filters.SearchFilter]
     pagination_class = FileSystemsLimitOffsetPagination
-    search_fields = ["path", "ref", "type"]
+    search_fields = ["path"]
 
     def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:
         queryset = queryset.filter(team=self.team)

--- a/posthog/api/test/test_file_system.py
+++ b/posthog/api/test/test_file_system.py
@@ -514,25 +514,6 @@ class TestFileSystemAPI(APIBaseTest):
         # Expecting 2 items with type starting with 'd'
         self.assertEqual(data["count"], 2)
 
-    def test_search_files_by_ref(self):
-        """
-        Ensure that searching with the ?search= query param returns items matching on the 'ref' field.
-        """
-        # Create items with unique ref values
-        FileSystem.objects.create(
-            team=self.team, path="SomePath/File1", type="doc", ref="unique-ref-123", created_by=self.user
-        )
-        FileSystem.objects.create(
-            team=self.team, path="OtherPath/File2", type="doc", ref="other-ref-456", created_by=self.user
-        )
-        # Using search to filter by part of the ref value
-        response = self.client.get(f"/api/projects/{self.team.id}/file_system/?search=unique-ref")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        data = response.json()
-        # Expecting only the item with ref "unique-ref-123"
-        self.assertEqual(data["count"], 1)
-        self.assertEqual(data["results"][0]["ref"], "unique-ref-123")
-
     def test_link_file_endpoint(self):
         """
         Test linking a file creates a new file with an updated path and that missing parent folders are auto-created.


### PR DESCRIPTION
## Problem

Shift+click doesn't work... and there are bugs here and there.

## Changes

- Adds multiselect when pressing SHIFT
- Fixes bunch of small bugs (double appending results, selecting load more, searching in ID fields, etc)

![2025-04-22 16 58 00](https://github.com/user-attachments/assets/008a0ba0-08b8-4340-8522-85ffe7127ef2)


## How did you test this code?

Updated tests and clicked around.