### PR TITLE
fix(cdp): rename metric

### DIFF
--- a/plugin-server/src/cdp/services/hog-watcher.service.ts
+++ b/plugin-server/src/cdp/services/hog-watcher.service.ts
@@ -25,7 +25,7 @@ export type HogWatcherFunctionState = {
 }
 
 export const hogFunctionExecutionTimeSummary = new Histogram({
-    name: 'cdp_hog_watcher_timings',
+    name: 'cdp_hog_watcher_duration',
     help: 'Processing time of hog function execution by kind',
     labelNames: ['kind'],
 })


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

old metric was still using bucket and calculated timings.. therefore renamed the metric to get the new values 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
