### PR TITLE
fix(flags): it's not an evaluation error if a personless person doesn't have cohort matches

### DIFF
--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -391,8 +391,7 @@ impl FeatureFlagMatcher {
         // Get cached static cohort results or evaluate them if not cached
         let static_cohort_matches = match self.flag_evaluation_state.get_static_cohort_matches() {
             Some(matches) => matches.clone(),
-            // TODO probably fine to return empty here, maybe just log but not error.
-            None => return Err(FlagError::StaticCohortMatchesNotCached),
+            None => HashMap::new(), // NB: this happens if a flag has static cohort filters but is targeting an anonymous user.  Shouldn't error, just return empty.
         };
 
         // Store all cohort match results, starting with static cohort results


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

One more noisy error that I should clean up.  This isn't as bad as the previous one because it doesn't fail all flag evaluations, but it does set `errorsWhileComputingFlags` to true in a place where I don't think it should.
