### PR TITLE
fix: survey summarize responses with new query format

### DIFF
--- a/ee/surveys/summaries/summarize_surveys.py
+++ b/ee/surveys/summaries/summarize_surveys.py
@@ -1,5 +1,3 @@
-import json
-
 import openai
 
 from datetime import datetime
@@ -8,7 +6,6 @@ from typing import Optional, cast
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_select
 from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
-from posthog.schema import HogQLQueryResponse
 from posthog.utils import get_instance_region
 
 from prometheus_client import Histogram
@@ -49,16 +46,14 @@ TOKENS_IN_PROMPT_HISTOGRAM = Histogram(
 )
 
 
-def prepare_data(query_response: HogQLQueryResponse) -> list[str]:
-    response_values = []
-    properties_list: list[dict] = [json.loads(x[1]) for x in query_response.results]
-    for props in properties_list:
-        response_values.extend([value for key, value in props.items() if key.startswith("$survey_response") and value])
-    return response_values
-
-
 def summarize_survey_responses(
-    survey_id: str, question_index: Optional[int], survey_start: datetime, survey_end: datetime, team: Team, user: User
+    survey_id: str,
+    question_index: Optional[int],
+    question_id: Optional[str],
+    survey_start: datetime,
+    survey_end: datetime,
+    team: Team,
+    user: User,
 ):
     timer = ServerTimingsGathered()
 
@@ -66,12 +61,11 @@ def summarize_survey_responses(
         paginator = HogQLHasMorePaginator(limit=100, offset=0)
         q = parse_select(
             """
-            SELECT distinct_id, properties
+            SELECT getSurveyResponse({question_index}, {question_id})
             FROM events
             WHERE event == 'survey sent'
                 AND properties.$survey_id = {survey_id}
-                -- e.g. `$survey_response` or `$survey_response_2`
-                AND trim(JSONExtractString(properties, {survey_response_property})) != ''
+                AND trim(getSurveyResponse({question_index}, {question_id})) != ''
                 AND timestamp >= {start_date}
                 AND timestamp <= {end_date}
             """,
@@ -82,6 +76,8 @@ def summarize_survey_responses(
                 ),
                 "start_date": ast.Constant(value=survey_start),
                 "end_date": ast.Constant(value=survey_end),
+                "question_index": ast.Constant(value=question_index),
+                "question_id": ast.Constant(value=question_id),
             },
         )
 
@@ -94,7 +90,7 @@ def summarize_survey_responses(
 
     with timer("llm_api_prep"):
         instance_region = get_instance_region() or "HOBBY"
-        prepared_data = prepare_data(query_response)
+        prepared_data = [x[0] for x in query_response.results if x[0]]
 
     with timer("openai_completion"):
         result = openai.chat.completions.create(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2664,12 +2664,21 @@ const api = {
         async getResponsesCount(): Promise<{ [key: string]: number }> {
             return await new ApiRequest().surveysResponsesCount().get()
         },
-        async summarize_responses(surveyId: Survey['id'], questionIndex: number | undefined): Promise<any> {
-            let apiRequest = new ApiRequest().survey(surveyId).withAction('summarize_responses')
+        async summarize_responses(
+            surveyId: Survey['id'],
+            questionIndex: number | undefined,
+            questionId: string | undefined
+        ): Promise<any> {
+            const apiRequest = new ApiRequest().survey(surveyId).withAction('summarize_responses')
+            const queryParams: Record<string, string> = {}
+
             if (questionIndex !== undefined) {
-                apiRequest = apiRequest.withQueryString('questionIndex=' + questionIndex)
+                queryParams['question_index'] = questionIndex.toString()
             }
-            return await apiRequest.create()
+            if (questionId !== undefined) {
+                queryParams['question_id'] = questionId
+            }
+            return await apiRequest.withQueryString(queryParams).create()
         },
         async getSurveyStats({
             surveyId,

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -258,8 +258,8 @@ export const surveyLogic = kea<surveyLogicType>([
     }),
     loaders(({ props, actions, values }) => ({
         responseSummary: {
-            summarize: async ({ questionIndex }: { questionIndex?: number }) => {
-                return api.surveys.summarize_responses(props.id, questionIndex)
+            summarize: async ({ questionIndex, questionId }: { questionIndex?: number; questionId?: string }) => {
+                return api.surveys.summarize_responses(props.id, questionIndex, questionId)
             },
         },
         survey: {

--- a/frontend/src/scenes/surveys/surveyViewViz.tsx
+++ b/frontend/src/scenes/surveys/surveyViewViz.tsx
@@ -475,7 +475,7 @@ export function OpenTextViz({
                                 <IconInfo className="text-lg text-secondary shrink-0 ml-0.5 mt-0.5" />
                             </div>
                         </Tooltip>
-                        <ResponseSummariesButton questionIndex={questionIndex} />
+                        <ResponseSummariesButton questionIndex={questionIndex} questionId={question.id} />
                     </div>
                     <div className="text-xl font-bold mb-4">{question.question}</div>
                     <ResponseSummariesDisplay />
@@ -516,14 +516,20 @@ export function OpenTextViz({
     )
 }
 
-function ResponseSummariesButton({ questionIndex }: { questionIndex: number | undefined }): JSX.Element {
+function ResponseSummariesButton({
+    questionIndex,
+    questionId,
+}: {
+    questionIndex: number | undefined
+    questionId: string | undefined
+}): JSX.Element {
     const { summarize } = useActions(surveyLogic)
     const { responseSummary, responseSummaryLoading } = useValues(surveyLogic)
     const { dataProcessingAccepted, dataProcessingApprovalDisabledReason } = useValues(maxGlobalLogic)
     const [showConsentPopover, setShowConsentPopover] = useState(false)
 
     const summarizeQuestion = (): void => {
-        summarize({ questionIndex })
+        summarize({ questionIndex, questionId })
     }
 
     const handleSummarizeClick = (): void => {

--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -1153,9 +1153,19 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         except (ValueError, TypeError):
             question_index = None
 
+        try:
+            question_id_param = request.query_params.get("question_id", None)
+            question_id = question_id_param if question_id_param else None
+        except (ValueError, TypeError):
+            question_id = None
+
+        if question_index is None and question_id is None:
+            raise exceptions.ValidationError("question_index or question_id is required")
+
         summary = summarize_survey_responses(
             survey_id=survey_id,
             question_index=question_index,
+            question_id=question_id,
             survey_start=(survey.start_date or survey.created_at).replace(hour=0, minute=0, second=0, microsecond=0),
             survey_end=end_date,
             team=self.team,

--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -1155,9 +1155,7 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         try:
             question_id_param = request.query_params.get("question_id", None)
-            question_id = question_id_param if question_id_param else None
-        except (ValueError, TypeError):
-            question_id = None
+        question_id = question_id_param if question_id_param else None
 
         if question_index is None and question_id is None:
             raise exceptions.ValidationError("question_index or question_id is required")

--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -1153,9 +1153,7 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         except (ValueError, TypeError):
             question_index = None
 
-        try:
-            question_id_param = request.query_params.get("question_id", None)
-        question_id = question_id_param if question_id_param else None
+        question_id = request.query_params.get("question_id", None)
 
         if question_index is None and question_id is None:
             raise exceptions.ValidationError("question_index or question_id is required")


### PR DESCRIPTION
uses the new `getSurveyResponse` for the AI summarizer for open questions in surveys

## How did you test this code?

tested locally and checked if feature is still working as expected. no functional changes