### PR TITLE
fix: Pre-load mmdb

### DIFF
--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -262,6 +262,11 @@ jobs:
                   cache: pnpm
                   cache-dependency-path: pnpm-lock.yaml
 
+            - name: Download MaxMind Database
+              if: needs.changes.outputs.plugin-server == 'true'
+              run: |
+                  ./bin/download-mmdb
+
             - name: Install package.json dependencies with pnpm
               if: needs.changes.outputs.plugin-server == 'true'
               run: |

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -91,8 +91,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         REDIS_POOL_MIN_SIZE: 1,
         REDIS_POOL_MAX_SIZE: 3,
         DISABLE_MMDB: isTestEnv(),
-        MMDB_FILE_LOCATION:
-            isDevEnv() || isTestEnv() ? '../share/GeoLite2-City.mmdb' : '/s3/ingestion-assets/mmdb/GeoLite2-City.mmdb',
+        MMDB_FILE_LOCATION: '../share/GeoLite2-City.mmdb',
         DISTINCT_ID_LRU_SIZE: 10000,
         EVENT_PROPERTY_LRU_SIZE: 10000,
         JOB_QUEUES: 'graphile',

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -184,6 +184,9 @@ export async function createHub(
         cookielessManager,
     }
 
+    // NOTE: For whatever reason loading at this point is really fast versus lazy loading it when needed
+    await hub.geoipService.get()
+
     return {
         ...hub,
         legacyOneventCompareService: new LegacyOneventCompareService(hub as Hub),


### PR DESCRIPTION
## Problem

I'm completely stumped as to why but adding this at the hub creation point makes it take 40ms. Whereas lazy loading initial load took over 100 seconds... There's probably something more to understand here but for now I'm adding this here as a cheap win.

Fixes https://github.com/PostHog/posthog/issues/31392

## Changes

* Preload the mmdb DB

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
