### PR TITLE
feat(cdp): track metrics in hogwatcher

### DIFF
--- a/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -174,6 +174,16 @@ export class HogTransformerService {
 
                         // If the function is in a degraded state, skip it
                         if (functionState && functionState >= HogWatcherState.disabledForPeriod) {
+                            this.hogFunctionMonitoringService.produceAppMetric({
+                                team_id: event.team_id,
+                                app_source_id: hogFunction.id,
+                                metric_kind: 'failure',
+                                metric_name:
+                                    functionState === HogWatcherState.disabledForPeriod
+                                        ? 'disabled_temporarily'
+                                        : 'disabled_permanently',
+                                count: 1,
+                            })
                             continue
                         }
                     }

--- a/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -38,12 +38,6 @@ export const hogTransformationCompleted = new Counter({
     labelNames: ['type'],
 })
 
-export const hogTransformationDisabled = new Counter({
-    name: 'hog_transformation_disabled_total',
-    help: 'Number of times a transformation was skipped due to being disabled',
-    labelNames: ['state'],
-})
-
 export const hogWatcherLatency = new Histogram({
     name: 'hog_watcher_latency_seconds',
     help: 'Time spent in HogWatcher operations in seconds during ingestion',
@@ -180,11 +174,6 @@ export class HogTransformerService {
 
                         // If the function is in a degraded state, skip it
                         if (functionState && functionState >= HogWatcherState.disabledForPeriod) {
-                            hogTransformationDisabled
-                                .labels({
-                                    state: HogWatcherState[functionState],
-                                })
-                                .inc()
                             continue
                         }
                     }

--- a/plugin-server/src/cdp/services/hog-watcher.service.ts
+++ b/plugin-server/src/cdp/services/hog-watcher.service.ts
@@ -30,9 +30,9 @@ export const hogFunctionExecutionTimeSummary = new Histogram({
     labelNames: ['kind'],
 })
 
-export const hogTransformationDisabled = new Counter({
-    name: 'hog_transformation_disabled_total',
-    help: 'Number of times a transformation was skipped due to being disabled',
+export const hogFunctionStateChange = new Counter({
+    name: 'hog_function_state_change',
+    help: 'Number of times a transformation state changed',
     labelNames: ['state', 'kind'],
 })
 
@@ -239,7 +239,7 @@ export class HogWatcherService {
 
             // Finally track the results
             for (const id of functionsToDisablePermanently) {
-                hogTransformationDisabled
+                hogFunctionStateChange
                     .labels({
                         state: 'disabled_indefinitely',
                         kind: functionTypes[id],
@@ -250,7 +250,7 @@ export class HogWatcherService {
 
             for (const id of functionsTempDisabled) {
                 if (!functionsToDisablePermanently.includes(id)) {
-                    hogTransformationDisabled
+                    hogFunctionStateChange
                         .labels({
                             state: 'disabled_for_period',
                             kind: functionTypes[id],


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Right now we track the disabling of functions in many different places but not in the place it actually happens. 
We currently do not track disabled transformations in a metric in the hog-transformer

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- moves tracking of disabled hogfunctions (destinations, transformations) to the hogwatcher where it actually happens

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
