### PR TITLE
feat(project-tree): save to for actions and cohorts

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
@@ -62,6 +62,11 @@ export const getDefaultTreeNew = (): FileSystemImport[] =>
             href: () => urls.survey('new'),
         },
         {
+            path: `Cohort`,
+            type: 'cohort',
+            href: () => urls.cohort('new'),
+        },
+        {
             path: `Data/Source`,
             type: 'hog_function/source',
             href: () => urls.pipelineNodeNew(PipelineStage.Source),

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
@@ -1232,7 +1232,6 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                         if (
                             result.type &&
                             ([
-                                'cohort',
                                 'dashboard',
                                 'early_access_feature',
                                 'experiment',

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
@@ -1228,10 +1228,20 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                         const result = resp.results[0]
                         path = result.path
 
-                        if (result.type === 'insight' || result.type === 'notebook') {
-                            actions.createSavedItem(result)
-                        } else {
-                            // TODO: REMOVE THIS OLD LOGIC! ... in favor of directly passing _create_in_folder to the API calls
+                        // TODO: REMOVE THIS OLD LOGIC! ... in favor of directly passing _create_in_folder to the API calls
+                        if (
+                            result.type &&
+                            ([
+                                'cohort',
+                                'dashboard',
+                                'early_access_feature',
+                                'experiment',
+                                'feature_flag',
+                                'session_recording_playlist',
+                                'survey',
+                            ].includes(result.type) ||
+                                result.type.startsWith('hog_function/'))
+                        ) {
                             // Check if a "new" action was recently initiated for this object type.
                             // If so, move the item to the new path.
                             const { lastNewFolder } = values
@@ -1249,6 +1259,9 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                             if (lastNewFolder) {
                                 actions.setLastNewFolder(null)
                             }
+                            // </TODO>
+                        } else {
+                            actions.createSavedItem(result)
                         }
                     }
                 }

--- a/frontend/src/lib/components/SaveTo/SaveTo.tsx
+++ b/frontend/src/lib/components/SaveTo/SaveTo.tsx
@@ -10,7 +10,7 @@ import { splitPath } from '~/layout/panel-layout/ProjectTree/utils'
 
 export function SaveToModal(): JSX.Element {
     const { isOpen, form, isFeatureEnabled } = useValues(saveToLogic)
-    const { closeSaveTo, submitForm } = useActions(saveToLogic)
+    const { closeSaveToModal, submitForm } = useActions(saveToLogic)
     const allFolders = splitPath(form.folder || '')
 
     if (!isFeatureEnabled) {
@@ -19,7 +19,7 @@ export function SaveToModal(): JSX.Element {
 
     return (
         <LemonModal
-            onClose={closeSaveTo}
+            onClose={closeSaveToModal}
             isOpen={isOpen}
             title="Select a folder to save to"
             footer={

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -283,6 +283,7 @@ export const fileSystemTypes = {
 
 /** This const is auto-generated, as is the whole file */
 export const treeItemsNew = [
+    { type: 'action', path: 'Action', icon: <IconRocket />, href: () => urls.createAction() },
     {
         path: `Broadcast`,
         type: 'hog_function/broadcast',
@@ -309,7 +310,6 @@ export const treeItemsNew = [
 
 /** This const is auto-generated, as is the whole file */
 export const treeItemsExplore = [
-    { path: 'Data management/Actions', icon: <IconRocket />, href: () => urls.actions() },
     { path: 'Early access features', icon: <IconRocket />, href: () => urls.earlyAccessFeatures() },
     { path: 'Explore/Revenue analytics', icon: <IconPiggyBank />, href: () => urls.revenueAnalytics() },
     { path: 'People and groups/People', icon: <IconPerson />, href: () => urls.persons() },

--- a/frontend/src/queries/nodes/DataTable/EventRowActions.tsx
+++ b/frontend/src/queries/nodes/DataTable/EventRowActions.tsx
@@ -1,4 +1,5 @@
 import { IconWarning } from '@posthog/icons'
+import { openSaveToModal } from 'lib/components/SaveTo/saveToLogic'
 import ViewRecordingButton, { mightHaveRecording } from 'lib/components/ViewRecordingButton/ViewRecordingButton'
 import { IconLink } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -27,12 +28,18 @@ export function EventRowActions({ event }: EventActionProps): JSX.Element {
                     {getCurrentTeamId() && (
                         <LemonButton
                             onClick={() =>
-                                void createActionFromEvent(
-                                    getCurrentTeamId(),
-                                    event,
-                                    0,
-                                    teamLogic.findMounted()?.values.currentTeam?.data_attributes || []
-                                )
+                                openSaveToModal({
+                                    callback: (folder) => {
+                                        void createActionFromEvent(
+                                            getCurrentTeamId(),
+                                            event,
+                                            0,
+                                            teamLogic.findMounted()?.values.currentTeam?.data_attributes || [],
+                                            folder
+                                        )
+                                    },
+                                    defaultFolder: 'Unfiled/Actions',
+                                })
                             }
                             fullWidth
                             data-attr="events-table-create-action"

--- a/frontend/src/scenes/actions/ActionEdit.tsx
+++ b/frontend/src/scenes/actions/ActionEdit.tsx
@@ -5,6 +5,7 @@ import { router } from 'kea-router'
 import { EditableField } from 'lib/components/EditableField/EditableField'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { PageHeader } from 'lib/components/PageHeader'
+import { openSaveToModal } from 'lib/components/SaveTo/saveToLogic'
 import { IconPlayCircle } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonField } from 'lib/lemon-ui/LemonField'
@@ -27,7 +28,7 @@ export function ActionEdit({ action: loadedAction, id }: ActionEditLogicProps): 
     }
     const logic = actionEditLogic(logicProps)
     const { action, actionLoading, actionChanged } = useValues(logic)
-    const { submitAction, deleteAction } = useActions(logic)
+    const { submitAction, deleteAction, setActionValue } = useActions(logic)
     const { tags } = useValues(tagsModel)
     const { addProductIntentForCrossSell } = useActions(teamLogic)
 
@@ -149,7 +150,17 @@ export function ActionEdit({ action: loadedAction, id }: ActionEditLogicProps): 
                                     type="primary"
                                     htmlType="submit"
                                     loading={actionLoading}
-                                    onClick={submitAction}
+                                    onClick={() =>
+                                        id
+                                            ? submitAction()
+                                            : openSaveToModal({
+                                                  callback: (folder) => {
+                                                      setActionValue('_create_in_folder', folder)
+                                                      submitAction()
+                                                  },
+                                                  defaultFolder: 'Unfiled/Insights',
+                                              })
+                                    }
                                     disabledReason={!actionChanged && !id ? 'No changes to save' : undefined}
                                 >
                                     Save

--- a/frontend/src/scenes/actions/actionEditLogic.tsx
+++ b/frontend/src/scenes/actions/actionEditLogic.tsx
@@ -90,10 +90,11 @@ export const actionEditLogic = kea<actionEditLogicType>([
                     if (updatedAction.id) {
                         action = await api.actions.update(updatedAction.id, { ...updatedAction, steps: updatedSteps })
                     } else {
+                        const folder = updatedAction._create_in_folder ?? getLastNewFolder()
                         action = await api.actions.create({
                             ...updatedAction,
                             steps: updatedSteps,
-                            _create_in_folder: updatedAction._create_in_folder ?? getLastNewFolder(),
+                            ...(typeof folder === 'string' ? { _create_in_folder: folder } : {}),
                         })
                     }
                     breakpoint()

--- a/frontend/src/scenes/actions/actionEditLogic.tsx
+++ b/frontend/src/scenes/actions/actionEditLogic.tsx
@@ -10,7 +10,7 @@ import { eventDefinitionsTableLogic } from 'scenes/data-management/events/eventD
 import { sceneLogic } from 'scenes/sceneLogic'
 import { urls } from 'scenes/urls'
 
-import { refreshTreeItem } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
+import { getLastNewFolder, refreshTreeItem } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
 import { actionsModel } from '~/models/actionsModel'
 import { tagsModel } from '~/models/tagsModel'
 import { ActionStepType, ActionType } from '~/types'
@@ -72,8 +72,8 @@ export const actionEditLogic = kea<actionEditLogicType>([
                 ({
                     name: '',
                     steps: [DEFAULT_ACTION_STEP],
+                    _create_in_folder: null,
                 } as ActionType),
-
             submit: async (updatedAction, breakpoint) => {
                 let action: ActionType
                 // Remove URL from steps if it's not an autocapture or a pageview
@@ -90,7 +90,11 @@ export const actionEditLogic = kea<actionEditLogicType>([
                     if (updatedAction.id) {
                         action = await api.actions.update(updatedAction.id, { ...updatedAction, steps: updatedSteps })
                     } else {
-                        action = await api.actions.create({ ...updatedAction, steps: updatedSteps })
+                        action = await api.actions.create({
+                            ...updatedAction,
+                            steps: updatedSteps,
+                            _create_in_folder: updatedAction._create_in_folder ?? getLastNewFolder(),
+                        })
                     }
                     breakpoint()
                 } catch (response: any) {

--- a/frontend/src/scenes/activity/explore/createActionFromEvent.test.js
+++ b/frontend/src/scenes/activity/explore/createActionFromEvent.test.js
@@ -9,12 +9,20 @@ describe('createActionFromEvent()', () => {
     given(
         'subject',
         () => () =>
-            createActionFromEvent(given.teamId, given.event, given.increment, given.dataAttributes, given.recurse)
+            createActionFromEvent(
+                given.teamId,
+                given.event,
+                given.increment,
+                given.dataAttributes,
+                given.createInFolder,
+                given.recurse
+            )
     )
 
     given('teamId', () => 44)
     given('increment', () => 0)
     given('dataAttributes', () => [])
+    given('createInFolder', () => null)
     given('recurse', () => jest.fn())
 
     given('event', () => ({

--- a/frontend/src/scenes/activity/explore/createActionFromEvent.tsx
+++ b/frontend/src/scenes/activity/explore/createActionFromEvent.tsx
@@ -105,7 +105,7 @@ export async function createActionFromEvent(
         action = await api.actions.create(actionData)
     } catch (response: any) {
         if (response.type === 'validation_error' && response.code === 'unique' && increment < 30) {
-            return recurse(teamId, event, increment + 1, dataAttributes, recurse)
+            return recurse(teamId, event, increment + 1, dataAttributes, createInFolder, recurse)
         }
         lemonToast.error(
             <>

--- a/frontend/src/scenes/activity/explore/createActionFromEvent.tsx
+++ b/frontend/src/scenes/activity/explore/createActionFromEvent.tsx
@@ -47,9 +47,10 @@ export async function createActionFromEvent(
     event: EventType,
     increment: number,
     dataAttributes: string[],
+    createInFolder: string | null = null,
     recurse: typeof createActionFromEvent = createActionFromEvent
 ): Promise<void> {
-    const actionData: Pick<ActionType, 'name' | 'steps'> = {
+    const actionData: Pick<ActionType, 'name' | 'steps' | '_create_in_folder'> = {
         name: '',
         steps: [
             {
@@ -63,6 +64,7 @@ export async function createActionFromEvent(
                 ...(event.elements?.length > 0 ? elementsToAction(event.elements) : {}),
             },
         ],
+        _create_in_folder: createInFolder,
     }
     if (event.event === '$autocapture') {
         actionData.name = autoCaptureEventToDescription(event)

--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -3,6 +3,7 @@ import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
 import { actionToUrl, router } from 'kea-router'
 import api from 'lib/api'
+import { openSaveToModal } from 'lib/components/SaveTo/saveToLogic'
 import { ENTITY_MATCH_TYPE } from 'lib/constants'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
@@ -194,7 +195,14 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                 },
             }),
             submit: (cohort) => {
-                actions.saveCohort(cohort)
+                if (cohort.id !== 'new') {
+                    actions.saveCohort(cohort)
+                } else {
+                    openSaveToModal({
+                        defaultFolder: 'Untitled/Cohorts',
+                        callback: (folder) => actions.saveCohort({ ...cohort, _create_in_folder: folder }),
+                    })
+                }
             },
         },
     })),

--- a/frontend/src/scenes/cohorts/cohortSceneLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortSceneLogic.ts
@@ -37,7 +37,7 @@ export const cohortSceneLogic = kea<cohortSceneLogicType>([
         ],
         projectTreeRef: [
             () => [(_, props: CohortLogicProps) => props.id],
-            (id): ProjectTreeRef => ({ type: 'cohort', ref: String(id) }),
+            (id): ProjectTreeRef => ({ type: 'cohort', ref: id === 'new' ? null : String(id) }),
         ],
     }),
 ])

--- a/frontend/src/scenes/cohorts/cohortUtils.tsx
+++ b/frontend/src/scenes/cohorts/cohortUtils.tsx
@@ -96,6 +96,7 @@ export function createCohortFormData(cohort: CohortType): FormData {
         ...{ description: cohort.description ?? '' },
         ...(cohort.csv ? { csv: cohort.csv } : {}),
         ...(cohort.is_static ? { is_static: cohort.is_static } : {}),
+        ...(typeof cohort._create_in_folder === 'string' ? { _create_in_folder: cohort._create_in_folder } : {}),
         filters: JSON.stringify(
             cohort.is_static
                 ? {

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -207,8 +207,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                             <InsightSaveButton
                                 saveAs={() =>
                                     openSaveToModal({
-                                        callback: (folder) =>
-                                            typeof folder === 'string' ? saveAs(undefined, undefined, folder) : null,
+                                        callback: (folder) => saveAs(undefined, undefined, folder),
                                         defaultFolder: 'Unfiled/Insights',
                                     })
                                 }
@@ -216,10 +215,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                     insight.short_id
                                         ? saveInsight(redirectToViewMode)
                                         : openSaveToModal({
-                                              callback: (folder) =>
-                                                  typeof folder === 'string'
-                                                      ? saveInsight(redirectToViewMode, folder)
-                                                      : null,
+                                              callback: (folder) => saveInsight(redirectToViewMode, folder),
                                               defaultFolder: 'Unfiled/Insights',
                                           })
                                 }

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -12,7 +12,7 @@ import { ExportButton } from 'lib/components/ExportButton/ExportButton'
 import { exportsLogic } from 'lib/components/ExportButton/exportsLogic'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { PageHeader } from 'lib/components/PageHeader'
-import { saveToLogic } from 'lib/components/SaveTo/saveToLogic'
+import { openSaveToModal } from 'lib/components/SaveTo/saveToLogic'
 import { SharingModal } from 'lib/components/Sharing/SharingModal'
 import { SubscribeButton, SubscriptionsModal } from 'lib/components/Subscriptions/SubscriptionsModal'
 import { UserActivityIndicator } from 'lib/components/UserActivityIndicator/UserActivityIndicator'
@@ -95,8 +95,6 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
 
     const showCohortButton =
         isDataTableNode(query) || isDataVisualizationNode(query) || isHogQLQuery(query) || isEventsQuery(query)
-
-    const { openSaveTo } = useActions(saveToLogic)
 
     return (
         <>
@@ -208,16 +206,20 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                         ) : (
                             <InsightSaveButton
                                 saveAs={() =>
-                                    openSaveTo({
-                                        callback: (folder) => saveAs(undefined, undefined, folder),
+                                    openSaveToModal({
+                                        callback: (folder) =>
+                                            typeof folder === 'string' ? saveAs(undefined, undefined, folder) : null,
                                         defaultFolder: 'Unfiled/Insights',
                                     })
                                 }
                                 saveInsight={(redirectToViewMode) =>
                                     insight.short_id
                                         ? saveInsight(redirectToViewMode)
-                                        : openSaveTo({
-                                              callback: (folder) => saveInsight(redirectToViewMode, folder),
+                                        : openSaveToModal({
+                                              callback: (folder) =>
+                                                  typeof folder === 'string'
+                                                      ? saveInsight(redirectToViewMode, folder)
+                                                      : null,
                                               defaultFolder: 'Unfiled/Insights',
                                           })
                                 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -656,6 +656,7 @@ export interface ActionType {
     bytecode?: any[]
     bytecode_error?: string
     pinned_at: string | null
+    _create_in_folder?: string | null
 }
 
 /** Sync with plugin-server/src/types.ts */

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1415,6 +1415,7 @@ export interface CohortType {
         properties: CohortCriteriaGroupFilter
     }
     experiment_set?: number[]
+    _create_in_folder?: string | null
 }
 
 export interface InsightHistory {

--- a/posthog/api/action.py
+++ b/posthog/api/action.py
@@ -38,6 +38,7 @@ class ActionSerializer(TaggedItemSerializerMixin, serializers.HyperlinkedModelSe
     is_calculating = serializers.SerializerMethodField()
     is_action = serializers.BooleanField(read_only=True, default=True)
     creation_context = serializers.SerializerMethodField()
+    _create_in_folder = serializers.CharField(required=False, allow_blank=True, write_only=True)
 
     class Meta:
         model = Action
@@ -59,6 +60,7 @@ class ActionSerializer(TaggedItemSerializerMixin, serializers.HyperlinkedModelSe
             "bytecode_error",
             "pinned_at",
             "creation_context",
+            "_create_in_folder",
         ]
         read_only_fields = [
             "team_id",

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -95,6 +95,7 @@ logger = structlog.get_logger(__name__)
 class CohortSerializer(serializers.ModelSerializer):
     created_by = UserBasicSerializer(read_only=True)
     earliest_timestamp_func = get_earliest_timestamp
+    _create_in_folder = serializers.CharField(required=False, allow_blank=True, write_only=True)
 
     # If this cohort is an exposure cohort for an experiment
     experiment_set: serializers.PrimaryKeyRelatedField = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
@@ -117,6 +118,7 @@ class CohortSerializer(serializers.ModelSerializer):
             "count",
             "is_static",
             "experiment_set",
+            "_create_in_folder",
         ]
         read_only_fields = [
             "id",

--- a/posthog/api/test/test_action.py
+++ b/posthog/api/test/test_action.py
@@ -440,3 +440,31 @@ class TestActionApi(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
 
         deletion_response = self.client.delete(f"/api/projects/{self.team.id}/actions/{response.json()['id']}")
         self.assertEqual(deletion_response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    def test_create_action_in_specific_folder(self):
+        """
+        Verify that creating an Action with '_create_in_folder' stores its FileSystem entry
+        under the specified folder.
+        """
+        # 1. Create an Action, passing `_create_in_folder`
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/actions/",
+            data={
+                "name": "user signed up in folder",
+                "_create_in_folder": "Special Folder/Actions",
+            },
+            HTTP_ORIGIN="http://testserver",
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+
+        action_id = response.json()["id"]
+        assert action_id is not None
+
+        # 2. Verify the FileSystem entry
+        from posthog.models.file_system.file_system import FileSystem
+
+        fs_entry = FileSystem.objects.filter(team=self.team, ref=str(action_id), type="action").first()
+        assert fs_entry is not None, "A FileSystem entry was not created for this Action."
+        assert (
+            "Special Folder/Actions" in fs_entry.path
+        ), f"Expected folder to include 'Special Folder/Actions' but got '{fs_entry.path}'."

--- a/products/actions/manifest.tsx
+++ b/products/actions/manifest.tsx
@@ -20,11 +20,12 @@ export const manifest: ProductManifest = {
             href: (ref: string) => urls.action(ref),
         },
     },
-    treeItemsExplore: [
+    treeItemsNew: [
         {
-            path: 'Data management/Actions',
+            type: 'action',
+            path: 'Action',
             icon: <IconRocket />,
-            href: () => urls.actions(),
+            href: () => urls.createAction(),
         },
     ],
 }


### PR DESCRIPTION
## Changes

Add the "save to" modal to the next products. Followup to https://github.com/PostHog/posthog/pull/31710

- [x] Actions
- [x] Cohorts
- [ ] Dashboards
- [ ] Experiments
- [ ] Feature flags
- [ ] Hog functions
- [ ] Surveys
- [ ] Replay playlists
- [ ] Early access features

## How did you test this code?

Actions:

![2025-04-29 22 38 26](https://github.com/user-attachments/assets/19c2be0c-7222-4e11-98fb-5bba147d7aed)

Cohorts:

![2025-04-29 23 16 47](https://github.com/user-attachments/assets/6e8acc33-0f0b-4220-be94-7ce5f61692ad)
