### PR TITLE
chore(capture-mirror): create verbose error log on incompatible form decoding for mirror 

### DIFF
--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -35,6 +35,7 @@ pub struct State {
     pub token_dropper: Arc<TokenDropper>,
     pub event_size_limit: usize,
     pub historical_cfg: HistoricalConfig,
+    pub is_mirror_deploy: bool,
 }
 
 #[derive(Clone)]
@@ -108,6 +109,7 @@ pub fn router<
     enable_historical_rerouting: bool,
     historical_rerouting_threshold_days: i64,
     historical_tokens_keys: Option<String>,
+    is_mirror_deploy: bool,
 ) -> Router {
     let state = State {
         sink: Arc::new(sink),
@@ -121,6 +123,7 @@ pub fn router<
             historical_rerouting_threshold_days,
             historical_tokens_keys,
         ),
+        is_mirror_deploy,
     };
 
     // Very permissive CORS policy, as old SDK versions

--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -183,6 +183,7 @@ where
         config.enable_historical_rerouting,
         config.historical_rerouting_threshold_days,
         config.historical_tokens_keys,
+        config.is_mirror_deploy,
     );
 
     // run our app with hyper

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -77,9 +77,10 @@ async fn handle_common(
                 .decode(&input.data)
                 .map_err(|e| {
                     if state.is_mirror_deploy {
-                        // lets see if this is base64 encoded at all, and what info we may be missing here
+                        // get a peek at the headers and a short snip of the payload in mirror
+                        // see which capture.py "kludge warning" these may map to, if any
                         error!("failed to decode mirrored form data: {} w/ headers << {:?} >> and data: {:?}...",
-                            e, &headers, &input.data[0..input.data.len().min(255)]);
+                            e, &headers, &input.data[0..input.data.len().min(40)]);
                     } else {
                         error!("failed to decode form data: {}", e);
                     }

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -14,7 +14,7 @@ use limiters::token_dropper::TokenDropper;
 use metrics::counter;
 use serde_json::json;
 use serde_json::Value;
-use tracing::instrument;
+use tracing::{debug, error, instrument, warn};
 
 use crate::prometheus::report_dropped_events;
 use crate::v0_request::{
@@ -69,14 +69,21 @@ async fn handle_common(
         "application/x-www-form-urlencoded" => {
             tracing::Span::current().record("content_type", "application/x-www-form-urlencoded");
 
-            let input: EventFormData = serde_urlencoded::from_bytes(body.deref()).map_err(|e| {
-                tracing::error!("failed to decode body: {}", e);
-                CaptureError::RequestDecodingError(String::from("invalid form data"))
-            })?;
+            let mut input: EventFormData =
+                serde_urlencoded::from_bytes(body.deref()).map_err(|e| {
+                    error!("failed to decode body: {}", e);
+                    CaptureError::RequestDecodingError(String::from("invalid form data"))
+                })?;
             let payload = base64::engine::general_purpose::STANDARD
-                .decode(input.data)
+                .decode(&input.data)
                 .map_err(|e| {
-                    tracing::error!("failed to decode form data: {}", e);
+                    if state.is_mirror_deploy {
+                        // lets see if this is base64 encoded at all, and what info we may be missing here
+                        error!("failed to decode mirrored form data: {} w/ headers << {:?} >> and data: {:?}...",
+                            e, &headers, input.data.truncate(255));
+                    } else {
+                        error!("failed to decode form data: {}", e);
+                    }
                     CaptureError::RequestDecodingError(String::from("missing data field"))
                 })?;
             RawRequest::from_bytes(payload.into(), state.event_size_limit)
@@ -104,7 +111,7 @@ async fn handle_common(
     tracing::Span::current().record("batch_size", events.len());
 
     if events.is_empty() {
-        tracing::log::warn!("rejected empty batch");
+        warn!("rejected empty batch");
         return Err(CaptureError::EmptyBatch);
     }
 
@@ -131,7 +138,7 @@ async fn handle_common(
         return Err(CaptureError::BillingLimit);
     }
 
-    tracing::debug!(context=?context, events=?events, "decoded request");
+    debug!(context=?context, events=?events, "decoded request");
 
     Ok((context, events))
 }

--- a/rust/capture/tests/django_compat.rs
+++ b/rust/capture/tests/django_compat.rs
@@ -122,6 +122,7 @@ async fn it_matches_django_capture_behaviour() -> anyhow::Result<()> {
         let enable_historical_rerouting = false;
         let historical_rerouting_threshold_days = 1_i64;
         let historical_tokens_keys = None;
+        let is_mirror_deploy = false;
 
         let app = router(
             timesource,
@@ -137,6 +138,7 @@ async fn it_matches_django_capture_behaviour() -> anyhow::Result<()> {
             enable_historical_rerouting,
             historical_rerouting_threshold_days,
             historical_tokens_keys,
+            is_mirror_deploy,
         );
 
         let client = TestClient::new(app);


### PR DESCRIPTION
## Problem
Errors like this indicate we're compressing and not detecting it properly, or not base64 encoding these forms as expected in `capture-rs` at this step:

```
2025-04-29T23:08:31.138553Z ERROR event{user_agent="<REDACTED>" content_encoding="unknown" compression="unknown" path="/e" content_type="application/x-www-form-urlencoded"}: capture::v0_endpoint: failed to decode form data: Invalid symbol 61, offset 1257.

```

There are some other more generic errors that likely map to missing compression types that `capture.py` supports, but I'd like to get a look at these form payloads to see if it lumps in with those or not. Parallel work to deal with all that is in flight, PRs on the way

## Changes
Log more verbosely when b64 decode step in `www-form-encoded` deserialization codepath fails in mirror deploy only

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally, CI, soon mirror deploy