### PR TITLE
chore: update the robots.txt with more endpoints

### DIFF
--- a/posthog/views.py
+++ b/posthog/views.py
@@ -100,10 +100,6 @@ Disallow: /*%40*
 Disallow: /*@*
 
 # Block authentication paths
-Disallow: /login
-Disallow: /login/
-Disallow: /signup
-Disallow: /signup/
 Disallow: /verify_email/
 Disallow: /authorize_and_redirect
 
@@ -112,6 +108,7 @@ Disallow: /e/
 Disallow: /s/
 Disallow: /i/
 Disallow: /decide/
+Disallow: /flags/
 """
     return HttpResponse(ROBOTS_TXT_CONTENT, content_type="text/plain")
 

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -80,11 +80,39 @@ def stats(request):
 
 
 def robots_txt(request):
-    ROBOTS_TXT_CONTENT = (
-        "User-agent: *\nDisallow: /shared_dashboard/\nDisallow: /shared/"
-        if is_cloud()
-        else "User-agent: *\nDisallow: /"
-    )
+    # Block all on self-hosted instances
+    if not is_cloud():
+        return HttpResponse("User-agent: *\nDisallow: /", content_type="text/plain")
+
+    ROBOTS_TXT_CONTENT = """User-agent: *
+
+# Block shared paths
+Disallow: /shared_dashboard/
+Disallow: /shared/
+
+# Block URLs with sensitive query parameters
+Disallow: /*?*email=
+Disallow: /*?*organization_name=
+Disallow: /*?*first_name=
+Disallow: /*?*token=
+Disallow: /*?*sharing_access_token=
+Disallow: /*%40*
+Disallow: /*@*
+
+# Block authentication paths
+Disallow: /login
+Disallow: /login/
+Disallow: /signup
+Disallow: /signup/
+Disallow: /verify_email/
+Disallow: /authorize_and_redirect
+
+# Block ingestion paths
+Disallow: /e/
+Disallow: /s/
+Disallow: /i/
+Disallow: /decide/
+"""
     return HttpResponse(ROBOTS_TXT_CONTENT, content_type="text/plain")
 
 


### PR DESCRIPTION
## Problem

We've got some URLs being scraped that shouldn't be. See https://posthog.slack.com/archives/C0428JHABK2/p1745920149016009 for more information. 

## Changes

Updating robots.txt for cloud in order to make sure sensitive and ingestion URLs aren't being scraped. This is also trying to stop archive.org and similar scrapers from including these URLS (although they don't always respect robots). 

## Does this work well for both Cloud and self-hosted?

It doesn't have an impact.

## How did you test this code?

Manually - so easy to test when the API renders it 👌
