### PR TITLE
feat: add v2 blocks to session replay events

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-metadata-store.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-metadata-store.test.ts
@@ -97,7 +97,7 @@ describe('SessionMetadataStore', () => {
 
         expect(mockProducer.queueMessages).toHaveBeenCalledTimes(1)
         const queuedMessage = mockProducer.queueMessages.mock.calls[0][0] as TopicMessage
-        expect(queuedMessage.topic).toBe('clickhouse_session_replay_events_v2_test_test')
+        expect(queuedMessage.topic).toBe('clickhouse_session_replay_events_test')
         const queuedMessages = queuedMessage.messages
         const parsedEvents = queuedMessages.map((msg) => parseJSON(msg.value as string))
 
@@ -107,72 +107,112 @@ describe('SessionMetadataStore', () => {
                 session_id: 'session123',
                 team_id: 1,
                 distinct_id: 'user1',
-                batch_id: 'batch123',
                 first_timestamp: '2025-01-01 10:00:00.000',
                 last_timestamp: '2025-01-01 10:00:02.000',
+                first_url: null,
+                urls: [],
+                click_count: 0,
+                keypress_count: 0,
+                mouse_activity_count: 0,
+                active_milliseconds: 0,
+                console_log_count: 0,
+                console_warn_count: 0,
+                console_error_count: 0,
+                size: 0,
+                message_count: 0,
+                snapshot_source: null,
+                snapshot_library: null,
+                event_count: 0,
                 block_url: 's3://bucket/file1?range=bytes=0-99',
-                first_url: 'https://example.com',
-                urls: ['https://example.com', 'https://example.com/page2'],
-                click_count: 5,
-                keypress_count: 10,
-                mouse_activity_count: 15,
-                active_milliseconds: 2000,
-                console_log_count: 3,
-                console_warn_count: 2,
-                console_error_count: 1,
-                size: 1024,
-                message_count: 50,
-                snapshot_source: 'web',
-                snapshot_library: 'rrweb@1.0.0',
-                event_count: 25,
+                first_timestamp_secondary: '2025-01-01 10:00:00.000',
+                last_timestamp_secondary: '2025-01-01 10:00:02.000',
+                first_url_secondary: 'https://example.com',
+                urls_secondary: ['https://example.com', 'https://example.com/page2'],
+                click_count_secondary: 5,
+                keypress_count_secondary: 10,
+                mouse_activity_count_secondary: 15,
+                active_milliseconds_secondary: 2000,
+                console_log_count_secondary: 3,
+                console_warn_count_secondary: 2,
+                console_error_count_secondary: 1,
+                size_secondary: 1024,
+                message_count_secondary: 50,
+                snapshot_source_secondary: 'web',
+                snapshot_library_secondary: 'rrweb@1.0.0',
+                event_count_secondary: 25,
             },
             {
                 uuid: expect.any(String),
                 session_id: 'different456',
                 team_id: 2,
                 distinct_id: 'user2',
-                batch_id: 'batch123',
                 first_timestamp: '2025-01-01 10:00:01.500',
                 last_timestamp: '2025-01-01 10:00:03.500',
-                block_url: 's3://bucket/file1?range=bytes=100-249',
-                first_url: 'https://example.com/different',
-                urls: ['https://example.com/different'],
-                click_count: 2,
-                keypress_count: 5,
-                mouse_activity_count: 8,
-                active_milliseconds: 1500,
-                console_log_count: 1,
-                console_warn_count: 1,
+                first_url: null,
+                urls: [],
+                click_count: 0,
+                keypress_count: 0,
+                mouse_activity_count: 0,
+                active_milliseconds: 0,
+                console_log_count: 0,
+                console_warn_count: 0,
                 console_error_count: 0,
-                size: 512,
-                message_count: 30,
-                snapshot_source: 'web',
-                snapshot_library: 'rrweb@1.0.0',
-                event_count: 15,
+                size: 0,
+                message_count: 0,
+                snapshot_source: null,
+                snapshot_library: null,
+                event_count: 0,
+                block_url: 's3://bucket/file1?range=bytes=100-249',
+                first_url_secondary: 'https://example.com/different',
+                urls_secondary: ['https://example.com/different'],
+                click_count_secondary: 2,
+                keypress_count_secondary: 5,
+                mouse_activity_count_secondary: 8,
+                active_milliseconds_secondary: 1500,
+                console_log_count_secondary: 1,
+                console_warn_count_secondary: 1,
+                console_error_count_secondary: 0,
+                size_secondary: 512,
+                message_count_secondary: 30,
+                snapshot_source_secondary: 'web',
+                snapshot_library_secondary: 'rrweb@1.0.0',
+                event_count_secondary: 15,
             },
             {
                 uuid: expect.any(String),
                 session_id: 'session123',
                 team_id: 1,
                 distinct_id: 'user1',
-                batch_id: 'batch123',
                 first_timestamp: '2025-01-01 10:00:03.000',
                 last_timestamp: '2025-01-01 10:00:05.000',
+                first_url: null,
+                urls: [],
+                click_count: 0,
+                keypress_count: 0,
+                mouse_activity_count: 0,
+                active_milliseconds: 0,
+                console_log_count: 0,
+                console_warn_count: 0,
+                console_error_count: 0,
+                size: 0,
+                message_count: 0,
+                snapshot_source: null,
+                snapshot_library: null,
                 block_url: 's3://bucket/file1?range=bytes=250-449',
-                first_url: 'https://example.com',
-                urls: ['https://example.com', 'https://example.com/page3'],
-                click_count: 7,
-                keypress_count: 15,
-                mouse_activity_count: 20,
-                active_milliseconds: 2500,
-                console_log_count: 4,
-                console_warn_count: 1,
-                console_error_count: 2,
-                size: 2048,
-                message_count: 70,
-                snapshot_source: 'web',
-                snapshot_library: 'rrweb@1.0.0',
-                event_count: 35,
+                first_url_secondary: 'https://example.com',
+                urls_secondary: ['https://example.com', 'https://example.com/page3'],
+                click_count_secondary: 7,
+                keypress_count_secondary: 15,
+                mouse_activity_count_secondary: 20,
+                active_milliseconds_secondary: 2500,
+                console_log_count_secondary: 4,
+                console_warn_count_secondary: 1,
+                console_error_count_secondary: 2,
+                size_secondary: 2048,
+                message_count_secondary: 70,
+                snapshot_source_secondary: 'web',
+                snapshot_library_secondary: 'rrweb@1.0.0',
+                event_count_secondary: 35,
             },
         ])
 
@@ -191,7 +231,7 @@ describe('SessionMetadataStore', () => {
     it('should handle empty blocks array', async () => {
         await store.storeSessionBlocks([])
         expect(mockProducer.queueMessages).toHaveBeenCalledWith({
-            topic: 'clickhouse_session_replay_events_v2_test_test',
+            topic: 'clickhouse_session_replay_events_test',
             messages: [],
         })
         expect(mockProducer.flush).toHaveBeenCalledTimes(1)
@@ -263,22 +303,22 @@ describe('SessionMetadataStore', () => {
 
         const queuedMessage = mockProducer.queueMessages.mock.calls[0][0] as TopicMessage
         const parsedEvent = parseJSON(queuedMessage.messages[0].value as string)
-        expect(parsedEvent.event_count).toBe(8)
+        expect(parsedEvent.event_count_secondary).toBe(8)
         expect(parsedEvent.block_url).toBeNull()
         expect(parsedEvent.distinct_id).toBe('user1')
-        expect(parsedEvent.first_url).toBe('https://example.com')
-        expect(parsedEvent.urls).toEqual(['https://example.com'])
-        expect(parsedEvent.click_count).toBe(3)
-        expect(parsedEvent.keypress_count).toBe(7)
-        expect(parsedEvent.mouse_activity_count).toBe(12)
-        expect(parsedEvent.active_milliseconds).toBe(1000)
-        expect(parsedEvent.console_log_count).toBe(1)
-        expect(parsedEvent.console_warn_count).toBe(0)
-        expect(parsedEvent.console_error_count).toBe(0)
-        expect(parsedEvent.size).toBe(512)
-        expect(parsedEvent.message_count).toBe(25)
-        expect(parsedEvent.snapshot_source).toBe('web')
-        expect(parsedEvent.snapshot_library).toBe('rrweb@1.0.0')
+        expect(parsedEvent.first_url_secondary).toBe('https://example.com')
+        expect(parsedEvent.urls_secondary).toEqual(['https://example.com'])
+        expect(parsedEvent.click_count_secondary).toBe(3)
+        expect(parsedEvent.keypress_count_secondary).toBe(7)
+        expect(parsedEvent.mouse_activity_count_secondary).toBe(12)
+        expect(parsedEvent.active_milliseconds_secondary).toBe(1000)
+        expect(parsedEvent.console_log_count_secondary).toBe(1)
+        expect(parsedEvent.console_warn_count_secondary).toBe(0)
+        expect(parsedEvent.console_error_count_secondary).toBe(0)
+        expect(parsedEvent.size_secondary).toBe(512)
+        expect(parsedEvent.message_count_secondary).toBe(25)
+        expect(parsedEvent.snapshot_source_secondary).toBe('web')
+        expect(parsedEvent.snapshot_library_secondary).toBe('rrweb@1.0.0')
         expect(mockProducer.flush).toHaveBeenCalledTimes(1)
     })
 
@@ -342,36 +382,36 @@ describe('SessionMetadataStore', () => {
         expect(parsedEvents[0].batch_id).toBe('batch1')
         expect(parsedEvents[1].batch_id).toBe('batch2')
         expect(parsedEvents[0]).toMatchObject({
-            first_url: 'https://example.com',
-            urls: ['https://example.com'],
-            event_count: 12,
-            click_count: 1,
-            keypress_count: 2,
-            mouse_activity_count: 3,
-            active_milliseconds: 500,
-            console_log_count: 1,
-            console_warn_count: 0,
-            console_error_count: 0,
-            size: 256,
-            message_count: 15,
-            snapshot_source: 'web',
-            snapshot_library: 'rrweb@1.0.0',
+            first_url_secondary: 'https://example.com',
+            urls_secondary: ['https://example.com'],
+            event_count_secondary: 12,
+            click_count_secondary: 1,
+            keypress_count_secondary: 2,
+            mouse_activity_count_secondary: 3,
+            active_milliseconds_secondary: 500,
+            console_log_count_secondary: 1,
+            console_warn_count_secondary: 0,
+            console_error_count_secondary: 0,
+            size_secondary: 256,
+            message_count_secondary: 15,
+            snapshot_source_secondary: 'web',
+            snapshot_library_secondary: 'rrweb@1.0.0',
         })
         expect(parsedEvents[1]).toMatchObject({
-            first_url: 'https://example.com/other',
-            urls: ['https://example.com/other'],
-            event_count: 18,
-            click_count: 4,
-            keypress_count: 5,
-            mouse_activity_count: 6,
-            active_milliseconds: 750,
-            console_log_count: 2,
-            console_warn_count: 1,
-            console_error_count: 1,
-            size: 384,
-            message_count: 20,
-            snapshot_source: 'web',
-            snapshot_library: 'rrweb@1.0.0',
+            first_url_secondary: 'https://example.com/other',
+            urls_secondary: ['https://example.com/other'],
+            event_count_secondary: 18,
+            click_count_secondary: 4,
+            keypress_count_secondary: 5,
+            mouse_activity_count_secondary: 6,
+            active_milliseconds_secondary: 750,
+            console_log_count_secondary: 2,
+            console_warn_count_secondary: 1,
+            console_error_count_secondary: 1,
+            size_secondary: 384,
+            message_count_secondary: 20,
+            snapshot_source_secondary: 'web',
+            snapshot_library_secondary: 'rrweb@1.0.0',
         })
         expect(mockProducer.flush).toHaveBeenCalledTimes(1)
     })

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-metadata-store.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-metadata-store.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto'
 
-import { KAFKA_CLICKHOUSE_SESSION_REPLAY_EVENTS_V2_TEST } from '../../../../config/kafka-topics'
+import { KAFKA_CLICKHOUSE_SESSION_REPLAY_EVENTS } from '../../../../config/kafka-topics'
 import { KafkaProducerWrapper } from '../../../../kafka/producer'
 import { TimestampFormat } from '../../../../types'
 import { logger } from '../../../../utils/logger'
@@ -16,32 +16,53 @@ export class SessionMetadataStore {
         logger.info('🔍', 'session_metadata_store_storing_blocks', { count: blocks.length })
 
         const events = blocks.map((metadata) => ({
+            // Common fields, setting them from both V1 and V2 is ok
             uuid: randomUUID(),
             session_id: metadata.sessionId,
             team_id: metadata.teamId,
             distinct_id: metadata.distinctId,
-            batch_id: metadata.batchId,
+            // We set the primary timestamps because they have to be non-null, it won't cause issues
             first_timestamp: castTimestampOrNow(metadata.startDateTime, TimestampFormat.ClickHouse),
             last_timestamp: castTimestampOrNow(metadata.endDateTime, TimestampFormat.ClickHouse),
+            // Primary fields, will be set by V1 at this stage
+            first_url: null,
+            urls: [],
+            click_count: 0,
+            keypress_count: 0,
+            mouse_activity_count: 0,
+            active_milliseconds: 0,
+            console_log_count: 0,
+            console_warn_count: 0,
+            console_error_count: 0,
+            size: 0,
+            message_count: 0,
+            snapshot_source: null,
+            snapshot_library: null,
+            event_count: 0,
+            // V2-specific fields
+            batch_id: metadata.batchId,
             block_url: metadata.blockUrl,
-            first_url: metadata.firstUrl,
-            urls: metadata.urls || [],
-            click_count: metadata.clickCount || 0,
-            keypress_count: metadata.keypressCount || 0,
-            mouse_activity_count: metadata.mouseActivityCount || 0,
-            active_milliseconds: metadata.activeMilliseconds || 0,
-            console_log_count: metadata.consoleLogCount || 0,
-            console_warn_count: metadata.consoleWarnCount || 0,
-            console_error_count: metadata.consoleErrorCount || 0,
-            size: metadata.size || 0,
-            message_count: metadata.messageCount || 0,
-            snapshot_source: metadata.snapshotSource,
-            snapshot_library: metadata.snapshotLibrary,
-            event_count: metadata.eventCount || 0,
+            // Secondary fields for V2 switchover
+            first_timestamp_secondary: castTimestampOrNow(metadata.startDateTime, TimestampFormat.ClickHouse),
+            last_timestamp_secondary: castTimestampOrNow(metadata.endDateTime, TimestampFormat.ClickHouse),
+            first_url_secondary: metadata.firstUrl,
+            urls_secondary: metadata.urls || [],
+            click_count_secondary: metadata.clickCount || 0,
+            keypress_count_secondary: metadata.keypressCount || 0,
+            mouse_activity_count_secondary: metadata.mouseActivityCount || 0,
+            active_milliseconds_secondary: metadata.activeMilliseconds || 0,
+            console_log_count_secondary: metadata.consoleLogCount || 0,
+            console_warn_count_secondary: metadata.consoleWarnCount || 0,
+            console_error_count_secondary: metadata.consoleErrorCount || 0,
+            size_secondary: metadata.size || 0,
+            message_count_secondary: metadata.messageCount || 0,
+            event_count_secondary: metadata.eventCount || 0,
+            snapshot_source_secondary: metadata.snapshotSource,
+            snapshot_library_secondary: metadata.snapshotLibrary,
         }))
 
         await this.producer.queueMessages({
-            topic: KAFKA_CLICKHOUSE_SESSION_REPLAY_EVENTS_V2_TEST,
+            topic: KAFKA_CLICKHOUSE_SESSION_REPLAY_EVENTS,
             messages: events.map((event) => ({
                 key: event.session_id,
                 value: JSON.stringify(event),

--- a/posthog/clickhouse/migrations/0115_add_block_columns_to_session_replay_events.py
+++ b/posthog/clickhouse/migrations/0115_add_block_columns_to_session_replay_events.py
@@ -1,0 +1,35 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions, NodeRole
+from posthog.session_recordings.sql.session_replay_event_migrations_sql import (
+    ADD_BLOCK_COLUMNS_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    ADD_BLOCK_COLUMNS_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    ADD_BLOCK_COLUMNS_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL,
+    DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL,
+    DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL,
+)
+from posthog.session_recordings.sql.session_replay_event_sql import (
+    SESSION_REPLAY_EVENTS_TABLE_MV_SQL,
+    KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL,
+)
+
+# The Kafka table only has block_url String (not arrays). Block array columns are only in the aggregate tables.
+operations = [
+    # 1. Drop the old materialized view so it's no longer pulling from Kafka
+    run_sql_with_exceptions(DROP_SESSION_REPLAY_EVENTS_TABLE_MV_SQL()),
+    # 2. Drop the Kafka table
+    run_sql_with_exceptions(DROP_KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    # 3. Sharded table (physical storage)
+    run_sql_with_exceptions(ADD_BLOCK_COLUMNS_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    # 4. Writable table (for writing to sharded table)
+    run_sql_with_exceptions(ADD_BLOCK_COLUMNS_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    # 5. Distributed table (for reading)
+    run_sql_with_exceptions(ADD_BLOCK_COLUMNS_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    # 6. Also run on coordinator node without the cluster clause
+    run_sql_with_exceptions(
+        ADD_BLOCK_COLUMNS_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL().replace("on CLUSTER '{cluster}'", ""),
+        node_role=NodeRole.COORDINATOR,
+    ),
+    # 7. Recreate the Kafka table with the updated schema
+    run_sql_with_exceptions(KAFKA_SESSION_REPLAY_EVENTS_TABLE_SQL()),
+    # 8. Recreate the materialized view with the updated schema
+    run_sql_with_exceptions(SESSION_REPLAY_EVENTS_TABLE_MV_SQL()),
+]

--- a/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
@@ -196,9 +196,9 @@ ADD_BLOCK_COLUMNS_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SE
 
 ALTER_SESSION_REPLAY_ADD_SECONDARY_COLUMNS = """
     ALTER TABLE {table_name} on CLUSTER '{cluster}'
-        ADD COLUMN IF NOT EXISTS min_first_timestamp_secondary SimpleAggregateFunction(min, DateTime64(6, 'UTC')),
-        ADD COLUMN IF NOT EXISTS max_last_timestamp_secondary SimpleAggregateFunction(max, DateTime64(6, 'UTC')),
-        ADD COLUMN IF NOT EXISTS first_url_secondary AggregateFunction(argMin, Nullable(VARCHAR), DateTime64(6, 'UTC')),
+        ADD COLUMN IF NOT EXISTS min_first_timestamp_secondary SimpleAggregateFunction(min, Nullable(DateTime64(6, 'UTC'))),
+        ADD COLUMN IF NOT EXISTS max_last_timestamp_secondary SimpleAggregateFunction(max, Nullable(DateTime64(6, 'UTC'))),
+        ADD COLUMN IF NOT EXISTS first_url_secondary AggregateFunction(argMin, Nullable(VARCHAR), Nullable(DateTime64(6, 'UTC'))),
         ADD COLUMN IF NOT EXISTS all_urls_secondary SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
         ADD COLUMN IF NOT EXISTS click_count_secondary SimpleAggregateFunction(sum, Int64),
         ADD COLUMN IF NOT EXISTS keypress_count_secondary SimpleAggregateFunction(sum, Int64),
@@ -210,8 +210,8 @@ ALTER_SESSION_REPLAY_ADD_SECONDARY_COLUMNS = """
         ADD COLUMN IF NOT EXISTS size_secondary SimpleAggregateFunction(sum, Int64),
         ADD COLUMN IF NOT EXISTS message_count_secondary SimpleAggregateFunction(sum, Int64),
         ADD COLUMN IF NOT EXISTS event_count_secondary SimpleAggregateFunction(sum, Int64),
-        ADD COLUMN IF NOT EXISTS snapshot_source_secondary AggregateFunction(argMin, LowCardinality(Nullable(String)), DateTime64(6, 'UTC')),
-        ADD COLUMN IF NOT EXISTS snapshot_library_secondary AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))
+        ADD COLUMN IF NOT EXISTS snapshot_source_secondary AggregateFunction(argMin, LowCardinality(Nullable(String)), Nullable(DateTime64(6, 'UTC'))),
+        ADD COLUMN IF NOT EXISTS snapshot_library_secondary AggregateFunction(argMin, Nullable(String), Nullable(DateTime64(6, 'UTC')))
 """
 
 ADD_SECONDARY_COLUMNS_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_SECONDARY_COLUMNS.format(

--- a/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_migrations_sql.py
@@ -156,3 +156,35 @@ ADD_LIBRARY_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_L
     table_name=SESSION_REPLAY_EVENTS_DATA_TABLE(),
     cluster=settings.CLICKHOUSE_CLUSTER,
 )
+
+# =========================
+# MIGRATION: Add block columns to support session recording v2 implementation
+# This migration adds block_url to the kafka table, and block_first_timestamps, block_last_timestamps, and block_urls
+# to the sharded, writable, and distributed session replay events tables.
+# The Kafka table only has block_url String (not arrays).
+# These columns are required for the v2 session recording implementation.
+# =========================
+
+# 1. Sharded table (physical storage)
+ALTER_SESSION_REPLAY_ADD_BLOCK_COLUMNS = """
+    ALTER TABLE {table_name} on CLUSTER '{cluster}'
+        ADD COLUMN IF NOT EXISTS block_first_timestamps SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
+        ADD COLUMN IF NOT EXISTS block_last_timestamps SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
+        ADD COLUMN IF NOT EXISTS block_urls SimpleAggregateFunction(groupArrayArray, Array(String))
+"""
+ADD_BLOCK_COLUMNS_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_BLOCK_COLUMNS.format(
+    table_name=SESSION_REPLAY_EVENTS_DATA_TABLE(),
+    cluster=settings.CLICKHOUSE_CLUSTER,
+)
+
+# 2. Writable table (for writing to sharded table)
+ADD_BLOCK_COLUMNS_WRITABLE_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_BLOCK_COLUMNS.format(
+    table_name="writable_session_replay_events",
+    cluster=settings.CLICKHOUSE_CLUSTER,
+)
+
+# 3. Distributed table (for reading)
+ADD_BLOCK_COLUMNS_DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL = lambda: ALTER_SESSION_REPLAY_ADD_BLOCK_COLUMNS.format(
+    table_name="session_replay_events",
+    cluster=settings.CLICKHOUSE_CLUSTER,
+)

--- a/posthog/session_recordings/sql/session_replay_event_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_sql.py
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     distinct_id VARCHAR,
     first_timestamp DateTime64(6, 'UTC'),
     last_timestamp DateTime64(6, 'UTC'),
+    block_url Nullable(String),
     first_url Nullable(VARCHAR),
     urls Array(String),
     click_count Int64,
@@ -136,6 +137,9 @@ team_id,
 any(distinct_id) as distinct_id,
 min(first_timestamp) AS min_first_timestamp,
 max(last_timestamp) AS max_last_timestamp,
+groupArray(first_timestamp) AS block_first_timestamps,
+groupArray(last_timestamp) AS block_last_timestamps,
+groupArray(block_url) AS block_urls,
 -- TRICKY: ClickHouse will pick a relatively random first_url
 -- when it collapses the aggregating merge tree
 -- unless we teach it what we want...
@@ -174,6 +178,9 @@ group by session_id, team_id
 `session_id` String, `team_id` Int64, `distinct_id` String,
 `min_first_timestamp` DateTime64(6, 'UTC'),
 `max_last_timestamp` DateTime64(6, 'UTC'),
+`block_first_timestamps` SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
+`block_last_timestamps` SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
+`block_urls` SimpleAggregateFunction(groupArrayArray, Array(String)),
 `first_url` AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
 `all_urls` SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
 `click_count` Int64, `keypress_count` Int64,

--- a/posthog/session_recordings/sql/session_replay_event_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_sql.py
@@ -137,8 +137,8 @@ team_id,
 any(distinct_id) as distinct_id,
 min(first_timestamp) AS min_first_timestamp,
 max(last_timestamp) AS max_last_timestamp,
-groupArray(first_timestamp) AS block_first_timestamps,
-groupArray(last_timestamp) AS block_last_timestamps,
+groupArray(if(block_url != '', first_timestamp, NULL)) AS block_first_timestamps,
+groupArray(if(block_url != '', last_timestamp, NULL)) AS block_last_timestamps,
 groupArray(block_url) AS block_urls,
 -- TRICKY: ClickHouse will pick a relatively random first_url
 -- when it collapses the aggregating merge tree

--- a/posthog/session_recordings/sql/session_replay_event_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_sql.py
@@ -43,8 +43,8 @@ CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     snapshot_source LowCardinality(Nullable(String)),
     snapshot_library Nullable(String),
     -- Secondary columns for v2 migration
-    first_timestamp_secondary DateTime64(6, 'UTC'),
-    last_timestamp_secondary DateTime64(6, 'UTC'),
+    first_timestamp_secondary Nullable(DateTime64(6, 'UTC')),
+    last_timestamp_secondary Nullable(DateTime64(6, 'UTC')),
     first_url_secondary Nullable(VARCHAR),
     urls_secondary Array(String),
     click_count_secondary Int64,
@@ -108,9 +108,9 @@ CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     block_last_timestamps SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
     block_urls SimpleAggregateFunction(groupArrayArray, Array(String)),
     -- Secondary columns for v2 migration
-    min_first_timestamp_secondary SimpleAggregateFunction(min, DateTime64(6, 'UTC')),
-    max_last_timestamp_secondary SimpleAggregateFunction(max, DateTime64(6, 'UTC')),
-    first_url_secondary AggregateFunction(argMin, Nullable(VARCHAR), DateTime64(6, 'UTC')),
+    min_first_timestamp_secondary SimpleAggregateFunction(min, Nullable(DateTime64(6, 'UTC'))),
+    max_last_timestamp_secondary SimpleAggregateFunction(max, Nullable(DateTime64(6, 'UTC'))),
+    first_url_secondary AggregateFunction(argMin, Nullable(VARCHAR), Nullable(DateTime64(6, 'UTC'))),
     all_urls_secondary SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
     click_count_secondary SimpleAggregateFunction(sum, Int64),
     keypress_count_secondary SimpleAggregateFunction(sum, Int64),
@@ -122,8 +122,8 @@ CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     size_secondary SimpleAggregateFunction(sum, Int64),
     message_count_secondary SimpleAggregateFunction(sum, Int64),
     event_count_secondary SimpleAggregateFunction(sum, Int64),
-    snapshot_source_secondary AggregateFunction(argMin, LowCardinality(Nullable(String)), DateTime64(6, 'UTC')),
-    snapshot_library_secondary AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))
+    snapshot_source_secondary AggregateFunction(argMin, LowCardinality(Nullable(String)), Nullable(DateTime64(6, 'UTC'))),
+    snapshot_library_secondary AggregateFunction(argMin, Nullable(String), Nullable(DateTime64(6, 'UTC')))
 ) ENGINE = {engine}
 """
 
@@ -247,9 +247,9 @@ group by session_id, team_id
 `snapshot_library` AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
 `_timestamp` Nullable(DateTime),
 -- Secondary columns for v2 migration
-`min_first_timestamp_secondary` DateTime64(6, 'UTC'),
-`max_last_timestamp_secondary` DateTime64(6, 'UTC'),
-`first_url_secondary` AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
+`min_first_timestamp_secondary` Nullable(DateTime64(6, 'UTC')),
+`max_last_timestamp_secondary` Nullable(DateTime64(6, 'UTC')),
+`first_url_secondary` AggregateFunction(argMin, Nullable(String), Nullable(DateTime64(6, 'UTC'))),
 `all_urls_secondary` SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
 `click_count_secondary` Int64,
 `keypress_count_secondary` Int64,
@@ -261,8 +261,8 @@ group by session_id, team_id
 `size_secondary` Int64,
 `message_count_secondary` Int64,
 `event_count_secondary` Int64,
-`snapshot_source_secondary` AggregateFunction(argMin, LowCardinality(Nullable(String)), DateTime64(6, 'UTC')),
-`snapshot_library_secondary` AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))
+`snapshot_source_secondary` AggregateFunction(argMin, LowCardinality(Nullable(String)), Nullable(DateTime64(6, 'UTC'))),
+`snapshot_library_secondary` AggregateFunction(argMin, Nullable(String), Nullable(DateTime64(6, 'UTC')))
 )""",
     )
 )

--- a/posthog/session_recordings/sql/session_replay_event_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_sql.py
@@ -41,7 +41,22 @@ CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     event_count Int64,
     message_count Int64,
     snapshot_source LowCardinality(Nullable(String)),
-    snapshot_library Nullable(String)
+    snapshot_library Nullable(String),
+    -- Secondary columns for v2 migration
+    first_url_secondary Nullable(VARCHAR),
+    urls_secondary Array(String),
+    click_count_secondary Int64,
+    keypress_count_secondary Int64,
+    mouse_activity_count_secondary Int64,
+    active_milliseconds_secondary Int64,
+    console_log_count_secondary Int64,
+    console_warn_count_secondary Int64,
+    console_error_count_secondary Int64,
+    size_secondary Int64,
+    event_count_secondary Int64,
+    message_count_secondary Int64,
+    snapshot_source_secondary LowCardinality(Nullable(String)),
+    snapshot_library_secondary Nullable(String)
 ) ENGINE = {engine}
 """
 
@@ -85,7 +100,28 @@ CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     snapshot_source AggregateFunction(argMin, LowCardinality(Nullable(String)), DateTime64(6, 'UTC')),
     -- knowing something is mobile isn't enough, we need to know if e.g. RN or flutter
     snapshot_library AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC')),
-    _timestamp SimpleAggregateFunction(max, DateTime)
+    _timestamp SimpleAggregateFunction(max, DateTime),
+    -- Block columns for v2 migration
+    block_first_timestamps SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
+    block_last_timestamps SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
+    block_urls SimpleAggregateFunction(groupArrayArray, Array(String)),
+    -- Secondary columns for v2 migration
+    min_first_timestamp_secondary SimpleAggregateFunction(min, DateTime64(6, 'UTC')),
+    max_last_timestamp_secondary SimpleAggregateFunction(max, DateTime64(6, 'UTC')),
+    first_url_secondary AggregateFunction(argMin, Nullable(VARCHAR), DateTime64(6, 'UTC')),
+    all_urls_secondary SimpleAggregateFunction(groupUniqArrayArray, Array(String)),
+    click_count_secondary SimpleAggregateFunction(sum, Int64),
+    keypress_count_secondary SimpleAggregateFunction(sum, Int64),
+    mouse_activity_count_secondary SimpleAggregateFunction(sum, Int64),
+    active_milliseconds_secondary SimpleAggregateFunction(sum, Int64),
+    console_log_count_secondary SimpleAggregateFunction(sum, Int64),
+    console_warn_count_secondary SimpleAggregateFunction(sum, Int64),
+    console_error_count_secondary SimpleAggregateFunction(sum, Int64),
+    size_secondary SimpleAggregateFunction(sum, Int64),
+    message_count_secondary SimpleAggregateFunction(sum, Int64),
+    event_count_secondary SimpleAggregateFunction(sum, Int64),
+    snapshot_source_secondary AggregateFunction(argMin, LowCardinality(Nullable(String)), DateTime64(6, 'UTC')),
+    snapshot_library_secondary AggregateFunction(argMin, Nullable(String), DateTime64(6, 'UTC'))
 ) ENGINE = {engine}
 """
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We're switching over to Blobby V2 and in the first phase of the switchover we want to start writing V2 metadata to secondary `session_replay_events` columns.

## Changes

Depends on https://github.com/PostHog/posthog/pull/31790/files

- Changes the topic for metadata events to publish to `session_replay_events` instead of `session_replay_events_v2_test`
- Publishes empty metadata to the main columns, which are still managed by Blobby V1
- Publishes the computed metadata to the secondary columns

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

- Updated unit test
- Tested locally