### PR TITLE
fix: Fix revenue analytics docs

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -122,7 +122,7 @@ export const productConfiguration: Record<string, any> = {
     RevenueAnalytics: {
         name: 'Revenue Analytics',
         projectBased: true,
-        defaultDocsPath: '/docs/revenue-analytics',
+        defaultDocsPath: '/docs/web-analytics/revenue-analytics',
         activityScope: 'RevenueAnalytics',
     },
 }

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -117,7 +117,7 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
         projectBased: true,
         name: 'Revenue analytics',
         layout: 'app-container',
-        defaultDocsPath: '/docs/revenue-analytics',
+        defaultDocsPath: '/docs/web-analytics/revenue-analytics',
     },
     [Scene.Cohort]: {
         projectBased: true,

--- a/products/revenue_analytics/manifest.tsx
+++ b/products/revenue_analytics/manifest.tsx
@@ -10,7 +10,7 @@ export const manifest: ProductManifest = {
             name: 'Revenue Analytics',
             import: () => import('./frontend/RevenueAnalyticsScene'),
             projectBased: true,
-            defaultDocsPath: '/docs/revenue-analytics',
+            defaultDocsPath: '/docs/web-analytics/revenue-analytics',
             activityScope: 'RevenueAnalytics',
         },
     },


### PR DESCRIPTION
I thought they'd be in this path, but we ended up keeping it nested under Web Analytics for now, let's fix it so that the in-app docs open properly
