### PR TITLE
feat: publish empty sessions from v2 to v1 table

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-metadata-store.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-metadata-store.ts
@@ -18,9 +18,8 @@ export class SessionMetadataStore {
     public async storeSessionBlocks(blocks: SessionBlockMetadata[]): Promise<void> {
         logger.info('🔍', 'session_metadata_store_storing_blocks', { count: blocks.length })
 
-        const uuid = randomUUID()
         const eventsV2 = blocks.map((metadata) => ({
-            uuid,
+            uuid: randomUUID(),
             session_id: metadata.sessionId,
             team_id: metadata.teamId,
             distinct_id: metadata.distinctId,
@@ -59,7 +58,7 @@ export class SessionMetadataStore {
         // 10. we stop reading from session_replay_events_v2_test
         // 11. we remove the session_replay_events_v2_test tables and topics
         const eventsV1 = blocks.map((metadata) => ({
-            uuid,
+            uuid: randomUUID(),
             session_id: metadata.sessionId,
             team_id: metadata.teamId,
             distinct_id: metadata.distinctId,

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-metadata-store.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-metadata-store.ts
@@ -1,6 +1,9 @@
 import { randomUUID } from 'crypto'
 
-import { KAFKA_CLICKHOUSE_SESSION_REPLAY_EVENTS_V2_TEST } from '../../../../config/kafka-topics'
+import {
+    KAFKA_CLICKHOUSE_SESSION_REPLAY_EVENTS,
+    KAFKA_CLICKHOUSE_SESSION_REPLAY_EVENTS_V2_TEST,
+} from '../../../../config/kafka-topics'
 import { KafkaProducerWrapper } from '../../../../kafka/producer'
 import { TimestampFormat } from '../../../../types'
 import { logger } from '../../../../utils/logger'
@@ -15,8 +18,9 @@ export class SessionMetadataStore {
     public async storeSessionBlocks(blocks: SessionBlockMetadata[]): Promise<void> {
         logger.info('🔍', 'session_metadata_store_storing_blocks', { count: blocks.length })
 
-        const events = blocks.map((metadata) => ({
-            uuid: randomUUID(),
+        const uuid = randomUUID()
+        const eventsV2 = blocks.map((metadata) => ({
+            uuid,
             session_id: metadata.sessionId,
             team_id: metadata.teamId,
             distinct_id: metadata.distinctId,
@@ -40,9 +44,55 @@ export class SessionMetadataStore {
             event_count: metadata.eventCount || 0,
         }))
 
+        // We publish "empty" events for the old version to facilitate the transition.
+        //
+        // Transition plan:
+        // 1. we publish v2 metadata only to session_replay_events_v2_test
+        // 2. we publish empty events to session_replay_events, blobby v1 overwrites the metadata, so the data in the table is correct
+        // 3. we start serving all sessions from session_replay_events_v2_test
+        // 4. we stop blobby v1
+        // 5. we still use session_replay_events for listing sessions, it has all sessions because we're publishing "empty" events for the old version
+        // 6. we change the read queries to merge data from session_replay_events and session_replay_events_v2_test
+        // 7. we stop publishing empty events to session_replay_events
+        // 8. we stop publishing to session_replay_events_v2_test
+        // 9. we backfill missing data from session_replay_events_v2_test to session_replay_events
+        // 10. we stop reading from session_replay_events_v2_test
+        // 11. we remove the session_replay_events_v2_test tables and topics
+        const eventsV1 = blocks.map((metadata) => ({
+            uuid,
+            session_id: metadata.sessionId,
+            team_id: metadata.teamId,
+            distinct_id: metadata.distinctId,
+            batch_id: metadata.batchId,
+            first_timestamp: castTimestampOrNow(metadata.startDateTime, TimestampFormat.ClickHouse),
+            last_timestamp: castTimestampOrNow(metadata.endDateTime, TimestampFormat.ClickHouse),
+            block_url: null,
+            first_url: null,
+            urls: [],
+            click_count: 0,
+            keypress_count: 0,
+            mouse_activity_count: 0,
+            active_milliseconds: 0,
+            console_log_count: 0,
+            console_warn_count: 0,
+            console_error_count: 0,
+            size: 0,
+            message_count: 0,
+            snapshot_source: null,
+            snapshot_library: null,
+            event_count: 0,
+        }))
+
         await this.producer.queueMessages({
             topic: KAFKA_CLICKHOUSE_SESSION_REPLAY_EVENTS_V2_TEST,
-            messages: events.map((event) => ({
+            messages: eventsV2.map((event) => ({
+                key: event.session_id,
+                value: JSON.stringify(event),
+            })),
+        })
+        await this.producer.queueMessages({
+            topic: KAFKA_CLICKHOUSE_SESSION_REPLAY_EVENTS,
+            messages: eventsV1.map((event) => ({
                 key: event.session_id,
                 value: JSON.stringify(event),
             })),
@@ -50,6 +100,6 @@ export class SessionMetadataStore {
 
         await this.producer.flush()
 
-        logger.info('🔍', 'session_metadata_store_blocks_stored', { count: events.length })
+        logger.info('🔍', 'session_metadata_store_blocks_stored', { count: eventsV2.length })
     }
 }

--- a/posthog/clickhouse/migrations/0115_add_block_columns_to_session_replay_events.py
+++ b/posthog/clickhouse/migrations/0115_add_block_columns_to_session_replay_events.py
@@ -1,0 +1,35 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions, NodeRole
+from posthog.session_recordings.sql.session_replay_event_migrations_sql import (
+    ADD_BLOCK_COLUMNS_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    ADD_BLOCK_COLUMNS_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    ADD_BLOCK_COLUMNS_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL,
+    DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL,
+)
+from posthog.session_recordings.sql.session_replay_event_sql import (
+    SESSION_REPLAY_EVENTS_TABLE_MV_SQL,
+    KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL,
+)
+
+# The Kafka table only has block_url String (not arrays). Block array columns are only in the aggregate tables.
+operations = [
+    # 1. Drop the old materialized view so it's no longer pulling from Kafka
+    run_sql_with_exceptions(DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL()),
+    # 2. Drop the Kafka table
+    run_sql_with_exceptions(DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    # 3. Sharded table (physical storage)
+    run_sql_with_exceptions(ADD_BLOCK_COLUMNS_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    # 4. Writable table (for writing to sharded table)
+    run_sql_with_exceptions(ADD_BLOCK_COLUMNS_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    # 5. Distributed table (for reading)
+    run_sql_with_exceptions(ADD_BLOCK_COLUMNS_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    # 6. Also run on coordinator node without the cluster clause
+    run_sql_with_exceptions(
+        ADD_BLOCK_COLUMNS_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL().replace("on CLUSTER '{cluster}'", ""),
+        node_role=NodeRole.COORDINATOR,
+    ),
+    # 7. Recreate the Kafka table with the updated schema
+    run_sql_with_exceptions(KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    # 8. Recreate the materialized view with the updated schema
+    run_sql_with_exceptions(SESSION_REPLAY_EVENTS_TABLE_MV_SQL()),
+]

--- a/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
@@ -196,9 +196,9 @@ ADD_BLOCK_COLUMNS_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SE
 
 ALTER_SESSION_REPLAY_ADD_SECONDARY_COLUMNS = """
     ALTER TABLE {table_name} on CLUSTER '{cluster}'
-        ADD COLUMN IF NOT EXISTS min_first_timestamp_secondary SimpleAggregateFunction(min, DateTime64(6, 'UTC')),
-        ADD COLUMN IF NOT EXISTS max_last_timestamp_secondary SimpleAggregateFunction(max, DateTime64(6, 'UTC')),
-        ADD COLUMN IF NOT EXISTS first_url_secondary AggregateFunction(argMin, Nullable(VARCHAR), DateTime64(6, 'UTC')),
+        ADD COLUMN IF NOT EXISTS min_first_timestamp_secondary SimpleAggregateFunction(min, Nullable(DateTime64(6, 'UTC'))),
+        ADD COLUMN IF NOT EXISTS max_last_timestamp_secondary SimpleAggregateFunction(max, Nullable(DateTime64(6, 'UTC'))),
+        ADD COLUMN IF NOT EXISTS first_url_secondary AggregateFunction(argMin, Nullable(VARCHAR), Nullable(DateTime64(6, 'UTC'))),
         ADD COLUMN IF NOT EXISTS all_urls_secondary SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
         ADD COLUMN IF NOT EXISTS click_count_secondary SimpleAggregateFunction(sum, Int64),
         ADD COLUMN IF NOT EXISTS keypress_count_secondary SimpleAggregateFunction(sum, Int64),
@@ -210,8 +210,8 @@ ALTER_SESSION_REPLAY_ADD_SECONDARY_COLUMNS = """
         ADD COLUMN IF NOT EXISTS size_secondary SimpleAggregateFunction(sum, Int64),
         ADD COLUMN IF NOT EXISTS message_count_secondary SimpleAggregateFunction(sum, Int64),
         ADD COLUMN IF NOT EXISTS event_count_secondary SimpleAggregateFunction(sum, Int64),
-        ADD COLUMN IF NOT EXISTS snapshot_source_secondary AggregateFunction(argMin, LowCardinality(Nullable(String)), DateTime64(6, 'UTC')),
-        ADD COLUMN IF NOT EXISTS snapshot_library_secondary AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))
+        ADD COLUMN IF NOT EXISTS snapshot_source_secondary AggregateFunction(argMin, LowCardinality(Nullable(String)), Nullable(DateTime64(6, 'UTC'))),
+        ADD COLUMN IF NOT EXISTS snapshot_library_secondary AggregateFunction(argMin, Nullable(String), Nullable(DateTime64(6, 'UTC')))
 """
 
 ADD_SECONDARY_COLUMNS_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_SECONDARY_COLUMNS.format(

--- a/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
@@ -156,3 +156,35 @@ ADD_LIBRARY_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_L
     table_name=SESSION_REPLAY_EVENTS_DATA_TABLE(),
     cluster=settings.CLICKHOUSE_CLUSTER,
 )
+
+# =========================
+# MIGRATION: Add block columns to support session recording v2 implementation
+# This migration adds block_url to the kafka table, and block_first_timestamps, block_last_timestamps, and block_urls
+# to the sharded, writable, and distributed session replay events tables.
+# The Kafka table only has block_url String (not arrays).
+# These columns are required for the v2 session recording implementation.
+# =========================
+
+# 1. Sharded table (physical storage)
+ALTER_SESSION_REPLAY_ADD_BLOCK_COLUMNS = """
+    ALTER TABLE {table_name} on CLUSTER '{cluster}'
+        ADD COLUMN IF NOT EXISTS block_first_timestamps SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
+        ADD COLUMN IF NOT EXISTS block_last_timestamps SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
+        ADD COLUMN IF NOT EXISTS block_urls SimpleAggregateFunction(groupArrayArray, Array(String))
+"""
+ADD_BLOCK_COLUMNS_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_BLOCK_COLUMNS.format(
+    table_name=SESSION_REPLAY_EVENTS_DATA_TABLE(),
+    cluster=settings.CLICKHOUSE_CLUSTER,
+)
+
+# 2. Writable table (for writing to sharded table)
+ADD_BLOCK_COLUMNS_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_BLOCK_COLUMNS.format(
+    table_name="writable_session_replay_events",
+    cluster=settings.CLICKHOUSE_CLUSTER,
+)
+
+# 3. Distributed table (for reading)
+ADD_BLOCK_COLUMNS_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_BLOCK_COLUMNS.format(
+    table_name="session_replay_events",
+    cluster=settings.CLICKHOUSE_CLUSTER,
+)

--- a/posthog/session_recordings/sql/session_replay_event_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_sql.py
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     distinct_id VARCHAR,
     first_timestamp DateTime64(6, 'UTC'),
     last_timestamp DateTime64(6, 'UTC'),
+    block_url Nullable(String),
     first_url Nullable(VARCHAR),
     urls Array(String),
     click_count Int64,
@@ -136,6 +137,9 @@ team_id,
 any(distinct_id) as distinct_id,
 min(first_timestamp) AS min_first_timestamp,
 max(last_timestamp) AS max_last_timestamp,
+groupArray(first_timestamp) AS block_first_timestamps,
+groupArray(last_timestamp) AS block_last_timestamps,
+groupArray(block_url) AS block_urls,
 -- TRICKY: ClickHouse will pick a relatively random first_url
 -- when it collapses the aggregating merge tree
 -- unless we teach it what we want...
@@ -174,6 +178,9 @@ group by session_id, team_id
 `session_id` String, `team_id` Int64, `distinct_id` String,
 `min_first_timestamp` DateTime64(6, 'UTC'),
 `max_last_timestamp` DateTime64(6, 'UTC'),
+`block_first_timestamps` SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
+`block_last_timestamps` SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
+`block_urls` SimpleAggregateFunction(groupArrayArray, Array(String)),
 `first_url` AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
 `all_urls` SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
 `click_count` Int64, `keypress_count` Int64,

--- a/posthog/session_recordings/sql/session_replay_event_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_sql.py
@@ -137,8 +137,8 @@ team_id,
 any(distinct_id) as distinct_id,
 min(first_timestamp) AS min_first_timestamp,
 max(last_timestamp) AS max_last_timestamp,
-groupArray(first_timestamp) AS block_first_timestamps,
-groupArray(last_timestamp) AS block_last_timestamps,
+groupArray(if(block_url != '', first_timestamp, NULL)) AS block_first_timestamps,
+groupArray(if(block_url != '', last_timestamp, NULL)) AS block_last_timestamps,
 groupArray(block_url) AS block_urls,
 -- TRICKY: ClickHouse will pick a relatively random first_url
 -- when it collapses the aggregating merge tree

--- a/posthog/session_recordings/sql/session_replay_event_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_sql.py
@@ -43,8 +43,8 @@ CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     snapshot_source LowCardinality(Nullable(String)),
     snapshot_library Nullable(String),
     -- Secondary columns for v2 migration
-    first_timestamp_secondary DateTime64(6, 'UTC'),
-    last_timestamp_secondary DateTime64(6, 'UTC'),
+    first_timestamp_secondary Nullable(DateTime64(6, 'UTC')),
+    last_timestamp_secondary Nullable(DateTime64(6, 'UTC')),
     first_url_secondary Nullable(VARCHAR),
     urls_secondary Array(String),
     click_count_secondary Int64,
@@ -108,9 +108,9 @@ CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     block_last_timestamps SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
     block_urls SimpleAggregateFunction(groupArrayArray, Array(String)),
     -- Secondary columns for v2 migration
-    min_first_timestamp_secondary SimpleAggregateFunction(min, DateTime64(6, 'UTC')),
-    max_last_timestamp_secondary SimpleAggregateFunction(max, DateTime64(6, 'UTC')),
-    first_url_secondary AggregateFunction(argMin, Nullable(VARCHAR), DateTime64(6, 'UTC')),
+    min_first_timestamp_secondary SimpleAggregateFunction(min, Nullable(DateTime64(6, 'UTC'))),
+    max_last_timestamp_secondary SimpleAggregateFunction(max, Nullable(DateTime64(6, 'UTC'))),
+    first_url_secondary AggregateFunction(argMin, Nullable(VARCHAR), Nullable(DateTime64(6, 'UTC'))),
     all_urls_secondary SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
     click_count_secondary SimpleAggregateFunction(sum, Int64),
     keypress_count_secondary SimpleAggregateFunction(sum, Int64),
@@ -122,8 +122,8 @@ CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     size_secondary SimpleAggregateFunction(sum, Int64),
     message_count_secondary SimpleAggregateFunction(sum, Int64),
     event_count_secondary SimpleAggregateFunction(sum, Int64),
-    snapshot_source_secondary AggregateFunction(argMin, LowCardinality(Nullable(String)), DateTime64(6, 'UTC')),
-    snapshot_library_secondary AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))
+    snapshot_source_secondary AggregateFunction(argMin, LowCardinality(Nullable(String)), Nullable(DateTime64(6, 'UTC'))),
+    snapshot_library_secondary AggregateFunction(argMin, Nullable(String), Nullable(DateTime64(6, 'UTC')))
 ) ENGINE = {engine}
 """
 
@@ -247,9 +247,9 @@ group by session_id, team_id
 `snapshot_library` AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
 `_timestamp` Nullable(DateTime),
 -- Secondary columns for v2 migration
-`min_first_timestamp_secondary` DateTime64(6, 'UTC'),
-`max_last_timestamp_secondary` DateTime64(6, 'UTC'),
-`first_url_secondary` AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
+`min_first_timestamp_secondary` Nullable(DateTime64(6, 'UTC')),
+`max_last_timestamp_secondary` Nullable(DateTime64(6, 'UTC')),
+`first_url_secondary` AggregateFunction(argMin, Nullable(String), Nullable(DateTime64(6, 'UTC'))),
 `all_urls_secondary` SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
 `click_count_secondary` Int64,
 `keypress_count_secondary` Int64,
@@ -261,8 +261,8 @@ group by session_id, team_id
 `size_secondary` Int64,
 `message_count_secondary` Int64,
 `event_count_secondary` Int64,
-`snapshot_source_secondary` AggregateFunction(argMin, LowCardinality(Nullable(String)), DateTime64(6, 'UTC')),
-`snapshot_library_secondary` AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))
+`snapshot_source_secondary` AggregateFunction(argMin, LowCardinality(Nullable(String)), Nullable(DateTime64(6, 'UTC'))),
+`snapshot_library_secondary` AggregateFunction(argMin, Nullable(String), Nullable(DateTime64(6, 'UTC')))
 )""",
     )
 )

--- a/posthog/session_recordings/sql/session_replay_event_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_sql.py
@@ -41,7 +41,22 @@ CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     event_count Int64,
     message_count Int64,
     snapshot_source LowCardinality(Nullable(String)),
-    snapshot_library Nullable(String)
+    snapshot_library Nullable(String),
+    -- Secondary columns for v2 migration
+    first_url_secondary Nullable(VARCHAR),
+    urls_secondary Array(String),
+    click_count_secondary Int64,
+    keypress_count_secondary Int64,
+    mouse_activity_count_secondary Int64,
+    active_milliseconds_secondary Int64,
+    console_log_count_secondary Int64,
+    console_warn_count_secondary Int64,
+    console_error_count_secondary Int64,
+    size_secondary Int64,
+    event_count_secondary Int64,
+    message_count_secondary Int64,
+    snapshot_source_secondary LowCardinality(Nullable(String)),
+    snapshot_library_secondary Nullable(String)
 ) ENGINE = {engine}
 """
 
@@ -85,7 +100,28 @@ CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     snapshot_source AggregateFunction(argMin, LowCardinality(Nullable(String)), DateTime64(6, 'UTC')),
     -- knowing something is mobile isn't enough, we need to know if e.g. RN or flutter
     snapshot_library AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
-    _timestamp SimpleAggregateFunction(max, DateTime)
+    _timestamp SimpleAggregateFunction(max, DateTime),
+    -- Block columns for v2 migration
+    block_first_timestamps SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
+    block_last_timestamps SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
+    block_urls SimpleAggregateFunction(groupArrayArray, Array(String)),
+    -- Secondary columns for v2 migration
+    min_first_timestamp_secondary SimpleAggregateFunction(min, DateTime64(6, 'UTC')),
+    max_last_timestamp_secondary SimpleAggregateFunction(max, DateTime64(6, 'UTC')),
+    first_url_secondary AggregateFunction(argMin, Nullable(VARCHAR), DateTime64(6, 'UTC')),
+    all_urls_secondary SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+    click_count_secondary SimpleAggregateFunction(sum, Int64),
+    keypress_count_secondary SimpleAggregateFunction(sum, Int64),
+    mouse_activity_count_secondary SimpleAggregateFunction(sum, Int64),
+    active_milliseconds_secondary SimpleAggregateFunction(sum, Int64),
+    console_log_count_secondary SimpleAggregateFunction(sum, Int64),
+    console_warn_count_secondary SimpleAggregateFunction(sum, Int64),
+    console_error_count_secondary SimpleAggregateFunction(sum, Int64),
+    size_secondary SimpleAggregateFunction(sum, Int64),
+    message_count_secondary SimpleAggregateFunction(sum, Int64),
+    event_count_secondary SimpleAggregateFunction(sum, Int64),
+    snapshot_source_secondary AggregateFunction(argMin, LowCardinality(Nullable(String)), DateTime64(6, 'UTC')),
+    snapshot_library_secondary AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))
 ) ENGINE = {engine}
 """
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We're migrating session recording events to a new schema. This is a zero-downtime migration executed in phases:

### Phase 1: Dual Write Setup
1. ✅ [BLOB V2] Write v2 metadata to `session_replay_events_v2_test`
2. 🦔 [BLOB V2] Write empty events to `session_replay_events` (blobby v1 overwrites metadata)
3. [ClickHouse] Add block columns to `session_replay_events`

### Phase 2: Read Migration
4. [Django] Switch to serving all sessions from `session_replay_events_v2_test`
5. [BLOB V1] Stop blobby v1
6. [Django] Keep using `session_replay_events` for session listing only (actual metadata/blocks served from `session_replay_events_v2_test`)
7. [Django] Update read queries to merge data from both `session_replay_events` and `session_replay_events_v2_test`

### Phase 3: Cleanup
8. [BLOB V2] Stop publishing empty events to `session_replay_events`
9. [BLOB V2] Switch publishing from `session_replay_events_v2_test` to `session_replay_events`
10. [Temporal] Backfill missing data from `session_replay_events_v2_test` to `session_replay_events`
11. [Django] Stop reading from `session_replay_events_v2_test`
12. [ClickHouse] Remove `session_replay_events_v2_test` tables and topics

Each phase will have its own PR and can be rolled back independently if needed.

> ✅ = Completed
> 🦔 = Current PR

## Changes

- Publishes empty records to `session_replay_events` to make sure the table has records for all sessions, even after switching off blobby v1.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Unit tests.