### PR TITLE
feat(ingestion): size measurement for fetchPerson properties blobs

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -233,6 +233,9 @@ export function getDefaultConfig(): PluginsServerConfig {
         PROPERTY_DEFS_CONSUMER_ENABLED_TEAMS: isDevEnv() ? '*' : '',
         PROPERTY_DEFS_WRITE_DISABLED: isProdEnv() ? true : false, // For now we don't want to do writes on prod - only count them
 
+        // temporary: enable, rate limit expensive measurement in persons processing; value in [0,1]
+        PERSON_JSONB_SIZE_ESTIMATE_ENABLE: 0, // defaults to off
+
         // Session recording V2
         SESSION_RECORDING_MAX_BATCH_SIZE_KB: 100 * 1024, // 100MB
         SESSION_RECORDING_MAX_BATCH_AGE_MS: 10 * 1000, // 10 seconds

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -349,8 +349,8 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
 
     CDP_HOG_WATCHER_SAMPLE_RATE: number
 
-    // for enablement/sampling of expensive person JSONB sizes; value in [0, 1.0]
-    PERSON_JSONB_SIZE_ESTIMATE: number
+    // for enablement/sampling of expensive person JSONB sizes; value in [0,1]
+    PERSON_JSONB_SIZE_ESTIMATE_ENABLE: number
 }
 
 export interface Hub extends PluginsServerConfig {

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -348,6 +348,9 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
     PROPERTY_DEFS_WRITE_DISABLED: boolean
 
     CDP_HOG_WATCHER_SAMPLE_RATE: number
+
+    // for enablement/sampling of expensive person JSONB sizes; value in [0, 1.0]
+    PERSON_JSONB_SIZE_ESTIMATE: number
 }
 
 export interface Hub extends PluginsServerConfig {

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -524,7 +524,9 @@ export class DB {
             'personPropertiesSize'
         )
 
-        if (rows.length > 0) {
+        // the returned value from the DB query can be NULL if the record
+        // specified by the team and distinct ID inputs doesn't exist
+        if (rows.length > 0 && typeof rows[0].total_props_bytes === 'number') {
             return rows[0].total_props_bytes
         }
 

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -544,16 +544,12 @@ export class DB {
             'fetchPerson'
         )
 
-        // this may need to be sampled to not add drag to fetchPerson exec times.
-        // the row deserialization drills down into the client library, but we could
-        // implement RawPerson hydration here if we query for rows of a more basic type
         if (rows.length > 0) {
-            // recursively estimate the properties Record<string, any> size.
-            // expensive, but hopefully cheaper than JSON.stringify + length check
+            // estimate size of person properties blob fetched from DB
             const estimatedPropsBytes = this.estimateObjectSize(rows[0].properties || {})
             fetchPersonPropsSize.observe(estimatedPropsBytes)
 
-            // if larger than some arbitrary threshold (start conservative, adjust as we observe)
+            // if larger than size threshold (start conservative, adjust as we observe)
             // we should log the team and disinct_id associated with the properties
             if (estimatedPropsBytes >= EIGHT_MEGABYTE_PROPS_BLOB) {
                 logger.warn('⚠️', 'fetchPerson: large properties record detected', {
@@ -567,6 +563,8 @@ export class DB {
         }
     }
 
+    // recursively estimate the properties Record<string, any> size.
+    // hopefully cheaper than JSON.stringify + length check
     private estimateObjectSize(obj: Record<string, any>): number {
         let totalBytes = 0
 

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -526,7 +526,7 @@ export class DB {
 
         // the returned value from the DB query can be NULL if the record
         // specified by the team and distinct ID inputs doesn't exist
-        if (rows.length > 0 && typeof rows[0].total_props_bytes === 'number') {
+        if (rows.length > 0) {
             return rows[0].total_props_bytes
         }
 

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -508,7 +508,7 @@ export class DB {
         const queryString = `
             SELECT (octet_length(properties)::bigint +
                 octet_length(properties_last_updated_at)::bigint +
-                octet_length(properties_last_operation)::bigint) AS total_props_bytes::bigint
+                octet_length(properties_last_operation)::bigint) AS total_props_bytes
             FROM posthog_person
             JOIN posthog_persondistinctid ON (posthog_persondistinctid.person_id = posthog_person.id)
             WHERE

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -508,7 +508,7 @@ export class DB {
         const queryString = `
             SELECT (COALESCE(octet_length(properties::text)::bigint, 0::bigint) +
                 COALESCE(octet_length(properties_last_updated_at::text)::bigint, 0::bigint) +
-                COALESCE(octet_length(properties_last_operation::text)::bigint, 0::bigint) AS total_props_bytes
+                COALESCE(octet_length(properties_last_operation::text)::bigint, 0::bigint)) AS total_props_bytes
             FROM posthog_person
             JOIN posthog_persondistinctid ON (posthog_persondistinctid.person_id = posthog_person.id)
             WHERE

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -564,7 +564,6 @@ export class DB {
         }
         const values = [teamId, distinctId]
 
-        // very rough estimate of heapUsed change before and after fetchPerson query
         const { rows } = await this.postgres.query<RawPerson>(
             options.useReadReplica ? PostgresUse.COMMON_READ : PostgresUse.COMMON_WRITE,
             queryString,

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -499,10 +499,7 @@ export class DB {
         }
     }
 
-    // temporary: used to estimate large person properties JSONB blob sizes for measurement.
-    // NOTE - to avoid deserializing all TOAST objects on the DB size, we tolerate compressed
-    // sizes here. The result should still provide a good estimate of outliers we encounter
-    // if outlier size is contributing to the DB read I/O load we have observed w/fetchPerson
+    // temporary: measure person record JSONB blob sizes
     public async personPropertiesSize(teamId: number, distinctId: string): Promise<number> {
         const values = [teamId, distinctId]
         const queryString = `

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -521,7 +521,7 @@ export class DB {
             PostgresUse.COMMON_READ,
             queryString,
             values,
-            'fetchPerson'
+            'personPropertiesSize'
         )
 
         if (rows.length > 0) {

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -506,9 +506,9 @@ export class DB {
     public async personPropertiesSize(teamId: number, distinctId: string): Promise<number> {
         const values = [teamId, distinctId]
         const queryString = `
-            SELECT (octet_length(properties)::bigint +
-                octet_length(properties_last_updated_at)::bigint +
-                octet_length(properties_last_operation)::bigint) AS total_props_bytes
+            SELECT (octet_length(properties::text)::bigint +
+                octet_length(properties_last_updated_at::text)::bigint +
+                octet_length(properties_last_operation::text)::bigint) AS total_props_bytes
             FROM posthog_person
             JOIN posthog_persondistinctid ON (posthog_persondistinctid.person_id = posthog_person.id)
             WHERE

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -506,9 +506,9 @@ export class DB {
     public async personPropertiesSize(teamId: number, distinctId: string): Promise<number> {
         const values = [teamId, distinctId]
         const queryString = `
-            SELECT (octet_length(properties::text)::bigint +
-                octet_length(properties_last_updated_at::text)::bigint +
-                octet_length(properties_last_operation::text)::bigint) AS total_props_bytes
+            SELECT (COALESCE(octet_length(properties::text)::bigint, 0::bigint) +
+                COALESCE(octet_length(properties_last_updated_at::text)::bigint, 0::bigint) +
+                COALESCE(octet_length(properties_last_operation::text)::bigint, 0::bigint) AS total_props_bytes
             FROM posthog_person
             JOIN posthog_persondistinctid ON (posthog_persondistinctid.person_id = posthog_person.id)
             WHERE

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -527,7 +527,7 @@ export class DB {
         // the returned value from the DB query can be NULL if the record
         // specified by the team and distinct ID inputs doesn't exist
         if (rows.length > 0) {
-            return rows[0].total_props_bytes
+            return Number(rows[0].total_props_bytes)
         }
 
         return 0

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -516,7 +516,6 @@ export class DB {
                 AND posthog_persondistinctid.team_id = $1
                 AND posthog_persondistinctid.distinct_id = $2`
 
-        // very rough estimate of heapUsed change before and after fetchPerson query
         const { rows } = await this.postgres.query<PersonPropertiesSize>(
             PostgresUse.COMMON_READ,
             queryString,

--- a/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
@@ -11,7 +11,8 @@ export async function processPersonsStep(
     event: PluginEvent,
     team: Team,
     timestamp: DateTime,
-    processPerson: boolean
+    processPerson: boolean,
+    measurePersonJsonbSize: number = 0
 ): Promise<[PluginEvent, Person, Promise<void>]> {
     const [person, kafkaAck] = await new PersonState(
         event,
@@ -19,7 +20,8 @@ export async function processPersonsStep(
         String(event.distinct_id),
         timestamp,
         processPerson,
-        runner.hub.db
+        runner.hub.db,
+        measurePersonJsonbSize
     ).update()
 
     return [event, person, kafkaAck]

--- a/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
@@ -11,8 +11,7 @@ export async function processPersonsStep(
     event: PluginEvent,
     team: Team,
     timestamp: DateTime,
-    processPerson: boolean,
-    measurePersonJsonbSize: number = 0
+    processPerson: boolean
 ): Promise<[PluginEvent, Person, Promise<void>]> {
     const [person, kafkaAck] = await new PersonState(
         event,
@@ -21,7 +20,7 @@ export async function processPersonsStep(
         timestamp,
         processPerson,
         runner.hub.db,
-        measurePersonJsonbSize
+        runner.hub.PERSON_JSONB_SIZE_ESTIMATE_ENABLE
     ).update()
 
     return [event, person, kafkaAck]

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -268,7 +268,7 @@ export class EventPipelineRunner {
 
         const [postPersonEvent, person, personKafkaAck] = await this.runStep(
             processPersonsStep,
-            [this, normalizedEvent, team, timestamp, processPerson],
+            [this, normalizedEvent, team, timestamp, processPerson, this.hub.PERSON_JSONB_SIZE_ESTIMATE],
             event.team_id
         )
         kafkaAcks.push(personKafkaAck)

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -268,7 +268,7 @@ export class EventPipelineRunner {
 
         const [postPersonEvent, person, personKafkaAck] = await this.runStep(
             processPersonsStep,
-            [this, normalizedEvent, team, timestamp, processPerson, this.hub.PERSON_JSONB_SIZE_ESTIMATE_ENABLE],
+            [this, normalizedEvent, team, timestamp, processPerson],
             event.team_id
         )
         kafkaAcks.push(personKafkaAck)

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -268,7 +268,7 @@ export class EventPipelineRunner {
 
         const [postPersonEvent, person, personKafkaAck] = await this.runStep(
             processPersonsStep,
-            [this, normalizedEvent, team, timestamp, processPerson, this.hub.PERSON_JSONB_SIZE_ESTIMATE],
+            [this, normalizedEvent, team, timestamp, processPerson, this.hub.PERSON_JSONB_SIZE_ESTIMATE_ENABLE],
             event.team_id
         )
         kafkaAcks.push(personKafkaAck)

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -120,7 +120,7 @@ export class PersonState {
         private timestamp: DateTime,
         private processPerson: boolean, // $process_person_profile flag from the event
         private db: DB,
-        private measurePersonJsonbSize: number = 0 // value in [0, 1] controls enablement/rate of expensive measurement
+        private measurePersonJsonbSize: number
     ) {
         this.eventProperties = event.properties!
 

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -129,7 +129,7 @@ export class PersonState {
 
     // note: this captures compressed sizes for JSONB blobs due to TOAST on DB
     private async capturePersonPropertiesSizeEstimate() {
-        const estimatedBytes = await this.db.personPropertiesSize(this.team.id, this.distinctId)
+        const estimatedBytes: number = await this.db.personPropertiesSize(this.team.id, this.distinctId)
         personPropertiesSize.observe(estimatedBytes)
 
         // if larger than size threshold (start conservative, adjust as we observe)

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -44,8 +44,8 @@ const personPropertiesSize = new Histogram({
     name: 'person_properties_size',
     help: 'histogram of compressed person JSONB bytes retrieved in fetchPerson calls',
     labelNames: ['at'],
-    // 1kb, 8kb, 64kb, 512kb, 1mb, 2mb, 4mb, 8mb, 16mb, 64mb
-    buckets: [1024, 8192, 65536, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 67108864],
+    // 1kb, 8kb, 64kb, 512kb, 1mb, 2mb, 4mb, 8mb, 16mb, 64mb, inf+
+    buckets: [1024, 8192, 65536, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 67108864, Infinity],
 })
 
 // used to prevent identify from being used with generic IDs

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -86,7 +86,8 @@ describe('PersonState.update()', () => {
             event.distinct_id!,
             timestampParam,
             processPerson,
-            customHub ? customHub.db : hub.db
+            customHub ? customHub.db : hub.db,
+            0
         )
     }
 


### PR DESCRIPTION
## Problem
We'd like to get a histogram into Grafana to track the `properties` JSONB sizes coming back from `fetchPerson` calls during person processing, as well as some annotated logging for sufficiently large outlier blobs including team and distinct_id metadata.

## Changes
* Adds read-only DB query for combined `octet_length` of all JSONB cols on person rows
* Adds histogram capture and annotated logging to the most suspect `fetchPerson` codepaths

I iterated to this alternative, hopefully gets us close to minimizing performance hit on this hot codepath vs. an accurate measurement of the data we're moving around in persons processing.

There's potential caveat - we have to apply a `::text` conversion in `octet_length` calls on JSONB fields which will result in more accurate sizing of `TOAST`-compressed columns but will also increase resource util on the DB. I'm adding an env flag we can use to ramp this up/down in case it causes trouble on deploy.

I also left off the key-cardinality measurement for now, for reasons discussed at the team sync:
* May be a red herring vs. props blob size since we cap props-per-event to 10k
* Since we cap Kafka event msg size as well, it's likely the outliers we'll find with size checks are person profiles accumulating new props over many events in order to bloat out the DB records

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally and in CI