### PR TITLE
fix(project-tree): save to fixes

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -114,7 +114,7 @@ type LemonTreeBaseProps = Omit<HTMLAttributes<HTMLDivElement>, 'onDragEnd'> & {
     /** Whether the item can accept drops */
     isItemDroppable?: (item: TreeDataItem) => boolean
     /** The side action to render for the item. */
-    itemSideAction?: (item: TreeDataItem) => SideAction | undefined
+    itemSideAction?: (item: TreeDataItem) => React.ReactNode | undefined
     /** The context menu to render for the item. */
     itemContextMenu?: (item: TreeDataItem) => React.ReactNode
     /** Whether the item is loading */


### PR DESCRIPTION
## Problem

Creating a new folder in the "save to" dialog would open the folder in the project tree in the background for editing.

## Changes

- Save to -> new folder -> opens rename automatically. 
   - It's a bit of a hack and doesn't work in all cases, but will get us thorough the next days.
- Add the "project root" option to the folder select
- Make it actually work in the backend
- Also add the "Rename" option in the save to dialog

![2025-05-01 00 35 13](https://github.com/user-attachments/assets/4ee4a2f4-a08d-40bd-9b5f-4aee7c7fe354)

## How did you test this code?

Clicked in the UI