### PR TITLE
feat(project-tree): insights "save under"

### DIFF
--- a/frontend/src/lib/components/SaveUnder/SaveUnder.tsx
+++ b/frontend/src/lib/components/SaveUnder/SaveUnder.tsx
@@ -5,7 +5,6 @@ import { saveUnderLogic, SaveUnderLogicProps } from 'lib/components/SaveUnder/sa
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
-import { Tooltip } from 'lib/lemon-ui/Tooltip'
 
 import { splitPath } from '~/layout/panel-layout/ProjectTree/utils'
 
@@ -24,11 +23,7 @@ export function SaveUnderModal(): JSX.Element {
             title="Select a folder to save in"
             footer={
                 <>
-                    <div className="flex-1 flex gap-2 items-center">
-                        <LemonButton type="secondary" onClick={closeModal}>
-                            Close
-                        </LemonButton>
-                    </div>
+                    <div className="flex-1" />
                     <LemonButton
                         type="primary"
                         onClick={submitForm}
@@ -60,35 +55,27 @@ export function SaveUnderModal(): JSX.Element {
 }
 
 export function SaveUnder(props: SaveUnderLogicProps): JSX.Element {
-    const { openModal } = useActions(saveUnderLogic(props))
-    const { form, lastNewOperation } = useValues(saveUnderLogic(props))
-    const { objectRef, defaultFolder } = props
-    const actualFolder = lastNewOperation?.folder || form.folder || defaultFolder || defaultPath
-    const pathParts = splitPath(actualFolder)
-    const lastPath = pathParts.length > 0 ? pathParts[pathParts.length - 1] || defaultPath : defaultPath
-
     return (
         <BindLogic logic={saveUnderLogic} props={props}>
-            <div className="text-xs font-normal text-center mr-1">
-                <div className="text-muted">{!objectRef ? 'Save' : 'Saved'} under</div>
-                <Tooltip
-                    title={
-                        <>
-                            {pathParts.map((pathPart, index) => (
-                                <span key={index}>
-                                    {pathPart}
-                                    {index < pathParts.length - 1 ? ' / ' : ''}
-                                </span>
-                            ))}
-                        </>
-                    }
-                >
-                    <div className="underline cursor-pointer" onClick={openModal}>
-                        {lastPath}
-                    </div>
-                </Tooltip>
-            </div>
             <SaveUnderModal />
         </BindLogic>
     )
+}
+
+export interface UseSaveUnderResponse {
+    openModal: () => void
+    closeModal: () => void
+    SaveUnderModal: () => JSX.Element
+    selectedFolder: string | undefined
+}
+
+export function useSaveUnder(props: SaveUnderLogicProps): UseSaveUnderResponse {
+    const { openModal, closeModal } = useActions(saveUnderLogic(props))
+    const { lastNewOperation } = useValues(saveUnderLogic(props))
+    return {
+        openModal,
+        closeModal,
+        SaveUnderModal: () => <SaveUnder {...props} />,
+        selectedFolder: lastNewOperation?.objectType === props.type ? lastNewOperation?.folder : undefined,
+    }
 }

--- a/frontend/src/lib/components/SaveUnder/SaveUnder.tsx
+++ b/frontend/src/lib/components/SaveUnder/SaveUnder.tsx
@@ -20,7 +20,7 @@ export function SaveUnderModal(): JSX.Element {
         <LemonModal
             onClose={closeModal}
             isOpen={isOpen}
-            title="Select a folder to save in"
+            title="Select a folder to save to"
             footer={
                 <>
                     <div className="flex-1" />

--- a/frontend/src/lib/components/SaveUnder/SaveUnder.tsx
+++ b/frontend/src/lib/components/SaveUnder/SaveUnder.tsx
@@ -54,14 +54,6 @@ export function SaveUnderModal(): JSX.Element {
     )
 }
 
-export function SaveUnder(props: SaveUnderLogicProps): JSX.Element {
-    return (
-        <BindLogic logic={saveUnderLogic} props={props}>
-            <SaveUnderModal />
-        </BindLogic>
-    )
-}
-
 export interface UseSaveUnderResponse {
     openModal: () => void
     closeModal: () => void
@@ -75,7 +67,11 @@ export function useSaveUnder(props: SaveUnderLogicProps): UseSaveUnderResponse {
     return {
         openModal,
         closeModal,
-        SaveUnderModal: () => <SaveUnder {...props} />,
+        SaveUnderModal: () => (
+            <BindLogic logic={saveUnderLogic} props={props}>
+                <SaveUnderModal />
+            </BindLogic>
+        ),
         selectedFolder: lastNewOperation?.objectType === props.type ? lastNewOperation?.folder : undefined,
     }
 }

--- a/frontend/src/lib/components/SaveUnder/saveUnderLogic.tsx
+++ b/frontend/src/lib/components/SaveUnder/saveUnderLogic.tsx
@@ -50,6 +50,7 @@ export const saveUnderLogic = kea<saveUnderLogicType>([
                 if (props.onSave) {
                     actions.setLastNewOperation(values.lastNewOperation?.objectType || 'unknown', formValues.folder)
                     props.onSave(formValues.folder || props.defaultFolder || 'Unfiled')
+                    actions.closeModal()
                 }
             },
         },

--- a/frontend/src/lib/components/SaveUnder/saveUnderLogic.tsx
+++ b/frontend/src/lib/components/SaveUnder/saveUnderLogic.tsx
@@ -48,7 +48,7 @@ export const saveUnderLogic = kea<saveUnderLogicType>([
             }),
             submit: (formValues) => {
                 if (props.onSave) {
-                    actions.setLastNewOperation(values.lastNewOperation?.objectType || 'unknown', formValues.folder)
+                    actions.setLastNewOperation(values.lastNewOperation?.objectType || props.type, formValues.folder)
                     props.onSave(formValues.folder || props.defaultFolder || 'Unfiled')
                     actions.closeModal()
                 }

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -27,7 +27,7 @@ import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { LemonSwitch } from 'lib/lemon-ui/LemonSwitch'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { deleteInsightWithUndo } from 'lib/utils/deleteWithUndo'
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 import { NewDashboardModal } from 'scenes/dashboard/NewDashboardModal'
 import { insightCommandLogic } from 'scenes/insights/insightCommandLogic'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
@@ -100,14 +100,11 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
     const showCohortButton =
         isDataTableNode(query) || isDataVisualizationNode(query) || isHogQLQuery(query) || isEventsQuery(query)
 
-    const saveUnderProps: SaveUnderLogicProps = useMemo(
-        () => ({
-            defaultFolder: 'Unfiled/Insights',
-            type: 'insight',
-            onSave: saveInsight,
-        }),
-        []
-    )
+    const saveUnderProps: SaveUnderLogicProps = {
+        defaultFolder: 'Unfiled/Insights',
+        type: 'insight',
+        onSave: saveInsight,
+    }
     const { selectedFolder, openModal, SaveUnderModal } = useSaveUnder(saveUnderProps)
     const canSaveUnder = !selectedFolder && featureFlags[FEATURE_FLAGS.TREE_VIEW] && !insight.short_id
 

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -109,11 +109,11 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
         []
     )
     const { selectedFolder, openModal, SaveUnderModal } = useSaveUnder(saveUnderProps)
-    const mustSaveUnder = !selectedFolder && featureFlags[FEATURE_FLAGS.TREE_VIEW] && !insight.short_id
+    const canSaveUnder = !selectedFolder && featureFlags[FEATURE_FLAGS.TREE_VIEW] && !insight.short_id
 
     return (
         <>
-            {mustSaveUnder ? <SaveUnderModal /> : null}
+            {canSaveUnder ? <SaveUnderModal /> : null}
             {hasDashboardItemId && (
                 <>
                     <SubscriptionsModal
@@ -223,7 +223,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                             <InsightSaveButton
                                 saveAs={saveAs}
                                 saveInsight={saveInsight}
-                                saveUnder={mustSaveUnder ? openModal : undefined}
+                                saveUnder={canSaveUnder ? openModal : undefined}
                                 isSaved={hasDashboardItemId}
                                 addingToDashboard={!!insight.dashboards?.length && !insight.id}
                                 insightSaving={insightSaving}

--- a/frontend/src/scenes/insights/InsightSaveButton.tsx
+++ b/frontend/src/scenes/insights/InsightSaveButton.tsx
@@ -28,7 +28,7 @@ export function InsightSaveButton({
             disabled={disabled}
             loading={!disabled && insightSaving}
         >
-            {disabled ? 'No changes to be saved' : 'Save under...'}
+            {disabled ? 'No changes to be saved' : 'Save to...'}
         </LemonButton>
     ) : (
         <LemonButton
@@ -63,13 +63,7 @@ export function InsightSaveButton({
                 'data-attr': 'insight-save-dropdown',
             }}
         >
-            {disabled
-                ? 'No changes to be saved'
-                : saveUnder
-                ? 'Save under...'
-                : addingToDashboard
-                ? 'Save & add to dashboard'
-                : 'Save'}
+            {disabled ? 'No changes to be saved' : addingToDashboard ? 'Save & add to dashboard' : 'Save'}
         </LemonButton>
     )
 }

--- a/frontend/src/scenes/insights/InsightSaveButton.tsx
+++ b/frontend/src/scenes/insights/InsightSaveButton.tsx
@@ -2,6 +2,7 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 
 export function InsightSaveButton({
     saveAs,
+    saveUnder,
     saveInsight,
     isSaved,
     insightSaving,
@@ -9,6 +10,7 @@ export function InsightSaveButton({
     addingToDashboard,
 }: {
     saveAs: () => void
+    saveUnder?: () => void
     saveInsight: (redirectToViewMode?: boolean) => void
     isSaved: boolean | undefined
     insightSaving: boolean
@@ -18,7 +20,17 @@ export function InsightSaveButton({
     const disabled = isSaved && !insightChanged
     const saveAsAvailable = isSaved && !addingToDashboard
 
-    return (
+    return saveUnder ? (
+        <LemonButton
+            type="primary"
+            onClick={() => saveUnder()}
+            data-attr="insight-save-under-button"
+            disabled={disabled}
+            loading={!disabled && insightSaving}
+        >
+            {disabled ? 'No changes to be saved' : 'Save under...'}
+        </LemonButton>
+    ) : (
         <LemonButton
             type="primary"
             onClick={() => saveInsight(true)}
@@ -51,7 +63,13 @@ export function InsightSaveButton({
                 'data-attr': 'insight-save-dropdown',
             }}
         >
-            {disabled ? 'No changes to be saved' : addingToDashboard ? 'Save & add to dashboard' : 'Save'}
+            {disabled
+                ? 'No changes to be saved'
+                : saveUnder
+                ? 'Save under...'
+                : addingToDashboard
+                ? 'Save & add to dashboard'
+                : 'Save'}
         </LemonButton>
     )
 }


### PR DESCRIPTION
## Problem

The latest "save under" dialog took up space and was kind of weird overall

![image](https://github.com/user-attachments/assets/540108f8-1807-4c8d-8328-e1ac0eb1c0c3)

## Changes

Add an explicit "save to" button if we did not "new insight" into a folder

![2025-04-25 15 22 33](https://github.com/user-attachments/assets/f809cc84-4b80-4978-8fdf-7bcd6f70b11e)

Saved insights and new insights opened in a folder ("New..." -> "Insight..." -> "Trends") have a "Save" button like before.

![2025-04-25 15 16 25](https://github.com/user-attachments/assets/961d93ac-67b2-4290-80f2-37fff99db317)

## How did you test this code?

Clicked around