### PR TITLE
fix(flags): handle flags with empty filters

### DIFF
--- a/rust/feature-flags/src/flags/flag_models.rs
+++ b/rust/feature-flags/src/flags/flag_models.rs
@@ -6,10 +6,13 @@ use crate::properties::property_models::PropertyFilter;
 // TODO: Add integration tests across repos to ensure this doesn't happen.
 pub const TEAM_FLAGS_CACHE_PREFIX: &str = "posthog:1:team_feature_flags_";
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct FlagPropertyGroup {
+    #[serde(default)]
     pub properties: Option<Vec<PropertyFilter>>,
+    #[serde(default)]
     pub rollout_percentage: Option<f64>,
+    #[serde(default)]
     pub variant: Option<String>,
 }
 
@@ -25,13 +28,19 @@ pub struct MultivariateFlagOptions {
     pub variants: Vec<MultivariateFlagVariant>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct FlagFilters {
+    #[serde(default)]
     pub groups: Vec<FlagPropertyGroup>,
+    #[serde(default)]
     pub multivariate: Option<MultivariateFlagOptions>,
+    #[serde(default)]
     pub aggregation_group_type_index: Option<i32>,
+    #[serde(default)]
     pub payloads: Option<serde_json::Value>,
+    #[serde(default)]
     pub super_groups: Option<Vec<FlagPropertyGroup>>,
+    #[serde(default)]
     pub holdout_groups: Option<Vec<FlagPropertyGroup>>,
 }
 

--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -1505,4 +1505,27 @@ mod tests {
                 && (f.filters.groups[0].rollout_percentage.unwrap() - 33.33).abs() < f64::EPSILON));
         }
     }
+
+    #[test]
+    fn test_empty_filters_deserialization() {
+        let empty_filters_json = r#"{
+            "id": 1,
+            "team_id": 2,
+            "name": "Empty Filters Flag",
+            "key": "empty_filters",
+            "filters": {},
+            "deleted": false,
+            "active": true
+        }"#;
+
+        let flag: FeatureFlag =
+            serde_json::from_str(empty_filters_json).expect("Should deserialize empty filters");
+
+        assert_eq!(flag.filters.groups.len(), 0);
+        assert!(flag.filters.multivariate.is_none());
+        assert!(flag.filters.aggregation_group_type_index.is_none());
+        assert!(flag.filters.payloads.is_none());
+        assert!(flag.filters.super_groups.is_none());
+        assert!(flag.filters.holdout_groups.is_none());
+    }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

A few folks noticed that flags created with `sync_feature_flags` aren't working locally with the new `/flags` service.  This is because these flags are created with empty filters.

This also means flags with empty filters won't be parsed by our flags service in production, [there's enough of those flags](https://metabase.prod-us.posthog.dev/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiJzZWxlY3QgKiBmcm9tIHBvc3Rob2dfZmVhdHVyZWZsYWcgd2hlcmUgZmlsdGVycz0ne30nIiwidGVtcGxhdGUtdGFncyI6e319LCJkYXRhYmFzZSI6MzR9LCJkaXNwbGF5IjoidGFibGUiLCJwYXJhbWV0ZXJzIjpbXSwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e319) that I should fix it.

Stupid `not null` jsonb table definitions...

## Changes

- adds default parsing for empty filter objects and a test for good measure.

## Does this work well for both Cloud and self-hosted?

Yup

## How did you test this code?

wrote failing test
fixed code
test passes :)
