### PR TITLE
fix(data-warehouse): Taxonomic property filters for data warehouse person properties

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -85,7 +85,8 @@ export function OperatorValueSelect({
     size,
     editable,
 }: OperatorValueSelectProps): JSX.Element {
-    const propertyDefinition = propertyDefinitions.find((pd) => pd.name === propertyKey)
+    const lookupKey = type === PropertyFilterType.DataWarehousePersonProperty ? 'id' : 'name'
+    const propertyDefinition = propertyDefinitions.find((pd) => pd[lookupKey] === propertyKey)
 
     const isCohortProperty = propertyKey === 'id' && type === PropertyFilterType.Cohort
 

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -267,7 +267,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         logic: dataWarehouseJoinsLogic,
                         value: 'columnsJoinedToPersons',
                         getName: (personProperty: PersonProperty) => personProperty.name,
-                        getValue: (personProperty: PersonProperty) => personProperty.name,
+                        getValue: (personProperty: PersonProperty) => personProperty.id,
                         getPopoverHeader: () => 'Extended Person Property',
                     },
                     {

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -267,7 +267,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         logic: dataWarehouseJoinsLogic,
                         value: 'columnsJoinedToPersons',
                         getName: (personProperty: PersonProperty) => personProperty.name,
-                        getValue: (personProperty: PersonProperty) => personProperty.id,
+                        getValue: (personProperty: PersonProperty) => personProperty.name,
                         getPopoverHeader: () => 'Extended Person Property',
                     },
                     {

--- a/frontend/src/scenes/data-warehouse/external/dataWarehouseJoinsLogic.ts
+++ b/frontend/src/scenes/data-warehouse/external/dataWarehouseJoinsLogic.ts
@@ -1,12 +1,20 @@
 import { afterMount, connect, kea, path, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
-import { capitalizeFirstLetter } from 'lib/utils'
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
 
 import { DataWarehouseViewLink, PropertyDefinition, PropertyType } from '~/types'
 
 import type { dataWarehouseJoinsLogicType } from './dataWarehouseJoinsLogicType'
+
+const TYPE_MAPPING: Record<string, PropertyType> = {
+    datetime: PropertyType.DateTime,
+    string: PropertyType.String,
+    numeric: PropertyType.Numeric,
+    boolean: PropertyType.Boolean,
+    duration: PropertyType.Duration,
+    array: PropertyType.StringArray,
+}
 
 export const dataWarehouseJoinsLogic = kea<dataWarehouseJoinsLogicType>([
     path(['scenes', 'data-warehouse', 'external', 'dataWarehouseJoinsLogic']),
@@ -50,7 +58,7 @@ export const dataWarehouseJoinsLogic = kea<dataWarehouseJoinsLogicType>([
                                 id: `${join.field_name}.${column.name}`,
                                 name: `${join.field_name}: ${column.name}`,
                                 table: join.field_name,
-                                property_type: capitalizeFirstLetter(column.type) as PropertyType,
+                                property_type: TYPE_MAPPING[column.type.toLowerCase()] || PropertyType.String,
                             }))
                         )
                     }


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

The taxonomic property filter don't work well with data warehouse person properties, as they currently ignore the property type.

## Changes

- Fix the property type for `datetime` fields
- Fix how the property definitions are looked up. This is needed since [we use the `id` for the value, rather than the `name`](https://github.com/PostHog/posthog/blob/c1e31efb2965d2ad1a72ccbc0608a2275e896e52/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx#L270), like other types

I'm not sure if this is the best way to fix this problem as a lot of this code is new to me, so it was a bit trial and error.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Local testing. Though I couldn't actually get an insight to work with real data, as my Stripe data is just test data.
