### PR TITLE
chore(session_replay_api): moves all persons read to replica

### DIFF
--- a/posthog/models/person/person.py
+++ b/posthog/models/person/person.py
@@ -1,5 +1,6 @@
 from typing import Any, Optional
 
+from django.conf import settings
 from django.db import models, transaction
 from django.db.models import F, Q
 
@@ -9,6 +10,8 @@ from ..team import Team
 from .missing_person import uuidFromDistinctId
 
 MAX_LIMIT_DISTINCT_IDS = 2500
+
+READ_DB_FOR_PERSONS = "replica" if "replica" in settings.DATABASES else "default"
 
 
 class PersonManager(models.Manager):


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

chore(session_replay_api): moves all persons read to replica

## Changes

## Does this work well for both Cloud and self-hosted?


## How did you test this code?

