### PR TITLE
fix(flags): dont bill local evaluation requests if team has no feature flags

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -11,7 +11,8 @@ from posthog.exceptions_capture import capture_exception
 from statshog.defaults.django import statsd
 from typing import Optional
 
-from posthog.api.survey import SURVEY_TARGETING_FLAG_PREFIX, get_surveys_count, get_surveys_opt_in
+from posthog.api.feature_flag import SURVEY_TARGETING_FLAG_PREFIX
+from posthog.api.survey import get_surveys_count, get_surveys_opt_in
 from posthog.api.utils import (
     get_project_id,
     get_token,

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1035,7 +1035,7 @@ class FeatureFlagViewSet(
                     continue
 
             # Add request for analytics
-            if len(feature_flags) > 0 and not all(
+            if len(parsed_flags) > 0 and not all(
                 flag.key.startswith(SURVEY_TARGETING_FLAG_PREFIX) for flag in parsed_flags
             ):
                 increment_request_count(self.team.pk, 1, FlagRequestType.LOCAL_EVALUATION)

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -3,7 +3,6 @@ import time
 import logging
 from typing import Any, Optional, cast
 from datetime import datetime
-
 from django.db import transaction
 from django.db.models import QuerySet, Q, deletion, Prefetch
 from django.conf import settings
@@ -82,6 +81,7 @@ DATABASE_FOR_LOCAL_EVALUATION = (
 )
 
 BEHAVIOURAL_COHORT_FOUND_ERROR_CODE = "behavioral_cohort_found"
+SURVEY_TARGETING_FLAG_PREFIX = "survey-targeting-"
 
 MAX_PROPERTY_VALUES = 1000
 
@@ -1035,7 +1035,10 @@ class FeatureFlagViewSet(
                     continue
 
             # Add request for analytics
-            increment_request_count(self.team.pk, 1, FlagRequestType.LOCAL_EVALUATION)
+            if len(feature_flags) > 0 and not all(
+                flag.key.startswith(SURVEY_TARGETING_FLAG_PREFIX) for flag in parsed_flags
+            ):
+                increment_request_count(self.team.pk, 1, FlagRequestType.LOCAL_EVALUATION)
 
             duration = time.time() - start_time
             logger.info(

--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -26,6 +26,7 @@ from posthog.api.feature_flag import (
     BEHAVIOURAL_COHORT_FOUND_ERROR_CODE,
     FeatureFlagSerializer,
     MinimalFeatureFlagSerializer,
+    SURVEY_TARGETING_FLAG_PREFIX,
 )
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
@@ -50,7 +51,6 @@ from posthog.models.team.team import Team
 from posthog.models.user import User
 from posthog.utils_cors import cors_response
 
-SURVEY_TARGETING_FLAG_PREFIX = "survey-targeting-"
 ALLOWED_LINK_URL_SCHEMES = ["https", "mailto"]
 EMAIL_REGEX = r"^mailto:[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
 

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -3958,6 +3958,50 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             self.assertTrue(len(response_data["flags"]) > 0)
             self.assertNotIn("quotaLimited", response_data)
 
+    @patch("posthog.api.feature_flag.settings.DECIDE_FEATURE_FLAG_QUOTA_CHECK", False)
+    def test_local_evaluation_only_survey_targeting_flags(self):
+        FeatureFlag.objects.all().delete()
+
+        client = redis.get_client()
+
+        personal_api_key = generate_random_token_personal()
+        PersonalAPIKey.objects.create(label="X", user=self.user, secure_value=hash_key_value(personal_api_key))
+
+        with freeze_time("2022-05-07 12:23:07"):
+
+            def make_request_and_assert_requests_recorded(expected_requests: dict[str, int] | None = None):
+                response = self.client.get(
+                    f"/api/feature_flag/local_evaluation?token={self.team.api_token}",
+                    HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
+                )
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                self.assertEqual(
+                    client.hgetall(f"posthog:local_evaluation_requests:{self.team.pk}"),
+                    expected_requests or {},
+                )
+
+            # No requests should be recorded if there are no flags
+            make_request_and_assert_requests_recorded()
+
+            FeatureFlag.objects.create(
+                name="Survey Targeting Flag",
+                key="survey-targeting-flag",
+                team=self.team,
+                filters={"properties": [{"key": "survey-targeting-property", "value": "survey-targeting-value"}]},
+            )
+
+            # No requests should be recorded if the only flags are survey targeting flags
+            make_request_and_assert_requests_recorded()
+
+            # Requests should be recorded if there is one regular feature flag
+            FeatureFlag.objects.create(
+                name="Regular Feature Flag",
+                key="regular-feature-flag",
+                team=self.team,
+                filters={"properties": [{"key": "regular-property", "value": "regular-value"}]},
+            )
+            make_request_and_assert_requests_recorded({b"13766051": b"1"})
+
     @patch("posthog.api.feature_flag.report_user_action")
     def test_evaluation_reasons(self, mock_capture):
         FeatureFlag.objects.all().delete()

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -3969,7 +3969,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
 
         with freeze_time("2022-05-07 12:23:07"):
 
-            def make_request_and_assert_requests_recorded(expected_requests: dict[str, int] | None = None):
+            def make_request_and_assert_requests_recorded(expected_requests=None):
                 response = self.client.get(
                     f"/api/feature_flag/local_evaluation?token={self.team.api_token}",
                     HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",


### PR DESCRIPTION
## Problem

Context: https://posthoghelp.zendesk.com/agent/tickets/27479 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/31558)

## Changes

Just like /decide, we now skip a billing request if team has no feature flags or if the only flags are internal survey targeting flags

## Does this work well for both Cloud and self-hosted?

👍 

## How did you test this code?

Added tests to validate new behavior
