### PR TITLE
fix(flags): another TODO from the past that hurt me

### DIFF
--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -171,16 +171,15 @@ impl IntoResponse for FlagError {
             }
             FlagError::CohortNotFound(msg) => {
                 tracing::error!("Cohort not found: {}", msg);
-                (StatusCode::NOT_FOUND, msg)
+                (StatusCode::INTERNAL_SERVER_ERROR, msg)
             }
             FlagError::CohortFiltersParsingError => {
                 tracing::error!("Failed to parse cohort filters: {:?}", self);
-                // this should be a 500
                 (StatusCode::INTERNAL_SERVER_ERROR, "Failed to parse cohort filters. Please try again later or contact support if the problem persists.".to_string())
             }
             FlagError::CohortDependencyCycle(msg) => {
                 tracing::error!("Cohort dependency cycle: {}", msg);
-                (StatusCode::BAD_REQUEST, msg)
+                (StatusCode::INTERNAL_SERVER_ERROR, msg)
             }
             FlagError::PersonNotFound => {
                 (StatusCode::BAD_REQUEST, "Person not found. Please check your distinct_id and try again.".to_string())

--- a/rust/feature-flags/src/api/errors.rs
+++ b/rust/feature-flags/src/api/errors.rs
@@ -175,7 +175,8 @@ impl IntoResponse for FlagError {
             }
             FlagError::CohortFiltersParsingError => {
                 tracing::error!("Failed to parse cohort filters: {:?}", self);
-                (StatusCode::BAD_REQUEST, "Failed to parse cohort filters. Please try again later or contact support if the problem persists.".to_string())
+                // this should be a 500
+                (StatusCode::INTERNAL_SERVER_ERROR, "Failed to parse cohort filters. Please try again later or contact support if the problem persists.".to_string())
             }
             FlagError::CohortDependencyCycle(msg) => {
                 tracing::error!("Cohort dependency cycle: {}", msg);

--- a/rust/feature-flags/src/api/request_handler.rs
+++ b/rust/feature-flags/src/api/request_handler.rs
@@ -692,7 +692,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "country".to_string(),
-                        value: json!("US"),
+                        value: Some(json!("US")),
                         operator: Some(OperatorType::Exact),
                         prop_type: "person".to_string(),
                         group_type_index: None,
@@ -774,7 +774,7 @@ mod tests {
                     // Reference a non-existent cohort
                     properties: Some(vec![PropertyFilter {
                         key: "id".to_string(),
-                        value: json!(999999999), // Very large cohort ID that doesn't exist
+                        value: Some(json!(999999999)), // Very large cohort ID that doesn't exist
                         operator: None,
                         prop_type: "cohort".to_string(),
                         group_type_index: None,
@@ -1396,7 +1396,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "industry".to_string(),
-                        value: json!("tech"),
+                        value: Some(json!("tech")),
                         operator: Some(OperatorType::Exact),
                         prop_type: "group".to_string(),
                         group_type_index: Some(0),

--- a/rust/feature-flags/src/cohorts/cohort_operations.rs
+++ b/rust/feature-flags/src/cohorts/cohort_operations.rs
@@ -144,7 +144,8 @@ impl Cohort {
             for filter in &cohort_values.values {
                 if filter.is_cohort() {
                     // Assuming the value is a single integer CohortId
-                    if let Some(cohort_id) = filter.value.as_i64() {
+                    if let Some(cohort_id) = filter.value.as_ref().and_then(|value| value.as_i64())
+                    {
                         dependencies.insert(cohort_id as CohortId);
                     } else {
                         return Err(FlagError::CohortFiltersParsingError);
@@ -549,7 +550,7 @@ mod tests {
         let result = cohort.parse_filters().unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].key, "$initial_browser_version");
-        assert_eq!(result[0].value, json!(["125"]));
+        assert_eq!(result[0].value, Some(json!(["125"])));
         assert_eq!(result[0].prop_type, "person");
     }
 
@@ -562,7 +563,7 @@ mod tests {
                 values: vec![
                     PropertyFilter {
                         key: "email".to_string(),
-                        value: json!("test@example.com"),
+                        value: Some(json!("test@example.com")),
                         operator: None,
                         prop_type: "person".to_string(),
                         group_type_index: None,
@@ -570,7 +571,7 @@ mod tests {
                     },
                     PropertyFilter {
                         key: "age".to_string(),
-                        value: json!(25),
+                        value: Some(json!(25)),
                         operator: None,
                         prop_type: "person".to_string(),
                         group_type_index: None,
@@ -583,9 +584,9 @@ mod tests {
         let result = cohort_property.to_inner();
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].key, "email");
-        assert_eq!(result[0].value, json!("test@example.com"));
+        assert_eq!(result[0].value, Some(json!("test@example.com")));
         assert_eq!(result[1].key, "age");
-        assert_eq!(result[1].value, json!(25));
+        assert_eq!(result[1].value, Some(json!(25)));
     }
 
     #[tokio::test]

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -1515,7 +1515,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "email".to_string(),
-                        value: json!("override@example.com"),
+                        value: Some(json!("override@example.com")),
                         operator: None,
                         prop_type: "person".to_string(),
                         group_type_index: None,
@@ -1577,7 +1577,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "industry".to_string(),
-                        value: json!("tech"),
+                        value: Some(json!("tech")),
                         operator: None,
                         prop_type: "group".to_string(),
                         group_type_index: Some(1),
@@ -1808,7 +1808,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "email".to_string(),
-                        value: json!("test@example.com"),
+                        value: Some(json!("test@example.com")),
                         operator: Some(OperatorType::Exact),
                         prop_type: "person".to_string(),
                         group_type_index: None,
@@ -1941,7 +1941,7 @@ mod tests {
                     properties: Some(vec![
                         PropertyFilter {
                             key: "age".to_string(),
-                            value: json!(25),
+                            value: Some(json!(25)),
                             operator: Some(OperatorType::Gte),
                             prop_type: "person".to_string(),
                             group_type_index: None,
@@ -1949,7 +1949,7 @@ mod tests {
                         },
                         PropertyFilter {
                             key: "email".to_string(),
-                            value: json!("example@domain.com"),
+                            value: Some(json!("example@domain.com")),
                             operator: Some(OperatorType::Icontains),
                             prop_type: "person".to_string(),
                             group_type_index: None,
@@ -2177,7 +2177,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "email".to_string(),
-                        value: json!("test@example.com"),
+                        value: Some(json!("test@example.com")),
                         operator: None,
                         prop_type: "person".to_string(),
                         group_type_index: None,
@@ -2239,7 +2239,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "age".to_string(),
-                        value: json!(25),
+                        value: Some(json!(25)),
                         operator: Some(OperatorType::Gte),
                         prop_type: "person".to_string(),
                         group_type_index: None,
@@ -2339,7 +2339,7 @@ mod tests {
                     FlagPropertyGroup {
                         properties: Some(vec![PropertyFilter {
                             key: "email".to_string(),
-                            value: json!("user1@example.com"),
+                            value: Some(json!("user1@example.com")),
                             operator: None,
                             prop_type: "person".to_string(),
                             group_type_index: None,
@@ -2351,7 +2351,7 @@ mod tests {
                     FlagPropertyGroup {
                         properties: Some(vec![PropertyFilter {
                             key: "age".to_string(),
-                            value: json!(30),
+                            value: Some(json!(30)),
                             operator: Some(OperatorType::Gte),
                             prop_type: "person".to_string(),
                             group_type_index: None,
@@ -2582,7 +2582,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "id".to_string(),
-                        value: json!(cohort_row.id),
+                        value: Some(json!(cohort_row.id)),
                         operator: Some(OperatorType::In),
                         prop_type: "cohort".to_string(),
                         group_type_index: None,
@@ -2655,7 +2655,7 @@ mod tests {
                     FlagPropertyGroup {
                         properties: Some(vec![PropertyFilter {
                             key: "email".to_string(),
-                            value: json!("fake@posthog.com"),
+                            value: Some(json!("fake@posthog.com")),
                             operator: Some(OperatorType::Exact),
                             prop_type: "person".to_string(),
                             group_type_index: None,
@@ -2667,7 +2667,7 @@ mod tests {
                     FlagPropertyGroup {
                         properties: Some(vec![PropertyFilter {
                             key: "email".to_string(),
-                            value: json!("test@posthog.com"),
+                            value: Some(json!("test@posthog.com")),
                             operator: Some(OperatorType::Exact),
                             prop_type: "person".to_string(),
                             group_type_index: None,
@@ -2688,7 +2688,7 @@ mod tests {
                 super_groups: Some(vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "is_enabled".to_string(),
-                        value: json!(["true"]),
+                        value: Some(json!(["true"])),
                         operator: Some(OperatorType::Exact),
                         prop_type: "person".to_string(),
                         group_type_index: None,
@@ -2807,7 +2807,7 @@ mod tests {
                     FlagPropertyGroup {
                         properties: Some(vec![PropertyFilter {
                             key: "email".to_string(),
-                            value: json!("fake@posthog.com"),
+                            value: Some(json!("fake@posthog.com")),
                             operator: Some(OperatorType::Exact),
                             prop_type: "person".to_string(),
                             group_type_index: None,
@@ -2819,7 +2819,7 @@ mod tests {
                     FlagPropertyGroup {
                         properties: Some(vec![PropertyFilter {
                             key: "email".to_string(),
-                            value: json!("test@posthog.com"),
+                            value: Some(json!("test@posthog.com")),
                             operator: Some(OperatorType::Exact),
                             prop_type: "person".to_string(),
                             group_type_index: None,
@@ -2840,7 +2840,7 @@ mod tests {
                 super_groups: Some(vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "is_enabled".to_string(),
-                        value: json!("true"),
+                        value: Some(json!("true")),
                         operator: Some(OperatorType::Exact),
                         prop_type: "person".to_string(),
                         group_type_index: None,
@@ -2913,7 +2913,7 @@ mod tests {
                     FlagPropertyGroup {
                         properties: Some(vec![PropertyFilter {
                             key: "email".to_string(),
-                            value: json!("fake@posthog.com"),
+                            value: Some(json!("fake@posthog.com")),
                             operator: Some(OperatorType::Exact),
                             prop_type: "person".to_string(),
                             group_type_index: None,
@@ -2925,7 +2925,7 @@ mod tests {
                     FlagPropertyGroup {
                         properties: Some(vec![PropertyFilter {
                             key: "email".to_string(),
-                            value: json!("test@posthog.com"),
+                            value: Some(json!("test@posthog.com")),
                             operator: Some(OperatorType::Exact),
                             prop_type: "person".to_string(),
                             group_type_index: None,
@@ -2946,7 +2946,7 @@ mod tests {
                 super_groups: Some(vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "is_enabled".to_string(),
-                        value: json!(false),
+                        value: Some(json!(false)),
                         operator: Some(OperatorType::Exact),
                         prop_type: "person".to_string(),
                         group_type_index: None,
@@ -3088,7 +3088,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "id".to_string(),
-                        value: json!(cohort_row.id),
+                        value: Some(json!(cohort_row.id)),
                         operator: Some(OperatorType::In),
                         prop_type: "cohort".to_string(),
                         group_type_index: None,
@@ -3181,7 +3181,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "id".to_string(),
-                        value: json!(cohort_row.id),
+                        value: Some(json!(cohort_row.id)),
                         operator: Some(OperatorType::NotIn),
                         prop_type: "cohort".to_string(),
                         group_type_index: None,
@@ -3274,7 +3274,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "id".to_string(),
-                        value: json!(cohort_row.id),
+                        value: Some(json!(cohort_row.id)),
                         operator: Some(OperatorType::NotIn),
                         prop_type: "cohort".to_string(),
                         group_type_index: None,
@@ -3388,7 +3388,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "id".to_string(),
-                        value: json!(dependent_cohort_row.id),
+                        value: Some(json!(dependent_cohort_row.id)),
                         operator: Some(OperatorType::In),
                         prop_type: "cohort".to_string(),
                         group_type_index: None,
@@ -3481,7 +3481,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "id".to_string(),
-                        value: json!(cohort_row.id),
+                        value: Some(json!(cohort_row.id)),
                         operator: Some(OperatorType::In),
                         prop_type: "cohort".to_string(),
                         group_type_index: None,
@@ -3567,7 +3567,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "id".to_string(),
-                        value: json!(cohort.id),
+                        value: Some(json!(cohort.id)),
                         operator: Some(OperatorType::In),
                         prop_type: "cohort".to_string(),
                         group_type_index: None,
@@ -3652,7 +3652,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "id".to_string(),
-                        value: json!(cohort.id),
+                        value: Some(json!(cohort.id)),
                         operator: Some(OperatorType::In),
                         prop_type: "cohort".to_string(),
                         group_type_index: None,
@@ -3732,7 +3732,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "id".to_string(),
-                        value: json!(cohort.id),
+                        value: Some(json!(cohort.id)),
                         operator: Some(OperatorType::NotIn),
                         prop_type: "cohort".to_string(),
                         group_type_index: None,
@@ -3825,7 +3825,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "id".to_string(),
-                        value: json!(cohort.id),
+                        value: Some(json!(cohort.id)),
                         operator: Some(OperatorType::NotIn),
                         prop_type: "cohort".to_string(),
                         group_type_index: None,
@@ -3895,7 +3895,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "email".to_string(),
-                        value: json!("user3@example.com"),
+                        value: Some(json!("user3@example.com")),
                         operator: None,
                         prop_type: "person".to_string(),
                         group_type_index: None,
@@ -3991,7 +3991,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "email".to_string(),
-                        value: json!("user4@example.com"),
+                        value: Some(json!("user4@example.com")),
                         operator: None,
                         prop_type: "person".to_string(),
                         group_type_index: None,
@@ -4072,7 +4072,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "email".to_string(),
-                        value: json!("user5@example.com"),
+                        value: Some(json!("user5@example.com")),
                         operator: None,
                         prop_type: "person".to_string(),
                         group_type_index: None,
@@ -4102,7 +4102,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "age".to_string(),
-                        value: json!(30),
+                        value: Some(json!(30)),
                         operator: Some(OperatorType::Gt),
                         prop_type: "person".to_string(),
                         group_type_index: None,
@@ -4201,7 +4201,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "email".to_string(),
-                        value: json!("test@example.com"),
+                        value: Some(json!("test@example.com")),
                         operator: None,
                         prop_type: "person".to_string(),
                         group_type_index: None,
@@ -4272,7 +4272,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "email".to_string(),
-                        value: json!("test@example.com"),
+                        value: Some(json!("test@example.com")),
                         operator: None,
                         prop_type: "person".to_string(),
                         group_type_index: None,
@@ -4376,7 +4376,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "$some_prop".to_string(),
-                        value: json!(4),
+                        value: Some(json!(4)),
                         operator: Some(OperatorType::Gt),
                         prop_type: "person".to_string(),
                         group_type_index: None,
@@ -4409,7 +4409,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "$some_prop".to_string(),
-                        value: json!(4),
+                        value: Some(json!(4)),
                         operator: Some(OperatorType::Gt),
                         prop_type: "person".to_string(),
                         group_type_index: None,
@@ -4442,7 +4442,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "$some_prop".to_string(),
-                        value: json!(4),
+                        value: Some(json!(4)),
                         operator: Some(OperatorType::Gt),
                         prop_type: "person".to_string(),
                         group_type_index: None,
@@ -4713,7 +4713,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "id".to_string(),
-                        value: json!(cohort.id),
+                        value: Some(json!(cohort.id)),
                         operator: Some(OperatorType::In),
                         prop_type: "cohort".to_string(),
                         group_type_index: None,
@@ -4773,7 +4773,7 @@ mod tests {
                 groups: vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "email".to_string(),
-                        value: json!("test@example.com"),
+                        value: Some(json!("test@example.com")),
                         operator: Some(OperatorType::Exact),
                         prop_type: "person".to_string(),
                         group_type_index: None,
@@ -4842,7 +4842,7 @@ mod tests {
                     FlagPropertyGroup {
                         properties: Some(vec![PropertyFilter {
                             key: "email".to_string(),
-                            value: json!("@storytell.ai"),
+                            value: Some(json!("@storytell.ai")),
                             operator: Some(OperatorType::Icontains),
                             prop_type: "person".to_string(),
                             group_type_index: None,
@@ -4854,12 +4854,12 @@ mod tests {
                     FlagPropertyGroup {
                         properties: Some(vec![PropertyFilter {
                             key: "email".to_string(),
-                            value: json!([
+                            value: Some(json!([
                                 "simone.demarchi@outlook.com",
                                 "djokovic.dav@gmail.com",
                                 "dario.passarello@gmail.com",
                                 "matt.amick@purplewave.com"
-                            ]),
+                            ])),
                             operator: Some(OperatorType::Exact),
                             prop_type: "person".to_string(),
                             group_type_index: None,
@@ -4871,7 +4871,7 @@ mod tests {
                     FlagPropertyGroup {
                         properties: Some(vec![PropertyFilter {
                             key: "email".to_string(),
-                            value: json!("@posthog.com"),
+                            value: Some(json!("@posthog.com")),
                             operator: Some(OperatorType::Icontains),
                             prop_type: "person".to_string(),
                             group_type_index: None,
@@ -4887,7 +4887,7 @@ mod tests {
                 super_groups: Some(vec![FlagPropertyGroup {
                     properties: Some(vec![PropertyFilter {
                         key: "$feature_enrollment/artificial-hog".to_string(),
-                        value: json!(["true"]),
+                        value: Some(json!(["true"])),
                         operator: Some(OperatorType::Exact),
                         prop_type: "person".to_string(),
                         group_type_index: None,

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -585,7 +585,7 @@ mod tests {
         let property_filters = vec![
             PropertyFilter {
                 key: "email".to_string(),
-                value: json!("test@example.com"),
+                value: Some(json!("test@example.com")),
                 operator: None,
                 prop_type: "person".to_string(),
                 group_type_index: None,
@@ -593,7 +593,7 @@ mod tests {
             },
             PropertyFilter {
                 key: "age".to_string(),
-                value: json!(25),
+                value: Some(json!(25)),
                 operator: Some(OperatorType::Gte),
                 prop_type: "person".to_string(),
                 group_type_index: None,
@@ -607,7 +607,7 @@ mod tests {
         let property_filters_with_cohort = vec![
             PropertyFilter {
                 key: "email".to_string(),
-                value: json!("test@example.com"),
+                value: Some(json!("test@example.com")),
                 operator: None,
                 prop_type: "person".to_string(),
                 group_type_index: None,
@@ -615,7 +615,7 @@ mod tests {
             },
             PropertyFilter {
                 key: "cohort".to_string(),
-                value: json!(1),
+                value: Some(json!(1)),
                 operator: None,
                 prop_type: "cohort".to_string(),
                 group_type_index: None,

--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -19,7 +19,10 @@ impl PropertyFilter {
         if !self.is_cohort() {
             return None;
         }
-        self.value.as_i64().map(|id| id as CohortId)
+        self.value
+            .as_ref()
+            .and_then(|value| value.as_i64())
+            .map(|id| id as CohortId)
     }
 }
 
@@ -276,7 +279,7 @@ mod tests {
             .expect("Properties don't exist on flag")[0];
 
         assert_eq!(property_filter.key, "email");
-        assert_eq!(property_filter.value, "a@b.com");
+        assert_eq!(property_filter.value, Some(json!("a@b.com")));
         assert_eq!(property_filter.operator, None);
         assert_eq!(property_filter.prop_type, "person");
         assert_eq!(property_filter.group_type_index, None);
@@ -310,7 +313,7 @@ mod tests {
         assert_eq!(flag.key, "𝖚𝖙𝖋16_𝖙𝖊𝖘𝖙_𝖋𝖑𝖆𝖌");
         let property = &flag.filters.groups[0].properties.as_ref().unwrap()[0];
         assert_eq!(property.key, "𝖕𝖗𝖔𝖕𝖊𝖗𝖙𝖞");
-        assert_eq!(property.value, json!("𝓿𝓪𝓵𝓾𝓮"));
+        assert_eq!(property.value, Some(json!("𝓿𝓪𝓵𝓾𝓮")));
     }
 
     #[test]

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -227,7 +227,7 @@ mod tests {
                         groups: vec![FlagPropertyGroup {
                             properties: Some(vec![PropertyFilter {
                                 key: "country".to_string(),
-                                value: json!("US"),
+                                value: Some(json!("US")),
                                 operator: Some(OperatorType::Exact),
                                 prop_type: "person".to_string(),
                                 group_type_index: None,
@@ -274,7 +274,7 @@ mod tests {
                         groups: vec![FlagPropertyGroup {
                             properties: Some(vec![PropertyFilter {
                                 key: "is_premium".to_string(),
-                                value: json!(true),
+                                value: Some(json!(true)),
                                 operator: Some(OperatorType::Exact),
                                 prop_type: "person".to_string(),
                                 group_type_index: None,

--- a/rust/feature-flags/src/properties/property_models.rs
+++ b/rust/feature-flags/src/properties/property_models.rs
@@ -28,7 +28,7 @@ pub struct PropertyFilter {
     // TODO: Probably need a default for value?
     // incase operators like is_set, is_not_set are used
     // not guaranteed to have a value, if say created via api
-    pub value: serde_json::Value,
+    pub value: Option<serde_json::Value>,
     pub operator: Option<OperatorType>,
     #[serde(rename = "type")]
     // TODO: worth making a enum here to differentiate between cohort and person filters?

--- a/rust/feature-flags/src/properties/property_models.rs
+++ b/rust/feature-flags/src/properties/property_models.rs
@@ -25,9 +25,7 @@ pub enum OperatorType {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PropertyFilter {
     pub key: String,
-    // TODO: Probably need a default for value?
-    // incase operators like is_set, is_not_set are used
-    // not guaranteed to have a value, if say created via api
+    // NB: if a property filter is of type is_set or is_not_set, the value isn't used, and if it's a filter made by the API, the value is None.
     pub value: Option<serde_json::Value>,
     pub operator: Option<OperatorType>,
     #[serde(rename = "type")]


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Noticed some error logs for new flags that went like this

```
2025-04-23T19:47:10.268622Z ERROR ThreadId(03) feature_flags::flags::flag_matching: Error evaluating feature flag 'WIP_July_PHM_essentials_experiment' for distinct_id '72621': CohortFiltersParsingError
2025-04-23T19:47:13.583526Z ERROR ThreadId(26) feature_flags::cohorts::cohort_operations: Failed to parse filters for cohort 77585: missing field `value`
```

turns out, when property filters have a `is_set` or `is_not_set` value and they're created via the API, they just don't have a value field in the properties at all.  That's fine since we don't need it, but it breaks our parsing.  Woof.

Also, errors like this should be 500 errors, not 400s.  There's nothing wrong with the request, it's our fault for modeling the data incorrectly.

## Changes

Wore out my damn tab key changing all the tests.
