### PR TITLE
chore: move exceptions to separate tab

### DIFF
--- a/frontend/src/scenes/persons/PersonScene.tsx
+++ b/frontend/src/scenes/persons/PersonScene.tsx
@@ -270,7 +270,7 @@ export function PersonScene(): JSX.Element | null {
                     },
                     {
                         key: PersonsTabType.EXCEPTIONS,
-                        label: <span data-attr="persons-events-tab">Exceptions</span>,
+                        label: <span data-attr="persons-exceptions-tab">Exceptions</span>,
                         content: (
                             <Query
                                 query={{

--- a/frontend/src/scenes/persons/PersonScene.tsx
+++ b/frontend/src/scenes/persons/PersonScene.tsx
@@ -276,6 +276,7 @@ export function PersonScene(): JSX.Element | null {
                                 query={{
                                     kind: NodeKind.DataTableNode,
                                     full: true,
+                                    showEventFilter: false,
                                     hiddenColumns: ['person'],
                                     source: {
                                         kind: NodeKind.EventsQuery,

--- a/frontend/src/scenes/persons/PersonScene.tsx
+++ b/frontend/src/scenes/persons/PersonScene.tsx
@@ -224,6 +224,7 @@ export function PersonScene(): JSX.Element | null {
                                         kind: NodeKind.EventsQuery,
                                         select: defaultDataTableColumns(NodeKind.EventsQuery),
                                         personId: person.id,
+                                        where: ["notEquals(event, '$exception')"],
                                         after: '-24h',
                                     },
                                 }}
@@ -265,6 +266,26 @@ export function PersonScene(): JSX.Element | null {
                                     />
                                 </div>
                             </>
+                        ),
+                    },
+                    {
+                        key: PersonsTabType.EXCEPTIONS,
+                        label: <span data-attr="persons-events-tab">Exceptions</span>,
+                        content: (
+                            <Query
+                                query={{
+                                    kind: NodeKind.DataTableNode,
+                                    full: true,
+                                    hiddenColumns: ['person'],
+                                    source: {
+                                        kind: NodeKind.EventsQuery,
+                                        select: defaultDataTableColumns(NodeKind.EventsQuery),
+                                        personId: person.id,
+                                        event: '$exception',
+                                        after: '-24h',
+                                    },
+                                }}
+                            />
                         ),
                     },
                     {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1440,6 +1440,7 @@ export enum StepOrderValue {
 export enum PersonsTabType {
     FEED = 'feed',
     EVENTS = 'events',
+    EXCEPTIONS = 'exceptions',
     SESSION_RECORDINGS = 'sessionRecordings',
     PROPERTIES = 'properties',
     COHORTS = 'cohorts',


### PR DESCRIPTION
## Problem

Originally reported in https://posthog.slack.com/archives/C07AA937K9A/p1745356779401699

## Changes

Move exceptions to a separate tab so they don't clog up the default events stream for a user

<img width="777" alt="Screenshot 2025-04-25 at 11 25 47" src="https://github.com/user-attachments/assets/e7df2c19-97df-49fe-8949-e7c6e2f6ffed" />