### PR TITLE
feat(data-warehouse): Add partitioning for Microsoft SQL Server source

### DIFF
--- a/posthog/temporal/tests/data_imports/test_mssql_source.py
+++ b/posthog/temporal/tests/data_imports/test_mssql_source.py
@@ -13,6 +13,9 @@ OBJECT_STORAGE_ENDPOINT=http://localhost:19000 \
     MSSQL_DATABASE=database_name \
     pytest posthog/temporal/tests/data_imports/test_mssql_source.py
 ```
+
+(From my testing on Azure, the connection often fails the first time, but waiting for a bit and retrying works.
+This might be due to the fact that I am using a free tier of Azure SQL Database which might need a bit of time to wake up.)
 """
 
 import datetime as dt
@@ -30,6 +33,7 @@ import structlog
 
 from posthog.temporal.data_imports.pipelines.mssql.mssql import (
     _get_table_average_row_size,
+    _get_table_stats,
 )
 from posthog.temporal.tests.data_imports.conftest import run_external_data_job_workflow
 from posthog.warehouse.models import ExternalDataSchema, ExternalDataSource
@@ -204,43 +208,6 @@ def external_data_schema_full_refresh(external_data_source: ExternalDataSource, 
     return schema
 
 
-@pytest.mark.django_db(transaction=True)
-@pytest.mark.asyncio
-@SKIP_IF_MISSING_MSSQL_CREDENTIALS
-async def test_mssql_source_full_refresh(
-    team,
-    mssql_source_table: pymssql.Cursor,
-    external_data_source: ExternalDataSource,
-    external_data_schema_full_refresh: ExternalDataSchema,
-):
-    """Test that a full refresh sync works as expected."""
-    table_name = f"mssql_{MSSQL_TABLE_NAME}"
-    expected_num_rows = len(TEST_DATA)
-
-    res = await run_external_data_job_workflow(
-        team=team,
-        external_data_source=external_data_source,
-        external_data_schema=external_data_schema_full_refresh,
-        table_name=table_name,
-        expected_rows_synced=expected_num_rows,
-        expected_total_rows=expected_num_rows,
-        expected_columns=[
-            "uid",
-            "name",
-            "email",
-            "created_at",
-            "big_int",
-            "json_data",
-            "active",
-            "decimal_data",
-            "price",
-            "float_data",
-        ],
-    )
-
-    assert list(res.results) == TEST_DATA
-
-
 @pytest.fixture
 def external_data_schema_incremental(external_data_source: ExternalDataSource, team) -> ExternalDataSchema:
     schema = ExternalDataSchema.objects.create(
@@ -255,89 +222,6 @@ def external_data_schema_incremental(external_data_source: ExternalDataSource, t
         },
     )
     return schema
-
-
-@pytest.mark.django_db(transaction=True)
-@pytest.mark.asyncio
-@SKIP_IF_MISSING_MSSQL_CREDENTIALS
-async def test_mssql_source_incremental(
-    team,
-    mssql_source_table: pymssql.Cursor,
-    external_data_source: ExternalDataSource,
-    external_data_schema_incremental: ExternalDataSchema,
-):
-    """Test that an incremental sync works as expected."""
-    table_name = f"mssql_{MSSQL_TABLE_NAME}"
-    expected_num_rows = len(TEST_DATA)
-
-    res = await run_external_data_job_workflow(
-        team=team,
-        external_data_source=external_data_source,
-        external_data_schema=external_data_schema_incremental,
-        table_name=table_name,
-        expected_rows_synced=expected_num_rows,
-        expected_total_rows=expected_num_rows,
-        expected_columns=[
-            "uid",
-            "name",
-            "email",
-            "created_at",
-            "big_int",
-            "json_data",
-            "active",
-            "decimal_data",
-            "price",
-            "float_data",
-        ],
-    )
-
-    assert list(res.results) == TEST_DATA
-
-    # insert new data to be synced on next incremental run
-    NEW_TEST_DATA = [
-        (
-            4,
-            "Mo Doe",
-            "mo@example.com",
-            dt.datetime(2025, 1, 4, tzinfo=pytz.UTC),
-            999999999,
-            '{"key":null}',
-            True,
-            Decimal("1300.33"),
-            Decimal("199.99"),
-            17678785.0,
-        ),
-    ]
-
-    _insert_test_data(cursor=mssql_source_table, table_name=MSSQL_TABLE_NAME, data=NEW_TEST_DATA)
-    expected_total_num_rows = expected_num_rows + len(NEW_TEST_DATA)
-
-    res = await run_external_data_job_workflow(
-        team=team,
-        external_data_source=external_data_source,
-        external_data_schema=external_data_schema_incremental,
-        table_name=table_name,
-        expected_rows_synced=len(NEW_TEST_DATA),
-        expected_total_rows=expected_total_num_rows,
-        expected_columns=[
-            "uid",
-            "name",
-            "email",
-            "created_at",
-            "big_int",
-            "json_data",
-            "active",
-            "decimal_data",
-            "price",
-            "float_data",
-        ],
-    )
-
-    # Compare sorted results as rows may have been shuffled around, but we only care the data is there,
-    # not in which order.
-    assert sorted(res.results, key=operator.itemgetter(0)) == sorted(
-        TEST_DATA + NEW_TEST_DATA, key=operator.itemgetter(0)
-    )
 
 
 @pytest.fixture
@@ -361,218 +245,462 @@ def external_data_schema_incremental_using_created_at_column(
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 @SKIP_IF_MISSING_MSSQL_CREDENTIALS
-async def test_mssql_source_incremental_using_created_at_column(
-    team,
-    mssql_source_table: pymssql.Cursor,
-    external_data_source: ExternalDataSource,
-    external_data_schema_incremental_using_created_at_column: ExternalDataSchema,
-):
-    """Test that an incremental sync works as expected when using the `created_at` column as the incremental field."""
-    table_name = f"mssql_{MSSQL_TABLE_NAME}"
-    expected_num_rows = len(TEST_DATA)
+class TestEndToEndWorkflow:
+    async def test_full_refresh(
+        self,
+        team,
+        mssql_source_table: pymssql.Cursor,
+        external_data_source: ExternalDataSource,
+        external_data_schema_full_refresh: ExternalDataSchema,
+    ):
+        """Test that a full refresh sync works as expected."""
+        table_name = f"mssql_{MSSQL_TABLE_NAME}"
+        expected_num_rows = len(TEST_DATA)
 
-    res = await run_external_data_job_workflow(
-        team=team,
-        external_data_source=external_data_source,
-        external_data_schema=external_data_schema_incremental_using_created_at_column,
-        table_name=table_name,
-        expected_rows_synced=expected_num_rows,
-        expected_total_rows=expected_num_rows,
-        expected_columns=[
-            "uid",
-            "name",
-            "email",
-            "created_at",
-            "big_int",
-            "json_data",
-            "active",
-            "decimal_data",
-            "price",
-            "float_data",
-        ],
-    )
+        res = await run_external_data_job_workflow(
+            team=team,
+            external_data_source=external_data_source,
+            external_data_schema=external_data_schema_full_refresh,
+            table_name=table_name,
+            expected_rows_synced=expected_num_rows,
+            expected_total_rows=expected_num_rows,
+            expected_columns=[
+                "uid",
+                "name",
+                "email",
+                "created_at",
+                "big_int",
+                "json_data",
+                "active",
+                "decimal_data",
+                "price",
+                "float_data",
+            ],
+        )
 
-    assert list(res.results) == TEST_DATA
+        assert list(res.results) == TEST_DATA
 
-    # insert new data to be synced on next incremental run
-    NEW_TEST_DATA = [
-        (
-            4,
-            "Mo Doe",
-            "mo@example.com",
-            dt.datetime(2025, 1, 4, tzinfo=pytz.UTC),
-            999999999,
-            '{"key":null}',
-            True,
-            Decimal("1300.33"),
-            Decimal("199.99"),
-            17678785.0,
-        ),
-    ]
+    async def test_incremental(
+        self,
+        team,
+        mssql_source_table: pymssql.Cursor,
+        external_data_source: ExternalDataSource,
+        external_data_schema_incremental: ExternalDataSchema,
+    ):
+        """Test that an incremental sync works as expected."""
+        table_name = f"mssql_{MSSQL_TABLE_NAME}"
+        expected_num_rows = len(TEST_DATA)
 
-    _insert_test_data(cursor=mssql_source_table, table_name=MSSQL_TABLE_NAME, data=NEW_TEST_DATA)
-    expected_total_num_rows = expected_num_rows + len(NEW_TEST_DATA)
+        res = await run_external_data_job_workflow(
+            team=team,
+            external_data_source=external_data_source,
+            external_data_schema=external_data_schema_incremental,
+            table_name=table_name,
+            expected_rows_synced=expected_num_rows,
+            expected_total_rows=expected_num_rows,
+            expected_columns=[
+                "uid",
+                "name",
+                "email",
+                "created_at",
+                "big_int",
+                "json_data",
+                "active",
+                "decimal_data",
+                "price",
+                "float_data",
+            ],
+        )
 
-    res = await run_external_data_job_workflow(
-        team=team,
-        external_data_source=external_data_source,
-        external_data_schema=external_data_schema_incremental_using_created_at_column,
-        table_name=table_name,
-        expected_rows_synced=len(NEW_TEST_DATA),
-        expected_total_rows=expected_total_num_rows,
-        expected_columns=[
-            "uid",
-            "name",
-            "email",
-            "created_at",
-            "big_int",
-            "json_data",
-            "active",
-            "decimal_data",
-            "price",
-            "float_data",
-        ],
-    )
+        assert list(res.results) == TEST_DATA
 
-    # Compare sorted results as rows may have been shuffled around, but we only care the data is there,
-    # not in which order.
-    assert sorted(res.results, key=operator.itemgetter(0)) == sorted(
-        TEST_DATA + NEW_TEST_DATA, key=operator.itemgetter(0)
-    )
+        # insert new data to be synced on next incremental run
+        NEW_TEST_DATA = [
+            (
+                4,
+                "Mo Doe",
+                "mo@example.com",
+                dt.datetime(2025, 1, 4, tzinfo=pytz.UTC),
+                999999999,
+                '{"key":null}',
+                True,
+                Decimal("1300.33"),
+                Decimal("199.99"),
+                17678785.0,
+            ),
+        ]
+
+        _insert_test_data(cursor=mssql_source_table, table_name=MSSQL_TABLE_NAME, data=NEW_TEST_DATA)
+        expected_total_num_rows = expected_num_rows + len(NEW_TEST_DATA)
+
+        res = await run_external_data_job_workflow(
+            team=team,
+            external_data_source=external_data_source,
+            external_data_schema=external_data_schema_incremental,
+            table_name=table_name,
+            expected_rows_synced=len(NEW_TEST_DATA),
+            expected_total_rows=expected_total_num_rows,
+            expected_columns=[
+                "uid",
+                "name",
+                "email",
+                "created_at",
+                "big_int",
+                "json_data",
+                "active",
+                "decimal_data",
+                "price",
+                "float_data",
+            ],
+        )
+
+        # Compare sorted results as rows may have been shuffled around, but we only care the data is there,
+        # not in which order.
+        assert sorted(res.results, key=operator.itemgetter(0)) == sorted(
+            TEST_DATA + NEW_TEST_DATA, key=operator.itemgetter(0)
+        )
+
+    async def test_incremental_using_created_at_column(
+        self,
+        team,
+        mssql_source_table: pymssql.Cursor,
+        external_data_source: ExternalDataSource,
+        external_data_schema_incremental_using_created_at_column: ExternalDataSchema,
+    ):
+        """Test that an incremental sync works as expected when using the `created_at` column as the incremental field."""
+        table_name = f"mssql_{MSSQL_TABLE_NAME}"
+        expected_num_rows = len(TEST_DATA)
+
+        res = await run_external_data_job_workflow(
+            team=team,
+            external_data_source=external_data_source,
+            external_data_schema=external_data_schema_incremental_using_created_at_column,
+            table_name=table_name,
+            expected_rows_synced=expected_num_rows,
+            expected_total_rows=expected_num_rows,
+            expected_columns=[
+                "uid",
+                "name",
+                "email",
+                "created_at",
+                "big_int",
+                "json_data",
+                "active",
+                "decimal_data",
+                "price",
+                "float_data",
+            ],
+        )
+
+        assert list(res.results) == TEST_DATA
+
+        # insert new data to be synced on next incremental run
+        NEW_TEST_DATA = [
+            (
+                4,
+                "Mo Doe",
+                "mo@example.com",
+                dt.datetime(2025, 1, 4, tzinfo=pytz.UTC),
+                999999999,
+                '{"key":null}',
+                True,
+                Decimal("1300.33"),
+                Decimal("199.99"),
+                17678785.0,
+            ),
+        ]
+
+        _insert_test_data(cursor=mssql_source_table, table_name=MSSQL_TABLE_NAME, data=NEW_TEST_DATA)
+        expected_total_num_rows = expected_num_rows + len(NEW_TEST_DATA)
+
+        res = await run_external_data_job_workflow(
+            team=team,
+            external_data_source=external_data_source,
+            external_data_schema=external_data_schema_incremental_using_created_at_column,
+            table_name=table_name,
+            expected_rows_synced=len(NEW_TEST_DATA),
+            expected_total_rows=expected_total_num_rows,
+            expected_columns=[
+                "uid",
+                "name",
+                "email",
+                "created_at",
+                "big_int",
+                "json_data",
+                "active",
+                "decimal_data",
+                "price",
+                "float_data",
+            ],
+        )
+
+        # Compare sorted results as rows may have been shuffled around, but we only care the data is there,
+        # not in which order.
+        assert sorted(res.results, key=operator.itemgetter(0)) == sorted(
+            TEST_DATA + NEW_TEST_DATA, key=operator.itemgetter(0)
+        )
 
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 @SKIP_IF_MISSING_MSSQL_CREDENTIALS
-async def test_mssql_get_table_average_row_size(
-    mssql_source_table: pymssql.Cursor,
-    mssql_config: dict[str, Any],
-):
-    """Test that the average row size is calculated correctly.
+class TestGetTableAverageRowSize:
+    async def test_get_table_average_row_size(
+        self,
+        mssql_source_table: pymssql.Cursor,
+        mssql_config: dict[str, Any],
+    ):
+        """Test that the average row size is calculated correctly.
 
-    Here we use a table with a variety of column types and data to ensure the queries to calculate the average row size
-    are correct.
-    We don't assert the average row size here as it's hard to determine and is likely to be flaky.  We do this instead
-    in another test below.
-    """
-    average_row_size = _get_table_average_row_size(
-        cursor=mssql_source_table,
-        schema=mssql_config["schema"],
-        table_name=MSSQL_TABLE_NAME,
-        is_incremental=False,
-        incremental_field=None,
-        incremental_field_type=None,
-        db_incremental_field_last_value=None,
-        logger=structlog.get_logger(),
-    )
+        Here we use a table with a variety of column types and data to ensure the queries to calculate the average row size
+        are correct.
+        We don't assert the average row size here as it's hard to determine and is likely to be flaky.  We do this instead
+        in another test below.
+        """
+        average_row_size = _get_table_average_row_size(
+            cursor=mssql_source_table,
+            schema=mssql_config["schema"],
+            table_name=MSSQL_TABLE_NAME,
+            is_incremental=False,
+            incremental_field=None,
+            incremental_field_type=None,
+            db_incremental_field_last_value=None,
+            logger=structlog.get_logger(),
+        )
 
-    # Just assert that we do calculate a value and don't return None
-    assert isinstance(average_row_size, int)
-    # sanity check that the average row size is not too big or too small
-    assert average_row_size > 0
-    assert average_row_size < 1000
+        # Just assert that we do calculate a value and don't return None
+        assert isinstance(average_row_size, int)
+        # sanity check that the average row size is not too big or too small
+        assert average_row_size > 0
+        assert average_row_size < 1000
 
+    async def test_get_table_average_row_size_with_incremental_field(
+        self,
+        mssql_source_table: pymssql.Cursor,
+        mssql_config: dict[str, Any],
+    ):
+        """Test that the average row size is calculated correctly for an incremental sync.
 
-@pytest.mark.django_db(transaction=True)
-@pytest.mark.asyncio
-@SKIP_IF_MISSING_MSSQL_CREDENTIALS
-async def test_mssql_get_table_average_row_size_with_incremental_field(
-    mssql_source_table: pymssql.Cursor,
-    mssql_config: dict[str, Any],
-):
-    """Test that the average row size is calculated correctly for an incremental sync.
+        Here we use a table with a variety of column types and data to ensure the queries to calculate the average row size
+        are correct.
+        We don't assert the average row size here as it's hard to determine and is likely to be flaky.  We do this instead
+        in another test below.
+        """
+        average_row_size = _get_table_average_row_size(
+            cursor=mssql_source_table,
+            schema=mssql_config["schema"],
+            table_name=MSSQL_TABLE_NAME,
+            is_incremental=True,
+            incremental_field="created_at",
+            incremental_field_type=IncrementalFieldType.DateTime,
+            db_incremental_field_last_value=None,
+            logger=structlog.get_logger(),
+        )
 
-    Here we use a table with a variety of column types and data to ensure the queries to calculate the average row size
-    are correct.
-    We don't assert the average row size here as it's hard to determine and is likely to be flaky.  We do this instead
-    in another test below.
-    """
-    average_row_size = _get_table_average_row_size(
-        cursor=mssql_source_table,
-        schema=mssql_config["schema"],
-        table_name=MSSQL_TABLE_NAME,
-        is_incremental=True,
-        incremental_field="created_at",
-        incremental_field_type=IncrementalFieldType.DateTime,
-        db_incremental_field_last_value=None,
-        logger=structlog.get_logger(),
-    )
+        # Just assert that we do calculate a value and don't return None
+        assert isinstance(average_row_size, int)
+        # sanity check that the average row size is not too big or too small
+        assert average_row_size > 0
+        assert average_row_size < 1000
 
-    # Just assert that we do calculate a value and don't return None
-    assert isinstance(average_row_size, int)
-    # sanity check that the average row size is not too big or too small
-    assert average_row_size > 0
-    assert average_row_size < 1000
+    @pytest.fixture
+    def mssql_source_table_known_row_size(
+        self,
+        mssql_connection: pymssql.Connection,
+        mssql_config: dict[str, Any],
+    ) -> Generator[pymssql.Cursor, None, None]:
+        """Create a MS SQL Server table with deterministic row size and clean it up after the test."""
+        with mssql_connection.cursor() as cursor:
+            full_table_name = f"[{mssql_config['schema']}].[{MSSQL_TABLE_NAME}]"
 
-
-@pytest.fixture
-def mssql_source_table_known_row_size(
-    mssql_connection: pymssql.Connection, mssql_config: dict[str, Any]
-) -> Generator[pymssql.Cursor, None, None]:
-    """Create a MS SQL Server table with deterministic row size and clean it up after the test."""
-    with mssql_connection.cursor() as cursor:
-        full_table_name = f"[{mssql_config['schema']}].[{MSSQL_TABLE_NAME}]"
-
-        try:
-            # Create test table
-            cursor.execute(f"""
-                IF NOT EXISTS (
-                    SELECT *
-                    FROM sys.tables t
-                    JOIN sys.schemas s ON t.schema_id = s.schema_id
-                    WHERE s.name = '{mssql_config['schema']}'
-                    AND t.name = '{MSSQL_TABLE_NAME}'
-                )
-                BEGIN
-                    CREATE TABLE {full_table_name} (
-                        name NVARCHAR(255)
+            try:
+                # Create test table
+                cursor.execute(f"""
+                    IF NOT EXISTS (
+                        SELECT *
+                        FROM sys.tables t
+                        JOIN sys.schemas s ON t.schema_id = s.schema_id
+                        WHERE s.name = '{mssql_config['schema']}'
+                        AND t.name = '{MSSQL_TABLE_NAME}'
                     )
-                END
-            """)
-            mssql_connection.commit()
+                    BEGIN
+                        CREATE TABLE {full_table_name} (
+                            name NVARCHAR(255)
+                        )
+                    END
+                """)
+                mssql_connection.commit()
 
-            # Insert test data
-            data = [
-                ("0123456789",),
-                ("acbcdefghi",),
-                ("9876543210",),
-            ]
-            for row in data:
-                cursor.execute(
-                    f"INSERT INTO {full_table_name} (name) VALUES (%s)",
-                    row,
-                )
-            cursor.connection.commit()
+                # Insert test data
+                data = [
+                    ("0123456789",),
+                    ("acbcdefghi",),
+                    ("9876543210",),
+                ]
+                for row in data:
+                    cursor.execute(
+                        f"INSERT INTO {full_table_name} (name) VALUES (%s)",
+                        row,
+                    )
+                cursor.connection.commit()
 
-            yield cursor
+                yield cursor
 
-        finally:
-            # Cleanup
-            cursor.execute(f"DROP TABLE IF EXISTS {full_table_name}")
-            mssql_connection.commit()
+            finally:
+                # Cleanup
+                cursor.execute(f"DROP TABLE IF EXISTS {full_table_name}")
+                mssql_connection.commit()
+
+    async def test_get_table_average_row_size_calculates_correct_average_row_size(
+        self,
+        mssql_source_table_known_row_size: pymssql.Cursor,
+        mssql_config: dict[str, Any],
+    ):
+        """Test that the average row size is calculated correctly.
+
+        To do this, we test using a table with a known row size so we can assert the average row size is correct.
+        """
+        average_row_size = _get_table_average_row_size(
+            cursor=mssql_source_table_known_row_size,
+            schema=mssql_config["schema"],
+            table_name=MSSQL_TABLE_NAME,
+            is_incremental=False,
+            incremental_field=None,
+            incremental_field_type=None,
+            db_incremental_field_last_value=None,
+            logger=structlog.get_logger(),
+        )
+
+        # each character in column uses 2 bytes
+        assert average_row_size == 20
 
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 @SKIP_IF_MISSING_MSSQL_CREDENTIALS
-async def test_mssql_get_table_average_row_size_calculates_correct_average_row_size(
-    mssql_source_table_known_row_size: pymssql.Cursor,
-    mssql_config: dict[str, Any],
-):
-    """Test that the average row size is calculated correctly.
+class TestGetTableStats:
+    @pytest.fixture
+    def mssql_small_table(
+        self,
+        mssql_connection: pymssql.Connection,
+        mssql_config: dict[str, Any],
+    ) -> Generator[pymssql.Cursor, None, None]:
+        """Create a small test table with known size and row count."""
+        with mssql_connection.cursor() as cursor:
+            full_table_name = f"[{mssql_config['schema']}].[test_small]"
 
-    To do this, we test using a table with a known row size so we can assert the average row size is correct.
-    """
-    average_row_size = _get_table_average_row_size(
-        cursor=mssql_source_table_known_row_size,
-        schema=mssql_config["schema"],
-        table_name=MSSQL_TABLE_NAME,
-        is_incremental=False,
-        incremental_field=None,
-        incremental_field_type=None,
-        db_incremental_field_last_value=None,
-        logger=structlog.get_logger(),
-    )
+            try:
+                # Create test table
+                cursor.execute(f"""
+                    IF NOT EXISTS (
+                        SELECT *
+                        FROM sys.tables t
+                        JOIN sys.schemas s ON t.schema_id = s.schema_id
+                        WHERE s.name = '{mssql_config['schema']}'
+                        AND t.name = 'test_small'
+                    )
+                    BEGIN
+                        CREATE TABLE {full_table_name} (
+                            id INT IDENTITY(1,1) PRIMARY KEY,
+                            value INT
+                        )
+                    END
+                """)
+                mssql_connection.commit()
 
-    # each character in column uses 2 bytes
-    assert average_row_size == 20
+                # Insert exactly 1000 rows with small integers
+                cursor.execute(f"""
+                    WITH numbers AS (
+                        SELECT 1 as n
+                        UNION ALL
+                        SELECT n + 1
+                        FROM numbers
+                        WHERE n < 1000
+                    )
+                    INSERT INTO {full_table_name} (value)
+                    SELECT n FROM numbers
+                    OPTION (MAXRECURSION 1000)
+                """)
+                mssql_connection.commit()
+
+                yield cursor
+
+            finally:
+                # Cleanup
+                cursor.execute(f"DROP TABLE IF EXISTS {full_table_name}")
+                mssql_connection.commit()
+
+    @pytest.fixture
+    def mssql_empty_table(
+        self,
+        mssql_connection: pymssql.Connection,
+        mssql_config: dict[str, Any],
+    ) -> Generator[pymssql.Cursor, None, None]:
+        """Create an empty test table."""
+        with mssql_connection.cursor() as cursor:
+            full_table_name = f"[{mssql_config['schema']}].[test_empty]"
+
+            try:
+                # Create test table but don't insert any rows
+                cursor.execute(f"""
+                    IF NOT EXISTS (
+                        SELECT *
+                        FROM sys.tables t
+                        JOIN sys.schemas s ON t.schema_id = s.schema_id
+                        WHERE s.name = '{mssql_config['schema']}'
+                        AND t.name = 'test_empty'
+                    )
+                    BEGIN
+                        CREATE TABLE {full_table_name} (
+                            id INT IDENTITY(1,1) PRIMARY KEY,
+                            value INT
+                        )
+                    END
+                """)
+                mssql_connection.commit()
+
+                yield cursor
+
+            finally:
+                # Cleanup
+                cursor.execute(f"DROP TABLE IF EXISTS {full_table_name}")
+                mssql_connection.commit()
+
+    async def test_get_table_stats(
+        self,
+        mssql_small_table: pymssql.Cursor,
+        mssql_config: dict[str, Any],
+    ):
+        """Test that table stats are calculated correctly.
+
+        We test using a table with exactly 1000 rows of small integers,
+        so we can make some assertions about the size and row count.
+        """
+        total_rows, total_bytes = _get_table_stats(
+            cursor=mssql_small_table,
+            schema=mssql_config["schema"],
+            table_name="test_small",
+        )
+
+        assert total_rows == 1000  # We inserted exactly 1000 rows
+        # Size should be around 32KB
+        assert total_bytes > 30 * 1024
+        assert total_bytes < 34 * 1024
+
+    async def test_get_table_stats_empty_table(
+        self,
+        mssql_empty_table: pymssql.Cursor,
+        mssql_config: dict[str, Any],
+    ):
+        """Test that table stats work correctly with an empty table.
+
+        An empty table should return 0 rows and 0 bytes.
+        """
+        total_rows, total_bytes = _get_table_stats(
+            cursor=mssql_empty_table,
+            schema=mssql_config["schema"],
+            table_name="test_empty",
+        )
+
+        assert total_rows == 0
+        assert total_bytes == 0


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We don't current partition data for MS SQL.

## Changes

- Implement partitioning like we do for other SQL sources.
- Reorganised existing tests into classes to make them easier to follow.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added new tests
