### PR TITLE
fix(max): optimize message rendering

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -148,6 +148,7 @@
         "lodash.merge": "^4.6.2",
         "lodash.uniqby": "^4.7.0",
         "maplibre-gl": "^3.5.1",
+        "marked": "^15.0.11",
         "md5": "^2.3.0",
         "monaco-editor": "^0.49.0",
         "natural-orderby": "^3.0.2",

--- a/frontend/src/lib/components/CodeSnippet/CodeSnippet.tsx
+++ b/frontend/src/lib/components/CodeSnippet/CodeSnippet.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx'
 import { useValues } from 'kea'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
-import { type HTMLProps, useEffect, useState } from 'react'
+import React, { type HTMLProps, useEffect, useState } from 'react'
 import { PrismAsyncLight as SyntaxHighlighter } from 'react-syntax-highlighter'
 import bash from 'react-syntax-highlighter/dist/esm/languages/prism/bash'
 import csharp from 'react-syntax-highlighter/dist/esm/languages/prism/csharp'
@@ -144,7 +144,7 @@ export interface CodeSnippetProps {
     maxLinesWithoutExpansion?: number
 }
 
-export function CodeSnippet({
+export const CodeSnippet = React.memo(function CodeSnippet({
     children: text,
     language = Language.Text,
     wrap = false,
@@ -155,11 +155,13 @@ export function CodeSnippet({
     maxLinesWithoutExpansion,
 }: CodeSnippetProps): JSX.Element | null {
     const [expanded, setExpanded] = useState(false)
-    const [indexOfLimitNewline, setIndexOfLimitNewline] = useState(
+    const [indexOfLimitNewline, setIndexOfLimitNewline] = useState(() =>
         maxLinesWithoutExpansion ? indexOfNth(text || '', '\n', maxLinesWithoutExpansion) : -1
     )
-    const [lineCount, setLineCount] = useState(-1)
-    const [displayedText, setDisplayedText] = useState('')
+    const [lineCount, setLineCount] = useState(() => text?.split('\n').length || -1)
+    const [displayedText, setDisplayedText] = useState(
+        () => (indexOfLimitNewline === -1 || expanded ? text : text?.slice(0, indexOfLimitNewline)) ?? ''
+    )
 
     useEffect(() => {
         if (text) {
@@ -209,7 +211,7 @@ export function CodeSnippet({
             )}
         </div>
     )
-}
+})
 
 const syntaxHighlighterLineProps: HTMLProps<HTMLElement> = {
     style: { whiteSpace: 'pre-wrap', overflowWrap: 'anywhere' },

--- a/frontend/src/lib/lemon-ui/LemonMarkdown/LemonMarkdown.tsx
+++ b/frontend/src/lib/lemon-ui/LemonMarkdown/LemonMarkdown.tsx
@@ -2,10 +2,19 @@ import './LemonMarkdown.scss'
 
 import clsx from 'clsx'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
-import React from 'react'
+import React, { memo, useMemo } from 'react'
 import ReactMarkdown from 'react-markdown'
 
 import { Link } from '../Link'
+
+interface LemonMarkdownContainerProps {
+    children: React.ReactNode
+    className?: string
+}
+
+function LemonMarkdownContainer({ children, className }: LemonMarkdownContainerProps): JSX.Element {
+    return <div className={clsx('LemonMarkdown', className)}>{children}</div>
+}
 
 export interface LemonMarkdownProps {
     children: string
@@ -16,38 +25,60 @@ export interface LemonMarkdownProps {
     className?: string
 }
 
+const LemonMarkdownRenderer = memo(function LemonMarkdownRenderer({
+    children,
+    lowKeyHeadings = false,
+    disableDocsRedirect = false,
+}: LemonMarkdownProps): JSX.Element {
+    const renderers = useMemo<{ [nodeType: string]: React.ElementType }>(
+        () => ({
+            link: ({ href, children }: any): JSX.Element => (
+                <Link to={href} target="_blank" targetBlankIcon disableDocsPanel={disableDocsRedirect}>
+                    {children}
+                </Link>
+            ),
+            code: ({ language, value }: any): JSX.Element => (
+                <CodeSnippet language={language || Language.Text} compact>
+                    {value}
+                </CodeSnippet>
+            ),
+            ...(lowKeyHeadings
+                ? {
+                      heading: 'strong',
+                  }
+                : {}),
+        }),
+        [disableDocsRedirect, lowKeyHeadings]
+    )
+
+    return (
+        /* eslint-disable-next-line react/forbid-elements */
+        <ReactMarkdown
+            renderers={renderers}
+            disallowedTypes={['html']} // Don't want to deal with the security considerations of HTML
+        >
+            {children}
+        </ReactMarkdown>
+    )
+})
+
 /** Beautifully rendered Markdown. */
-export const LemonMarkdown = React.memo(function LemonMarkdown({
+function LemonMarkdownComponent({
     children,
     lowKeyHeadings = false,
     disableDocsRedirect = false,
     className,
 }: LemonMarkdownProps): JSX.Element {
     return (
-        <div className={clsx('LemonMarkdown', className)}>
-            {/* eslint-disable-next-line react/forbid-elements */}
-            <ReactMarkdown
-                renderers={{
-                    link: ({ href, children }) => (
-                        <Link to={href} target="_blank" targetBlankIcon disableDocsPanel={disableDocsRedirect}>
-                            {children}
-                        </Link>
-                    ),
-                    code: ({ language, value }) => (
-                        <CodeSnippet language={language || Language.Text} compact>
-                            {value}
-                        </CodeSnippet>
-                    ),
-                    ...(lowKeyHeadings
-                        ? {
-                              heading: 'strong',
-                          }
-                        : {}),
-                }}
-                disallowedTypes={['html']} // Don't want to deal with the security considerations of HTML
-            >
+        <LemonMarkdownContainer className={className}>
+            <LemonMarkdownRenderer lowKeyHeadings={lowKeyHeadings} disableDocsRedirect={disableDocsRedirect}>
                 {children}
-            </ReactMarkdown>
-        </div>
+            </LemonMarkdownRenderer>
+        </LemonMarkdownContainer>
     )
+}
+
+export const LemonMarkdown = Object.assign(LemonMarkdownComponent, {
+    Container: LemonMarkdownContainer,
+    Renderer: LemonMarkdownRenderer,
 })

--- a/frontend/src/scenes/max/MarkdownMessage.tsx
+++ b/frontend/src/scenes/max/MarkdownMessage.tsx
@@ -1,0 +1,33 @@
+import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
+import { marked } from 'marked'
+import { memo, useMemo } from 'react'
+
+function parseMarkdownIntoBlocks(markdown: string): string[] {
+    const tokens = marked.lexer(markdown)
+    return tokens.map((token) => token.raw)
+}
+
+/**
+ * The optimized markdown renderer for messages.
+ * Splits the markdown into blocks, so they can individually be memoized.
+ */
+export const MarkdownMessage = memo(function MarkdownMessage({
+    content,
+    id,
+    className,
+}: {
+    content: string
+    id: string
+    className?: string
+}): JSX.Element {
+    const blocks = useMemo(() => parseMarkdownIntoBlocks(content), [content])
+    return (
+        <LemonMarkdown.Container>
+            {blocks.map((block, index) => (
+                <LemonMarkdown.Renderer key={`${id}-block_${index}`} className={className}>
+                    {block}
+                </LemonMarkdown.Renderer>
+            ))}
+        </LemonMarkdown.Container>
+    )
+})

--- a/frontend/src/scenes/max/MarkdownMessage.tsx
+++ b/frontend/src/scenes/max/MarkdownMessage.tsx
@@ -22,11 +22,9 @@ export const MarkdownMessage = memo(function MarkdownMessage({
 }): JSX.Element {
     const blocks = useMemo(() => parseMarkdownIntoBlocks(content), [content])
     return (
-        <LemonMarkdown.Container>
+        <LemonMarkdown.Container className={className}>
             {blocks.map((block, index) => (
-                <LemonMarkdown.Renderer key={`${id}-block_${index}`} className={className}>
-                    {block}
-                </LemonMarkdown.Renderer>
+                <LemonMarkdown.Renderer key={`${id}-block_${index}`}>{block}</LemonMarkdown.Renderer>
             ))}
         </LemonMarkdown.Container>
     )

--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -15,7 +15,6 @@ import { useActions, useValues } from 'kea'
 import { BreakdownSummary, PropertiesSummary, SeriesSummary } from 'lib/components/Cards/InsightCard/InsightDetails'
 import { TopHeading } from 'lib/components/Cards/InsightCard/TopHeading'
 import { IconOpenInNew } from 'lib/lemon-ui/icons'
-import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import posthog from 'posthog-js'
 import React, { useMemo, useState } from 'react'
 import { urls } from 'scenes/urls'
@@ -33,6 +32,7 @@ import {
 import { DataVisualizationNode, InsightVizNode, NodeKind } from '~/queries/schema/schema-general'
 import { isHogQLQuery } from '~/queries/utils'
 
+import { MarkdownMessage } from './MarkdownMessage'
 import { maxLogic, MessageStatus, ThreadMessage } from './maxLogic'
 import {
     castAssistantQuery,
@@ -101,7 +101,10 @@ function MessageGroup({ messages, isFinal: isFinalGroup }: MessageGroupProps): J
                                 type="human"
                                 boxClassName={message.status === 'error' ? 'border-danger' : undefined}
                             >
-                                <LemonMarkdown>{message.content || '*No text.*'}</LemonMarkdown>
+                                <MarkdownMessage
+                                    content={message.content || '*No text.*'}
+                                    id={message.id || 'no-text'}
+                                />
                             </MessageTemplate>
                         )
                     } else if (
@@ -127,12 +130,12 @@ function MessageGroup({ messages, isFinal: isFinalGroup }: MessageGroupProps): J
                                     <Spinner className="text-xl" />
                                 </div>
                                 {message.substeps?.map((substep, substepIndex) => (
-                                    <LemonMarkdown
+                                    <MarkdownMessage
                                         key={substepIndex}
+                                        id={message.id || messageIndex.toString()}
                                         className="mt-1.5 leading-6 px-1 text-[0.6875rem] font-semibold bg-surface-secondary rounded w-fit"
-                                    >
-                                        {substep}
-                                    </LemonMarkdown>
+                                        content={substep}
+                                    />
                                 ))}
                             </MessageTemplate>
                         )
@@ -233,9 +236,10 @@ const TextAnswer = React.forwardRef<HTMLDivElement, TextAnswerProps>(function Te
             ref={ref}
             action={action}
         >
-            <LemonMarkdown>
-                {message.content || '*Max has failed to generate an answer. Please try again.*'}
-            </LemonMarkdown>
+            <MarkdownMessage
+                content={message.content || '*Max has failed to generate an answer. Please try again.*'}
+                id={message.id || 'error'}
+            />
         </MessageTemplate>
     )
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -829,6 +829,9 @@ importers:
       maplibre-gl:
         specifier: ^3.5.1
         version: 3.5.1
+      marked:
+        specifier: ^15.0.11
+        version: 15.0.11
       md5:
         specifier: ^2.3.0
         version: 2.3.0
@@ -11803,6 +11806,11 @@ packages:
     engines: {node: '>= 10'}
     peerDependencies:
       react: '>= 0.14.0'
+
+  marked@15.0.11:
+    resolution: {integrity: sha512-1BEXAU2euRCG3xwgLVT1y0xbJEld1XOrmRJpUwRCcy7rxhSCwMrmEu9LXoPhHSCJG41V7YcQ2mjKRr5BA3ITIA==}
+    engines: {node: '>= 18'}
+    hasBin: true
 
   marked@4.3.0:
     resolution: {integrity: sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==}
@@ -29010,6 +29018,8 @@ snapshots:
   markdown-to-jsx@7.3.2(react@18.2.0):
     dependencies:
       react: 18.2.0
+
+  marked@15.0.11: {}
 
   marked@4.3.0: {}
 


### PR DESCRIPTION
## Problem

Markdown rendering was unoptimized. It flickered and frequently re-rendered, so UX was crappy. This PR optimizes the rendering and nested components, except for the weird 8px difference I can't figure out where it's coming from. You can now use the `useEffect` hook to properly catch when the UI has finished rendering, so the thread can be scrolled without issues.

## Changes

- Split generated markdown into blocks, so we efficiently memoize blocks that have finished the generation, and re-render only new parts.
- Split the markdown component into a few parts to reuse the styling.
- Memoize renderers, so code blocks and links don't flicker while generated.
- Memoize and optimize the CodeSnippet component: eliminate the initial rerender and memoize it.

### Demo

![2025-04-29 11 37 47](https://github.com/user-attachments/assets/d295316f-77db-4663-8491-690ada969935)

![2025-04-29 11 37 47](https://github.com/user-attachments/assets/b82efaf7-9da4-45e2-8e55-59c8c6456d41)


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manual testing
