### PR TITLE
chore: add ephemeral properties columns

### DIFF
--- a/posthog/clickhouse/migrations/0114_add_ephemeral_props_column.py
+++ b/posthog/clickhouse/migrations/0114_add_ephemeral_props_column.py
@@ -1,0 +1,15 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+
+ALTER_EVENTS_TABLE_ADD_EPHEMERAL_PROPERTIES_COLUMNS = """
+ALTER TABLE {table_name}
+    ADD COLUMN IF NOT EXISTS `properties_map_ephemeral` Map(String, String) EPHEMERAL CAST(JSONExtractKeysAndValues(properties, 'String'), 'Map(String, String)'),
+    ADD COLUMN IF NOT EXISTS `person_properties_map_ephemeral` Map(String, String) EPHEMERAL CAST(JSONExtractKeysAndValues(person_properties, 'String'), 'Map(String, String)');
+
+"""
+
+
+def ALTER_EVENTS_TABLE_ADD_EPHEMERAL_PROPERTIES_COLUMNS_SQL():
+    return ALTER_EVENTS_TABLE_ADD_EPHEMERAL_PROPERTIES_COLUMNS.format(table_name="sharded_events")
+
+
+operations = [run_sql_with_exceptions(ALTER_EVENTS_TABLE_ADD_EPHEMERAL_PROPERTIES_COLUMNS_SQL(), sharded=True)]


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We extract all materialized columns deserializing JSON every time. This makes ingestion slow.

## Changes

Use an ephemeral column that parses the JSON once instead to increase the ingestion rate.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Made performance tests and ensured the change works fine. We can use the ephemeral map for some columns and JSONExtract for other as we need.
