### PR TITLE
feat: Added command server

### DIFF
--- a/plugin-server/src/cdp/cdp-api.test.ts
+++ b/plugin-server/src/cdp/cdp-api.test.ts
@@ -13,31 +13,6 @@ import { CdpApi } from './cdp-api'
 import { posthogFilterOutPlugin } from './legacy-plugins/_transformations/posthog-filter-out-plugin/template'
 import { HogFunctionInvocationGlobals, HogFunctionType } from './types'
 
-const mockConsumer = {
-    on: jest.fn(),
-    commitSync: jest.fn(),
-    commit: jest.fn(),
-    queryWatermarkOffsets: jest.fn(),
-    committed: jest.fn(),
-    assignments: jest.fn(),
-    isConnected: jest.fn(() => true),
-    getMetadata: jest.fn(),
-}
-
-jest.mock('../../src/kafka/batch-consumer', () => {
-    return {
-        startBatchConsumer: jest.fn(() =>
-            Promise.resolve({
-                join: () => ({
-                    finally: jest.fn(),
-                }),
-                stop: jest.fn(),
-                consumer: mockConsumer,
-            })
-        ),
-    }
-})
-
 jest.mock('../../src/utils/fetch', () => {
     return {
         trackedFetch: jest.fn(() =>

--- a/plugin-server/src/router.test.ts
+++ b/plugin-server/src/router.test.ts
@@ -1,7 +1,7 @@
 import supertest from 'supertest'
 
-import { PluginServer } from '../src/server'
-import { PluginServerMode } from '../src/types'
+import { PluginServer } from './server'
+import { PluginServerMode } from './types'
 
 describe('router', () => {
     jest.retryTimes(3) // Flakey due to reliance on kafka/clickhouse
@@ -30,6 +30,7 @@ describe('router', () => {
                 {
                   "checks": {
                     "ingestion-consumer-events_plugin_ingestion_test": "ok",
+                    "server-commands": "ok",
                   },
                   "status": "ok",
                 }
@@ -44,6 +45,7 @@ describe('router', () => {
                 {
                   "checks": {
                     "ingestion-consumer-events_plugin_ingestion_test": "ok",
+                    "server-commands": "ok",
                   },
                   "status": "ok",
                 }

--- a/plugin-server/src/utils/commands.test.ts
+++ b/plugin-server/src/utils/commands.test.ts
@@ -27,7 +27,6 @@ describe('Commands API', () => {
     })
 
     afterEach(async () => {
-        jest.setTimeout(10000)
         await closeHub(hub)
         await service.stop()
     })

--- a/plugin-server/src/utils/commands.test.ts
+++ b/plugin-server/src/utils/commands.test.ts
@@ -1,0 +1,68 @@
+import '../../tests/helpers/mocks/producer.mock'
+
+import express from 'express'
+import supertest from 'supertest'
+
+import { waitForExpect } from '~/tests/helpers/expectations'
+
+import { resetTestDatabase } from '../../tests/helpers/sql'
+import { Hub } from '../types'
+import { closeHub, createHub } from '../utils/db/hub'
+import { ServerCommands } from './commands'
+
+describe('Commands API', () => {
+    let hub: Hub
+    let app: express.Express
+    let service: ServerCommands
+
+    beforeEach(async () => {
+        await resetTestDatabase()
+        hub = await createHub()
+
+        service = new ServerCommands(hub)
+        app = express()
+        app.use(express.json())
+        app.use('/', service.router())
+        await service.start()
+    })
+
+    afterEach(async () => {
+        jest.setTimeout(10000)
+        await closeHub(hub)
+        await service.stop()
+    })
+
+    afterAll(() => {
+        jest.useRealTimers()
+    })
+
+    it('errors if missing command', async () => {
+        const res = await supertest(app).post(`/api/commands`).send({ command: 'missing', message: {} })
+        expect(res.status).toEqual(400)
+    })
+
+    it('succeeds with valid command', async () => {
+        const res = await supertest(app).post(`/api/commands`).send({ command: 'reload-plugins', message: {} })
+        expect(res.status).toEqual(200)
+    })
+
+    describe('command triggers', () => {
+        beforeEach(() => {
+            for (const command of Object.keys(service.messageMap)) {
+                jest.spyOn(service.messageMap, command)
+            }
+        })
+
+        it.each([
+            ['reload-plugins', {}],
+            ['reset-available-product-features-cache', { organizationId: '123' }],
+            ['populate-plugin-capabilities', { pluginId: '123' }],
+        ])('triggers the appropriate pubsub message', async (command, message) => {
+            await supertest(app).post(`/api/commands`).send({ command, message })
+            // Slight delay as it is received via the pubsub
+            await waitForExpect(() => {
+                expect(service.messageMap[command]).toHaveBeenCalledWith(JSON.stringify(message))
+            }, 100)
+        })
+    })
+})

--- a/plugin-server/src/utils/commands.ts
+++ b/plugin-server/src/utils/commands.ts
@@ -16,7 +16,7 @@ import { PubSub } from './pubsub'
  * don't need access to the pubsub redis
  */
 export class ServerCommands {
-    private messageMap: Record<string, (message: string) => Promise<void>> = {}
+    public readonly messageMap: Record<string, (message: string) => Promise<void>> = {}
     private pubsub: PubSub
 
     constructor(private hub: Hub) {
@@ -85,7 +85,7 @@ export class ServerCommands {
                 return
             }
 
-            await this.pubsub.publish(command, message)
+            await this.pubsub.publish(command, JSON.stringify(message))
 
             res.json({ success: true })
         }

--- a/plugin-server/src/utils/commands.ts
+++ b/plugin-server/src/utils/commands.ts
@@ -1,0 +1,92 @@
+import express from 'express'
+
+import { runInstrumentedFunction } from '../main/utils'
+import { Hub, PluginServerService } from '../types'
+import { reloadPlugins } from '../worker/tasks'
+import { populatePluginCapabilities } from '../worker/vm/lazy'
+import { parseJSON } from './json-parse'
+import { logger } from './logger'
+import { PubSub } from './pubsub'
+
+/**
+ * We have various use cases where an external service like django needs to communicate with the node services
+ *
+ * We used to do this via redis pubsub so that all workers could respond. Now we do it slightly differently and have
+ * this service to expose an API handler for commands and take care of triggering the pubsub, meaning the other services
+ * don't need access to the pubsub redis
+ */
+export class ServerCommands {
+    private messageMap: Record<string, (message: string) => Promise<void>> = {}
+    private pubsub: PubSub
+
+    constructor(private hub: Hub) {
+        this.messageMap = {
+            [this.hub.PLUGINS_RELOAD_PUBSUB_CHANNEL]: async () => {
+                logger.info('⚡', '[PubSub] Reloading plugins!')
+                await reloadPlugins(this.hub)
+            },
+            'reset-available-product-features-cache': async (message) => {
+                const { organizationId } = parseJSON(message) as { organizationId: string }
+                logger.info('⚡', '[PubSub] Resetting available product features cache!', { organizationId })
+
+                await runInstrumentedFunction({
+                    statsKey: 'reset-available-product-features-cache',
+                    func: () => Promise.resolve(this.hub.teamManager.orgAvailableFeaturesChanged(organizationId)),
+                })
+            },
+            'populate-plugin-capabilities': async (message) => {
+                const { pluginId } = parseJSON(message) as { pluginId: string }
+                logger.info('⚡', '[PubSub] Populating plugin capabilities!', { pluginId })
+                if (this.hub?.capabilities.appManagementSingleton) {
+                    await populatePluginCapabilities(this.hub, Number(pluginId))
+                }
+            },
+        }
+
+        this.pubsub = new PubSub(this.hub, this.messageMap)
+    }
+
+    public get service(): PluginServerService {
+        return {
+            id: 'server-commands',
+            onShutdown: async () => await this.stop(),
+            healthcheck: () => true,
+        }
+    }
+
+    async start() {
+        await this.pubsub.start()
+    }
+
+    async stop() {
+        await this.pubsub.stop()
+    }
+
+    public router(): express.Router {
+        const router = express.Router()
+
+        const asyncHandler =
+            (fn: (req: express.Request, res: express.Response) => Promise<void>) =>
+            (req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> =>
+                fn(req, res).catch(next)
+
+        router.post('/api/commands', asyncHandler(this.postCommand()))
+
+        return router
+    }
+
+    private postCommand =
+        () =>
+        async (req: express.Request, res: express.Response): Promise<void> => {
+            const { command, message } = req.body
+
+            if (!this.messageMap[command]) {
+                res.status(400).json({ error: 'Invalid command' })
+                return
+            }
+
+            await this.pubsub.publish(command, message)
+
+            res.json({ success: true })
+        }
+}


### PR DESCRIPTION
## Problem

Currently django talks to the node services via pubsub. This has always been a little tricky to manage with shared access to redis. Also not having a way to manually trigger this stuff makes it hard to test things.

## Changes

* Adds a new service for managing commands
* Exposes an api that we will move the django service over to using later

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
