### PR TITLE
feat: add person cache metrics

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/metrics.ts
+++ b/plugin-server/src/worker/ingestion/persons/metrics.ts
@@ -1,8 +1,14 @@
-import { Histogram } from 'prom-client'
+import { Counter, Histogram } from 'prom-client'
 
 export const personMethodCallsPerBatchHistogram = new Histogram({
     name: 'person_method_calls_per_batch',
     help: 'Number of calls to each person store method per distinct ID per batch',
     labelNames: ['method'],
     buckets: [0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, Infinity],
+})
+
+export const personCacheOperationsCounter = new Counter({
+    name: 'person_cache_operations_total',
+    help: 'Total number of cache hits and misses',
+    labelNames: ['cache', 'operation'],
 })

--- a/plugin-server/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
@@ -87,6 +87,12 @@ exports[`EventPipelineRunner runEventPipeline() runs steps starting from populat
       "2020-02-23T02:15:00.000Z",
       true,
       {
+        "cacheMetrics": {
+          "checkCacheHits": 0,
+          "checkCacheMisses": 0,
+          "updateCacheHits": 0,
+          "updateCacheMisses": 0,
+        },
         "db": {
           "kafkaProducer": {},
         },


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We're lacking direct metrics for person cache effectiveness.

## Changes

Adds hit/miss metrics for both person caches.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Will monitor metrics on production.