### PR TITLE
fix: wrong significance value for secondary metrics.

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/Overview.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Overview.tsx
@@ -46,6 +46,9 @@ export function SignificanceText({
     metricIndex: number
     isSecondary?: boolean
 }): JSX.Element {
+    /**
+     * Remove this functions from the logic and make them pure so this component can be tested
+     */
     const { isPrimaryMetricSignificant, isSecondaryMetricSignificant } = useValues(experimentLogic)
 
     return (
@@ -53,9 +56,7 @@ export function SignificanceText({
             <span>Your results are&nbsp;</span>
             <span className="font-semibold">
                 {`${
-                    isSecondary
-                        ? isSecondaryMetricSignificant(metricIndex)
-                        : isPrimaryMetricSignificant(metricIndex)
+                    (isSecondary ? isSecondaryMetricSignificant(metricIndex) : isPrimaryMetricSignificant(metricIndex))
                         ? 'significant'
                         : 'not significant'
                 }`}

--- a/frontend/src/scenes/experiments/MetricsView/ChartModal.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/ChartModal.tsx
@@ -54,7 +54,7 @@ export function ChartModal({
             <LemonBanner type={result?.significant ? 'success' : 'info'} className="mb-4">
                 <div className="items-center inline-flex flex-wrap">
                     <WinningVariantText result={result} experimentId={experimentId} />
-                    <SignificanceText metricIndex={metricIndex} />
+                    <SignificanceText metricIndex={metricIndex} isSecondary={isSecondary} />
                 </div>
             </LemonBanner>
             <SummaryTable metric={metric} metricIndex={metricIndex} isSecondary={isSecondary} />


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

The _Metrics Detail_ dialog is showing the wrong significance text.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Updated the `ChartModal` component to correctly pass down if the metric is secondary, and the `Overview` component to show the right string and not a `boolean`:

| Before | After |
| - | - | 
|  <img width="1200" alt="image" src="https://github.com/user-attachments/assets/5ae905be-3e52-46ce-9edc-0f8225281845" /> | <img width="1203" alt="image" src="https://github.com/user-attachments/assets/c02ee5e0-6e76-43d2-86a6-1044244f2d7f" /> |


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
