### PR TITLE
fix: rate limit too low

### DIFF
--- a/ee/session_recordings/persistence_tasks.py
+++ b/ee/session_recordings/persistence_tasks.py
@@ -28,12 +28,12 @@ REPLAY_NEEDS_PERSISTENCE_V2_COUNTER = Counter(
 )
 
 
-@shared_task(ignore_result=True, queue=CeleryQueue.SESSION_REPLAY_PERSISTENCE.value, rate_limit="10/m")
+@shared_task(ignore_result=True, queue=CeleryQueue.SESSION_REPLAY_PERSISTENCE.value, rate_limit="15/m")
 def persist_single_recording(id: str, team_id: int) -> None:
     persist_recording(id, team_id)
 
 
-@shared_task(ignore_result=True, queue=CeleryQueue.SESSION_REPLAY_PERSISTENCE.value, rate_limit="10/m")
+@shared_task(ignore_result=True, queue=CeleryQueue.SESSION_REPLAY_PERSISTENCE.value, rate_limit="15/m")
 def persist_single_recording_v2(id: str, team_id: int) -> None:
     persist_recording_v2(id, team_id)
 


### PR DESCRIPTION
https://github.com/PostHog/posthog/pull/31369

this introduced a rate limit to persistence tasks but as a result on a busy day we can't get through 24 hours of tasks in 24 hours

we're having to push up alerts and monitor this when previously it was ignorable 

let's loosen the rate limit a little to try and get through things faster