### PR TITLE
chore(ingestion): try extra-lean observability query

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -503,7 +503,7 @@ export class DB {
     public async personPropertiesSize(teamId: number, distinctId: string): Promise<number> {
         const values = [teamId, distinctId]
         const queryString = `
-            SELECT COALESCE(octet_length(properties::text)::bigint, 0::bigint) AS total_props_bytes
+            SELECT COALESCE(pg_column_size(properties)::bigint, 0::bigint) AS total_props_bytes
             FROM posthog_person
             JOIN posthog_persondistinctid ON (posthog_persondistinctid.person_id = posthog_person.id)
             WHERE


### PR DESCRIPTION
## Problem
Trying to make an important but potentially expensive observability query cheaper

## Changes
Use `pg_column_size` without decompression prior to measurement on DB side to make this cheaper

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally, CI, test deploy