### PR TITLE
fix(data-warehouse): Use the actual pagination query to get the chunk size

### DIFF
--- a/posthog/temporal/data_imports/pipelines/postgres/postgres.py
+++ b/posthog/temporal/data_imports/pipelines/postgres/postgres.py
@@ -1,10 +1,9 @@
 import dataclasses
 import math
 from collections.abc import Iterator
-from typing import Any, Optional
+from typing import Any, LiteralString, Optional, cast
 
 import psycopg
-import psycopg.rows
 import pyarrow as pa
 from dlt.common.normalizers.naming.snake_case import NamingConvention
 from psycopg import sql
@@ -40,10 +39,15 @@ def _build_query(
     incremental_field: Optional[str],
     incremental_field_type: Optional[IncrementalFieldType],
     db_incremental_field_last_value: Optional[Any],
+    add_limit: Optional[bool] = False,
 ) -> sql.Composed:
     query = sql.SQL("SELECT * FROM {}").format(sql.Identifier(schema, table_name))
 
     if not is_incremental:
+        if add_limit:
+            query_with_limit = cast(LiteralString, f"{query.as_string()} LIMIT 100")
+            return sql.SQL(query_with_limit).format()
+
         return query
 
     if incremental_field is None or incremental_field_type is None:
@@ -60,6 +64,10 @@ def _build_query(
         incremental_field=sql.Identifier(incremental_field),
         last_value=sql.Literal(db_incremental_field_last_value),
     )
+
+    if add_limit:
+        query_with_limit = cast(LiteralString, f"{query.as_string()} LIMIT 100")
+        return sql.SQL(query_with_limit).format()
 
     return query
 
@@ -87,14 +95,13 @@ def _get_primary_keys(cursor: psycopg.Cursor, schema: str, table_name: str) -> l
     return None
 
 
-def _get_table_chunk_size(cursor: psycopg.Cursor, schema: str, table_name: str, logger: FilteringBoundLogger) -> int:
+def _get_table_chunk_size(
+    cursor: psycopg.Cursor, inner_query: sql.Composed, schema: str, table_name: str, logger: FilteringBoundLogger
+) -> int:
     try:
         query = sql.SQL("""
-            SELECT SUM(pg_column_size(t.*)) / COUNT(t.*) FROM (
-                SELECT * FROM {}
-                LIMIT 100
-            ) as t
-        """).format(sql.Identifier(schema, table_name))
+            SELECT SUM(pg_column_size(t.*)) / COUNT(t.*) FROM ({}) as t
+        """).format(inner_query)
 
         cursor.execute(query)
         row = cursor.fetchone()
@@ -276,9 +283,19 @@ def postgres_source(
         sslkey="/tmp/no.txt",
     ) as connection:
         with connection.cursor() as cursor:
+            inner_query = _build_query(
+                schema,
+                table_name,
+                is_incremental,
+                incremental_field,
+                incremental_field_type,
+                db_incremental_field_last_value,
+                add_limit=True,
+            )
+
             primary_keys = _get_primary_keys(cursor, schema, table_name)
             table_structure = _get_table_structure(cursor, schema, table_name)
-            chunk_size = _get_table_chunk_size(cursor, schema, table_name, logger)
+            chunk_size = _get_table_chunk_size(cursor, inner_query, schema, table_name, logger)
             partition_settings = _get_partition_settings(cursor, schema, table_name) if is_incremental else None
 
             # Falback on checking for an `id` field on the table


### PR DESCRIPTION
## Problem
- I have a user who's table width has grown over time and so the latter pages of the table causes our pods to OOM due to us still chunking 20,000 rows at a time
- This is because our dynamic chunking takes _any_ 100 rows to get the column size, and thus isn't representative of the actual query we're about to page from
- For example, this users table was giving us a table width of 3637 bytes, and so we were chunking 20,000 rows at a time. When checking the table width of the incremental rows we're trying to actually pull, the table width came out as 60,067 bytes, which should give us pages of 2618 rows instead

## Changes
- Use the actual pagination query (with a limit) to get the dynamic chunk size for postgres sources

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Tested locally
