### PR TITLE
chore: hide exception properties

### DIFF
--- a/frontend/src/scenes/activity/explore/EventDetails.tsx
+++ b/frontend/src/scenes/activity/explore/EventDetails.tsx
@@ -14,6 +14,7 @@ import { pluralize } from 'lib/utils'
 import { AutocaptureImageTab, autocaptureToImage } from 'lib/utils/event-property-utls'
 import { ConversationDisplay } from 'products/llm_observability/frontend/ConversationDisplay/ConversationDisplay'
 import { useState } from 'react'
+import { INTERNAL_EXCEPTION_PROPERTY_KEYS } from 'scenes/error-tracking/utils'
 import { urls } from 'scenes/urls'
 
 import { KNOWN_PROMOTED_PROPERTY_PARENTS } from '~/taxonomy/taxonomy'
@@ -34,6 +35,7 @@ export function EventDetails({ event, tableProps }: EventDetailsProps): JSX.Elem
     const displayedEventProperties = {}
     const visibleSystemProperties = {}
     const featureFlagProperties = {}
+    const exceptionProperties = {}
     let setProperties = {}
     let setOnceProperties = {}
     let systemPropsCount = 0
@@ -47,6 +49,8 @@ export function EventDetails({ event, tableProps }: EventDetailsProps): JSX.Elem
         if (!CORE_FILTER_DEFINITIONS_BY_GROUP.events[key] || !CORE_FILTER_DEFINITIONS_BY_GROUP.events[key].system) {
             if (key.startsWith('$feature') || key === '$active_feature_flags') {
                 featureFlagProperties[key] = event.properties[key]
+            } else if (INTERNAL_EXCEPTION_PROPERTY_KEYS.includes(key)) {
+                exceptionProperties[key] = event.properties[key]
             } else if (key === '$set') {
                 setProperties = event.properties[key]
             } else if (key === '$set_once') {

--- a/frontend/src/scenes/error-tracking/utils.ts
+++ b/frontend/src/scenes/error-tracking/utils.ts
@@ -12,15 +12,20 @@ import { isPostHogProperty } from '~/taxonomy/taxonomy'
 
 import { DEFAULT_ERROR_TRACKING_DATE_RANGE, DEFAULT_ERROR_TRACKING_FILTER_GROUP } from './errorTrackingLogic'
 
-export const ERROR_TRACKING_LOGIC_KEY = 'errorTracking'
-const THIRD_PARTY_SCRIPT_ERROR = 'Script error.'
-
 export const SEARCHABLE_EXCEPTION_PROPERTIES = [
     '$exception_types',
     '$exception_values',
     '$exception_sources',
     '$exception_functions',
 ]
+export const INTERNAL_EXCEPTION_PROPERTY_KEYS = [
+    '$exception_list',
+    '$exception_fingerprint_record',
+    '$exception_proposed_fingerprint',
+    ...SEARCHABLE_EXCEPTION_PROPERTIES,
+]
+export const ERROR_TRACKING_LOGIC_KEY = 'errorTracking'
+const THIRD_PARTY_SCRIPT_ERROR = 'Script error.'
 
 const volumePeriods: ('volumeRange' | 'volumeDay')[] = ['volumeRange', 'volumeDay']
 const sumVolumes = (...arrays: number[][]): number[] =>


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

The `$exception_list` property renders really badly, we should remove it from the properties view

## Changes

|Before|After|
|----|----|
| ![Screenshot 2025-05-01 at 17 50 11](https://github.com/user-attachments/assets/d5ed3866-2bae-4147-9fa6-11c00d805d55) | ![Screenshot 2025-05-01 at 17 43 19](https://github.com/user-attachments/assets/ae19831b-750d-4cbe-9121-00fe14942fd2) |