### PR TITLE
chore: rephrase online indicator + link to docs

### DIFF
--- a/frontend/src/scenes/web-analytics/WebAnalyticsLiveUserCount.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsLiveUserCount.tsx
@@ -24,19 +24,26 @@ const TooltipContent = (): JSX.Element | null => {
         return null
     }
 
-    const updatedAgoString =
-        liveUserUpdatedSecondsAgo === 0
-            ? ' (updated just now)'
-            : liveUserUpdatedSecondsAgo == null
-            ? ''
-            : ` (updated ${liveUserUpdatedSecondsAgo} seconds ago)`
-
     const usersOnlineString = `${humanFriendlyNumber(liveUserCount)} ${
         liveUserCount === 1 ? 'user has' : 'users have'
     } been seen recently`
     const inTeamString = currentTeam ? ` in ${currentTeam.name}` : ''
-    const tooltip = `${usersOnlineString}${inTeamString}${updatedAgoString}`
-    return <>{tooltip}</>
+    const updatedString =
+        liveUserUpdatedSecondsAgo === 0
+            ? 'updated just now'
+            : liveUserUpdatedSecondsAgo == null
+            ? ''
+            : `updated ${liveUserUpdatedSecondsAgo} seconds ago`
+
+    return (
+        <div>
+            <div>
+                {usersOnlineString}
+                {inTeamString}
+            </div>
+            {updatedString && <div>({updatedString})</div>}
+        </div>
+    )
 }
 
 export const WebAnalyticsLiveUserCount = (): JSX.Element | null => {

--- a/frontend/src/scenes/web-analytics/WebAnalyticsLiveUserCount.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsLiveUserCount.tsx
@@ -32,8 +32,8 @@ const TooltipContent = (): JSX.Element | null => {
             : ` (updated ${liveUserUpdatedSecondsAgo} seconds ago)`
 
     const usersOnlineString = `${humanFriendlyNumber(liveUserCount)} ${
-        liveUserCount === 1 ? 'user is' : 'users are'
-    } online`
+        liveUserCount === 1 ? 'user has' : 'users have'
+    } been seen recently`
     const inTeamString = currentTeam ? ` in ${currentTeam.name}` : ''
     const tooltip = `${usersOnlineString}${inTeamString}${updatedAgoString}`
     return <>{tooltip}</>
@@ -48,11 +48,16 @@ export const WebAnalyticsLiveUserCount = (): JSX.Element | null => {
     }
 
     return (
-        <Tooltip title={<TooltipContent />} interactive={true} delayMs={0}>
+        <Tooltip
+            title={<TooltipContent />}
+            interactive={true}
+            delayMs={0}
+            docLink="https://posthog.com/docs/web-analytics/faq#i-am-online-but-the-online-user-count-is-not-reflecting-my-user"
+        >
             <div className="flex flex-row items-center justify-center">
                 <div className={clsx('live-user-indicator', liveUserCount > 0 ? 'online' : 'offline')} />
                 <span className="whitespace-nowrap" data-attr="web-analytics-live-user-count">
-                    <strong>{humanFriendlyLargeNumber(liveUserCount)}</strong> online
+                    <strong>{humanFriendlyLargeNumber(liveUserCount)}</strong> recently online
                 </span>
             </div>
         </Tooltip>


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

Depends on https://github.com/PostHog/posthog.com/pull/11330 for the docs link to work on the correct hash.

## Problem

We’ve received multiple support tickets related to user status display. The current text may be unclear, so this PR adds a clearer explanation and a link to the relevant documentation.  
Also considering changing the wording from “recently online” to simply “online” to save space.

## Changes

| Before | After |
|--------|-------|
| <img width="597" alt="After" src="https://github.com/user-attachments/assets/3e059ea1-a563-436e-8ce6-e1f6b5b3c136" /> | <img width="528" alt="Before" src="https://github.com/user-attachments/assets/8b9776b5-3a9a-4c1d-abbf-d69c6ed6e1e6" /> |

- Added clearer messaging for user online status  
- Included link to documentation for further clarity  
- Possible wording change to streamline UI

## Does this work well for both Cloud and self-hosted?

✅ Yes

## How did you test this code?

Manually
