### PR TITLE
chore(ingestion): remove additional JSONB field checks from RO tracking query

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -503,9 +503,7 @@ export class DB {
     public async personPropertiesSize(teamId: number, distinctId: string): Promise<number> {
         const values = [teamId, distinctId]
         const queryString = `
-            SELECT (COALESCE(octet_length(properties::text)::bigint, 0::bigint) +
-                COALESCE(octet_length(properties_last_updated_at::text)::bigint, 0::bigint) +
-                COALESCE(octet_length(properties_last_operation::text)::bigint, 0::bigint)) AS total_props_bytes
+            SELECT COALESCE(octet_length(properties::text)::bigint, 0::bigint) AS total_props_bytes
             FROM posthog_person
             JOIN posthog_persondistinctid ON (posthog_persondistinctid.person_id = posthog_person.id)
             WHERE


### PR DESCRIPTION
## Problem
Expensive observability query may be too heavy to deploy at 100% ramped in prod envs

## Changes
Remove combined checks on less important JSONB fields in persons table, focus on `properties` blob sizing for now

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally, CI, test deploy observation