### PR TITLE
test(data-warehouse): Add basic tests for database types resolution

### DIFF
--- a/posthog/warehouse/models/table.py
+++ b/posthog/warehouse/models/table.py
@@ -43,13 +43,13 @@ if TYPE_CHECKING:
 SERIALIZED_FIELD_TO_CLICKHOUSE_MAPPING: dict[DatabaseSerializedFieldType, str] = {
     DatabaseSerializedFieldType.INTEGER: "Int64",
     DatabaseSerializedFieldType.FLOAT: "Float64",
+    DatabaseSerializedFieldType.DECIMAL: "Decimal",
     DatabaseSerializedFieldType.STRING: "String",
     DatabaseSerializedFieldType.DATETIME: "DateTime64",
     DatabaseSerializedFieldType.DATE: "Date",
     DatabaseSerializedFieldType.BOOLEAN: "Bool",
     DatabaseSerializedFieldType.ARRAY: "Array",
     DatabaseSerializedFieldType.JSON: "Map",
-    DatabaseSerializedFieldType.DECIMAL: "Decimal",
 }
 
 ExtractErrors = {

--- a/posthog/warehouse/models/test/test_table.py
+++ b/posthog/warehouse/models/test/test_table.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from posthog.hogql.database.models import DateTimeDatabaseField, IntegerDatabaseField, StringDatabaseField
 from posthog.test.base import BaseTest
 from posthog.warehouse.models import DataWarehouseCredential, DataWarehouseTable
+from posthog.warehouse.models.table import SERIALIZED_FIELD_TO_CLICKHOUSE_MAPPING
 
 
 class TestTable(BaseTest):
@@ -264,3 +265,69 @@ class TestTable(BaseTest):
             table.hogql_definition().structure,
             "`id` String, `mrr` Nullable(Int64)",
         )
+
+    def test_comprehensive_table_definition(self):
+        base_columns = {
+            "int64": {"clickhouse": "Int64", "hogql": "IntegerDatabaseField"},
+            "float64": {"clickhouse": "Float64", "hogql": "FloatDatabaseField"},
+            "decimal": {"clickhouse": "Decimal(10, 2)", "hogql": "DecimalDatabaseField"},
+            "string": {"clickhouse": "String", "hogql": "StringDatabaseField"},
+            "datetime": {"clickhouse": "DateTime64(3, 'UTC')", "hogql": "DateTimeDatabaseField"},
+            "date": {"clickhouse": "Date", "hogql": "DateDatabaseField"},
+            "boolean": {"clickhouse": "Bool", "hogql": "BooleanDatabaseField"},
+            "array": {"clickhouse": "Array(String)", "hogql": "StringArrayDatabaseField"},
+            "map": {"clickhouse": "Map(String, String)", "hogql": "StringJSONDatabaseField"},
+        }
+
+        # Assert this is a comprehensive list of all possible ClickHouse types
+        assert len({val["clickhouse"] for key, val in base_columns.items()}) == len(
+            SERIALIZED_FIELD_TO_CLICKHOUSE_MAPPING
+        )
+
+        # Create a nullable copy for each of the above
+        nullable_columns = {
+            f"{key}_nullable": {"clickhouse": f"Nullable({val['clickhouse']})", "hogql": val["hogql"]}
+            for key, val in base_columns.items()
+        }
+
+        # Merge the two dictionaries
+        columns = {**base_columns, **nullable_columns}
+
+        credential = DataWarehouseCredential.objects.create(access_key="test", access_secret="test", team=self.team)
+        table = DataWarehouseTable.objects.create(
+            name="bla",
+            url_pattern="https://databeach-hackathon.s3.amazonaws.com/tim_test/test_events6.pqt",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            team=self.team,
+            columns=columns,
+            credential=credential,
+        )
+
+        definition = table.hogql_definition()
+        assert len(definition.fields) == len(columns)
+        assert (
+            definition.structure == "`int64` Int64, `float64` Float64, `decimal` Decimal(10, 2), "
+            "`string` String, `datetime` DateTime64(3, 'UTC'), `date` Date, "
+            "`boolean` Bool, `array` Array(String), `map` Map(String, String), "
+            "`int64_nullable` Nullable(Int64), `float64_nullable` Nullable(Float64), "
+            "`decimal_nullable` Nullable(Decimal(10, 2)), `string_nullable` Nullable(String), "
+            "`datetime_nullable` Nullable(DateTime64(3, 'UTC')), `date_nullable` Nullable(Date), "
+            "`boolean_nullable` Nullable(Bool), `array_nullable` Nullable(Array(String)), "
+            "`map_nullable` Nullable(Map(String, String))"
+        )
+
+    def assert_raises_with_invalid_hog_column_type(self, column_type):
+        credential = DataWarehouseCredential.objects.create(access_key="test", access_secret="test", team=self.team)
+        table = DataWarehouseTable.objects.create(
+            name="bla",
+            url_pattern="https://databeach-hackathon.s3.amazonaws.com/tim_test/test_events6.pqt",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            team=self.team,
+            columns={
+                "id": {"clickhouse": column_type, "hogql": "RandomUnknownDatabaseField"},
+            },
+            credential=credential,
+        )
+
+        with self.assertRaises(Exception):
+            table.hogql_definition()


### PR DESCRIPTION
We've had a couple bugs because we don't have 100% coverage for our type-level resolution for our data warehouse. This adds some very basic coverage, we need to increase it.