### PR TITLE
feat(project-tree): tree table mode with column resizing

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -2,9 +2,11 @@ import { IconChevronRight, IconFolderPlus } from '@posthog/icons'
 import { useActions, useValues } from 'kea'
 import { MoveFilesModal } from 'lib/components/FileSystem/MoveFilesModal'
 import { FlaggedFeature } from 'lib/components/FlaggedFeature'
+import { ResizableDiv } from 'lib/components/ResizeElement/ResizeElement'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonTag } from 'lib/lemon-ui/LemonTag'
 import { LemonTree, LemonTreeRef, TreeDataItem, TreeMode } from 'lib/lemon-ui/LemonTree/LemonTree'
+import { Tooltip } from 'lib/lemon-ui/Tooltip/Tooltip'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import {
     ContextMenuGroup,
@@ -50,6 +52,8 @@ export function ProjectTree(): JSX.Element {
         editingItemId,
         checkedItemsArray,
         movingItems,
+        treeTableColumnSizes,
+        treeTableTotalWidth,
     } = useValues(projectTreeLogic)
 
     const {
@@ -71,6 +75,7 @@ export function ProjectTree(): JSX.Element {
         clearScrollTarget,
         setEditingItemId,
         setMovingItems,
+        setTreeTableColumnSizes,
     } = useActions(projectTreeLogic)
 
     const { showLayoutPanel, setPanelTreeRef, clearActivePanelIdentifier, setProjectTreeMode } =
@@ -479,6 +484,94 @@ export function ProjectTree(): JSX.Element {
                                 <ButtonPrimitive menuItem>New folder</ButtonPrimitive>
                             </ContextMenuItem>
                         </ContextMenuGroup>
+                    )
+                }}
+                tableModeTotalWidth={treeTableTotalWidth}
+                tableModeHeader={() => {
+                    return (
+                        <>
+                            {/* Headers */}
+                            {treeTableKeys?.headers.map((header, index) => (
+                                <ResizableDiv
+                                    key={header.key}
+                                    defaultWidth={header.width || 0}
+                                    onResize={(width) => {
+                                        setTreeTableColumnSizes([
+                                            ...treeTableColumnSizes.slice(0, index),
+                                            width,
+                                            ...treeTableColumnSizes.slice(index + 1),
+                                        ])
+                                    }}
+                                    className="absolute h-[30px] flex items-center"
+                                    style={{
+                                        transform: `translateX(${header.offset || 0}px)`,
+                                    }}
+                                    aria-label={`Resize handle for column "${header.title}"`}
+                                >
+                                    <ButtonPrimitive
+                                        key={header.key}
+                                        fullWidth
+                                        className="pointer-events-none rounded-none text-secondary font-bold text-xs uppercase flex gap-2 motion-safe:transition-[left] duration-50"
+                                        style={{
+                                            paddingLeft: index === 0 ? '30px' : undefined,
+                                        }}
+                                    >
+                                        <span>{header.title}</span>
+                                    </ButtonPrimitive>
+                                </ResizableDiv>
+                            ))}
+                        </>
+                    )
+                }}
+                tableModeRow={(item, firstColumnOffset) => {
+                    return (
+                        <>
+                            {treeTableKeys?.headers.slice(0).map((header, index) => {
+                                const width = header.width || 0
+                                const offset = header.offset || 0
+                                const value = header.key.split('.').reduce((obj, key) => (obj as any)?.[key], item)
+
+                                const widthAdjusted = width - (index === 0 ? firstColumnOffset : 0)
+                                const offsetAdjusted = index === 0 ? offset : offset - 12
+
+                                return (
+                                    <span
+                                        key={header.key}
+                                        className="text-left flex items-center h-[var(--button-height-base)]"
+                                        // eslint-disable-next-line react/forbid-dom-props
+                                        style={{
+                                            // First we keep relative
+                                            position: index === 0 ? 'relative' : 'absolute',
+                                            transform: `translateX(${offsetAdjusted}px)`,
+                                            // First column we offset for the icons
+                                            width: `${widthAdjusted}px`,
+                                            paddingLeft: index !== 0 ? '6px' : undefined,
+                                        }}
+                                    >
+                                        <Tooltip
+                                            title={
+                                                typeof header.tooltip === 'function'
+                                                    ? header.tooltip(value)
+                                                    : header.tooltip
+                                            }
+                                            placement="top-start"
+                                        >
+                                            <span
+                                                className={cn(
+                                                    'starting:opacity-0 opacity-100 delay-50 motion-safe:transition-opacity duration-100 font-normal truncate',
+                                                    {
+                                                        'font-normal': index > 1,
+                                                        // 'opacity-0': index !== 1 && isEmptyFolder,
+                                                    }
+                                                )}
+                                            >
+                                                {header.formatFunction ? header.formatFunction(value) : value}
+                                            </span>
+                                        </Tooltip>
+                                    </span>
+                                )
+                            })}
+                        </>
                     )
                 }}
             />

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
@@ -99,6 +99,7 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
         clearScrollTarget: true,
         setEditingItemId: (id: string) => ({ id }),
         setMovingItems: (items: FileSystemEntry[]) => ({ items }),
+        setTreeTableColumnSizes: (sizes: number[]) => ({ sizes }),
     }),
     loaders(({ actions, values }) => ({
         unfiledItems: [
@@ -483,8 +484,19 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                 setEditingItemId: (_, { id }) => id,
             },
         ],
+        treeTableColumnSizes: [
+            [350, 200, 200] as number[],
+            { persist: true },
+            {
+                setTreeTableColumnSizes: (_, { sizes }) => sizes,
+            },
+        ],
     }),
     selectors({
+        treeTableColumnOffsets: [
+            (s) => [s.treeTableColumnSizes],
+            (sizes): number[] => sizes.map((_, index) => sizes.slice(0, index).reduce((acc, s) => acc + s, 0)),
+        ],
         savedItems: [
             (s) => [s.folders, s.folderStates],
             (folders): FileSystemEntry[] =>
@@ -753,31 +765,35 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
         ],
         // TODO: use treeData + some other logic to determine the keys
         treeTableKeys: [
-            () => [],
-            (): TreeTableViewKeys => ({
+            (s) => [s.treeTableColumnSizes, s.treeTableColumnOffsets],
+            (sizes, offsets): TreeTableViewKeys => ({
                 headers: [
                     {
                         key: 'name',
                         title: 'Name',
                         tooltip: (value: string) => value,
-                        width: 350,
+                        width: sizes[0],
+                        offset: offsets[0],
                     },
                     {
                         key: 'record.created_at',
                         title: 'Created at',
                         formatFunction: (value: string) => dayjs(value).format('MMM D, YYYY'),
                         tooltip: (value: string) => dayjs(value).format('MMM D, YYYY HH:mm:ss'),
-                        width: 200,
+                        width: sizes[1],
+                        offset: offsets[1],
                     },
                     {
                         key: 'record.created_by.first_name',
                         title: 'Created by',
                         tooltip: (value: string) => value,
-                        width: 200,
+                        width: sizes[2],
+                        offset: offsets[2],
                     },
                 ],
             }),
         ],
+        treeTableTotalWidth: [(s) => [s.treeTableColumnSizes], (sizes): number => sizes.reduce((acc, s) => acc + s, 0)],
         checkedItemCountNumeric: [
             (s) => [s.checkedItems],
             (checkedItems): number => Object.values(checkedItems).filter((v) => !!v).length,

--- a/frontend/src/lib/components/ResizeElement/ResizeElement.tsx
+++ b/frontend/src/lib/components/ResizeElement/ResizeElement.tsx
@@ -1,0 +1,167 @@
+import { cn } from 'lib/utils/css-classes'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+
+type ResizableDivProps = {
+    defaultWidth: number
+    minWidth?: number
+    maxWidth?: number
+    onResize: (width: number) => void
+    children?: React.ReactNode
+    className?: string
+    style?: React.CSSProperties
+}
+
+export function ResizableDiv({
+    defaultWidth,
+    minWidth = 100,
+    maxWidth = 1000,
+    onResize,
+    children,
+    className,
+    style,
+    ...props
+}: ResizableDivProps): JSX.Element {
+    const [width, setWidth] = useState(defaultWidth)
+    const containerRef = useRef<HTMLDivElement>(null)
+    const startXRef = useRef<number>(0)
+    const startWidthRef = useRef<number>(0)
+    const isResizing = useRef(false)
+    const rafRef = useRef<number | null>(null)
+    const currentWidthRef = useRef(defaultWidth)
+
+    // Update the current width ref when state changes
+    useEffect(() => {
+        currentWidthRef.current = width
+    }, [width])
+
+    // Function to apply width directly to DOM for smoother resizing
+    const applyWidth = useCallback((newWidth: number) => {
+        if (containerRef.current) {
+            containerRef.current.style.width = `${newWidth}px`
+        }
+        currentWidthRef.current = newWidth
+    }, [])
+
+    const handleMouseDown = useCallback((e: React.MouseEvent | React.TouchEvent) => {
+        document.body.classList.add('is-resizing')
+        const clientX = 'touches' in e ? e.touches[0].clientX : e.clientX
+        startXRef.current = clientX
+        startWidthRef.current = currentWidthRef.current
+        isResizing.current = true
+        e.preventDefault()
+    }, [])
+
+    const handleMove = useCallback(
+        (clientX: number) => {
+            if (!isResizing.current) {
+                return
+            }
+
+            // Cancel any ongoing animation frame
+            if (rafRef.current !== null) {
+                cancelAnimationFrame(rafRef.current)
+            }
+
+            // Schedule a new frame for smooth animation
+            rafRef.current = requestAnimationFrame(() => {
+                // Calculate the difference from start position
+                const deltaX = clientX - startXRef.current
+
+                // Apply the delta to the starting width
+                const newWidth = Math.min(Math.max(startWidthRef.current + deltaX, minWidth), maxWidth)
+
+                // Apply width directly to DOM for smoother animation
+                applyWidth(newWidth)
+
+                // Call onResize callback but not setState (we'll do that on mouseup)
+                onResize(newWidth)
+
+                rafRef.current = null
+            })
+        },
+        [applyWidth, maxWidth, minWidth, onResize]
+    )
+
+    const handleMouseMove = useCallback(
+        (e: MouseEvent) => {
+            handleMove(e.clientX)
+        },
+        [handleMove]
+    )
+
+    const handleTouchMove = useCallback(
+        (e: TouchEvent) => {
+            handleMove(e.touches[0].clientX)
+        },
+        [handleMove]
+    )
+
+    const handleEnd = useCallback(() => {
+        if (isResizing.current) {
+            // Only update React state once at the end of resize
+            setWidth(currentWidthRef.current)
+            isResizing.current = false
+
+            // Clean up any pending animation frame
+            if (rafRef.current !== null) {
+                cancelAnimationFrame(rafRef.current)
+                rafRef.current = null
+            }
+            document.body.classList.remove('is-resizing')
+        }
+    }, [])
+
+    // Use effect for adding/removing global event listeners
+    useEffect(() => {
+        document.addEventListener('mousemove', handleMouseMove)
+        document.addEventListener('mouseup', handleEnd)
+        document.addEventListener('touchmove', handleTouchMove)
+        document.addEventListener('touchend', handleEnd)
+
+        return () => {
+            document.removeEventListener('mousemove', handleMouseMove)
+            document.removeEventListener('mouseup', handleEnd)
+            document.removeEventListener('touchmove', handleTouchMove)
+            document.removeEventListener('touchend', handleEnd)
+
+            // Clean up any pending animation frame
+            if (rafRef.current !== null) {
+                cancelAnimationFrame(rafRef.current)
+            }
+        }
+    }, [handleEnd, handleMouseMove, handleTouchMove])
+
+    return (
+        <div
+            ref={containerRef}
+            // eslint-disable-next-line react/forbid-dom-props
+            style={{ width, ...style }}
+            className={cn('relative', className)}
+        >
+            {children}
+            <div
+                onMouseDown={handleMouseDown}
+                onTouchStart={handleMouseDown}
+                className={cn(
+                    'group absolute top-0 right-0 w-1 h-full cursor-ew-resize w-[var(--resizer-thickness)] touch-none overflow-hidden hover:bg-accent-highlight-primary after:content-[""] after:absolute after:top-0 after:w-[1px] after:h-full after:bg-border-primary after:-translate-x-1/2 after:left-1/2',
+                    {
+                        'bg-accent-highlight-primary': isResizing.current,
+                    }
+                )}
+                role="separator"
+                tabIndex={0}
+                onKeyDown={(e) => {
+                    if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+                        e.preventDefault()
+                        const delta = e.key === 'ArrowLeft' ? -10 : 10
+                        const newWidth = Math.min(Math.max(width + delta, minWidth), maxWidth)
+                        setWidth(newWidth)
+                        applyWidth(newWidth)
+                        onResize(newWidth)
+                    }
+                }}
+                {...props}
+            />
+        </div>
+    )
+}

--- a/frontend/src/lib/components/Resizer/Resizer.scss
+++ b/frontend/src/lib/components/Resizer/Resizer.scss
@@ -19,8 +19,6 @@
 }
 
 .Resizer {
-    --resizer-thickness: 8px;
-
     position: absolute;
     z-index: var(--z-resizer);
     user-select: none; // Fixes inadvertent selection of scene text when resizing

--- a/frontend/src/lib/lemon-ui/Link/Link.tsx
+++ b/frontend/src/lib/lemon-ui/Link/Link.tsx
@@ -62,6 +62,8 @@ export type LinkProps = Pick<React.HTMLProps<HTMLAnchorElement>, 'target' | 'cla
     tooltip?: TooltipProps['title']
     tooltipDocLink?: TooltipProps['docLink']
     tooltipPlacement?: TooltipProps['placement']
+
+    style?: React.CSSProperties
 }
 
 const shouldForcePageLoad = (input: any): boolean => {

--- a/frontend/src/lib/lemon-ui/Link/Link.tsx
+++ b/frontend/src/lib/lemon-ui/Link/Link.tsx
@@ -62,8 +62,6 @@ export type LinkProps = Pick<React.HTMLProps<HTMLAnchorElement>, 'target' | 'cla
     tooltip?: TooltipProps['title']
     tooltipDocLink?: TooltipProps['docLink']
     tooltipPlacement?: TooltipProps['placement']
-
-    style?: React.CSSProperties
 }
 
 const shouldForcePageLoad = (input: any): boolean => {

--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -613,6 +613,7 @@
     --project-navbar-width-collapsed: 45px;
     --project-panel-width: 320px;
     --project-panel-inner-width: calc(var(--project-panel-width) - (var(--spacing) * 2));
+    --resizer-thickness: 8px;
 
     // The space the panel is from the left edge of the screen on mobile
     --panel-layout-mobile-offset: 40px;


### PR DESCRIPTION
## Problem
Table mode in project tree is about to get a lot more crowded with more metadata, so a persistent column resizing to show more information is imperative 

![2025-05-01 14 32 49](https://github.com/user-attachments/assets/b0188da1-58ca-48f1-8e32-251995f5d0c0)

## Changes
* Added reducer `treeTableColumnSizes` for holding column sizes
* Added selector `treeTableColumnOffsets` for managing the columns positions in relation to the column sizes
* Finally tack both on to `treeTableKeys` where we distribute this information accordingly into the DOM
* Added a `<ResizeElement>` component, because `<Resizer>` was more about the handler and not the size of the element itself.
* Cleaned up lemon tree DOM (less `<span>`'s  🪓  

## How did you test this code?
Clicking around, moving stuff, checking tree default mode worked as expected.
