### PR TITLE
feat(insights): Add session props in funnels

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/Breakdown.tsx
+++ b/frontend/src/queries/nodes/InsightViz/Breakdown.tsx
@@ -5,7 +5,7 @@ import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { EditorFilterProps } from '~/types'
 
 export function Breakdown({ insightProps }: EditorFilterProps): JSX.Element {
-    const { breakdownFilter, display, isTrends, isSingleSeries, isDataWarehouseSeries } = useValues(
+    const { breakdownFilter, display, isTrends, isSingleSeries, isDataWarehouseSeries, isFunnels } = useValues(
         insightVizDataLogic(insightProps)
     )
     const { updateBreakdownFilter, updateDisplay } = useActions(insightVizDataLogic(insightProps))
@@ -17,6 +17,7 @@ export function Breakdown({ insightProps }: EditorFilterProps): JSX.Element {
                 breakdownFilter={breakdownFilter}
                 display={display}
                 isTrends={isTrends}
+                isFunnels={isFunnels}
                 updateBreakdownFilter={updateBreakdownFilter}
                 updateDisplay={updateDisplay}
                 disabledReason={

--- a/frontend/src/scenes/dashboard/DashboardEditBar.tsx
+++ b/frontend/src/scenes/dashboard/DashboardEditBar.tsx
@@ -122,6 +122,7 @@ export function DashboardEditBar(): JSX.Element {
                             insightProps={insightProps}
                             breakdownFilter={temporaryFilters.breakdown_filter}
                             isTrends={false}
+                            isFunnels={false}
                             showLabel={false}
                             updateBreakdownFilter={(breakdown_filter) => {
                                 if (dashboardMode !== DashboardMode.Edit) {

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/BreakdownTag.tsx
@@ -21,6 +21,7 @@ type EditableBreakdownTagProps = {
     breakdown: string | number
     breakdownType: BreakdownType
     isTrends: boolean
+    isFunnels: boolean
     size?: 'small' | 'medium'
 }
 
@@ -28,13 +29,14 @@ export function EditableBreakdownTag({
     breakdown,
     breakdownType,
     isTrends,
+    isFunnels,
     size = 'medium',
 }: EditableBreakdownTagProps): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const [filterOpen, setFilterOpen] = useState(false)
     const [menuOpen, setMenuOpen] = useState(false)
 
-    const logicProps = { insightProps, breakdown, breakdownType, isTrends }
+    const logicProps = { insightProps, breakdown, breakdownType, isTrends, isFunnels }
     const { removeBreakdown } = useActions(breakdownTagLogic(logicProps))
     const { isMultipleBreakdownsEnabled, isHistogramable, isNormalizeable, taxonomicBreakdownType } = useValues(
         breakdownTagLogic(logicProps)

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -17,6 +17,7 @@ export interface TaxonomicBreakdownFilterProps {
     breakdownFilter?: BreakdownFilter | null
     display?: ChartDisplayType | null
     isTrends: boolean
+    isFunnels: boolean
     disabledReason?: string
     updateBreakdownFilter: (breakdownFilter: BreakdownFilter) => void
     updateDisplay: (display: ChartDisplayType | undefined) => void
@@ -29,6 +30,7 @@ export function TaxonomicBreakdownFilter({
     breakdownFilter,
     display,
     isTrends,
+    isFunnels,
     disabledReason,
     updateBreakdownFilter,
     updateDisplay,
@@ -38,6 +40,7 @@ export function TaxonomicBreakdownFilter({
     const logicProps: TaxonomicBreakdownFilterLogicProps = {
         insightProps,
         isTrends,
+        isFunnels,
         display,
         breakdownFilter: breakdownFilter || {},
         updateBreakdownFilter,

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -57,6 +57,7 @@ export function TaxonomicBreakdownFilter({
                 key={breakdown.property}
                 breakdown={breakdown.property}
                 breakdownType={breakdown.type ?? 'event'}
+                isFunnels={isFunnels}
                 isTrends={isTrends}
                 size={size}
             />
@@ -65,6 +66,7 @@ export function TaxonomicBreakdownFilter({
                 key={breakdown}
                 breakdown={breakdown}
                 breakdownType={breakdownFilter?.breakdown_type ?? 'event'}
+                isFunnels={isFunnels}
                 isTrends={isTrends}
                 size={size}
             />

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
@@ -26,6 +26,7 @@ export type TaxonomicBreakdownFilterLogicProps = {
     breakdownFilter: BreakdownFilter
     display?: ChartDisplayType | null
     isTrends: boolean
+    isFunnels: boolean
     updateBreakdownFilter: ((breakdownFilter: BreakdownFilter) => void) | null
     updateDisplay: ((display: ChartDisplayType | undefined) => void) | null
 }
@@ -138,7 +139,10 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
             (flags, isTrends) => isTrends && multipleBreakdownsEnabled(flags),
         ],
         breakdownFilter: [(_, p) => [p.breakdownFilter], (breakdownFilter) => breakdownFilter],
-        includeSessions: [(_, p) => [p.isTrends], (isTrends) => isTrends],
+        includeSessions: [
+            (_, p) => [p.isTrends, p.isFunnels],
+            (isTrends: boolean, isFunnels: boolean) => isTrends || isFunnels,
+        ],
         isAddBreakdownDisabled: [
             (s) => [s.breakdownFilter, s.isMultipleBreakdownsEnabled, s.isDataWarehouseSeries],
             ({ breakdown, breakdowns, breakdown_type }, isMultipleBreakdownsEnabled, isDataWarehouseSeries) => {

--- a/posthog/hogql_queries/insights/funnels/base.py
+++ b/posthog/hogql_queries/insights/funnels/base.py
@@ -249,6 +249,9 @@ class FunnelBase(ABC):
             )
         elif breakdownType == "data_warehouse_person_property" and isinstance(breakdown, str):
             return ast.Field(chain=["person", *breakdown.split(".")])
+        elif breakdownType == "session":
+            properties_column = "session"
+            return get_breakdown_expr(breakdown, properties_column)
         else:
             raise ValidationError(detail=f"Unsupported breakdown type: {breakdownType}")
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

A user requested this here: https://posthoghelp.zendesk.com/agent/tickets/29800 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/31794)

Some more discussion on slack here https://posthog.slack.com/archives/C0368RPHLQH/p1745948242455909

## Changes
Add support for session properties in funnel breakdowns

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Looked at it manually

<img width="666" alt="Screenshot 2025-04-29 at 21 38 15" src="https://github.com/user-attachments/assets/fe37a62b-0d28-438f-ac25-4e891c59fe02" />
