### PR TITLE
feat(toolbox): warn of active flox environment when connecting to a toolbox

### DIFF
--- a/infra-scripts/clitools/toolbox.py
+++ b/infra-scripts/clitools/toolbox.py
@@ -20,6 +20,11 @@ from toolbox.pod import get_toolbox_pod, claim_pod, connect_to_pod, delete_pod
 def main():
     """Main entry point for the toolbox command."""
     try:
+        # If we're in a flox environment, exit
+        if "FLOX_ENV" in os.environ:
+            print("⚠️ Please exit the flox environment by typing `exit` before connecting to a toolbox.")  # noqa: T201
+            sys.exit(0)
+
         # Set up argument parser
         parser = argparse.ArgumentParser(
             description="Connect to a toolbox pod and manage pod claims. This script will automatically connect you to your latest claimed pod.",


### PR DESCRIPTION
## Problem

The toolbox doesn't play well with flox.

## Changes

Warns of active flox env before connecting to a toolbox.

## How did you test this code?

Ran manually