### PR TITLE
feat: Sanitize bad characters in token

### DIFF
--- a/plugin-server/src/utils/event.test.ts
+++ b/plugin-server/src/utils/event.test.ts
@@ -1,8 +1,8 @@
 import { KafkaMessage } from 'kafkajs'
 import { DateTime } from 'luxon'
 
-import { ClickHouseTimestamp, ProjectId, RawKafkaEvent } from '../../src/types'
-import { formPipelineEvent, normalizeEvent, parseRawClickHouseEvent } from '../../src/utils/event'
+import { ClickHouseTimestamp, ProjectId, RawKafkaEvent } from '../types'
+import { formPipelineEvent, normalizeEvent, parseRawClickHouseEvent } from './event'
 
 describe('normalizeEvent()', () => {
     describe('distinctId', () => {
@@ -43,6 +43,12 @@ describe('normalizeEvent()', () => {
             key2_once: 'value2',
             key3_once: 'value4',
         })
+    })
+
+    it('sanitizes token', () => {
+        const event = { token: '\u0000' }
+        const sanitized = normalizeEvent(event as any)
+        expect(sanitized.token).toBe('\uFFFD')
     })
 })
 

--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -205,6 +205,10 @@ export function normalizeProcessPerson(event: PluginEvent, processPerson: boolea
 export function normalizeEvent<T extends PipelineEvent | PluginEvent>(event: T): T {
     event.distinct_id = sanitizeString(String(event.distinct_id))
 
+    if ('token' in event) {
+        event.token = sanitizeString(String(event.token))
+    }
+
     let properties = event.properties ?? {}
     if (event['$set']) {
         properties['$set'] = { ...properties['$set'], ...event['$set'] }


### PR DESCRIPTION
## Problem

Normalizing the event doesn't account for tokens with bad characters. This fixes it.

## Changes

* Add the sanitize method for the token in normalize path
* We could do more here to ensure token validity but opting for a quick fix for now

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
