### PR TITLE
fix: metric. can be saved with no series

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
@@ -116,6 +116,7 @@ export function ExperimentMetricForm({
                         buttonCopy="Add step"
                         showSeriesIndicator={false}
                         hideRename={true}
+                        hideDeleteBtn={(_, index) => index === 0}
                         sortable={true}
                         showNestedArrow={true}
                         // showNumericalPropsOnly={true}

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
@@ -75,7 +75,7 @@ export interface ActionFilterProps {
     propertiesTaxonomicGroupTypes?: TaxonomicFilterGroupType[]
     /** Whether properties shown should be limited to just numerical types */
     showNumericalPropsOnly?: boolean
-    hideDeleteBtn?: boolean
+    hideDeleteBtn?: boolean | ((filter: LocalFilter, index: number) => boolean)
     readOnly?: boolean
     renderRow?: ({
         seriesIndicator,
@@ -178,7 +178,6 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
         actionsTaxonomicGroupTypes,
         propertiesTaxonomicGroupTypes,
         propertyFiltersPopover,
-        hideDeleteBtn,
         disabled,
         readOnly,
         renderRow,
@@ -237,6 +236,11 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
                                     showNestedArrow={showNestedArrow}
                                     singleFilter={singleFilter}
                                     hideFilter={hideFilter || readOnly}
+                                    hideDeleteBtn={
+                                        typeof hideDeleteBtn === 'function'
+                                            ? hideDeleteBtn(filter, index)
+                                            : hideDeleteBtn
+                                    }
                                     {...commonProps}
                                 />
                             ))}


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

The `ExperimentMetricForm` (used when creating primary, secondary, and shared metrics) does not have validations for empty series. Instead of adding am extra validation on the form, we disable the _delete_ button on the first element of the series.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We've modified the `hideDeleteBtn` prop of the `ActionFilter` component to accept either `bool` or a function that returns `bool`. That callback function takes a `filter` and `index` parameter. Although we only use `index`, including the `filter`, future-proof this callback.
This change is safe because `hideDeleteBtn` defaults to `false` if not provided at all.

An alternative we've evaluated was to use the `renderRow` _render prop_. But it was a bit overkill for our use case. With `renderRow`, we have to provide the whole layout of the filter row.	

| Before | After |
| - | - |
| <img width="800" alt="image" src="https://github.com/user-attachments/assets/412f0858-5c36-453e-9f59-c11cb388bbee" /> | <img width="800" alt="image" src="https://github.com/user-attachments/assets/b9fcc57f-3c78-4c22-841d-308dc1b5a22f" /> |


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
