### PR TITLE
fix(max): merge messages from subgraphs

### DIFF
--- a/ee/hogai/test/test_assistant.py
+++ b/ee/hogai/test/test_assistant.py
@@ -1237,6 +1237,6 @@ class TestAssistant(ClickhouseTestMixin, NonAtomicBaseTest):
         self.assertEqual(len(messages_with_id), 1, "There should be exactly one message with the test ID")
         self.assertEqual(
             messages_with_id[0].content,
-            first_content,
-            "The merged message should have the content of the first message",
+            updated_content,
+            "The merged message should have the content of the last message",
         )

--- a/ee/hogai/test/test_assistant.py
+++ b/ee/hogai/test/test_assistant.py
@@ -1185,5 +1185,58 @@ class TestAssistant(ClickhouseTestMixin, NonAtomicBaseTest):
         self.conversation.refresh_from_db()
         # Verify the title has been set
         self.assertEqual(self.conversation.title, "Generated Conversation Title")
+        assert self.conversation.updated_at is not None
+        assert initial_updated_at is not None
         self.assertGreater(self.conversation.updated_at, initial_updated_at)
         self.assertEqual(self.conversation.created_at, initial_created_at)
+
+    def test_merges_messages_with_same_id(self):
+        """Test that messages with the same ID are merged into one."""
+        message_id = str(uuid4())
+
+        # Create a simple graph that will return messages with the same ID but different content
+        first_content = "First version of message"
+        updated_content = "Updated version of message"
+
+        class MessageUpdatingNode:
+            def __init__(self):
+                self.call_count = 0
+
+            def __call__(self, state):
+                self.call_count += 1
+                content = first_content if self.call_count == 1 else updated_content
+                return {"messages": [AssistantMessage(id=message_id, content=content)]}
+
+        updater = MessageUpdatingNode()
+        graph = (
+            AssistantGraph(self.team)
+            .add_node(AssistantNodeName.ROOT, updater)
+            .add_edge(AssistantNodeName.START, AssistantNodeName.ROOT)
+            .add_edge(AssistantNodeName.ROOT, AssistantNodeName.END)
+            .compile()
+        )
+        config = {"configurable": {"thread_id": self.conversation.id}}
+
+        # First run should add the message with initial content
+        output = self._run_assistant_graph(graph, conversation=self.conversation)
+        self.assertEqual(len(output), 2)  # Human message + AI message
+        self.assertEqual(output[1][1]["id"], message_id)
+        self.assertEqual(output[1][1]["content"], first_content)
+
+        # Second run should update the message with new content
+        output = self._run_assistant_graph(graph, conversation=self.conversation)
+        self.assertEqual(len(output), 2)  # Human message + AI message
+        self.assertEqual(output[1][1]["id"], message_id)
+        self.assertEqual(output[1][1]["content"], updated_content)
+
+        # Verify the message was actually replaced, not duplicated
+        messages = graph.get_state(config).values["messages"]
+
+        # Count messages with our test ID
+        messages_with_id = [msg for msg in messages if msg.id == message_id]
+        self.assertEqual(len(messages_with_id), 1, "There should be exactly one message with the test ID")
+        self.assertEqual(
+            messages_with_id[0].content,
+            first_content,
+            "The merged message should have the content of the first message",
+        )

--- a/ee/hogai/utils/test/test_state.py
+++ b/ee/hogai/utils/test/test_state.py
@@ -1,0 +1,41 @@
+from ee.hogai.utils.types import add_and_merge_messages
+from posthog.schema import AssistantMessage
+from posthog.test.base import BaseTest
+
+
+class TestState(BaseTest):
+    def test_merge_messages_with_same_id(self):
+        """Test that when messages with the same ID are merged, the message from the right list replaces the one in the left list."""
+        # Create two messages with the same ID
+        message_id = "test-id-123"
+        left_message = AssistantMessage(id=message_id, content="Left message content")
+        right_message = AssistantMessage(id=message_id, content="Right message content")
+
+        # Merge the messages
+        left = [left_message]
+        right = [right_message]
+        result = add_and_merge_messages(left, right)
+
+        # Verify that the message from the right list replaces the one in the left list
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].id, message_id)
+        self.assertEqual(result[0].content, "Right message content")
+
+    def test_merge_messages_with_same_content_no_id(self):
+        """Test that messages with the same content but no ID are not merged."""
+        # Create two messages with the same content but no ID
+        left_message = AssistantMessage(content="Same content")
+        right_message = AssistantMessage(content="Same content")
+
+        # Merge the messages
+        left = [left_message]
+        right = [right_message]
+        result = add_and_merge_messages(left, right)
+
+        # Verify that both messages are in the result with different IDs
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].content, "Same content")
+        self.assertEqual(result[1].content, "Same content")
+        self.assertIsNotNone(result[0].id)
+        self.assertIsNotNone(result[1].id)
+        self.assertNotEqual(result[0].id, result[1].id)

--- a/ee/hogai/utils/types.py
+++ b/ee/hogai/utils/types.py
@@ -42,10 +42,8 @@ def add_and_merge_messages(
         message from `right` will replace the message from `left`.
     """
     # coerce to list
-    if not isinstance(left, list):
-        left = list(left)
-    if not isinstance(right, list):
-        right = list(right)
+    left = list(left)
+    right = list(right)
 
     # assign missing ids
     for m in left:

--- a/ee/hogai/utils/types.py
+++ b/ee/hogai/utils/types.py
@@ -1,4 +1,4 @@
-import operator
+import uuid
 from collections.abc import Sequence
 from enum import StrEnum
 from typing import Annotated, Literal, Optional, Union
@@ -21,6 +21,50 @@ AIMessageUnion = Union[
     AssistantMessage, VisualizationMessage, FailureMessage, ReasoningMessage, AssistantToolCallMessage
 ]
 AssistantMessageUnion = Union[HumanMessage, AIMessageUnion]
+
+
+def add_and_merge_messages(
+    left: Sequence[AssistantMessageUnion], right: Sequence[AssistantMessageUnion]
+) -> Sequence[AssistantMessageUnion]:
+    """Merges two lists of messages, updating existing messages by ID.
+
+    By default, this ensures the state is "append-only", unless the
+    new message has the same ID as an existing message.
+
+    Args:
+        left: The base list of messages.
+        right: The list of messages to merge
+            into the base list.
+
+    Returns:
+        A new list of messages with the messages from `right` merged into `left`.
+        If a message in `right` has the same ID as a message in `left`, the
+        message from `right` will replace the message from `left`.
+    """
+    # coerce to list
+    if not isinstance(left, list):
+        left = list(left)
+    if not isinstance(right, list):
+        right = list(right)
+
+    # assign missing ids
+    for m in left:
+        if m.id is None:
+            m.id = str(uuid.uuid4())
+    for m in right:
+        if m.id is None:
+            m.id = str(uuid.uuid4())
+
+    # merge
+    left_idx_by_id = {m.id: i for i, m in enumerate(left)}
+    merged = left.copy()
+    for m in right:
+        if (existing_idx := left_idx_by_id.get(m.id)) is not None:
+            merged[existing_idx] = m
+        else:
+            merged.append(m)
+
+    return merged
 
 
 class _SharedAssistantState(BaseModel):
@@ -82,7 +126,7 @@ class _SharedAssistantState(BaseModel):
 
 
 class AssistantState(_SharedAssistantState):
-    messages: Annotated[Sequence[AssistantMessageUnion], operator.add]
+    messages: Annotated[Sequence[AssistantMessageUnion], add_and_merge_messages]
     """
     Messages exposed to the user.
     """


### PR DESCRIPTION
## Problem

Subgraphs use the same reducer function for messages as the root state. When the state comes from the subgraph to the main graph, two lists of messages are concatenated, so a conversation has many duplicates. By default, it is handled by the [add_messages](https://github.com/langchain-ai/langgraph/blob/main/libs/langgraph/langgraph/graph/message.py#L53) from LangChain, but we use our own messages, so it didn't work. It explains why the generation quality was lower this week.

## Changes

Fix the reducer function of messages to merge duplicated messages by their IDs.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manual testing, unit tests
