### PR TITLE
fix: set ttl on old group data cache keys

### DIFF
--- a/posthog/management/commands/fix_stale_group_cache.py
+++ b/posthog/management/commands/fix_stale_group_cache.py
@@ -1,0 +1,147 @@
+from django.core.management.base import BaseCommand, CommandError
+from posthog.redis import get_client
+import random
+
+from structlog import get_logger
+
+logger = get_logger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Set TTL on old idle group_data_cache_v2 keys that are missing a TTL. Supports --dry-run. Adds random TTL to avoid expiration storms."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Only report how many keys would be updated, without modifying Redis.",
+        )
+        parser.add_argument(
+            "--idle-threshold-days",
+            type=int,
+            default=90,
+            help="Minimum idle time in days for a key to be considered stale.",
+        )
+        parser.add_argument(
+            "--min-ttl-days",
+            type=int,
+            default=2,
+            help="Minimum TTL in days to set on stale keys.",
+        )
+        parser.add_argument(
+            "--max-ttl-days",
+            type=int,
+            default=4,
+            help="Maximum TTL in days to set on stale keys.",
+        )
+
+    def _gather_keys_with_no_ttl(self, keys) -> list[dict]:
+        pipe = self._redis_client.pipeline()
+        decoded_keys = []
+        for key in keys:
+            if isinstance(key, bytes):
+                key = key.decode("utf-8")
+            decoded_keys.append(key)
+            pipe.object("idletime", key)
+            pipe.ttl(key)
+        redis_results = pipe.execute()
+        # Build a list of dicts for easier consumption
+        results = []
+        for i, key in enumerate(decoded_keys):
+            # TRICKY: we get idletime and ttl in pairs
+            # so to look up the idletime for key1, we need to get redis_results[2 * i]
+            # and the ttl for key1, we need to get redis_results[2 * i + 1]
+            idletime = redis_results[2 * i]
+            ttl = redis_results[2 * i + 1]
+            if ttl != -1:
+                # if a key has a ttl, it's not stale
+                continue
+            results.append({"key": key, "idletime": idletime, "ttl": ttl})
+        return results
+
+    def _expire_idle_keys(self, results: list[dict]) -> tuple[int, int]:
+        """
+        Expire idle keys based on their idletime and ttl.
+        """
+        checked = 0
+        updated = 0
+        pipe = self._redis_client.pipeline()
+        keys_to_expire = []
+
+        for result in results:
+            key = result["key"]
+            idletime = result["idletime"]
+            ttl = result["ttl"]
+
+            if idletime is None:
+                continue  # Key disappeared between SCAN and OBJECT IDLETIME
+
+            if idletime > self._idle_threshold_seconds:
+                if self._dry_run:
+                    updated += 1
+                else:
+                    if ttl == -1:
+                        random_ttl = random.randint(self._ttl_min_seconds, self._ttl_max_seconds)
+                        pipe.expire(key, random_ttl)
+                        keys_to_expire.append(key)
+                        updated += 1
+
+            checked += 1
+
+            if checked % 1000 == 0:
+                logger.info("Checked keys", checked=checked, updated=updated, dry_run=self._dry_run)
+
+        if not self._dry_run and keys_to_expire:
+            pipe.execute()
+
+        return checked, updated
+
+    def handle(self, *args, **options):
+        min_ttl_days = options["min_ttl_days"]
+        max_ttl_days = options["max_ttl_days"]
+        if min_ttl_days > max_ttl_days:
+            raise CommandError("--min-ttl-days cannot be greater than --max-ttl-days")
+
+        self._redis_client = get_client()
+
+        idle_threshold_days = options["idle_threshold_days"]
+        min_ttl_days = options["min_ttl_days"]
+        max_ttl_days = options["max_ttl_days"]
+
+        self._idle_threshold_seconds = idle_threshold_days * 24 * 3600
+        self._ttl_min_seconds = min_ttl_days * 24 * 3600
+        self._ttl_max_seconds = max_ttl_days * 24 * 3600
+
+        self._dry_run = options["dry_run"]
+
+        cursor = 0
+
+        # so, we'll scan 500k pages of 1000 keys each, or a max of 500M keys
+        # at least an order of magnitude more than we need
+        # but means that if the cursor is not advancing, we'll break out of the loop
+        page_size = 1000
+        max_iterations = 500_000
+        iteration = 0
+
+        logger.info(
+            f"Starting scan. Dry run is set to {self._dry_run}. {'Will change TTL' if not self._dry_run else 'Will not change TTL'}",
+            idle_threshold_days=idle_threshold_days,
+            min_ttl_days=min_ttl_days,
+            max_ttl_days=max_ttl_days,
+        )
+
+        while True:
+            # SCAN does NOT affect key idle time.
+            cursor, keys = self._redis_client.scan(cursor=cursor, match="group_data_cache_v2*", count=page_size)
+
+            results = self._gather_keys_with_no_ttl(keys)
+
+            (checked, updated) = self._expire_idle_keys(results)
+
+            iteration += 1
+            if cursor == 0 or iteration >= max_iterations:
+                if iteration >= max_iterations:
+                    logger.warn("Max iterations reached, breaking out of scan loop", iteration=iteration)
+                break
+
+        logger.info("Done", checked=checked, updated=updated, dry_run=self._dry_run)

--- a/posthog/management/commands/fix_stale_group_cache.py
+++ b/posthog/management/commands/fix_stale_group_cache.py
@@ -1,10 +1,13 @@
 from django.core.management.base import BaseCommand, CommandError
 from posthog.redis import get_client
 import random
+import logging
+import argparse
 
 from structlog import get_logger
 
 logger = get_logger(__name__)
+logger.setLevel(logging.INFO)
 
 
 class Command(BaseCommand):
@@ -13,7 +16,8 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
             "--dry-run",
-            action="store_true",
+            action=argparse.BooleanOptionalAction,
+            default=True,
             help="Only report how many keys would be updated, without modifying Redis.",
         )
         parser.add_argument(
@@ -97,6 +101,10 @@ class Command(BaseCommand):
         return checked, updated
 
     def handle(self, *args, **options):
+        logger.info(
+            f"Starting scan fix_stale_group_cache",
+        )
+
         min_ttl_days = options["min_ttl_days"]
         max_ttl_days = options["max_ttl_days"]
         if min_ttl_days > max_ttl_days:

--- a/posthog/management/commands/fix_stale_group_cache.py
+++ b/posthog/management/commands/fix_stale_group_cache.py
@@ -113,10 +113,8 @@ class Command(BaseCommand):
         self._redis_client = get_client()
 
         idle_threshold_days = options["idle_threshold_days"]
-        min_ttl_days = options["min_ttl_days"]
-        max_ttl_days = options["max_ttl_days"]
-
         self._idle_threshold_seconds = idle_threshold_days * 24 * 3600
+
         self._ttl_min_seconds = min_ttl_days * 24 * 3600
         self._ttl_max_seconds = max_ttl_days * 24 * 3600
 

--- a/posthog/management/commands/test/test_fix_stale_group_cache.py
+++ b/posthog/management/commands/test/test_fix_stale_group_cache.py
@@ -8,6 +8,9 @@ def fake_redis():
     # Simulate a Redis client with scan, object, ttl, and expire
     class FakeRedis:
         def __init__(self):
+            self.reset()
+
+        def reset(self):
             self.keys = {
                 "group_data_cache_v2:1": {"idletime": 8000000, "ttl": -1},
                 "group_data_cache_v2:2": {"idletime": 100, "ttl": -1},
@@ -52,9 +55,19 @@ def test_dry_run_sets_no_ttl(mock_get_client, fake_redis):
 
 
 @patch("posthog.management.commands.fix_stale_group_cache.get_client")
+def test_default_is_dry_run(mock_get_client, fake_redis):
+    mock_get_client.return_value = fake_redis
+    call_command("fix_stale_group_cache", "--idle-threshold-days=1")
+    # Should not set any TTLs in dry run
+    assert fake_redis.expired == {}
+
+
+@patch("posthog.management.commands.fix_stale_group_cache.get_client")
 def test_real_run_sets_ttl(mock_get_client, fake_redis):
     mock_get_client.return_value = fake_redis
-    call_command("fix_stale_group_cache", "--idle-threshold-days=1", "--min-ttl-days=1", "--max-ttl-days=1")
+    call_command(
+        "fix_stale_group_cache", "--idle-threshold-days=1", "--min-ttl-days=1", "--max-ttl-days=1", "--no-dry-run"
+    )
     # Only keys with idletime > threshold and ttl == -1 get expired
     assert "group_data_cache_v2:1" in fake_redis.expired
     # group_data_cache_v2:2 is not idle enough, group_data_cache_v2:3 already has TTL
@@ -64,12 +77,54 @@ def test_real_run_sets_ttl(mock_get_client, fake_redis):
 def test_min_ttl_greater_than_max_raises(mock_get_client, fake_redis):
     mock_get_client.return_value = fake_redis
     with pytest.raises(CommandError):
-        call_command("fix_stale_group_cache", "--min-ttl-days=5", "--max-ttl-days=1")
+        call_command("fix_stale_group_cache", "--min-ttl-days=5", "--max-ttl-days=1", "--no-dry-run")
 
 
 @patch("posthog.management.commands.fix_stale_group_cache.get_client")
 def test_idle_threshold_respected(mock_get_client, fake_redis):
     mock_get_client.return_value = fake_redis
-    call_command("fix_stale_group_cache", "--idle-threshold-days=100000")
+    call_command("fix_stale_group_cache", "--idle-threshold-days=100000", "--no-dry-run")
     # No keys should be expired, as none are idle enough
     assert fake_redis.expired == {}
+
+
+# ... existing code ...
+
+
+@patch("posthog.management.commands.fix_stale_group_cache.get_client")
+def test_ttl_randomization_varies_and_within_bounds(mock_get_client, fake_redis):
+    mock_get_client.return_value = fake_redis
+    min_days = 2
+    max_days = 5
+
+    # Call 1
+    call_command(
+        "fix_stale_group_cache",
+        "--idle-threshold-days=1",
+        f"--min-ttl-days={min_days}",
+        f"--max-ttl-days={max_days}",
+        "--no-dry-run",
+    )
+    ttls_1 = list(fake_redis.expired.values())
+
+    # Reset expired and call again
+    fake_redis.reset()
+    call_command(
+        "fix_stale_group_cache",
+        "--idle-threshold-days=1",
+        f"--min-ttl-days={min_days}",
+        f"--max-ttl-days={max_days}",
+        "--no-dry-run",
+    )
+    ttls_2 = list(fake_redis.expired.values())
+
+    # Should have at least one TTL set each time
+    assert ttls_1 and ttls_2
+
+    # Check all TTLs are within bounds (in seconds)
+    for ttl in ttls_1 + ttls_2:
+        days = ttl // (24 * 3600)
+        assert min_days <= days <= max_days, f"TTL {ttl} not in range {min_days}-{max_days}"
+
+    # Check that at least one TTL differs between runs (randomization)
+    assert set(ttls_1) != set(ttls_2), f"TTLs did not vary: {ttls_1} vs {ttls_2}"

--- a/posthog/management/commands/test/test_fix_stale_group_cache.py
+++ b/posthog/management/commands/test/test_fix_stale_group_cache.py
@@ -1,0 +1,75 @@
+import pytest
+from unittest.mock import patch
+from django.core.management import call_command, CommandError
+
+
+@pytest.fixture
+def fake_redis():
+    # Simulate a Redis client with scan, object, ttl, and expire
+    class FakeRedis:
+        def __init__(self):
+            self.keys = {
+                "group_data_cache_v2:1": {"idletime": 8000000, "ttl": -1},
+                "group_data_cache_v2:2": {"idletime": 100, "ttl": -1},
+                "group_data_cache_v2:3": {"idletime": 8000000, "ttl": 100},
+            }
+            self.expired = {}
+
+        def scan(self, cursor=0, match=None, count=None):
+            # Return all keys at once for simplicity
+            return 0, list(self.keys.keys())
+
+        def pipeline(self):
+            return self
+
+        def object(self, what, key):
+            self._last_key = key
+            return self
+
+        def ttl(self, key):
+            return self
+
+        def execute(self):
+            # Return idletime and ttl for each key in order
+            results = []
+            for key in self.keys:
+                results.append(self.keys[key]["idletime"])
+                results.append(self.keys[key]["ttl"])
+            return results
+
+        def expire(self, key, ttl):
+            self.expired[key] = ttl
+
+    return FakeRedis()
+
+
+@patch("posthog.management.commands.fix_stale_group_cache.get_client")
+def test_dry_run_sets_no_ttl(mock_get_client, fake_redis):
+    mock_get_client.return_value = fake_redis
+    call_command("fix_stale_group_cache", "--dry-run", "--idle-threshold-days=1")
+    # Should not set any TTLs in dry run
+    assert fake_redis.expired == {}
+
+
+@patch("posthog.management.commands.fix_stale_group_cache.get_client")
+def test_real_run_sets_ttl(mock_get_client, fake_redis):
+    mock_get_client.return_value = fake_redis
+    call_command("fix_stale_group_cache", "--idle-threshold-days=1", "--min-ttl-days=1", "--max-ttl-days=1")
+    # Only keys with idletime > threshold and ttl == -1 get expired
+    assert "group_data_cache_v2:1" in fake_redis.expired
+    # group_data_cache_v2:2 is not idle enough, group_data_cache_v2:3 already has TTL
+
+
+@patch("posthog.management.commands.fix_stale_group_cache.get_client")
+def test_min_ttl_greater_than_max_raises(mock_get_client, fake_redis):
+    mock_get_client.return_value = fake_redis
+    with pytest.raises(CommandError):
+        call_command("fix_stale_group_cache", "--min-ttl-days=5", "--max-ttl-days=1")
+
+
+@patch("posthog.management.commands.fix_stale_group_cache.get_client")
+def test_idle_threshold_respected(mock_get_client, fake_redis):
+    mock_get_client.return_value = fake_redis
+    call_command("fix_stale_group_cache", "--idle-threshold-days=100000")
+    # No keys should be expired, as none are idle enough
+    assert fake_redis.expired == {}


### PR DESCRIPTION
see: https://posthog.slack.com/archives/C08PEQL3TAT

the majority of redis cluster RAM is some old group data keys which we no longer set (or read)

they have no TTL set (or at least a random sample in the EU don't)

we're hitting RAM limits under some conditions

the redis cluster max memory policy is set to volatile-lru

this means it doesn't evict keys with no ttl

so these keys will sit using memory forever

this PR adds a management command to scan for them and add a random TTL between 2 and 4 days out

that lets redis evict them based on pressure and means we won't have a big storm of CPU use in redis expiring >2.5M keys

* can run with `./manage.py fix_stale_group_cache --no-dry-run` to actually make the change
* can run with `./manage.py fix_stale_group_cache --dry-run` to actually make no changes but output stats

by default dry run is true