### PR TITLE
fix(cdp): GoogleAdsIntegration: fix account selector

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -632,7 +632,7 @@ class GoogleAdsIntegration:
             )
 
             if response.status_code != 200:
-                return []
+                return accounts
 
             data = response.json()
 


### PR DESCRIPTION
## Problem

At the moment, we would wipe the entire array if one Google Ads account is not accessible.

Instead, we should ignore that account and return the accounts that have successfully been checked.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
