### PR TITLE
fix(max): capture details for insights and handle switching entities

### DIFF
--- a/ee/hogai/eval/eval_root.py
+++ b/ee/hogai/eval/eval_root.py
@@ -125,7 +125,7 @@ def eval_root(call_node):
                         tool_call_id="call_XdLOyLrHbjoBBACDCZd8WyNS",
                         content=json.dumps(
                             {
-                                "query_kind": "trends",
+                                "query_kind": "sql",
                                 "query_description": 'You\'ll be given a JSON object with the results of a query.\n\nHere is the generated ClickHouse SQL query used to retrieve the results:\n\n```\nSELECT DISTINCT person.properties.name AS user_name\nFROM events\nWHERE event = \'$pageview\'\n  AND toYear(timestamp) = toYear(now())\n```\n\nYou\'ll be given a JSON object with the results of a query.\n\nHere is the results table of the HogQLQuery I created to answer your latest question:\n\n```\n[[null],["Mario Bridges"],["Alexander Dickson"],["YCombinator"],["Andrea Dickson"]]\n```\n\nThe current date and time is 2025-05-01 10:12:06 UTC, which is 2025-05-01 10:12:06 in this project\'s timezone (UTC).\nIt\'s expected that the data point for the current period can have a drop in value, as data collection is still ongoing for it. Do not point this out.',
                             }
                         ),
@@ -133,7 +133,7 @@ def eval_root(call_node):
                     AssistantMessage(
                         content="Here's the list of user names who have completed a page view Year-To-Date (YTD):\n\n- Mario Bridges\n- Alexander Dickson\n- YCombinator\n- Andrea Dickson\n\nThat's quite a crowd! If you need anything else, just let me know!"
                     ),
-                    HumanMessage(content="give me a list of the companies only"),
+                    HumanMessage(content="give me a list of the companies only associated with the users"),
                 ],
                 expected=AssistantToolCall(
                     id="2",
@@ -165,7 +165,7 @@ def eval_root(call_node):
                         tool_call_id="call_XdLOyLrHbjoBBACDCZd8WyNS",
                         content=json.dumps(
                             {
-                                "query_kind": "trends",
+                                "query_kind": "sql",
                                 "query_description": 'You\'ll be given a JSON object with the results of a query.\n\nHere is the generated ClickHouse SQL query used to retrieve the results:\n\n```\nSELECT DISTINCT person.properties.name AS user_name\nFROM events\nWHERE event = \'$pageview\'\n  AND toYear(timestamp) = toYear(now())\n```\n\nYou\'ll be given a JSON object with the results of a query.\n\nHere is the results table of the HogQLQuery I created to answer your latest question:\n\n```\n[[null],["Mario Bridges"],["Alexander Dickson"],["YCombinator"],["Andrea Dickson"]]\n```\n\nThe current date and time is 2025-05-01 10:12:06 UTC, which is 2025-05-01 10:12:06 in this project\'s timezone (UTC).\nIt\'s expected that the data point for the current period can have a drop in value, as data collection is still ongoing for it. Do not point this out.',
                             }
                         ),

--- a/ee/hogai/eval/eval_root.py
+++ b/ee/hogai/eval/eval_root.py
@@ -45,6 +45,8 @@ def call_node(demo_org_team_user):
 def eval_root(call_node):
     MaxEval(
         experiment_name="root",
+        task=call_node,
+        scores=[ToolRelevance(semantic_similarity_args={"query_description"})],
         data=[
             EvalCase(
                 input="Create an SQL insight to calculate active users recently",
@@ -62,7 +64,7 @@ def eval_root(call_node):
                     args={"query_kind": "sql", "query_description": "Calculate the number of active users recently"},
                 ),
             ),
-            # Should propagate the dates from the previous messages
+            # Should propagate the dates from the previous insight request
             EvalCase(
                 input=[
                     HumanMessage(content="what is the trend of pageviews ytd 2025"),
@@ -102,7 +104,78 @@ def eval_root(call_node):
                     },
                 ),
             ),
+            # When the company name appears in the query results, it should NOT confuse the agent and it should still generate a new insight
+            EvalCase(
+                input=[
+                    HumanMessage(content="List all user names who have completed a page view YTD"),
+                    AssistantMessage(
+                        content="",
+                        tool_calls=[
+                            AssistantToolCall(
+                                id="call_XdLOyLrHbjoBBACDCZd8WyNS",
+                                name="create_and_query_insight",
+                                args={
+                                    "query_kind": "sql",
+                                    "query_description": "List all user names who have completed a page view Year-To-Date (YTD).",
+                                },
+                            )
+                        ],
+                    ),
+                    AssistantToolCallMessage(
+                        tool_call_id="call_XdLOyLrHbjoBBACDCZd8WyNS",
+                        content=json.dumps(
+                            {
+                                "query_kind": "trends",
+                                "query_description": 'You\'ll be given a JSON object with the results of a query.\n\nHere is the generated ClickHouse SQL query used to retrieve the results:\n\n```\nSELECT DISTINCT person.properties.name AS user_name\nFROM events\nWHERE event = \'$pageview\'\n  AND toYear(timestamp) = toYear(now())\n```\n\nYou\'ll be given a JSON object with the results of a query.\n\nHere is the results table of the HogQLQuery I created to answer your latest question:\n\n```\n[[null],["Mario Bridges"],["Alexander Dickson"],["YCombinator"],["Andrea Dickson"]]\n```\n\nThe current date and time is 2025-05-01 10:12:06 UTC, which is 2025-05-01 10:12:06 in this project\'s timezone (UTC).\nIt\'s expected that the data point for the current period can have a drop in value, as data collection is still ongoing for it. Do not point this out.',
+                            }
+                        ),
+                    ),
+                    AssistantMessage(
+                        content="Here's the list of user names who have completed a page view Year-To-Date (YTD):\n\n- Mario Bridges\n- Alexander Dickson\n- YCombinator\n- Andrea Dickson\n\nThat's quite a crowd! If you need anything else, just let me know!"
+                    ),
+                    HumanMessage(content="give me a list of the companies only"),
+                ],
+                expected=AssistantToolCall(
+                    id="2",
+                    name="create_and_query_insight",
+                    args={
+                        "query_kind": "sql",
+                        "query_description": "List all companies who have completed a page view Year-To-Date (YTD).",
+                    },
+                ),
+            ),
+            # Must reuse the previous data
+            EvalCase(
+                input=[
+                    HumanMessage(content="List all user names who have completed a page view YTD"),
+                    AssistantMessage(
+                        content="",
+                        tool_calls=[
+                            AssistantToolCall(
+                                id="call_XdLOyLrHbjoBBACDCZd8WyNS",
+                                name="create_and_query_insight",
+                                args={
+                                    "query_kind": "sql",
+                                    "query_description": "List all user names who have completed a page view Year-To-Date (YTD).",
+                                },
+                            )
+                        ],
+                    ),
+                    AssistantToolCallMessage(
+                        tool_call_id="call_XdLOyLrHbjoBBACDCZd8WyNS",
+                        content=json.dumps(
+                            {
+                                "query_kind": "trends",
+                                "query_description": 'You\'ll be given a JSON object with the results of a query.\n\nHere is the generated ClickHouse SQL query used to retrieve the results:\n\n```\nSELECT DISTINCT person.properties.name AS user_name\nFROM events\nWHERE event = \'$pageview\'\n  AND toYear(timestamp) = toYear(now())\n```\n\nYou\'ll be given a JSON object with the results of a query.\n\nHere is the results table of the HogQLQuery I created to answer your latest question:\n\n```\n[[null],["Mario Bridges"],["Alexander Dickson"],["YCombinator"],["Andrea Dickson"]]\n```\n\nThe current date and time is 2025-05-01 10:12:06 UTC, which is 2025-05-01 10:12:06 in this project\'s timezone (UTC).\nIt\'s expected that the data point for the current period can have a drop in value, as data collection is still ongoing for it. Do not point this out.',
+                            }
+                        ),
+                    ),
+                    AssistantMessage(
+                        content="Here's the list of user names who have completed a page view Year-To-Date (YTD):\n\n- Mario Bridges\n- Alexander Dickson\n- YCombinator\n- Andrea Dickson\n\nThat's quite a crowd! If you need anything else, just let me know!"
+                    ),
+                    HumanMessage(content="List all user names who have completed a page view YTD"),
+                ],
+                expected=None,
+            ),
         ],
-        task=call_node,
-        scores=[ToolRelevance(semantic_similarity_args={"query_description"})],
     )

--- a/ee/hogai/eval/eval_root.py
+++ b/ee/hogai/eval/eval_root.py
@@ -1,11 +1,15 @@
+import json
+
 import pytest
 from braintrust import EvalCase
+
+from ee.hogai.graph import AssistantGraph
+from ee.hogai.utils.types import AssistantMessageUnion, AssistantNodeName, AssistantState
+from ee.models.assistant import Conversation
+from posthog.schema import AssistantMessage, AssistantToolCall, AssistantToolCallMessage, HumanMessage
+
 from .conftest import MaxEval
 from .scorers import ToolRelevance
-from ee.hogai.utils.types import AssistantState, AssistantNodeName
-from ee.hogai.graph import AssistantGraph
-from ee.models.assistant import Conversation
-from posthog.schema import HumanMessage, AssistantMessage, AssistantToolCall
 
 
 @pytest.fixture
@@ -24,11 +28,12 @@ def call_node(demo_org_team_user):
         .compile()
     )
 
-    def callable(message: str) -> AssistantMessage:
+    def callable(messages: str | list[AssistantMessageUnion]) -> AssistantMessage:
         conversation = Conversation.objects.create(team=demo_org_team_user[1], user=demo_org_team_user[2])
-        raw_state = graph.invoke(
-            AssistantState(messages=[HumanMessage(content=message)]), {"configurable": {"thread_id": conversation.id}}
+        initial_state = AssistantState(
+            messages=[HumanMessage(content=messages)] if isinstance(messages, str) else messages
         )
+        raw_state = graph.invoke(initial_state, {"configurable": {"thread_id": conversation.id}})
         state = AssistantState.model_validate(raw_state)
         assert isinstance(state.messages[-1], AssistantMessage)
         return state.messages[-1]
@@ -55,6 +60,46 @@ def eval_root(call_node):
                     id="2",
                     name="create_and_query_insight",
                     args={"query_kind": "sql", "query_description": "Calculate the number of active users recently"},
+                ),
+            ),
+            # Should propagate the dates from the previous messages
+            EvalCase(
+                input=[
+                    HumanMessage(content="what is the trend of pageviews ytd 2025"),
+                    AssistantMessage(
+                        content="",
+                        tool_calls=[
+                            AssistantToolCall(
+                                id="call_vaTlpWMBgGyvYVIMfj1ecW8F",
+                                name="create_and_query_insight",
+                                args={
+                                    "query_kind": "trends",
+                                    "query_description": "Trend of pageviews year-to-date 2025",
+                                },
+                            )
+                        ],
+                    ),
+                    AssistantToolCallMessage(
+                        tool_call_id="call_vaTlpWMBgGyvYVIMfj1ecW8F",
+                        content=json.dumps(
+                            {
+                                "query_kind": "trends",
+                                "query_description": "Here is the results table of the TrendsQuery I created to answer your latest question: ``` Date|$pageview 2025-01-01|6982 2025-02-01|9953 2025-03-01|7507 2025-04-01|795 2025-05-01|3 ``` The current date and time is 2025-05-01 09:07:56 UTC, which is 2025-05-01 09:07:56 in this project's timezone (UTC). It's expected that the data point for the current period can have a drop in value, as data collection is still ongoing for it. Do not point this out.",
+                            }
+                        ),
+                    ),
+                    AssistantMessage(
+                        content="Here's the trend of pageviews for the year-to-date 2025: - January: 6,982 pageviews - February: 9,953 pageviews - March: 7,507 pageviews - April: 795 pageviews - May (so far): 3 pageviews Looks like February was a busy month! If you have any more questions or need further insights, just let me know!"
+                    ),
+                    HumanMessage(content="list the users"),
+                ],
+                expected=AssistantToolCall(
+                    id="2",
+                    name="create_and_query_insight",
+                    args={
+                        "query_kind": "sql",
+                        "query_description": "List all users who have completed a page view in year-to-date 2025.",
+                    },
                 ),
             ),
         ],

--- a/ee/hogai/graph/query_executor/nodes.py
+++ b/ee/hogai/graph/query_executor/nodes.py
@@ -8,23 +8,6 @@ from django.core.serializers.json import DjangoJSONEncoder
 from langchain_core.runnables import RunnableConfig
 from rest_framework.exceptions import APIException
 
-from .format import (
-    FunnelResultsFormatter,
-    RetentionResultsFormatter,
-    SQLResultsFormatter,
-    TrendsResultsFormatter,
-)
-from .prompts import (
-    FALLBACK_EXAMPLE_PROMPT,
-    FUNNEL_STEPS_EXAMPLE_PROMPT,
-    FUNNEL_TIME_TO_CONVERT_EXAMPLE_PROMPT,
-    FUNNEL_TRENDS_EXAMPLE_PROMPT,
-    QUERY_RESULTS_PROMPT,
-    RETENTION_EXAMPLE_PROMPT,
-    TRENDS_EXAMPLE_PROMPT,
-    SQL_EXAMPLE_PROMPT,
-)
-from ..base import AssistantNode
 from ee.hogai.utils.types import AssistantNodeName, AssistantState, PartialAssistantState
 from posthog.api.services.query import process_query_dict
 from posthog.clickhouse.client.execute_async import get_query_status
@@ -41,6 +24,25 @@ from posthog.schema import (
     FailureMessage,
     FunnelVizType,
     VisualizationMessage,
+)
+
+from ..base import AssistantNode
+from .format import (
+    FunnelResultsFormatter,
+    RetentionResultsFormatter,
+    SQLResultsFormatter,
+    TrendsResultsFormatter,
+)
+from .prompts import (
+    FALLBACK_EXAMPLE_PROMPT,
+    FUNNEL_STEPS_EXAMPLE_PROMPT,
+    FUNNEL_TIME_TO_CONVERT_EXAMPLE_PROMPT,
+    FUNNEL_TRENDS_EXAMPLE_PROMPT,
+    QUERY_RESULTS_PROMPT,
+    RETENTION_EXAMPLE_PROMPT,
+    SQL_EXAMPLE_PROMPT,
+    SQL_QUERY_PROMPT,
+    TRENDS_EXAMPLE_PROMPT,
 )
 
 
@@ -120,14 +122,17 @@ class QueryExecutorNode(AssistantNode):
             results = json.dumps(results_response["results"], cls=DjangoJSONEncoder, separators=(",", ":"))
             example_prompt = FALLBACK_EXAMPLE_PROMPT
 
-        formatted_query_result = QUERY_RESULTS_PROMPT.format(
-            example=example_prompt,
+        query_result = QUERY_RESULTS_PROMPT.format(
             query_kind=viz_message.answer.kind,
             results=results,
             utc_datetime_display=self.utc_now,
             project_datetime_display=self.project_now,
             project_timezone=self.project_timezone,
         )
+
+        formatted_query_result = f"{example_prompt}\n\n{query_result}"
+        if isinstance(viz_message.answer, AssistantHogQLQuery):
+            formatted_query_result = f"{example_prompt}\n\n{SQL_QUERY_PROMPT.format(query=viz_message.answer.query)}\n\n{formatted_query_result}"
 
         return PartialAssistantState(
             messages=[

--- a/ee/hogai/graph/query_executor/prompts.py
+++ b/ee/hogai/graph/query_executor/prompts.py
@@ -21,7 +21,7 @@ Date|$pageview|sign up
 """.strip()
 
 SQL_QUERY_PROMPT = """
-Here is the generated ClickHouse SQL query used to retrieve the results:
+Here is the generated HogQL (a PostHog's subset of ClickHouse SQL) query used to retrieve the results:
 
 ```
 {query}

--- a/ee/hogai/graph/query_executor/prompts.py
+++ b/ee/hogai/graph/query_executor/prompts.py
@@ -1,6 +1,4 @@
 QUERY_RESULTS_PROMPT = """
-{example}
-
 Here is the results table of the {query_kind} I created to answer your latest question:
 
 ```
@@ -22,6 +20,13 @@ Date|$pageview|sign up
 ```
 """.strip()
 
+SQL_QUERY_PROMPT = """
+Here is the generated ClickHouse SQL query used to retrieve the results:
+
+```
+{query}
+```
+""".strip()
 
 FUNNEL_STEPS_EXAMPLE_PROMPT = """
 You are given a table with the results of a funnel query. Values are separated by the pipe character "|" and rows are separated by newlines. The first column is the metric name, and the rest are the values for each metric. The first row is the header row with series names received from the query. Rows can be separated by a line with "---", indicating a series with a breakdown. For example, `---control` indicates that the series is for the value `control`.

--- a/ee/hogai/graph/root/nodes.py
+++ b/ee/hogai/graph/root/nodes.py
@@ -1,5 +1,7 @@
 import datetime
+import importlib
 import math
+import pkgutil
 from typing import Literal, TypeVar, cast
 from uuid import uuid4
 
@@ -15,25 +17,24 @@ from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnableConfig
 from langchain_openai import ChatOpenAI
 from pydantic import BaseModel
-from ee.hogai.tool import CONTEXTUAL_TOOL_NAME_TO_TOOL, create_and_query_insight, search_documentation
 
-from .prompts import (
-    ROOT_HARD_LIMIT_REACHED_PROMPT,
-    ROOT_SYSTEM_PROMPT,
-)
-from ..base import AssistantNode
+import products
+from ee.hogai.tool import CONTEXTUAL_TOOL_NAME_TO_TOOL, create_and_query_insight, search_documentation
 from ee.hogai.utils.types import AssistantState, PartialAssistantState
 from posthog.schema import (
     AssistantContextualTool,
     AssistantMessage,
     AssistantToolCall,
     AssistantToolCallMessage,
-    HumanMessage,
     FailureMessage,
+    HumanMessage,
 )
-import importlib
-import pkgutil
-import products
+
+from ..base import AssistantNode
+from .prompts import (
+    ROOT_HARD_LIMIT_REACHED_PROMPT,
+    ROOT_SYSTEM_PROMPT,
+)
 
 # TRICKY: Dynamically import max_tools from all products
 for module_info in pkgutil.iter_modules(products.__path__):

--- a/ee/hogai/graph/root/prompts.py
+++ b/ee/hogai/graph/root/prompts.py
@@ -58,8 +58,7 @@ If the user asks for multiple insights, you need to decompose a query into multi
 `create_and_query_insight` does let you write SQL.
 
 Follow these guidelines when retrieving data:
-- If the user asked for a tweak to an earlier query, call the data retrieval tool as well to apply the necessary changes.
-- If the same insight is already in the conversation history, reuse the retrieved data.
+- If the same insight is already in the conversation history, reuse the retrieved data only when this does not violate the <data_analysis_guidelines> section (i.e. only when a presence-check, count, or sort on existing columns is enough).
 - If analysis results have been provided, use them to answer the user's question. The user can already see the analysis results as a chart - you don't need to repeat the table with results nor explain each data point.
 - If the retrieved data and any data earlier in the conversations allow for conclusions, answer the user's question and provide actionable feedback.
 - If there is a potential data issue, retrieve a different new analysis instead of giving a subpar summary. Note: empty data is NOT a potential data issue.
@@ -69,6 +68,12 @@ IMPORTANT: Avoid generic advice. Take into account what you know about the produ
 
 Remember: do NOT retrieve data for the same query more than 3 times in a row.
 </data_retrieval>
+
+<data_analysis_guidelines>
+Understand the user's query and reuse the existing data only when the answer is a **straightforward** presence-check, count, or sort **that requires no new columns and no semantic classification**. Otherwise, retrieve new data.
+Examples:
+- The user first asked about users and then made a similar request about companies. You cannot reuse the existing data because it contains users, not companies, even if the data contains company names.
+</data_analysis_guidelines>
 
 <posthog_documentation>
 The tool `search_documentation` helps you answer questions about PostHog features, concepts, and usage by searching through the official documentation.

--- a/ee/hogai/tool.py
+++ b/ee/hogai/tool.py
@@ -1,11 +1,13 @@
-from abc import abstractmethod
 import json
-from typing import Literal, Any
+from abc import abstractmethod
+from typing import Any, Literal
+
+from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel, Field
+
 from ee.hogai.graph.root.prompts import ROOT_INSIGHT_DESCRIPTION_PROMPT
 from posthog.schema import AssistantContextualTool
-from langchain_core.runnables import RunnableConfig
 
 MaxSupportedQueryKind = Literal["trends", "funnel", "retention", "sql"]
 
@@ -20,7 +22,9 @@ class create_and_query_insight(BaseModel):
     This tool is also relevant if the user asks to write SQL.
     """
 
-    query_description: str = Field(description="The description of the query being asked.")
+    query_description: str = Field(
+        description="The description of the query being asked. Include all relevant details from the current conversation in the query description, as the tool cannot access the conversation history."
+    )
     query_kind: MaxSupportedQueryKind = Field(description=ROOT_INSIGHT_DESCRIPTION_PROMPT)
 
 


### PR DESCRIPTION
## Problem

Fixes for the feedback: https://posthog.slack.com/archives/C06NZEZ7V3Q/p1746018107522049.

Two problems identified:
- The insight tool captured minimal relevant details from the conversation. Since the taxonomy planner doesn't have access to the whole conversation history, we must capture more details in the insight plan generated by the root node.
- The root node doesn't understand the shape of the SQL query. Furthermore, it doesn't understand what tables or fields were used to retrieve the data, so the further refinement is clunky. It happens frequently when you analyze data with a similar domain, such as names. If you initially asked the agent to return user names and a company name was retrieved, the refinement prompt to show companies associated with those users would output a single company name. Instead, It must create a fresh insight.

## Changes

- Prompt tweaks.
- Output SQL to the tool node result.

## Does this work well for both Cloud and self-hosted?

No

## How did you test this code?

Evals
