### PR TITLE
feat(project-tree): "new" menu with icons

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -203,7 +203,6 @@ export function ProjectTree(): JSX.Element {
                                             <MenuSub key={treeItem.id}>
                                                 <MenuSubTrigger asChild inset>
                                                     <ButtonPrimitive menuItem>
-                                                        {treeItem.icon}
                                                         {treeItem.name ||
                                                             treeItem.id.charAt(0).toUpperCase() + treeItem.id.slice(1)}
                                                         ...

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -1,4 +1,4 @@
-import { IconChevronRight, IconFolderPlus } from '@posthog/icons'
+import { IconChevronRight, IconFolder, IconFolderPlus } from '@posthog/icons'
 import { useActions, useValues } from 'kea'
 import { MoveFilesModal } from 'lib/components/FileSystem/MoveFilesModal'
 import { FlaggedFeature } from 'lib/components/FlaggedFeature'
@@ -191,15 +191,19 @@ export function ProjectTree(): JSX.Element {
                                         createFolder(item.record?.path)
                                     }}
                                 >
-                                    <ButtonPrimitive menuItem>Folder</ButtonPrimitive>
+                                    <ButtonPrimitive menuItem>
+                                        <IconFolder />
+                                        Folder
+                                    </ButtonPrimitive>
                                 </MenuItem>
                                 <MenuSeparator />
                                 {treeItemsNew.map((treeItem): JSX.Element => {
                                     if (treeItem.children) {
                                         return (
                                             <MenuSub key={treeItem.id}>
-                                                <MenuSubTrigger asChild>
+                                                <MenuSubTrigger asChild inset>
                                                     <ButtonPrimitive menuItem>
+                                                        {treeItem.icon}
                                                         {treeItem.name ||
                                                             treeItem.id.charAt(0).toUpperCase() + treeItem.id.slice(1)}
                                                         ...
@@ -221,6 +225,7 @@ export function ProjectTree(): JSX.Element {
                                                             }}
                                                         >
                                                             <ButtonPrimitive menuItem className="capitalize">
+                                                                {child.icon}
                                                                 {child.name}
                                                             </ButtonPrimitive>
                                                         </MenuItem>
@@ -242,7 +247,10 @@ export function ProjectTree(): JSX.Element {
                                                 treeItem.onClick?.()
                                             }}
                                         >
-                                            <ButtonPrimitive menuItem>{treeItem.name}</ButtonPrimitive>
+                                            <ButtonPrimitive menuItem>
+                                                {treeItem.icon}
+                                                {treeItem.name}
+                                            </ButtonPrimitive>
                                         </MenuItem>
                                     )
                                 })}

--- a/frontend/src/lib/ui/ContextMenu/ContextMenu.tsx
+++ b/frontend/src/lib/ui/ContextMenu/ContextMenu.tsx
@@ -25,7 +25,7 @@ const ContextMenuSubTrigger = React.forwardRef<
     }
 >(
     ({ className, inset, ...props }, ref): JSX.Element => (
-        <ContextMenuPrimitive.SubTrigger ref={ref} className={cn(inset && 'pl-8', className)} {...props} />
+        <ContextMenuPrimitive.SubTrigger ref={ref} className={cn(inset && 'pl-7', className)} {...props} />
     )
 )
 ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName
@@ -77,7 +77,7 @@ const ContextMenuItem = React.forwardRef<
     }
 >(
     ({ className, inset, ...props }, ref): JSX.Element => (
-        <ContextMenuPrimitive.Item ref={ref} className={cn(inset && 'pl-8', className)} {...props} />
+        <ContextMenuPrimitive.Item ref={ref} className={cn(inset && 'pl-7', className)} {...props} />
     )
 )
 ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName
@@ -140,7 +140,7 @@ const ContextMenuLabel = React.forwardRef<
     ({ className, inset, ...props }, ref): JSX.Element => (
         <ContextMenuPrimitive.Label
             ref={ref}
-            className={cn('px-2 py-1.5 text-sm font-semibold text-foreground', inset && 'pl-8', className)}
+            className={cn('px-2 py-1.5 text-sm font-semibold text-foreground', inset && 'pl-7', className)}
             {...props}
         />
     )

--- a/frontend/src/lib/ui/DropdownMenu/DropdownMenu.tsx
+++ b/frontend/src/lib/ui/DropdownMenu/DropdownMenu.tsx
@@ -49,7 +49,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
         inset?: boolean
     }
 >(({ className, inset, ...props }, ref): JSX.Element => {
-    return <DropdownMenuPrimitive.SubTrigger ref={ref} className={cn(inset && 'pl-8', className)} {...props} />
+    return <DropdownMenuPrimitive.SubTrigger ref={ref} className={cn(inset && 'pl-7', className)} {...props} />
 })
 DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName
 
@@ -125,7 +125,7 @@ const DropdownMenuItem = React.forwardRef<
         inset?: boolean
     }
 >(({ className, inset, ...props }, ref): JSX.Element => {
-    return <DropdownMenuPrimitive.Item ref={ref} className={cn(inset && 'pl-8', className)} {...props} />
+    return <DropdownMenuPrimitive.Item ref={ref} className={cn(inset && 'pl-7', className)} {...props} />
 })
 DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
 
@@ -171,7 +171,7 @@ const DropdownMenuLabel = React.forwardRef<
     }
 >(
     ({ className, inset, children, ...props }, ref): JSX.Element => (
-        <DropdownMenuPrimitive.Label ref={ref} className={cn('px-2', inset && 'pl-8', className)} asChild {...props}>
+        <DropdownMenuPrimitive.Label ref={ref} className={cn('px-2', inset && 'pl-7', className)} asChild {...props}>
             <Label intent="menu">{children}</Label>
         </DropdownMenuPrimitive.Label>
     )


### PR DESCRIPTION
## Problem
People like icons for visual queues

![2025-04-30 22 37 08](https://github.com/user-attachments/assets/f4a89ab5-ea38-4bad-8a7c-13c79f6c2a74)

## Changes
* Add icons to new menu
* Fix context/dropdown menu inset padding

## How did you test this code?
Clicking, made new project works fine.