### PR TITLE
chore: bring back team and group deletes on celery

### DIFF
--- a/posthog/models/async_deletion/delete_events.py
+++ b/posthog/models/async_deletion/delete_events.py
@@ -32,7 +32,7 @@ TABLES_TO_DELETE_TEAM_DATA_FROM = [
 
 
 class AsyncEventDeletion(AsyncDeletionProcess):
-    DELETION_TYPES = [DeletionType.Team, DeletionType.Group, DeletionType.Person]
+    DELETION_TYPES = [DeletionType.Team, DeletionType.Group]
 
     def process(self, deletions: list[AsyncDeletion]):
         deletions_counter.labels(deletion_type="event").inc(len(deletions))

--- a/posthog/models/async_deletion/delete_events.py
+++ b/posthog/models/async_deletion/delete_events.py
@@ -91,7 +91,7 @@ class AsyncEventDeletion(AsyncDeletionProcess):
         sync_execute(
             query,
             args,
-            settings={},
+            settings={"lightweight_deletes_sync": 0},
         )
 
         # Team data needs to be deleted from other models as well, groups/persons handles deletions on a schema level
@@ -114,7 +114,7 @@ class AsyncEventDeletion(AsyncDeletionProcess):
             sync_execute(
                 query,
                 args,
-                settings={},
+                settings={"lightweight_deletes_sync": 0},
             )
 
     def _verify_by_group(self, deletion_type: int, async_deletions: list[AsyncDeletion]) -> list[AsyncDeletion]:


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

When we migrated deletes to Dagster, that only included Person deletes, but not Team or Group deletes.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

While we create the Dagster job, bring back the celery task that deletes team and group related data.

## Does this work well for both Cloud and self-hosted?

Yes
