### PR TITLE
chore(sql-editor): Styling and component updates to the SQL editor

### DIFF
--- a/frontend/src/lib/components/ExportButton/ExportButton.tsx
+++ b/frontend/src/lib/components/ExportButton/ExportButton.tsx
@@ -16,12 +16,14 @@ export interface ExportButtonItem {
     insight?: number
 }
 
-export interface ExportButtonProps extends Pick<LemonButtonProps, 'disabledReason' | 'icon' | 'type' | 'fullWidth'> {
+export interface ExportButtonProps
+    extends Pick<LemonButtonProps, 'disabledReason' | 'icon' | 'sideIcon' | 'type' | 'fullWidth'> {
     items: ExportButtonItem[]
+    buttonCopy?: string
 }
 
 export const ExportButton: React.FunctionComponent<ExportButtonProps & React.RefAttributes<HTMLButtonElement>> =
-    forwardRef(function ExportButton({ items, ...buttonProps }, ref): JSX.Element {
+    forwardRef(function ExportButton({ items, buttonCopy, ...buttonProps }, ref): JSX.Element {
         useMountedLogic(exportsLogic)
 
         const { actions } = exportsLogic
@@ -81,7 +83,7 @@ export const ExportButton: React.FunctionComponent<ExportButtonProps & React.Ref
                     ),
                 }}
             >
-                Export
+                {buttonCopy ?? 'Export'}
             </LemonButtonWithDropdown>
         )
     })

--- a/frontend/src/queries/nodes/DataVisualization/Components/SideBar.scss
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SideBar.scss
@@ -1,6 +1,6 @@
 .DataVisualization {
     .LemonTabs .LemonTabs__bar {
-        margin-bottom: 0;
+        margin-bottom: 1px;
     }
 
     .SideBar {

--- a/frontend/src/queries/nodes/DataVisualization/Components/SideBar.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SideBar.tsx
@@ -36,7 +36,7 @@ const TABS_TO_CONTENT: Record<SideBarTab, TabContent> = {
 }
 
 const ContentWrapper = ({ children }: { children: JSX.Element }): JSX.Element => {
-    return <div className="SideBar bg-surface-primary border p-4 rounded-t-none border-t-0">{children}</div>
+    return <div className="SideBar bg-surface-primary border p-4 rounded-t-none">{children}</div>
 }
 
 export const SideBar = (): JSX.Element => {

--- a/frontend/src/scenes/data-warehouse/editor/EditorScene.scss
+++ b/frontend/src/scenes/data-warehouse/editor/EditorScene.scss
@@ -1,8 +1,6 @@
 .EditorScene {
     .LemonTabs__bar {
-        --lemon-tabs-slider-width: 0px;
-
-        margin-bottom: 0;
+        margin-bottom: 1px;
     }
 
     .OutputPane {

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -569,7 +569,7 @@ const Content = ({
 }: any): JSX.Element | null => {
     if (responseLoading) {
         return (
-            <div className="flex flex-1 p-2 w-full justify-center items-center">
+            <div className="flex flex-1 p-2 w-full justify-center items-center border-t">
                 <StatelessInsightLoadingState
                     queryId={queryId}
                     pollResponse={pollResponse}
@@ -597,7 +597,7 @@ const Content = ({
                 ? 'Query results will appear here.'
                 : 'Query results will be visualized here.'
         return (
-            <div className="flex flex-1 justify-center items-center">
+            <div className="flex flex-1 justify-center items-center border-t">
                 <span className="text-secondary mt-3">
                     {msg} Press <KeyboardShortcut command enter /> to run the query.
                 </span>

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -1,8 +1,17 @@
 import 'react-data-grid/lib/styles.css'
 import './DataGrid.scss'
 
-import { IconCode, IconCopy, IconExpand45, IconGear, IconMinus, IconPlus } from '@posthog/icons'
-import { LemonButton, LemonModal, LemonTable, LemonTabs } from '@posthog/lemon-ui'
+import {
+    IconCode,
+    IconCopy,
+    IconDownload,
+    IconExpand45,
+    IconGear,
+    IconGraph,
+    IconMinus,
+    IconPlus,
+} from '@posthog/icons'
+import { LemonButton, LemonModal, LemonTable } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { ExportButton } from 'lib/components/ExportButton/ExportButton'
@@ -301,12 +310,10 @@ export function OutputPane(): JSX.Element {
     const hasColumns = columns.length > 1
 
     return (
-        <div className="OutputPane flex flex-col w-full flex-1 bg-primary">
-            <div className="flex flex-row justify-between align-center py-2 px-4 w-full h-[50px] border-b">
-                <LemonTabs
-                    activeKey={activeTab}
-                    onChange={(tab) => setActiveTab(tab as OutputTab)}
-                    tabs={[
+        <div className="OutputPane flex flex-col w-full flex-1 bg-white">
+            <div className="flex flex-row justify-between align-center w-full h-[50px]">
+                <div className="flex h-[50px] gap-2 ml-4">
+                    {[
                         {
                             key: OutputTab.Results,
                             label: 'Results',
@@ -315,9 +322,23 @@ export function OutputPane(): JSX.Element {
                             key: OutputTab.Visualization,
                             label: 'Visualization',
                         },
-                    ]}
-                />
-                <div className="flex gap-2">
+                    ].map((tab) => (
+                        <div
+                            key={tab.key}
+                            className={clsx(
+                                'flex-1 bold content-center px-2 pt-[3px] cursor-pointer border-b-[medium]',
+                                {
+                                    'font-semibold !border-brand-yellow': tab.key === activeTab,
+                                    'border-transparent': tab.key !== activeTab,
+                                }
+                            )}
+                            onClick={() => setActiveTab(tab.key)}
+                        >
+                            {tab.label}
+                        </div>
+                    ))}
+                </div>
+                <div className="flex gap-2 py-2 px-4">
                     {showLegacyFilters && (
                         <DateRange
                             key="date-range"
@@ -329,22 +350,6 @@ export function OutputPane(): JSX.Element {
                                 })
                                 runQuery(query.query)
                             }}
-                        />
-                    )}
-                    {activeTab === OutputTab.Results && exportContext && (
-                        <ExportButton
-                            disabledReason={!hasColumns ? 'No results to export' : undefined}
-                            type="secondary"
-                            items={[
-                                {
-                                    export_format: ExporterFormat.CSV,
-                                    export_context: exportContext,
-                                },
-                                {
-                                    export_format: ExporterFormat.XLSX,
-                                    export_context: exportContext,
-                                },
-                            ]}
                         />
                     )}
                     {activeTab === OutputTab.Visualization && (
@@ -369,6 +374,7 @@ export function OutputPane(): JSX.Element {
                                                 disabledReason={!updateInsightButtonEnabled && 'No updates to save'}
                                                 type="primary"
                                                 onClick={() => updateInsight()}
+                                                id="sql-editor-update-insight"
                                                 sideAction={{
                                                     dropdown: {
                                                         placement: 'bottom-end',
@@ -393,8 +399,9 @@ export function OutputPane(): JSX.Element {
                                                 disabledReason={!hasColumns ? 'No results to save' : undefined}
                                                 type="primary"
                                                 onClick={() => saveAsInsight()}
+                                                id="sql-editor-save-insight"
                                             >
-                                                Create insight
+                                                Save insight
                                             </LemonButton>
                                         )}
                                     </div>
@@ -407,9 +414,30 @@ export function OutputPane(): JSX.Element {
                             disabledReason={!hasColumns ? 'No results to visualize' : undefined}
                             type="secondary"
                             onClick={() => setActiveTab(OutputTab.Visualization)}
+                            id="sql-editor-create-insight"
+                            icon={<IconGraph />}
                         >
-                            Visualize
+                            Create insight
                         </LemonButton>
+                    )}
+                    {activeTab === OutputTab.Results && exportContext && (
+                        <ExportButton
+                            disabledReason={!hasColumns ? 'No results to export' : undefined}
+                            type="secondary"
+                            icon={<IconDownload />}
+                            sideIcon={null}
+                            buttonCopy=""
+                            items={[
+                                {
+                                    export_format: ExporterFormat.CSV,
+                                    export_context: exportContext,
+                                },
+                                {
+                                    export_format: ExporterFormat.XLSX,
+                                    export_context: exportContext,
+                                },
+                            ]}
+                        />
                     )}
                 </div>
             </div>
@@ -591,7 +619,7 @@ const Content = ({
 
     if (activeTab === OutputTab.Visualization) {
         return (
-            <div className="flex-1 absolute top-0 left-0 right-0 bottom-0 px-4 py-1 hide-scrollbar">
+            <div className="flex-1 absolute top-0 left-0 right-0 bottom-0 px-4 py-1 hide-scrollbar border-t">
                 <InternalDataTableVisualization
                     uniqueKey={vizKey}
                     query={sourceQuery}

--- a/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
@@ -49,6 +49,35 @@ export function QueryWindow({ onSetMonacoAndEditor }: QueryWindowProps): JSX.Ele
 
     const isMaterializedView = !!editingView?.status
 
+    const AddSQLVariablesButton = useMemo(
+        () => (
+            <LemonButton
+                onClick={() => setActiveTab(EditorSidebarTab.QueryVariables)}
+                icon={<IconBrackets />}
+                type="tertiary"
+                size="xsmall"
+                id="sql-editor-query-window-add-variables"
+            >
+                Add SQL variables
+            </LemonButton>
+        ),
+        []
+    )
+    const MaterializeButton = useMemo(
+        () => (
+            <LemonButton
+                onClick={() => setActiveTab(EditorSidebarTab.QueryInfo)}
+                icon={<IconBolt />}
+                type="tertiary"
+                size="xsmall"
+                id="sql-editor-query-window-materialize"
+            >
+                Materialize
+            </LemonButton>
+        ),
+        []
+    )
+
     return (
         <div className="flex flex-1 flex-col h-full overflow-hidden">
             <div className="flex flex-row overflow-x-auto">
@@ -85,28 +114,33 @@ export function QueryWindow({ onSetMonacoAndEditor }: QueryWindowProps): JSX.Ele
             <div className="flex flex-row justify-start align-center w-full pl-2 pr-2 bg-white border-b">
                 <RunButton />
                 <LemonDivider vertical />
-                {editingView ? (
-                    <LemonButton
-                        onClick={() =>
-                            updateDataWarehouseSavedQuery({
-                                id: editingView.id,
-                                query: {
-                                    ...sourceQuery.source,
-                                    query: queryInput,
-                                },
-                                types: response?.types ?? [],
-                                shouldRematerialize: isMaterializedView,
-                            })
-                        }
-                        disabledReason={updatingDataWarehouseSavedQuery ? 'Saving...' : ''}
-                        icon={<IconDownload />}
-                        type="tertiary"
-                        size="xsmall"
-                        id={`sql-editor-query-window-update-${isMaterializedView ? 'materialize' : 'view'}`}
-                    >
-                        {isMaterializedView ? 'Update and re-materialize view' : 'Update view'}
-                    </LemonButton>
-                ) : (
+                {editingView && (
+                    <>
+                        <LemonButton
+                            onClick={() =>
+                                updateDataWarehouseSavedQuery({
+                                    id: editingView.id,
+                                    query: {
+                                        ...sourceQuery.source,
+                                        query: queryInput,
+                                    },
+                                    types: response?.types ?? [],
+                                    shouldRematerialize: isMaterializedView,
+                                })
+                            }
+                            disabledReason={updatingDataWarehouseSavedQuery ? 'Saving...' : ''}
+                            icon={<IconDownload />}
+                            type="tertiary"
+                            size="xsmall"
+                            id={`sql-editor-query-window-update-${isMaterializedView ? 'materialize' : 'view'}`}
+                        >
+                            {isMaterializedView ? 'Update and re-materialize view' : 'Update view'}
+                        </LemonButton>
+                        {!isMaterializedView && MaterializeButton}
+                    </>
+                )}
+                {editingInsight && AddSQLVariablesButton}
+                {!editingInsight && !editingView && (
                     <>
                         <LemonButton
                             onClick={() => saveAsView()}
@@ -117,24 +151,8 @@ export function QueryWindow({ onSetMonacoAndEditor }: QueryWindowProps): JSX.Ele
                         >
                             Save as view
                         </LemonButton>
-                        <LemonButton
-                            onClick={() => setActiveTab(EditorSidebarTab.QueryInfo)}
-                            icon={<IconBolt />}
-                            type="tertiary"
-                            size="xsmall"
-                            id="sql-editor-query-window-materialize"
-                        >
-                            Materialize
-                        </LemonButton>
-                        <LemonButton
-                            onClick={() => setActiveTab(EditorSidebarTab.QueryVariables)}
-                            icon={<IconBrackets />}
-                            type="tertiary"
-                            size="xsmall"
-                            id="sql-editor-query-window-add-variables"
-                        >
-                            Add SQL variables
-                        </LemonButton>
+                        {MaterializeButton}
+                        {AddSQLVariablesButton}
                     </>
                 )}
             </div>

--- a/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
@@ -1,5 +1,5 @@
 import { Monaco } from '@monaco-editor/react'
-import { IconBolt, IconDownload, IconPlayFilled, IconSidebarClose } from '@posthog/icons'
+import { IconBolt, IconBrackets, IconDownload, IconPlayFilled, IconSidebarClose } from '@posthog/icons'
 import { LemonDivider } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
@@ -82,7 +82,7 @@ export function QueryWindow({ onSetMonacoAndEditor }: QueryWindowProps): JSX.Ele
                     </span>
                 </div>
             )}
-            <div className="flex flex-row justify-start align-center w-full ml-2 mr-2">
+            <div className="flex flex-row justify-start align-center w-full pl-2 pr-2 bg-white border-b">
                 <RunButton />
                 <LemonDivider vertical />
                 {editingView ? (
@@ -125,6 +125,15 @@ export function QueryWindow({ onSetMonacoAndEditor }: QueryWindowProps): JSX.Ele
                             id="sql-editor-query-window-materialize"
                         >
                             Materialize
+                        </LemonButton>
+                        <LemonButton
+                            onClick={() => setActiveTab(EditorSidebarTab.QueryVariables)}
+                            icon={<IconBrackets />}
+                            type="tertiary"
+                            size="xsmall"
+                            id="sql-editor-query-window-add-variables"
+                        >
+                            Add SQL variables
                         </LemonButton>
                     </>
                 )}


### PR DESCRIPTION
## Changes
- Updated the styles of the SQL editor and reconfigured some of the buttons
  - Changed the output panel tabs to be a custom component to allow for a yellow bottom border to match the query tabs
  - Changed the tabs and the "action bar" to have a white background, matching the editor
  - Changed the "Visualise" button to be "Create insight" with an icon
  - Changed the export button to be just an icon
  - Updated the action bar buttons to be visible depending on whether you're looking at an insight or view or other (e.g. materialize wont be shown when editing an insight)
  - Added an "Add SQL variables" button to the action bar
  - Reintroduced a top border + tab styles to the visualization chart settings


https://github.com/user-attachments/assets/dd7d39db-5315-4d53-8a98-f41e3fd54ae9


## Does this work well for both Cloud and self-hosted?
Yup

## How did you test this code?
Yup - locally see vid