### PR TITLE
chore(data-warehouse): Add a non retryable error for missing bigquery tables

### DIFF
--- a/posthog/temporal/data_imports/external_data_job.py
+++ b/posthog/temporal/data_imports/external_data_job.py
@@ -44,9 +44,7 @@ Any_Source_Errors: list[str] = [
 ]
 
 Non_Retryable_Schema_Errors: dict[ExternalDataSource.Type, list[str]] = {
-    ExternalDataSource.Type.BIGQUERY: [
-        "PermissionDenied: 403 request failed",
-    ],
+    ExternalDataSource.Type.BIGQUERY: ["PermissionDenied: 403 request failed", "NotFound: 404"],
     ExternalDataSource.Type.STRIPE: [
         "401 Client Error: Unauthorized for url: https://api.stripe.com",
         "403 Client Error: Forbidden for url: https://api.stripe.com",


### PR DESCRIPTION
## Changes
- When a user deletes a bigquery table, we should stop syncing it. 
- Adds a new retryable error for not found tables