### PR TITLE
chore: show invites in admin portal for an organization

### DIFF
--- a/posthog/admin/admins/organization_admin.py
+++ b/posthog/admin/admins/organization_admin.py
@@ -4,6 +4,7 @@ from django.core.management import call_command
 from django.utils.html import format_html
 from django.urls import reverse
 from posthog.admin.inlines.organization_member_inline import OrganizationMemberInline
+from posthog.admin.inlines.organization_invite_inline import OrganizationInviteInline
 from posthog.admin.inlines.project_inline import ProjectInline
 from posthog.admin.inlines.team_inline import TeamInline
 from posthog.admin.paginators.no_count_paginator import NoCountPaginator
@@ -44,7 +45,7 @@ class OrganizationAdmin(admin.ModelAdmin):
         "customer_trust_scores",
         "is_hipaa",
     ]
-    inlines = [ProjectInline, TeamInline, OrganizationMemberInline]
+    inlines = [ProjectInline, TeamInline, OrganizationMemberInline, OrganizationInviteInline]
     readonly_fields = [
         "id",
         "created_at",

--- a/posthog/admin/inlines/organization_invite_inline.py
+++ b/posthog/admin/inlines/organization_invite_inline.py
@@ -1,0 +1,19 @@
+from django.contrib import admin
+
+from posthog.models.organization_invite import OrganizationInvite
+
+
+class OrganizationInviteInline(admin.TabularInline):
+    extra = 0
+    model = OrganizationInvite
+    readonly_fields = ("created_at", "updated_at", "emailing_attempt_made", "private_project_access")
+    autocomplete_fields = ("organization",)
+
+    can_delete = False
+    show_change_link = False
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

I was debugging a support issue where it would have been helpful to have the invites for an org in the admin dashboard

## Changes

Added read-only view of the invites.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Ran locally
