### PR TITLE
chore(capture): wire up log_level and mirror deploy sentinel value in capture-rs

### DIFF
--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -2,6 +2,7 @@ use std::{net::SocketAddr, num::NonZeroU32};
 
 use envconfig::Envconfig;
 use health::HealthStrategy;
+use tracing::Level;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum CaptureMode {
@@ -85,6 +86,12 @@ pub struct Config {
 
     #[envconfig(default = "ALL")]
     pub healthcheck_strategy: HealthStrategy,
+
+    #[envconfig(default = "false")]
+    pub is_mirror_deploy: bool,
+
+    #[envconfig(default = "info")]
+    pub log_level: Level,
 }
 
 #[derive(Envconfig, Clone)]

--- a/rust/capture/src/main.rs
+++ b/rust/capture/src/main.rs
@@ -7,7 +7,6 @@ use opentelemetry_sdk::trace::{BatchConfig, RandomIdGenerator, Sampler, Tracer};
 use opentelemetry_sdk::{runtime, Resource};
 use tokio::signal;
 use tracing::level_filters::LevelFilter;
-use tracing::Level;
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -76,7 +75,7 @@ async fn main() {
                 &config.otel_service_name,
             ))
         })
-        .with_filter(LevelFilter::from_level(Level::INFO));
+        .with_filter(LevelFilter::from_level(config.log_level));
     tracing_subscriber::registry()
         .with(log_layer)
         .with(otel_layer)

--- a/rust/capture/tests/common.rs
+++ b/rust/capture/tests/common.rs
@@ -23,7 +23,7 @@ use time::OffsetDateTime;
 use tokio::net::TcpListener;
 use tokio::sync::Notify;
 use tokio::time::timeout;
-use tracing::{info, warn};
+use tracing::{info, warn, Level};
 
 use capture::config::{CaptureMode, Config, KafkaConfig};
 use capture::server::serve;
@@ -43,6 +43,8 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     enable_historical_rerouting: false,
     historical_rerouting_threshold_days: 1_i64,
     historical_tokens_keys: None,
+    is_mirror_deploy: false,
+    log_level: Level::INFO,
     kafka: KafkaConfig {
         kafka_producer_linger_ms: 0, // Send messages as soon as possible
         kafka_producer_queue_mib: 10,


### PR DESCRIPTION
## Problem
While debugging errors for the `posthog-events-django` -> `capture-rs` migration, I want to be able to special case chatty logging and other alternate shim code I'm testing without breaking the live `capture-rs` deployment.

## Changes
* Adds paramaterizable log level to `capture-rs`
* Adds mirror deployment sentinel flag to `capture-rs` for special casing new code

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally, CI, mirror deploy