### PR TITLE
fix(sql-editor): Pre-populate the filters object when the placeholder is used

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -311,7 +311,7 @@ export function OutputPane(): JSX.Element {
 
     return (
         <div className="OutputPane flex flex-col w-full flex-1 bg-white">
-            <div className="flex flex-row justify-between align-center w-full h-[50px]">
+            <div className="flex flex-row justify-between align-center w-full h-[50px] overflow-y-auto">
                 <div className="flex h-[50px] gap-2 ml-4">
                     {[
                         {

--- a/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
@@ -903,6 +903,25 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
         },
     })),
     subscriptions(({ props, actions, values }) => ({
+        showLegacyFilters: (showLegacyFilters: boolean) => {
+            if (showLegacyFilters) {
+                actions.setSourceQuery({
+                    ...values.sourceQuery,
+                    source: {
+                        ...values.sourceQuery.source,
+                        filters: {},
+                    },
+                })
+            } else {
+                actions.setSourceQuery({
+                    ...values.sourceQuery,
+                    source: {
+                        ...values.sourceQuery.source,
+                        filters: undefined,
+                    },
+                })
+            }
+        },
         activeModelUri: (activeModelUri) => {
             if (props.monaco) {
                 const _model = props.monaco.editor.getModel(activeModelUri.uri)
@@ -988,12 +1007,9 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
             },
         ],
         showLegacyFilters: [
-            (s) => [s.sourceQuery],
-            (sourceQuery) => {
-                return (
-                    sourceQuery.source.query.indexOf('{filters}') !== -1 ||
-                    sourceQuery.source.query.indexOf('{filters.') !== -1
-                )
+            (s) => [s.queryInput],
+            (queryInput) => {
+                return queryInput.indexOf('{filters}') !== -1 || queryInput.indexOf('{filters.') !== -1
             },
         ],
         dataLogicKey: [


### PR DESCRIPTION
## Problem
- https://github.com/PostHog/posthog/issues/30880
- https://posthog.slack.com/archives/C019RAX2XBN/p1745423806902049
- When you write a query using `{filters}`, it'll get a squiggly red underline suggesting that filters cant be resolved

## Changes
- Update the `sourceQuery` object when you write `{filters}` so that the backend can resolve the placeholder via the metadata query
- Also updates the UI for showing/hiding the filters on key press instead of waiting for the user to hit run

## Does this work well for both Cloud and self-hosted?
Yup

## How did you test this code?
Tested locally