### PR TITLE
feat: add session replay events blocks columns 

### DIFF
--- a/posthog/clickhouse/migrations/0115_add_block_columns_to_session_replay_events.py
+++ b/posthog/clickhouse/migrations/0115_add_block_columns_to_session_replay_events.py
@@ -22,14 +22,12 @@ operations = [
     # 4. Writable table (for writing to sharded table)
     run_sql_with_exceptions(ADD_BLOCK_COLUMNS_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL()),
     # 5. Distributed table (for reading)
-    run_sql_with_exceptions(ADD_BLOCK_COLUMNS_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL()),
-    # 6. Also run on coordinator node without the cluster clause
     run_sql_with_exceptions(
-        ADD_BLOCK_COLUMNS_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL().replace("on CLUSTER '{cluster}'", ""),
-        node_role=NodeRole.COORDINATOR,
+        ADD_BLOCK_COLUMNS_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL(),
+        node_role=NodeRole.ALL,
     ),
-    # 7. Recreate the Kafka table with the updated schema
+    # 6. Recreate the Kafka table with the updated schema
     run_sql_with_exceptions(KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL()),
-    # 8. Recreate the materialized view with the updated schema
+    # 7. Recreate the materialized view with the updated schema
     run_sql_with_exceptions(SESSION_REPLAY_EVENTS_TABLE_MV_SQL()),
 ]

--- a/posthog/clickhouse/migrations/0115_add_block_columns_to_session_replay_events.py
+++ b/posthog/clickhouse/migrations/0115_add_block_columns_to_session_replay_events.py
@@ -1,0 +1,35 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions, NodeRole
+from posthog.session_recordings.sql.session_replay_event_migrations_sql import (
+    ADD_BLOCK_COLUMNS_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    ADD_BLOCK_COLUMNS_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    ADD_BLOCK_COLUMNS_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL,
+    DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL,
+)
+from posthog.session_recordings.sql.session_replay_event_sql import (
+    SESSION_REPLAY_EVENTS_TABLE_MV_SQL,
+    KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL,
+)
+
+# The Kafka table only has block_url String (not arrays). Block array columns are only in the aggregate tables.
+operations = [
+    # 1. Drop the old materialized view so it's no longer pulling from Kafka
+    run_sql_with_exceptions(DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL()),
+    # 2. Drop the Kafka table
+    run_sql_with_exceptions(DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    # 3. Sharded table (physical storage)
+    run_sql_with_exceptions(ADD_BLOCK_COLUMNS_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    # 4. Writable table (for writing to sharded table)
+    run_sql_with_exceptions(ADD_BLOCK_COLUMNS_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    # 5. Distributed table (for reading)
+    run_sql_with_exceptions(ADD_BLOCK_COLUMNS_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    # 6. Also run on coordinator node without the cluster clause
+    run_sql_with_exceptions(
+        ADD_BLOCK_COLUMNS_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL().replace("on CLUSTER '{cluster}'", ""),
+        node_role=NodeRole.COORDINATOR,
+    ),
+    # 7. Recreate the Kafka table with the updated schema
+    run_sql_with_exceptions(KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    # 8. Recreate the materialized view with the updated schema
+    run_sql_with_exceptions(SESSION_REPLAY_EVENTS_TABLE_MV_SQL()),
+]

--- a/posthog/clickhouse/migrations/0115_add_block_columns_to_session_replay_events.py
+++ b/posthog/clickhouse/migrations/0115_add_block_columns_to_session_replay_events.py
@@ -18,7 +18,7 @@ operations = [
     # 2. Drop the Kafka table
     run_sql_with_exceptions(DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL()),
     # 3. Sharded table (physical storage)
-    run_sql_with_exceptions(ADD_BLOCK_COLUMNS_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    run_sql_with_exceptions(ADD_BLOCK_COLUMNS_SESSION_REPLAY_EVENTS_TABLE_SQL(), sharded=True),
     # 4. Writable table (for writing to sharded table)
     run_sql_with_exceptions(ADD_BLOCK_COLUMNS_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL()),
     # 5. Distributed table (for reading)

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -469,6 +469,7 @@
       distinct_id VARCHAR,
       first_timestamp DateTime64(6, 'UTC'),
       last_timestamp DateTime64(6, 'UTC'),
+      block_url Nullable(String),
       first_url Nullable(VARCHAR),
       urls Array(String),
       click_count Int64,
@@ -1535,6 +1536,7 @@
       distinct_id VARCHAR,
       first_timestamp DateTime64(6, 'UTC'),
       last_timestamp DateTime64(6, 'UTC'),
+      block_url Nullable(String),
       first_url Nullable(VARCHAR),
       urls Array(String),
       click_count Int64,
@@ -2321,6 +2323,9 @@
   `session_id` String, `team_id` Int64, `distinct_id` String,
   `min_first_timestamp` DateTime64(6, 'UTC'),
   `max_last_timestamp` DateTime64(6, 'UTC'),
+  `block_first_timestamps` SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
+  `block_last_timestamps` SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
+  `block_urls` SimpleAggregateFunction(groupArrayArray, Array(String)),
   `first_url` AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
   `all_urls` SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
   `click_count` Int64, `keypress_count` Int64,
@@ -2338,6 +2343,9 @@
   any(distinct_id) as distinct_id,
   min(first_timestamp) AS min_first_timestamp,
   max(last_timestamp) AS max_last_timestamp,
+  groupArray(if(block_url != '', first_timestamp, NULL)) AS block_first_timestamps,
+  groupArray(if(block_url != '', last_timestamp, NULL)) AS block_last_timestamps,
+  groupArray(block_url) AS block_urls,
   -- TRICKY: ClickHouse will pick a relatively random first_url
   -- when it collapses the aggregating merge tree
   -- unless we teach it what we want...

--- a/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
@@ -156,3 +156,35 @@ ADD_LIBRARY_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_L
     table_name=SESSION_REPLAY_EVENTS_DATA_TABLE(),
     cluster=settings.CLICKHOUSE_CLUSTER,
 )
+
+# =========================
+# MIGRATION: Add block columns to support session recording v2 implementation
+# This migration adds block_url to the kafka table, and block_first_timestamps, block_last_timestamps, and block_urls
+# to the sharded, writable, and distributed session replay events tables.
+# The Kafka table only has block_url String (not arrays).
+# These columns are required for the v2 session recording implementation.
+# =========================
+
+# 1. Sharded table (physical storage)
+ALTER_SESSION_REPLAY_ADD_BLOCK_COLUMNS = """
+    ALTER TABLE {table_name} on CLUSTER '{cluster}'
+        ADD COLUMN IF NOT EXISTS block_first_timestamps SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
+        ADD COLUMN IF NOT EXISTS block_last_timestamps SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
+        ADD COLUMN IF NOT EXISTS block_urls SimpleAggregateFunction(groupArrayArray, Array(String))
+"""
+ADD_BLOCK_COLUMNS_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_BLOCK_COLUMNS.format(
+    table_name=SESSION_REPLAY_EVENTS_DATA_TABLE(),
+    cluster=settings.CLICKHOUSE_CLUSTER,
+)
+
+# 2. Writable table (for writing to sharded table)
+ADD_BLOCK_COLUMNS_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_BLOCK_COLUMNS.format(
+    table_name="writable_session_replay_events",
+    cluster=settings.CLICKHOUSE_CLUSTER,
+)
+
+# 3. Distributed table (for reading)
+ADD_BLOCK_COLUMNS_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_BLOCK_COLUMNS.format(
+    table_name="session_replay_events",
+    cluster=settings.CLICKHOUSE_CLUSTER,
+)

--- a/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
@@ -167,24 +167,21 @@ ADD_LIBRARY_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_L
 
 # 1. Sharded table (physical storage)
 ALTER_SESSION_REPLAY_ADD_BLOCK_COLUMNS = """
-    ALTER TABLE {table_name} on CLUSTER '{cluster}'
+    ALTER TABLE {table_name}
         ADD COLUMN IF NOT EXISTS block_first_timestamps SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
         ADD COLUMN IF NOT EXISTS block_last_timestamps SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
         ADD COLUMN IF NOT EXISTS block_urls SimpleAggregateFunction(groupArrayArray, Array(String))
 """
 ADD_BLOCK_COLUMNS_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_BLOCK_COLUMNS.format(
     table_name=SESSION_REPLAY_EVENTS_DATA_TABLE(),
-    cluster=settings.CLICKHOUSE_CLUSTER,
 )
 
 # 2. Writable table (for writing to sharded table)
 ADD_BLOCK_COLUMNS_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_BLOCK_COLUMNS.format(
     table_name="writable_session_replay_events",
-    cluster=settings.CLICKHOUSE_CLUSTER,
 )
 
 # 3. Distributed table (for reading)
 ADD_BLOCK_COLUMNS_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_BLOCK_COLUMNS.format(
     table_name="session_replay_events",
-    cluster=settings.CLICKHOUSE_CLUSTER,
 )

--- a/posthog/session_recordings/sql/session_replay_event_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_sql.py
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     distinct_id VARCHAR,
     first_timestamp DateTime64(6, 'UTC'),
     last_timestamp DateTime64(6, 'UTC'),
+    block_url Nullable(String),
     first_url Nullable(VARCHAR),
     urls Array(String),
     click_count Int64,
@@ -136,6 +137,9 @@ team_id,
 any(distinct_id) as distinct_id,
 min(first_timestamp) AS min_first_timestamp,
 max(last_timestamp) AS max_last_timestamp,
+groupArray(first_timestamp) AS block_first_timestamps,
+groupArray(last_timestamp) AS block_last_timestamps,
+groupArray(block_url) AS block_urls,
 -- TRICKY: ClickHouse will pick a relatively random first_url
 -- when it collapses the aggregating merge tree
 -- unless we teach it what we want...
@@ -174,6 +178,9 @@ group by session_id, team_id
 `session_id` String, `team_id` Int64, `distinct_id` String,
 `min_first_timestamp` DateTime64(6, 'UTC'),
 `max_last_timestamp` DateTime64(6, 'UTC'),
+`block_first_timestamps` SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
+`block_last_timestamps` SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
+`block_urls` SimpleAggregateFunction(groupArrayArray, Array(String)),
 `first_url` AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
 `all_urls` SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
 `click_count` Int64, `keypress_count` Int64,

--- a/posthog/session_recordings/sql/session_replay_event_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_sql.py
@@ -137,8 +137,8 @@ team_id,
 any(distinct_id) as distinct_id,
 min(first_timestamp) AS min_first_timestamp,
 max(last_timestamp) AS max_last_timestamp,
-groupArray(first_timestamp) AS block_first_timestamps,
-groupArray(last_timestamp) AS block_last_timestamps,
+groupArray(if(block_url != '', first_timestamp, NULL)) AS block_first_timestamps,
+groupArray(if(block_url != '', last_timestamp, NULL)) AS block_last_timestamps,
 groupArray(block_url) AS block_urls,
 -- TRICKY: ClickHouse will pick a relatively random first_url
 -- when it collapses the aggregating merge tree


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We're switching over to Blobby V2 and in the first phase of the switchover we want to start writing V2 metadata to secondary `session_replay_events` columns.

## Changes

- Adds `block_urls`, `block_first_timestamps`, and `block_last_timestamps` columns to `session_replay_events`
- Adds secondary copies of the metadata columns to facilitate the migration
- Stores empty arrays for block fields by default

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Tested locally.