### PR TITLE
fix: stop redistributing personless events

### DIFF
--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -26,7 +26,6 @@ import { parseJSON } from '../utils/json-parse'
 import { logger } from '../utils/logger'
 import { captureException } from '../utils/posthog'
 import { retryIfRetriable } from '../utils/retries'
-import { UUIDT } from '../utils/utils'
 import { EventPipelineResult, EventPipelineRunner } from '../worker/ingestion/event-pipeline/runner'
 import { MeasuringPersonsStore } from '../worker/ingestion/persons/measuring-person-store'
 import { PersonsStoreForDistinctIdBatch } from '../worker/ingestion/persons/persons-store-for-distinct-id-batch'
@@ -530,11 +529,10 @@ export class IngestionConsumer {
                 continue
             }
 
-            let eventKey = `${event.token}:${event.distinct_id}`
+            const eventKey = `${event.token}:${event.distinct_id}`
 
             if (this.shouldSkipPerson(event.token, event.distinct_id)) {
                 // If we are skipping person processing, then we can parallelize processing of this event for dramatic performance gains
-                eventKey = new UUIDT().toString()
                 event.properties = {
                     ...(event.properties ?? {}),
                     $process_person_profile: false,

--- a/plugin-server/src/ingestion/ingestion-consumer.ts
+++ b/plugin-server/src/ingestion/ingestion-consumer.ts
@@ -532,7 +532,6 @@ export class IngestionConsumer {
             const eventKey = `${event.token}:${event.distinct_id}`
 
             if (this.shouldSkipPerson(event.token, event.distinct_id)) {
-                // If we are skipping person processing, then we can parallelize processing of this event for dramatic performance gains
                 event.properties = {
                     ...(event.properties ?? {}),
                     $process_person_profile: false,


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

For events with `$process_person_profile` we redistribute them internally in ingestion to process events in parallel. This was an optimization to run fetchPerson queries in parallel, but now that we have a cache for those queries, it actually makes things slow.

## Changes

Restores the batching on token + distinct ID for personless events.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

- There are regression tests
- The reordering change will drop a number of warning logs on production