### PR TITLE
fix(insights): replace regex with plain python

### DIFF
--- a/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
@@ -106,11 +106,12 @@ def hidden_legend_keys_to_breakdowns(hidden_legend_keys: dict | None) -> list[st
 def transform_legacy_hidden_legend_keys(hidden_legend_keys):
     transformed_keys = {}
     for key, value in hidden_legend_keys.items():
-        old_format_match = re.match(r"\w+\/.+\/\d+\/(.+)", str(key))
-        if old_format_match:
+        parts = str(key).split("/", 3)
+        if len(parts) == 4 and parts[2].isdigit():  # old format match
+            series_key = parts[3]
             # Don't override values for series if already set from a previously-seen old-format key
-            if old_format_match[1] not in transformed_keys:
-                transformed_keys[old_format_match[1]] = value
+            if series_key not in transformed_keys:
+                transformed_keys[series_key] = value
         else:
             transformed_keys[key] = value
     return transformed_keys


### PR DESCRIPTION
## Problem

See https://posthog.slack.com/archives/C0368RPHLQH/p1745414643546189

## Changes

Replaces the regex with plain python to avoid static analysis warnings like this.

## How did you test this code?

The `posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py` tests still succeed