### PR TITLE
fix(project-tree): error in lemon tree in insight "save to..."

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -1312,7 +1312,9 @@ const LemonTree = forwardRef<LemonTreeRef, LemonTreeProps>(
                 const element = containerRef.current?.querySelector(
                     `[data-id="${CSS.escape(defaultSelectedFolderOrNodeId)}"]`
                 ) as HTMLElement
-                element.focus()
+                if (element) {
+                    element.focus()
+                }
                 setSelectedId(defaultSelectedFolderOrNodeId)
             }
         }, [defaultSelectedFolderOrNodeId, hasFocusedContent])


### PR DESCRIPTION

## Problem
when using the new "save to..." button in insight save button, lemon tree threw an error with `defaultSelectedFolderOrNodeId`

Before:
![2025-04-28 14 41 01](https://github.com/user-attachments/assets/326038c7-e652-4b24-853f-85c6fa8d4c46)

After:
![2025-04-28 14 41 46](https://github.com/user-attachments/assets/f0fa9fca-f730-41c9-a562-41cc9ca8edde)

## Changes
Check if element exists before calling `element.focus()`

## How did you test this code?
Clicking roun'