### PR TITLE
fix(web-analytics): Show languages and timezone even if geoip is disabled

### DIFF
--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.test.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.test.ts
@@ -42,7 +42,6 @@ describe('taxonomicBreakdownFilterLogic', () => {
                 insightProps,
                 breakdownFilter: {},
                 isTrends: true,
-                isFunnels: false,
                 updateBreakdownFilter,
                 updateDisplay,
             })
@@ -70,7 +69,6 @@ describe('taxonomicBreakdownFilterLogic', () => {
                     breakdown: ['all', 1],
                 },
                 isTrends: true,
-                isFunnels: false,
                 updateBreakdownFilter,
                 updateDisplay,
             })
@@ -99,8 +97,6 @@ describe('taxonomicBreakdownFilterLogic', () => {
                 insightProps,
                 breakdownFilter: {},
                 isTrends: true,
-                isFunnels: false,
-
                 updateBreakdownFilter,
                 updateDisplay,
             })
@@ -124,8 +120,6 @@ describe('taxonomicBreakdownFilterLogic', () => {
                 insightProps,
                 breakdownFilter: {},
                 isTrends: true,
-                isFunnels: false,
-
                 updateBreakdownFilter,
                 updateDisplay,
             })
@@ -152,8 +146,6 @@ describe('taxonomicBreakdownFilterLogic', () => {
                     breakdown_type: 'person',
                 },
                 isTrends: true,
-                isFunnels: false,
-
                 display: ChartDisplayType.WorldMap,
                 updateBreakdownFilter,
                 updateDisplay,
@@ -177,8 +169,6 @@ describe('taxonomicBreakdownFilterLogic', () => {
                 insightProps,
                 breakdownFilter: {},
                 isTrends: true,
-                isFunnels: false,
-
                 updateBreakdownFilter,
                 updateDisplay,
             })
@@ -198,8 +188,6 @@ describe('taxonomicBreakdownFilterLogic', () => {
                 insightProps,
                 breakdownFilter: {},
                 isTrends: true,
-                isFunnels: false,
-
                 updateBreakdownFilter,
                 updateDisplay,
             })
@@ -225,8 +213,6 @@ describe('taxonomicBreakdownFilterLogic', () => {
                 insightProps,
                 breakdownFilter: {},
                 isTrends: true,
-                isFunnels: false,
-
                 updateBreakdownFilter,
                 updateDisplay,
             })
@@ -244,8 +230,6 @@ describe('taxonomicBreakdownFilterLogic', () => {
                     breakdown_type: 'event',
                 },
                 isTrends: true,
-                isFunnels: false,
-
                 updateBreakdownFilter,
                 updateDisplay,
             })
@@ -262,8 +246,6 @@ describe('taxonomicBreakdownFilterLogic', () => {
                     breakdowns: [],
                 },
                 isTrends: true,
-                isFunnels: false,
-
                 updateBreakdownFilter,
                 updateDisplay,
             })
@@ -287,8 +269,6 @@ describe('taxonomicBreakdownFilterLogic', () => {
                     ],
                 },
                 isTrends: true,
-                isFunnels: false,
-
                 updateBreakdownFilter,
                 updateDisplay,
             })

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.test.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.test.ts
@@ -42,6 +42,7 @@ describe('taxonomicBreakdownFilterLogic', () => {
                 insightProps,
                 breakdownFilter: {},
                 isTrends: true,
+                isFunnels: false,
                 updateBreakdownFilter,
                 updateDisplay,
             })
@@ -69,6 +70,7 @@ describe('taxonomicBreakdownFilterLogic', () => {
                     breakdown: ['all', 1],
                 },
                 isTrends: true,
+                isFunnels: false,
                 updateBreakdownFilter,
                 updateDisplay,
             })
@@ -97,6 +99,8 @@ describe('taxonomicBreakdownFilterLogic', () => {
                 insightProps,
                 breakdownFilter: {},
                 isTrends: true,
+                isFunnels: false,
+
                 updateBreakdownFilter,
                 updateDisplay,
             })
@@ -120,6 +124,8 @@ describe('taxonomicBreakdownFilterLogic', () => {
                 insightProps,
                 breakdownFilter: {},
                 isTrends: true,
+                isFunnels: false,
+
                 updateBreakdownFilter,
                 updateDisplay,
             })
@@ -146,6 +152,8 @@ describe('taxonomicBreakdownFilterLogic', () => {
                     breakdown_type: 'person',
                 },
                 isTrends: true,
+                isFunnels: false,
+
                 display: ChartDisplayType.WorldMap,
                 updateBreakdownFilter,
                 updateDisplay,
@@ -169,6 +177,8 @@ describe('taxonomicBreakdownFilterLogic', () => {
                 insightProps,
                 breakdownFilter: {},
                 isTrends: true,
+                isFunnels: false,
+
                 updateBreakdownFilter,
                 updateDisplay,
             })
@@ -188,6 +198,8 @@ describe('taxonomicBreakdownFilterLogic', () => {
                 insightProps,
                 breakdownFilter: {},
                 isTrends: true,
+                isFunnels: false,
+
                 updateBreakdownFilter,
                 updateDisplay,
             })
@@ -213,6 +225,8 @@ describe('taxonomicBreakdownFilterLogic', () => {
                 insightProps,
                 breakdownFilter: {},
                 isTrends: true,
+                isFunnels: false,
+
                 updateBreakdownFilter,
                 updateDisplay,
             })
@@ -230,6 +244,8 @@ describe('taxonomicBreakdownFilterLogic', () => {
                     breakdown_type: 'event',
                 },
                 isTrends: true,
+                isFunnels: false,
+
                 updateBreakdownFilter,
                 updateDisplay,
             })
@@ -246,6 +262,8 @@ describe('taxonomicBreakdownFilterLogic', () => {
                     breakdowns: [],
                 },
                 isTrends: true,
+                isFunnels: false,
+
                 updateBreakdownFilter,
                 updateDisplay,
             })
@@ -269,6 +287,8 @@ describe('taxonomicBreakdownFilterLogic', () => {
                     ],
                 },
                 isTrends: true,
+                isFunnels: false,
+
                 updateBreakdownFilter,
                 updateDisplay,
             })

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -66,7 +66,7 @@ export const toUtcOffsetFormat = (value: number): string => {
     const formattedMinutes = decimalPartAsMinutes > 0 ? `:${decimalPartAsMinutes}` : ''
 
     // E.g. UTC-3, UTC, UTC+5:30, UTC+11:45
-    return `UTC${sign}${Math.abs(integerPart)}${formattedMinutes}`
+    return `UTC${sign}${integerPart}${formattedMinutes}`
 }
 
 type VariationCellProps = { isPercentage?: boolean; reverseColors?: boolean }

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -52,21 +52,21 @@ import { HeatmapButton } from '../CrossSellButtons/HeatmapButton'
 import { ReplayButton } from '../CrossSellButtons/ReplayButton'
 import { pageReportsLogic } from '../pageReportsLogic'
 
-const toUtcOffsetFormat = (value: number): string => {
+export const toUtcOffsetFormat = (value: number): string => {
     if (value === 0) {
         return 'UTC'
     }
 
-    const integerPart = Math.floor(value)
-    const sign = integerPart > 0 ? '+' : '-'
+    const sign = value > 0 ? '+' : '-'
+    const integerPart = Math.abs(Math.trunc(value))
 
     // India has half-hour offsets, and Australia has 45-minute offsets, why?
-    const decimalPart = value - integerPart
+    const decimalPart = Math.abs(value) - integerPart
     const decimalPartAsMinutes = decimalPart * 60
     const formattedMinutes = decimalPartAsMinutes > 0 ? `:${decimalPartAsMinutes}` : ''
 
     // E.g. UTC-3, UTC, UTC+5:30, UTC+11:45
-    return `UTC${sign}${integerPart}${formattedMinutes}`
+    return `UTC${sign}${Math.abs(integerPart)}${formattedMinutes}`
 }
 
 type VariationCellProps = { isPercentage?: boolean; reverseColors?: boolean }

--- a/frontend/src/scenes/web-analytics/tiles/webAnalyticsTile.test.ts
+++ b/frontend/src/scenes/web-analytics/tiles/webAnalyticsTile.test.ts
@@ -1,0 +1,16 @@
+import { toUtcOffsetFormat } from './WebAnalyticsTile'
+
+describe('toUtcOffsetFormat', () => {
+    it.each([
+        [0, 'UTC'],
+        [0.25, 'UTC+0:15'],
+        [1, 'UTC+1'],
+        [1.5, 'UTC+1:30'],
+        [-0, 'UTC'],
+        [-0.25, 'UTC-0:15'],
+        [-1, 'UTC-1'],
+        [-1.5, 'UTC-1:30'],
+    ])('should format %d to %s', (minutes, expected) => {
+        expect(toUtcOffsetFormat(minutes)).toEqual(expected)
+    })
+})

--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -662,7 +662,10 @@ GROUP BY session_id, breakdown_value
                 return ast.Field(chain=["properties", "$browser_language"])
             case WebStatsBreakdown.TIMEZONE:
                 # Value is in minutes, turn it to hours, works even for fractional timezone offsets (I'm looking at you, Australia)
-                return parse_expr("toFloat(properties.$timezone_offset) / 60")
+                # see the docs here for why this the negative is necessary
+                # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset#negative_values_and_positive_values
+                # the example given is that for UTC+10, -600 will be returned.
+                return parse_expr("-toFloat(properties.$timezone_offset) / 60")
             case WebStatsBreakdown.FRUSTRATION_METRICS:
                 return self._apply_path_cleaning(ast.Field(chain=["events", "properties", "$pathname"]))
             case _:

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
@@ -3998,7 +3998,7 @@
   FROM
     (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
             count() AS filtered_pageview_count,
-            divide(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone_offset'), ''), 'null'), '^"|"$', ''), 'Float64'), 60) AS breakdown_value,
+            divide(minus(0, accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone_offset'), ''), 'null'), '^"|"$', ''), 'Float64')), 60) AS breakdown_value,
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
@@ -4057,7 +4057,7 @@
   FROM
     (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
             count() AS filtered_pageview_count,
-            divide(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone_offset'), ''), 'null'), '^"|"$', ''), 'Float64'), 60) AS breakdown_value,
+            divide(minus(0, accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone_offset'), ''), 'null'), '^"|"$', ''), 'Float64')), 60) AS breakdown_value,
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
@@ -4116,7 +4116,7 @@
   FROM
     (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
             count() AS filtered_pageview_count,
-            divide(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone_offset'), ''), 'null'), '^"|"$', ''), 'Float64'), 60) AS breakdown_value,
+            divide(minus(0, accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone_offset'), ''), 'null'), '^"|"$', ''), 'Float64')), 60) AS breakdown_value,
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp
@@ -4175,7 +4175,7 @@
   FROM
     (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
             count() AS filtered_pageview_count,
-            divide(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone_offset'), ''), 'null'), '^"|"$', ''), 'Float64'), 60) AS breakdown_value,
+            divide(minus(0, accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone_offset'), ''), 'null'), '^"|"$', ''), 'Float64')), 60) AS breakdown_value,
             events__session.session_id AS session_id,
             any(events__session.`$is_bounce`) AS is_bounce,
             min(events__session.`$start_timestamp`) AS start_timestamp

--- a/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
@@ -1202,9 +1202,9 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
         for idx, (timezone_offset, before_session_id, after_session_id) in enumerate(
             [
                 (0, str(uuid7(before_date)), str(uuid7(after_date))),  # UTC
-                (330, str(uuid7(before_date)), str(uuid7(after_date))),  # Calcutta UTC+5:30
-                (-240, str(uuid7(before_date)), str(uuid7(after_date))),  # New York UTC-4
-                (-180, str(uuid7(before_date)), str(uuid7(after_date))),  # Brasilia UTC-3
+                (-330, str(uuid7(before_date)), str(uuid7(after_date))),  # Calcutta UTC+5:30
+                (240, str(uuid7(before_date)), str(uuid7(after_date))),  # New York UTC-4
+                (180, str(uuid7(before_date)), str(uuid7(after_date))),  # Brasilia UTC-3
             ]
         ):
             _create_person(


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

If GeoIP is disabled, we disable the whole tile, but some queries would still work

## Changes

Show languages and timezone even if GeoIP is disabled

Additionally fix toggling the right property when languages are clicked.

Additionally fix a couple of bugs around how timezones were displayed

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Ran locally, also added some tests for the timezone formatting
