### PR TITLE
feat: Add timers for summary stages. Improve error handling.

### DIFF
--- a/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/playerMetaLogic.tsx
@@ -103,6 +103,7 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
         sessionSummaryFeedback: (feedback: 'good' | 'bad') => ({ feedback }),
         setSessionSummaryContent: (content: SessionSummaryContent) => ({ content }),
         summarizeSession: () => ({}),
+        setSessionSummaryLoading: (isLoading: boolean) => ({ isLoading }),
     }),
     reducers(() => ({
         summaryHasHadFeedback: [
@@ -122,6 +123,7 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
             {
                 summarizeSession: () => true,
                 setSessionSummaryContent: () => false,
+                setSessionSummaryLoading: (_, { isLoading }) => isLoading,
             },
         ],
     })),
@@ -343,7 +345,7 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
                             }
                         } catch (e) {
                             // Don't handle errors as we can afford to fail some chunks silently.
-                            // Also, there should not be any unparseable chunks coming from the server as they are validated before being sent.
+                            // However, there should not be any unparseable chunks coming from the server as they are validated before being sent.
                         }
                     },
                 })
@@ -359,6 +361,8 @@ export const playerMetaLogic = kea<playerMetaLogicType>([
             } catch (err) {
                 lemonToast.error('Failed to load session summary. Please, try again.')
                 throw err
+            } finally {
+                actions.setSessionSummaryLoading(false)
             }
         },
     })),

--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummary.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummary.tsx
@@ -425,7 +425,7 @@ function LoadingTimer(): JSX.Element {
         return () => clearInterval(interval)
     }, [])
 
-    return <span>({elapsedSeconds}s)</span>
+    return <span>{elapsedSeconds}s</span>
 }
 
 export function PlayerSidebarSessionSummary(): JSX.Element | null {
@@ -436,7 +436,14 @@ export function PlayerSidebarSessionSummary(): JSX.Element | null {
         <div className="rounded border bg-surface-primary px-2 py-1">
             {sessionSummaryLoading ? (
                 <>
-                    Researching the session... <Spinner /> <LoadingTimer />
+                    <div className="flex items-center justify-between">
+                        <div>
+                            Researching the session... <Spinner />
+                        </div>
+                        <div className="flex items-center gap-1 ml-auto font-mono text-xs">
+                            <LoadingTimer />
+                        </div>
+                    </div>
                 </>
             ) : sessionSummary ? (
                 <SessionSummary />

--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummary.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummary.tsx
@@ -203,15 +203,21 @@ interface SessionSummaryLoadingStateProps {
     operation: string
     counter?: number
     name?: string
+    outOf?: number
 }
 
-function SessionSummaryLoadingState({ operation, counter, name }: SessionSummaryLoadingStateProps): JSX.Element {
+function SessionSummaryLoadingState({ operation, counter, name, outOf }: SessionSummaryLoadingStateProps): JSX.Element {
     return (
         <div className="mb-4 grid grid-cols-[auto_1fr] gap-x-2">
             <Spinner className="text-2xl row-span-2 self-center" />
             <span className="text-muted">
                 {operation}
-                {counter !== undefined && <span className="font-semibold"> ({counter})</span>}
+                {counter !== undefined && (
+                    <span className="font-semibold">
+                        ({counter}
+                        {outOf ? ` of ${outOf}` : ''})
+                    </span>
+                )}
                 {name ? ':' : ''}
             </span>
             {name ? (
@@ -285,6 +291,7 @@ function SessionSummary(): JSX.Element {
                 operation: 'Researching key actions for the segment',
                 counter: currentSegment?.meta?.key_action_count ?? undefined,
                 name: currentSegment?.name ?? undefined,
+                outOf: segments.length,
             }
         }
         // If no segments have key actions or outcomes, it means we are researching the segments for the session

--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummary.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummary.tsx
@@ -56,6 +56,20 @@ interface SegmentMetaProps {
     meta: SegmentMeta | null | undefined
 }
 
+function LoadingTimer(): JSX.Element {
+    const [elapsedSeconds, setElapsedSeconds] = useState(0)
+
+    useEffect(() => {
+        const interval = setInterval(() => {
+            setElapsedSeconds((prev) => prev + 1)
+        }, 1000)
+
+        return () => clearInterval(interval)
+    }, [])
+
+    return <span className="font-mono text-xs">{elapsedSeconds}s</span>
+}
+
 function SegmentMetaTable({ meta }: SegmentMetaProps): JSX.Element | null {
     if (!meta) {
         return null
@@ -211,16 +225,21 @@ function SessionSummaryLoadingState({ operation, counter, name, outOf }: Session
     return (
         <div className="mb-4 grid grid-cols-[auto_1fr] gap-x-2">
             <Spinner className="text-2xl row-span-2 self-center" />
-            <span className="text-muted">
-                {operation}
-                {counter !== undefined && (
-                    <span className="font-semibold">
-                        ({counter}
-                        {outOf ? ` of ${outOf}` : ''})
-                    </span>
-                )}
-                {name ? ':' : ''}
-            </span>
+            <div className="flex items-center justify-between">
+                <span className="text-muted">
+                    {operation}
+                    {counter !== undefined && (
+                        <span className="font-semibold">
+                            ({counter}
+                            {outOf ? ` of ${outOf}` : ''})
+                        </span>
+                    )}
+                    {name ? ':' : ''}
+                </span>
+                <div className="flex items-center gap-1 ml-auto font-mono text-xs">
+                    <LoadingTimer />
+                </div>
+            </div>
             {name ? (
                 <div className="font-semibold">{name}</div>
             ) : (
@@ -414,20 +433,6 @@ function LoadSessionSummaryButton(): JSX.Element {
     )
 }
 
-function LoadingTimer(): JSX.Element {
-    const [elapsedSeconds, setElapsedSeconds] = useState(0)
-
-    useEffect(() => {
-        const interval = setInterval(() => {
-            setElapsedSeconds((prev) => prev + 1)
-        }, 1000)
-
-        return () => clearInterval(interval)
-    }, [])
-
-    return <span>{elapsedSeconds}s</span>
-}
-
 export function PlayerSidebarSessionSummary(): JSX.Element | null {
     const { logicProps } = useValues(sessionRecordingPlayerLogic)
     const { sessionSummary, sessionSummaryLoading } = useValues(playerMetaLogic(logicProps))
@@ -440,7 +445,7 @@ export function PlayerSidebarSessionSummary(): JSX.Element | null {
                         <div>
                             Researching the session... <Spinner />
                         </div>
-                        <div className="flex items-center gap-1 ml-auto font-mono text-xs">
+                        <div className="flex items-center gap-1 ml-auto">
                             <LoadingTimer />
                         </div>
                     </div>

--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummary.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummary.tsx
@@ -12,6 +12,7 @@ import { LemonBanner, LemonCollapse, LemonDivider, LemonSkeleton, LemonTag, Link
 import { useActions, useValues } from 'kea'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { Spinner } from 'lib/lemon-ui/Spinner'
+import { useEffect, useState } from 'react'
 import { playerMetaLogic } from 'scenes/session-recordings/player/player-meta/playerMetaLogic'
 import { sessionRecordingPlayerLogic } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
 
@@ -413,6 +414,20 @@ function LoadSessionSummaryButton(): JSX.Element {
     )
 }
 
+function LoadingTimer(): JSX.Element {
+    const [elapsedSeconds, setElapsedSeconds] = useState(0)
+
+    useEffect(() => {
+        const interval = setInterval(() => {
+            setElapsedSeconds((prev) => prev + 1)
+        }, 1000)
+
+        return () => clearInterval(interval)
+    }, [])
+
+    return <span>({elapsedSeconds}s)</span>
+}
+
 export function PlayerSidebarSessionSummary(): JSX.Element | null {
     const { logicProps } = useValues(sessionRecordingPlayerLogic)
     const { sessionSummary, sessionSummaryLoading } = useValues(playerMetaLogic(logicProps))
@@ -421,7 +436,7 @@ export function PlayerSidebarSessionSummary(): JSX.Element | null {
         <div className="rounded border bg-surface-primary px-2 py-1">
             {sessionSummaryLoading ? (
                 <>
-                    Thinking... <Spinner />{' '}
+                    Researching the session... <Spinner /> <LoadingTimer />
                 </>
             ) : sessionSummary ? (
                 <SessionSummary />


### PR DESCRIPTION
## Changes

- Add timers (seconds) for each summary stage for a more predictable UX
- Add "out of" counter for better progression display

![CleanShot 2025-04-29 at 21 17 51](https://github.com/user-attachments/assets/4b721d37-e245-44fe-a749-cb28367b2121)

- Reset loading state if BE error happens (previously it stayed in the "Thinking..." stage indefinetely)
- Follow-up (next PR) - provide meaningful error messages (for example, when no events for a realtime replay)

![CleanShot 2025-04-29 at 21 16 41](https://github.com/user-attachments/assets/ac3a9085-34ec-4561-9d0d-430c8719c943)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
