### PR TITLE
chore: skip onboarding step for wizard

### DIFF
--- a/frontend/src/scenes/products/productsLogic.ts
+++ b/frontend/src/scenes/products/productsLogic.ts
@@ -40,9 +40,20 @@ export const productsLogic = kea<productsLogicType>([
                 return
             }
 
+            const isFromWizard = router.values.searchParams['source'] === 'wizard'
+
+            const requiresFurtherSetup = [ProductKey.ERROR_TRACKING, ProductKey.FEATURE_FLAGS, ProductKey.EXPERIMENTS]
+
+            const secondStepKey =
+                values.firstProductOnboarding === ProductKey.WEB_ANALYTICS
+                    ? OnboardingStepKey.AUTHORIZED_DOMAINS
+                    : OnboardingStepKey.PRODUCT_CONFIGURATION
+
             const stepKey =
                 values.firstProductOnboarding === ProductKey.DATA_WAREHOUSE
                     ? OnboardingStepKey.LINK_DATA
+                    : isFromWizard && !requiresFurtherSetup.includes(values.firstProductOnboarding)
+                    ? secondStepKey
                     : OnboardingStepKey.INSTALL
 
             router.actions.push(urls.onboarding(values.firstProductOnboarding, stepKey))


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Users that setup with the wizard directly (and didn't already have an account) can skip the install step for products that don't require further setup.

## Changes

Support a `source=wizard` param that allows the user to skip the installation step for integrations that don't require further setup.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Ran locally
