### PR TITLE
feat: batch cache person fetches per distinct ID

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -253,6 +253,9 @@ export function getDefaultConfig(): PluginsServerConfig {
                 24) * // amount of time salt is valid in one timezone
             60 *
             60,
+
+        PERSON_CACHE_ENABLED_FOR_UPDATES: true,
+        PERSON_CACHE_ENABLED_FOR_CHECKS: true,
     }
 }
 

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -130,7 +130,10 @@ export class IngestionConsumer {
         this.ingestionWarningLimiter = new MemoryRateLimiter(1, 1.0 / 3600)
         this.hogTransformer = new HogTransformerService(hub)
 
-        this.personStore = new MeasuringPersonsStore(this.hub.db)
+        this.personStore = new MeasuringPersonsStore(this.hub.db, {
+            personCacheEnabledForUpdates: this.hub.PERSON_CACHE_ENABLED_FOR_UPDATES,
+            personCacheEnabledForChecks: this.hub.PERSON_CACHE_ENABLED_FOR_CHECKS,
+        })
         this.kafkaConsumer = new KafkaConsumer({ groupId: this.groupId, topic: this.topic })
     }
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -139,6 +139,8 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
     INGESTION_OVERFLOW_ENABLED: boolean // whether or not overflow rerouting is enabled (only used by analytics-ingestion)
     INGESTION_FORCE_OVERFLOW_BY_TOKEN_DISTINCT_ID: string // comma-separated list of either tokens or token:distinct_id combinations to force events to route to overflow
     INGESTION_OVERFLOW_PRESERVE_PARTITION_LOCALITY: boolean // whether or not Kafka message keys should be preserved or discarded when messages are rerouted to overflow
+    PERSON_CACHE_ENABLED_FOR_UPDATES: boolean // whether to cache persons for fetchForUpdate calls
+    PERSON_CACHE_ENABLED_FOR_CHECKS: boolean // whether to cache persons for fetchForChecking calls
     TASK_TIMEOUT: number // how many seconds until tasks are timed out
     DATABASE_URL: string // Postgres database URL
     DATABASE_READONLY_URL: string // Optional read-only replica to the main Postgres database

--- a/plugin-server/src/worker/ingestion/persons/measuring-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/measuring-person-store.ts
@@ -99,34 +99,7 @@ export class MeasuringPersonsStoreForDistinctIdBatch implements PersonsStoreForD
         this.personCheckCache = new Map()
     }
 
-    private getCacheKey(teamId: number, distinctId: string): string {
-        return `${teamId}:${distinctId}`
-    }
-
-    private clearCache(): void {
-        this.personCache.clear()
-        this.personCheckCache.clear()
-    }
-
-    private getCachedPerson(teamId: number, distinctId: string): InternalPerson | null | undefined {
-        const cacheKey = this.getCacheKey(teamId, distinctId)
-        return this.personCache.get(cacheKey)
-    }
-
-    private getCheckCachedPerson(teamId: number, distinctId: string): InternalPerson | null | undefined {
-        const cacheKey = this.getCacheKey(teamId, distinctId)
-        return this.personCheckCache.get(cacheKey)
-    }
-
-    private setCachedPerson(teamId: number, distinctId: string, person: InternalPerson | null): void {
-        const cacheKey = this.getCacheKey(teamId, distinctId)
-        this.personCache.set(cacheKey, person)
-    }
-
-    private setCheckCachedPerson(teamId: number, distinctId: string, person: InternalPerson | null): void {
-        const cacheKey = this.getCacheKey(teamId, distinctId)
-        this.personCheckCache.set(cacheKey, person)
-    }
+    // Public interface methods
 
     async inTransaction<T>(description: string, transaction: (tx: TransactionClient) => Promise<T>): Promise<T> {
         return await this.db.postgres.transaction(PostgresUse.COMMON_WRITE, description, transaction)
@@ -263,6 +236,39 @@ export class MeasuringPersonsStoreForDistinctIdBatch implements PersonsStoreForD
     getMethodCounts(): Map<MethodName, number> {
         return new Map(this.methodCounts)
     }
+
+    // Private cache management methods
+
+    private getCacheKey(teamId: number, distinctId: string): string {
+        return `${teamId}:${distinctId}`
+    }
+
+    private clearCache(): void {
+        this.personCache.clear()
+        this.personCheckCache.clear()
+    }
+
+    private getCachedPerson(teamId: number, distinctId: string): InternalPerson | null | undefined {
+        const cacheKey = this.getCacheKey(teamId, distinctId)
+        return this.personCache.get(cacheKey)
+    }
+
+    private getCheckCachedPerson(teamId: number, distinctId: string): InternalPerson | null | undefined {
+        const cacheKey = this.getCacheKey(teamId, distinctId)
+        return this.personCheckCache.get(cacheKey)
+    }
+
+    private setCachedPerson(teamId: number, distinctId: string, person: InternalPerson | null): void {
+        const cacheKey = this.getCacheKey(teamId, distinctId)
+        this.personCache.set(cacheKey, person)
+    }
+
+    private setCheckCachedPerson(teamId: number, distinctId: string, person: InternalPerson | null): void {
+        const cacheKey = this.getCacheKey(teamId, distinctId)
+        this.personCheckCache.set(cacheKey, person)
+    }
+
+    // Private utility methods
 
     private incrementCount(method: MethodName): void {
         this.methodCounts.set(method, (this.methodCounts.get(method) || 0) + 1)

--- a/plugin-server/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
@@ -92,6 +92,10 @@ exports[`EventPipelineRunner runEventPipeline() runs steps starting from populat
         },
         "distinctId": "my_id",
         "methodCounts": {},
+        "options": {
+          "personCacheEnabledForChecks": true,
+          "personCacheEnabledForUpdates": true,
+        },
         "personCache": {},
         "personCheckCache": {},
         "token": "token1",

--- a/plugin-server/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
@@ -92,6 +92,8 @@ exports[`EventPipelineRunner runEventPipeline() runs steps starting from populat
         },
         "distinctId": "my_id",
         "methodCounts": {},
+        "personCache": {},
+        "personCheckCache": {},
         "token": "token1",
       },
     ],


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

For each distinct id in a batch, we run fetch person queries on every event, even if we don't change the person at all. This causes a lot of unnecessary queries and latency in ingestion.

## Changes

- Adds two caches for `fetchforUpdate` and `fetchForChecking` person store operations
- Invalidates all caches for distinct ID batch whenever any person-related write operation occurs

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Plenty of existing regression tests.