### PR TITLE
feat(home): warns user if they have event restrictions applied

### DIFF
--- a/frontend/src/layout/navigation/ProjectNotice.tsx
+++ b/frontend/src/layout/navigation/ProjectNotice.tsx
@@ -169,6 +169,12 @@ export function ProjectNotice(): JSX.Element | null {
                 children: 'Reload page',
             },
         },
+
+        event_ingestion_restriction: {
+            message:
+                'Event ingestion restrictions have been applied to a token in this project. Please contact support.',
+            type: 'warning',
+        },
     }
 
     const relevantNotice = NOTICES[projectNoticeVariant]

--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -3,6 +3,7 @@ import { loaders } from 'kea-loaders'
 import { windowValues } from 'kea-window-values'
 import api from 'lib/api'
 import { apiStatusLogic } from 'lib/logic/apiStatusLogic'
+import { eventIngestionRestrictionLogic } from 'lib/logic/eventIngestionRestrictionLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { membersLogic } from 'scenes/organization/membersLogic'
 import { organizationLogic } from 'scenes/organizationLogic'
@@ -20,6 +21,7 @@ export type ProjectNoticeVariant =
     | 'unverified_email'
     | 'is_impersonated'
     | 'internet_connection_issue'
+    | 'event_ingestion_restriction'
 
 export const navigationLogic = kea<navigationLogicType>([
     path(['layout', 'navigation', 'navigationLogic']),
@@ -102,6 +104,7 @@ export const navigationLogic = kea<navigationLogicType>([
                 s.memberCount,
                 apiStatusLogic.selectors.internetConnectionIssue,
                 s.projectNoticesAcknowledged,
+                eventIngestionRestrictionLogic.selectors.hasAnyRestriction,
             ],
             (
                 organization,
@@ -110,7 +113,8 @@ export const navigationLogic = kea<navigationLogicType>([
                 user,
                 memberCount,
                 internetConnectionIssue,
-                projectNoticesAcknowledged
+                projectNoticesAcknowledged,
+                hasEventIngestionRestriction
             ): ProjectNoticeVariant | null => {
                 if (!organization) {
                     return null
@@ -133,6 +137,8 @@ export const navigationLogic = kea<navigationLogicType>([
                     !currentTeam.ingested_event
                 ) {
                     return 'real_project_with_no_events'
+                } else if (hasEventIngestionRestriction) {
+                    return 'event_ingestion_restriction'
                 } else if (!projectNoticesAcknowledged['invite_teammates'] && memberCount === 1) {
                     return 'invite_teammates'
                 }

--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -119,7 +119,6 @@ export const navigationLogic = kea<navigationLogicType>([
                 if (!organization) {
                     return null
                 }
-
                 if (internetConnectionIssue) {
                     return 'internet_connection_issue'
                 } else if (user?.is_impersonated) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1160,10 +1160,6 @@ class ApiRequest {
         return this.environments().current().addPathComponent('authenticate_wizard')
     }
 
-		public eventIngestionRestrictionConfig(): ApiRequest {
-			return this.environments().current().addPathComponent('event_ingestion_restriction_config')
-		}
-
     public messagingTemplates(): ApiRequest {
         return this.environments().current().addPathComponent('messaging_templates')
     }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1160,6 +1160,10 @@ class ApiRequest {
         return this.environments().current().addPathComponent('authenticate_wizard')
     }
 
+		public eventIngestionRestrictionConfig(): ApiRequest {
+			return this.environments().current().addPathComponent('event_ingestion_restriction_config')
+		}
+
     public messagingTemplates(): ApiRequest {
         return this.environments().current().addPathComponent('messaging_templates')
     }

--- a/frontend/src/lib/logic/eventIngestionRestrictionLogic.test.ts
+++ b/frontend/src/lib/logic/eventIngestionRestrictionLogic.test.ts
@@ -1,0 +1,72 @@
+import { expectLogic, partial } from 'kea-test-utils'
+import api from 'lib/api'
+
+import { initKeaTests } from '~/test/init'
+
+import { eventIngestionRestrictionLogic, RestrictionType } from './eventIngestionRestrictionLogic'
+
+jest.mock('lib/api')
+
+describe('eventIngestionRestrictionLogic', () => {
+    let logic: ReturnType<typeof eventIngestionRestrictionLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        logic = eventIngestionRestrictionLogic()
+    })
+
+    it('loads event ingestion restrictions', async () => {
+        jest.spyOn(api, 'get').mockResolvedValue([
+            {
+                restriction_type: RestrictionType.DROP_EVENT_FROM_INGESTION,
+                distinct_ids: ['user1', 'user2'],
+            },
+        ])
+
+        logic.mount()
+
+        //
+        expect(api.get).toHaveBeenCalledWith('api/environments/@current/get_event_ingestion_restriction_config/')
+
+        await expectLogic(logic)
+            .toDispatchActions(['loadEventIngestionRestrictions'])
+            .toDispatchActionsInAnyOrder(['loadEventIngestionRestrictionsSuccess'])
+            .toMatchValues({
+                eventIngestionRestrictions: [
+                    {
+                        restriction_type: RestrictionType.DROP_EVENT_FROM_INGESTION,
+                        distinct_ids: ['user1', 'user2'],
+                    },
+                ],
+                hasAnyRestriction: true,
+            })
+    })
+
+    it('handles empty restrictions', async () => {
+        jest.spyOn(api, 'get').mockResolvedValue([])
+
+        logic.mount()
+
+        await expectLogic(logic)
+            .toDispatchActions(['loadEventIngestionRestrictions', 'loadEventIngestionRestrictionsSuccess'])
+            .toMatchValues({
+                eventIngestionRestrictions: [],
+                hasAnyRestriction: false,
+            })
+    })
+
+    it('handles API errors', async () => {
+        const error = new Error('API error')
+        jest.spyOn(api, 'get').mockRejectedValue(error)
+
+        logic.mount()
+
+        await expectLogic(logic)
+            .toDispatchActions(['loadEventIngestionRestrictions', 'loadEventIngestionRestrictionsFailure'])
+            .toMatchValues({
+                eventIngestionRestrictions: [],
+                eventIngestionRestrictionsError: partial(error),
+                hasAnyRestriction: false,
+            })
+    })
+})

--- a/frontend/src/lib/logic/eventIngestionRestrictionLogic.test.ts
+++ b/frontend/src/lib/logic/eventIngestionRestrictionLogic.test.ts
@@ -25,8 +25,7 @@ describe('eventIngestionRestrictionLogic', () => {
 
         logic.mount()
 
-        //
-        expect(api.get).toHaveBeenCalledWith('api/environments/@current/get_event_ingestion_restriction_config/')
+        expect(api.get).toHaveBeenCalledWith('api/environments/@current/get_event_ingestion_restrictions/')
 
         await expectLogic(logic)
             .toDispatchActions(['loadEventIngestionRestrictions'])

--- a/frontend/src/lib/logic/eventIngestionRestrictionLogic.test.ts
+++ b/frontend/src/lib/logic/eventIngestionRestrictionLogic.test.ts
@@ -25,7 +25,10 @@ describe('eventIngestionRestrictionLogic', () => {
 
         logic.mount()
 
-        expect(api.get).toHaveBeenCalledWith('api/environments/@current/get_event_ingestion_restrictions/')
+        const hasMatchingCall = (api.get as jest.Mock).mock.calls.some(
+            (call) => call[0] === 'api/environments/@current/get_event_ingestion_restrictions/'
+        )
+        expect(hasMatchingCall).toBe(true)
 
         await expectLogic(logic)
             .toDispatchActions(['loadEventIngestionRestrictions'])

--- a/frontend/src/lib/logic/eventIngestionRestrictionLogic.test.ts
+++ b/frontend/src/lib/logic/eventIngestionRestrictionLogic.test.ts
@@ -1,4 +1,4 @@
-import { expectLogic, partial } from 'kea-test-utils'
+import { expectLogic } from 'kea-test-utils'
 import api from 'lib/api'
 
 import { initKeaTests } from '~/test/init'
@@ -51,21 +51,6 @@ describe('eventIngestionRestrictionLogic', () => {
             .toDispatchActions(['loadEventIngestionRestrictions', 'loadEventIngestionRestrictionsSuccess'])
             .toMatchValues({
                 eventIngestionRestrictions: [],
-                hasAnyRestriction: false,
-            })
-    })
-
-    it('handles API errors', async () => {
-        const error = new Error('API error')
-        jest.spyOn(api, 'get').mockRejectedValue(error)
-
-        logic.mount()
-
-        await expectLogic(logic)
-            .toDispatchActions(['loadEventIngestionRestrictions', 'loadEventIngestionRestrictionsFailure'])
-            .toMatchValues({
-                eventIngestionRestrictions: [],
-                eventIngestionRestrictionsError: partial(error),
                 hasAnyRestriction: false,
             })
     })

--- a/frontend/src/lib/logic/eventIngestionRestrictionLogic.test.ts
+++ b/frontend/src/lib/logic/eventIngestionRestrictionLogic.test.ts
@@ -26,7 +26,7 @@ describe('eventIngestionRestrictionLogic', () => {
         logic.mount()
 
         const hasMatchingCall = (api.get as jest.Mock).mock.calls.some(
-            (call) => call[0] === 'api/environments/@current/get_event_ingestion_restrictions/'
+            (call) => call[0] === 'api/environments/@current/event_ingestion_restrictions/'
         )
         expect(hasMatchingCall).toBe(true)
 

--- a/frontend/src/lib/logic/eventIngestionRestrictionLogic.ts
+++ b/frontend/src/lib/logic/eventIngestionRestrictionLogic.ts
@@ -1,0 +1,55 @@
+import { actions, events, kea, listeners, path, reducers, selectors } from 'kea'
+import api from 'lib/api'
+
+import type { eventIngestionRestrictionLogicType } from './eventIngestionRestrictionLogicType'
+
+export enum RestrictionType {
+    DROP_EVENT_FROM_INGESTION = 'drop_event_from_ingestion',
+    SKIP_PERSON_PROCESSING = 'skip_person_processing',
+    FORCE_OVERFLOW_FROM_INGESTION = 'force_overflow_from_ingestion',
+}
+
+export interface EventIngestionRestriction {
+    restriction_type: RestrictionType
+    distinct_ids: string[] | null
+}
+
+export const eventIngestionRestrictionLogic = kea<eventIngestionRestrictionLogicType>([
+    path(['lib', 'logic', 'eventIngestionRestrictionLogic']),
+    actions({
+        loadEventIngestionRestrictionConfig: true,
+        loadEventIngestionRestrictionConfigSuccess: (_, { eventIngestionRestrictions }) => ({eventIngestionRestrictions})
+    }),
+    reducers({
+        eventIngestionRestrictions: [
+            [] as EventIngestionRestriction[],
+            {
+                loadEventIngestionRestrictionConfigSuccess: (_, { eventIngestionRestrictions }) =>
+                    eventIngestionRestrictions,
+            },
+        ],
+    }),
+    selectors({
+        hasAnyRestriction: [
+            (s) => [s.eventIngestionRestrictions],
+            (eventIngestionRestrictions): boolean => eventIngestionRestrictions.length > 0,
+        ],
+    }),
+    events(({ actions }) => ({
+        afterMount: () => {
+            actions.loadEventIngestionRestrictionConfig()
+        },
+    })),
+    listeners(({ actions }) => ({
+        loadEventIngestionRestrictionConfig: async () => {
+            try {
+                const eventIngestionRestrictions = await api.get(
+                    `api/environments/@current/get_event_ingestion_restriction_config/`
+                )
+                actions.loadEventIngestionRestrictionConfigSuccess({ eventIngestionRestrictions })
+            } catch (error) {
+                console.error('Failed to load event ingestion restriction config:', error)
+            }
+        },
+    })),
+])

--- a/frontend/src/scenes/App.tsx
+++ b/frontend/src/scenes/App.tsx
@@ -4,6 +4,7 @@ import { useThemedHtml } from 'lib/hooks/useThemedHtml'
 import { ToastCloseButton } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { SpinnerOverlay } from 'lib/lemon-ui/Spinner/Spinner'
 import { apiStatusLogic } from 'lib/logic/apiStatusLogic'
+import { eventIngestionRestrictionLogic } from 'lib/logic/eventIngestionRestrictionLogic'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { Slide, ToastContainer } from 'react-toastify'
 import { appScenes } from 'scenes/appScenes'
@@ -70,6 +71,7 @@ export function App(): JSX.Element | null {
     const { showApp, showingDelayedSpinner } = useValues(appLogic)
     useMountedLogic(sceneLogic({ scenes: appScenes }))
     useMountedLogic(apiStatusLogic)
+    useMountedLogic(eventIngestionRestrictionLogic)
     useThemedHtml()
 
     if (showApp) {

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -807,8 +807,8 @@ class TeamViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.Mo
 
         return response.Response({"success": True}, status=200)
 
-    @action(methods=["GET"], detail=True, url_path="get_event_ingestion_restriction_config")
-    def get_event_ingestion_restriction_config(self, request, **kwargs):
+    @action(methods=["GET"], detail=True, required_scopes=["team:read"], url_path="event_ingestion_restrictions")
+    def event_ingestion_restrictions(self, request, **kwargs):
         team = self.get_object()
         restrictions = EventIngestionRestrictionConfig.objects.filter(token=team.api_token)
         data = [

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -35,6 +35,7 @@ from posthog.models.project import Project
 from posthog.models.scopes import APIScopeObjectOrNotSupported
 from posthog.models.signals import mute_selected_signals
 from posthog.models.team.util import delete_batch_exports, delete_bulky_postgres_data
+from posthog.models.event_ingestion_restriction_config import EventIngestionRestrictionConfig
 from posthog.models.utils import UUIDT
 from posthog.permissions import (
     CREATE_ACTIONS,
@@ -805,6 +806,19 @@ class TeamViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.Mo
         cache.set(cache_key, wizard_data, SETUP_WIZARD_CACHE_TIMEOUT)
 
         return response.Response({"success": True}, status=200)
+
+    @action(methods=["GET"], detail=True, url_path="get_event_ingestion_restriction_config")
+    def get_event_ingestion_restriction_config(self, request, **kwargs):
+        team = self.get_object()
+        restrictions = EventIngestionRestrictionConfig.objects.filter(token=team.api_token)
+        data = [
+            {
+                "restriction_type": restriction.restriction_type,
+                "distinct_ids": restriction.distinct_ids,
+            }
+            for restriction in restrictions
+        ]
+        return response.Response(data)
 
     @cached_property
     def user_permissions(self):


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Operators can set event ingestion restrictions for tokens and token:distinct_ids through django admin to restrict misbehaving customers. Surface a warning to the user if they have any restrictions in place against their accout.

## Changes

Added a new endpoint to return the event ingestion restrictions for a teams api token.
Added a request to this endpoint when app is mounted.
Surface a warning to the user through the ProjectNotice component if there exist any restrictions.

<img width="1464" alt="Screenshot 2025-05-01 at 10 02 03 AM" src="https://github.com/user-attachments/assets/e85fdd7e-8603-4de8-b91a-ad389ab69b7a" />


## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Tested locally by creating a restriction token.
Added a unit test for the data fetch/logic.
Note: I had to re-run one of the storybook tests to get it green...not sure if this test is already flaky or if i introduced flake.