### PR TITLE
chore: add status to slack alert

### DIFF
--- a/frontend/src/scenes/onboarding/error-tracking/onboardingErrorTrackingAlertsLogic.ts
+++ b/frontend/src/scenes/onboarding/error-tracking/onboardingErrorTrackingAlertsLogic.ts
@@ -29,6 +29,7 @@ const DEFAULT_SLACK_INPUTS: Record<string, any> = {
             {
                 type: 'context',
                 elements: [
+                    { type: 'plain_text', text: 'Status: {event.properties.status}' },
                     { type: 'mrkdwn', text: 'Project: <{project.url}|{project.name}>' },
                     {
                         type: 'mrkdwn',

--- a/posthog/cdp/templates/slack/template_slack.py
+++ b/posthog/cdp/templates/slack/template_slack.py
@@ -222,6 +222,7 @@ if (res.status != 200 or res.body.ok == false) {
                         {
                             "type": "context",
                             "elements": [
+                                {"type": "plain_text", "text": "Status: {event.properties.status}"},
                                 {"type": "mrkdwn", "text": "Project: <{project.url}|{project.name}>"},
                                 {"type": "mrkdwn", "text": "Alert: <{source.url}|{source.name}>"},
                             ],
@@ -261,6 +262,7 @@ if (res.status != 200 or res.body.ok == false) {
                         {
                             "type": "context",
                             "elements": [
+                                {"type": "plain_text", "text": "Status: {event.properties.status}"},
                                 {"type": "mrkdwn", "text": "Project: <{project.url}|{project.name}>"},
                                 {"type": "mrkdwn", "text": "Alert: <{source.url}|{source.name}>"},
                             ],

--- a/rust/cymbal/src/issue_resolution.rs
+++ b/rust/cymbal/src/issue_resolution.rs
@@ -51,7 +51,7 @@ impl IssueStatus {
             IssueStatus::Archived => "Archived",
             IssueStatus::Active => "Active",
             IssueStatus::Resolved => "Resolved",
-            IssueStatus::PendingRelease => "Pending pelease",
+            IssueStatus::PendingRelease => "Pending Release",
             IssueStatus::Suppressed => "Suppressed",
         }
     }

--- a/rust/cymbal/src/issue_resolution.rs
+++ b/rust/cymbal/src/issue_resolution.rs
@@ -45,6 +45,18 @@ pub enum IssueStatus {
     Suppressed,
 }
 
+impl IssueStatus {
+    fn as_str(&self) -> &'static str {
+        match self {
+            IssueStatus::Archived => "Archived",
+            IssueStatus::Active => "Active",
+            IssueStatus::Resolved => "Resolved",
+            IssueStatus::PendingRelease => "Pending pelease",
+            IssueStatus::Suppressed => "Suppressed",
+        }
+    }
+}
+
 impl Issue {
     pub async fn load_by_fingerprint<'c, E>(
         executor: E,
@@ -355,9 +367,7 @@ async fn send_internal_event(
     event
         .insert_prop("description", issue.description.clone())
         .expect("Strings are serializable");
-    event
-        .insert_prop("status", issue.status.clone())
-        .expect("Strings are serializable");
+    event.insert_prop("status", issue.status.as_str())?;
 
     if let Some(assignment) = new_assignment {
         if let Some(user_id) = assignment.user_id {

--- a/rust/cymbal/src/issue_resolution.rs
+++ b/rust/cymbal/src/issue_resolution.rs
@@ -355,6 +355,9 @@ async fn send_internal_event(
     event
         .insert_prop("description", issue.description.clone())
         .expect("Strings are serializable");
+    event
+        .insert_prop("status", issue.status.clone())
+        .expect("Strings are serializable");
 
     if let Some(assignment) = new_assignment {
         if let Some(user_id) = assignment.user_id {


### PR DESCRIPTION
## Problem

Requested in https://posthoghelp.zendesk.com/agent/tickets/29782 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/32279)

## Changes

Adds the status to the Slack message template
