### PR TITLE
fix(project-tree): save to nits 

### DIFF
--- a/frontend/src/lib/components/FolderSelect/FolderSelect.tsx
+++ b/frontend/src/lib/components/FolderSelect/FolderSelect.tsx
@@ -43,7 +43,6 @@ export function FolderSelect({ value, onChange, className }: FolderSelectProps):
         const allFolders = getAllFolderIds(value)
         const newExpandedFolders = allFolders.filter((folder) => !expandedFolders.includes(folder))
         if (newExpandedFolders.length > 0) {
-            setExpandedFolders([...expandedFolders, ...newExpandedFolders])
             for (const folder of newExpandedFolders) {
                 if (!touchedFolders.includes(folder)) {
                     loadFolderIfNotLoaded(folder)
@@ -55,7 +54,7 @@ export function FolderSelect({ value, onChange, className }: FolderSelectProps):
     }, [value, expandedFolders, touchedFolders])
 
     return (
-        <div className={clsx('bg-[white] p-2 border rounded-[var(--radius)] overflow-y-scroll', className)}>
+        <div className={clsx('bg-surface-primary p-2 border rounded-[var(--radius)] overflow-y-scroll', className)}>
             <LemonTree
                 ref={treeRef}
                 className="px-0 py-1"

--- a/frontend/src/lib/components/FolderSelect/FolderSelect.tsx
+++ b/frontend/src/lib/components/FolderSelect/FolderSelect.tsx
@@ -1,3 +1,4 @@
+import { IconCheckCircle } from '@posthog/icons'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { LemonTree, LemonTreeRef } from 'lib/lemon-ui/LemonTree/LemonTree'
@@ -32,7 +33,7 @@ export function FolderSelect({ value, onChange, className }: FolderSelectProps):
     const { createFolder, loadFolderIfNotLoaded } = useActions(projectTreeLogic)
 
     const treeRef = useRef<LemonTreeRef>(null)
-
+    const [selectedFolder, setSelectedFolder] = useState<string | undefined>(value)
     const [expandedFolders, setExpandedFolders] = useState<string[]>([])
     const [touchedFolders, setTouchedFolders] = useState<string[]>([])
 
@@ -57,17 +58,19 @@ export function FolderSelect({ value, onChange, className }: FolderSelectProps):
         <div className={clsx('bg-surface-primary p-2 border rounded-[var(--radius)] overflow-y-scroll', className)}>
             <LemonTree
                 ref={treeRef}
+                folderSelectMode
                 className="px-0 py-1"
                 data={projectTreeOnlyFolders}
                 mode="tree"
                 tableViewKeys={treeTableKeys}
-                defaultSelectedFolderOrNodeId={value ? 'project-tree/' + value : undefined}
+                defaultSelectedFolderOrNodeId={value ? 'project-folder/' + value : undefined}
                 isItemActive={(item) => item.record?.path === value}
                 enableMultiSelection={false}
                 showFolderActiveState={true}
                 checkedItemCount={0}
                 onFolderClick={(folder) => {
                     if (folder?.id) {
+                        setSelectedFolder(folder?.record?.path)
                         if (!touchedFolders.includes(folder?.id)) {
                             loadFolderIfNotLoaded(folder?.id)
                             setTouchedFolders([...touchedFolders, folder?.id])
@@ -84,6 +87,20 @@ export function FolderSelect({ value, onChange, className }: FolderSelectProps):
                             }
                         }
                     }
+                }}
+                renderItem={(item) => {
+                    return (
+                        <span>
+                            {item.record?.path === selectedFolder ? (
+                                <span className="flex items-center gap-1">
+                                    {item.displayName}
+                                    <IconCheckCircle className="size-4 text-success" />
+                                </span>
+                            ) : (
+                                item.displayName
+                            )}
+                        </span>
+                    )
                 }}
                 expandedItemIds={expandedFolders}
                 onSetExpandedItemIds={setExpandedFolders}

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -141,6 +141,9 @@ type LemonTreeBaseProps = Omit<HTMLAttributes<HTMLDivElement>, 'onDragEnd'> & {
     setFocusToElementFromId?: (id: string) => void
     /** Set the focus to the last focused element. */
     setFocusToLastFocusedElement?: () => void
+
+    /** Whether to enable folder select mode. */
+    folderSelectMode?: boolean
 }
 
 export type LemonTreeProps = LemonTreeBaseProps & {
@@ -215,6 +218,7 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
             checkedItemCount,
             setFocusToElementFromId,
             setFocusToLastFocusedElement,
+            folderSelectMode = false,
             ...props
         },
         ref
@@ -354,6 +358,7 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                                                             multiSelectionOffset={iconWrapperOffsetMultiSelection}
                                                             checkedItemCount={checkedItemCount}
                                                             onItemChecked={onItemChecked}
+                                                            folderSelectMode={folderSelectMode}
                                                         />
                                                     )}
 
@@ -393,6 +398,8 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                                                                         getItemActiveState(item),
                                                                     'group-hover/lemon-tree-button-group:bg-fill-button-tertiary-hover cursor-pointer':
                                                                         !isEmptyFolder,
+                                                                    'opacity-50 cursor-default':
+                                                                        folderSelectMode && !isFolder,
                                                                 }
                                                             )}
                                                             role="treeitem"
@@ -664,6 +671,7 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                                                 disableKeyboardInput={disableKeyboardInput}
                                                 setFocusToElementFromId={setFocusToElementFromId}
                                                 onItemNameChange={onItemNameChange}
+                                                folderSelectMode={folderSelectMode}
                                                 {...props}
                                             />
                                         </AccordionPrimitive.Content>
@@ -755,6 +763,7 @@ const LemonTree = forwardRef<LemonTreeRef, LemonTreeProps>(
             checkedItemCount,
             tableViewKeys,
             emptySpaceContextMenu,
+            folderSelectMode = false,
             ...props
         },
         ref: ForwardedRef<LemonTreeRef>
@@ -854,7 +863,9 @@ const LemonTree = forwardRef<LemonTreeRef, LemonTreeProps>(
                 const nodeArray = nodes instanceof Array ? nodes : [nodes]
 
                 nodeArray.forEach((node) => {
-                    items.push(node)
+                    if (!folderSelectMode || (folderSelectMode && node.children)) {
+                        items.push(node)
+                    }
                     if (node.children && expandedItemIdsState?.includes(node.id)) {
                         traverse(node.children)
                     }
@@ -863,7 +874,7 @@ const LemonTree = forwardRef<LemonTreeRef, LemonTreeProps>(
 
             traverse(data)
             return items
-        }, [data, expandedItemIdsState])
+        }, [data, expandedItemIdsState, folderSelectMode])
 
         // Focus on provided content ref
         const focusContent = useCallback(() => {
@@ -1003,6 +1014,8 @@ const LemonTree = forwardRef<LemonTreeRef, LemonTreeProps>(
                     const willBeOpen = item?.children ? !expandedItemIdsState.includes(item.id) : undefined
                     item.onClick(willBeOpen)
                 }
+
+                setSelectedId(item?.id)
             },
             [expandedItemIdsState, onFolderClick, onNodeClick, focusContent]
         )
@@ -1435,6 +1448,7 @@ const LemonTree = forwardRef<LemonTreeRef, LemonTreeProps>(
                             isDragging={isDragging}
                             checkedItemCount={checkedItemCount}
                             setFocusToElementFromId={focusElementFromId}
+                            folderSelectMode={folderSelectMode}
                             {...props}
                         />
                     </TreeNodeDroppable>

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -863,6 +863,7 @@ const LemonTree = forwardRef<LemonTreeRef, LemonTreeProps>(
                 const nodeArray = nodes instanceof Array ? nodes : [nodes]
 
                 nodeArray.forEach((node) => {
+                    // if folderSelectMode we don't return folder items
                     if (!folderSelectMode || (folderSelectMode && node.children)) {
                         items.push(node)
                     }

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTreeUtils.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTreeUtils.tsx
@@ -19,6 +19,7 @@ type TreeNodeDisplayIconWrapperProps = {
     multiSelectionOffset: number
     checkedItemCount?: number
     onItemChecked?: (id: string, checked: boolean, shift: boolean) => void
+    folderSelectMode: boolean
 }
 
 export const TreeNodeDisplayIconWrapper = ({
@@ -31,6 +32,7 @@ export const TreeNodeDisplayIconWrapper = ({
     onItemChecked,
     defaultOffset,
     multiSelectionOffset,
+    folderSelectMode,
 }: TreeNodeDisplayIconWrapperProps): JSX.Element => {
     return (
         <>
@@ -44,7 +46,7 @@ export const TreeNodeDisplayIconWrapper = ({
                     'absolute flex items-center justify-center bg-transparent flex-shrink-0 h-[var(--button-height-base)] z-3',
                     {
                         // Apply group class only when there are no checked items
-                        'group/lemon-tree-icon-wrapper': checkedItemCount === 0,
+                        'group/lemon-tree-icon-wrapper': checkedItemCount === 0 && !folderSelectMode,
                     }
                 )}
             >
@@ -56,7 +58,7 @@ export const TreeNodeDisplayIconWrapper = ({
                     className={cn('absolute z-2', {
                         // Apply hidden class only when hovering the (conditional)group and there are no checked items
                         'hidden group-hover/lemon-tree-icon-wrapper:block transition-all duration-50':
-                            checkedItemCount === 0,
+                            checkedItemCount === 0 || folderSelectMode,
                     })}
                     style={{
                         left: `${defaultOffset}px`,


### PR DESCRIPTION
## Problem
* "Save to" didn't account for darkmode
* Folders were not closeable 
* lemon tree allowed clicking non-folders
* no visual queue (other than highlighted background) was showing the item was selected
* Lemon tree didn't update `aria-selected` properly

Before:
<img width="1099" alt="image" src="https://github.com/user-attachments/assets/fe2f0f7e-7c95-49f3-9d46-4f945867a7fc" />
![2025-04-28 16 07 59](https://github.com/user-attachments/assets/7b49e106-76e3-479d-8e81-f8b564ff395a)

After:
![2025-04-28 16 08 58](https://github.com/user-attachments/assets/ceeeb070-6909-4b7a-91a1-53113a9568b0)


## Changes
* fixed darkmode
* fixed folders closing
* added `folderSelectMode` which "disables" non-folders and greys out non-folders
* Added checkmark to selected folder in `FolderSelect` `renderItem()`
* Fixed `aria-selected` to always represent the item clicked/entered on
* Keyboard navigation in `folderSelectMode` skips non-folder items

## How did you test this code?
Locally