### PR TITLE
fix(variables): insight variable dashboard race condition

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -576,7 +576,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     return dashboard
                         ? {
                               ...state,
-                              // don't update filters if we're previewing
+                              // don't update filters if we're previewing or initial load with variables
                               ...(payload?.action === 'preview' || payload?.action === 'initial_load_with_variables'
                                   ? {}
                                   : dashboard.variables ?? {}),
@@ -605,7 +605,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     dashboard
                         ? {
                               ...state,
-                              // don't update filters if we're previewing
+                              // don't update filters if we're previewing or initial load with variables
                               ...(payload?.action === 'preview' || payload?.action === 'initial_load_with_variables'
                                   ? {}
                                   : dashboard.variables ?? {}),

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -223,6 +223,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
             refresh?: RefreshType
             action:
                 | 'initial_load'
+                | 'initial_load_with_variables'
                 | 'update'
                 | 'refresh'
                 | 'load_missing'
@@ -571,14 +572,17 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     }
                 },
                 resetVariables: (_, { variables }) => ({ ...variables }),
-                loadDashboardSuccess: (state, { dashboard, payload }) =>
-                    dashboard
+                loadDashboardSuccess: (state, { dashboard, payload }) => {
+                    return dashboard
                         ? {
                               ...state,
                               // don't update filters if we're previewing
-                              ...(payload?.action === 'preview' ? {} : dashboard.variables ?? {}),
+                              ...(payload?.action === 'preview' || payload?.action === 'initial_load_with_variables'
+                                  ? {}
+                                  : dashboard.variables ?? {}),
                           }
-                        : state,
+                        : state
+                },
             },
         ],
         urlVariables: [
@@ -602,7 +606,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         ? {
                               ...state,
                               // don't update filters if we're previewing
-                              ...(payload?.action === 'preview' ? {} : dashboard.variables ?? {}),
+                              ...(payload?.action === 'preview' || payload?.action === 'initial_load_with_variables'
+                                  ? {}
+                                  : dashboard.variables ?? {}),
                           }
                         : state,
             },
@@ -1713,7 +1719,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
             if (QUERY_VARIABLES_KEY in router.values.searchParams) {
                 actions.loadDashboard({
                     refresh: 'lazy_async',
-                    action: 'initial_load',
+                    action: 'initial_load_with_variables',
                 })
             }
 
@@ -1773,7 +1779,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
 
             return [
                 currentLocation.pathname,
-                { ...encodeURLVariables(newUrlVariables), ...newSearchParams },
+                { ...newSearchParams, ...encodeURLVariables(newUrlVariables) },
                 currentLocation.hashParams,
             ]
         },


### PR DESCRIPTION
## Problem

- race condition between loaddashboardsuccess and get variables causes some insights to be added with a value and other insights to use another value

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- remove race condition by using a completely new flag when initializing dashboards. when urls are present, the dashboard variables won't be used. Insights will be freshly loaded using the variable provided
- also fix ordering of actiontoURL so that url updates on variable changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
