### PR TITLE
fix: one code to rule them all

### DIFF
--- a/ee/session_recordings/session_summary/summarize_session.py
+++ b/ee/session_recordings/session_summary/summarize_session.py
@@ -133,4 +133,4 @@ class ReplaySummarizer:
         # TODO Make the output streamable (the main reason behind using YAML
         # to keep it partially parsable to avoid waiting for the LLM to finish)
 
-        return {"content": session_summary.data, "timings": timer.get_all_timings()}
+        return {"content": session_summary.data, "timings_header": timer.to_header_string()}

--- a/ee/session_recordings/session_summary/tests/test_summarize_session.py
+++ b/ee/session_recordings/session_summary/tests/test_summarize_session.py
@@ -118,7 +118,7 @@ class TestReplaySummarizer:
             mock_enrich_summary.assert_called_once()
             # Verify result structure
             assert "content" in result
-            assert "timings" in result
+            assert "timings_header" in result
             assert result["content"] == {"summary": "test", "key_events": []}
 
     def test_summarize_recording_no_metadata(self, summarizer: ReplaySummarizer):

--- a/ee/surveys/summaries/summarize_surveys.py
+++ b/ee/surveys/summaries/summarize_surveys.py
@@ -134,4 +134,4 @@ we're trying to identify what to work on
     logger.info("survey_summary_response", result=result)
 
     content: str = result.choices[0].message.content or ""
-    return {"content": content, "timings": timer.get_all_timings()}
+    return {"content": content, "timings_header": timer.to_header_string()}

--- a/posthog/api/activity_log.py
+++ b/posthog/api/activity_log.py
@@ -292,8 +292,6 @@ class ActivityLogViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, mixins
         with timer("serialize"):
             serialized_data = ActivityLogSerializer(instance=page_of_data, many=True, context={"user": user}).data
 
-        timings = timer.get_all_timings()
-
         response = Response(
             status=status.HTTP_200_OK,
             data={
@@ -302,9 +300,7 @@ class ActivityLogViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, mixins
             },
         )
 
-        response.headers["Server-Timing"] = ", ".join(
-            f"{key};dur={round(duration, ndigits=2)}" for key, duration in timings.items()
-        )
+        response.headers["Server-Timing"] = timer.to_header_string()
 
         return response
 

--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -1161,7 +1161,7 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             team=self.team,
             user=user,
         )
-        timings = summary.pop("timings", None)
+        timings_header = summary.pop("timings_header", None)
         cache.set(cache_key, summary, timeout=30)
 
         posthoganalytics.capture(
@@ -1170,10 +1170,8 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         # let the browser cache for half the time we cache on the server
         r = Response(summary, headers={"Cache-Control": "max-age=15"})
-        if timings:
-            r.headers["Server-Timing"] = ", ".join(
-                f"{key};dur={round(duration, ndigits=2)}" for key, duration in timings.items()
-            )
+        if timings_header:
+            r.headers["Server-Timing"] = timings_header
         return r
 
 

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -399,10 +399,6 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, U
         return recording
 
     def list(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
-        logger.error(
-            "list_recordings_response_started",
-        )
-
         user_distinct_id = cast(User, request.user).distinct_id
 
         try:
@@ -414,11 +410,6 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, U
                 context=self.get_serializer_context(),
             )
 
-            logger.error(
-                "list_recordings_response_successful",
-                user_distinct_id=user_distinct_id,
-                headers=response.headers,
-            )
             return response
         except CHQueryErrorTooManySimultaneousQueries:
             raise Throttled(detail="Too many simultaneous queries. Try again later.")

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -826,17 +826,15 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, U
 
         replay_summarizer = ReplaySummarizer(recording, user, self.team)
         summary = replay_summarizer.summarize_recording()
-        timings = summary.pop("timings", None)
+        timings_header = summary.pop("timings_header", None)
         cache.set(cache_key, summary, timeout=30)
 
         posthoganalytics.capture(event="session summarized", distinct_id=str(user.distinct_id), properties=summary)
 
         # let the browser cache for half the time we cache on the server
         r = Response(summary, headers={"Cache-Control": "max-age=15"})
-        if timings:
-            r.headers["Server-Timing"] = ", ".join(
-                f"{key};dur={round(duration, ndigits=2)}" for key, duration in timings.items()
-            )
+        if timings_header:
+            r.headers["Server-Timing"] = timings_header
         return r
 
     def _stream_blob_to_client(


### PR DESCRIPTION
there are several code paths that add a `Server-Timings` header

but we've learned we need to limit its size or ALBs can be unhappy

this pushes them all through that one code path to make sure they're limited everywhere