### PR TITLE
feat(project-tree): inline new folder creation 

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTreeUtils.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTreeUtils.tsx
@@ -307,7 +307,11 @@ export const InlineEditField = ({
     return (
         <form
             onSubmit={onSubmit}
-            className={cn(buttonVariants({ menuItem: true, size: 'base', sideActionLeft: true }), className)}
+            className={cn(
+                buttonVariants({ menuItem: true, size: 'base', sideActionLeft: true }),
+                className,
+                'bg-fill-button-tertiary-active'
+            )}
         >
             {/* Spacer to offset button padding */}
             <div


### PR DESCRIPTION
## Problem
Browser dialogs are poo; when creating a folder in project tree (tree-view) a dialog pops up asking you to name a folder

![2025-04-28 10 29 57](https://github.com/user-attachments/assets/94e64496-96fe-4e5a-9b4a-4f5c2b7cee47)

## Changes
* Remove dialog on folder create, use default "Untitled folder" as name
* Auto focus and enter edit mode for newly created folder
* Add button active background to inline edit wrapping div

## How did you test this code?
Locally, clicking round'