### PR TITLE
feat(project-tree): archive folder and corresponding menu item

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -29,7 +29,7 @@ import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
 import { FileSystemEntry } from '~/queries/schema/schema-general'
 
 import { PanelLayoutPanel } from '../PanelLayoutPanel'
-import { projectTreeLogic } from './projectTreeLogic'
+import { PROJECT_TREE_ARCHIVE_NAME, projectTreeLogic } from './projectTreeLogic'
 import { calculateMovePath } from './utils'
 
 export function ProjectTree(): JSX.Element {
@@ -315,6 +315,27 @@ export function ProjectTree(): JSX.Element {
                     }}
                 >
                     <ButtonPrimitive menuItem>Move to...</ButtonPrimitive>
+                </MenuItem>
+
+                <MenuItem
+                    asChild
+                    onClick={(e: any) => {
+                        e.stopPropagation()
+
+                        if (checkedItemCountNumeric > 0) {
+                            moveCheckedItems(PROJECT_TREE_ARCHIVE_NAME)
+                        } else {
+                            const { newPath, isValidMove } = calculateMovePath(
+                                item.record as unknown as FileSystemEntry,
+                                PROJECT_TREE_ARCHIVE_NAME
+                            )
+                            if (isValidMove) {
+                                moveItem(item.record as unknown as FileSystemEntry, newPath)
+                            }
+                        }
+                    }}
+                >
+                    <ButtonPrimitive menuItem>Archive</ButtonPrimitive>
                 </MenuItem>
             </>
         )

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
@@ -286,7 +286,15 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
     })),
     reducers({
         folders: [
-            {} as Record<string, FileSystemEntry[]>,
+            {
+                '': [
+                    {
+                        id: `project-folder/${PROJECT_TREE_ARCHIVE_NAME}`,
+                        path: PROJECT_TREE_ARCHIVE_NAME,
+                        type: 'folder',
+                    },
+                ],
+            } as Record<string, FileSystemEntry[]>,
             {
                 loadFolderSuccess: (state, { folder, entries }) => ({ ...state, [folder]: entries }),
                 createSavedItem: (state, { savedItem }) => {

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTreeUtils.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTreeUtils.tsx
@@ -1,5 +1,5 @@
 import { useDraggable, useDroppable } from '@dnd-kit/core'
-import { IconChevronRight, IconDocument, IconFolder, IconFolderOpenFilled } from '@posthog/icons'
+import { IconArchive, IconChevronRight, IconDocument, IconFolder, IconFolderOpenFilled } from '@posthog/icons'
 import { buttonVariants } from 'lib/ui/Button/ButtonPrimitives'
 import { cn } from 'lib/utils/css-classes'
 import { CSSProperties, useEffect, useRef } from 'react'
@@ -160,6 +160,10 @@ export const TreeNodeDisplayIcon = ({
 
     if (isFolder) {
         iconElement = isOpen ? <IconFolderOpenFilled /> : <IconFolder />
+
+        if (item.name === 'Archived') {
+            iconElement = <IconArchive />
+        }
     }
 
     if (isFile) {


### PR DESCRIPTION
## Problem
Project tree deletes don't work right now, and I thought in the meantime we could have an `Achived` folder and a matching menu item to move stuff there

Working menu items
![2025-04-29 23 12 55](https://github.com/user-attachments/assets/46457332-5a28-4d05-9cb5-b95de0d0c769)

On load folder is there
![2025-04-29 23 12 13](https://github.com/user-attachments/assets/cf72354c-206d-48c1-a4c6-cd4a5674001d)


## Changes
Add new default folder in the tree `Archived`
Add new menu item "Archive"

## How did you test this code?
Created new project, move things around etc.