### PR TITLE
feat(sql-editor): Added a share button on the editor

### DIFF
--- a/frontend/src/lib/components/ExportButton/ExportButton.tsx
+++ b/frontend/src/lib/components/ExportButton/ExportButton.tsx
@@ -17,7 +17,7 @@ export interface ExportButtonItem {
 }
 
 export interface ExportButtonProps
-    extends Pick<LemonButtonProps, 'disabledReason' | 'icon' | 'sideIcon' | 'type' | 'fullWidth'> {
+    extends Pick<LemonButtonProps, 'disabledReason' | 'icon' | 'sideIcon' | 'id' | 'type' | 'fullWidth'> {
     items: ExportButtonItem[]
     buttonCopy?: string
 }

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -10,8 +10,9 @@ import {
     IconGraph,
     IconMinus,
     IconPlus,
+    IconShare,
 } from '@posthog/icons'
-import { LemonButton, LemonModal, LemonTable } from '@posthog/lemon-ui'
+import { LemonButton, LemonModal, LemonTable, Tooltip } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { ExportButton } from 'lib/components/ExportButton/ExportButton'
@@ -192,8 +193,9 @@ export function OutputPane(): JSX.Element {
         updateInsightButtonEnabled,
         showLegacyFilters,
         localStorageResponse,
+        queryInput,
     } = useValues(multitabEditorLogic)
-    const { saveAsInsight, updateInsight, setSourceQuery, runQuery } = useActions(multitabEditorLogic)
+    const { saveAsInsight, updateInsight, setSourceQuery, runQuery, shareTab } = useActions(multitabEditorLogic)
     const { isDarkModeOn } = useValues(themeLogic)
     const {
         response: dataNodeResponse,
@@ -421,23 +423,37 @@ export function OutputPane(): JSX.Element {
                         </LemonButton>
                     )}
                     {activeTab === OutputTab.Results && exportContext && (
-                        <ExportButton
-                            disabledReason={!hasColumns ? 'No results to export' : undefined}
-                            type="secondary"
-                            icon={<IconDownload />}
-                            sideIcon={null}
-                            buttonCopy=""
-                            items={[
-                                {
-                                    export_format: ExporterFormat.CSV,
-                                    export_context: exportContext,
-                                },
-                                {
-                                    export_format: ExporterFormat.XLSX,
-                                    export_context: exportContext,
-                                },
-                            ]}
-                        />
+                        <Tooltip title="Export the table results" className={!hasColumns ? 'hidden' : ''}>
+                            <ExportButton
+                                id="sql-editor-export"
+                                disabledReason={!hasColumns ? 'No results to export' : undefined}
+                                type="secondary"
+                                icon={<IconDownload />}
+                                sideIcon={null}
+                                buttonCopy=""
+                                items={[
+                                    {
+                                        export_format: ExporterFormat.CSV,
+                                        export_context: exportContext,
+                                    },
+                                    {
+                                        export_format: ExporterFormat.XLSX,
+                                        export_context: exportContext,
+                                    },
+                                ]}
+                            />
+                        </Tooltip>
+                    )}
+                    {activeTab === OutputTab.Results && (
+                        <Tooltip title="Share your current query">
+                            <LemonButton
+                                id="sql-editor-share"
+                                disabledReason={!queryInput && 'No query to share'}
+                                type="secondary"
+                                icon={<IconShare />}
+                                onClick={() => shareTab()}
+                            />
+                        </Tooltip>
                     )}
                 </div>
             </div>

--- a/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
@@ -9,6 +9,7 @@ import { LemonField } from 'lib/lemon-ui/LemonField'
 import { initModel } from 'lib/monaco/CodeEditor'
 import { codeEditorLogic } from 'lib/monaco/codeEditorLogic'
 import { removeUndefinedAndNull } from 'lib/utils'
+import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import isEqual from 'lodash.isequal'
 import { editor, Uri } from 'monaco-editor'
 import { insightsApi } from 'scenes/insights/utils/api'
@@ -141,6 +142,7 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
         onAcceptSuggestedQueryInput: (shouldRunQuery?: boolean) => ({ shouldRunQuery }),
         onRejectSuggestedQueryInput: true,
         setResponse: (response: Record<string, any> | null) => ({ response, currentTab: values.activeModelUri }),
+        shareTab: true,
     })),
     propsChanged(({ actions, props }, oldProps) => {
         if (!oldProps.monaco && !oldProps.editor && props.monaco && props.editor) {
@@ -287,6 +289,43 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
         ],
     })),
     listeners(({ values, props, actions, asyncActions }) => ({
+        shareTab: () => {
+            const currentTab = values.activeModelUri
+            if (!currentTab) {
+                return
+            }
+
+            if (currentTab.insight) {
+                const currentUrl = new URL(window.location.href)
+                const shareUrl = new URL(currentUrl.origin + currentUrl.pathname)
+                shareUrl.searchParams.set('open_insight', currentTab.insight.short_id)
+
+                if (currentTab.insight.query?.kind === NodeKind.DataVisualizationNode) {
+                    const query = (currentTab.insight.query as DataVisualizationNode).source.query
+                    if (values.queryInput !== query) {
+                        shareUrl.searchParams.set('open_query', values.queryInput)
+                    }
+                }
+
+                void copyToClipboard(shareUrl.toString(), 'share link')
+            } else if (currentTab.view) {
+                const currentUrl = new URL(window.location.href)
+                const shareUrl = new URL(currentUrl.origin + currentUrl.pathname)
+                shareUrl.searchParams.set('open_view', currentTab.view.id)
+
+                if (values.queryInput != currentTab.view.query.query) {
+                    shareUrl.searchParams.set('open_query', values.queryInput)
+                }
+
+                void copyToClipboard(shareUrl.toString(), 'share link')
+            } else {
+                const currentUrl = new URL(window.location.href)
+                const shareUrl = new URL(currentUrl.origin + currentUrl.pathname)
+                shareUrl.searchParams.set('open_query', values.queryInput)
+
+                void copyToClipboard(shareUrl.toString(), 'share link')
+            }
+        },
         setSuggestedQueryInput: ({ suggestedQueryInput }) => {
             if (values.queryInput) {
                 actions._setSuggestedQueryInput(suggestedQueryInput)
@@ -1045,12 +1084,7 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
             let tabAdded = false
 
             const createQueryTab = async (): Promise<void> => {
-                if (searchParams.open_query) {
-                    // Open query string
-                    actions.createTab(searchParams.open_query)
-                    tabAdded = true
-                    router.actions.replace(router.values.location.pathname)
-                } else if (searchParams.open_view) {
+                if (searchParams.open_view) {
                     // Open view
                     const viewId = searchParams.open_view
                     const view = values.dataWarehouseSavedQueries.find((n) => n.id === viewId)
@@ -1059,7 +1093,9 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
                         return
                     }
 
-                    actions.editView(view.query.query, view)
+                    const queryToOpen = searchParams.open_query ? searchParams.open_query : view.query.query
+
+                    actions.editView(queryToOpen, view)
                     tabAdded = true
                     router.actions.replace(router.values.location.pathname)
                 } else if (searchParams.open_insight) {
@@ -1084,10 +1120,16 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
                         query = (insight.query as DataVisualizationNode).source.query
                     }
 
-                    actions.editInsight(query, insight)
+                    const queryToOpen = searchParams.open_query ? searchParams.open_query : query
 
-                    // Only run the query if the results aren't already cached locally
-                    if (insight.query?.kind === NodeKind.DataVisualizationNode && insight.query) {
+                    actions.editInsight(queryToOpen, insight)
+
+                    // Only run the query if the results aren't already cached locally and we're not using the open_query search param
+                    if (
+                        insight.query?.kind === NodeKind.DataVisualizationNode &&
+                        insight.query &&
+                        !searchParams.open_query
+                    ) {
                         dataNodeLogic({
                             key: values.dataLogicKey,
                             query: (insight.query as DataVisualizationNode).source,
@@ -1105,6 +1147,11 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
                         actions.runQuery()
                     }
 
+                    tabAdded = true
+                    router.actions.replace(router.values.location.pathname)
+                } else if (searchParams.open_query) {
+                    // Open query string
+                    actions.createTab(searchParams.open_query)
                     tabAdded = true
                     router.actions.replace(router.values.location.pathname)
                 }


### PR DESCRIPTION
## Problem
- People wanna share their queries with their friends!!

## Changes
- Added a share button, this will create a URL and copy it to the clipboard -
  - If on a view, it'll include the view ID
  - If on an insight, it'll include the insight short_id
  - Else, it'll just include the query written
- If the current query is different from the shared view/insight, then the current query is what will be used when someone opens the URL, and not the saved insight/view

<img width="448" alt="image" src="https://github.com/user-attachments/assets/836280f6-a2d5-4d2a-8139-d10fd1c46a24" />


## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Tested locally
