### PR TITLE
feat(max): conversations retrieve and list actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ playwright/test-results/
 
 # Dist release target dir
 target/*
+
+# Ignore user's Cursor rules
+.cursor/**/user*.mdc

--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -41,7 +41,8 @@ class MessageSerializer(serializers.Serializer):
 class ConversationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Conversation
-        fields = "__all__"
+        fields = ["id", "status", "type", "messages"]
+        read_only_fields = fields
 
     messages = serializers.SerializerMethodField()
 

--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -47,8 +47,7 @@ class ConversationSerializer(serializers.ModelSerializer):
 
     def get_messages(self, conversation: Conversation):
         graph: CompiledStateGraph = self.context["assistant_graph"]
-        config = {"configurable": {"thread_id": str(conversation.id)}}
-        snapshot = graph.get_state(config)
+        snapshot = graph.get_state({"configurable": {"thread_id": str(conversation.id)}})
         try:
             state = AssistantState.model_validate(snapshot.values)
             return state.model_dump()["messages"]

--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -2,22 +2,25 @@ from typing import cast
 
 import pydantic
 from django.http import StreamingHttpResponse
+from langgraph.graph.state import CompiledStateGraph
 from rest_framework import serializers, status
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
+from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from ee.hogai.assistant import Assistant
-from ee.hogai.utils.types import AssistantMode
+from ee.hogai.graph.graph import AssistantGraph
+from ee.hogai.utils.types import AssistantMode, AssistantState
 from ee.models.assistant import Conversation
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.exceptions import Conflict
 from posthog.models.user import User
 from posthog.rate_limit import AIBurstRateThrottle, AISustainedRateThrottle
-from posthog.schema import HumanMessage
 from posthog.renderers import ServerSentEventRenderer
+from posthog.schema import HumanMessage
 
 
 class MessageSerializer(serializers.Serializer):
@@ -35,15 +38,40 @@ class MessageSerializer(serializers.Serializer):
         return data
 
 
-class ConversationViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
+class ConversationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Conversation
+        fields = "__all__"
+
+    messages = serializers.SerializerMethodField()
+
+    def get_messages(self, conversation: Conversation):
+        graph: CompiledStateGraph = self.context["assistant_graph"]
+        config = {"configurable": {"thread_id": str(conversation.id)}}
+        snapshot = graph.get_state(config)
+        try:
+            state = AssistantState.model_validate(snapshot.values)
+            return state.model_dump()["messages"]
+        except:
+            return []
+
+
+class ConversationViewSet(TeamAndOrgViewSetMixin, ListModelMixin, RetrieveModelMixin, GenericViewSet):
     scope_object = "INTERNAL"
-    serializer_class = MessageSerializer
+    serializer_class = ConversationSerializer
     queryset = Conversation.objects.all()
     lookup_url_kwarg = "conversation"
 
     def safely_get_queryset(self, queryset):
         # Only allow access to conversations created by the current user
-        return queryset.filter(user=self.request.user)
+        qs = queryset.filter(user=self.request.user)
+
+        # Allow sending messages to any conversation
+        if self.action == "create":
+            return qs
+
+        # But retrieval must only return conversations from the assistant and with a title.
+        return qs.filter(title__isnull=False, type=Conversation.Type.ASSISTANT)
 
     def get_throttles(self):
         if self.action == "create":
@@ -54,6 +82,16 @@ class ConversationViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
         if self.action == "create":
             return [ServerSentEventRenderer()]
         return super().get_renderers()
+
+    def get_serializer_class(self):
+        if self.action == "create":
+            return MessageSerializer
+        return super().get_serializer_class()
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context["assistant_graph"] = AssistantGraph(self.team).compile_full_graph()
+        return context
 
     def create(self, request: Request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)

--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -41,7 +41,7 @@ class MessageSerializer(serializers.Serializer):
 class ConversationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Conversation
-        fields = ["id", "status", "type", "messages"]
+        fields = ["id", "status", "title", "messages"]
         read_only_fields = fields
 
     messages = serializers.SerializerMethodField()

--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -52,7 +52,7 @@ class ConversationSerializer(serializers.ModelSerializer):
         try:
             state = AssistantState.model_validate(snapshot.values)
             return state.model_dump()["messages"]
-        except:
+        except (pydantic.ValidationError, KeyError):
             return []
 
 

--- a/ee/api/test/test_conversation.py
+++ b/ee/api/test/test_conversation.py
@@ -171,7 +171,9 @@ class TestConversation(APIBaseTest):
             self.assertTrue("Streaming error" in str(context.exception))
 
     def test_cancel_conversation(self):
-        conversation = Conversation.objects.create(user=self.user, team=self.team)
+        conversation = Conversation.objects.create(
+            user=self.user, team=self.team, title="Test conversation", type=Conversation.Type.ASSISTANT
+        )
         response = self.client.patch(
             f"/api/environments/{self.team.id}/conversations/{conversation.id}/cancel/",
         )
@@ -180,7 +182,13 @@ class TestConversation(APIBaseTest):
         self.assertEqual(conversation.status, Conversation.Status.CANCELING)
 
     def test_cancel_already_canceling_conversation(self):
-        conversation = Conversation.objects.create(user=self.user, team=self.team, status=Conversation.Status.CANCELING)
+        conversation = Conversation.objects.create(
+            user=self.user,
+            team=self.team,
+            status=Conversation.Status.CANCELING,
+            title="Test conversation",
+            type=Conversation.Type.ASSISTANT,
+        )
         response = self.client.patch(
             f"/api/environments/{self.team.id}/conversations/{conversation.id}/cancel/",
         )
@@ -226,3 +234,90 @@ class TestConversation(APIBaseTest):
             },
         )
         self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+
+    def test_create_with_non_assistant_conversation(self):
+        # Create a conversation with a non-assistant type
+        conversation = Conversation.objects.create(user=self.user, team=self.team, type=Conversation.Type.TOOL_CALL)
+        with patch.object(Assistant, "_stream", return_value=["test response"]):
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/conversations/",
+                {
+                    "conversation": str(conversation.id),
+                    "content": "test query",
+                    "trace_id": str(uuid.uuid4()),
+                },
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_create_with_no_title_conversation(self):
+        # Create a conversation without a title
+        conversation = Conversation.objects.create(user=self.user, team=self.team, title=None)
+        with patch.object(Assistant, "_stream", return_value=["test response"]):
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/conversations/",
+                {
+                    "conversation": str(conversation.id),
+                    "content": "test query",
+                    "trace_id": str(uuid.uuid4()),
+                },
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_list_only_returns_assistant_conversations_with_title(self):
+        # Create different types of conversations
+        conversation1 = Conversation.objects.create(
+            user=self.user, team=self.team, title="Conversation 1", type=Conversation.Type.ASSISTANT
+        )
+        Conversation.objects.create(user=self.user, team=self.team, title=None, type=Conversation.Type.ASSISTANT)
+        Conversation.objects.create(user=self.user, team=self.team, title="Tool call", type=Conversation.Type.TOOL_CALL)
+
+        with patch("ee.hogai.graph.graph.AssistantGraph.compile_full_graph"):
+            response = self.client.get(f"/api/environments/{self.team.id}/conversations/")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            # Only one conversation should be returned (the one with title and type ASSISTANT)
+            results = response.json()["results"]
+            self.assertEqual(len(results), 1)
+            self.assertEqual(results[0]["id"], str(conversation1.id))
+            self.assertEqual(results[0]["title"], "Conversation 1")
+            self.assertEqual(results[0]["type"], Conversation.Type.ASSISTANT)
+            self.assertIn("messages", results[0])
+            self.assertIn("status", results[0])
+
+    def test_retrieve_conversation_without_title_returns_404(self):
+        conversation = Conversation.objects.create(
+            user=self.user, team=self.team, title=None, type=Conversation.Type.ASSISTANT
+        )
+
+        with patch("ee.hogai.graph.graph.AssistantGraph.compile_full_graph"):
+            response = self.client.get(f"/api/environments/{self.team.id}/conversations/{conversation.id}/")
+            self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_retrieve_non_assistant_conversation_returns_404(self):
+        conversation = Conversation.objects.create(
+            user=self.user, team=self.team, title="Tool call", type=Conversation.Type.TOOL_CALL
+        )
+
+        with patch("ee.hogai.graph.graph.AssistantGraph.compile_full_graph"):
+            response = self.client.get(f"/api/environments/{self.team.id}/conversations/{conversation.id}/")
+            self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_conversation_serializer_returns_empty_messages_on_validation_error(self):
+        conversation = Conversation.objects.create(
+            user=self.user, team=self.team, title="Conversation with validation error", type=Conversation.Type.ASSISTANT
+        )
+
+        # Mock the get_state method to return data that will cause a validation error
+        with patch("langgraph.graph.state.CompiledStateGraph.get_state") as mock_get_state:
+
+            class MockSnapshot:
+                values = {"invalid_key": "invalid_value"}  # Invalid structure for AssistantState
+
+            mock_get_state.return_value = MockSnapshot()
+
+            with patch("ee.hogai.graph.graph.AssistantGraph.compile_full_graph"):
+                response = self.client.get(f"/api/environments/{self.team.id}/conversations/{conversation.id}/")
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                # Should return empty messages array when validation fails
+                self.assertEqual(response.json()["messages"], [])

--- a/ee/api/test/test_conversation.py
+++ b/ee/api/test/test_conversation.py
@@ -280,7 +280,6 @@ class TestConversation(APIBaseTest):
             self.assertEqual(len(results), 1)
             self.assertEqual(results[0]["id"], str(conversation1.id))
             self.assertEqual(results[0]["title"], "Conversation 1")
-            self.assertEqual(results[0]["type"], Conversation.Type.ASSISTANT)
             self.assertIn("messages", results[0])
             self.assertIn("status", results[0])
 


### PR DESCRIPTION
## Problem

Customers want to see the message history, but we don't have endpoints.

## Changes

- Add list and retrieve actions to the conversations API.
- Retrieve the latest messages in the serializer.
- Add user-defined cursor rules because everything was included in git by default.

## Does this work well for both Cloud and self-hosted?

No

## How did you test this code?

Unit tests