### PR TITLE
fix: Improve drop warning

### DIFF
--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
@@ -1058,6 +1058,17 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                 return configStr.includes('groups.') || configStr.includes('{groups}')
             },
         ],
+        mightDropEvents: [
+            (s) => [s.configuration, s.type],
+            (configuration, type) => {
+                if (type !== 'transformation') {
+                    return false
+                }
+                const hogCode = configuration.hog || ''
+
+                return mightDropEvents(hogCode)
+            },
+        ],
     })),
 
     listeners(({ actions, values, cache }) => ({


### PR DESCRIPTION
## Problem

Feedback about the drop warning being really misleading. Reading it back its really poorly worded.

## Changes
|Before|After|
|----|----|
| <img width="1394" alt="Screenshot 2025-05-02 at 11 04 00" src="https://github.com/user-attachments/assets/917297aa-7dca-41df-93c6-a53607103f5f" /> | <img width="1418" alt="Screenshot 2025-05-02 at 11 03 13" src="https://github.com/user-attachments/assets/eace1c71-9082-4bf1-82f4-274fdd408e11" /> |





* Changed the wording to be more explicit and less sensational
* Made it an info instead of a big yellow warning
* Moved the logic into the kea logic and removed the debounce (even with a big function that code runs fast) 

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
