### PR TITLE
fix(flags): panic if serve returns

### DIFF
--- a/rust/feature-flags/src/main.rs
+++ b/rust/feature-flags/src/main.rs
@@ -1,3 +1,5 @@
+use std::intrinsics::unreachable;
+
 use envconfig::Envconfig;
 use tokio::signal;
 use tracing_subscriber::fmt;
@@ -50,5 +52,6 @@ async fn main() {
     let listener = tokio::net::TcpListener::bind(config.address)
         .await
         .expect("could not bind port");
-    serve(config, listener, shutdown()).await
+    serve(config, listener, shutdown()).await;
+    unreachable!("Server exited unexpectedly");
 }

--- a/rust/feature-flags/src/main.rs
+++ b/rust/feature-flags/src/main.rs
@@ -1,5 +1,3 @@
-use std::intrinsics::unreachable;
-
 use envconfig::Envconfig;
 use tokio::signal;
 use tracing_subscriber::fmt;


### PR DESCRIPTION
Flags comes up faster than the DB is created in local dev, then fails to make a new connection, and exits. It exits quietly, because `serve` doesn't return an error, and the docker stack doesn't restart it as a result. This change panics if `serve` ever returns, which means the container will be restarted locally and in hobby deploys etc.