### PR TITLE
fix(experiments): fix isLegacyExperiment for shared metrics

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/LegacyExperimentHeader.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/LegacyExperimentHeader.tsx
@@ -13,6 +13,8 @@ export function LegacyExperimentHeader(): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
 
     const showNewEngineBanner =
+        // We don't want to show the banner if the experiment has already started
+        !experiment.start_date &&
         // We use the isLegacyExperiment to check if the experiment does _not_ have any legacy metrics added already
         // We don't want to show the banner then, as we can't automatically migrate yet. So that would be confusing,
         // as it has no effect then.

--- a/frontend/src/scenes/experiments/utils.test.ts
+++ b/frontend/src/scenes/experiments/utils.test.ts
@@ -31,7 +31,6 @@ import {
 } from '~/types'
 
 import { getNiceTickValues } from './MetricsView/utils'
-import { SharedMetric } from './SharedMetrics/sharedMetricLogic'
 import {
     exposureConfigToFilter,
     featureFlagEligibleForExperiment,
@@ -40,7 +39,6 @@ import {
     getViewRecordingFilters,
     isLegacyExperiment,
     isLegacyExperimentQuery,
-    isLegacySharedMetric,
     metricToFilter,
     metricToQuery,
     percentageDistribution,
@@ -955,8 +953,10 @@ describe('hasLegacyMetrics', () => {
             metrics_secondary: [],
             saved_metrics: [
                 {
-                    kind: NodeKind.ExperimentTrendsQuery,
-                    count_query: { kind: NodeKind.TrendsQuery, series: [] },
+                    query: {
+                        kind: NodeKind.ExperimentTrendsQuery,
+                        count_query: { kind: NodeKind.TrendsQuery, series: [] },
+                    },
                 },
             ],
         } as unknown as Experiment
@@ -991,33 +991,23 @@ describe('hasLegacyMetrics', () => {
 
         expect(isLegacyExperiment(experiment)).toBe(false)
     })
-})
-
-describe('hasLegacySharedMetrics', () => {
-    it('returns true if shared metrics contain legacy query', () => {
-        const sharedMetric = {
-            query: {
-                kind: NodeKind.ExperimentTrendsQuery,
-                count_query: { kind: NodeKind.TrendsQuery, series: [] },
-            },
-        } as unknown as SharedMetric
-
-        expect(isLegacySharedMetric(sharedMetric)).toBe(true)
-    })
 
     it('returns false if shared metrics contain no legacy queries', () => {
-        const sharedMetric = {
-            query: {
-                kind: NodeKind.ExperimentMetric,
-                metric_type: ExperimentMetricType.MEAN,
-                source: { kind: NodeKind.EventsNode, event: 'test' },
-            },
-        } as unknown as SharedMetric
+        const experiment = {
+            ...experimentJson,
+            metrics: [],
+            metrics_secondary: [],
+            saved_metrics: [
+                {
+                    query: {
+                        kind: NodeKind.ExperimentMetric,
+                        metric_type: ExperimentMetricType.MEAN,
+                        source: { kind: NodeKind.EventsNode, event: 'test' },
+                    },
+                },
+            ],
+        } as unknown as Experiment
 
-        expect(isLegacySharedMetric(sharedMetric)).toBe(false)
-    })
-
-    it('returns false for empty shared metrics array', () => {
-        expect(isLegacySharedMetric({} as SharedMetric)).toBe(false)
+        expect(isLegacyExperiment(experiment)).toBe(false)
     })
 })

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -679,15 +679,18 @@ export const isLegacyExperimentQuery = (query: unknown): query is ExperimentTren
     )
 }
 
+/**
+ * The legacy query runner uses ExperimentTrendsQuery and ExperimentFunnelsQuery
+ * to run experiments.
+ *
+ * We should remove these legacy metrics once we've migrated all experiments to the new query runner.
+ */
 export const isLegacyExperiment = ({ metrics, metrics_secondary, saved_metrics }: Experiment): boolean => {
-    const allMetrics = [...metrics, ...metrics_secondary, ...saved_metrics]
-    /**
-     * The legacy query runner uses ExperimentTrendsQuery and ExperimentFunnelsQuery
-     * to run experiments.
-     *
-     * We should remove these legacy metrics once we've migrated all experiments to the new query runner.
-     */
-    return allMetrics.some(isLegacyExperimentQuery)
+    // saved_metrics has a different structure and so we need to check for it separately
+    if (saved_metrics.some(isLegacySharedMetric)) {
+        return true
+    }
+    return [...metrics, ...metrics_secondary].some(isLegacyExperimentQuery)
 }
 
 export const isLegacySharedMetric = ({ query }: SharedMetric): boolean => isLegacyExperimentQuery(query)


### PR DESCRIPTION
## Problem
We have a small bug with our check for legacy experiments. It returns false if an experiment only contains shared legacy metrics.

## Changes
Use the existing `isLegacySharedMetric` function to check shared metrics. Update tests so shared metrics has the same structure as in the `saved_metrics` object these functions are actually called with.

Also, don't display the banner on launched experiments (has start_date set).

## How did you test this code?

- Manually tested this by adding a shared metric, banner disappears then
- Tests passes
