### PR TITLE
feat(plugin-server): instrument updatePerson query execution

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -680,7 +680,7 @@ export class DB {
 
         if (rows.length == 0) {
             throw new NoRowsUpdatedError(
-                `Person with team_id="${person.team_id}" and uuid="${person.uuid} couldn't be updated`
+                `Person with team_id="${person.team_id}" and uuid="${person.uuid}" couldn't be updated`
             )
         }
         const updatedPerson = this.toPerson(rows[0])


### PR DESCRIPTION
## Problem
[See this PR description for details](https://github.com/PostHog/posthog/pull/31531)

## Changes
Instrument `updatePerson` DB query which is only called from `person-state.ts` in `updatePersonDeprecated` function.

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally and in CI