### PR TITLE
fix(experiments): fix funnel metric preview ordering

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
@@ -126,6 +126,22 @@ export function ExperimentMetricForm({
                     />
                 )}
             </div>
+            <div>
+                <LemonLabel
+                    className="mb-1"
+                    info={
+                        <>
+                            The preview uses data from the past 14 days to show how the metric will appear.
+                            <br />
+                            For funnel metrics, we simulate experiment exposure by inserting a page-view event at the
+                            start of the funnel. In the experiment evaluation, this will be replaced by the actual
+                            experiment-exposure event.
+                        </>
+                    }
+                >
+                    Preview
+                </LemonLabel>
+            </div>
             {/* :KLUDGE: Query chart type is inferred from the initial state, so need to render Trends and Funnels separately */}
             {metric.metric_type === ExperimentMetricType.MEAN &&
                 metric.source.kind !== NodeKind.ExperimentDataWarehouseNode && (

--- a/frontend/src/scenes/experiments/utils.test.ts
+++ b/frontend/src/scenes/experiments/utils.test.ts
@@ -36,6 +36,7 @@ import {
     featureFlagEligibleForExperiment,
     filterToExposureConfig,
     filterToMetricConfig,
+    getFunnelPreviewSeries,
     getViewRecordingFilters,
     isLegacyExperiment,
     isLegacyExperimentQuery,
@@ -1009,5 +1010,56 @@ describe('hasLegacyMetrics', () => {
         } as unknown as Experiment
 
         expect(isLegacyExperiment(experiment)).toBe(false)
+    })
+})
+
+describe('getFunnelPreviewSeries', () => {
+    it('returns the correct series for a funnel metric with events and actions', () => {
+        const metric: ExperimentMetric = {
+            kind: NodeKind.ExperimentMetric,
+            metric_type: ExperimentMetricType.FUNNEL,
+            series: [
+                {
+                    event: 'checkout started',
+                    kind: NodeKind.EventsNode,
+                    name: 'checkout started',
+                },
+                {
+                    id: 1,
+                    kind: NodeKind.ActionsNode,
+                    name: 'purchase completed',
+                },
+                {
+                    event: 'survey submitted',
+                    kind: NodeKind.EventsNode,
+                    name: 'survey submitted',
+                },
+            ],
+        }
+
+        const series = getFunnelPreviewSeries(metric)
+        expect(series).toEqual([
+            {
+                kind: NodeKind.EventsNode,
+                event: '$pageview',
+                name: '$pageview',
+                custom_name: 'Placeholder for experiment exposure',
+            },
+            {
+                kind: NodeKind.EventsNode,
+                event: 'checkout started',
+                name: 'checkout started',
+            },
+            {
+                kind: NodeKind.ActionsNode,
+                id: 1,
+                name: 'purchase completed',
+            },
+            {
+                kind: NodeKind.EventsNode,
+                event: 'survey submitted',
+                name: 'survey submitted',
+            },
+        ])
     })
 })

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -8,8 +8,10 @@ import { actionsAndEventsToSeries } from '~/queries/nodes/InsightQuery/utils/fil
 import {
     ActionsNode,
     AnyEntityNode,
+    DataWarehouseNode,
     EventsNode,
     ExperimentEventExposureConfig,
+    ExperimentFunnelMetric,
     ExperimentFunnelMetricStep,
     ExperimentFunnelMetricTypeProps,
     ExperimentFunnelsQuery,
@@ -25,6 +27,7 @@ import {
 } from '~/queries/schema/schema-general'
 import { isFunnelsQuery, isNodeWithSource, isTrendsQuery, isValidQueryForExperiment } from '~/queries/utils'
 import {
+    ActionFilter,
     ChartDisplayType,
     Experiment,
     ExperimentMetricMathType,
@@ -609,18 +612,6 @@ export function metricToQuery(
                     } as TrendsQuery
             }
         case ExperimentMetricType.FUNNEL: {
-            const filter = metricToFilter(metric)
-            const { events, actions } = filter
-            // NOTE: hack for now
-            // insert a pageview event at the beginning of the funnel to simulate the exposure criteria
-            events?.unshift({
-                kind: NodeKind.EventsNode,
-                id: '$pageview',
-                event: '$pageview',
-                name: '$pageview',
-                custom_name: 'Placeholder for experiment exposure',
-                properties: [],
-            })
             return {
                 kind: NodeKind.FunnelsQuery,
                 filterTestAccounts,
@@ -632,16 +623,46 @@ export function metricToQuery(
                 funnelsFilter: {
                     layout: FunnelLayout.horizontal,
                 },
-                series: actionsAndEventsToSeries(
-                    { actions: actions, events, data_warehouse: [] } as any,
-                    true,
-                    MathAvailability.None
-                ),
+                series: getFunnelPreviewSeries(metric),
             } as FunnelsQuery
         }
         default:
             return undefined
     }
+}
+
+const shiftOrderRight = (step: ActionFilter): ActionFilter => ({
+    ...step,
+    order: (step.order ?? 0) + 1,
+})
+
+export function getFunnelPreviewSeries(
+    metric: ExperimentFunnelMetric
+): (EventsNode | ActionsNode | DataWarehouseNode)[] {
+    const filter = metricToFilter(metric)
+    let { events, actions } = filter
+
+    // Shift all events and actions to the right to make space for the exposure event
+    events = (events as ActionFilter[])?.map(shiftOrderRight)
+    actions = (actions as ActionFilter[])?.map(shiftOrderRight)
+
+    // Insert a pageview event at the beginning of the funnel to simulate the exposure criteria.
+    // An in improvement that could be considered later is to use the traffic estimation in the running
+    // time calculator.
+    events?.unshift({
+        kind: NodeKind.EventsNode,
+        id: '$pageview',
+        event: '$pageview',
+        name: '$pageview',
+        custom_name: 'Placeholder for experiment exposure',
+        properties: [],
+        order: 0,
+    })
+    return actionsAndEventsToSeries(
+        { actions: actions, events, data_warehouse: [] } as any,
+        true,
+        MathAvailability.None
+    )
 }
 
 export function getMathAvailability(metricType: ExperimentMetricType): MathAvailability {


### PR DESCRIPTION
## Problem
When adding an action to a funnel metric, it displays _before_ the exposure criteria event, which is misleading. Only affecting the preview.
<img width="1013" alt="Screenshot 2025-04-30 at 11 25 26" src="https://github.com/user-attachments/assets/87873e86-bb62-44c3-83af-5d7984b44979" />

## Changes
Extract the metric to funnel preview series to it's own function. Shift both actions and events order to the right to make space for the exposure placeholder event. Add tests to verify the logic.
<img width="1008" alt="Screenshot 2025-04-30 at 11 25 55" src="https://github.com/user-attachments/assets/60192a8a-8ae8-478f-b22d-9057b5e2734c" />

Also, add a tooltip to the preview to explain behavior. 
<img width="460" alt="Screenshot 2025-04-30 at 12 50 33" src="https://github.com/user-attachments/assets/4e56b9d7-85c4-480d-a4ce-545e058378a8" />

## How did you test this code?

- Manually added a metric with an action and confirmed it's working
- Added tests
