### PR TITLE
chore: add a pnpm start command

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
         "format:frontend": "pnpm --filter=@posthog/frontend run format",
         "format": "pnpm format:backend && pnpm format:frontend",
         "cleandep": "rm -rf node_modules && pnpm -r exec rm -rf node_modules",
-        "storybook": "pnpm turbo --filter=@posthog/storybook start"
+        "storybook": "pnpm turbo --filter=@posthog/storybook start",
+        "start": "./bin/start"
     },
     "dependencies": {
         "concurrently": "^5.3.0",


### PR DESCRIPTION
I keep typing `pnpm start` when i mean to type `./bin/start`

let's just add `pnpm start` to make my life easier