### PR TITLE
feat(plugin-server): instrument insertPerson DB calls

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -554,7 +554,7 @@ export class DB {
         distinctIds?: { distinctId: string; version?: number }[],
         tx?: TransactionClient
     ): Promise<InternalPerson> {
-        distinctIds ||= []
+        distinctIds = distinctIds || []
 
         for (const distinctId of distinctIds) {
             distinctId.version ||= 0

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -564,7 +564,7 @@ export class DB {
         const personVersion = 0
 
         const { rows } = await runInstrumentedFunction({
-            timeoutMessage: 'DB timeout in person-state.ts createPerson at updatePerson',
+            timeoutMessage: 'DB timeout in db.ts createPerson at updatePerson',
             timeout: 60000, // this shouldn't fail the operation, just log a warning
             func: async () =>
                 this.postgres.query<RawPerson>(


### PR DESCRIPTION
## Problem
[Details in this PR description.](https://github.com/PostHog/posthog/pull/31531)

## Changes
Instrument `db.ts` `createPerson` DB query execution step for `insertPerson`. Only called from `person-state.ts` during person processing.

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally and in CI
