### PR TITLE
feat(project-tree): save as to project tree replay playlists

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
@@ -1243,11 +1243,7 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                         path = result.path
 
                         // TODO: REMOVE THIS OLD LOGIC! ... in favor of directly passing _create_in_folder to the API calls
-                        if (
-                            result.type &&
-                            (['dashboard', 'session_recording_playlist'].includes(result.type) ||
-                                result.type.startsWith('hog_function/'))
-                        ) {
+                        if (result.type && (result.type === 'dashboard' || result.type.startsWith('hog_function/'))) {
                             // Check if a "new" action was recently initiated for this object type.
                             // If so, move the item to the new path.
                             const { lastNewFolder } = values

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
@@ -1241,30 +1241,7 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                     if (resp.results && resp.results.length > 0) {
                         const result = resp.results[0]
                         path = result.path
-
-                        // TODO: REMOVE THIS OLD LOGIC! ... in favor of directly passing _create_in_folder to the API calls
-                        if (result.type && (result.type === 'dashboard' || result.type.startsWith('hog_function/'))) {
-                            // Check if a "new" action was recently initiated for this object type.
-                            // If so, move the item to the new path.
-                            const { lastNewFolder } = values
-                            if (result.path.startsWith('Unfiled/') && typeof lastNewFolder === 'string') {
-                                const newPath = joinPath([
-                                    ...splitPath(lastNewFolder),
-                                    ...splitPath(result.path).slice(-1),
-                                ])
-                                actions.createSavedItem({ ...result, path: newPath })
-                                path = newPath
-                                await api.fileSystem.move(result.id, newPath)
-                            } else {
-                                actions.createSavedItem(result)
-                            }
-                            if (lastNewFolder) {
-                                actions.setLastNewFolder(null)
-                            }
-                            // </TODO>
-                        } else {
-                            actions.createSavedItem(result)
-                        }
+                        actions.createSavedItem(result)
                     }
                 }
 

--- a/frontend/src/lib/components/SaveTo/saveToLogic.tsx
+++ b/frontend/src/lib/components/SaveTo/saveToLogic.tsx
@@ -104,3 +104,19 @@ export function openSaveToModal(props: OpenSaveToProps): void {
         props.callback?.(props.folder ?? props.defaultFolder ?? '')
     }
 }
+
+export async function asyncSaveToModal(
+    props: Omit<OpenSaveToProps, 'callback' | 'cancelCallback'>
+): Promise<string | null> {
+    return new Promise((resolve) => {
+        openSaveToModal({
+            ...props,
+            callback: (folder) => {
+                resolve(folder)
+            },
+            cancelCallback: () => {
+                resolve(null)
+            },
+        })
+    })
+}

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -306,6 +306,7 @@ export const treeItemsNew = [
     { path: `Insight/Trends`, type: 'insight', href: () => urls.insightNew({ type: InsightType.TRENDS }) },
     { path: `Insight/User paths`, type: 'insight', href: () => urls.insightNew({ type: InsightType.PATHS }) },
     { path: `Notebook`, type: 'notebook', href: () => urls.notebook('new') },
+    { path: `Replay playlist`, type: 'session_recording_playlist', href: () => urls.replayPlaylist('new') },
 ]
 
 /** This const is auto-generated, as is the whole file */

--- a/frontend/src/scenes/session-recordings/SessionRecordings.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordings.tsx
@@ -11,6 +11,7 @@ import {
 import { FilmCameraHog, WarningHog } from 'lib/components/hedgehogs'
 import { PageHeader } from 'lib/components/PageHeader'
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
+import { asyncSaveToModal } from 'lib/components/SaveTo/saveToLogic'
 import { VersionCheckerBanner } from 'lib/components/VersionChecker/VersionCheckerBanner'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { useAsyncHandler } from 'lib/hooks/useAsyncHandler'
@@ -44,7 +45,12 @@ function Header(): JSX.Element {
     const { filters } = useValues(sessionRecordingsPlaylistLogic({ updateSearchParams: true }))
 
     const newPlaylistHandler = useAsyncHandler(async () => {
-        await createPlaylist({}, true)
+        const folder = await asyncSaveToModal({ defaultFolder: 'Unfiled/Replay playlists' })
+        if (typeof folder === 'string') {
+            await createPlaylist({ _create_in_folder: folder }, true)
+        } else {
+            await createPlaylist({}, true)
+        }
         reportRecordingPlaylistCreated('new')
     })
 

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistSceneLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistSceneLogic.ts
@@ -234,10 +234,10 @@ export const sessionRecordingsPlaylistSceneLogic = kea<sessionRecordingsPlaylist
     })),
 
     afterMount(({ actions, props }) => {
-        if (props.shortId !== 'new') {
+        if (props.shortId && props.shortId !== 'new') {
             actions.getPlaylist()
+            actions.loadPinnedRecordings()
         }
-        actions.loadPinnedRecordings()
     }),
 
     urlToAction(({ actions }) => ({

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1539,6 +1539,7 @@ export interface SessionRecordingPlaylistType {
      * marked as has more if the filters count onoy matched one page and there are more available
      */
     recordings_counts?: PlaylistRecordingsCounts
+    _create_in_folder?: string | null
 }
 
 export interface SessionRecordingSegmentType {

--- a/posthog/session_recordings/session_recording_playlist_api.py
+++ b/posthog/session_recordings/session_recording_playlist_api.py
@@ -126,6 +126,7 @@ def log_playlist_activity(
 
 class SessionRecordingPlaylistSerializer(serializers.ModelSerializer):
     recordings_counts = serializers.SerializerMethodField()
+    _create_in_folder = serializers.CharField(required=False, allow_blank=True, write_only=True)
 
     class Meta:
         model = SessionRecordingPlaylist
@@ -143,6 +144,7 @@ class SessionRecordingPlaylistSerializer(serializers.ModelSerializer):
             "last_modified_at",
             "last_modified_by",
             "recordings_counts",
+            "_create_in_folder",
         ]
         read_only_fields = [
             "id",

--- a/posthog/session_recordings/test/test_session_recording_playlist.py
+++ b/posthog/session_recordings/test/test_session_recording_playlist.py
@@ -13,6 +13,7 @@ from rest_framework import status
 
 from posthog import redis
 from posthog.models import SessionRecording, SessionRecordingPlaylistItem, Team
+from posthog.models.file_system.file_system import FileSystem
 from posthog.models.user import User
 from posthog.session_recordings.models.session_recording_event import SessionRecordingViewed
 from posthog.session_recordings.models.session_recording_playlist import (
@@ -632,3 +633,24 @@ class TestSessionRecordingPlaylist(APIBaseTest):
             ).count()
             == 0
         )
+
+    def test_create_playlist_in_specific_folder(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/session_recording_playlists",
+            {
+                "name": "Playlist in folder",
+                "filters": {"events": [{"id": "$pageview"}]},
+                "_create_in_folder": "Special Folder/Session Recordings",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.json())
+        playlist_id = response.json()["short_id"]
+
+        self.assertTrue(playlist_id)
+
+        fs_entry = FileSystem.objects.filter(
+            team=self.team, ref=str(playlist_id), type="session_recording_playlist"
+        ).first()
+        self.assertIsNotNone(fs_entry)
+        self.assertIn("Special Folder/Session Recordings", fs_entry.path)

--- a/posthog/session_recordings/test/test_session_recording_playlist.py
+++ b/posthog/session_recordings/test/test_session_recording_playlist.py
@@ -647,10 +647,10 @@ class TestSessionRecordingPlaylist(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.json())
         playlist_id = response.json()["short_id"]
 
-        self.assertTrue(playlist_id)
+        assert playlist_id is not None
 
         fs_entry = FileSystem.objects.filter(
             team=self.team, ref=str(playlist_id), type="session_recording_playlist"
         ).first()
-        self.assertIsNotNone(fs_entry)
-        self.assertIn("Special Folder/Session Recordings", fs_entry.path)
+        assert fs_entry is not None
+        assert "Special Folder/Session Recordings" in fs_entry.path

--- a/products/replay/manifest.tsx
+++ b/products/replay/manifest.tsx
@@ -29,6 +29,13 @@ export const manifest: ProductManifest = {
             href: (ref: string) => urls.replayPlaylist(ref),
         },
     },
+    treeItemsNew: [
+        {
+            path: `Replay playlist`,
+            type: 'session_recording_playlist',
+            href: () => urls.replayPlaylist('new'),
+        },
+    ],
     treeItemsExplore: [
         {
             path: 'Recordings/Recordings',


### PR DESCRIPTION
## Changes

Add the "save to" modal to replay playlists (active only when the tree view flag is enabled).

- [x] Insights https://github.com/PostHog/posthog/pull/31710
- [x] Notebooks https://github.com/PostHog/posthog/pull/31710
- [x] Actions https://github.com/PostHog/posthog/pull/31732
- [x] Cohorts https://github.com/PostHog/posthog/pull/31732
- [x] Surveys https://github.com/PostHog/posthog/pull/31745
- [x] Feature flags https://github.com/PostHog/posthog/pull/31745
- [x] Early access features https://github.com/PostHog/posthog/pull/31745
- [x] Experiments https://github.com/PostHog/posthog/pull/31745
- [x] Replay playlists (this PR)
- [ ] Dashboards
- [ ] Hog functions

## How did you test this code?

![2025-04-30 13 46 59](https://github.com/user-attachments/assets/4df0cf4e-ff80-4823-b85f-151f77906022)
