### PR TITLE
fix: Deserialize number to string for distinct_id

### DIFF
--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -1,11 +1,29 @@
 use std::collections::HashMap;
 
 use bytes::Bytes;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use tracing::instrument;
 
 use crate::api::errors::FlagError;
+
+fn deserialize_distinct_id<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrNumber {
+        String(String),
+        Number(i64),
+    }
+
+    let opt = Option::<StringOrNumber>::deserialize(deserializer)?;
+    Ok(opt.map(|val| match val {
+        StringOrNumber::String(s) => s,
+        StringOrNumber::Number(n) => n.to_string(),
+    }))
+}
 
 #[derive(Debug, Clone, Copy)]
 pub enum FlagRequestType {
@@ -21,7 +39,12 @@ pub struct FlagRequest {
         skip_serializing_if = "Option::is_none"
     )]
     pub token: Option<String>,
-    #[serde(alias = "$distinct_id", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        alias = "$distinct_id",
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_distinct_id",
+        default
+    )]
     pub distinct_id: Option<String>,
     pub geoip_disable: Option<bool>,
     #[serde(default)]
@@ -157,6 +180,35 @@ mod tests {
             Ok(id) => assert_eq!(id, "alakazam"),
             _ => panic!("expected distinct id"),
         };
+    }
+
+    #[test]
+    fn numeric_distinct_id_is_returned_correctly() {
+        let json = json!({
+            "$distinct_id": 8675309,
+            "token": "my_token1",
+        });
+        let bytes = Bytes::from(json.to_string());
+
+        let flag_payload = FlagRequest::from_bytes(bytes).expect("failed to parse request");
+
+        match flag_payload.extract_distinct_id() {
+            Ok(id) => assert_eq!(id, "8675309"),
+            _ => panic!("expected distinct id"),
+        };
+    }
+
+    #[test]
+    fn missing_distinct_id_is_handled_correctly() {
+        let json = json!({
+            "token": "my_token1",
+        });
+        let bytes = Bytes::from(json.to_string());
+
+        let flag_payload = FlagRequest::from_bytes(bytes).expect("failed to parse request");
+
+        // First verify the field is None
+        assert_eq!(flag_payload.distinct_id, Option::<String>::None);
     }
 
     #[tokio::test]

--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -15,7 +15,7 @@ where
     #[serde(untagged)]
     enum StringOrNumber {
         String(String),
-        Number(i64),
+        Number(serde_json::Number),
     }
 
     let opt = Option::<StringOrNumber>::deserialize(deserializer)?;
@@ -209,6 +209,18 @@ mod tests {
 
         // First verify the field is None
         assert_eq!(flag_payload.distinct_id, Option::<String>::None);
+    }
+
+    #[test]
+    fn float_distinct_id_is_handled_correctly() {
+        let json = json!({
+            "$distinct_id": 123.45,
+            "token": "my_token1",
+        });
+        let bytes = Bytes::from(json.to_string());
+
+        let flag_payload = FlagRequest::from_bytes(bytes).expect("failed to parse request");
+        assert_eq!(flag_payload.distinct_id, Some("123.45".to_string()));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Distinct IDs can be numbers, strings, or UUIDs. As far as JSON is concerned, UUID and strings are the same thing. So we just have to worry about numbers.

## Problem

Passing a number as a `distinct_id` to `/flags` causes an exception: `Failed to decode request: invalid JSON.`

Fixes: https://github.com/PostHog/posthog-python/issues/225

## Changes

This PR adds a custom deserializer to the `distinct_id` property of `FlagRequest` to ensure numbers don't break things. I chose to use a custom deserializer rather than modeling the `distinct_id` with an enum type (aka something similar to a `string | number`) to minimize impact on the rest of the code.

Also, `distinct_id` is stored as a string in our db, so converting numbers to strings before using it elsewhere seems like the right thing to do.


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Unit tests.
Manual testing.