### PR TITLE
chore: add max width and height to LearnMorePopover

### DIFF
--- a/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
@@ -337,7 +337,7 @@ export const LearnMorePopover = ({ url, title, description }: LearnMorePopoverPr
             visible={isOpen}
             onClickOutside={() => setIsOpen(false)}
             overlay={
-                <div className="p-4">
+                <div className="p-4 max-w-160 max-h-160 overflow-auto">
                     <div className="flex flex-row w-full">
                         <h2 className="flex-1">{title}</h2>
                         <LemonButton


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C0368RPHLQH/p1745343539060499

There was no max-width being enforced, so the Popover would grow for those longer paragraphs.

## Changes

<img width="1451" alt="Screenshot 2025-04-22 at 21 31 50" src="https://github.com/user-attachments/assets/b206ee92-a44d-45a6-a2bc-02f55c51995f" />

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manually