### PR TITLE
fix(project-tree): sort folders first in api, fix bugs

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
@@ -130,6 +130,9 @@ export function convertFileSystemEntryToTreeDataItem({
                 } else {
                     // We have a folder without an id, but the incoming one has an id. Remove the current one
                     currentLevel = currentLevel.filter((node) => !folderMatch(node))
+                    if (folderNode) {
+                        folderNode.children = currentLevel
+                    }
                     if (existingFolder.children) {
                         accumulatedChildren = [...accumulatedChildren, ...existingFolder.children]
                     }
@@ -171,7 +174,7 @@ export function convertFileSystemEntryToTreeDataItem({
             if (!node.children) {
                 node.children = []
             }
-            if (accumulatedChildren) {
+            if (accumulatedChildren && accumulatedChildren.length > 0) {
                 node.children = [...node.children, ...accumulatedChildren]
             }
             if (folderStates[item.path] === 'has-more') {


### PR DESCRIPTION
## Problem

Fix a few more folder bugs

## Changes

- "Load more" and "loading" didn't show up if you were loading an item in a large folder (e.g. refreshing the page on a feature flag)
- The API did not sort folders first nor in a case insensitive way, leading to jumping of the screen when pressing "load more"

![2025-04-23 10 06 00](https://github.com/user-attachments/assets/641e9584-21e3-4841-8fb2-d8e1560af72b)

## How did you test this code?

Backend tests. Frontend in the UI.