### PR TITLE
chore(flags): improving error logs around DB access

### DIFF
--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -247,12 +247,15 @@ impl From<CustomDatabaseError> for FlagError {
 
 impl From<sqlx::Error> for FlagError {
     fn from(e: sqlx::Error) -> Self {
-        // TODO: Be more precise with error handling here
-        tracing::error!("sqlx error: {}", e);
-        println!("sqlx error: {}", e);
         match e {
-            sqlx::Error::RowNotFound => FlagError::RowNotFound,
-            _ => FlagError::DatabaseError(e.to_string()),
+            sqlx::Error::RowNotFound => {
+                tracing::error!("Row not found in database query");
+                FlagError::RowNotFound
+            }
+            _ => {
+                tracing::error!("Database error occurred: {}", e);
+                FlagError::DatabaseError(e.to_string())
+            }
         }
     }
 }

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -53,7 +53,8 @@ impl FlagService {
                         }
                         (Ok(token), false)
                     }
-                    Err(_) => {
+                    Err(e) => {
+                        tracing::error!("Token validation failed for token '{}': {:?}", token, e);
                         inc(
                             TOKEN_VALIDATION_ERRORS_COUNTER,
                             &[("reason".to_string(), "token_not_found".to_string())],


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Seeing a lot of this useless error in my logs
```
2025-04-23T19:03:29.662378Z ERROR ThreadId(05) feature_flags::api::errors: sqlx error: no rows returned by a query that expected to return at least one row
sqlx error: no rows returned by a query that expected to return at least one row
```
My guess is that they're coming from 401 errors (based on our contour metrics; the 401s are the bits of orange at the top)

<img width="837" alt="image" src="https://github.com/user-attachments/assets/103fe591-6234-4e66-9db6-5f7d7759d33e" />

And I want to look into those errors further bc I they seem higher than I expected – I just want to confirm that we're not doing 401s stupidly.  

But to do that, I need logs.  hence this change.
