### PR TITLE
fix(llmo): pagination in traces

### DIFF
--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.test.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.test.ts
@@ -311,6 +311,29 @@ describe('dataNodeLogic', () => {
         })
     })
 
+    it('can load next data for TracesQuery', async () => {
+        logic = dataNodeLogic({
+            key: testUniqueKey,
+            query: { kind: NodeKind.TracesQuery },
+        })
+        const results = [{}, {}, {}]
+        mockedQuery.mockResolvedValueOnce({ results, hasMore: true })
+        logic.mount()
+        await expectLogic(logic)
+            .toMatchValues({ responseLoading: true, canLoadNextData: false, nextQuery: null, response: null })
+            .delay(0)
+        await expectLogic(logic).toMatchValues({
+            responseLoading: false,
+            canLoadNextData: true,
+            nextQuery: {
+                kind: NodeKind.TracesQuery,
+                limit: 100,
+                offset: 3,
+            },
+            response: partial({ results }),
+        })
+    })
+
     it('can autoload new data for EventsQuery', async () => {
         const results = [
             [

--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -48,6 +48,8 @@ import {
     QueryStatus,
     QueryTiming,
     RefreshType,
+    TracesQuery,
+    TracesQueryResponse,
 } from '~/queries/schema/schema-general'
 import {
     isActorsQuery,
@@ -58,6 +60,7 @@ import {
     isInsightActorsQuery,
     isInsightQueryNode,
     isPersonsNode,
+    isTracesQuery,
 } from '~/queries/utils'
 
 import type { dataNodeLogicType } from './dataNodeLogicType'
@@ -337,7 +340,8 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                         isEventsQuery(props.query) ||
                         isActorsQuery(props.query) ||
                         isGroupsQuery(props.query) ||
-                        isErrorTrackingQuery(props.query)
+                        isErrorTrackingQuery(props.query) ||
+                        isTracesQuery(props.query)
                     ) {
                         const newResponse =
                             (await performQuery(
@@ -351,6 +355,7 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                             | ActorsQueryResponse
                             | GroupsQueryResponse
                             | ErrorTrackingQueryResponse
+                            | TracesQueryResponse
                         return {
                             ...queryResponse,
                             results: [...(queryResponse?.results ?? []), ...(newResponse?.results ?? [])],
@@ -586,7 +591,8 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                     (isEventsQuery(query) ||
                         isActorsQuery(query) ||
                         isGroupsQuery(query) ||
-                        isErrorTrackingQuery(query)) &&
+                        isErrorTrackingQuery(query) ||
+                        isTracesQuery(query)) &&
                     !responseError &&
                     !dataLoading
                 ) {
@@ -597,9 +603,10 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                                 | ActorsQueryResponse
                                 | GroupsQueryResponse
                                 | ErrorTrackingQueryResponse
+                                | TracesQueryResponse
                         )?.hasMore
                     ) {
-                        const sortKey = query.orderBy?.[0] ?? 'timestamp DESC'
+                        const sortKey = isTracesQuery(query) ? null : query.orderBy?.[0] ?? 'timestamp DESC'
                         if (isEventsQuery(query) && sortKey === 'timestamp DESC') {
                             const typedResults = (response as EventsQueryResponse)?.results
                             const sortColumnIndex = query.select
@@ -626,12 +633,13 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                                     | ActorsQueryResponse
                                     | GroupsQueryResponse
                                     | ErrorTrackingQueryResponse
+                                    | TracesQueryResponse
                             )?.results
                             return {
                                 ...query,
                                 offset: typedResults?.length || 0,
                                 limit: Math.max(100, Math.min(2 * (typedResults?.length || 100), LOAD_MORE_ROWS_LIMIT)),
-                            } as EventsQuery | ActorsQuery | GroupsQuery | ErrorTrackingQuery
+                            } as EventsQuery | ActorsQuery | GroupsQuery | ErrorTrackingQuery | TracesQuery
                         }
                     }
                 }


### PR DESCRIPTION
## Problem

Found out today that users can't see traces after the first 100 records. It was an oversight.

## Changes

- Support pagination in the dataNodeLogic for TracesQuery.

### Demo

<img width="1262" alt="Screenshot 2025-04-30 at 14 00 53" src="https://github.com/user-attachments/assets/8a76bb6a-71df-4af3-a8fc-d52ccc0a0273" />
<img width="1241" alt="Screenshot 2025-04-30 at 14 01 05" src="https://github.com/user-attachments/assets/70a1eaca-f97a-424c-a32a-91b1b670e441" />


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manual testing and unit tests.
