### PR TITLE
SUPPORT SUPERDAY - Add a link to report bug on GitHub in Help Panel

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
@@ -427,7 +427,7 @@ export function SidePanelSupport(): JSX.Element {
                                         <LemonButton
                                             type="secondary"
                                             status="alt"
-                                            to="https://github.com/PostHog/posthog/issues/new?&labels=enhancement&template=bug_report.yml"
+                                            to="https://github.com/PostHog/posthog/issues/new?&labels=bug&template=bug_report.yml"
                                             icon={<IconBug />}
                                             targetBlank
                                         >

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
@@ -1,4 +1,4 @@
-import { IconFeatures, IconHelmet, IconMap } from '@posthog/icons'
+import { IconBug, IconFeatures, IconHelmet, IconMap } from '@posthog/icons'
 import { LemonButton, Link } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { SupportForm } from 'lib/components/Support/SupportForm'
@@ -421,6 +421,17 @@ export function SidePanelSupport(): JSX.Element {
                                             targetBlank
                                         >
                                             Request a feature
+                                        </LemonButton>
+                                    </li>
+                                    <li>
+                                        <LemonButton
+                                            type="secondary"
+                                            status="alt"
+                                            to="https://github.com/PostHog/posthog/issues/new?&labels=enhancement&template=bug_report.yml"
+                                            icon={<IconBug />}
+                                            targetBlank
+                                        >
+                                            Report a bug
                                         </LemonButton>
                                     </li>
                                 </ul>


### PR DESCRIPTION

## Problem

Request:

We have a support menu inside of our app ([link](https://us.posthog.com/project/69696#panel=support%3Asupport%3A%3A%3Afalse)), which contains a link to request a new feature. Could you add another button that will allow you to report a bug on GitHub?

## Changes

Added a link to open the bug report template in a new issue in the posthog/posthog repo on GitHub

![Screenshot of new link, highlighted with an orange box](https://github.com/user-attachments/assets/a9272e6f-44b7-45fb-87ed-258ec4e7402a)

## Does this work well for both Cloud and self-hosted?

I don't believe it will have an impact, as purely a minor UI change

## How did you test this code?

Ran the development environment locally and viewed the Help Tab panel.  Saw the new link correctly displayed, and validated that it opened the GitHub new issue page correctly with the correct template.



