### PR TITLE
feat: toolbox - add k8s context switching

### DIFF
--- a/infra-scripts/clitools/run_tests.sh
+++ b/infra-scripts/clitools/run_tests.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
 # Run the tests
-python3 -m unittest test_toolbox.py -v 
+# Get directory of this script
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR"
+python3 -m unittest test_toolbox.py -v

--- a/infra-scripts/clitools/test_toolbox.py
+++ b/infra-scripts/clitools/test_toolbox.py
@@ -421,9 +421,8 @@ class TestToolbox(unittest.TestCase):
 
     @patch("toolbox.kubernetes.get_available_contexts")
     @patch("toolbox.kubernetes.get_current_context")
-    @patch("toolbox.kubernetes.switch_context")
     @patch("builtins.input")
-    def test_select_context(self, mock_input, mock_switch, mock_get_current, mock_get_available):
+    def test_select_context(self, mock_input, mock_get_current, mock_get_available):
         """Test selecting kubernetes context."""
         # Setup mocks
         mock_get_available.return_value = ["context1", "context2", "context3"]
@@ -438,7 +437,15 @@ class TestToolbox(unittest.TestCase):
         mock_get_available.assert_called_once()
         mock_get_current.assert_called_once()
         mock_input.assert_called_once()
-        mock_switch.assert_not_called()  # No switch should happen
+
+    @patch("toolbox.kubernetes.get_available_contexts")
+    @patch("toolbox.kubernetes.get_current_context")
+    def test_select_context_current_none(self, mock_get_current, mock_get_available):
+        """Test select_context exits if current context is None."""
+        mock_get_available.return_value = ["context1", "context2"]
+        mock_get_current.return_value = None
+        with self.assertRaises(SystemExit):
+            select_context()
 
 
 if __name__ == "__main__":

--- a/infra-scripts/clitools/toolbox.py
+++ b/infra-scripts/clitools/toolbox.py
@@ -1,271 +1,24 @@
 #!/usr/bin/env python3
+"""
+Toolbox command for connecting to PostHog toolbox pods in a Kubernetes environment.
+"""
 
-import subprocess
-import json
-from datetime import datetime, timedelta
 import sys
+import os
 import argparse
-import time
+from datetime import datetime, timedelta
 
+# Add the current directory to the path to allow importing from the toolbox package
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-def get_current_user() -> dict:
-    """Get user identity from kubectl auth and parse it into labels."""
-    try:
-        print("Attempting to get user identity...")  # noqa: T201
-        whoami = subprocess.run(["kubectl", "auth", "whoami", "-o", "json"], capture_output=True, text=True, check=True)
-
-        user_info = json.loads(whoami.stdout)
-        user_info = user_info["status"]["userInfo"]  # Navigate to the correct nesting level
-
-        # First try to get the ARN from the extra info
-        if "extra" in user_info and "arn" in user_info["extra"]:
-            return parse_arn(user_info["extra"]["arn"][0])  # The ARN is in a list
-
-        # Fallback to sessionName if available
-        if "extra" in user_info and "sessionName" in user_info["extra"]:
-            return {"toolbox-claimed": sanitize_label(user_info["extra"]["sessionName"][0])}
-
-        # Final fallback to username
-        return {"toolbox-claimed": sanitize_label(f"k8s-user/{user_info['username']}")}
-
-    except subprocess.CalledProcessError as e:
-        print(f"Command failed with return code {e.returncode}")  # noqa: T201
-        print(f"Output: {e.output}")  # noqa: T201
-        print(f"Stderr: {e.stderr}")  # noqa: T201
-        sys.exit(1)
-    except Exception as k8s_error:
-        print(f"Error: Failed to get user identity: {k8s_error}")  # noqa: T201
-        print(f"Error type: {type(k8s_error)}")  # noqa: T201
-        sys.exit(1)
-
-
-def get_toolbox_pod(user: str, check_claimed: bool = True) -> tuple[str, bool]:
-    """Get an available toolbox pod name.
-
-    Args:
-        user: Current user ARN
-        check_claimed: If True, first look for pods already claimed by the user
-
-    Returns:
-        Tuple of (pod_name, is_already_claimed)
-    """
-    wait_start = datetime.now()
-    max_wait = timedelta(minutes=5)
-    update_interval = timedelta(seconds=30)
-    next_update = wait_start
-
-    while True:
-        try:
-            result = subprocess.run(
-                [
-                    "kubectl",
-                    "get",
-                    "pods",
-                    "-n",
-                    "posthog",
-                    "-l",
-                    "app.kubernetes.io/name=posthog-toolbox-django",
-                    "-o",
-                    "json",
-                ],
-                capture_output=True,
-                text=True,
-                check=True,
-            )
-            pods = json.loads(result.stdout)["items"]
-
-            if check_claimed:
-                # Get user ID from ARN and sanitize it
-                user_id = sanitize_label(user.split("/")[-1] if "/" in user else user)
-                # First look for pods already claimed by this user
-                claimed_pods = [
-                    pod["metadata"]["name"]
-                    for pod in pods
-                    if pod["status"]["phase"] == "Running"
-                    and pod.get("metadata", {}).get("labels", {}).get("toolbox-claimed") == user_id
-                    and not pod.get("metadata", {}).get("deletionTimestamp")
-                ]
-
-                if claimed_pods:
-                    print("⚠️  Found pod already claimed by you")  # noqa: T201
-                    return claimed_pods[0], True
-                print("No pods currently claimed by you, looking for available pods...")  # noqa: T201
-
-            # Look for unclaimed pods
-            available_pods = [
-                pod["metadata"]["name"]
-                for pod in pods
-                if pod["status"]["phase"] in ("Running", "Pending")
-                and "toolbox-claimed" not in pod.get("metadata", {}).get("labels", {})
-                and "terminate-after" not in pod.get("metadata", {}).get("labels", {})
-                and not pod.get("metadata", {}).get("deletionTimestamp")
-            ]
-
-            if available_pods:
-                return available_pods[0], False
-
-            # No pods available, check if we should wait or timeout
-            current_time = datetime.now()
-            if current_time - wait_start > max_wait:
-                print("\n❌ No pods became available after 5 minutes.")  # noqa: T201
-                print("Please reach out to #team-infrastructure for assistance.")  # noqa: T201
-                sys.exit(1)
-
-            # Check if we should print an update
-            if current_time >= next_update:
-                wait_time = current_time - wait_start
-                print(f"⏳ Waiting for available pod... ({int(wait_time.total_seconds())}s)")  # noqa: T201
-                next_update = current_time + update_interval
-
-            # Wait before next check
-            time.sleep(2)
-
-        except Exception as e:
-            print(f"Error getting toolbox pod: {e}")  # noqa: T201
-            sys.exit(1)
-
-
-def parse_arn(arn: str) -> dict:
-    """Parse AWS ARN into components."""
-    try:
-        # Handle AWS STS assumed-role ARN format
-        # Format: arn:aws:sts::ACCOUNT:assumed-role/AWSReservedSSO_developers_0847e649a00cc5e7/michael.k@posthog.com
-        parts = arn.split(":")
-        if len(parts) != 6 or "assumed-role" not in parts[5]:
-            return {"toolbox-claimed": sanitize_label(arn)}  # fallback for unexpected format
-
-        # Extract role path and session name
-        role_and_session = parts[5].split("/")
-        if len(role_and_session) < 3:
-            return {"toolbox-claimed": sanitize_label(arn)}
-
-        role_path = role_and_session[1]  # The full role path (e.g. AWSReservedSSO_developers_0847e649a00cc5e7)
-        session_name = role_and_session[2]  # The session name (email)
-
-        # Extract role name from the role path (e.g. "developers" from "AWSReservedSSO_developers_0847e649a00cc5e7")
-        role_parts = role_path.split("_")
-        role_name = role_parts[1]  # For AWSReservedSSO_* format
-
-        # Sanitize values for kubernetes labels
-        session_name = sanitize_label(session_name)
-        role_name = sanitize_label(role_name)
-
-        print(f"Parsed ARN: session_name={session_name}, role_name={role_name}")  # noqa: T201
-
-        return {
-            "toolbox-claimed": session_name,  # The sanitized email address
-            "role-name": role_name,  # The role name (e.g. "developers")
-            "assumed-role": "true",
-        }
-    except Exception as e:
-        print(f"Warning: Failed to parse ARN ({e}), using fallback format")  # noqa: T201
-        return {"toolbox-claimed": sanitize_label(arn)}  # fallback for any parsing errors
-
-
-def sanitize_label(value: str) -> str:
-    """Sanitize a value to be a valid kubernetes label value."""
-    # Replace @ with _at_ and keep dots
-    sanitized = value.replace("@", "_at_")
-    # Ensure it starts and ends with alphanumeric
-    sanitized = sanitized.strip("_")
-    return sanitized
-
-
-def claim_pod(pod_name: str, user_labels: dict, timestamp: int):
-    """Claim the pod by updating its labels."""
-
-    human_readable = datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %H:%M:%S %Z")
-    print(f"Claiming pod {pod_name} for user {user_labels.get('toolbox-claimed', 'unknown')} until {human_readable}")  # noqa: T201
-    try:
-        # Get current labels
-        result = subprocess.run(
-            ["kubectl", "get", "pod", "-n", "posthog", pod_name, "-o", "jsonpath={.metadata.labels}"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-
-        current_labels = json.loads(result.stdout)
-
-        # Remove all labels except app.kubernetes.io/name
-        for label_name in current_labels.keys():
-            if label_name != "app.kubernetes.io/name":
-                subprocess.run(
-                    ["kubectl", "label", "pod", "-n", "posthog", pod_name, f"{label_name}-"],
-                    check=True,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                )
-
-        # Add karpenter.sh/do-not-disrupt annotation
-        subprocess.run(
-            [
-                "kubectl",
-                "annotate",
-                "pod",
-                "-n",
-                "posthog",
-                pod_name,
-                "karpenter.sh/do-not-disrupt=true",
-                "--overwrite=true",
-            ],
-            check=True,
-        )
-
-        # Build label arguments
-        label_args = [f"{key}={value}" for key, value in {**user_labels, "terminate-after": str(timestamp)}.items()]
-
-        # Add new labels
-        subprocess.run(["kubectl", "label", "pod", "-n", "posthog", pod_name, *label_args], check=True)
-
-        # Wait for pod to be ready
-        print("⏳ Waiting for pod to be ready")  # noqa: T201
-        subprocess.run(["kubectl", "wait", "--for=condition=Ready", "--timeout=5m", "-n", "posthog", "pod", pod_name])
-    except Exception as e:
-        print(f"Error claiming pod: {e}")  # noqa: T201
-        sys.exit(1)
-
-
-def delete_pod(pod_name: str):
-    """Delete the specified pod.
-
-    Args:
-        pod_name: Name of the pod to delete
-    """
-    response = input("\n❓ Would you like to delete this pod now? [y/N]: ").lower().strip()
-    if response == "y":
-        print("🗑️  Deleting pod...")  # noqa: T201
-        try:
-            subprocess.run(
-                [
-                    "kubectl",
-                    "delete",
-                    "pod",
-                    "-n",
-                    "posthog",
-                    pod_name,
-                    "--wait=false",  # Don't wait for pod deletion to complete
-                ],
-                check=True,
-            )
-            print("✅ Pod scheduled for deletion")  # noqa: T201
-        except subprocess.CalledProcessError as e:
-            print(f"❌ Failed to delete pod: {e}")  # noqa: T201
-    else:
-        print("👋 Pod will remain running until its scheduled termination time")  # noqa: T201
-
-
-def connect_to_pod(pod_name: str):
-    """Connect to the specified pod using kubectl exec.
-
-    Args:
-        pod_name: Name of the pod to connect to
-    """
-    print(f"🚀 Connecting to pod {pod_name}...")  # noqa: T201
-    subprocess.run(["kubectl", "exec", "-it", "-n", "posthog", pod_name, "--", "bash"])
+# Import functions from the modular package
+from toolbox.kubernetes import select_context
+from toolbox.user import get_current_user
+from toolbox.pod import get_toolbox_pod, claim_pod, connect_to_pod, delete_pod
 
 
 def main():
+    """Main entry point for the toolbox command."""
     try:
         # Set up argument parser
         parser = argparse.ArgumentParser(
@@ -286,6 +39,10 @@ def main():
         args = parser.parse_args()
 
         print("🛠️  Connecting to toolbox pod...")  # noqa: T201
+
+        # Let user select kubernetes context
+        selected_context = select_context()
+        print(f"🔄 Using kubernetes context: {selected_context}")  # noqa: T201
 
         # Get current user labels
         user_labels = get_current_user()

--- a/infra-scripts/clitools/toolbox/README.md
+++ b/infra-scripts/clitools/toolbox/README.md
@@ -1,0 +1,41 @@
+# Toolbox Utility
+
+A command line utility to connect to PostHog toolbox pods in a Kubernetes environment.
+
+## Features
+
+- Lists and switches between available Kubernetes contexts
+- Automatically identifies the current user from Kubernetes authentication
+- Finds and claims toolbox pods
+- Sets expiration time for claimed pods
+- Connects to claimed pods using kubectl exec
+- Allows pod deletion after use
+
+## Package Structure
+
+The toolbox utility uses a hybrid approach with modular functions in a package but the main entry point in the top-level script:
+
+- **Main script**:
+  - `toolbox.py` - Main script with argument parsing and the core workflow
+
+- **Support modules**:
+  - `toolbox/kubernetes.py` - Functions for working with Kubernetes contexts
+  - `toolbox/user.py` - User identification and ARN parsing
+  - `toolbox/pod.py` - Pod management (finding, claiming, connecting, deleting)
+
+This structure keeps the main flow in a single script for easy understanding while separating the implementation details into modular components.
+
+## Usage
+
+```bash
+# Basic usage (claims pod for 12 hours by default)
+python toolbox.py
+
+# Claim a pod for 24 hours
+python toolbox.py --claim-duration 24
+
+# Update the termination time of an existing claimed pod
+python toolbox.py --update-claim
+```
+
+Before connecting to a pod, the utility now allows you to select a Kubernetes context, making it easier to work with multiple clusters. 

--- a/infra-scripts/clitools/toolbox/__init__.py
+++ b/infra-scripts/clitools/toolbox/__init__.py
@@ -1,0 +1,3 @@
+"""
+Toolbox package for connecting to PostHog toolbox pod.
+"""

--- a/infra-scripts/clitools/toolbox/kubernetes.py
+++ b/infra-scripts/clitools/toolbox/kubernetes.py
@@ -18,7 +18,7 @@ def get_available_contexts() -> list:
         sys.exit(1)
 
 
-def get_current_context() -> str:
+def get_current_context() -> str | None:
     """Get current kubernetes context."""
     try:
         result = subprocess.run(["kubectl", "config", "current-context"], capture_output=True, text=True, check=True)

--- a/infra-scripts/clitools/toolbox/kubernetes.py
+++ b/infra-scripts/clitools/toolbox/kubernetes.py
@@ -43,6 +43,9 @@ def select_context():
     """List available contexts and let user select one."""
     contexts = get_available_contexts()
     current = get_current_context()
+    if current is None:
+        print("❌ Could not determine current kubernetes context.")  # noqa: T201
+        sys.exit(1)
 
     if not contexts:
         print("❌ No kubernetes contexts found.")  # noqa: T201

--- a/infra-scripts/clitools/toolbox/kubernetes.py
+++ b/infra-scripts/clitools/toolbox/kubernetes.py
@@ -28,7 +28,7 @@ def get_current_context() -> str | None:
         return None
 
 
-def switch_context(context: str):
+def switch_context(context: str) -> bool:
     """Switch to specified kubernetes context."""
     try:
         subprocess.run(["kubectl", "config", "use-context", context], check=True)

--- a/infra-scripts/clitools/toolbox/kubernetes.py
+++ b/infra-scripts/clitools/toolbox/kubernetes.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Kubernetes context management functions."""
+
+import subprocess
+import sys
+
+
+def get_available_contexts() -> list:
+    """Get available kubernetes contexts."""
+    try:
+        result = subprocess.run(
+            ["kubectl", "config", "get-contexts", "-o", "name"], capture_output=True, text=True, check=True
+        )
+        contexts = [context.strip() for context in result.stdout.strip().split("\n") if context.strip()]
+        return contexts
+    except subprocess.CalledProcessError as e:
+        print(f"Error getting kubernetes contexts: {e}")  # noqa: T201
+        sys.exit(1)
+
+
+def get_current_context() -> str:
+    """Get current kubernetes context."""
+    try:
+        result = subprocess.run(["kubectl", "config", "current-context"], capture_output=True, text=True, check=True)
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        print(f"Error getting current kubernetes context: {e}")  # noqa: T201
+        return None
+
+
+def switch_context(context: str):
+    """Switch to specified kubernetes context."""
+    try:
+        subprocess.run(["kubectl", "config", "use-context", context], check=True)
+        print(f"✅ Switched to context: {context}")  # noqa: T201
+        return True
+    except subprocess.CalledProcessError as e:
+        print(f"Error switching kubernetes context: {e}")  # noqa: T201
+        return False
+
+
+def select_context():
+    """List available contexts and let user select one."""
+    contexts = get_available_contexts()
+    current = get_current_context()
+
+    if not contexts:
+        print("❌ No kubernetes contexts found.")  # noqa: T201
+        sys.exit(1)
+
+    print("\n🔍 Available kubernetes contexts:")  # noqa: T201
+    for i, context in enumerate(contexts, 1):
+        if context == current:
+            print(f"  {i}. {context} (current)")  # noqa: T201
+        else:
+            print(f"  {i}. {context}")  # noqa: T201
+
+    print(f"\nCurrently using: {current}")  # noqa: T201
+    response = input("Enter context number to switch or press Enter to continue with current context: ").strip()
+
+    if response:
+        try:
+            index = int(response) - 1
+            if 0 <= index < len(contexts):
+                if switch_context(contexts[index]):
+                    return contexts[index]
+                else:
+                    print("⚠️ Failed to switch context, continuing with current context.")  # noqa: T201
+                    return current
+            else:
+                print("⚠️ Invalid selection, continuing with current context.")  # noqa: T201
+                return current
+        except ValueError:
+            print("⚠️ Invalid input, continuing with current context.")  # noqa: T201
+            return current
+
+    return current

--- a/infra-scripts/clitools/toolbox/pod.py
+++ b/infra-scripts/clitools/toolbox/pod.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Pod management functions."""
+
+import subprocess
+import json
+import sys
+import time
+from datetime import datetime, timedelta
+
+
+def get_toolbox_pod(user: str, check_claimed: bool = True) -> tuple[str, bool]:
+    """Get an available toolbox pod name.
+
+    Args:
+        user: Current user ARN
+        check_claimed: If True, first look for pods already claimed by the user
+
+    Returns:
+        Tuple of (pod_name, is_already_claimed)
+    """
+    wait_start = datetime.now()
+    max_wait = timedelta(minutes=5)
+    update_interval = timedelta(seconds=30)
+    next_update = wait_start
+
+    while True:
+        try:
+            result = subprocess.run(
+                [
+                    "kubectl",
+                    "get",
+                    "pods",
+                    "-n",
+                    "posthog",
+                    "-l",
+                    "app.kubernetes.io/name=posthog-toolbox-django",
+                    "-o",
+                    "json",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            pods = json.loads(result.stdout)["items"]
+
+            if check_claimed:
+                # Get user ID from ARN and sanitize it
+                user_id = sanitize_label(user.split("/")[-1] if "/" in user else user)
+                # First look for pods already claimed by this user
+                claimed_pods = [
+                    pod["metadata"]["name"]
+                    for pod in pods
+                    if pod["status"]["phase"] == "Running"
+                    and pod.get("metadata", {}).get("labels", {}).get("toolbox-claimed") == user_id
+                    and not pod.get("metadata", {}).get("deletionTimestamp")
+                ]
+
+                if claimed_pods:
+                    print("⚠️  Found pod already claimed by you")  # noqa: T201
+                    return claimed_pods[0], True
+                print("No pods currently claimed by you, looking for available pods...")  # noqa: T201
+
+            # Look for unclaimed pods
+            available_pods = [
+                pod["metadata"]["name"]
+                for pod in pods
+                if pod["status"]["phase"] in ("Running", "Pending")
+                and "toolbox-claimed" not in pod.get("metadata", {}).get("labels", {})
+                and "terminate-after" not in pod.get("metadata", {}).get("labels", {})
+                and not pod.get("metadata", {}).get("deletionTimestamp")
+            ]
+
+            if available_pods:
+                return available_pods[0], False
+
+            # No pods available, check if we should wait or timeout
+            current_time = datetime.now()
+            if current_time - wait_start > max_wait:
+                print("\n❌ No pods became available after 5 minutes.")  # noqa: T201
+                print("Please reach out to #team-infrastructure for assistance.")  # noqa: T201
+                sys.exit(1)
+
+            # Check if we should print an update
+            if current_time >= next_update:
+                wait_time = current_time - wait_start
+                print(f"⏳ Waiting for available pod... ({int(wait_time.total_seconds())}s)")  # noqa: T201
+                next_update = current_time + update_interval
+
+            # Wait before next check
+            time.sleep(2)
+
+        except Exception as e:
+            print(f"Error getting toolbox pod: {e}")  # noqa: T201
+            sys.exit(1)
+
+
+def claim_pod(pod_name: str, user_labels: dict, timestamp: int):
+    """Claim the pod by updating its labels."""
+
+    human_readable = datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %H:%M:%S %Z")
+    print(f"Claiming pod {pod_name} for user {user_labels.get('toolbox-claimed', 'unknown')} until {human_readable}")  # noqa: T201
+    try:
+        # Get current labels
+        result = subprocess.run(
+            ["kubectl", "get", "pod", "-n", "posthog", pod_name, "-o", "jsonpath={.metadata.labels}"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        current_labels = json.loads(result.stdout)
+
+        # Remove all labels except app.kubernetes.io/name
+        for label_name in current_labels.keys():
+            if label_name != "app.kubernetes.io/name":
+                subprocess.run(
+                    ["kubectl", "label", "pod", "-n", "posthog", pod_name, f"{label_name}-"],
+                    check=True,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+
+        # Add karpenter.sh/do-not-disrupt annotation
+        subprocess.run(
+            [
+                "kubectl",
+                "annotate",
+                "pod",
+                "-n",
+                "posthog",
+                pod_name,
+                "karpenter.sh/do-not-disrupt=true",
+                "--overwrite=true",
+            ],
+            check=True,
+        )
+
+        # Build label arguments
+        label_args = [f"{key}={value}" for key, value in {**user_labels, "terminate-after": str(timestamp)}.items()]
+
+        # Add new labels
+        subprocess.run(["kubectl", "label", "pod", "-n", "posthog", pod_name, *label_args], check=True)
+
+        # Wait for pod to be ready
+        print("⏳ Waiting for pod to be ready")  # noqa: T201
+        subprocess.run(["kubectl", "wait", "--for=condition=Ready", "--timeout=5m", "-n", "posthog", "pod", pod_name])
+    except Exception as e:
+        print(f"Error claiming pod: {e}")  # noqa: T201
+        sys.exit(1)
+
+
+def connect_to_pod(pod_name: str):
+    """Connect to the specified pod using kubectl exec.
+
+    Args:
+        pod_name: Name of the pod to connect to
+    """
+    print(f"🚀 Connecting to pod {pod_name}...")  # noqa: T201
+    subprocess.run(["kubectl", "exec", "-it", "-n", "posthog", pod_name, "--", "bash"])
+
+
+def delete_pod(pod_name: str):
+    """Delete the specified pod.
+
+    Args:
+        pod_name: Name of the pod to delete
+    """
+    response = input("\n❓ Would you like to delete this pod now? [y/N]: ").lower().strip()
+    if response == "y":
+        print("🗑️  Deleting pod...")  # noqa: T201
+        try:
+            subprocess.run(
+                [
+                    "kubectl",
+                    "delete",
+                    "pod",
+                    "-n",
+                    "posthog",
+                    pod_name,
+                    "--wait=false",  # Don't wait for pod deletion to complete
+                ],
+                check=True,
+            )
+            print("✅ Pod scheduled for deletion")  # noqa: T201
+        except subprocess.CalledProcessError as e:
+            print(f"❌ Failed to delete pod: {e}")  # noqa: T201
+    else:
+        print("👋 Pod will remain running until its scheduled termination time")  # noqa: T201
+
+
+def sanitize_label(value: str) -> str:
+    """Sanitize a value to be a valid kubernetes label value."""
+    # Replace @ with _at_ and keep dots
+    sanitized = value.replace("@", "_at_")
+    # Ensure it starts and ends with alphanumeric
+    sanitized = sanitized.strip("_")
+    return sanitized

--- a/infra-scripts/clitools/toolbox/pod.py
+++ b/infra-scripts/clitools/toolbox/pod.py
@@ -146,7 +146,14 @@ def claim_pod(pod_name: str, user_labels: dict, timestamp: int):
 
         # Wait for pod to be ready
         print("⏳ Waiting for pod to be ready")  # noqa: T201
-        subprocess.run(["kubectl", "wait", "--for=condition=Ready", "--timeout=5m", "-n", "posthog", "pod", pod_name])
+        try:
+            subprocess.run(
+                ["kubectl", "wait", "--for=condition=Ready", "--timeout=5m", "-n", "posthog", "pod", pod_name],
+                check=True,
+            )
+        except subprocess.CalledProcessError:
+            print(f"❌ Pod {pod_name} did not become ready within 5 minutes.")  # noqa: T201
+            sys.exit(1)
     except Exception as e:
         print(f"Error claiming pod: {e}")  # noqa: T201
         sys.exit(1)

--- a/infra-scripts/clitools/toolbox/pod.py
+++ b/infra-scripts/clitools/toolbox/pod.py
@@ -89,8 +89,11 @@ def get_toolbox_pod(user: str, check_claimed: bool = True) -> tuple[str, bool]:
             # Wait before next check
             time.sleep(2)
 
+        except subprocess.CalledProcessError as e:
+            print(f"kubectl failed: {e.stderr or e}")  # noqa: T201
+            sys.exit(1)
         except Exception as e:
-            print(f"Error getting toolbox pod: {e}")  # noqa: T201
+            print(f"Unexpected error getting toolbox pod: {e}")  # noqa: T201
             sys.exit(1)
 
 

--- a/infra-scripts/clitools/toolbox/user.py
+++ b/infra-scripts/clitools/toolbox/user.py
@@ -56,6 +56,8 @@ def parse_arn(arn: str) -> dict:
 
         # Extract role name from the role path (e.g. "developers" from "AWSReservedSSO_developers_0847e649a00cc5e7")
         role_parts = role_path.split("_")
+        if len(role_parts) < 2:
+            return {"toolbox-claimed": sanitize_label(arn)}  # fallback for unexpected format
         role_name = role_parts[1]  # For AWSReservedSSO_* format
 
         # Sanitize values for kubernetes labels

--- a/infra-scripts/clitools/toolbox/user.py
+++ b/infra-scripts/clitools/toolbox/user.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""User identification and pod claiming functions."""
+
+import subprocess
+import json
+import sys
+
+
+def get_current_user() -> dict:
+    """Get user identity from kubectl auth and parse it into labels."""
+    try:
+        print("Attempting to get user identity...")  # noqa: T201
+        whoami = subprocess.run(["kubectl", "auth", "whoami", "-o", "json"], capture_output=True, text=True, check=True)
+
+        user_info = json.loads(whoami.stdout)
+        user_info = user_info["status"]["userInfo"]  # Navigate to the correct nesting level
+
+        # First try to get the ARN from the extra info
+        if "extra" in user_info and "arn" in user_info["extra"]:
+            return parse_arn(user_info["extra"]["arn"][0])  # The ARN is in a list
+
+        # Fallback to sessionName if available
+        if "extra" in user_info and "sessionName" in user_info["extra"]:
+            return {"toolbox-claimed": sanitize_label(user_info["extra"]["sessionName"][0])}
+
+        # Final fallback to username
+        return {"toolbox-claimed": sanitize_label(f"k8s-user/{user_info['username']}")}
+
+    except subprocess.CalledProcessError as e:
+        print(f"Command failed with return code {e.returncode}")  # noqa: T201
+        print(f"Output: {e.output}")  # noqa: T201
+        print(f"Stderr: {e.stderr}")  # noqa: T201
+        sys.exit(1)
+    except Exception as k8s_error:
+        print(f"Error: Failed to get user identity: {k8s_error}")  # noqa: T201
+        print(f"Error type: {type(k8s_error)}")  # noqa: T201
+        sys.exit(1)
+
+
+def parse_arn(arn: str) -> dict:
+    """Parse AWS ARN into components."""
+    try:
+        # Handle AWS STS assumed-role ARN format
+        # Format: arn:aws:sts::ACCOUNT:assumed-role/AWSReservedSSO_developers_0847e649a00cc5e7/michael.k@posthog.com
+        parts = arn.split(":")
+        if len(parts) != 6 or "assumed-role" not in parts[5]:
+            return {"toolbox-claimed": sanitize_label(arn)}  # fallback for unexpected format
+
+        # Extract role path and session name
+        role_and_session = parts[5].split("/")
+        if len(role_and_session) < 3:
+            return {"toolbox-claimed": sanitize_label(arn)}
+
+        role_path = role_and_session[1]  # The full role path (e.g. AWSReservedSSO_developers_0847e649a00cc5e7)
+        session_name = role_and_session[2]  # The session name (email)
+
+        # Extract role name from the role path (e.g. "developers" from "AWSReservedSSO_developers_0847e649a00cc5e7")
+        role_parts = role_path.split("_")
+        role_name = role_parts[1]  # For AWSReservedSSO_* format
+
+        # Sanitize values for kubernetes labels
+        session_name = sanitize_label(session_name)
+        role_name = sanitize_label(role_name)
+
+        print(f"Parsed ARN: session_name={session_name}, role_name={role_name}")  # noqa: T201
+
+        return {
+            "toolbox-claimed": session_name,  # The sanitized email address
+            "role-name": role_name,  # The role name (e.g. "developers")
+            "assumed-role": "true",
+        }
+    except Exception as e:
+        print(f"Warning: Failed to parse ARN ({e}), using fallback format")  # noqa: T201
+        return {"toolbox-claimed": sanitize_label(arn)}  # fallback for any parsing errors
+
+
+def sanitize_label(value: str) -> str:
+    """Sanitize a value to be a valid kubernetes label value."""
+    # Replace @ with _at_ and keep dots
+    sanitized = value.replace("@", "_at_")
+    # Ensure it starts and ends with alphanumeric
+    sanitized = sanitized.strip("_")
+    return sanitized


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

The user is currently not aware of which k8s context they'd be using when starting the toolbox script. This can lead to connecting to the wrong environment or errors. 


## Changes

Prompt the user for the k8s context, use the current one as default. 

## Does this work well for both Cloud and self-hosted?

Cloud only, as this is a maintenance script. 

## How did you test this code?

python tests, mocking kubectl commands. 