### PR TITLE
chore(batch-exports): Support updating multiple batch export schedules in command

### DIFF
--- a/posthog/management/commands/test/test_update_batch_export_schedules.py
+++ b/posthog/management/commands/test/test_update_batch_export_schedules.py
@@ -4,6 +4,7 @@ import logging
 import pytest
 from asgiref.sync import async_to_sync
 from django.core.management import call_command
+from django.core.management.base import CommandError
 from temporalio.client import Client as TemporalClient
 from temporalio.service import RPCError
 
@@ -12,11 +13,29 @@ from posthog.api.test.test_team import create_team
 from posthog.batch_exports.service import pause_batch_export, sync_batch_export
 from posthog.models import BatchExport, BatchExportDestination
 from posthog.temporal.common.client import sync_connect
-from posthog.temporal.common.schedule import update_schedule
+from posthog.temporal.common.schedule import describe_schedule, update_schedule
 
 pytestmark = [
     pytest.mark.django_db,
 ]
+
+DUMMY_CONFIG = {
+    "S3": {
+        "bucket_name": "my-production-s3-bucket",
+        "region": "us-east-1",
+        "prefix": "posthog-events/",
+        "aws_access_key_id": "abc123",
+        "aws_secret_access_key": "secret",
+        "invalid_key": "invalid_value",
+    },
+    "Snowflake": {
+        "account": "test-account",
+        "user": "test-user",
+        "database": "test-database",
+        "warehouse": "test-warehouse",
+        "schema": "test-schema",
+    },
+}
 
 
 @pytest.fixture
@@ -38,24 +57,20 @@ def team(organization, timezone):
 
 
 @pytest.fixture
-def batch_export(team):
+def team_2(organization, timezone):
+    return create_team(organization=organization, timezone=timezone)
+
+
+def _create_batch_export(team, destination_type, timezone):
     destination_data = {
-        "type": "S3",
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
-            "invalid_key": "invalid_value",
-        },
+        "type": destination_type,
+        "config": DUMMY_CONFIG[destination_type],
     }
 
     batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
+        "name": f"{destination_type}-batch-export",
         "interval": "hour",
     }
-
     destination = BatchExportDestination(**destination_data)
     batch_export = BatchExport(team=team, destination=destination, **batch_export_data)
 
@@ -84,14 +99,6 @@ def cleanup_temporal_schedules(temporal: TemporalClient):
             continue
 
 
-@async_to_sync
-async def describe_schedule(temporal: TemporalClient, schedule_id: str):
-    """Return the description of a Temporal Schedule with the given id."""
-    handle = temporal.get_schedule_handle(schedule_id)
-    temporal_schedule = await handle.describe()
-    return temporal_schedule
-
-
 @pytest.fixture
 def temporal():
     """Return a TemporalClient instance."""
@@ -100,22 +107,36 @@ def temporal():
     cleanup_temporal_schedules(client)
 
 
-@pytest.mark.django_db
+def _update_schedule(temporal: TemporalClient, batch_export: BatchExport, jitter: dt.timedelta):
+    schedule = describe_schedule(temporal, str(batch_export.id))
+    new_schedule = schedule.schedule
+    new_schedule.spec.jitter = jitter
+    update_schedule(temporal, str(batch_export.id), new_schedule, keep_tz=True)
+    schedule = describe_schedule(temporal, str(batch_export.id))
+    assert schedule.schedule.spec.jitter == jitter
+
+
+def _assert_schedule(
+    temporal: TemporalClient, batch_export: BatchExport, timezone: str, jitter: dt.timedelta, paused: bool
+):
+    schedule = describe_schedule(temporal, str(batch_export.id))
+    assert schedule.schedule.spec.time_zone_name == timezone
+    assert schedule.schedule.spec.jitter == jitter
+    assert schedule.schedule.state.paused == paused
+
+
 @pytest.mark.parametrize(
     "timezone",
     ["US/Pacific", "UTC"],
 )
 @pytest.mark.parametrize("paused", (True, False))
-def test_update_batch_export_schedules(timezone, paused, batch_export, temporal):
+def test_update_batch_export_schedules_for_single_batch_export(team, timezone, paused, temporal):
     """Test the update_batch_export_schedules command updates the schedule for a batch export."""
 
+    batch_export = _create_batch_export(team, "S3", timezone)
+
     # Manually update the schedule so we can check that the command updates it
-    schedule = describe_schedule(temporal, str(batch_export.id))
-    new_schedule = schedule.schedule
-    new_schedule.spec.jitter = dt.timedelta(hours=6)
-    update_schedule(temporal, str(batch_export.id), new_schedule, keep_tz=True)
-    schedule = describe_schedule(temporal, str(batch_export.id))
-    assert schedule.schedule.spec.jitter == dt.timedelta(hours=6)
+    _update_schedule(temporal, batch_export, dt.timedelta(hours=6))
 
     if paused is True:
         pause_batch_export(temporal, str(batch_export.id))
@@ -125,10 +146,81 @@ def test_update_batch_export_schedules(timezone, paused, batch_export, temporal)
         f"--batch-export-id={batch_export.id}",
     )
 
-    # Check that the schedule was updated
-    schedule = describe_schedule(temporal, str(batch_export.id))
-    assert schedule.schedule.spec.time_zone_name == timezone
-    # Check that the jitter was reset
-    assert schedule.schedule.spec.jitter == dt.timedelta(minutes=15)
-    # Ensure the schedule state was preserved
-    assert schedule.schedule.state.paused == paused
+    _assert_schedule(temporal, batch_export, timezone, dt.timedelta(minutes=15), paused)
+
+
+def test_update_batch_export_schedules_for_all_batch_exports_of_a_given_destination_type(team, timezone, temporal):
+    """Test the update_batch_export_schedules command updates the schedule for all batch exports of a given destination type."""
+
+    batch_export_s3_1 = _create_batch_export(team, "S3", timezone)
+    batch_export_s3_2 = _create_batch_export(team, "S3", timezone)
+    batch_export_snowflake = _create_batch_export(team, "Snowflake", timezone)
+
+    # Manually update the schedule so we can check that the command updates it
+    _update_schedule(temporal, batch_export_s3_1, dt.timedelta(hours=6))
+    _update_schedule(temporal, batch_export_s3_2, dt.timedelta(hours=6))
+    _update_schedule(temporal, batch_export_snowflake, dt.timedelta(hours=6))
+
+    call_command(
+        "update_batch_export_schedules",
+        f"--destination-type=S3",
+    )
+
+    # check that the S3 batch exports were updated
+    _assert_schedule(temporal, batch_export_s3_1, timezone, dt.timedelta(minutes=15), False)
+    _assert_schedule(temporal, batch_export_s3_2, timezone, dt.timedelta(minutes=15), False)
+
+    # check that the Snowflake batch export was not updated
+    _assert_schedule(temporal, batch_export_snowflake, timezone, dt.timedelta(hours=6), False)
+
+
+def test_update_batch_export_schedules_for_all_batch_exports_of_a_given_team(team, team_2, timezone, temporal):
+    """Test the update_batch_export_schedules command updates the schedule for all batch exports of a given destination type."""
+
+    batch_export_1 = _create_batch_export(team, "S3", timezone)
+    batch_export_2 = _create_batch_export(team, "S3", timezone)
+    batch_export_team_2 = _create_batch_export(team_2, "S3", timezone)
+
+    # Manually update the schedule so we can check that the command updates it
+    _update_schedule(temporal, batch_export_1, dt.timedelta(hours=6))
+    _update_schedule(temporal, batch_export_2, dt.timedelta(hours=6))
+    _update_schedule(temporal, batch_export_team_2, dt.timedelta(hours=6))
+
+    call_command(
+        "update_batch_export_schedules",
+        f"--team-id={team.id}",
+    )
+
+    # check that the batch exports for the given team were updated
+    _assert_schedule(temporal, batch_export_1, timezone, dt.timedelta(minutes=15), False)
+    _assert_schedule(temporal, batch_export_2, timezone, dt.timedelta(minutes=15), False)
+
+    # check that the batch exports for the other team were not updated
+    _assert_schedule(temporal, batch_export_team_2, timezone, dt.timedelta(hours=6), False)
+
+
+def test_update_batch_export_schedules_raises_error_if_no_batch_export_id_or_destination_type_or_team_id_provided(
+    team, timezone, temporal
+):
+    """Test the update_batch_export_schedules command raises an error if no batch export id, destination type, or team id is provided."""
+
+    with pytest.raises(CommandError):
+        call_command(
+            "update_batch_export_schedules",
+        )
+
+
+def test_update_batch_export_schedules_raises_error_if_no_batch_exports_found(team, timezone, temporal):
+    """Test the update_batch_export_schedules command raises an error if no batch exports are found."""
+
+    batch_export_snowflake = _create_batch_export(team, "Snowflake", timezone)
+    _update_schedule(temporal, batch_export_snowflake, dt.timedelta(hours=6))
+
+    with pytest.raises(CommandError):
+        call_command(
+            "update_batch_export_schedules",
+            f"--destination-type=S3",
+        )
+
+    # check that the Snowflake batch export was not updated
+    _assert_schedule(temporal, batch_export_snowflake, timezone, dt.timedelta(hours=6), False)

--- a/posthog/management/commands/test/test_update_batch_export_schedules.py
+++ b/posthog/management/commands/test/test_update_batch_export_schedules.py
@@ -175,7 +175,7 @@ def test_update_batch_export_schedules_for_all_batch_exports_of_a_given_destinat
 
 
 def test_update_batch_export_schedules_for_all_batch_exports_of_a_given_team(team, team_2, timezone, temporal):
-    """Test the update_batch_export_schedules command updates the schedule for all batch exports of a given destination type."""
+    """Test the update_batch_export_schedules command updates the schedule for all batch exports of a given team."""
 
     batch_export_1 = _create_batch_export(team, "S3", timezone)
     batch_export_2 = _create_batch_export(team, "S3", timezone)

--- a/posthog/management/commands/update_batch_export_schedules.py
+++ b/posthog/management/commands/update_batch_export_schedules.py
@@ -50,7 +50,7 @@ class Command(BaseCommand):
                 query_set = query_set.filter(destination__type=options["destination_type"])
 
             if options["team_id"]:
-                query_set = query_set.filter(team__id=int(options["team_id"]))
+                query_set = query_set.filter(team_id=int(options["team_id"]))
 
             batch_exports = list(query_set)
         else:

--- a/posthog/management/commands/update_batch_export_schedules.py
+++ b/posthog/management/commands/update_batch_export_schedules.py
@@ -1,4 +1,8 @@
+import logging
+import time
+
 import structlog
+from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
 from posthog.batch_exports.service import sync_batch_export
@@ -11,29 +15,61 @@ class Command(BaseCommand):
     help = "Updates the Temporal schedule for a batch export"
 
     def add_arguments(self, parser):
-        # TODO - add a way to update all batch exports
-        parser.add_argument("--batch-export-id", default=None, type=str, help="Batch export ID to update")
+        parser.add_argument("--batch-export-id", default=None, type=str, help="Single batch export ID to update")
+        parser.add_argument("--team-id", default=None, type=str, help="Team ID for which to update all batch exports")
+        parser.add_argument(
+            "--destination-type", default=None, type=str, help="Update all batch exports for a given destination type"
+        )
 
-    def handle(self, **options):
-        batch_export_id = options["batch_export_id"]
-        # verbose = options["verbosity"] > 1
-
-        if not batch_export_id:
-            raise CommandError("Batch export ID is required")
-
-        # TODO - run in a loop once we support multiple batch exports
-        try:
-            batch_export: BatchExport = BatchExport.objects.get(id=batch_export_id, deleted=False)
-        except BatchExport.DoesNotExist:
-            raise CommandError("Batch export not found")
-        except BatchExport.MultipleObjectsReturned:
-            raise CommandError("More than one existing batch export found (this should never happen)!")
-
-        logger.info("Updating batch export schedule...", batch_export_id=batch_export.id)
+    def _update_batch_export_schedule(self, batch_export: BatchExport):
+        logger.info("Updating batch export schedule...", batch_export_id=str(batch_export.id))
 
         try:
             sync_batch_export(batch_export, created=False)
         except Exception:
-            logger.exception("Error updating batch export schedule", batch_export_id=batch_export.id)
+            logger.exception("Error updating batch export schedule", batch_export_id=str(batch_export.id))
 
-        logger.info("Batch export schedule updated")
+    def handle(self, **options):
+        logger.setLevel(logging.INFO)
+        batch_export_id = options["batch_export_id"]
+
+        batch_exports: list[BatchExport] = []
+
+        if batch_export_id:
+            try:
+                batch_export: BatchExport = BatchExport.objects.get(id=batch_export_id, deleted=False)
+                batch_exports.append(batch_export)
+            except BatchExport.DoesNotExist:
+                raise CommandError("Batch export not found")
+            except BatchExport.MultipleObjectsReturned:
+                raise CommandError("More than one existing batch export found (this should never happen)!")
+        elif options["destination_type"] or options["team_id"]:
+            query_set = BatchExport.objects.filter(deleted=False)
+
+            if options["destination_type"]:
+                query_set = query_set.filter(destination__type=options["destination_type"])
+
+            if options["team_id"]:
+                query_set = query_set.filter(team__id=options["team_id"])
+
+            batch_exports = list(query_set)
+        else:
+            # Do we want to allow it to run on all batch exports?
+            raise CommandError("No batch export ID or destination type or team ID provided")
+
+        if len(batch_exports) == 0:
+            raise CommandError("No batch exports found")
+
+        if not settings.TEST:
+            confirm = input(f"\n\tWill update schedules for {len(batch_exports)} batch exports. Proceed? (y/n) ")
+            if confirm.strip().lower() != "y":
+                logger.info("Aborting")
+                return
+
+        for batch_export in batch_exports:
+            self._update_batch_export_schedule(batch_export)
+            if not settings.TEST:
+                # add a small delay to avoid flooding Temporal with requests
+                time.sleep(0.5)
+
+        logger.info("Done!")

--- a/posthog/management/commands/update_batch_export_schedules.py
+++ b/posthog/management/commands/update_batch_export_schedules.py
@@ -16,7 +16,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("--batch-export-id", default=None, type=str, help="Single batch export ID to update")
-        parser.add_argument("--team-id", default=None, type=str, help="Team ID for which to update all batch exports")
+        parser.add_argument("--team-id", default=None, type=int, help="Team ID for which to update all batch exports")
         parser.add_argument(
             "--destination-type", default=None, type=str, help="Update all batch exports for a given destination type"
         )

--- a/posthog/management/commands/update_batch_export_schedules.py
+++ b/posthog/management/commands/update_batch_export_schedules.py
@@ -1,5 +1,4 @@
 import logging
-import time
 
 import structlog
 from django.conf import settings
@@ -50,7 +49,7 @@ class Command(BaseCommand):
                 query_set = query_set.filter(destination__type=options["destination_type"])
 
             if options["team_id"]:
-                query_set = query_set.filter(team_id=int(options["team_id"]))
+                query_set = query_set.filter(team_id=options["team_id"])
 
             batch_exports = list(query_set)
         else:
@@ -68,8 +67,5 @@ class Command(BaseCommand):
 
         for batch_export in batch_exports:
             self._update_batch_export_schedule(batch_export)
-            if not settings.TEST:
-                # add a small delay to avoid flooding Temporal with requests
-                time.sleep(0.5)
 
         logger.info("Done!")

--- a/posthog/management/commands/update_batch_export_schedules.py
+++ b/posthog/management/commands/update_batch_export_schedules.py
@@ -50,7 +50,7 @@ class Command(BaseCommand):
                 query_set = query_set.filter(destination__type=options["destination_type"])
 
             if options["team_id"]:
-                query_set = query_set.filter(team__id=options["team_id"])
+                query_set = query_set.filter(team__id=int(options["team_id"]))
 
             batch_exports = list(query_set)
         else:


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Currently the `update_batch_export_schedules` command only supports updating one batch export

## Changes

Support updating batch exports based on team id or destination type (S3, Snowflake, etc).

I wasn't sure whether to allow updating all batch exports (by not passing in any filters). I decided against it but don't have strong feelings about allowing it.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Tested locally and added more unit tests
