### PR TITLE
chore: change page reports label to beta

### DIFF
--- a/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
@@ -398,8 +398,8 @@ const pageReportsTab = (featureFlags: FeatureFlagsSet): { key: ProductTab; label
             label: (
                 <div className="flex items-center gap-1">
                     Page reports
-                    <LemonTag type="completion" className="uppercase">
-                        Alpha
+                    <LemonTag type="warning" className="uppercase">
+                        Beta
                     </LemonTag>
                 </div>
             ),


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

I think it is still valid to keep it with the beta indicator, just to give the idea that this is a work in progress while I work on other stuff. Hopefully, releasing it to everyone will provide us with more feedback upon which to act.

## Changes

<img width="398" alt="image" src="https://github.com/user-attachments/assets/c40726a2-440c-4328-b934-5c74db38ef4f" />

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manually.