### PR TITLE
feat(query-history): query history diff check api

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/QueryHistoryModal.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryHistoryModal.tsx
@@ -141,7 +141,7 @@ export function QueryHistoryModal(): JSX.Element {
     const { editingView } = useValues(multitabEditorLogic)
 
     return (
-        <LemonModal title="View History" isOpen={isHistoryModalOpen} onClose={closeHistoryModal} width={800}>
+        <LemonModal title="View history" isOpen={isHistoryModalOpen} onClose={closeHistoryModal} width={800}>
             <div className="ActivityLog">
                 <QueryHistoryLog id={editingView?.id} />
             </div>

--- a/posthog/warehouse/api/test/test_saved_query.py
+++ b/posthog/warehouse/api/test/test_saved_query.py
@@ -669,6 +669,21 @@ class TestSavedQuery(APIBaseTest):
 
             self.assertEqual(response.status_code, 200, response.content)
 
+            # this should fail because the activity log has changed
+            response = self.client.patch(
+                f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query['id']}",
+                {
+                    "query": {
+                        "kind": "HogQLQuery",
+                        "query": "select event as event from events LIMIT 1",
+                    },
+                    "current_query": saved_query["query"]["query"],
+                },
+            )
+
+            self.assertEqual(response.status_code, 400, response.content)
+            self.assertEqual(response.json()["detail"], "The query was modified by someone else.")
+
             activity_logs = ActivityLog.objects.filter(
                 item_id=saved_query["id"], scope="DataWarehouseSavedQuery"
             ).order_by("-created_at")


### PR DESCRIPTION
## Problem

- users can override each others saved query changes without realizing 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- add api that blocks overriding changes and guarantees order

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
