### PR TITLE
fix(data-warehouse): Fix schedules for data imports

### DIFF
--- a/frontend/src/scenes/data-warehouse/external/forms/SchemaForm.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/SchemaForm.tsx
@@ -83,7 +83,7 @@ export default function SchemaForm(): JSX.Element {
                                 ),
                                 key: 'sync_time_of_day',
                                 tooltip:
-                                    'Time of day in which the first sync will run. The sync interval will be offset from the anchor time. This will not apply to sync intervals one hour or less.',
+                                    'The sync interval will be offset from the anchor time. This will not apply to sync intervals one hour or less.',
                                 render: function RenderSyncTimeOfDay(_, schema) {
                                     const utcTime = schema.sync_time_of_day || '00:00:00'
                                     const localTime = isProjectTime

--- a/frontend/src/scenes/data-warehouse/settings/source/Schemas.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/Schemas.tsx
@@ -103,7 +103,7 @@ export const SchemaTable = ({ schemas, isLoading }: SchemaTableProps): JSX.Eleme
                                 </div>
                             </div>
                         ),
-                        tooltip: `Time of day in which the first sync will run. The sync frequency will be offset from the anchor time. This will not apply to sync intervals one hour or less.`,
+                        tooltip: `The sync frequency will be offset from the anchor time. This will not apply to sync intervals one hour or less.`,
                         key: 'sync_time_of_day',
                         render: function RenderSyncTimeOfDayLocal(_, schema) {
                             const utcTime = schema.sync_time_of_day || '00:00:00'

--- a/frontend/src/scenes/data-warehouse/utils.ts
+++ b/frontend/src/scenes/data-warehouse/utils.ts
@@ -19,7 +19,7 @@ export const defaultQuery = (table: string, columns: DatabaseSchemaField[]): Dat
 /**
  * This is meant to provide a human-readable sentence that computes the times of day in which a sync
  * will occur.
- * "The sync runs at 11:00 AM, 5:00 PM, and 11:00 PM UTC"
+ * "The sync runs at 5:00 AM, 11:00 AM, 5:00 PM, and 11:00 PM UTC"
  * @param anchorTime - The time at which the sync was anchored (UTC)
  * @param syncFrequency - Interval at which the sync will reoccur
  */
@@ -45,10 +45,20 @@ export const syncAnchorIntervalToHumanReadable = (
         return `The sync runs monthly at ${humanTimeFormatter(hours, minutes)} UTC`
     }
 
+    // by this point the syncFrequency should be in the format "6hour" or "12hour"
+    const intervalMatch = syncFrequency.match(/\d+/)?.[0]
+    if (!intervalMatch) {
+        return ''
+    }
+    const interval = Number(intervalMatch)
     const syncTimes: string[] = []
-    const interval = syncFrequency === '6hour' ? 6 : 12
 
-    for (let i = hours; i < 24; i += interval) {
+    // get the first sync time
+    let start = hours
+    while (start >= interval) {
+        start -= interval
+    }
+    for (let i = start; i < 24; i += interval) {
         syncTimes.push(humanTimeFormatter(i, minutes))
     }
 

--- a/posthog/warehouse/data_load/service.py
+++ b/posthog/warehouse/data_load/service.py
@@ -1,43 +1,40 @@
 from dataclasses import asdict
-from datetime import timedelta
+from datetime import UTC, datetime, time, timedelta
 from typing import TYPE_CHECKING
-from datetime import datetime
 
+import s3fs
+import temporalio
+from asgiref.sync import async_to_sync
+from django.conf import settings
 from temporalio.client import (
+    Client as TemporalClient,
     Schedule,
     ScheduleActionStartWorkflow,
+    ScheduleIntervalSpec,
     ScheduleOverlapPolicy,
     SchedulePolicy,
     ScheduleSpec,
     ScheduleState,
-    ScheduleCalendarSpec,
-    ScheduleRange,
-    ScheduleIntervalSpec,
 )
 from temporalio.common import RetryPolicy
+
 from posthog.constants import DATA_WAREHOUSE_TASK_QUEUE
 from posthog.temporal.common.client import async_connect, sync_connect
 from posthog.temporal.common.schedule import (
     a_create_schedule,
     a_delete_schedule,
+    a_schedule_exists,
     a_trigger_schedule,
     a_update_schedule,
     create_schedule,
+    delete_schedule,
     pause_schedule,
-    a_schedule_exists,
     schedule_exists,
     trigger_schedule,
-    update_schedule,
-    delete_schedule,
     unpause_schedule,
+    update_schedule,
 )
 from posthog.temporal.utils import ExternalDataWorkflowInputs
-import temporalio
-from temporalio.client import Client as TemporalClient
-from asgiref.sync import async_to_sync
-
-from django.conf import settings
-import s3fs
 
 if TYPE_CHECKING:
     from posthog.warehouse.models import ExternalDataSource
@@ -88,42 +85,28 @@ def to_temporal_schedule(
         ),
     )
 
-    # Determine spec based on frequency
-    if sync_frequency <= timedelta(hours=1):
-        spec = ScheduleSpec(intervals=[ScheduleIntervalSpec(every=sync_frequency)], jitter=jitter)
-    else:
-        spec = ScheduleSpec(
-            calendars=[get_calendar_spec(hour_of_day, minute_of_hour, sync_frequency)],
-            jitter=jitter if minute_of_hour == 0 and hour_of_day == 0 else None,
-        )
+    sync_time = time(hour_of_day, minute_of_hour)
+    schedule_start = datetime.combine(datetime.today(), sync_time, tzinfo=UTC)
+
+    # Create the spec for the schedule based on the sync frequency and sync time
+    # The sync time is applied using a combination of the offset and the start_at time
+    spec = ScheduleSpec(
+        intervals=[
+            ScheduleIntervalSpec(
+                every=sync_frequency,
+                offset=timedelta(minutes=sync_time.hour * 60 + sync_time.minute) % sync_frequency,
+            )
+        ],
+        start_at=schedule_start,
+        # if custom sync time, don't apply jitter
+        jitter=jitter if minute_of_hour == 0 and hour_of_day == 0 else None,
+    )
 
     return Schedule(
         action=action,
         spec=spec,
-        state=ScheduleState(note=f"Schedule for external data source: {external_data_schema.pk}"),
+        state=ScheduleState(note=f"Schedule for external data schema: {external_data_schema.pk}"),
         policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
-    )
-
-
-def get_calendar_spec(hour_of_day: int, minute_of_hour: int, sync_frequency: timedelta) -> ScheduleCalendarSpec:
-    hours_per_day = 24
-    seconds_per_hour = 3600
-    step = max(int(sync_frequency.total_seconds() // seconds_per_hour), 1)
-
-    # If step is greater than or equal to 24 hours, we only need one execution per day
-    if step >= hours_per_day:
-        return ScheduleCalendarSpec(
-            hour=[ScheduleRange(start=hour_of_day, end=hour_of_day, step=step)],
-            minute=[ScheduleRange(start=minute_of_hour, end=minute_of_hour, step=1)],
-        )
-
-    end_hour = hour_of_day
-    while (end_hour + step) < hours_per_day:
-        end_hour += step
-
-    return ScheduleCalendarSpec(
-        hour=[ScheduleRange(start=hour_of_day, end=end_hour, step=step)],
-        minute=[ScheduleRange(start=minute_of_hour, end=minute_of_hour, step=1)],
     )
 
 

--- a/posthog/warehouse/data_load/service.py
+++ b/posthog/warehouse/data_load/service.py
@@ -86,7 +86,7 @@ def to_temporal_schedule(
     )
 
     sync_time = time(hour_of_day, minute_of_hour)
-    schedule_start = datetime.combine(datetime.today(), sync_time, tzinfo=UTC)
+    schedule_start = datetime.combine(datetime.now(UTC).date(), sync_time, tzinfo=UTC)
 
     # Create the spec for the schedule based on the sync frequency and sync time
     # The sync time is applied using a combination of the offset and the start_at time

--- a/posthog/warehouse/data_load/test/test_service.py
+++ b/posthog/warehouse/data_load/test/test_service.py
@@ -57,7 +57,7 @@ async def organization():
 
 @pytest_asyncio.fixture
 async def team(organization):
-    name = f"BatchExportsTestTeam-{random.randint(1, 99999)}"
+    name = f"TestTeam-{random.randint(1, 99999)}"
     team = await sync_to_async(Team.objects.create)(organization=organization, name=name)
 
     yield team

--- a/posthog/warehouse/data_load/test/test_service.py
+++ b/posthog/warehouse/data_load/test/test_service.py
@@ -1,69 +1,197 @@
-import unittest
-from datetime import timedelta
-from temporalio.client import ScheduleCalendarSpec, ScheduleRange
+import datetime as dt
+import logging
+import random
+import uuid
 
-from posthog.warehouse.data_load.service import get_calendar_spec
+import pytest
+import pytest_asyncio
+from asgiref.sync import async_to_sync, sync_to_async
+from temporalio.client import Client as TemporalClient
+from temporalio.service import RPCError
+
+from posthog.models import Organization, Team
+from posthog.temporal.common.client import sync_connect
+from posthog.warehouse.data_load.service import get_sync_schedule
+from posthog.warehouse.models import ExternalDataSchema, ExternalDataSource
+
+pytestmark = [
+    pytest.mark.django_db,
+]
 
 
-class TestGetCalendarSpec(unittest.TestCase):
-    def test_basic_daily_schedule(self):
-        # Test with daily schedule at midnight, expect 1 execution per day
-        result = get_calendar_spec(0, 0, timedelta(days=1))
-        expected = ScheduleCalendarSpec(
-            hour=[ScheduleRange(start=0, end=0, step=24)], minute=[ScheduleRange(start=0, end=0, step=1)]
-        )
-        self.assertEqual(result.hour, expected.hour)
-        self.assertEqual(result.minute, expected.minute)
+@async_to_sync
+async def delete_temporal_schedule(temporal: TemporalClient, schedule_id: str):
+    """Delete a Temporal Schedule with the given id."""
+    handle = temporal.get_schedule_handle(schedule_id)
+    await handle.delete()
 
-    def test_every_6_hours_at_12_am(self):
-        # Test with 6 hour frequency staring at 12:00, expect 4 executions per day
-        result = get_calendar_spec(0, 0, timedelta(hours=6))
-        expected = ScheduleCalendarSpec(
-            hour=[ScheduleRange(start=0, end=18, step=6)], minute=[ScheduleRange(start=0, end=0, step=1)]
-        )
-        self.assertEqual(result.hour, expected.hour)
-        self.assertEqual(result.minute, expected.minute)
 
-    def test_every_6_hours(self):
-        # Test with 6-hour frequency starting at 3:00, expect 4 executions per day
-        result = get_calendar_spec(3, 0, timedelta(hours=6))
-        expected = ScheduleCalendarSpec(
-            hour=[ScheduleRange(start=3, end=21, step=6)], minute=[ScheduleRange(start=0, end=0, step=1)]
-        )
-        self.assertEqual(result.hour, expected.hour)
-        self.assertEqual(result.minute, expected.minute)
+def cleanup_temporal_schedules(client):
+    """Clean up any Temporal Schedules created during the test."""
+    for schedule in ExternalDataSchema.objects.all():
+        try:
+            delete_temporal_schedule(client, str(schedule.id))
+        except RPCError:
+            # Assume this is fine as we are tearing down, but don't fail silently.
+            logging.warning("Schedule %s has already been deleted, ignoring.", schedule.id)
+            continue
 
-    def test_every_12_hours(self):
-        # Test with 12-hour frequency starting at 6:30, expect 2 executions per day
-        result = get_calendar_spec(6, 30, timedelta(hours=12))
-        expected = ScheduleCalendarSpec(
-            hour=[ScheduleRange(start=6, end=18, step=12)], minute=[ScheduleRange(start=30, end=30, step=1)]
-        )
-        self.assertEqual(result.hour, expected.hour)
-        self.assertEqual(result.minute, expected.minute)
 
-    def test_odd_hour_frequency(self):
-        # Test with 5-hour frequency starting at 2:15
-        result = get_calendar_spec(2, 15, timedelta(hours=5))
-        expected = ScheduleCalendarSpec(
-            hour=[ScheduleRange(start=2, end=22, step=5)], minute=[ScheduleRange(start=15, end=15, step=1)]
-        )
-        self.assertEqual(result.hour, expected.hour)
-        self.assertEqual(result.minute, expected.minute)
+@pytest.fixture
+def temporal():
+    """Return a TemporalClient instance."""
+    client = sync_connect()
+    yield client
+    cleanup_temporal_schedules(client)
 
-    def test_late_start_time(self):
-        # Test with 8-hour frequency starting at 22:00, expect 1 execution per day
-        result = get_calendar_spec(22, 0, timedelta(hours=8))
-        expected = ScheduleCalendarSpec(
-            hour=[ScheduleRange(start=22, end=22, step=8)], minute=[ScheduleRange(start=0, end=0, step=1)]
-        )
-        self.assertEqual(result.hour, expected.hour)
-        self.assertEqual(result.minute, expected.minute)
 
-    def test_frequency_larger_than_day(self):
-        result = get_calendar_spec(9, 45, timedelta(hours=36))
-        expected = ScheduleCalendarSpec(
-            hour=[ScheduleRange(start=9, end=9, step=36)], minute=[ScheduleRange(start=45, end=45, step=1)]
-        )
-        self.assertEqual(result.hour, expected.hour)
-        self.assertEqual(result.minute, expected.minute)
+@pytest_asyncio.fixture
+async def organization():
+    """A test organization."""
+    name = f"TestOrg-{random.randint(1, 99999)}"
+    org = await Organization.objects.acreate(name=name, is_ai_data_processing_approved=True, slug=name)
+
+    yield org
+    await org.adelete()
+
+
+@pytest_asyncio.fixture
+async def team(organization):
+    name = f"BatchExportsTestTeam-{random.randint(1, 99999)}"
+    team = await sync_to_async(Team.objects.create)(organization=organization, name=name)
+
+    yield team
+
+    await sync_to_async(team.delete)()
+
+
+@pytest_asyncio.fixture
+async def external_data_source(team):
+    source = await ExternalDataSource.objects.acreate(
+        source_id=str(uuid.uuid4()),
+        connection_id=str(uuid.uuid4()),
+        destination_id=str(uuid.uuid4()),
+        team=team,
+        status="running",
+        source_type="Test",
+        job_inputs={"test_key": "test-key"},
+    )
+    return source
+
+
+async def _create_external_data_schema(team, external_data_source, sync_frequency_interval, sync_time_of_day):
+    schema = await ExternalDataSchema.objects.acreate(
+        name="TestSchema",
+        team_id=team.pk,
+        source_id=external_data_source.pk,
+        sync_type="full_refresh",
+        sync_type_config={},
+        sync_frequency_interval=sync_frequency_interval,
+        sync_time_of_day=sync_time_of_day,
+    )
+    return schema
+
+
+def _get_expected_jitter(external_data_schema, sync_time):
+    assert external_data_schema.sync_frequency_interval is not None
+    # replicate how we define jitter in the service
+    if external_data_schema.sync_frequency_interval <= dt.timedelta(hours=1):
+        jitter = dt.timedelta(minutes=1)
+    elif sync_time.hour != 0 or sync_time.minute != 0:
+        jitter = None
+    elif external_data_schema.sync_frequency_interval <= dt.timedelta(hours=12):
+        jitter = dt.timedelta(minutes=30)
+    else:
+        jitter = dt.timedelta(hours=1)
+    return jitter
+
+
+def _get_expected_start_time(external_data_schema, sync_time, now):
+    schedule_start = dt.datetime.combine(dt.date.today(), sync_time, tzinfo=dt.UTC)
+    assert external_data_schema.sync_frequency_interval is not None
+    while schedule_start < now:
+        schedule_start += external_data_schema.sync_frequency_interval
+    return schedule_start
+
+
+@pytest.mark.parametrize(
+    "sync_frequency_interval",
+    [
+        dt.timedelta(minutes=5),
+        dt.timedelta(hours=6),
+        dt.timedelta(hours=12),
+        dt.timedelta(hours=24),
+        dt.timedelta(days=7),
+        # monthly is currently defined as 30 days
+        dt.timedelta(days=30),
+    ],
+)
+@pytest.mark.parametrize(
+    "sync_time_of_day",
+    [
+        "00:00:00",
+        "07:11:00",
+        "22:59:00",
+    ],
+)
+@pytest.mark.asyncio
+async def test_get_sync_schedule(external_data_source, team, sync_frequency_interval, sync_time_of_day, temporal):
+    """Test that the sync schedule is created correctly.
+
+    We do this by creating a schedule in Temporal with the result of `get_sync_schedule` and then checking that the
+    upcoming scheduled runs are correct. This is the most reliable way to test that the schedule is correct as it's not
+    easy to determine based purely on the ScheduleSpec.
+    """
+    external_data_schema = await _create_external_data_schema(
+        team=team,
+        external_data_source=external_data_source,
+        sync_frequency_interval=sync_frequency_interval,
+        sync_time_of_day=sync_time_of_day,
+    )
+    assert external_data_schema.sync_frequency_interval is not None
+
+    result = get_sync_schedule(
+        external_data_schema=external_data_schema,
+    )
+
+    now = dt.datetime.now(dt.UTC)
+    assert external_data_schema.sync_time_of_day is not None
+    sync_time = dt.datetime.strptime(str(external_data_schema.sync_time_of_day), "%H:%M:%S").time()
+
+    # create a schedule with the result to test that it's correct
+    schedule_handle = await temporal.create_schedule(
+        id=str(external_data_schema.id),
+        schedule=result,
+        trigger_immediately=False,
+    )
+    schedule_desc = await schedule_handle.describe()
+    next_runs: list[dt.datetime] = schedule_desc.info.next_action_times
+    assert len(next_runs) > 0
+
+    jitter = _get_expected_jitter(external_data_schema, sync_time)
+    schedule_start = _get_expected_start_time(external_data_schema, sync_time, now)
+    expected_runs = [schedule_start + i * external_data_schema.sync_frequency_interval for i in range(len(next_runs))]
+
+    # For some reason, Temporal will not schedule the first run more than 10 or 11 days in the future
+    # so we need to handle this case separately. We don't care too much about this since we will always create the
+    # schedule using `trigger_immediately=True` and we don't want the tests to be flaky, so we just check the first
+    # run is within an expected range and the interval is correct.
+    if external_data_schema.sync_frequency_interval > dt.timedelta(days=7):
+        next_run = next_runs[0]
+        assert next_run < schedule_start + external_data_schema.sync_frequency_interval
+        # Check interval between runs
+        for i in range(len(next_runs) - 1):
+            delta = next_runs[i + 1] - next_runs[i]
+            if jitter is not None:
+                assert delta < external_data_schema.sync_frequency_interval + jitter
+                assert delta > external_data_schema.sync_frequency_interval - jitter
+            else:
+                assert delta == external_data_schema.sync_frequency_interval
+    else:
+        # Compare actual vs expected runs
+        for actual, expected in zip(next_runs, expected_runs):
+            if jitter is not None:
+                assert actual < expected + jitter
+                assert actual > expected - jitter
+            else:
+                assert actual == expected


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

The schedules we create for data import jobs were not being created as expected.

Some examples:
- Weekly schedules were actually running on a daily basis
- The sync start time was a hard start time for _every_ day. For example, schedules of 6 hours that started after 6am would never run before 6am, which is counter-intuitive.

## Changes

- Simplify how we create schedules in Temporal; rather than using calendar schedules we use intervals + offset & start time
- Add extensive tests that test when the runs are actually scheduled inside Temporal
- Update wording on front-end

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added new tests.

Also tested locally that weekly schedules are now being applied as expected.

## Deployment

Once deployed, we will also need to run a script to update the schedules in Temporal.
