### PR TITLE
fix: limit server-timings header to 10k characters

### DIFF
--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -529,7 +529,7 @@ class ServerTimingsGathered:
 
     def to_header_string(self, hogql_timings: list[QueryTiming] | None = None) -> str:
         timings = self.generate_timings(hogql_timings).items()
-        result = []
+        result: list[str] = []
         current_length = 0
 
         for key, duration in timings:

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -529,4 +529,4 @@ class ServerTimingsGathered:
     def to_header_string(self, hogql_timings: list[QueryTiming] | None = None):
         return ", ".join(
             f"{key};dur={round(duration, ndigits=2)}" for key, duration in self.generate_timings(hogql_timings).items()
-        )
+        )[:10000]  # limit to 10k characters (alb limit is 16k per header line, or 32k for all repsonse headers)

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -37,6 +37,7 @@ from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.schema import QueryTiming
 from posthog.utils import load_data_from_request
 from posthog.utils_cors import cors_response
+from posthoganalytics import capture_exception
 
 logger = structlog.get_logger(__name__)
 
@@ -526,7 +527,24 @@ class ServerTimingsGathered:
         all_timings = {**timings_dict, **hogql_timings_dict}
         return all_timings
 
-    def to_header_string(self, hogql_timings: list[QueryTiming] | None = None):
-        return ", ".join(
-            f"{key};dur={round(duration, ndigits=2)}" for key, duration in self.generate_timings(hogql_timings).items()
-        )[:10000]  # limit to 10k characters (alb limit is 16k per header line, or 32k for all repsonse headers)
+    def to_header_string(self, hogql_timings: list[QueryTiming] | None = None) -> str:
+        timings = self.generate_timings(hogql_timings).items()
+        result = []
+        current_length = 0
+
+        for key, duration in timings:
+            timing_str = f"{key};dur={round(duration, ndigits=2)}"
+            # +2 for ", " separator, except for first item
+            new_length = current_length + len(timing_str) + (2 if result else 0)
+
+            if new_length > 10000:
+                capture_exception(
+                    Exception(f"Server timing header exceeded 10k limit with {len(timings)} timings"),
+                    properties={"timings": timings},
+                )
+                break
+
+            result.append(timing_str)
+            current_length = new_length
+
+        return ", ".join(result)


### PR DESCRIPTION

> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

in some cases this header could blow up the maximum header/response size for ALBs

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
