### PR TITLE
fix: add email property sanitization

### DIFF
--- a/posthog/email.py
+++ b/posthog/email.py
@@ -1,8 +1,9 @@
 import sys
-from typing import Optional
+from typing import Optional, Any
 
 import lxml
 import toronado
+import html
 from celery import shared_task
 from django.conf import settings
 from django.core import exceptions, mail
@@ -129,9 +130,6 @@ def _send_via_http(
                 if record.sent_at:
                     continue
 
-                # Convert any Decimal values to float for JSON serialization
-                properties = {k: float(v) if isinstance(v, Decimal) else v for k, v in properties.items()}
-
                 payload = {
                     "transactional_message_id": get_customer_io_template_id(template_name),
                     "to": dest["raw_email"],
@@ -221,6 +219,54 @@ def _send_via_smtp(
                 )
 
 
+def sanitize_email_properties(properties: dict[str, Any]) -> dict[str, Any]:
+    """
+    Sanitizes properties that will be used in email templates to prevent HTML injection.
+    This function recursively processes dictionaries, lists, and scalar values to ensure
+    all string values are properly escaped.
+
+    Args:
+        properties: Dictionary of properties to sanitize
+
+    Returns:
+        Sanitized copy of the properties dictionary
+    """
+    if properties is None:
+        return {}
+
+    # Special keys that should not be sanitized (e.g., URL query parameters)
+    skip_sanitization_keys = ["utm_tags"]
+
+    def sanitize_value(value: Any) -> Any:
+        if isinstance(value, str):
+            return html.escape(value)
+        elif isinstance(value, dict):
+            return {k: sanitize_value(v) for k, v in value.items()}
+        elif isinstance(value, list):
+            return [sanitize_value(item) for item in value]
+        elif hasattr(value, "_meta") and hasattr(value, "pk"):
+            # Handle Django models by converting to string and escaping
+            return html.escape(str(value))
+        elif isinstance(value, Decimal):
+            # Convert Decimal to float for JSON serialization
+            return float(value)
+        elif isinstance(value, int | float | bool | type(None)):
+            # These types are safe as-is
+            return value
+        else:
+            # For any other types, convert to string and escape
+            return html.escape(str(value))
+
+    result = {}
+    for k, v in properties.items():
+        if k in skip_sanitization_keys:
+            result[k] = v  # Skip sanitization for special keys
+        else:
+            result[k] = sanitize_value(v)
+
+    return result
+
+
 @shared_task(**EMAIL_TASK_KWARGS)
 def _send_email(
     campaign_key: str,
@@ -284,11 +330,7 @@ class EmailMessage:
         self.reply_to = reply_to
         self.template_name = template_name
 
-        # Convert any Django models to strings for JSON serialization
-        self.properties = {
-            k: str(v) if hasattr(v, "_meta") and hasattr(v, "pk") else v  # Check if it's a Django model
-            for k, v in template_context.items()
-        }
+        self.properties = sanitize_email_properties(template_context)
 
         template = get_template(f"email/{template_name}.html")
         self.html_body = inline_css(template.render(template_context))
@@ -296,7 +338,8 @@ class EmailMessage:
         self.headers = headers if headers else {}
 
     def add_recipient(self, email: str, name: Optional[str] = None) -> None:
-        self.to.append({"recipient": f'"{name}" <{email}>' if name else email, "raw_email": email})
+        sanitized_name = html.escape(name) if name else None
+        self.to.append({"recipient": f'"{sanitized_name}" <{email}>' if sanitized_name else email, "raw_email": email})
 
     def send(self, send_async: bool = True) -> None:
         if not self.to:

--- a/posthog/email.py
+++ b/posthog/email.py
@@ -219,7 +219,7 @@ def _send_via_smtp(
                 )
 
 
-def sanitize_email_properties(properties: dict[str, Any]) -> dict[str, Any]:
+def sanitize_email_properties(properties: dict[str, Any] | None) -> dict[str, Any]:
     """
     Sanitizes properties that will be used in email templates to prevent HTML injection.
     This function recursively processes dictionaries, lists, and scalar values to ensure

--- a/posthog/email.py
+++ b/posthog/email.py
@@ -230,12 +230,18 @@ def sanitize_email_properties(properties: dict[str, Any]) -> dict[str, Any]:
 
     Returns:
         Sanitized copy of the properties dictionary
+
+    Raises:
+        TypeError: If an unsupported type is encountered
     """
     if properties is None:
         return {}
 
     # Special keys that should not be sanitized (e.g., URL query parameters)
     skip_sanitization_keys = ["utm_tags"]
+
+    # Supported types (besides containers like dict and list)
+    supported_types = (str, int, float, bool, type(None), Decimal)
 
     def sanitize_value(value: Any) -> Any:
         if isinstance(value, str):
@@ -254,8 +260,11 @@ def sanitize_email_properties(properties: dict[str, Any]) -> dict[str, Any]:
             # These types are safe as-is
             return value
         else:
-            # For any other types, convert to string and escape
-            return html.escape(str(value))
+            # Raise an error for unsupported types - this is a security measure to prevent uncaught injections
+            raise TypeError(
+                f"Unsupported type in email properties: {type(value).__name__}. "
+                f"Only {', '.join(t.__name__ for t in supported_types)}, dict, list, and Django models are supported."
+            )
 
     result = {}
     for k, v in properties.items():

--- a/posthog/test/test_email.py
+++ b/posthog/test/test_email.py
@@ -5,7 +5,7 @@ from freezegun import freeze_time
 from unittest.mock import patch, MagicMock
 from decimal import Decimal
 
-from posthog.email import EmailMessage, _send_email
+from posthog.email import EmailMessage, _send_email, sanitize_email_properties
 from posthog.models import MessagingRecord, Organization, Person, Team, User
 from posthog.models.instance_setting import override_instance_config
 from posthog.test.base import BaseTest
@@ -164,3 +164,90 @@ class TestEmail(BaseTest):
             # Verify the message wasn't marked as sent
             record = MessagingRecord.objects.filter(campaign_key="test_campaign").first()
             self.assertIsNone(record)
+
+    def test_sanitize_email_properties(self) -> None:
+        # Test with various types of input including potential HTML injection
+        properties = {
+            "name": 'Test User"><img src=1 onerror=alert(1)>',
+            "project_name": '<script>alert("XSS")</script>',
+            "nested": {
+                "html_content": '<b>Bold text</b><img src="x" onerror="javascript:alert(1)">',
+                "safe_number": 123,
+            },
+            "list_with_html": ["normal text", "<script>bad()</script>", 42],
+            "decimal_value": Decimal("1.23"),
+            "boolean_value": True,
+            "none_value": None,
+            "utm_tags": "utm_source=posthog&utm_medium=email&utm_campaign=test",
+        }
+
+        sanitized = sanitize_email_properties(properties)
+
+        # Check that strings are properly escaped
+        self.assertEqual(sanitized["name"], "Test User&quot;&gt;&lt;img src=1 onerror=alert(1)&gt;")
+        self.assertEqual(sanitized["project_name"], "&lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt;")
+
+        # Check that nested dictionaries are sanitized
+        self.assertEqual(
+            sanitized["nested"]["html_content"],
+            "&lt;b&gt;Bold text&lt;/b&gt;&lt;img src=&quot;x&quot; onerror=&quot;javascript:alert(1)&quot;&gt;",
+        )
+
+        # Check that numbers and booleans are preserved
+        self.assertEqual(sanitized["nested"]["safe_number"], 123)
+        self.assertEqual(sanitized["decimal_value"], 1.23)
+        self.assertEqual(sanitized["boolean_value"], True)
+        self.assertEqual(sanitized["none_value"], None)
+
+        # Check that lists are sanitized
+        self.assertEqual(sanitized["list_with_html"][0], "normal text")
+        self.assertEqual(sanitized["list_with_html"][1], "&lt;script&gt;bad()&lt;/script&gt;")
+        self.assertEqual(sanitized["list_with_html"][2], 42)
+
+        # Check that utm_tags are not sanitized (to preserve valid URL query parameters)
+        self.assertEqual(sanitized["utm_tags"], "utm_source=posthog&utm_medium=email&utm_campaign=test")
+
+    def test_email_message_sanitizes_properties(self) -> None:
+        # Test that EmailMessage constructor properly sanitizes template_context
+        with override_instance_config("EMAIL_HOST", "localhost"):
+            template_context = {
+                "name": 'User"><img src=x onerror=alert(1)>',
+                "project_name": '<script>alert("XSS")</script>',
+                "utm_tags": "utm_source=posthog&utm_medium=email&utm_campaign=test_custom",
+            }
+
+            message = EmailMessage(
+                campaign_key="test_campaign",
+                subject="Test subject",
+                template_name="2fa_enabled",
+                template_context=template_context,
+            )
+
+            # Verify properties were sanitized
+            self.assertEqual(message.properties["name"], "User&quot;&gt;&lt;img src=x onerror=alert(1)&gt;")
+            self.assertEqual(message.properties["project_name"], "&lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt;")
+
+            # Verify utm_tags are preserved without sanitization
+            self.assertEqual(
+                message.properties["utm_tags"], "utm_source=posthog&utm_medium=email&utm_campaign=test_custom"
+            )
+
+            # Original template_context should be used for rendering (Django templates have their own escaping)
+            self.assertIn("utm_source=posthog", message.properties["utm_tags"])
+
+    def test_add_recipient_sanitizes_name(self) -> None:
+        # Test that add_recipient properly sanitizes the name parameter
+        with override_instance_config("EMAIL_HOST", "localhost"):
+            message = EmailMessage(campaign_key="test_campaign", subject="Test subject", template_name="2fa_enabled")
+
+            # Add recipient with a malicious name containing HTML/JavaScript
+            message.add_recipient(email="test@example.com", name='Malicious"><script>alert("XSS")</script>')
+
+            # Verify the name was properly sanitized in the recipient string
+            self.assertEqual(
+                message.to[0]["recipient"],
+                '"Malicious&quot;&gt;&lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt;" <test@example.com>',
+            )
+
+            # Raw email should remain unchanged
+            self.assertEqual(message.to[0]["raw_email"], "test@example.com")

--- a/posthog/test/test_email.py
+++ b/posthog/test/test_email.py
@@ -207,6 +207,19 @@ class TestEmail(BaseTest):
         # Check that utm_tags are not sanitized (to preserve valid URL query parameters)
         self.assertEqual(sanitized["utm_tags"], "utm_source=posthog&utm_medium=email&utm_campaign=test")
 
+    def test_sanitize_email_properties_raises_for_unsupported_types(self) -> None:
+        # Test that sanitize_email_properties raises TypeError for unsupported types
+        properties = {
+            "custom_object": type("CustomObject", (), {})(),  # Create a simple custom object
+        }
+
+        with self.assertRaises(TypeError) as context:
+            sanitize_email_properties(properties)
+
+        # Check that the error message contains useful information
+        self.assertIn("Unsupported type in email properties: CustomObject", str(context.exception))
+        self.assertIn("Only str, int, float, bool, NoneType, Decimal", str(context.exception))
+
     def test_email_message_sanitizes_properties(self) -> None:
         # Test that EmailMessage constructor properly sanitizes template_context
         with override_instance_config("EMAIL_HOST", "localhost"):


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Report: https://posthog.slack.com/archives/C0428JHABK2/p1746119564050479.

We weren't properly sanitizing properties that are forwarded through our to email provider.

## Changes

Adding a sanitize function that does a bunch of checks because on the property type.

## Does this work well for both Cloud and self-hosted?

It doesn't have an impact.

## How did you test this code?

Added tests