### PR TITLE
chore: use o4-mini and generate a trace id based off of the hash

### DIFF
--- a/posthog/api/wizard.py
+++ b/posthog/api/wizard.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from typing import Optional
 
@@ -24,7 +25,7 @@ from .utils import action
 
 SETUP_WIZARD_CACHE_PREFIX = "setup-wizard:v1:"
 SETUP_WIZARD_CACHE_TIMEOUT = 600
-SETUP_WIZARD_MODEL = "o3-mini"
+SETUP_WIZARD_MODEL = "o4-mini"
 
 
 class SetupWizardSerializer(serializers.Serializer):
@@ -125,11 +126,14 @@ class SetupWizardViewSet(viewsets.ViewSet):
 
         distinct_id = wizard_data.get("user_distinct_id")
 
+        trace_id = hashlib.sha256(hash.encode()).hexdigest()
+
         result = openai.chat.completions.create(
             model=SETUP_WIZARD_MODEL,
             messages=messages,
             response_format={"type": "json_schema", "json_schema": json_schema},  # type: ignore
             posthog_distinct_id=distinct_id,
+            posthog_trace_id=trace_id,
             posthog_properties={
                 "ai_product": "wizard",
                 "ai_feature": "query",


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We want to see all the generations in a single trace for a setup run of the installation wizard

## Changes

- Add `posthog_trace_id`
- Update model to `o4-mini`

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Ran the model change locally - will check the traces come through correctly in prod
