### PR TITLE
fix(project-tree): tree view table mode column alignment

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -393,7 +393,7 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                                                                 {renderItem(
                                                                     item,
                                                                     <span
-                                                                        className={cn('xxxxx', {
+                                                                        className={cn({
                                                                             'font-semibold': isFolder,
                                                                         })}
                                                                     >
@@ -413,9 +413,18 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                                                             </>
                                                         ) : (
                                                             <span
-                                                                className={cn('yyyyyy', {
+                                                                className={cn('truncate', {
                                                                     'font-semibold': isFolder && !isEmptyFolder,
                                                                 })}
+                                                                // eslint-disable-next-line react/forbid-dom-props
+                                                                style={{
+                                                                    paddingRight:
+                                                                        mode === 'table'
+                                                                            ? DEPTH_OFFSET === 0
+                                                                                ? `3px`
+                                                                                : `${emptySpaceOffset - 20}px`
+                                                                            : undefined,
+                                                                }}
                                                             >
                                                                 <Tooltip
                                                                     title={mode === 'table' ? displayName : undefined}
@@ -444,6 +453,14 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                                                                     <span
                                                                         key={header.key}
                                                                         className="truncate text-left"
+                                                                        // eslint-disable-next-line react/forbid-dom-props
+                                                                        style={{
+                                                                            // -20 is to handle the offset of the icon (size-5)
+                                                                            marginLeft:
+                                                                                DEPTH_OFFSET === 0
+                                                                                    ? `3px`
+                                                                                    : `-${emptySpaceOffset - 20}px`,
+                                                                        }}
                                                                     >
                                                                         <Tooltip
                                                                             title={
@@ -1218,11 +1235,22 @@ const LemonTree = forwardRef<LemonTreeRef, LemonTreeProps>(
                         {tableViewKeys?.headers.map((header, index) => (
                             <div
                                 key={header.key}
-                                className={cn('text-secondary font-bold text-xs uppercase flex gap-2', {
-                                    'pl-px': index === 0,
-                                })}
+                                className="text-secondary font-bold text-xs uppercase flex gap-2 transition-[padding] duration-50"
+                                // eslint-disable-next-line react/forbid-dom-props
+                                style={{
+                                    // To match the nodes padding
+                                    paddingLeft: checkedItemCount && checkedItemCount >= 1 ? `26px` : undefined,
+                                }}
                             >
-                                <span>{header.title}</span>
+                                <span
+                                    // eslint-disable-next-line react/forbid-dom-props
+                                    style={{
+                                        // To match the nodes padding
+                                        marginLeft: index === 0 ? `-1px` : undefined,
+                                    }}
+                                >
+                                    {header.title}
+                                </span>
                             </div>
                         ))}
                     </div>


### PR DESCRIPTION
## Problem
Project tree table mode columns were misaligned and not truncating text properly

Before:
<img width="977" alt="image" src="https://github.com/user-attachments/assets/a2b888e8-bc11-4d05-b7a5-9ebbe84bf07d" />

After:
![2025-04-23 10 52 45](https://github.com/user-attachments/assets/c1dd3732-97b2-46ab-b1d5-3fd45c308184)


## Changes
* Add compensating margins to both tree nodes and tree table headers so that the table looks like an actual table

## How did you test this code?
Locally