### PR TITLE
fix(ai): Fixed missing local var

### DIFF
--- a/products/data_warehouse/backend/hogql_fixer_ai.py
+++ b/products/data_warehouse/backend/hogql_fixer_ai.py
@@ -134,6 +134,7 @@ Below is the current HogQL query and the error message
 
 def _get_schema_description(ai_context: dict[Any, Any], hogql_context: HogQLContext, database: Database) -> str:
     serialized_database = serialize_database(hogql_context)
+    schema_description = ""
 
     try:
         query = ai_context.get("hogql_query", None)


### PR DESCRIPTION
## Changes
- Needed to set a default value for `schema_description` when a query has no valid tables (e.g. if someone mistypes a table name) - the code path didn't set `schema_description` and so it threw when trying to return it 