### PR TITLE
fix(sql-editor): Change copy based on whether we're editing an insight or creating one

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -414,10 +414,10 @@ export function OutputPane(): JSX.Element {
                             disabledReason={!hasColumns ? 'No results to visualize' : undefined}
                             type="secondary"
                             onClick={() => setActiveTab(OutputTab.Visualization)}
-                            id="sql-editor-create-insight"
+                            id={`sql-editor-${editingInsight ? 'view' : 'create'}-insight`}
                             icon={<IconGraph />}
                         >
-                            Create insight
+                            {editingInsight ? 'View insight' : 'Create insight'}
                         </LemonButton>
                     )}
                     {activeTab === OutputTab.Results && exportContext && (

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -411,7 +411,7 @@ export function OutputPane(): JSX.Element {
                     )}
                     {activeTab === OutputTab.Results && (
                         <LemonButton
-                            disabledReason={!hasColumns ? 'No results to visualize' : undefined}
+                            disabledReason={!hasColumns && !editingInsight ? 'No results to visualize' : undefined}
                             type="secondary"
                             onClick={() => setActiveTab(OutputTab.Visualization)}
                             id={`sql-editor-${editingInsight ? 'view' : 'create'}-insight`}


### PR DESCRIPTION
## Changes
- When editing an insight, we want to change the copy of the "Create insight" button to something that makes more sense