### PR TITLE
fix(cdp): wrong label for metrics

### DIFF
--- a/plugin-server/src/cdp/services/hog-watcher.service.ts
+++ b/plugin-server/src/cdp/services/hog-watcher.service.ts
@@ -28,7 +28,6 @@ export const hogFunctionExecutionTimeSummary = new Histogram({
     name: 'cdp_hog_watcher_timings',
     help: 'Processing time of hog function execution by kind',
     labelNames: ['kind'],
-    buckets: [0, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, Infinity],
 })
 
 // TODO: Future follow up - we should swap this to an API call or something.
@@ -150,7 +149,7 @@ export class HogWatcherService {
 
                 for (const timing of result.invocation.timings) {
                     // Record metrics for this timing entry
-                    hogFunctionExecutionTimeSummary.labels(timing.kind).observe(timing.duration_ms)
+                    hogFunctionExecutionTimeSummary.labels({ kind: timing.kind }).observe(timing.duration_ms)
                     const ratio = Math.max(timing.duration_ms - lowerBound, 0) / (upperBound - lowerBound)
 
                     // Add to the total cost for this result


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Seems like my metrics do not get labled correctly due to how i implemented it 

![Screenshot 2025-04-23 at 09 06 03](https://github.com/user-attachments/assets/4ec14c8b-5084-4496-9a45-892acefd3c46)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- changed code to do what its supposed to do

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
