### PR TITLE
fix(capture): make event too large a 413, add extra context

### DIFF
--- a/rust/capture/src/api.rs
+++ b/rust/capture/src/api.rs
@@ -51,8 +51,8 @@ pub enum CaptureError {
 
     #[error("transient error, please retry")]
     RetryableSinkError,
-    #[error("maximum event size exceeded")]
-    EventTooBig,
+    #[error("maximum event size exceeded: {0}")]
+    EventTooBig(String),
     #[error("invalid event could not be processed")]
     NonRetryableSinkError,
 
@@ -78,12 +78,13 @@ impl IntoResponse for CaptureError {
             | CaptureError::MissingEventName
             | CaptureError::MissingDistinctId
             | CaptureError::InvalidCookielessMode
-            | CaptureError::EventTooBig
             | CaptureError::NonRetryableSinkError
             | CaptureError::MissingSessionId
             | CaptureError::MissingWindowId
             | CaptureError::InvalidSessionId
             | CaptureError::MissingSnapshotData => (StatusCode::BAD_REQUEST, self.to_string()),
+
+            CaptureError::EventTooBig(_) => (StatusCode::PAYLOAD_TOO_LARGE, self.to_string()),
 
             CaptureError::NoTokenError
             | CaptureError::MultipleTokensError

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -299,7 +299,9 @@ impl KafkaSink {
             Err((e, _)) => match e.rdkafka_error_code() {
                 Some(RDKafkaErrorCode::MessageSizeTooLarge) => {
                     report_dropped_events("kafka_message_size", 1);
-                    Err(CaptureError::EventTooBig)
+                    Err(CaptureError::EventTooBig(
+                        "Event rejected by kafka during send".to_string(),
+                    ))
                 }
                 _ => {
                     // TODO(maybe someday): Don't drop them but write them somewhere and try again
@@ -322,7 +324,9 @@ impl KafkaSink {
             Ok(Err((KafkaError::MessageProduction(RDKafkaErrorCode::MessageSizeTooLarge), _))) => {
                 // Rejected by broker due to message size
                 report_dropped_events("kafka_message_size", 1);
-                Err(CaptureError::EventTooBig)
+                Err(CaptureError::EventTooBig(
+                    "Event rejected by kafka broker during ack".to_string(),
+                ))
             }
             Ok(Err((err, _))) => {
                 // Unretriable produce error
@@ -538,7 +542,7 @@ mod tests {
         };
 
         match sink.send(big_event).await {
-            Err(CaptureError::EventTooBig) => {} // Expected
+            Err(CaptureError::EventTooBig(_)) => {} // Expected
             Err(err) => panic!("wrong error code {}", err),
             Ok(()) => panic!("should have errored"),
         };
@@ -548,7 +552,7 @@ mod tests {
         let err = [RDKafkaRespErr::RD_KAFKA_RESP_ERR_MSG_SIZE_TOO_LARGE; 1];
         cluster.request_errors(RDKafkaApiKey::Produce, &err);
         match sink.send(event.clone()).await {
-            Err(CaptureError::EventTooBig) => {} // Expected
+            Err(CaptureError::EventTooBig(_)) => {} // Expected
             Err(err) => panic!("wrong error code {}", err),
             Ok(()) => panic!("should have errored"),
         };

--- a/rust/capture/src/test_endpoint.rs
+++ b/rust/capture/src/test_endpoint.rs
@@ -194,7 +194,10 @@ pub fn from_bytes(bytes: Bytes, limit: usize, comp: String) -> Result<RawRequest
             if buf.len() > limit {
                 metrics::counter!(GZIP_FAILED, "reason" => "too_big", "comp" => comp.clone())
                     .increment(1);
-                return Err(CaptureError::EventTooBig);
+                return Err(CaptureError::EventTooBig(format!(
+                    "Event or batch exceeded {} during unzipping",
+                    limit
+                )));
             }
         }
         match String::from_utf8(buf) {
@@ -213,7 +216,10 @@ pub fn from_bytes(bytes: Bytes, limit: usize, comp: String) -> Result<RawRequest
             CaptureError::RequestDecodingError(String::from("invalid body encoding"))
         })?;
         if s.len() > limit {
-            return Err(CaptureError::EventTooBig);
+            return Err(CaptureError::EventTooBig(format!(
+                "Event or batch exceeded {}, wasn't compressed",
+                limit
+            )));
         }
         s
     };

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -242,7 +242,7 @@ pub async fn recording(
                     CaptureError::MissingEventName => "missing_event_name",
                     CaptureError::RequestDecodingError(_) => "request_decoding_error",
                     CaptureError::RequestParsingError(_) => "request_parsing_error",
-                    CaptureError::EventTooBig => "event_too_big",
+                    CaptureError::EventTooBig(_) => "event_too_big",
                     CaptureError::NonRetryableSinkError => "sink_error",
                     CaptureError::InvalidSessionId => "invalid_session_id",
                     CaptureError::MissingSnapshotData => "missing_snapshot_data",

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -110,7 +110,10 @@ impl RawRequest {
                 if buf.len() > limit {
                     tracing::error!("GZIP decompression limit reached");
                     report_dropped_events("event_too_big", 1);
-                    return Err(CaptureError::EventTooBig);
+                    return Err(CaptureError::EventTooBig(format!(
+                        "Event or batch exceeded {} during unzipping",
+                        limit
+                    )));
                 }
             }
             match String::from_utf8(buf) {
@@ -130,7 +133,10 @@ impl RawRequest {
             if s.len() > limit {
                 tracing::error!("Request size limit reached");
                 report_dropped_events("event_too_big", 1);
-                return Err(CaptureError::EventTooBig);
+                return Err(CaptureError::EventTooBig(format!(
+                    "Event or batch wasn't compressed, size exceeded {}",
+                    limit
+                )));
             }
             s
         };

--- a/rust/capture/tests/events.rs
+++ b/rust/capture/tests/events.rs
@@ -1134,8 +1134,7 @@ async fn it_limits_non_batch_endpoints_to_2mb() -> Result<()> {
     });
 
     let res = server.capture_events(ok_event.to_string()).await;
-    // The events are too large to go in kafka, so we get a maximum event size exceeded error, but that's ok, because that's a 400, not a 413
-    assert_eq!(StatusCode::BAD_REQUEST, res.status());
+    assert_eq!(StatusCode::PAYLOAD_TOO_LARGE, res.status());
 
     let res = server.capture_events(nok_event.to_string()).await;
     assert_eq!(StatusCode::PAYLOAD_TOO_LARGE, res.status());
@@ -1175,8 +1174,7 @@ async fn it_limits_batch_endpoints_to_20mb() -> Result<()> {
     });
 
     let res = server.capture_to_batch(ok_event.to_string()).await;
-    // The events are too large to go in kafka, so we get a maximum event size exceeded error, but that's ok, because that's a 400, not a 413
-    assert_eq!(StatusCode::BAD_REQUEST, res.status());
+    assert_eq!(StatusCode::PAYLOAD_TOO_LARGE, res.status());
     let res = server.capture_to_batch(nok_event.to_string()).await;
     assert_eq!(StatusCode::PAYLOAD_TOO_LARGE, res.status());
 


### PR DESCRIPTION
We sent this as a 400 but it really shouldn't be, and we also should add extra info as there's a few ways it can happen.