### PR TITLE
feat(sql-editor): Added the column types to the results table

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -87,7 +87,7 @@ const cleanClickhouseType = (type: string | undefined): string | undefined => {
     }
 
     // Replace newline characters followed by empty space
-    type = type.replace(RegExp(/\n\s+/), '')
+    type = type.replace(/\n\s+/, '')
 
     if (type.startsWith('Nullable(')) {
         type = type.replace('Nullable(', '')


### PR DESCRIPTION
## Problem
- I often have no idea what the column types of the results are, making it hard to know what potential functions I should use on the column to do transformations

## Changes
- Display the column type in the header of the column on the results tab of the editor

<img width="926" alt="image" src="https://github.com/user-attachments/assets/d3fbc679-45c5-4296-82b2-ef8ed3891fa4" />

<img width="931" alt="image" src="https://github.com/user-attachments/assets/3f1b62fc-dda4-450a-a0ca-e719f0606788" />


## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Tested locally