### PR TITLE
feat: add support for multiple ClickHouse users

### DIFF
--- a/bin/start-backend
+++ b/bin/start-backend
@@ -4,4 +4,7 @@ set -e
 export OBJECT_STORAGE_ENDPOINT=http://localhost:19000
 export SESSION_RECORDING_V2_S3_ENDPOINT=http://localhost:19000
 
+export CLICKHOUSE_API_USER="api"
+export CLICKHOUSE_API_PASSWORD="apipass"
+
 uvicorn --reload posthog.asgi:application --host 0.0.0.0 --log-level debug --reload-include "posthog/" --reload-include "ee/" --reload-include "products/"

--- a/bin/start-celery
+++ b/bin/start-celery
@@ -3,6 +3,9 @@
 
 set -e
 
+export CLICKHOUSE_API_USER="api"
+export CLICKHOUSE_API_PASSWORD="apipass"
+
 source ./bin/celery-queues.env
 
 # start celery worker with heartbeat (-B)

--- a/docker/clickhouse/users-dev.xml
+++ b/docker/clickhouse/users-dev.xml
@@ -31,6 +31,10 @@
             <readonly>1</readonly>
         </readonly>
 
+        <api>
+            <profile>api</profile>
+        </api>
+
     </profiles>
 
     <!-- Users and ACL. -->
@@ -117,6 +121,18 @@
             <!-- User can create other users and grant rights to them. -->
             <!-- <access_management>1</access_management> -->
         </default>
+
+        <api>
+            <password>apipass</password>
+
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+
+            <profile>api</profile>
+
+            <quota>default</quota>
+        </api>
     </users>
 
     <!-- Quotas. -->

--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -69,7 +69,7 @@ def init_clickhouse_users() -> Mapping[ClickHouseUser, tuple[str, str]]:
     return user_dict
 
 
-def get_clickhouse_user(user: ClickHouseUser) -> tuple[str, str]:
+def get_clickhouse_creds(user: ClickHouseUser) -> tuple[str, str]:
     global __user_dict
     if not __user_dict:
         __user_dict = init_clickhouse_users()
@@ -184,7 +184,7 @@ def get_pool(
 
     Note that the same pool should be returned every call.
     """
-    (user, password) = __user_dict[ch_user] if ch_user in __user_dict else __user_dict[ClickHouseUser.DEFAULT]
+    (user, password) = get_clickhouse_creds(ch_user)
 
     if team_id is not None and str(team_id) in settings.CLICKHOUSE_PER_TEAM_SETTINGS:
         user_settings = settings.CLICKHOUSE_PER_TEAM_SETTINGS[str(team_id)]

--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -63,9 +63,9 @@ def init_clickhouse_users() -> Mapping[ClickHouseUser, tuple[str, str]]:
         if user and password:
             user_dict[u] = (user, password)
         elif bool(user) != bool(password):
-            logging.warn(f"only one of clickhouse user/password provided, check your config")
+            logging.warning(f"only one of clickhouse user/password provided, check your config")
     user_names = ",".join([x.name for x in user_dict.keys()])
-    logging.warn(f"initialized clickhouse users: {user_names}")
+    logging.warning(f"initialized clickhouse users: {user_names}")
     return user_dict
 
 

--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -1,3 +1,5 @@
+import logging
+import os
 from contextlib import contextmanager
 from enum import Enum
 from functools import cache
@@ -9,6 +11,7 @@ from clickhouse_driver import Client as SyncClient
 from clickhouse_pool import ChPool
 from django.conf import settings
 
+from posthog.settings import data_stores
 from posthog.utils import patchable
 
 
@@ -28,6 +31,49 @@ class NodeRole(Enum):
 
 
 _default_workload = Workload.ONLINE
+
+
+class ClickHouseUser(Enum):
+    # Default, not annotated queries goes here.
+    DEFAULT = "default"
+    # All /api/ requests called programmatically
+    API = "api"
+    # All /api/ requests coming from our app
+    APP = "app"
+    BATCH_EXPORT = "batch_export"
+    COHORTS = "cohorts"
+    CACHE_WARMUP = "cache_warmup"
+
+    # Dev Operations - do not normally use
+    OPS = "ops"
+    # Only for migrations - do not normally use
+    MIGRATIONS = "migrations"
+
+
+__user_dict: Mapping[ClickHouseUser, tuple[str, str]] | None = None
+
+
+def init_clickhouse_users() -> Mapping[ClickHouseUser, tuple[str, str]]:
+    user_dict = {
+        ClickHouseUser.DEFAULT: (data_stores.CLICKHOUSE_USER, data_stores.CLICKHOUSE_PASSWORD),
+    }
+    for u in ClickHouseUser:
+        user = os.getenv(f"CLICKHOUSE_{u.name.upper()}_USER")
+        password = os.getenv(f"CLICKHOUSE_{u.name.upper()}_PASSWORD")
+        if user and password:
+            user_dict[u] = (user, password)
+        elif bool(user) != bool(password):
+            logging.warn(f"only one of clickhouse user/password provided, check your config")
+    user_names = ",".join([x.name for x in user_dict.keys()])
+    logging.warn(f"initialized clickhouse users: {user_names}")
+    return user_dict
+
+
+def get_clickhouse_user(user: ClickHouseUser) -> tuple[str, str]:
+    global __user_dict
+    if not __user_dict:
+        __user_dict = init_clickhouse_users()
+    return __user_dict[user] if user in __user_dict else __user_dict[ClickHouseUser.DEFAULT]
 
 
 class ProxyClient:
@@ -86,7 +132,8 @@ def get_http_client(**overrides):
         "settings": {"mutations_sync": "1"} if settings.TEST else {},
         # Without this, OPTIMIZE table and other queries will regularly run into timeouts
         "send_receive_timeout": 30 if settings.TEST else 999_999_999,
-        "autogenerate_session_id": True,  # beware, this makes each query to run in a separate session - no temporary tables will work
+        "autogenerate_session_id": True,
+        # beware, this makes each query to run in a separate session - no temporary tables will work
         "pool_mgr": _clickhouse_http_pool_mgr,
         **overrides,
     }
@@ -94,7 +141,12 @@ def get_http_client(**overrides):
 
 
 @patchable
-def get_client_from_pool(workload: Workload = Workload.DEFAULT, team_id=None, readonly=False):
+def get_client_from_pool(
+    workload: Workload = Workload.DEFAULT,
+    team_id=None,
+    readonly=False,
+    ch_user: ClickHouseUser = ClickHouseUser.DEFAULT,
+):
     """
     Returns the client for a given workload.
 
@@ -118,17 +170,27 @@ def get_client_from_pool(workload: Workload = Workload.DEFAULT, team_id=None, re
 
         return get_http_client()
 
-    return get_pool(workload=workload, team_id=team_id, readonly=readonly).get_client()
+    return get_pool(workload=workload, team_id=team_id, readonly=readonly, ch_user=ch_user).get_client()
 
 
-def get_pool(workload: Workload = Workload.DEFAULT, team_id=None, readonly=False):
+def get_pool(
+    workload: Workload = Workload.DEFAULT,
+    team_id=None,
+    readonly=False,
+    ch_user: ClickHouseUser = ClickHouseUser.DEFAULT,
+):
     """
     Returns the right connection pool given a workload.
 
     Note that the same pool should be returned every call.
     """
+    (user, password) = __user_dict[ch_user] if ch_user in __user_dict else __user_dict[ClickHouseUser.DEFAULT]
+
     if team_id is not None and str(team_id) in settings.CLICKHOUSE_PER_TEAM_SETTINGS:
-        return make_ch_pool(**settings.CLICKHOUSE_PER_TEAM_SETTINGS[str(team_id)])
+        user_settings = settings.CLICKHOUSE_PER_TEAM_SETTINGS[str(team_id)]
+        if "user" not in user_settings:
+            user_settings = {**user_settings, "user": user, "password": password}
+        return make_ch_pool(**user_settings)
 
     # Note that `readonly` does nothing if the relevant vars are not set!
     if readonly and settings.READONLY_CLICKHOUSE_USER is not None and settings.READONLY_CLICKHOUSE_PASSWORD:
@@ -140,9 +202,9 @@ def get_pool(workload: Workload = Workload.DEFAULT, team_id=None, readonly=False
     if (
         workload == Workload.OFFLINE or workload == Workload.DEFAULT and _default_workload == Workload.OFFLINE
     ) and settings.CLICKHOUSE_OFFLINE_CLUSTER_HOST is not None:
-        return make_ch_pool(host=settings.CLICKHOUSE_OFFLINE_CLUSTER_HOST, verify=False)
+        return make_ch_pool(host=settings.CLICKHOUSE_OFFLINE_CLUSTER_HOST, verify=False, user=user, password=password)
 
-    return make_ch_pool()
+    return make_ch_pool(user=user, password=password)
 
 
 def default_client(host=settings.CLICKHOUSE_HOST):

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -5,7 +5,7 @@ import math
 from clickhouse_driver.errors import ServerException
 
 from posthog.clickhouse.client.async_task_chain import task_chain_context, execute_task_chain
-from posthog.clickhouse.client.connection import Workload
+from posthog.clickhouse.client.connection import Workload, ClickHouseUser
 import uuid
 
 from django.test import TestCase, SimpleTestCase
@@ -440,10 +440,10 @@ class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):
         result = sync_execute(query)
 
         # Verify first call was with OFFLINE workload
-        mock_get_client.assert_any_call(Workload.OFFLINE, None, False)
+        mock_get_client.assert_any_call(Workload.OFFLINE, None, False, ClickHouseUser.API)
 
         # Verify second call was with ONLINE workload
-        mock_get_client.assert_any_call(Workload.ONLINE, None, False)
+        mock_get_client.assert_any_call(Workload.ONLINE, None, False, ClickHouseUser.API)
 
         # Verify final result
         self.assertEqual(result, "success")


### PR DESCRIPTION
## Problem

We want to have separate query pools for different workflows (App, API, cache warmup, cohorts, etc.)
Allow different workloads to specify ClickHouse user.

## Changes

Add enum with type of users. 
Add code initializing users with passwords from env variables.
Add overriding default for APP and API.

<img width="1497" alt="Screenshot 2025-04-25 at 00 34 28" src="https://github.com/user-attachments/assets/85df2798-cf1c-405f-98f8-444527b2b149" />

## Does this work well for both Cloud and self-hosted?

Yes. The change fall backs to a default user if no other user is configured

## How did you test this code?

Tests. Run.