### PR TITLE
fix: too much dollars, not enough grammar

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarOverviewOtherWatchers.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarOverviewOtherWatchers.tsx
@@ -28,7 +28,7 @@ function OtherWatchersDisplay({ metadata }: { metadata?: SessionRecordingType })
         <div className="flex flex-row deprecated-space-x-2 items-center justify-center px-2 py-1">
             <ProfileBubbles people={metadata.viewers.map((v) => ({ email: v }))} />
             <span>
-                {count} other ${varyingText} watched this recording.
+                {count} other {varyingText} watched this recording.
             </span>
         </div>
     )


### PR DESCRIPTION
this component has a `$` as if it's a template string

but it isn't

so shows wrong

![Screenshot 2025-04-28 at 13 12 59](https://github.com/user-attachments/assets/f32a292d-8b9d-4f01-8627-811e9ec184e6)

well, not any more