### PR TITLE
chore(tag-materialization): Tag a materialization request in clickhouse

### DIFF
--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -492,6 +492,7 @@ def hogql_table(query: str, team: Team, table_name: str, table_columns: dlt_typi
             max_execution_time=60 * 20, max_memory_usage=180 * 1000 * 1000 * 1000
         )  # 20 mins, 180gb, 2x execution_time, 4x max_memory_usage as the /query endpoint async workers
 
+        # Pass the query_type parameter to influence tags in a thread safe way
         response = await asyncio.to_thread(
             execute_hogql_query,
             query,
@@ -499,6 +500,7 @@ def hogql_table(query: str, team: Team, table_name: str, table_columns: dlt_typi
             settings=settings,
             limit_context=LimitContext.SAVED_QUERY,
             workload=Workload.OFFLINE,
+            query_type="materialization",
         )
 
         if not response.columns:


### PR DESCRIPTION
## Problem
We with to annotate these queries some that we can aggregate them to determine cost metrics.

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Materialization runs as it did before