### PR TITLE
feat(data-warehouse): MS SQL source: add dynamic chunking

### DIFF
--- a/posthog/temporal/data_imports/pipelines/mssql/mssql.py
+++ b/posthog/temporal/data_imports/pipelines/mssql/mssql.py
@@ -220,7 +220,7 @@ def _get_table_average_row_size(
         logger.debug(f"_get_table_average_row_size: No results returned.")
         return None
 
-    row_size_bytes = row[0] or 1
+    row_size_bytes = max(row[0] or 0, 1)
     return row_size_bytes
 
 

--- a/posthog/temporal/data_imports/pipelines/mssql/mssql.py
+++ b/posthog/temporal/data_imports/pipelines/mssql/mssql.py
@@ -20,6 +20,7 @@ from posthog.temporal.data_imports.pipelines.pipeline.utils import (
 )
 from posthog.temporal.data_imports.pipelines.sql_database.settings import (
     DEFAULT_CHUNK_SIZE,
+    DEFAULT_TABLE_SIZE_BYTES,
 )
 from posthog.warehouse.models import IncrementalFieldType
 
@@ -31,10 +32,12 @@ def _build_query(
     incremental_field: str | None,
     incremental_field_type: IncrementalFieldType | None,
     db_incremental_field_last_value: Any | None,
+    add_limit: bool = False,
 ) -> tuple[str, dict[str, Any]]:
-    query = f"SELECT * FROM [{schema}].[{table_name}]"
+    base_query = "SELECT {top} * FROM [{schema}].[{table_name}]"
 
     if not is_incremental:
+        query = base_query.format(top="TOP 100" if add_limit else "", schema=schema, table_name=table_name)
         return query, {}
 
     if incremental_field is None or incremental_field_type is None:
@@ -43,7 +46,8 @@ def _build_query(
     if db_incremental_field_last_value is None:
         db_incremental_field_last_value = incremental_type_to_initial_value(incremental_field_type)
 
-    query = f"SELECT * FROM [{schema}].[{table_name}] WHERE [{incremental_field}] > %(incremental_value)s ORDER BY [{incremental_field}] ASC"
+    query = base_query.format(top="TOP 100" if add_limit else "", schema=schema, table_name=table_name)
+    query = f"{query} WHERE [{incremental_field}] > %(incremental_value)s ORDER BY [{incremental_field}] ASC"
 
     return query, {
         "incremental_value": db_incremental_field_last_value,
@@ -169,6 +173,95 @@ def _get_arrow_schema(table_structure: list[TableStructureRow]) -> pa.Schema:
     return pa.schema(fields)
 
 
+def _get_table_average_row_size(
+    cursor: Cursor,
+    schema: str,
+    table_name: str,
+    is_incremental: bool,
+    incremental_field: str | None,
+    incremental_field_type: IncrementalFieldType | None,
+    db_incremental_field_last_value: Any | None,
+    logger: FilteringBoundLogger,
+) -> int | None:
+    query, args = _build_query(
+        schema,
+        table_name,
+        is_incremental,
+        incremental_field,
+        incremental_field_type,
+        db_incremental_field_last_value,
+        add_limit=True,
+    )
+
+    # Get column names from the table
+    cursor.execute(
+        f"SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = %(schema)s AND TABLE_NAME = %(table)s ORDER BY ORDINAL_POSITION",
+        {"schema": schema, "table": table_name},
+    )
+    rows = cursor.fetchall()
+    if not rows:
+        logger.debug(f"_get_table_average_row_size: No columns found.")
+        return None
+
+    columns = [row[0] for row in rows]
+
+    # Build the DATALENGTH sum for each column
+    datalength_sum = " + ".join(f"DATALENGTH([{col}])" for col in columns)
+
+    size_query = f"""
+        SELECT AVG({datalength_sum}) as avg_row_size
+        FROM ({query}) as t
+    """
+
+    cursor.execute(size_query, args)
+    row = cursor.fetchone()
+
+    if row is None or row[0] is None:
+        logger.debug(f"_get_table_average_row_size: No results returned.")
+        return None
+
+    row_size_bytes = row[0] or 1
+    return row_size_bytes
+
+
+def _get_table_chunk_size(
+    cursor: Cursor,
+    schema: str,
+    table_name: str,
+    is_incremental: bool,
+    incremental_field: str | None,
+    incremental_field_type: IncrementalFieldType | None,
+    db_incremental_field_last_value: Any | None,
+    logger: FilteringBoundLogger,
+) -> int:
+    try:
+        row_size_bytes = _get_table_average_row_size(
+            cursor,
+            schema,
+            table_name,
+            is_incremental,
+            incremental_field,
+            incremental_field_type,
+            db_incremental_field_last_value,
+            logger,
+        )
+        if row_size_bytes is None:
+            logger.debug(
+                f"_get_table_chunk_size: Could not calculate row size. Using DEFAULT_CHUNK_SIZE={DEFAULT_CHUNK_SIZE}"
+            )
+            return DEFAULT_CHUNK_SIZE
+    except Exception as e:
+        logger.debug(f"_get_table_chunk_size: Error: {e}. Using DEFAULT_CHUNK_SIZE={DEFAULT_CHUNK_SIZE}", exc_info=e)
+        return DEFAULT_CHUNK_SIZE
+
+    chunk_size = int(DEFAULT_TABLE_SIZE_BYTES / row_size_bytes)
+    min_chunk_size = min(chunk_size, DEFAULT_CHUNK_SIZE)
+    logger.debug(
+        f"_get_table_chunk_size: row_size_bytes={row_size_bytes}. DEFAULT_TABLE_SIZE_BYTES={DEFAULT_TABLE_SIZE_BYTES}. Using CHUNK_SIZE={min_chunk_size}"
+    )
+    return min_chunk_size
+
+
 def mssql_source(
     host: str,
     port: int,
@@ -198,6 +291,16 @@ def mssql_source(
         with connection.cursor() as cursor:
             primary_keys = _get_primary_keys(cursor, schema, table_name)
             table_structure = _get_table_structure(cursor, schema, table_name)
+            chunk_size = _get_table_chunk_size(
+                cursor,
+                schema,
+                table_name,
+                is_incremental,
+                incremental_field,
+                incremental_field_type,
+                db_incremental_field_last_value,
+                logger,
+            )
 
             # Fallback on checking for an `id` field on the table
             if primary_keys is None:
@@ -231,7 +334,7 @@ def mssql_source(
                 column_names = [column[0] for column in cursor.description or []]
 
                 while True:
-                    rows = cursor.fetchmany(DEFAULT_CHUNK_SIZE)
+                    rows = cursor.fetchmany(chunk_size)
                     if not rows:
                         break
 

--- a/posthog/temporal/tests/data_imports/test_mssql_source.py
+++ b/posthog/temporal/tests/data_imports/test_mssql_source.py
@@ -26,9 +26,14 @@ from typing import Any
 import pymssql
 import pytest
 import pytz
+import structlog
 
+from posthog.temporal.data_imports.pipelines.mssql.mssql import (
+    _get_table_average_row_size,
+)
 from posthog.temporal.tests.data_imports.conftest import run_external_data_job_workflow
 from posthog.warehouse.models import ExternalDataSchema, ExternalDataSource
+from posthog.warehouse.types import IncrementalFieldType
 
 pytestmark = pytest.mark.usefixtures("minio_client")
 
@@ -135,40 +140,42 @@ def mssql_source_table(
     with mssql_connection.cursor() as cursor:
         full_table_name = f"[{mssql_config['schema']}].[{MSSQL_TABLE_NAME}]"
 
-        # Create test table
-        cursor.execute(f"""
-            IF NOT EXISTS (
-                SELECT *
-                FROM sys.tables t
-                JOIN sys.schemas s ON t.schema_id = s.schema_id
-                WHERE s.name = '{mssql_config['schema']}'
-                AND t.name = '{MSSQL_TABLE_NAME}'
-            )
-            BEGIN
-                CREATE TABLE {full_table_name} (
-                    uid INTEGER PRIMARY KEY,
-                    name NVARCHAR(255),
-                    email NVARCHAR(255),
-                    created_at DATETIME2 DEFAULT GETUTCDATE(),
-                    big_int BIGINT,
-                    json_data JSON,
-                    active BIT,
-                    decimal_data DECIMAL(10, 2),
-                    price MONEY,
-                    float_data FLOAT
+        try:
+            # Create test table
+            cursor.execute(f"""
+                IF NOT EXISTS (
+                    SELECT *
+                    FROM sys.tables t
+                    JOIN sys.schemas s ON t.schema_id = s.schema_id
+                    WHERE s.name = '{mssql_config['schema']}'
+                    AND t.name = '{MSSQL_TABLE_NAME}'
                 )
-            END
-        """)
-        mssql_connection.commit()
+                BEGIN
+                    CREATE TABLE {full_table_name} (
+                        uid INTEGER PRIMARY KEY,
+                        name NVARCHAR(255),
+                        email NVARCHAR(255),
+                        created_at DATETIME2 DEFAULT GETUTCDATE(),
+                        big_int BIGINT,
+                        json_data JSON,
+                        active BIT,
+                        decimal_data DECIMAL(10, 2),
+                        price MONEY,
+                        float_data FLOAT
+                    )
+                END
+            """)
+            mssql_connection.commit()
 
-        # Insert test data
-        _insert_test_data(cursor=cursor, table_name=full_table_name, data=TEST_DATA)
+            # Insert test data
+            _insert_test_data(cursor=cursor, table_name=full_table_name, data=TEST_DATA)
 
-        yield cursor
+            yield cursor
 
-        # Cleanup
-        cursor.execute(f"DROP TABLE IF EXISTS {full_table_name}")
-        mssql_connection.commit()
+        finally:
+            # Cleanup
+            cursor.execute(f"DROP TABLE IF EXISTS {full_table_name}")
+            mssql_connection.commit()
 
 
 @pytest.fixture
@@ -432,3 +439,143 @@ async def test_mssql_source_incremental_using_created_at_column(
     assert sorted(res.results, key=operator.itemgetter(0)) == sorted(
         TEST_DATA + NEW_TEST_DATA, key=operator.itemgetter(0)
     )
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+@SKIP_IF_MISSING_MSSQL_CREDENTIALS
+async def test_mssql_get_table_average_row_size(
+    mssql_source_table: pymssql.Cursor,
+    mssql_config: dict[str, Any],
+):
+    """Test that the average row size is calculated correctly.
+
+    Here we use a table with a variety of column types and data to ensure the queries to calculate the average row size
+    are correct.
+    We don't assert the average row size here as it's hard to determine and is likely to be flaky.  We do this instead
+    in the test below.
+    """
+    average_row_size = _get_table_average_row_size(
+        cursor=mssql_source_table,
+        schema=mssql_config["schema"],
+        table_name=MSSQL_TABLE_NAME,
+        is_incremental=False,
+        incremental_field=None,
+        incremental_field_type=None,
+        db_incremental_field_last_value=None,
+        logger=structlog.get_logger(),
+    )
+
+    # Just assert that we do calculate a value and don't return None
+    assert isinstance(average_row_size, int)
+    # sanity check that the average row size is not too big or too small
+    assert average_row_size > 0
+    assert average_row_size < 1000
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+@SKIP_IF_MISSING_MSSQL_CREDENTIALS
+async def test_mssql_get_table_average_row_size_with_incremental_field(
+    mssql_source_table: pymssql.Cursor,
+    mssql_config: dict[str, Any],
+):
+    """Test that the average row size is calculated correctly.
+
+    Here we use a table with a variety of column types and data to ensure the queries to calculate the average row size
+    are correct.
+    We don't assert the average row size here as it's hard to determine and is likely to be flaky.  We do this instead
+    in the test below.
+    """
+    average_row_size = _get_table_average_row_size(
+        cursor=mssql_source_table,
+        schema=mssql_config["schema"],
+        table_name=MSSQL_TABLE_NAME,
+        is_incremental=True,
+        incremental_field="created_at",
+        incremental_field_type=IncrementalFieldType.DateTime,
+        db_incremental_field_last_value=None,
+        logger=structlog.get_logger(),
+    )
+
+    # Just assert that we do calculate a value and don't return None
+    assert isinstance(average_row_size, int)
+    # sanity check that the average row size is not too big or too small
+    assert average_row_size > 0
+    assert average_row_size < 1000
+
+
+@pytest.fixture
+def mssql_source_table_known_row_size(
+    mssql_connection: pymssql.Connection, mssql_config: dict[str, Any]
+) -> Generator[pymssql.Cursor, None, None]:
+    """Create a MS SQL Server table with deterministic row size and clean it up after the test."""
+    with mssql_connection.cursor() as cursor:
+        full_table_name = f"[{mssql_config['schema']}].[{MSSQL_TABLE_NAME}]"
+
+        try:
+            # Create test table
+            cursor.execute(f"""
+                IF NOT EXISTS (
+                    SELECT *
+                    FROM sys.tables t
+                    JOIN sys.schemas s ON t.schema_id = s.schema_id
+                    WHERE s.name = '{mssql_config['schema']}'
+                    AND t.name = '{MSSQL_TABLE_NAME}'
+                )
+                BEGIN
+                    CREATE TABLE {full_table_name} (
+                        name NVARCHAR(255)
+                    )
+                END
+            """)
+            mssql_connection.commit()
+
+            # Insert test data
+            data = [
+                ("0123456789",),
+                ("acbcdefghi",),
+                ("9876543210",),
+            ]
+            for row in data:
+                cursor.execute(
+                    f"INSERT INTO {full_table_name} (name) VALUES (%s)",
+                    row,
+                )
+            cursor.connection.commit()
+
+            yield cursor
+
+        finally:
+            # Cleanup
+            cursor.execute(f"DROP TABLE IF EXISTS {full_table_name}")
+            mssql_connection.commit()
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+@SKIP_IF_MISSING_MSSQL_CREDENTIALS
+async def test_mssql_get_table_average_row_size_calculates_correct_average_row_size(
+    team,
+    mssql_source_table_known_row_size: pymssql.Cursor,
+    mssql_config: dict[str, Any],
+    external_data_source: ExternalDataSource,
+    external_data_schema_full_refresh: ExternalDataSchema,
+):
+    """Test that the average row size is calculated correctly.
+
+    To do this, we test using a table with a known row size so we can assert the average row size is correct.
+    """
+    average_row_size = _get_table_average_row_size(
+        cursor=mssql_source_table_known_row_size,
+        schema=mssql_config["schema"],
+        table_name=MSSQL_TABLE_NAME,
+        is_incremental=False,
+        incremental_field=None,
+        incremental_field_type=None,
+        db_incremental_field_last_value=None,
+        logger=structlog.get_logger(),
+    )
+
+    # each character in column uses 2 bytes
+    assert average_row_size == 20

--- a/posthog/temporal/tests/data_imports/test_mssql_source.py
+++ b/posthog/temporal/tests/data_imports/test_mssql_source.py
@@ -453,7 +453,7 @@ async def test_mssql_get_table_average_row_size(
     Here we use a table with a variety of column types and data to ensure the queries to calculate the average row size
     are correct.
     We don't assert the average row size here as it's hard to determine and is likely to be flaky.  We do this instead
-    in the test below.
+    in another test below.
     """
     average_row_size = _get_table_average_row_size(
         cursor=mssql_source_table,
@@ -480,12 +480,12 @@ async def test_mssql_get_table_average_row_size_with_incremental_field(
     mssql_source_table: pymssql.Cursor,
     mssql_config: dict[str, Any],
 ):
-    """Test that the average row size is calculated correctly.
+    """Test that the average row size is calculated correctly for an incremental sync.
 
     Here we use a table with a variety of column types and data to ensure the queries to calculate the average row size
     are correct.
     We don't assert the average row size here as it's hard to determine and is likely to be flaky.  We do this instead
-    in the test below.
+    in another test below.
     """
     average_row_size = _get_table_average_row_size(
         cursor=mssql_source_table,
@@ -556,11 +556,8 @@ def mssql_source_table_known_row_size(
 @pytest.mark.asyncio
 @SKIP_IF_MISSING_MSSQL_CREDENTIALS
 async def test_mssql_get_table_average_row_size_calculates_correct_average_row_size(
-    team,
     mssql_source_table_known_row_size: pymssql.Cursor,
     mssql_config: dict[str, Any],
-    external_data_source: ExternalDataSource,
-    external_data_schema_full_refresh: ExternalDataSchema,
 ):
     """Test that the average row size is calculated correctly.
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We use a default chunk size for iterating over MS SQL data currently.

## Changes

Use a dynamic chunk size like we do for other SQL sources (I copied the approach used by Postgres).

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added new tests
