### PR TITLE
fix(add-missing-db-field-mapping): Add missing key in database field mapping

### DIFF
--- a/posthog/warehouse/models/table.py
+++ b/posthog/warehouse/models/table.py
@@ -49,6 +49,7 @@ SERIALIZED_FIELD_TO_CLICKHOUSE_MAPPING: dict[DatabaseSerializedFieldType, str] =
     DatabaseSerializedFieldType.BOOLEAN: "Bool",
     DatabaseSerializedFieldType.ARRAY: "Array",
     DatabaseSerializedFieldType.JSON: "Map",
+    DatabaseSerializedFieldType.DECIMAL: "Decimal",
 }
 
 ExtractErrors = {

--- a/posthog/warehouse/models/util.py
+++ b/posthog/warehouse/models/util.py
@@ -103,6 +103,7 @@ STR_TO_HOGQL_MAPPING = {
     "DateDatabaseField": DateDatabaseField,
     "DateTimeDatabaseField": DateTimeDatabaseField,
     "IntegerDatabaseField": IntegerDatabaseField,
+    "DecimalDatabaseField": DecimalDatabaseField,
     "FloatDatabaseField": FloatDatabaseField,
     "StringArrayDatabaseField": StringArrayDatabaseField,
     "StringDatabaseField": StringDatabaseField,


### PR DESCRIPTION
## Problem
```
Traceback (most recent call last):
  File "/python-runtime/lib/python3.11/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/python-runtime/lib/python3.11/site-packages/rest_framework/mixins.py", line 42, in list
    serializer = self.get_serializer(page, many=True)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/python-runtime/lib/python3.11/site-packages/rest_framework/generics.py", line 113, in get_serializer
    kwargs.setdefault('context', self.get_serializer_context())
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/posthog/warehouse/api/external_data_source.py", line 359, in get_serializer_context
    context["database"] = create_hogql_database(team_id=self.team_id)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/posthog/hogql/database/database.py", line 457, in create_hogql_database
    views[saved_query.name] = saved_query.hogql_definition(modifiers)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/posthog/warehouse/models/datawarehouse_saved_query.py", line 171, in hogql_definition
    return self.table.hogql_definition(modifiers)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/posthog/warehouse/models/table.py", line 302, in hogql_definition
    hogql_type = STR_TO_HOGQL_MAPPING[type["hogql"]]
                 ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
KeyError: 'DecimalDatabaseField'
```

## Changes

- [x] Add missing key in a mapping

## Does this work well for both Cloud and self-hosted?
Yes
