### PR TITLE
fix: Remove non-existent path

### DIFF
--- a/common/tailwind/tailwind.config.js
+++ b/common/tailwind/tailwind.config.js
@@ -311,7 +311,6 @@ const config = {
         '../../ee/frontend/**/*.{ts,tsx}',
         '../../frontend/src/index.html',
         '../../products/**/frontend/**/*.{ts,tsx}',
-        '../../common/**/frontend/**/*.{ts,tsx}',
         '!../../frontend/src/**/*Type.ts',
     ],
     darkMode: ['selector', '[theme="dark"]'],


### PR DESCRIPTION
We dont have anything in these paths, but storybook cant run locally if this is selected, let's just remove it. It's probably related to us running stuff from inside `node_modules` incorrectly