### PR TITLE
chore: Port local evaluation endpoint to Rust

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2247,6 +2247,7 @@ dependencies = [
  "metrics",
  "moka",
  "once_cell",
+ "pbkdf2",
  "percent-encoding",
  "petgraph",
  "rand",
@@ -2259,6 +2260,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
+ "sha2",
  "sqlx",
  "strum",
  "thiserror 1.0.69",
@@ -4249,6 +4251,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
 dependencies = [
  "regex",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash",
+ "sha2",
 ]
 
 [[package]]

--- a/rust/common/limiters/src/redis.rs
+++ b/rust/common/limiters/src/redis.rs
@@ -14,7 +14,7 @@ use tracing::instrument;
 /// We have an async celery worker that regularly checks on accounts + assesses if they are beyond
 /// a billing limit. If this is the case, a key is set in redis.
 ///
-/// For replay sessions we also check if too many events are coming in in ingestion for a single session
+/// For replay sessions we also check if too many events are coming in ingestion for a single session
 /// and set a redis key to redirect further events to overflow.
 ///
 /// For feature flag evaluations we still return a 200 response, but add an entry to the response body

--- a/rust/feature-flags/Cargo.toml
+++ b/rust/feature-flags/Cargo.toml
@@ -51,6 +51,8 @@ dateparser = "0.2.1"
 rust_decimal = "1.37.1"
 rayon = "1.10.0"
 percent-encoding = "2.3.1"
+sha2 = "0.10"
+pbkdf2 = { version = "0.12", features = ["simple"] }
 
 [lints]
 workspace = true

--- a/rust/feature-flags/src/api/auth.rs
+++ b/rust/feature-flags/src/api/auth.rs
@@ -1,4 +1,13 @@
-use crate::api::{errors::FlagDefinitionsError, request_handler::RequestInfo};
+use crate::api::request_handler::RequestInfo;
+use crate::client::database::Client;
+use crate::flags::models::PersonalAPIKey;
+use base64::engine::general_purpose;
+use base64::Engine;
+use chrono::{Duration, Utc};
+use pbkdf2::pbkdf2_hmac_array;
+use sha2::{Digest, Sha256};
+use sqlx::FromRow;
+use thiserror::Error;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum ApiKeySource {
@@ -7,9 +16,31 @@ pub enum ApiKeySource {
     Query,
 }
 
+#[derive(Error, Debug)]
+pub enum AuthError {
+    #[error("Invalid personal API key")]
+    InvalidPersonalApiKey,
+
+    #[error("No personal API key in request")]
+    NoPersonalApiKey,
+
+    #[error("Invalid key")]
+    InvalidKey(String),
+
+    #[error("Internal error: {0}")]
+    Internal(String),
+
+    #[error("Request decoding error: {0}")]
+    RequestDecodingError(String),
+
+    #[error("Invalid scopes: {0}")]
+    InvalidScopes(String),
+}
+
+// Ported from auth.py
 pub fn find_personal_api_key_with_source(
     request: &RequestInfo,
-) -> Result<(String, ApiKeySource), FlagDefinitionsError> {
+) -> Result<(String, ApiKeySource), AuthError> {
     // Per the docs: https://posthog.com/docs/api
     // We try to read the personal API token from these three places in order.
     // We use the first one we find.
@@ -23,22 +54,26 @@ pub fn find_personal_api_key_with_source(
     let query = &request.meta;
 
     // We try to read the personal API token from the bearer token first.
-    let bearer_token = headers
-        .get("Authorization")
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.split_whitespace().nth(1).unwrap_or("").to_string());
-
-    if let Some(bearer_token) = bearer_token {
-        return Ok((bearer_token, ApiKeySource::AuthorizationHeader));
+    if let Some(auth_header) = headers.get("Authorization").and_then(|v| v.to_str().ok()) {
+        let mut parts = auth_header.split_whitespace();
+        match (parts.next(), parts.next()) {
+            (Some("Bearer"), Some(token)) if !token.is_empty() => {
+                return Ok((token.to_string(), ApiKeySource::AuthorizationHeader));
+            }
+            (Some("Bearer"), Some(_)) => {
+                return Err(AuthError::NoPersonalApiKey);
+            }
+            _ => {}
+        }
     }
 
     // We try to read the personal API token from the request body.
     if !body.is_empty() {
         let request_body = String::from_utf8(body.to_vec())
-            .map_err(|e| FlagDefinitionsError::RequestDecodingError(e.to_string()))?;
+            .map_err(|e| AuthError::RequestDecodingError(e.to_string()))?;
 
         let request_body_json: serde_json::Value = serde_json::from_str(&request_body)
-            .map_err(|e| FlagDefinitionsError::RequestDecodingError(e.to_string()))?;
+            .map_err(|e| AuthError::RequestDecodingError(e.to_string()))?;
 
         let personal_api_token = request_body_json
             .get("personal_api_key")
@@ -57,13 +92,175 @@ pub fn find_personal_api_key_with_source(
         return Ok((personal_api_token, ApiKeySource::Query));
     }
 
-    return Err(FlagDefinitionsError::NoPersonalApiKeyError);
+    return Err(AuthError::NoPersonalApiKey);
+}
+
+const LEGACY_PERSONAL_API_KEY_SALT: &str = "posthog_personal_api_key";
+const PERSONAL_API_KEY_MODES_TO_TRY: &[(&str, Option<u32>)] = &[
+    ("sha256", None),
+    ("pbkdf2", Some(260_000)),
+    ("pbkdf2", Some(390_000)),
+];
+
+// Ported from auth.py
+pub fn hash_key_value(
+    value: &str,
+    mode: &str,
+    iterations: Option<u32>,
+) -> Result<String, AuthError> {
+    match mode {
+        "pbkdf2" => {
+            let iterations = iterations.ok_or_else(|| {
+                AuthError::Internal(
+                    "Iterations must be provided when using legacy PBKDF2 mode".to_string(),
+                )
+            })?;
+
+            // 32 bytes output, just like Django
+            let hash = pbkdf2_hmac_array::<Sha256, 32>(
+                value.as_bytes(),
+                LEGACY_PERSONAL_API_KEY_SALT.as_bytes(),
+                iterations,
+            );
+
+            // Django's PBKDF2PasswordHasher encodes as: "pbkdf2_sha256$<iterations>$<salt>$<b64hash>"
+            let hash_b64 = general_purpose::STANDARD.encode(hash);
+
+            Ok(format!(
+                "pbkdf2_sha256${}${}${}",
+                iterations, LEGACY_PERSONAL_API_KEY_SALT, hash_b64
+            ))
+        }
+        "sha256" => {
+            if iterations.is_some() {
+                return Err(AuthError::Internal(
+                    "Iterations must not be provided when using simple hashing mode".to_string(),
+                ));
+            }
+
+            let mut hasher = Sha256::new();
+            hasher.update(value.as_bytes());
+            Ok(format!("sha256${:x}", hasher.finalize()))
+        }
+        _ => Err(AuthError::Internal("Invalid hash mode".to_string())),
+    }
+}
+
+// Ported from auth.py
+pub async fn validate_personal_api_key(
+    pool: &(dyn Client + Send + Sync),
+    personal_api_key: &str,
+    source: ApiKeySource,
+) -> Result<PersonalAPIKey, AuthError> {
+    let mut personal_api_key_row = None;
+    let mut mode_used = None;
+
+    // Try each mode until we find a match
+    for &(mode, iterations) in PERSONAL_API_KEY_MODES_TO_TRY {
+        let secure_value = hash_key_value(personal_api_key, mode, iterations)?;
+        // The stored team_id is always null because personal API keys are no
+        // longer scoped to a team, but a user.
+        // TODO: We might want to consider using a LEFT JOIN to get the team_id
+        // and organization_id for legacy personal API keys so that we can warn
+        // on keys for users that don't have a team. I'm fine with leaving this
+        // as is for now.
+        let query = "SELECT 
+                pk.id,
+                u.current_team_id as team_id,
+                t.organization_id,
+                pk.user_id,
+                pk.label,
+                pk.value,
+                pk.mask_value,
+                pk.secure_value,
+                pk.created_at,
+                pk.last_used_at,
+                pk.scopes,
+                pk.scoped_teams,
+                pk.scoped_organizations
+            FROM posthog_personalapikey pk
+            INNER JOIN posthog_user u ON pk.user_id = u.id
+            INNER JOIN posthog_team t ON t.id = u.current_team_id
+            WHERE pk.secure_value = $1 AND u.is_active = true";
+        let rows = pool
+            .run_query(query.to_string(), vec![secure_value], None)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to fetch personal API key from database: {}", e);
+                AuthError::Internal(format!("Database query error: {}", e))
+            })?;
+
+        if let Some(row) = rows.first() {
+            personal_api_key_row = Some(
+                PersonalAPIKey::from_row(row)
+                    .map_err(|e| AuthError::Internal(format!("Failed to parse row: {}", e)))?,
+            );
+            mode_used = Some(mode);
+            break;
+        }
+    }
+
+    let api_key = personal_api_key_row.ok_or_else(|| {
+        AuthError::InvalidKey(format!(
+            "Personal API key found in request {:?} is invalid.",
+            source
+        ))
+    })?;
+
+    // Upgrade the key if it's not using the latest mode (sha256)
+    if mode_used.unwrap() != "sha256" {
+        let secure_value = hash_key_value(personal_api_key, "sha256", None)?;
+        let update_query = "UPDATE posthog_personalapikey SET secure_value = $1 WHERE id = $2";
+        pool.run_query(
+            update_query.to_string(),
+            vec![secure_value, api_key.id.clone()],
+            None,
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to update API key hash: {}", e);
+            AuthError::Internal(format!("Failed to update API key hash: {}", e))
+        })?;
+    }
+
+    Ok(api_key)
+}
+
+// Ported from auth.py
+pub async fn authenticate_personal_api_key(
+    pool: &(dyn Client + Send + Sync),
+    request: &RequestInfo,
+) -> Result<PersonalAPIKey, AuthError> {
+    let (personal_api_key, source) = find_personal_api_key_with_source(request)?;
+    let mut personal_api_key = validate_personal_api_key(pool, &personal_api_key, source).await?;
+
+    // Update last_used_at if needed (if None or more than 1 hour ago)
+    let now = Utc::now();
+    let needs_update = match personal_api_key.last_used_at {
+        None => true,
+        Some(last) => now.signed_duration_since(last) > Duration::hours(1),
+    };
+    if needs_update {
+        let update_query = "UPDATE posthog_personalapikey SET last_used_at = NOW() WHERE id = $1";
+        pool.run_query(
+            update_query.to_string(),
+            vec![personal_api_key.id.clone()],
+            None,
+        )
+        .await
+        .map_err(|e| AuthError::Internal(format!("Failed to update last_used_at: {}", e)))?;
+        // Update the struct in memory too
+        personal_api_key.last_used_at = Some(now);
+    }
+
+    Ok(personal_api_key)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::api::request_handler::{FlagsQueryParams, RequestInfo};
+    use crate::utils::test_utils::insert_personal_api_key_for_user;
     use axum::http::{HeaderMap, HeaderValue, Method};
     use bytes::Bytes;
     use uuid::Uuid;
@@ -97,7 +294,7 @@ mod tests {
     }
 
     #[test]
-    fn test_decode_personal_api_token_from_body() {
+    fn test_find_personal_api_token_from_body() {
         let request = RequestInfo {
             id: Uuid::new_v4(),
             ip: "127.0.0.1".parse().unwrap(),
@@ -119,7 +316,7 @@ mod tests {
     }
 
     #[test]
-    fn test_decode_personal_api_token_from_query() {
+    fn test_find_personal_api_token_from_query() {
         let request = RequestInfo {
             id: Uuid::new_v4(),
             ip: "127.0.0.1".parse().unwrap(),
@@ -141,7 +338,7 @@ mod tests {
     }
 
     #[test]
-    fn test_decode_personal_api_token_priority() {
+    fn test_find_personal_api_token_priority() {
         // Test that bearer token takes precedence over body and query
         let mut headers = HeaderMap::new();
         headers.insert(
@@ -169,7 +366,7 @@ mod tests {
     }
 
     #[test]
-    fn test_decode_personal_api_token_missing() {
+    fn test_find_personal_api_token_missing() {
         let request = RequestInfo {
             id: Uuid::new_v4(),
             ip: "127.0.0.1".parse().unwrap(),
@@ -186,14 +383,11 @@ mod tests {
         };
 
         let result = find_personal_api_key_with_source(&request);
-        assert!(matches!(
-            result,
-            Err(FlagDefinitionsError::NoPersonalApiKeyError)
-        ));
+        assert!(matches!(result, Err(AuthError::NoPersonalApiKey)));
     }
 
     #[test]
-    fn test_decode_personal_api_token_invalid_body() {
+    fn test_find_personal_api_token_invalid_body() {
         let request = RequestInfo {
             id: Uuid::new_v4(),
             ip: "127.0.0.1".parse().unwrap(),
@@ -210,9 +404,172 @@ mod tests {
         };
 
         let result = find_personal_api_key_with_source(&request);
-        assert!(matches!(
-            result,
-            Err(FlagDefinitionsError::RequestDecodingError(_))
-        ));
+        assert!(matches!(result, Err(AuthError::RequestDecodingError(_))));
+    }
+
+    #[test]
+    fn test_find_personal_api_key_with_source_empty_bearer() {
+        let mut headers = HeaderMap::new();
+        headers.insert("Authorization", HeaderValue::from_static("Bearer "));
+
+        let request = RequestInfo {
+            id: Uuid::new_v4(),
+            ip: "127.0.0.1".parse().unwrap(),
+            headers,
+            body: Bytes::new(),
+            method: Method::GET,
+            meta: FlagsQueryParams {
+                version: None,
+                compression: None,
+                lib_version: None,
+                sent_at: None,
+                personal_api_key: None,
+            },
+        };
+
+        let result = find_personal_api_key_with_source(&request);
+        assert!(matches!(result, Err(AuthError::NoPersonalApiKey)));
+    }
+
+    #[test]
+    fn test_hash_key_value_sha256() {
+        let value = "phx_XalGN9039Jm7WFAZwFSZQ3yv0Kgo7qJyOHe11b2fHaZU6FS";
+        let hash = "sha256$a8991682dd3f0c6d22227115714af2d2e9f5da9978495e29c35f65f16ee52559";
+        assert!(hash.starts_with("sha256$"));
+        // Should be deterministic
+        assert_eq!(hash, hash_key_value(value, "sha256", None).unwrap());
+    }
+
+    #[test]
+    fn test_hash_key_value_pbkdf2() {
+        let value = "testkey";
+        let hash = hash_key_value(value, "pbkdf2", Some(260_000)).unwrap();
+        assert!(hash.starts_with("pbkdf2_sha256$260000$posthog_personal_api_key$"));
+    }
+
+    #[test]
+    fn test_hash_key_value_pbkdf2_missing_iterations() {
+        let value = "testkey";
+        let err = hash_key_value(value, "pbkdf2", None).unwrap_err();
+        assert!(matches!(err, AuthError::Internal(_)));
+    }
+
+    #[test]
+    fn test_hash_key_value_sha256_with_iterations_should_error() {
+        let value = "testkey";
+        let err = hash_key_value(value, "sha256", Some(123)).unwrap_err();
+        assert!(matches!(err, AuthError::Internal(_)));
+    }
+
+    #[tokio::test]
+    async fn test_validate_personal_api_key_valid() {
+        use crate::utils::test_utils::setup_pg_reader_client;
+        let client = setup_pg_reader_client(None).await;
+
+        // Truncate the table to avoid unique constraint errors
+        let mut conn = client
+            .get_connection()
+            .await
+            .expect("Failed to get connection");
+        sqlx::query("TRUNCATE TABLE posthog_personalapikey CASCADE")
+            .execute(&mut *conn)
+            .await
+            .expect("Failed to truncate posthog_personalapikey");
+
+        // Insert a team and get its user_id (adapt as needed for your schema)
+        let team = crate::utils::test_utils::insert_new_team_in_pg(client.clone(), None)
+            .await
+            .expect("Failed to insert team");
+        let user = crate::utils::test_utils::insert_user_for_team_in_pg(client.clone(), team.id)
+            .await
+            .expect("Failed to insert user");
+        let user_id = user.id;
+        let api_key_str = "phx_JVRb8fNi0XyIKGgUCyi29ZJUOXEr6NF2dKBy5Ws8XVeF11C";
+        insert_personal_api_key_for_user(client.clone(), user_id, api_key_str)
+            .await
+            .expect("Failed to insert personal API key");
+
+        let result = validate_personal_api_key(
+            client.as_ref(),
+            api_key_str,
+            ApiKeySource::AuthorizationHeader,
+        )
+        .await;
+
+        let api_key = result.expect("validate_personal_api_key failed");
+        assert_eq!(
+            api_key.secure_value.as_deref(),
+            Some(
+                hash_key_value(api_key_str, "sha256", None)
+                    .unwrap()
+                    .as_str()
+            )
+        );
+        assert!(!api_key.id.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_validate_personal_api_key_invalid() {
+        use crate::utils::test_utils::setup_pg_reader_client;
+        let client = setup_pg_reader_client(None).await;
+        // This key is a valid format, but does not exist in the database
+        let result = validate_personal_api_key(
+            client.as_ref(),
+            "phx_XalGN9039Jm7WFAZwFSZQ3yv0Kgo7qJyOHe11b2fHaZU6FS",
+            ApiKeySource::AuthorizationHeader,
+        )
+        .await;
+        assert!(matches!(result, Err(AuthError::InvalidKey(_))));
+    }
+
+    #[tokio::test]
+    async fn test_authenticate_personal_api_key_valid() {
+        use crate::utils::test_utils::{
+            insert_new_team_in_pg, insert_personal_api_key_for_user, insert_user_for_team_in_pg,
+            setup_pg_reader_client,
+        };
+        use axum::http::{HeaderMap, HeaderValue, Method};
+        use bytes::Bytes;
+        use uuid::Uuid;
+
+        let client = setup_pg_reader_client(None).await;
+        // Truncate the table to avoid unique constraint errors
+        let mut conn = client
+            .get_connection()
+            .await
+            .expect("Failed to get connection");
+        sqlx::query("TRUNCATE TABLE posthog_personalapikey CASCADE")
+            .execute(&mut *conn)
+            .await
+            .expect("Failed to truncate posthog_personalapikey");
+
+        let team = insert_new_team_in_pg(client.clone(), None)
+            .await
+            .expect("Failed to insert team");
+        let user = insert_user_for_team_in_pg(client.clone(), team.id)
+            .await
+            .expect("Failed to insert user");
+        let api_key_str = "phx_KIwIaTavK0c4uE4s0iPj6Ir7uGpDhHpius8pKs80GZd0Srp";
+        insert_personal_api_key_for_user(client.clone(), user.id, api_key_str)
+            .await
+            .expect("Failed to insert personal API key");
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "Authorization",
+            HeaderValue::from_str(&format!("Bearer {}", api_key_str)).unwrap(),
+        );
+        let request = RequestInfo {
+            id: Uuid::new_v4(),
+            ip: "127.0.0.1".parse().unwrap(),
+            headers,
+            body: Bytes::new(),
+            method: Method::GET,
+            meta: crate::api::request_handler::FlagsQueryParams::default(),
+        };
+        let api_key = authenticate_personal_api_key(client.as_ref(), &request)
+            .await
+            .expect("Should authenticate");
+        assert_eq!(api_key.team_id, Some(team.id));
     }
 }

--- a/rust/feature-flags/src/api/auth.rs
+++ b/rust/feature-flags/src/api/auth.rs
@@ -1,3 +1,4 @@
+use crate::api::errors::FlagError;
 use crate::api::request_handler::RequestInfo;
 use crate::client::database::Client;
 use crate::flags::models::PersonalAPIKey;
@@ -35,6 +36,21 @@ pub enum AuthError {
 
     #[error("Invalid scopes: {0}")]
     InvalidScopes(String),
+}
+
+impl From<crate::api::auth::AuthError> for FlagError {
+    fn from(e: crate::api::auth::AuthError) -> Self {
+        use crate::api::auth::AuthError;
+        match e {
+            AuthError::InvalidPersonalApiKey | AuthError::NoPersonalApiKey => {
+                FlagError::NoPersonalApiKeyError
+            }
+            AuthError::InvalidKey(_) => FlagError::PersonalApiKeyValidationError,
+            AuthError::Internal(msg) => FlagError::Internal(msg),
+            AuthError::RequestDecodingError(msg) => FlagError::RequestDecodingError(msg),
+            AuthError::InvalidScopes(msg) => FlagError::InvalidScopes(msg),
+        }
+    }
 }
 
 // Ported from auth.py
@@ -168,6 +184,7 @@ pub async fn validate_personal_api_key(
                 pk.id,
                 u.current_team_id as team_id,
                 t.organization_id,
+                t.project_id,
                 pk.user_id,
                 pk.label,
                 pk.value,
@@ -285,6 +302,7 @@ mod tests {
                 lib_version: None,
                 sent_at: None,
                 personal_api_key: None,
+                send_cohorts: None,
             },
         };
 
@@ -307,6 +325,7 @@ mod tests {
                 lib_version: None,
                 sent_at: None,
                 personal_api_key: None,
+                send_cohorts: None,
             },
         };
 
@@ -329,6 +348,7 @@ mod tests {
                 lib_version: None,
                 sent_at: None,
                 personal_api_key: Some("test-token".to_string()),
+                send_cohorts: None,
             },
         };
 
@@ -357,6 +377,7 @@ mod tests {
                 lib_version: None,
                 sent_at: None,
                 personal_api_key: Some("query-token".to_string()),
+                send_cohorts: None,
             },
         };
 
@@ -379,6 +400,7 @@ mod tests {
                 lib_version: None,
                 sent_at: None,
                 personal_api_key: None,
+                send_cohorts: None,
             },
         };
 
@@ -400,6 +422,7 @@ mod tests {
                 lib_version: None,
                 sent_at: None,
                 personal_api_key: None,
+                send_cohorts: None,
             },
         };
 
@@ -424,6 +447,7 @@ mod tests {
                 lib_version: None,
                 sent_at: None,
                 personal_api_key: None,
+                send_cohorts: None,
             },
         };
 

--- a/rust/feature-flags/src/api/auth.rs
+++ b/rust/feature-flags/src/api/auth.rs
@@ -1,0 +1,218 @@
+use crate::api::{errors::FlagDefinitionsError, request_handler::RequestInfo};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ApiKeySource {
+    AuthorizationHeader,
+    Body,
+    Query,
+}
+
+pub fn find_personal_api_key_with_source(
+    request: &RequestInfo,
+) -> Result<(String, ApiKeySource), FlagDefinitionsError> {
+    // Per the docs: https://posthog.com/docs/api
+    // We try to read the personal API token from these three places in order.
+    // We use the first one we find.
+    // The bearer token: Authorization: "Bearer ${POSTHOG_PERSONAL_API_KEY}"
+    // The request body: { "personal_api_key": "..."}
+    // The query param: ?personal_api_key=...
+    // Then we return the key along with where we found it.
+
+    let body = &request.body;
+    let headers = &request.headers;
+    let query = &request.meta;
+
+    // We try to read the personal API token from the bearer token first.
+    let bearer_token = headers
+        .get("Authorization")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.split_whitespace().nth(1).unwrap_or("").to_string());
+
+    if let Some(bearer_token) = bearer_token {
+        return Ok((bearer_token, ApiKeySource::AuthorizationHeader));
+    }
+
+    // We try to read the personal API token from the request body.
+    if !body.is_empty() {
+        let request_body = String::from_utf8(body.to_vec())
+            .map_err(|e| FlagDefinitionsError::RequestDecodingError(e.to_string()))?;
+
+        let request_body_json: serde_json::Value = serde_json::from_str(&request_body)
+            .map_err(|e| FlagDefinitionsError::RequestDecodingError(e.to_string()))?;
+
+        let personal_api_token = request_body_json
+            .get("personal_api_key")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        if let Some(personal_api_token) = personal_api_token {
+            return Ok((personal_api_token, ApiKeySource::Body));
+        }
+    }
+
+    // Try to read it from the query string parameters.
+    let personal_api_token = query.personal_api_key.clone();
+
+    if let Some(personal_api_token) = personal_api_token {
+        return Ok((personal_api_token, ApiKeySource::Query));
+    }
+
+    return Err(FlagDefinitionsError::NoPersonalApiKeyError);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::request_handler::{FlagsQueryParams, RequestInfo};
+    use axum::http::{HeaderMap, HeaderValue, Method};
+    use bytes::Bytes;
+    use uuid::Uuid;
+
+    #[test]
+    fn test_find_personal_api_key_with_source_from_bearer() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "Authorization",
+            HeaderValue::from_static("Bearer test-token"),
+        );
+
+        let request = RequestInfo {
+            id: Uuid::new_v4(),
+            ip: "127.0.0.1".parse().unwrap(),
+            headers,
+            body: Bytes::new(),
+            method: Method::GET,
+            meta: FlagsQueryParams {
+                version: None,
+                compression: None,
+                lib_version: None,
+                sent_at: None,
+                personal_api_key: None,
+            },
+        };
+
+        let (key, source) = find_personal_api_key_with_source(&request).unwrap();
+        assert_eq!(key, "test-token");
+        assert_eq!(source, ApiKeySource::AuthorizationHeader);
+    }
+
+    #[test]
+    fn test_decode_personal_api_token_from_body() {
+        let request = RequestInfo {
+            id: Uuid::new_v4(),
+            ip: "127.0.0.1".parse().unwrap(),
+            headers: HeaderMap::new(),
+            body: Bytes::from(r#"{"personal_api_key": "test-token"}"#),
+            method: Method::GET,
+            meta: FlagsQueryParams {
+                version: None,
+                compression: None,
+                lib_version: None,
+                sent_at: None,
+                personal_api_key: None,
+            },
+        };
+
+        let (key, source) = find_personal_api_key_with_source(&request).unwrap();
+        assert_eq!(key, "test-token");
+        assert_eq!(source, ApiKeySource::Body);
+    }
+
+    #[test]
+    fn test_decode_personal_api_token_from_query() {
+        let request = RequestInfo {
+            id: Uuid::new_v4(),
+            ip: "127.0.0.1".parse().unwrap(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+            method: Method::GET,
+            meta: FlagsQueryParams {
+                version: None,
+                compression: None,
+                lib_version: None,
+                sent_at: None,
+                personal_api_key: Some("test-token".to_string()),
+            },
+        };
+
+        let (key, source) = find_personal_api_key_with_source(&request).unwrap();
+        assert_eq!(key, "test-token");
+        assert_eq!(source, ApiKeySource::Query);
+    }
+
+    #[test]
+    fn test_decode_personal_api_token_priority() {
+        // Test that bearer token takes precedence over body and query
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "Authorization",
+            HeaderValue::from_static("Bearer bearer-token"),
+        );
+        let request = RequestInfo {
+            id: Uuid::new_v4(),
+            ip: "127.0.0.1".parse().unwrap(),
+            headers,
+            body: Bytes::from(r#"{"personal_api_key": "body-token"}"#),
+            method: Method::GET,
+            meta: FlagsQueryParams {
+                version: None,
+                compression: None,
+                lib_version: None,
+                sent_at: None,
+                personal_api_key: Some("query-token".to_string()),
+            },
+        };
+
+        let (key, source) = find_personal_api_key_with_source(&request).unwrap();
+        assert_eq!(key, "bearer-token");
+        assert_eq!(source, ApiKeySource::AuthorizationHeader);
+    }
+
+    #[test]
+    fn test_decode_personal_api_token_missing() {
+        let request = RequestInfo {
+            id: Uuid::new_v4(),
+            ip: "127.0.0.1".parse().unwrap(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+            method: Method::GET,
+            meta: FlagsQueryParams {
+                version: None,
+                compression: None,
+                lib_version: None,
+                sent_at: None,
+                personal_api_key: None,
+            },
+        };
+
+        let result = find_personal_api_key_with_source(&request);
+        assert!(matches!(
+            result,
+            Err(FlagDefinitionsError::NoPersonalApiKeyError)
+        ));
+    }
+
+    #[test]
+    fn test_decode_personal_api_token_invalid_body() {
+        let request = RequestInfo {
+            id: Uuid::new_v4(),
+            ip: "127.0.0.1".parse().unwrap(),
+            headers: HeaderMap::new(),
+            body: Bytes::from("invalid json"),
+            method: Method::GET,
+            meta: FlagsQueryParams {
+                version: None,
+                compression: None,
+                lib_version: None,
+                sent_at: None,
+                personal_api_key: None,
+            },
+        };
+
+        let result = find_personal_api_key_with_source(&request);
+        assert!(matches!(
+            result,
+            Err(FlagDefinitionsError::RequestDecodingError(_))
+        ));
+    }
+}

--- a/rust/feature-flags/src/api/auth.rs
+++ b/rust/feature-flags/src/api/auth.rs
@@ -185,6 +185,7 @@ pub async fn validate_personal_api_key(
                 u.current_team_id as team_id,
                 t.organization_id,
                 t.project_id,
+                t.api_token as project_api_key,
                 pk.user_id,
                 pk.label,
                 pk.value,

--- a/rust/feature-flags/src/api/flag_definition_types.rs
+++ b/rust/feature-flags/src/api/flag_definition_types.rs
@@ -1,9 +1,14 @@
+use crate::flags::flag_models::FeatureFlag;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use uuid::Uuid;
 
-#[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FlagDefinitionsResponse {
     pub request_id: Uuid,
-    pub msg: String,
+
+    pub flags: Vec<FeatureFlag>,
+
+    pub group_type_mapping: HashMap<String, String>,
 }

--- a/rust/feature-flags/src/api/flag_definition_types.rs
+++ b/rust/feature-flags/src/api/flag_definition_types.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FlagDefinitionsResponse {
+    pub request_id: Uuid,
+    pub msg: String,
+}

--- a/rust/feature-flags/src/api/flag_definition_types.rs
+++ b/rust/feature-flags/src/api/flag_definition_types.rs
@@ -11,4 +11,7 @@ pub struct FlagDefinitionsResponse {
     pub flags: Vec<FeatureFlag>,
 
     pub group_type_mapping: HashMap<String, String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quota_limited: Option<Vec<String>>, // list of quota limited resources
 }

--- a/rust/feature-flags/src/api/flag_definition_types.rs
+++ b/rust/feature-flags/src/api/flag_definition_types.rs
@@ -14,4 +14,5 @@ pub struct FlagDefinitionsResponse {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quota_limited: Option<Vec<String>>, // list of quota limited resources
+    pub cohorts: HashMap<String, serde_json::Value>,
 }

--- a/rust/feature-flags/src/api/flag_definitions_endpoint.rs
+++ b/rust/feature-flags/src/api/flag_definitions_endpoint.rs
@@ -1,6 +1,6 @@
 use crate::{
     api::{
-        auth::AuthError,
+        errors::FlagError,
         flag_definition_types::FlagDefinitionsResponse,
         flag_definitions_request_handler::process_flags_definitions_request,
         request_handler::{FlagsQueryParams, RequestContext, RequestInfo},
@@ -27,7 +27,7 @@ pub async fn flag_definitions(
     method: Method,
     _: MatchedPath,
     body: Bytes,
-) -> Result<Json<FlagDefinitionsResponse>, AuthError> {
+) -> Result<Json<FlagDefinitionsResponse>, FlagError> {
     let request_id = Uuid::new_v4();
 
     let context = RequestContext {
@@ -44,6 +44,5 @@ pub async fn flag_definitions(
 
     let response = process_flags_definitions_request(&context).await?;
 
-    // TODO: Implement the actual flag definitions logic
     Ok(Json(response))
 }

--- a/rust/feature-flags/src/api/flag_definitions_endpoint.rs
+++ b/rust/feature-flags/src/api/flag_definitions_endpoint.rs
@@ -1,6 +1,6 @@
 use crate::{
     api::{
-        errors::FlagDefinitionsError,
+        auth::AuthError,
         flag_definition_types::FlagDefinitionsResponse,
         flag_definitions_request_handler::process_flags_definitions_request,
         request_handler::{FlagsQueryParams, RequestContext, RequestInfo},
@@ -27,7 +27,7 @@ pub async fn flag_definitions(
     method: Method,
     _: MatchedPath,
     body: Bytes,
-) -> Result<Json<FlagDefinitionsResponse>, FlagDefinitionsError> {
+) -> Result<Json<FlagDefinitionsResponse>, AuthError> {
     let request_id = Uuid::new_v4();
 
     let context = RequestContext {
@@ -42,7 +42,7 @@ pub async fn flag_definitions(
         state,
     };
 
-    let response = process_flags_definitions_request(context).await?;
+    let response = process_flags_definitions_request(&context).await?;
 
     // TODO: Implement the actual flag definitions logic
     Ok(Json(response))

--- a/rust/feature-flags/src/api/flag_definitions_endpoint.rs
+++ b/rust/feature-flags/src/api/flag_definitions_endpoint.rs
@@ -1,0 +1,46 @@
+use crate::{
+    api::{
+        errors::FlagDefinitionsError,
+        flag_definition_types::FlagDefinitionsResponse,
+        request_handler::{FlagsQueryParams, RequestContext},
+        flag_definitions_request_handler::process_flags_definitions_request,
+    },
+    router,
+};
+
+use axum::{
+    debug_handler,
+    extract::{MatchedPath, Query, State},
+    http::{HeaderMap, Method},
+    Json,
+};
+use axum_client_ip::InsecureClientIp;
+use bytes::Bytes;
+use uuid::Uuid;
+
+#[debug_handler]
+pub async fn flag_definitions(
+    state: State<router::State>,
+    InsecureClientIp(ip): InsecureClientIp,
+    Query(query_params): Query<FlagsQueryParams>,
+    headers: HeaderMap,
+    method: Method,
+    path: MatchedPath,
+    body: Bytes,
+) -> Result<Json<FlagDefinitionsResponse>, FlagDefinitionsError> {
+    let request_id = Uuid::new_v4();
+
+    let context = RequestContext {
+        request_id,
+        state,
+        ip,
+        headers: headers.clone(),
+        meta: query_params.clone(),
+        body: Bytes::new(),
+    };
+
+    let response = process_flags_definitions_request(context).await?;
+
+    // TODO: Implement the actual flag definitions logic
+    Ok(Json(response))
+}

--- a/rust/feature-flags/src/api/flag_definitions_endpoint.rs
+++ b/rust/feature-flags/src/api/flag_definitions_endpoint.rs
@@ -2,8 +2,8 @@ use crate::{
     api::{
         errors::FlagDefinitionsError,
         flag_definition_types::FlagDefinitionsResponse,
-        request_handler::{FlagsQueryParams, RequestContext},
         flag_definitions_request_handler::process_flags_definitions_request,
+        request_handler::{FlagsQueryParams, RequestContext, RequestInfo},
     },
     router,
 };
@@ -25,18 +25,21 @@ pub async fn flag_definitions(
     Query(query_params): Query<FlagsQueryParams>,
     headers: HeaderMap,
     method: Method,
-    path: MatchedPath,
+    _: MatchedPath,
     body: Bytes,
 ) -> Result<Json<FlagDefinitionsResponse>, FlagDefinitionsError> {
     let request_id = Uuid::new_v4();
 
     let context = RequestContext {
-        request_id,
+        request: RequestInfo {
+            id: request_id,
+            ip,
+            headers: headers.clone(),
+            meta: query_params.clone(),
+            body: body.clone(),
+            method,
+        },
         state,
-        ip,
-        headers: headers.clone(),
-        meta: query_params.clone(),
-        body: Bytes::new(),
     };
 
     let response = process_flags_definitions_request(context).await?;

--- a/rust/feature-flags/src/api/flag_definitions_request_handler.rs
+++ b/rust/feature-flags/src/api/flag_definitions_request_handler.rs
@@ -1,0 +1,189 @@
+use crate::{
+    api::{errors::FlagDefinitionsError, flag_definition_types::FlagDefinitionsResponse, request_handler::{FlagsQueryParams, RequestContext}},
+};
+use axum::http::HeaderMap;
+use bytes::Bytes;
+
+pub async fn process_flags_definitions_request(
+    context: RequestContext,
+) -> Result<FlagDefinitionsResponse, FlagDefinitionsError> {
+    let personal_api_key =
+        decode_personal_api_token(&context.headers, context.body, &context.meta)?;
+
+    let response = FlagDefinitionsResponse {
+        request_id: context.request_id,
+        msg: format!(
+            "Hello world! Your personal api key is: {}",
+            personal_api_key
+        ),
+    };
+
+    return Ok(response);
+}
+
+pub fn decode_personal_api_token(
+    headers: &HeaderMap,
+    body: Bytes,
+    query: &FlagsQueryParams,
+) -> Result<String, FlagDefinitionsError> {
+    // Per the docs: https://posthog.com/docs/api
+    // We try to read the personal API token from these three places in order.
+    // We use the first one we find.
+    // The bearer token: Authorization: "Bearer ${POSTHOG_PERSONAL_API_KEY}"
+    // The request body: { "personal_api_key": "..."}
+    // The query param: ?personal_api_key=...
+
+    // We try to read the personal API token from the bearer token first.
+    let bearer_token = headers
+        .get("Authorization")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.split_whitespace().nth(1).unwrap_or("").to_string());
+
+    if let Some(bearer_token) = bearer_token {
+        return Ok(bearer_token);
+    }
+
+    // We try to read the personal API token from the request body.
+    if !body.is_empty() {
+        let request_body = String::from_utf8(body.to_vec())
+            .map_err(|e| FlagDefinitionsError::RequestDecodingError(e.to_string()))?;
+
+        let request_body_json: serde_json::Value = serde_json::from_str(&request_body)
+            .map_err(|e| FlagDefinitionsError::RequestDecodingError(e.to_string()))?;
+
+        let personal_api_token = request_body_json
+            .get("personal_api_key")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        if let Some(personal_api_token) = personal_api_token {
+            return Ok(personal_api_token);
+        }
+    }
+
+    // Try to read it from the query string parameters.
+    let personal_api_token = query.personal_api_key.clone();
+
+    if let Some(personal_api_token) = personal_api_token {
+        return Ok(personal_api_token);
+    }
+
+    return Err(FlagDefinitionsError::NoPersonalApiKeyError);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    #[test]
+    fn test_decode_personal_api_token_from_bearer() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "Authorization",
+            HeaderValue::from_static("Bearer test-token"),
+        );
+        let body = Bytes::new();
+        let query = FlagsQueryParams {
+            version: None,
+            compression: None,
+            lib_version: None,
+            sent_at: None,
+            personal_api_key: None,
+        };
+
+        let result = decode_personal_api_token(&headers, body, &query).unwrap();
+        assert_eq!(result, "test-token");
+    }
+
+    #[test]
+    fn test_decode_personal_api_token_from_body() {
+        let headers = HeaderMap::new();
+        let body = Bytes::from(r#"{"personal_api_key": "test-token"}"#);
+        let query = FlagsQueryParams {
+            version: None,
+            compression: None,
+            lib_version: None,
+            sent_at: None,
+            personal_api_key: None,
+        };
+
+        let result = decode_personal_api_token(&headers, body, &query).unwrap();
+        assert_eq!(result, "test-token");
+    }
+
+    #[test]
+    fn test_decode_personal_api_token_from_query() {
+        let headers = HeaderMap::new();
+        let body = Bytes::new();
+        let query = FlagsQueryParams {
+            version: None,
+            compression: None,
+            lib_version: None,
+            sent_at: None,
+            personal_api_key: Some("test-token".to_string()),
+        };
+
+        let result = decode_personal_api_token(&headers, body, &query).unwrap();
+        assert_eq!(result, "test-token");
+    }
+
+    #[test]
+    fn test_decode_personal_api_token_priority() {
+        // Test that bearer token takes precedence over body and query
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "Authorization",
+            HeaderValue::from_static("Bearer bearer-token"),
+        );
+        let body = Bytes::from(r#"{"personal_api_key": "body-token"}"#);
+        let query = FlagsQueryParams {
+            version: None,
+            compression: None,
+            lib_version: None,
+            sent_at: None,
+            personal_api_key: Some("query-token".to_string()),
+        };
+
+        let result = decode_personal_api_token(&headers, body, &query).unwrap();
+        assert_eq!(result, "bearer-token");
+    }
+
+    #[test]
+    fn test_decode_personal_api_token_missing() {
+        let headers = HeaderMap::new();
+        let body = Bytes::new();
+        let query = FlagsQueryParams {
+            version: None,
+            compression: None,
+            lib_version: None,
+            sent_at: None,
+            personal_api_key: None,
+        };
+
+        let result = decode_personal_api_token(&headers, body, &query);
+        assert!(matches!(
+            result,
+            Err(FlagDefinitionsError::NoPersonalApiKeyError)
+        ));
+    }
+
+    #[test]
+    fn test_decode_personal_api_token_invalid_body() {
+        let headers = HeaderMap::new();
+        let body = Bytes::from("invalid json");
+        let query = FlagsQueryParams {
+            version: None,
+            compression: None,
+            lib_version: None,
+            sent_at: None,
+            personal_api_key: None,
+        };
+
+        let result = decode_personal_api_token(&headers, body, &query);
+        assert!(matches!(
+            result,
+            Err(FlagDefinitionsError::RequestDecodingError(_))
+        ));
+    }
+}

--- a/rust/feature-flags/src/api/flag_definitions_request_handler.rs
+++ b/rust/feature-flags/src/api/flag_definitions_request_handler.rs
@@ -1,18 +1,27 @@
 use crate::api::{
-    auth::find_personal_api_key_with_source, errors::FlagDefinitionsError,
-    flag_definition_types::FlagDefinitionsResponse, request_handler::RequestContext,
+    auth::{authenticate_personal_api_key, AuthError},
+    flag_definition_types::FlagDefinitionsResponse,
+    permissions::has_permission,
+    request_handler::RequestContext,
 };
 
 pub async fn process_flags_definitions_request(
-    context: RequestContext,
-) -> Result<FlagDefinitionsResponse, FlagDefinitionsError> {
-    let (personal_api_key, _) = find_personal_api_key_with_source(&context.request)?;
+    context: &RequestContext,
+) -> Result<FlagDefinitionsResponse, AuthError> {
+    let api_key =
+        authenticate_personal_api_key(context.state.reader.as_ref(), &context.request).await?;
+
+    if let Err(e) = has_permission(&api_key, "feature_flag", &["feature_flag:read"]) {
+        return Err(AuthError::InvalidScopes(e.to_string()));
+    }
+
+    // TODO: Query the flag definitions from the cache/database
 
     let response = FlagDefinitionsResponse {
         request_id: context.request.id,
         msg: format!(
-            "Hello world! Your personal api key is: {}",
-            personal_api_key
+            "Hello world! Your personal api key is authenticated and valid for team: {:?}",
+            api_key.team_id
         ),
     };
 

--- a/rust/feature-flags/src/api/flag_definitions_request_handler.rs
+++ b/rust/feature-flags/src/api/flag_definitions_request_handler.rs
@@ -1,29 +1,53 @@
 use crate::api::{
-    auth::{authenticate_personal_api_key, AuthError},
-    flag_definition_types::FlagDefinitionsResponse,
-    permissions::has_permission,
+    auth::authenticate_personal_api_key, errors::FlagError,
+    flag_definition_types::FlagDefinitionsResponse, permissions::has_permission,
     request_handler::RequestContext,
 };
+use crate::client::database::Client;
+use crate::flags::flag_group_type_mapping::GroupTypeMappingCache;
+use crate::flags::flag_service::FlagService;
+use std::sync::Arc;
 
 pub async fn process_flags_definitions_request(
     context: &RequestContext,
-) -> Result<FlagDefinitionsResponse, AuthError> {
+) -> Result<FlagDefinitionsResponse, FlagError> {
     let api_key =
         authenticate_personal_api_key(context.state.reader.as_ref(), &context.request).await?;
 
     if let Err(e) = has_permission(&api_key, "feature_flag", &["feature_flag:read"]) {
-        return Err(AuthError::InvalidScopes(e.to_string()));
+        return Err(FlagError::InvalidScopes(e.to_string()));
     }
 
+    // TODO: Quota limited check.
+
     // TODO: Query the flag definitions from the cache/database
+    let flag_service = FlagService::new(context.state.redis.clone(), context.state.reader.clone());
+    let project_id = api_key.project_id.unwrap();
+    let all_flags = flag_service.get_flags_from_cache_or_pg(project_id).await?;
+
+    let group_type_mapping =
+        get_sorted_group_type_mapping(project_id, context.state.reader.clone()).await?;
 
     let response = FlagDefinitionsResponse {
         request_id: context.request.id,
-        msg: format!(
-            "Hello world! Your personal api key is authenticated and valid for team: {:?}",
-            api_key.team_id
-        ),
+        flags: all_flags.flags,
+        group_type_mapping,
     };
 
     return Ok(response);
+}
+
+async fn get_sorted_group_type_mapping(
+    project_id: i64,
+    reader: Arc<dyn Client + Send + Sync>,
+) -> Result<std::collections::HashMap<String, String>, FlagError> {
+    let mut group_type_mapping_cache = GroupTypeMappingCache::new(project_id);
+    group_type_mapping_cache.init(reader).await?;
+    let mapping = group_type_mapping_cache.get_group_type_index_to_type_map()?;
+    let mut mapping_vec: Vec<_> = mapping.iter().collect();
+    mapping_vec.sort_by_key(|(idx, _)| *idx);
+    Ok(mapping_vec
+        .into_iter()
+        .map(|(idx, name)| (idx.to_string(), name.clone()))
+        .collect())
 }

--- a/rust/feature-flags/src/api/flag_definitions_request_handler.rs
+++ b/rust/feature-flags/src/api/flag_definitions_request_handler.rs
@@ -1,17 +1,15 @@
-use crate::{
-    api::{errors::FlagDefinitionsError, flag_definition_types::FlagDefinitionsResponse, request_handler::{FlagsQueryParams, RequestContext}},
+use crate::api::{
+    auth::find_personal_api_key_with_source, errors::FlagDefinitionsError,
+    flag_definition_types::FlagDefinitionsResponse, request_handler::RequestContext,
 };
-use axum::http::HeaderMap;
-use bytes::Bytes;
 
 pub async fn process_flags_definitions_request(
     context: RequestContext,
 ) -> Result<FlagDefinitionsResponse, FlagDefinitionsError> {
-    let personal_api_key =
-        decode_personal_api_token(&context.headers, context.body, &context.meta)?;
+    let (personal_api_key, _) = find_personal_api_key_with_source(&context.request)?;
 
     let response = FlagDefinitionsResponse {
-        request_id: context.request_id,
+        request_id: context.request.id,
         msg: format!(
             "Hello world! Your personal api key is: {}",
             personal_api_key
@@ -19,171 +17,4 @@ pub async fn process_flags_definitions_request(
     };
 
     return Ok(response);
-}
-
-pub fn decode_personal_api_token(
-    headers: &HeaderMap,
-    body: Bytes,
-    query: &FlagsQueryParams,
-) -> Result<String, FlagDefinitionsError> {
-    // Per the docs: https://posthog.com/docs/api
-    // We try to read the personal API token from these three places in order.
-    // We use the first one we find.
-    // The bearer token: Authorization: "Bearer ${POSTHOG_PERSONAL_API_KEY}"
-    // The request body: { "personal_api_key": "..."}
-    // The query param: ?personal_api_key=...
-
-    // We try to read the personal API token from the bearer token first.
-    let bearer_token = headers
-        .get("Authorization")
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.split_whitespace().nth(1).unwrap_or("").to_string());
-
-    if let Some(bearer_token) = bearer_token {
-        return Ok(bearer_token);
-    }
-
-    // We try to read the personal API token from the request body.
-    if !body.is_empty() {
-        let request_body = String::from_utf8(body.to_vec())
-            .map_err(|e| FlagDefinitionsError::RequestDecodingError(e.to_string()))?;
-
-        let request_body_json: serde_json::Value = serde_json::from_str(&request_body)
-            .map_err(|e| FlagDefinitionsError::RequestDecodingError(e.to_string()))?;
-
-        let personal_api_token = request_body_json
-            .get("personal_api_key")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
-
-        if let Some(personal_api_token) = personal_api_token {
-            return Ok(personal_api_token);
-        }
-    }
-
-    // Try to read it from the query string parameters.
-    let personal_api_token = query.personal_api_key.clone();
-
-    if let Some(personal_api_token) = personal_api_token {
-        return Ok(personal_api_token);
-    }
-
-    return Err(FlagDefinitionsError::NoPersonalApiKeyError);
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use axum::http::HeaderValue;
-
-    #[test]
-    fn test_decode_personal_api_token_from_bearer() {
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            "Authorization",
-            HeaderValue::from_static("Bearer test-token"),
-        );
-        let body = Bytes::new();
-        let query = FlagsQueryParams {
-            version: None,
-            compression: None,
-            lib_version: None,
-            sent_at: None,
-            personal_api_key: None,
-        };
-
-        let result = decode_personal_api_token(&headers, body, &query).unwrap();
-        assert_eq!(result, "test-token");
-    }
-
-    #[test]
-    fn test_decode_personal_api_token_from_body() {
-        let headers = HeaderMap::new();
-        let body = Bytes::from(r#"{"personal_api_key": "test-token"}"#);
-        let query = FlagsQueryParams {
-            version: None,
-            compression: None,
-            lib_version: None,
-            sent_at: None,
-            personal_api_key: None,
-        };
-
-        let result = decode_personal_api_token(&headers, body, &query).unwrap();
-        assert_eq!(result, "test-token");
-    }
-
-    #[test]
-    fn test_decode_personal_api_token_from_query() {
-        let headers = HeaderMap::new();
-        let body = Bytes::new();
-        let query = FlagsQueryParams {
-            version: None,
-            compression: None,
-            lib_version: None,
-            sent_at: None,
-            personal_api_key: Some("test-token".to_string()),
-        };
-
-        let result = decode_personal_api_token(&headers, body, &query).unwrap();
-        assert_eq!(result, "test-token");
-    }
-
-    #[test]
-    fn test_decode_personal_api_token_priority() {
-        // Test that bearer token takes precedence over body and query
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            "Authorization",
-            HeaderValue::from_static("Bearer bearer-token"),
-        );
-        let body = Bytes::from(r#"{"personal_api_key": "body-token"}"#);
-        let query = FlagsQueryParams {
-            version: None,
-            compression: None,
-            lib_version: None,
-            sent_at: None,
-            personal_api_key: Some("query-token".to_string()),
-        };
-
-        let result = decode_personal_api_token(&headers, body, &query).unwrap();
-        assert_eq!(result, "bearer-token");
-    }
-
-    #[test]
-    fn test_decode_personal_api_token_missing() {
-        let headers = HeaderMap::new();
-        let body = Bytes::new();
-        let query = FlagsQueryParams {
-            version: None,
-            compression: None,
-            lib_version: None,
-            sent_at: None,
-            personal_api_key: None,
-        };
-
-        let result = decode_personal_api_token(&headers, body, &query);
-        assert!(matches!(
-            result,
-            Err(FlagDefinitionsError::NoPersonalApiKeyError)
-        ));
-    }
-
-    #[test]
-    fn test_decode_personal_api_token_invalid_body() {
-        let headers = HeaderMap::new();
-        let body = Bytes::from("invalid json");
-        let query = FlagsQueryParams {
-            version: None,
-            compression: None,
-            lib_version: None,
-            sent_at: None,
-            personal_api_key: None,
-        };
-
-        let result = decode_personal_api_token(&headers, body, &query);
-        assert!(matches!(
-            result,
-            Err(FlagDefinitionsError::RequestDecodingError(_))
-        ));
-    }
 }

--- a/rust/feature-flags/src/api/flag_definitions_request_handler.rs
+++ b/rust/feature-flags/src/api/flag_definitions_request_handler.rs
@@ -7,8 +7,11 @@ use crate::client::database::Client;
 use crate::cohorts::cohort_cache_manager::CohortCacheManager;
 use crate::flags::flag_group_type_mapping::GroupTypeMappingCache;
 use crate::flags::flag_service::FlagService;
+use crate::flags::flag_models::FeatureFlag;
 use limiters::redis::ServiceName;
 use std::{collections::HashMap, sync::Arc};
+use std::collections::HashSet;
+use serde_json;
 
 pub async fn process_flags_definitions_request(
     context: &RequestContext,
@@ -37,18 +40,13 @@ pub async fn process_flags_definitions_request(
         });
     }
 
-    // TODO: Query the flag definitions from the cache/database
     let flag_service = FlagService::new(context.state.redis.clone(), context.state.reader.clone());
     let project_id = api_key.project_id.unwrap();
     let all_flags = flag_service.get_flags_from_cache_or_pg(project_id).await?;
 
+    // TODO: We should only send cohorts for flags that have filter properties that reference cohorts
     let cohorts = if context.request.meta.send_cohorts.unwrap_or(false) {
-        let cohort_cache = CohortCacheManager::new(context.state.reader.clone(), None, None);
-        let cohorts = cohort_cache.get_cohorts(project_id).await?;
-        cohorts
-            .into_iter()
-            .filter_map(|cohort| cohort.filters.map(|f| (cohort.id.to_string(), f)))
-            .collect()
+        get_cohorts_for_flags(&all_flags.flags, project_id, context.state.reader.clone()).await?
     } else {
         HashMap::new()
     };
@@ -80,4 +78,137 @@ async fn get_sorted_group_type_mapping(
         .into_iter()
         .map(|(idx, name)| (idx.to_string(), name.clone()))
         .collect())
+}
+
+fn get_cohort_ids_for_flags(flags: &Vec<FeatureFlag>) -> HashSet<i32> {
+    let mut cohort_ids = HashSet::new();
+    for flag in flags {
+        for condition in &flag.filters.groups {
+            if let Some(properties) = &condition.properties {
+                for property in properties {
+                    if property.prop_type == "cohort" {
+                        if let Some(value) = &property.value {
+                            if let Some(cohort_id) = value.as_str().and_then(|s| s.parse::<i32>().ok()) {
+                                cohort_ids.insert(cohort_id);
+                            }
+                        }   
+                    }
+                }
+            }
+        }
+    }
+    cohort_ids
+}
+
+async fn get_cohorts_for_flags(flags: &Vec<FeatureFlag>, project_id: i64, reader: Arc<dyn Client + Send + Sync>) -> Result<HashMap<String, serde_json::Value>, FlagError> {
+    // First collect all cohort IDs referenced in flag conditions
+    let cohort_ids = get_cohort_ids_for_flags(flags);
+
+    // If no cohorts are referenced, return empty map
+    if cohort_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    // Get all cohorts and filter to just the ones we need
+    let cohort_cache = CohortCacheManager::new(reader, None, None);
+    let all_cohorts = cohort_cache.get_cohorts(project_id).await?;
+    
+    // Transform into the expected format, filtering to only referenced cohorts
+    let cohorts = all_cohorts
+        .into_iter()
+        .filter(|cohort| cohort_ids.contains(&cohort.id))
+        .filter_map(|cohort| cohort.filters.map(|f| (cohort.id.to_string(), f)))
+        .collect();
+
+    Ok(cohorts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::flags::flag_models::{FeatureFlag, FlagPropertyGroup};
+    use crate::properties::property_models::PropertyFilter;
+    use serde_json::json;
+    use crate::flags::flag_models::FlagFilters;
+
+    #[test]
+    fn test_get_cohort_ids_for_flags() {
+        let flags = vec![
+            FeatureFlag {
+                filters: FlagFilters {
+                    groups: vec![
+                        FlagPropertyGroup {
+                            properties: Some(vec![
+                                PropertyFilter {
+                                    prop_type: "cohort".to_string(),
+                                    value: Some(json!("123")),
+                                    key: "".to_string(),
+                                    operator: None,
+                                    group_type_index: None,
+                                    negation: Some(false),
+                                }
+                            ]),
+                            ..Default::default()
+                        }
+                    ],
+                    ..Default::default()
+                },
+                id: 0,                    // Add minimum required fields
+                team_id: 0,
+                key: "test".to_string(),
+                name: Some("test".to_string()),
+                active: true,
+                deleted: false,
+                ensure_experience_continuity: false,
+                version: Some(1),
+            }
+        ];
+
+        let cohort_ids = get_cohort_ids_for_flags(&flags);
+        assert_eq!(cohort_ids, vec![123].into_iter().collect::<HashSet<_>>());
+    }
+
+    #[test]
+    fn test_get_cohort_ids_empty_flags() {
+        let flags = vec![];
+        let cohort_ids = get_cohort_ids_for_flags(&flags);
+        assert!(cohort_ids.is_empty());
+    }
+
+    #[test]
+    fn test_get_cohort_ids_no_cohort_properties() {
+        let flags = vec![
+            FeatureFlag {
+                filters: FlagFilters {
+                    groups: vec![
+                        FlagPropertyGroup {
+                            properties: Some(vec![
+                                PropertyFilter {
+                                    prop_type: "person".to_string(),
+                                    value: Some(json!("value")),
+                                    key: "".to_string(),
+                                    operator: None,
+                                    group_type_index: None,
+                                    negation: Some(false),
+                                }
+                            ]),
+                            ..Default::default()
+                        }
+                    ],
+                    ..Default::default()
+                },
+                id: 0,                    // Add minimum required fields
+                team_id: 0,
+                key: "test".to_string(),
+                name: Some("test".to_string()),
+                active: true,
+                deleted: false,
+                ensure_experience_continuity: false,
+                version: Some(1),
+            }
+        ];
+
+        let cohort_ids = get_cohort_ids_for_flags(&flags);
+        assert!(cohort_ids.is_empty());
+    }
 }

--- a/rust/feature-flags/src/api/mod.rs
+++ b/rust/feature-flags/src/api/mod.rs
@@ -4,6 +4,7 @@ pub mod errors;
 pub mod flag_definition_types;
 pub mod flag_definitions_endpoint;
 pub mod flag_definitions_request_handler;
+pub mod permissions;
 pub mod request_handler;
 pub mod test_endpoint;
 pub mod types;

--- a/rust/feature-flags/src/api/mod.rs
+++ b/rust/feature-flags/src/api/mod.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod endpoint;
 pub mod errors;
 pub mod flag_definition_types;

--- a/rust/feature-flags/src/api/mod.rs
+++ b/rust/feature-flags/src/api/mod.rs
@@ -1,5 +1,8 @@
 pub mod endpoint;
 pub mod errors;
+pub mod flag_definition_types;
+pub mod flag_definitions_endpoint;
+pub mod flag_definitions_request_handler;
 pub mod request_handler;
 pub mod test_endpoint;
 pub mod types;

--- a/rust/feature-flags/src/api/permissions.rs
+++ b/rust/feature-flags/src/api/permissions.rs
@@ -106,6 +106,7 @@ mod tests {
             last_used_at: None,
             team_id,
             organization_id,
+            project_id: Some(23),
             user_id: 1,
             scoped_organizations: scoped_organizations,
             scoped_teams: scoped_teams,

--- a/rust/feature-flags/src/api/permissions.rs
+++ b/rust/feature-flags/src/api/permissions.rs
@@ -1,0 +1,268 @@
+use crate::flags::models::PersonalAPIKey;
+use uuid::Uuid;
+pub fn has_permission(
+    personal_api_key: &PersonalAPIKey,
+    scope_object: &str,
+    required_scopes: &[&str], // or Vec<String>
+) -> Result<(), String> {
+    let key_scopes = &personal_api_key.scopes;
+
+    // TRICKY: Legacy API keys have no scopes and are allowed to do anything, even if the view is unsupported.
+    if key_scopes.is_empty() {
+        return Ok(());
+    }
+
+    // If no required scopes, deny
+    if required_scopes.is_empty() {
+        return Err("This action does not support Personal API Key access".to_owned());
+    }
+
+    check_team_and_org_permissions(
+        personal_api_key,
+        personal_api_key.team_id,
+        personal_api_key.organization_id,
+        scope_object,
+    )?;
+
+    // Wildcard: allow everything
+    if key_scopes.iter().any(|s| s == "*") {
+        return Ok(());
+    }
+
+    // Check each required scope
+    for required_scope in required_scopes {
+        let has_scope = key_scopes.contains(&required_scope.to_string())
+            || (required_scope.ends_with(":read")
+                && key_scopes.contains(&required_scope.replace(":read", ":write")));
+        if !has_scope {
+            return Err(format!(
+                "API key missing required scope '{}'",
+                required_scope
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+pub fn check_team_and_org_permissions(
+    personal_api_key: &PersonalAPIKey,
+    team_id: Option<i32>,
+    organization_id: Uuid,
+    scope_object: &str,
+) -> Result<(), String> {
+    if scope_object == "user" {
+        return Ok(());
+    }
+
+    let scoped_teams = &personal_api_key.scoped_teams;
+    match (scoped_teams.is_empty(), team_id) {
+        (false, Some(id)) if !scoped_teams.contains(&id) => {
+            return Err(format!(
+                "API key does not have access to the requested project: ID {}.",
+                id
+            ));
+        }
+        (false, None) => {
+            return Err(
+                "API keys with scoped projects are only supported on project-based endpoints."
+                    .to_owned(),
+            );
+        }
+        _ => {}
+    }
+
+    let scoped_organizations = &personal_api_key.scoped_organizations;
+    if !scoped_organizations.is_empty() {
+        if !scoped_organizations.contains(&organization_id.to_string()) {
+            return Err(format!(
+                "API key does not have access to the requested organization: ID {}.",
+                organization_id
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::flags::models::PersonalAPIKey;
+    use uuid::Uuid;
+    fn make_key(
+        scopes: Vec<String>,
+        scoped_organizations: Vec<String>,
+        scoped_teams: Vec<i32>,
+        team_id: Option<i32>,
+        organization_id: Uuid,
+    ) -> PersonalAPIKey {
+        PersonalAPIKey {
+            id: "id".to_string(),
+            label: "label".to_string(),
+            value: None,
+            secure_value: None,
+            created_at: chrono::Utc::now(),
+            last_used_at: None,
+            team_id,
+            organization_id,
+            user_id: 1,
+            scoped_organizations: scoped_organizations,
+            scoped_teams: scoped_teams,
+            scopes: scopes,
+            mask_value: "mask".to_string(),
+        }
+    }
+
+    #[test]
+    fn allows_wildcard_scope() {
+        let org_id = Uuid::parse_str("123e4567-e89b-12d3-a456-426614174000").unwrap();
+        let key = make_key(vec!["*".to_string()], vec![], vec![], Some(42), org_id);
+        assert!(has_permission(&key, "feature_flag", &["feature_flag:read"]).is_ok());
+    }
+
+    #[test]
+    fn allows_legacy_key() {
+        let org_id = Uuid::parse_str("123e4567-e89b-12d3-a456-426614174000").unwrap();
+        let key = make_key(vec![], vec![], vec![], Some(42), org_id);
+        assert!(has_permission(&key, "feature_flag", &["feature_flag:read"]).is_ok());
+    }
+
+    #[test]
+    fn denies_missing_scope() {
+        let org_id = Uuid::parse_str("123e4567-e89b-12d3-a456-426614174000").unwrap();
+        let key = make_key(
+            vec!["feature_flag:read".to_string()],
+            vec![],
+            vec![],
+            Some(42),
+            org_id,
+        );
+        let err = has_permission(&key, "feature_flag", &["feature_flag:write"]).unwrap_err();
+        assert!(err.contains("API key missing required scope"));
+    }
+
+    #[test]
+    fn denies_if_required_scopes_empty() {
+        let org_id = Uuid::parse_str("123e4567-e89b-12d3-a456-426614174000").unwrap();
+        let key = make_key(
+            vec!["feature_flag:read".to_string()],
+            vec![],
+            vec![],
+            Some(42),
+            org_id,
+        );
+        let err = has_permission(&key, "feature_flag", &[]).unwrap_err();
+        assert!(err.contains("does not support Personal API Key access"));
+    }
+
+    #[test]
+    fn allows_read_scope() {
+        let org_id = Uuid::parse_str("123e4567-e89b-12d3-a456-426614174000").unwrap();
+        let key = make_key(
+            vec![
+                "feature_flag:read".to_string(),
+                "something_else:read".to_string(),
+            ],
+            vec![],
+            vec![],
+            Some(42),
+            org_id,
+        );
+        assert!(has_permission(&key, "feature_flag", &["feature_flag:read"]).is_ok());
+    }
+
+    #[test]
+    fn allows_read_with_write_scope() {
+        let org_id = Uuid::parse_str("123e4567-e89b-12d3-a456-426614174000").unwrap();
+        let key = make_key(
+            vec!["feature_flag:write".to_string()],
+            vec![],
+            vec![],
+            Some(42),
+            org_id,
+        );
+        assert!(has_permission(&key, "feature_flag", &["feature_flag:read"]).is_ok());
+    }
+
+    #[test]
+    fn allows_read_scope_when_scoped_teams_matches() {
+        let org_id = Uuid::parse_str("123e4567-e89b-12d3-a456-426614174000").unwrap();
+        let key = make_key(
+            vec!["feature_flag:read".to_string()],
+            vec![],
+            vec![42, 1, 41],
+            Some(42),
+            org_id,
+        );
+        assert!(has_permission(&key, "feature_flag", &["feature_flag:read"]).is_ok());
+    }
+
+    #[test]
+    fn allows_read_scope_when_scoped_teams_empty() {
+        let org_id = Uuid::parse_str("123e4567-e89b-12d3-a456-426614174000").unwrap();
+        let key = make_key(
+            vec!["feature_flag:read".to_string()],
+            vec![],
+            vec![],
+            Some(42),
+            org_id,
+        );
+        assert!(has_permission(&key, "feature_flag", &["feature_flag:read"]).is_ok());
+    }
+
+    #[test]
+    fn denies_read_scope_when_scoped_teams_does_not_match() {
+        let org_id = Uuid::parse_str("123e4567-e89b-12d3-a456-426614174000").unwrap();
+        let key = make_key(
+            vec!["feature_flag:read".to_string()],
+            vec![],
+            vec![23, 1, 41],
+            Some(42),
+            org_id,
+        );
+        let err = has_permission(&key, "feature_flag", &["feature_flag:write"]).unwrap_err();
+        assert!(err.contains("API key does not have access to the requested project: ID 42."));
+    }
+
+    #[test]
+    fn allows_read_scope_when_scoped_orgs_matches() {
+        let org_id = Uuid::parse_str("123e4567-e89b-12d3-a456-426614174000").unwrap();
+        let key = make_key(
+            vec!["feature_flag:read".to_string()],
+            vec![org_id.to_string()],
+            vec![],
+            Some(42),
+            org_id,
+        );
+        assert!(has_permission(&key, "feature_flag", &["feature_flag:read"]).is_ok());
+    }
+
+    #[test]
+    fn allows_read_scope_when_scoped_orgs_empty() {
+        let org_id = Uuid::parse_str("123e4567-e89b-12d3-a456-426614174000").unwrap();
+        let key = make_key(
+            vec!["feature_flag:read".to_string()],
+            vec![],
+            vec![],
+            Some(42),
+            org_id,
+        );
+        assert!(has_permission(&key, "feature_flag", &["feature_flag:read"]).is_ok());
+    }
+
+    #[test]
+    fn denies_read_scope_when_scoped_orgs_does_not_match() {
+        let org_id = Uuid::parse_str("123e4567-e89b-12d3-a456-426614174000").unwrap();
+        let org_id2 = "123e4567-e89b-12d3-a456-426614174001";
+        let key = make_key(
+            vec!["feature_flag:read".to_string()],
+            vec![org_id2.to_string()],
+            vec![],
+            Some(42),
+            org_id,
+        );
+        let err = has_permission(&key, "feature_flag", &["feature_flag:write"]).unwrap_err();
+        assert!(err.contains("API key does not have access to the requested organization: ID 123e4567-e89b-12d3-a456-426614174000."));
+    }
+}

--- a/rust/feature-flags/src/api/permissions.rs
+++ b/rust/feature-flags/src/api/permissions.rs
@@ -112,6 +112,7 @@ mod tests {
             scoped_teams: scoped_teams,
             scopes: scopes,
             mask_value: "mask".to_string(),
+            project_api_key: "project_api_key".to_string(),
         }
     }
 

--- a/rust/feature-flags/src/api/request_handler.rs
+++ b/rust/feature-flags/src/api/request_handler.rs
@@ -74,6 +74,9 @@ pub struct FlagsQueryParams {
 
     /// Optional personal API key.
     pub personal_api_key: Option<String>,
+
+    /// Whether to send cohorts to the client. Only applies to the flags definition endpoint.
+    pub send_cohorts: Option<bool>,
 }
 
 /// Represents information about the request.

--- a/rust/feature-flags/src/api/request_handler.rs
+++ b/rust/feature-flags/src/api/request_handler.rs
@@ -71,6 +71,9 @@ pub struct FlagsQueryParams {
     /// Optional timestamp indicating when the request was sent
     #[serde(alias = "_")]
     pub sent_at: Option<i64>,
+
+    /// Optional personal API key.
+    pub personal_api_key: Option<String>,
 }
 pub struct RequestContext {
     /// Shared state holding services (DB, Redis, GeoIP, etc.)

--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -253,14 +253,20 @@ mod tests {
             token: Some("".to_string()),
             ..Default::default()
         };
-        assert!(matches!(flag_request.extract_token(), Err(FlagError::NoTokenError)));
+        assert!(matches!(
+            flag_request.extract_token(),
+            Err(FlagError::NoTokenError)
+        ));
 
         // Test missing token
         let flag_request = FlagRequest {
             token: None,
             ..Default::default()
         };
-        assert!(matches!(flag_request.extract_token(), Err(FlagError::NoTokenError)));
+        assert!(matches!(
+            flag_request.extract_token(),
+            Err(FlagError::NoTokenError)
+        ));
     }
 
     #[tokio::test]

--- a/rust/feature-flags/src/flags/flag_request.rs
+++ b/rust/feature-flags/src/flags/flag_request.rs
@@ -223,6 +223,46 @@ mod tests {
         assert_eq!(flag_payload.distinct_id, Some("123.45".to_string()));
     }
 
+    #[test]
+    fn test_extract_properties() {
+        let flag_request = FlagRequest {
+            person_properties: Some(HashMap::from([
+                ("key1".to_string(), json!("value1")),
+                ("key2".to_string(), json!(42)),
+            ])),
+            ..Default::default()
+        };
+
+        let properties = flag_request.extract_properties();
+        assert_eq!(properties.len(), 2);
+        assert_eq!(properties.get("key1").unwrap(), &json!("value1"));
+        assert_eq!(properties.get("key2").unwrap(), &json!(42));
+    }
+
+    #[test]
+    fn test_extract_token() {
+        // Test valid token
+        let flag_request = FlagRequest {
+            token: Some("valid_token".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(flag_request.extract_token().unwrap(), "valid_token");
+
+        // Test empty token
+        let flag_request = FlagRequest {
+            token: Some("".to_string()),
+            ..Default::default()
+        };
+        assert!(matches!(flag_request.extract_token(), Err(FlagError::NoTokenError)));
+
+        // Test missing token
+        let flag_request = FlagRequest {
+            token: None,
+            ..Default::default()
+        };
+        assert!(matches!(flag_request.extract_token(), Err(FlagError::NoTokenError)));
+    }
+
     #[tokio::test]
     async fn token_is_returned_correctly() {
         let redis_client = setup_redis_client(None);
@@ -249,22 +289,6 @@ mod tests {
             Ok(extracted_token) => assert_eq!(extracted_token, team.api_token),
             Err(e) => panic!("Failed to extract and verify token: {:?}", e),
         };
-    }
-
-    #[test]
-    fn test_extract_properties() {
-        let flag_request = FlagRequest {
-            person_properties: Some(HashMap::from([
-                ("key1".to_string(), json!("value1")),
-                ("key2".to_string(), json!(42)),
-            ])),
-            ..Default::default()
-        };
-
-        let properties = flag_request.extract_properties();
-        assert_eq!(properties.len(), 2);
-        assert_eq!(properties.get("key1").unwrap(), &json!("value1"));
-        assert_eq!(properties.get("key2").unwrap(), &json!(42));
     }
 
     #[tokio::test]

--- a/rust/feature-flags/src/flags/flag_service.rs
+++ b/rust/feature-flags/src/flags/flag_service.rs
@@ -30,7 +30,7 @@ impl FlagService {
         }
     }
 
-    /// Verifies the token against the cache or the database.
+    /// Verifies the Project API token against the cache or the database.
     /// If the token is not found in the cache, it will be verified against the database,
     /// and the result will be cached in redis.
     pub async fn verify_token(&self, token: &str) -> Result<String, FlagError> {
@@ -169,6 +169,41 @@ mod tests {
     };
 
     use super::*;
+
+    #[tokio::test]
+    async fn test_verify_token() {
+        let redis_client = setup_redis_client(None);
+        let pg_client = setup_pg_reader_client(None).await;
+        let team = insert_new_team_in_redis(redis_client.clone())
+            .await
+            .expect("Failed to insert new team in Redis");
+
+        let flag_service = FlagService::new(redis_client.clone(), pg_client.clone());
+
+        // Test valid token in Redis
+        let result = flag_service.verify_token(&team.api_token).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), team.api_token);
+
+        // Test valid token in PostgreSQL (simulate Redis miss)
+        // First, remove the team from Redis
+        redis_client
+            .del(format!("team:{}", team.api_token))
+            .await
+            .expect("Failed to remove team from Redis");
+
+        let result = flag_service.verify_token(&team.api_token).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), team.api_token);
+
+        // Test invalid token
+        let result = flag_service.verify_token("invalid_token").await;
+        assert!(matches!(result, Err(FlagError::TokenValidationError)));
+
+        // Verify that the team was re-added to Redis after PostgreSQL hit
+        let redis_team = Team::from_redis(redis_client.clone(), &team.api_token).await;
+        assert!(redis_team.is_ok());
+    }
 
     #[tokio::test]
     async fn test_get_team_from_cache_or_pg() {

--- a/rust/feature-flags/src/flags/mod.rs
+++ b/rust/feature-flags/src/flags/mod.rs
@@ -7,3 +7,4 @@ pub mod flag_models;
 pub mod flag_operations;
 pub mod flag_request;
 pub mod flag_service;
+pub mod models;

--- a/rust/feature-flags/src/flags/models.rs
+++ b/rust/feature-flags/src/flags/models.rs
@@ -11,6 +11,7 @@ pub struct PersonalAPIKey {
     pub created_at: DateTime<Utc>,
     pub last_used_at: Option<DateTime<Utc>>,
     pub team_id: Option<i32>,
+    pub project_id: Option<i64>,
     pub organization_id: Uuid,
     pub user_id: i32,
     pub scoped_organizations: Vec<String>,

--- a/rust/feature-flags/src/flags/models.rs
+++ b/rust/feature-flags/src/flags/models.rs
@@ -1,0 +1,20 @@
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use uuid::Uuid;
+
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct PersonalAPIKey {
+    pub id: String,
+    pub label: String,
+    pub value: Option<String>,
+    pub secure_value: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub last_used_at: Option<DateTime<Utc>>,
+    pub team_id: Option<i32>,
+    pub organization_id: Uuid,
+    pub user_id: i32,
+    pub scoped_organizations: Vec<String>,
+    pub scoped_teams: Vec<i32>,
+    pub scopes: Vec<String>,
+    pub mask_value: String,
+}

--- a/rust/feature-flags/src/flags/models.rs
+++ b/rust/feature-flags/src/flags/models.rs
@@ -12,6 +12,7 @@ pub struct PersonalAPIKey {
     pub last_used_at: Option<DateTime<Utc>>,
     pub team_id: Option<i32>,
     pub project_id: Option<i64>,
+    pub project_api_key: String,
     pub organization_id: Uuid,
     pub user_id: i32,
     pub scoped_organizations: Vec<String>,

--- a/rust/feature-flags/src/router.rs
+++ b/rust/feature-flags/src/router.rs
@@ -18,7 +18,7 @@ use tower_http::{
 };
 
 use crate::{
-    api::{endpoint, test_endpoint},
+    api::{endpoint, flag_definitions_endpoint, test_endpoint},
     client::database::Client as DatabaseClient,
     cohorts::cohort_cache_manager::CohortCacheManager,
     config::{Config, TeamIdsToTrack},
@@ -100,9 +100,23 @@ where
         .route("/flags/", post(endpoint::flags).get(endpoint::flags))
         .layer(ConcurrencyLimitLayer::new(config.max_concurrency));
 
+    let flag_definitions_router = Router::new()
+        .route(
+            "/flags/definitions",
+            post(flag_definitions_endpoint::flag_definitions)
+                .get(flag_definitions_endpoint::flag_definitions),
+        )
+        .route(
+            "/flags/definitions/",
+            post(flag_definitions_endpoint::flag_definitions)
+                .get(flag_definitions_endpoint::flag_definitions),
+        )
+        .layer(ConcurrencyLimitLayer::new(config.max_concurrency));
+
     let router = Router::new()
         .merge(status_router)
         .merge(flags_router)
+        .merge(flag_definitions_router)
         .merge(test_router)
         .layer(TraceLayer::new_for_http())
         .layer(cors)

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -550,7 +550,8 @@ pub async fn insert_personal_api_key_for_user(
     user_id: i32,
     key_plaintext: &str,
 ) -> Result<(), anyhow::Error> {
-    let secure_value = hash_key_value(key_plaintext, "sha256", None).unwrap();
+    let secure_value = hash_key_value(key_plaintext, "sha256", None)
+        .with_context(|| format!("Failed to hash key value for user ID {}", user_id))?;
     let mask_value = format!(
         "{}...{}",
         &key_plaintext[..4],

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     team::team_models::{Team, TEAM_TOKEN_CACHE_PREFIX},
 };
-use anyhow::Error;
+use anyhow::{Context, Error};
 use axum::async_trait;
 use chrono::Utc;
 use common_redis::{Client as RedisClientTrait, RedisClient};


### PR DESCRIPTION
This is a draft PR to port the local evaluation endpoint to Rust. There's some opinionated decisions in the PR that are worth calling out, but happy to be flexible and re-evaluate.

1. New endpoint is `/flags/definitions` - In my view, local evaluation happens on the client. What this service does is provide the flag definitions.
2. Refactored `RequestContext` into two parts, the state and the request info.
3. Implemented this as another endpoint on the existing flags service. We may want to put it in its own service?
4. Kinda cheating by loading everything in a single query with a join. I could do what `request_handler.rs` does and load the `team` separately.

This currently validates personal api key and scopes and returns flag definitions and group type mappings. It does not send cohorts yet.

Todo:

- [ ] Implement cohorts - Only return cohorts referenced by a flag's filter properties
- [x] Implement quota limiting
- [ ] Review to make sure behavior exactly matches Django local evaluation.
- [ ] Logging
- [ ] Review caching and cache initialization. Unless I'm missing something, it looks like the `group_type_mapping_cache` is calling init on every request which means it always hits the db.