### PR TITLE
feat(sql-editor): Added smooth scrolling when opening a new tab

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/QueryTabs.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryTabs.tsx
@@ -1,10 +1,11 @@
 import { IconPlus, IconX } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 import clsx from 'clsx'
-import { useEffect, useState } from 'react'
+import { useValues } from 'kea'
+import { useEffect, useRef, useState } from 'react'
 
 import AutoTab from './AutoTab'
-import { NEW_QUERY, QueryTab } from './multitabEditorLogic'
+import { multitabEditorLogic, NEW_QUERY, QueryTab } from './multitabEditorLogic'
 
 interface QueryTabsProps {
     models: QueryTab[]
@@ -16,9 +17,24 @@ interface QueryTabsProps {
 }
 
 export function QueryTabs({ models, onClear, onClick, onAdd, onRename, activeModelUri }: QueryTabsProps): JSX.Element {
+    const { allTabs } = useValues(multitabEditorLogic)
+    const containerRef = useRef<HTMLDivElement | null>(null)
+    const prevTabsCountRef = useRef(allTabs.length)
+
+    useEffect(() => {
+        if (allTabs.length > prevTabsCountRef.current) {
+            containerRef.current?.scrollTo({
+                left: containerRef.current.scrollWidth,
+                behavior: 'smooth',
+            })
+        }
+
+        prevTabsCountRef.current = allTabs.length
+    }, [allTabs])
+
     return (
         <>
-            <div className="flex flex-row overflow-scroll hide-scrollbar h-10">
+            <div className="flex flex-row overflow-scroll hide-scrollbar h-10" ref={containerRef}>
                 {models.map((model: QueryTab) => (
                     <QueryTabComponent
                         key={model.uri.path}
@@ -49,7 +65,7 @@ function QueryTabComponent({ model, active, onClear, onClick, onRename }: QueryT
 
     useEffect(() => {
         setTabName(model.view?.name || model.name || NEW_QUERY)
-    }, [model.view?.name])
+    }, [model.view?.name, model.name])
 
     const handleRename = (): void => {
         setIsEditing(false)


### PR DESCRIPTION
## Problem
- Opening a new tab in the SQL editor can get lost in the query tab scroller when you already have a bunch open

## Changes
- Auto scroll far right on the query tabs when you add a new tab

https://github.com/user-attachments/assets/a7d851ad-8452-474e-a3e6-18c9811ec7a3


## Does this work well for both Cloud and self-hosted?
Yup

## How did you test this code?
Opened a bunch of tabs 💡 