### PR TITLE
chore(ingestion): logs info on person update race condition

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -681,6 +681,11 @@ export class DB {
         // Without races, the returned person (updatedPerson) should have a version that's only +1 the person in memory
         const versionDisparity = updatedPerson.version - person.version - 1
         if (versionDisparity > 0) {
+            logger.info('🧑‍🦰', 'Person update version mismatch', {
+                team_id: updatedPerson.team_id,
+                person_id: updatedPerson.id,
+                version_disparity: versionDisparity,
+            })
             personUpdateVersionMismatchCounter.inc()
         }
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Main postgres DB can run into trouble when the ingestion pipeline simultaneously processes events for the same person.
Operators would like to know the person id and team id of the events that trigger locks on the database, so they can take appropriate action.

## Changes

Adds an info log when we have a race condition on a person row update that gives us the person id and the team id.


## Does this work well for both Cloud and self-hosted?


## How did you test this code?
