### PR TITLE
fix(retention): include all non-empty rows in retention mean calculation

### DIFF
--- a/frontend/src/scenes/retention/RetentionTable.tsx
+++ b/frontend/src/scenes/retention/RetentionTable.tsx
@@ -96,8 +96,7 @@ export function RetentionTable({ inSharedMode = false }: { inSharedMode?: boolea
                                                     const validRows = breakdownRows.filter((row) => {
                                                         return !(
                                                             row.values?.[interval]?.isCurrentPeriod ||
-                                                            !row.values?.[interval] ||
-                                                            row.values?.[interval]?.count <= 0
+                                                            row.cohortSize <= 0
                                                         )
                                                     })
 


### PR DESCRIPTION
## Problem

For my understanding it would make more sense to include all rows that have a non-zero cohort in the mean calculation, instead of removing those where the row is zero for the respective interval.

Triggered by this ticket https://posthoghelp.zendesk.com/agent/tickets/29656 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/31414)

## Changes

Implements this.

## How did you test this code?

Tested with a retention insight