### PR TITLE
fix(hoql): Replace % in call aliases

### DIFF
--- a/posthog/hogql/escape_sql.py
+++ b/posthog/hogql/escape_sql.py
@@ -25,6 +25,13 @@ singlequote_escape_chars_map = {**escape_chars_map, "'": "\\'"}
 backquote_escape_chars_map = {**escape_chars_map, "`": "\\`"}
 
 
+def safe_identifier(identifier: str) -> str:
+    if "%" in identifier:
+        identifier = identifier.replace("%", "")
+
+    return identifier
+
+
 # Copied from clickhouse_driver.util.escape_param
 def escape_param_clickhouse(value: str) -> str:
     return "'{}'".format("".join(singlequote_escape_chars_map.get(c, c) for c in str(value)))

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -31,6 +31,7 @@ from posthog.hogql.escape_sql import (
     escape_clickhouse_string,
     escape_hogql_identifier,
     escape_hogql_string,
+    safe_identifier,
 )
 from posthog.hogql.functions import (
     ADD_OR_NULL_DATETIME_FUNCTIONS,
@@ -385,7 +386,7 @@ class _Printer(Visitor):
                             # Non-unique hidden alias. Skip.
                             column = column.expr
                     elif isinstance(column, ast.Call):
-                        column_alias = print_prepared_ast(column, self.context, dialect="hogql")
+                        column_alias = safe_identifier(print_prepared_ast(column, self.context, dialect="hogql"))
                         column = ast.Alias(alias=column_alias, expr=column)
                     columns.append(self.visit(column))
             else:

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -17,6 +17,7 @@ from posthog.hogql.database.s3_table import S3Table
 from posthog.hogql.database.schema.events import EventsTable
 from posthog.hogql.database.schema.persons import PersonsTable
 from posthog.hogql.errors import ImpossibleASTError, QueryError, ResolutionError
+from posthog.hogql.escape_sql import safe_identifier
 from posthog.hogql.functions import find_hogql_posthog_function
 from posthog.hogql.functions.action import matches_action
 from posthog.hogql.functions.cohort import cohort_query_node
@@ -214,7 +215,7 @@ class Resolver(CloningVisitor):
             elif isinstance(new_expr.type, ast.CallType):
                 from posthog.hogql.printer import print_prepared_ast
 
-                alias = print_prepared_ast(node=new_expr, context=self.context, dialect="hogql")
+                alias = safe_identifier(print_prepared_ast(node=new_expr, context=self.context, dialect="hogql"))
             else:
                 alias = None
 

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -2306,3 +2306,14 @@ class TestPrinter(BaseTest):
         query = parse_expr("avgArray([1, 2, 3])")
         printed = print_ast(query, HogQLContext(team_id=self.team.pk), dialect="hogql")
         assert printed == "avgArray([1, 2, 3])"
+
+    def test_print_percentage_call_alias(self):
+        select = parse_select("SELECT concat('%', 'word', '%') LIMIT 1")
+        printed = print_ast(
+            select, HogQLContext(team_id=self.team.pk, enable_select_queries=True), dialect="clickhouse"
+        )
+
+        assert (
+            printed
+            == "SELECT concat(%(hogql_val_0)s, %(hogql_val_1)s, %(hogql_val_2)s) AS `concat('', 'word', '')` LIMIT 1"
+        )


### PR DESCRIPTION
## Problem
- Because we alias un-aliased Call nodes by taking the full string representation of the node as the alias, if the call contains a `%` anywhere then the query will fail as we disallow `%` in identifiers
- Test case: `select concat('%', 'string')`

## Changes
- When aliasing Call nodes, just replace any `%` string with an empty string

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Tested locally + added unit test
