### PR TITLE
fix(data-warehouse): Use the full loading state animation

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
@@ -4,10 +4,9 @@ import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { ExportButton } from 'lib/components/ExportButton/ExportButton'
-import { LoadingBar } from 'lib/lemon-ui/LoadingBar'
 import { useCallback, useState } from 'react'
 import { DatabaseTableTreeWithItems } from 'scenes/data-warehouse/external/DataWarehouseTables'
-import { InsightErrorState } from 'scenes/insights/EmptyStates'
+import { InsightErrorState, StatelessInsightLoadingState } from 'scenes/insights/EmptyStates'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import { HogQLBoldNumber } from 'scenes/insights/views/BoldNumber/BoldNumber'
@@ -163,6 +162,8 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
 
     const { toggleChartSettingsPanel } = useActions(dataVisualizationLogic)
 
+    const { queryId, pollResponse } = useValues(dataNodeLogic)
+
     const setQuerySource = useCallback(
         (source: HogQLQuery) => props.setQuery?.({ ...props.query, source }),
         [props.setQuery, props.query]
@@ -174,7 +175,7 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
     if (!showEditingUI && (!response || responseLoading)) {
         component = (
             <div className="flex flex-col flex-1 justify-center items-center bg-surface-primary h-full">
-                <LoadingBar />
+                <StatelessInsightLoadingState queryId={queryId} pollResponse={pollResponse} />
             </div>
         )
     } else if (visualizationType === ChartDisplayType.ActionsTable) {


### PR DESCRIPTION
## Problem
- When loading a SQL insight on a dashboard, we show just a loading bar

<img width="1114" alt="image" src="https://github.com/user-attachments/assets/d2a9bd24-c999-41ec-9977-b7067c3c7c71" />


## Changes
- Use the full loading animation component instead

<img width="765" alt="image" src="https://github.com/user-attachments/assets/23f6f546-6c1e-4e3d-b5bd-7c0689ba702d" />


## Does this work well for both Cloud and self-hosted?
yup

## How did you test this code?
see screenshot