### PR TITLE
chore: Swap all reads to persons to reader DB

### DIFF
--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -17,7 +17,7 @@ from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
 from posthog.hogql_queries.query_runner import QueryRunner, get_query_runner
 from posthog.models import Action, Person
 from posthog.models.element import chain_to_elements
-from posthog.models.person.person import get_distinct_ids_for_subquery
+from posthog.models.person.person import READ_DB_FOR_PERSONS, get_distinct_ids_for_subquery
 from posthog.models.person.util import get_persons_by_distinct_ids
 from posthog.schema import DashboardFilter, EventsQuery, EventsQueryResponse, CachedEventsQueryResponse
 from posthog.utils import relative_date_parse
@@ -118,7 +118,7 @@ class EventsQueryRunner(QueryRunner):
                 if self.query.personId:
                     with self.timings.measure("person_id"):
                         person: Optional[Person] = get_pk_or_uuid(
-                            Person.objects.filter(team=self.team), self.query.personId
+                            Person.objects.db_manager(READ_DB_FOR_PERSONS).filter(team=self.team), self.query.personId
                         ).first()
                         where_exprs.append(
                             ast.CompareOperation(

--- a/posthog/models/event/query_event_list.py
+++ b/posthog/models/event/query_event_list.py
@@ -15,7 +15,7 @@ from posthog.models.event.sql import (
     SELECT_EVENT_BY_TEAM_AND_CONDITIONS_FILTERS_SQL,
     SELECT_EVENT_BY_TEAM_AND_CONDITIONS_SQL,
 )
-from posthog.models.person.person import get_distinct_ids_for_subquery
+from posthog.models.person.person import READ_DB_FOR_PERSONS, get_distinct_ids_for_subquery
 from posthog.models.property.util import parse_prop_grouped_clauses
 from posthog.queries.insight import insight_query_with_columns
 from posthog.utils import relative_date_parse
@@ -44,7 +44,7 @@ def parse_request_params(
             params.update({"before": v})
         elif k == "person_id":
             result += """AND distinct_id IN (%(distinct_ids)s) """
-            person = get_pk_or_uuid(Person.objects.filter(team=team), v).first()
+            person = get_pk_or_uuid(Person.objects.db_manager(READ_DB_FOR_PERSONS).filter(team=team), v).first()
             params.update({"distinct_ids": get_distinct_ids_for_subquery(person, team)})
         elif k == "distinct_id":
             result += "AND distinct_id = %(distinct_id)s "

--- a/posthog/models/feature_flag/flag_matching.py
+++ b/posthog/models/feature_flag/flag_matching.py
@@ -21,6 +21,7 @@ from posthog.models.filters.mixins.utils import cached_property
 from posthog.models.group import Group
 from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.models.person import Person, PersonDistinctId
+from posthog.models.person.person import READ_DB_FOR_PERSONS
 from posthog.models.property import GroupTypeIndex, GroupTypeName
 from posthog.models.property.property import Property
 from posthog.models.cohort import Cohort, CohortOrEmpty
@@ -1233,7 +1234,7 @@ def check_flag_evaluation_query_is_ok(feature_flag: FeatureFlag, project_id: int
     group_type_index = feature_flag.aggregation_group_type_index
 
     base_query: QuerySet = (
-        Person.objects.filter(team__project_id=project_id)
+        Person.objects.db_manager(READ_DB_FOR_PERSONS).filter(team__project_id=project_id)
         if group_type_index is None
         else Group.objects.filter(team__project_id=project_id, group_type_index=group_type_index)
     )

--- a/posthog/models/person/util.py
+++ b/posthog/models/person/util.py
@@ -19,6 +19,7 @@ from posthog.kafka_client.topics import (
     KAFKA_PERSON_OVERRIDES,
 )
 from posthog.models.person import Person, PersonDistinctId
+from posthog.models.person.person import READ_DB_FOR_PERSONS
 from posthog.models.person.sql import (
     BULK_INSERT_PERSON_DISTINCT_ID2,
     INSERT_PERSON_BULK_SQL,
@@ -218,7 +219,7 @@ def create_person_override(
 
 
 def get_persons_by_distinct_ids(team_id: int, distinct_ids: list[str]) -> QuerySet:
-    return Person.objects.filter(
+    return Person.objects.db_manager(READ_DB_FOR_PERSONS).filter(
         team_id=team_id,
         persondistinctid__team_id=team_id,
         persondistinctid__distinct_id__in=distinct_ids,
@@ -226,7 +227,7 @@ def get_persons_by_distinct_ids(team_id: int, distinct_ids: list[str]) -> QueryS
 
 
 def get_persons_by_uuids(team: Team, uuids: list[str]) -> QuerySet:
-    return Person.objects.filter(team_id=team.pk, uuid__in=uuids)
+    return Person.objects.db_manager(READ_DB_FOR_PERSONS).filter(team_id=team.pk, uuid__in=uuids)
 
 
 def delete_person(person: Person, sync: bool = False) -> None:
@@ -257,7 +258,8 @@ def _delete_person(
 def _get_distinct_ids_with_version(person: Person) -> dict[str, int]:
     return {
         distinct_id: int(version or 0)
-        for distinct_id, version in PersonDistinctId.objects.filter(person=person, team_id=person.team_id)
+        for distinct_id, version in PersonDistinctId.objects.db_manager(READ_DB_FOR_PERSONS)
+        .filter(person=person, team_id=person.team_id)
         .order_by("id")
         .values_list("distinct_id", "version")
     }

--- a/posthog/queries/actor_base_query.py
+++ b/posthog/queries/actor_base_query.py
@@ -21,6 +21,7 @@ from posthog.models.filters.retention_filter import RetentionFilter
 from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.models.group import Group
 from posthog.models.person import Person
+from posthog.models.person.person import READ_DB_FOR_PERSONS
 from posthog.queries.insight import insight_sync_execute
 from posthog.schema import ActorsQuery
 
@@ -273,17 +274,18 @@ def get_people(
 ) -> tuple[QuerySet[Person], list[SerializedPerson]]:
     """Get people from raw SQL results in data model and dict formats"""
     distinct_id_subquery = Subquery(
-        PersonDistinctId.objects.filter(person_id=OuterRef("person_id")).values_list("id", flat=True)[
-            :distinct_id_limit
-        ]
+        PersonDistinctId.objects.db_manager(READ_DB_FOR_PERSONS)
+        .filter(person_id=OuterRef("person_id"))
+        .values_list("id", flat=True)[:distinct_id_limit]
     )
     persons: QuerySet[Person] = (
-        Person.objects.filter(team_id=team.pk, uuid__in=people_ids)
+        Person.objects.db_manager(READ_DB_FOR_PERSONS)
+        .filter(team_id=team.pk, uuid__in=people_ids)
         .prefetch_related(
             Prefetch(
                 "persondistinctid_set",
                 to_attr="distinct_ids_cache",
-                queryset=PersonDistinctId.objects.filter(id__in=distinct_id_subquery),
+                queryset=PersonDistinctId.objects.db_manager(READ_DB_FOR_PERSONS).filter(id__in=distinct_id_subquery),
             )
         )
         .order_by("-created_at", "uuid")

--- a/posthog/session_recordings/models/session_recording.py
+++ b/posthog/session_recordings/models/session_recording.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.db import models
 
 from posthog.models.person.missing_person import MissingPerson
-from posthog.models.person.person import Person
+from posthog.models.person.person import READ_DB_FOR_PERSONS, Person
 from posthog.models.signals import mutable_receiver
 from posthog.models.team.team import Team
 from posthog.models.utils import UUIDModel
@@ -134,7 +134,7 @@ class SessionRecording(UUIDModel):
             return
 
         try:
-            self.person = Person.objects.get(
+            self.person = Person.objects.db_manager(READ_DB_FOR_PERSONS).get(
                 persondistinctid__distinct_id=self.distinct_id,
                 persondistinctid__team_id=self.team.pk,
                 team=self.team,


### PR DESCRIPTION
## Problem

We want to really keep as much as possible off the write DB

## Changes

* Changes all instances i could find for `objects.filter` which i think are the worst offenders

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
