### PR TITLE
feat(plugin-server): instrument fetchPerson calls for ingestion workers

### DIFF
--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -123,7 +123,7 @@ export class PersonState {
         if (!this.processPerson) {
             let existingPerson = await runInstrumentedFunction({
                 timeoutMessage: 'DB timeout in person-state.ts update at fetchPerson (read replica)',
-                timeout: 60000, // TODO: safe timeout here?
+                timeout: 60000, // this shouldn't fail the operation, just log a warning
                 func: async () => this.db.fetchPerson(this.team.id, this.distinctId, { useReadReplica: true }),
                 statsKey: 'db-tx-person-state-update-fetchPerson-ro',
                 teamId: this.team.id,
@@ -151,7 +151,7 @@ export class PersonState {
                         // so that we properly associate this event with the Person we got merged into.
                         existingPerson = await runInstrumentedFunction({
                             timeoutMessage: 'DB timeout in person-state.ts update at fetchPerson',
-                            timeout: 60000, // TODO: safe timeout here?
+                            timeout: 60000, // this shouldn't fail the operation, just log a warning
                             func: async () =>
                                 this.db.fetchPerson(this.team.id, this.distinctId, { useReadReplica: false }),
                             statsKey: 'db-tx-person-state-update-fetchPerson-rw',
@@ -522,7 +522,7 @@ export class PersonState {
 
         const otherPerson = await runInstrumentedFunction({
             timeoutMessage: 'DB timeout in person-state.ts mergeDistinctIds (otherPerson)',
-            timeout: 60000, // TODO: safe timeout here?
+            timeout: 60000, // this shouldn't fail the operation, just log a warning
             func: async () => this.db.fetchPerson(teamId, otherPersonDistinctId),
             statsKey: 'db-tx-person-state-mergeDistinctIds-other-rw',
             teamId: teamId,
@@ -531,7 +531,7 @@ export class PersonState {
 
         const mergeIntoPerson = await runInstrumentedFunction({
             timeoutMessage: 'DB timeout in person-state.ts mergeDistinctIds (mergeIntoPerson)',
-            timeout: 60000, // TODO: safe timeout here?
+            timeout: 60000, // this shouldn't fail the operation, just log a warning
             func: async () => this.db.fetchPerson(teamId, mergeIntoDistinctId),
             statsKey: 'db-tx-person-state-mergeDistinctIds-into-rw',
             teamId: teamId,

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -127,7 +127,8 @@ export class PersonState {
                 func: async () => this.db.fetchPerson(this.team.id, this.distinctId, { useReadReplica: true }),
                 statsKey: 'db-tx-person-state-update-fetchPerson-ro',
                 teamId: this.team.id,
-                logExecutionTime: true,
+                logExecutionTime: false,
+                sendTimeoutGuardToSentry: false,
             })
 
             if (!existingPerson) {
@@ -156,7 +157,8 @@ export class PersonState {
                                 this.db.fetchPerson(this.team.id, this.distinctId, { useReadReplica: false }),
                             statsKey: 'db-tx-person-state-update-fetchPerson-rw',
                             teamId: this.team.id,
-                            logExecutionTime: true,
+                            logExecutionTime: false,
+                            sendTimeoutGuardToSentry: false,
                         })
                     }
                 }
@@ -243,7 +245,8 @@ export class PersonState {
             func: async () => this.db.fetchPerson(this.team.id, this.distinctId),
             statsKey: 'db-tx-person-state-createOrGetPerson-fetchPerson-rw',
             teamId: this.team.id,
-            logExecutionTime: true,
+            logExecutionTime: false,
+            sendTimeoutGuardToSentry: false,
         })
 
         if (person) {
@@ -526,7 +529,8 @@ export class PersonState {
             func: async () => this.db.fetchPerson(teamId, otherPersonDistinctId),
             statsKey: 'db-tx-person-state-mergeDistinctIds-other-rw',
             teamId: teamId,
-            logExecutionTime: true,
+            logExecutionTime: false,
+            sendTimeoutGuardToSentry: false,
         })
 
         const mergeIntoPerson = await runInstrumentedFunction({
@@ -535,7 +539,8 @@ export class PersonState {
             func: async () => this.db.fetchPerson(teamId, mergeIntoDistinctId),
             statsKey: 'db-tx-person-state-mergeDistinctIds-into-rw',
             teamId: teamId,
-            logExecutionTime: true,
+            logExecutionTime: false,
+            sendTimeoutGuardToSentry: false,
         })
 
         // A note about the `distinctIdVersion` logic you'll find below:


### PR DESCRIPTION
## Problem
`#team-ingestion` would like more granular visibility into the timing of our top persons-processing related Postgres operations, most of which are run against the primary DB.

This PR instruments all cases of `fetchPerson` execution in `person-state.ts` where person processing and merging logic is implemented. This query is the usually at the top of our wait graphs when observing the DB under load.

The next two most important operations (`insertPerson` and `updatePerson`) will be handled in follow-on PRs.

## Changes
Wrap all calls to `fetchPerson` DB utility in `runInstrumentedFunction`.

Open question for reviewers:

Should I add a new env var or other quicker-and-dirtier gating to allowlist only certain tokens or teams to this behavior? I think this came up in incident sync yesterday

I decided to forego the timeout warnings to error tracking or the logs for now vs. pure metrics output, so additional scoping may not matter much but I'm happy to update the PR if you disagree 👍 

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally and in CI