### PR TITLE
fix: Flags logic typing

### DIFF
--- a/frontend/src/lib/logic/featureFlagLogic.ts
+++ b/frontend/src/lib/logic/featureFlagLogic.ts
@@ -1,4 +1,5 @@
 import { actions, afterMount, kea, path, reducers } from 'kea'
+import { FeatureFlagKey } from 'lib/constants'
 import { getAppContext } from 'lib/utils/getAppContext'
 import posthog from 'posthog-js'
 
@@ -7,7 +8,7 @@ import { AppContext } from '~/types'
 import type { featureFlagLogicType } from './featureFlagLogicType'
 
 export type FeatureFlagsSet = {
-    [flag: string]: boolean | string
+    [flag in FeatureFlagKey]?: boolean | string
 }
 const eventsNotified: Record<string, boolean> = {}
 function notifyFlagIfNeeded(flag: string, flagState: string | boolean | undefined): void {
@@ -48,7 +49,7 @@ function spyOnFeatureFlags(featureFlags: FeatureFlagsSet): FeatureFlagsSet {
                         return () => availableFlags
                     }
                     const flagString = flag.toString()
-                    const flagState = availableFlags[flagString]
+                    const flagState = availableFlags[flagString as FeatureFlagKey]
                     notifyFlagIfNeeded(flagString, flagState)
                     return flagState
                 },


### PR DESCRIPTION
## Problem

Our typing of the flags logic doesn't show people that they're doing it wrong when it could

## Changes

* Change the type to reference the constants

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
