### PR TITLE
revert: "chore: log with headers to confirm replay listing success"

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -406,17 +406,11 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, U
             query = filter_from_params_to_query(request.GET.dict())
 
             self._maybe_report_recording_list_filters_changed(request, team=self.team)
-            response = list_recordings_response(
+            return list_recordings_response(
                 list_recordings_from_query(query, cast(User, request.user), team=self.team),
                 context=self.get_serializer_context(),
             )
 
-            logger.info(
-                "list_recordings_response_successful",
-                user_distinct_id=user_distinct_id,
-                headers=response.headers,
-            )
-            return response
         except CHQueryErrorTooManySimultaneousQueries:
             raise Throttled(detail="Too many simultaneous queries. Try again later.")
         except (ServerException, Exception) as e:


### PR DESCRIPTION
Reverts PostHog/posthog#31501

was superseded by the fix here https://github.com/PostHog/posthog/pull/31503