### PR TITLE
fix(defensive-divide-by-none): Fix mysql division error

### DIFF
--- a/posthog/temporal/data_imports/pipelines/mysql/mysql.py
+++ b/posthog/temporal/data_imports/pipelines/mysql/mysql.py
@@ -114,7 +114,7 @@ def _get_partition_settings(
 
     table_size, row_count = result
 
-    if row_count == 0:
+    if table_size is None or row_count is None or row_count == 0:
         return None
 
     avg_row_size = table_size / row_count


### PR DESCRIPTION
We are getting a type division error related to this. 

Log from production we are encountering:
```
  File "/python-runtime/lib/python3.11/site-packages/temporalio/worker/_activity.py", line 705, in execute_activity
    return await loop.run_in_executor(input.executor, func, *args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/python-runtime/lib/python3.11/site-packages/temporalio/worker/_activity.py", line 774, in _execute_sync_activity
    return fn(*args)
           ^^^^^^^^^
  File "/code/posthog/temporal/data_imports/workflow_activities/import_data_sync.py", line 365, in import_data_activity_sync
    source = mysql_source(
             ^^^^^^^^^^^^^
  File "/code/posthog/temporal/data_imports/pipelines/mysql/mysql.py", line 295, in mysql_source
    partition_settings = _get_partition_settings(cursor, schema, table_name) if is_incremental else None
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/posthog/temporal/data_imports/pipelines/mysql/mysql.py", line 120, in _get_partition_settings
    avg_row_size = table_size / row_count
                   ~~~~~~~~~~~^~~~~~~~~~~
TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'
```


## Changes
- [x] Protect against a division that is dangerous

## Does this work well for both Cloud and self-hosted?
Yes

