### PR TITLE
fix: Default node fetch timeout

### DIFF
--- a/plugin-server/src/utils/fetch.ts
+++ b/plugin-server/src/utils/fetch.ts
@@ -110,7 +110,7 @@ export class SecureFetch {
                     this.options?.allowUnsafe ?? (process.env.NODE_ENV?.includes('functional-tests') || !isProdEnv())
 
                 if (allowUnsafe) {
-                    // NOTE: Agent is false to disable keep alive, an increase parallelization
+                    // NOTE: Agent is false to disable keep alive, and increase parallelization
                     return await fetch(url, { ...init, agent: false })
                 }
 

--- a/plugin-server/src/utils/fetch.ts
+++ b/plugin-server/src/utils/fetch.ts
@@ -111,11 +111,8 @@ export class SecureFetch {
                     this.options?.allowUnsafe ?? (process.env.NODE_ENV?.includes('functional-tests') || !isProdEnv())
 
                 if (allowUnsafe) {
-                    const start = performance.now()
                     // NOTE: Agent is false to disable keep alive, an increase parallelization
-                    const res = await fetch(url, { ...init, agent: false })
-                    logger.info('Fetch took', performance.now() - start, url, res.status)
-                    return res
+                    return await fetch(url, { ...init, agent: false })
                 }
 
                 validateUrl(request.url)

--- a/plugin-server/src/utils/fetch.ts
+++ b/plugin-server/src/utils/fetch.ts
@@ -10,7 +10,6 @@ import { URL } from 'url'
 import { defaultConfig } from '../config/config'
 import { runInstrumentedFunction } from '../main/utils'
 import { isProdEnv } from './env-utils'
-import { logger } from './logger'
 
 export type { Response }
 

--- a/plugin-server/src/utils/fetch.ts
+++ b/plugin-server/src/utils/fetch.ts
@@ -7,8 +7,10 @@ import net from 'node:net'
 import fetch, { type RequestInfo, type RequestInit, type Response, FetchError, Request } from 'node-fetch'
 import { URL } from 'url'
 
+import { defaultConfig } from '../config/config'
 import { runInstrumentedFunction } from '../main/utils'
 import { isProdEnv } from './env-utils'
+import { logger } from './logger'
 
 export type { Response }
 
@@ -87,28 +89,39 @@ const httpStaticLookup: net.LookupFunction = async (hostname, options, cb) => {
     }
 }
 
+const COMMON_AGENT_OPTIONS: http.AgentOptions = { keepAlive: false }
+
+const getSafeAgent = (url: URL) => {
+    return url.protocol === 'http:'
+        ? new http.Agent({ ...COMMON_AGENT_OPTIONS, lookup: httpStaticLookup })
+        : new https.Agent({ ...COMMON_AGENT_OPTIONS, lookup: httpStaticLookup })
+}
+
 export class SecureFetch {
     constructor(private options?: { allowUnsafe?: boolean }) {}
 
-    fetch(url: RequestInfo, init?: RequestInit): Promise<Response> {
+    fetch(url: RequestInfo, init: RequestInit = {}): Promise<Response> {
         return runInstrumentedFunction({
             statsKey: 'secureFetch',
             func: async () => {
+                init.timeout = init.timeout ?? defaultConfig.EXTERNAL_REQUEST_TIMEOUT_MS
                 const request = new Request(url, init)
 
                 const allowUnsafe =
                     this.options?.allowUnsafe ?? (process.env.NODE_ENV?.includes('functional-tests') || !isProdEnv())
+
                 if (allowUnsafe) {
-                    return await fetch(url, init)
+                    const start = performance.now()
+                    // NOTE: Agent is false to disable keep alive, an increase parallelization
+                    const res = await fetch(url, { ...init, agent: false })
+                    logger.info('Fetch took', performance.now() - start, url, res.status)
+                    return res
                 }
 
                 validateUrl(request.url)
                 return await fetch(url, {
                     ...init,
-                    agent: ({ protocol }: URL) =>
-                        protocol === 'http:'
-                            ? new http.Agent({ lookup: httpStaticLookup })
-                            : new https.Agent({ lookup: httpStaticLookup }),
+                    agent: getSafeAgent,
                 })
             },
         })

--- a/plugin-server/tests/worker/ingestion/event-pipeline/event-pipeline-integration.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/event-pipeline-integration.test.ts
@@ -165,6 +165,7 @@ describe('Event Pipeline integration test', () => {
         }
 
         expect(fetch).toHaveBeenCalledWith('https://webhook.example.com/', {
+            agent: false,
             body: JSON.stringify(expectedPayload, undefined, 4),
             headers: { 'Content-Type': 'application/json' },
             method: 'POST',

--- a/plugin-server/tests/worker/ingestion/hooks.test.ts
+++ b/plugin-server/tests/worker/ingestion/hooks.test.ts
@@ -51,6 +51,7 @@ describe('hooks', () => {
                 [
                   "https://example.com/",
                   {
+                    "agent": false,
                     "body": "{
                     "hook": {
                         "id": "id",
@@ -101,6 +102,7 @@ describe('hooks', () => {
                 [
                   "https://example.com/",
                   {
+                    "agent": false,
                     "body": "{
                     "hook": {
                         "id": "id",

--- a/plugin-server/tests/worker/vm.extra-lazy.test.ts
+++ b/plugin-server/tests/worker/vm.extra-lazy.test.ts
@@ -43,7 +43,7 @@ describe('VMs are extra lazy 💤', () => {
         await lazyVm.getPluginMethod('onEvent')
         expect(lazyVm.ready).toEqual(true)
         expect(lazyVm.setupPluginIfNeeded).toHaveBeenCalled()
-        expect(fetch).toHaveBeenCalledWith('https://onevent.com/', undefined)
+        expect(fetch).toHaveBeenCalledWith('https://onevent.com/', { agent: false, timeout: 10000 })
     })
 
     test('getting methods and tasks returns null if plugin is in errored state', async () => {

--- a/plugin-server/tests/worker/vm.test.ts
+++ b/plugin-server/tests/worker/vm.test.ts
@@ -122,7 +122,10 @@ describe('vm tests', () => {
         })
         expect(fetch).not.toHaveBeenCalled()
         await vm.methods.teardownPlugin!()
-        expect(fetch).toHaveBeenCalledWith('https://google.com/results.json?query=hoho', undefined)
+        expect(fetch).toHaveBeenCalledWith('https://google.com/results.json?query=hoho', {
+            agent: false,
+            timeout: 10000,
+        })
     })
 
     test('processEvent', async () => {
@@ -376,7 +379,10 @@ describe('vm tests', () => {
                 event: 'export',
             }
             await vm.methods.onEvent!(event)
-            expect(fetch).toHaveBeenCalledWith('https://google.com/results.json?query=export', undefined)
+            expect(fetch).toHaveBeenCalledWith('https://google.com/results.json?query=export', {
+                agent: false,
+                timeout: 10000,
+            })
         })
 
         test('export default', async () => {
@@ -395,7 +401,10 @@ describe('vm tests', () => {
                 event: 'default export',
             }
             await vm.methods.onEvent!(event)
-            expect(fetch).toHaveBeenCalledWith('https://google.com/results.json?query=default export', undefined)
+            expect(fetch).toHaveBeenCalledWith('https://google.com/results.json?query=default export', {
+                agent: false,
+                timeout: 10000,
+            })
         })
     })
 
@@ -725,7 +734,10 @@ describe('vm tests', () => {
         }
 
         await vm.methods.processEvent!(event)
-        expect(fetch).toHaveBeenCalledWith('https://google.com/results.json?query=fetched', undefined)
+        expect(fetch).toHaveBeenCalledWith('https://google.com/results.json?query=fetched', {
+            agent: false,
+            timeout: 10000,
+        })
 
         expect(event.properties).toEqual({ count: 2, query: 'bla', results: [true, true] })
     })
@@ -747,7 +759,10 @@ describe('vm tests', () => {
         }
 
         await vm.methods.processEvent!(event)
-        expect(fetch).toHaveBeenCalledWith('https://google.com/results.json?query=fetched', undefined)
+        expect(fetch).toHaveBeenCalledWith('https://google.com/results.json?query=fetched', {
+            agent: false,
+            timeout: 10000,
+        })
 
         expect(event.properties).toEqual({ count: 2, query: 'bla', results: [true, true] })
     })
@@ -768,7 +783,10 @@ describe('vm tests', () => {
         }
 
         await vm.methods.processEvent!(event)
-        expect(fetch).toHaveBeenCalledWith('https://google.com/results.json?query=fetched', undefined)
+        expect(fetch).toHaveBeenCalledWith('https://google.com/results.json?query=fetched', {
+            agent: false,
+            timeout: 10000,
+        })
 
         expect(event.properties).toEqual({ count: 2, query: 'bla', results: [true, true] })
     })
@@ -921,7 +939,10 @@ describe('vm tests', () => {
             event: 'onEvent',
         }
         await vm.methods.onEvent!(event)
-        expect(fetch).toHaveBeenCalledWith('https://google.com/results.json?query=onEvent', undefined)
+        expect(fetch).toHaveBeenCalledWith('https://google.com/results.json?query=onEvent', {
+            agent: false,
+            timeout: 10000,
+        })
     })
 
     test('imports', async () => {


### PR DESCRIPTION
## Problem

Locally fetch is slow as it uses a shared http agent with keep alive leading to essentially serial requests.

Also we have a var for controlling timeouts but it isn't always implemented in the parent so applying in the fetch class itself

## Changes

* Sets the default (its pretty high by default and then each service overrides individually

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
