### PR TITLE
fix(data-warehouse): Fix pausing data import schedules

### DIFF
--- a/posthog/warehouse/api/external_data_schema.py
+++ b/posthog/warehouse/api/external_data_schema.py
@@ -1,3 +1,4 @@
+import datetime as dt
 from typing import Any, Optional
 
 import structlog
@@ -15,7 +16,9 @@ from posthog.temporal.data_imports.pipelines.bigquery import (
     filter_incremental_fields as filter_bigquery_incremental_fields,
     get_schemas as get_bigquery_schemas,
 )
-from posthog.temporal.data_imports.pipelines.schemas import PIPELINE_TYPE_INCREMENTAL_FIELDS_MAPPING
+from posthog.temporal.data_imports.pipelines.schemas import (
+    PIPELINE_TYPE_INCREMENTAL_FIELDS_MAPPING,
+)
 from posthog.warehouse.data_load.service import (
     cancel_external_data_workflow,
     external_data_workflow_exists,
@@ -172,7 +175,8 @@ class ExternalDataSchemaSerializer(serializers.ModelSerializer):
                 instance.sync_frequency_interval = sync_frequency_interval
 
         if sync_time_of_day is not None:
-            if sync_time_of_day != instance.sync_time_of_day:
+            new_time = dt.datetime.strptime(str(sync_time_of_day), "%H:%M:%S").time()
+            if new_time != instance.sync_time_of_day:
                 was_sync_time_of_day_updated = True
                 validated_data["sync_time_of_day"] = sync_time_of_day
                 instance.sync_time_of_day = sync_time_of_day
@@ -189,10 +193,10 @@ class ExternalDataSchemaSerializer(serializers.ModelSerializer):
                 unpause_external_data_schedule(str(instance.id))
         else:
             if should_sync is True:
-                sync_external_data_job_workflow(instance, create=True)
+                sync_external_data_job_workflow(instance, create=True, should_sync=should_sync)
 
         if was_sync_frequency_updated or was_sync_time_of_day_updated:
-            sync_external_data_job_workflow(instance, create=False)
+            sync_external_data_job_workflow(instance, create=False, should_sync=should_sync)
 
         if trigger_refresh:
             instance.sync_type_config.update({"reset_pipeline": True})

--- a/posthog/warehouse/api/external_data_schema.py
+++ b/posthog/warehouse/api/external_data_schema.py
@@ -175,7 +175,11 @@ class ExternalDataSchemaSerializer(serializers.ModelSerializer):
                 instance.sync_frequency_interval = sync_frequency_interval
 
         if sync_time_of_day is not None:
-            new_time = dt.datetime.strptime(str(sync_time_of_day), "%H:%M:%S").time()
+            try:
+                new_time = dt.datetime.strptime(str(sync_time_of_day), "%H:%M:%S").time()
+            except ValueError:
+                raise ValidationError("Invalid sync time of day")
+
             if new_time != instance.sync_time_of_day:
                 was_sync_time_of_day_updated = True
                 validated_data["sync_time_of_day"] = sync_time_of_day

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -37,8 +37,8 @@ from posthog.temporal.data_imports.pipelines.schemas import (
     PIPELINE_TYPE_SCHEMA_DEFAULT_MAPPING,
 )
 from posthog.temporal.data_imports.pipelines.stripe import (
-    validate_credentials as validate_stripe_credentials,
     StripePermissionError,
+    validate_credentials as validate_stripe_credentials,
 )
 from posthog.temporal.data_imports.pipelines.vitally import (
     validate_credentials as validate_vitally_credentials,
@@ -527,7 +527,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         try:
             for active_schema in active_schemas:
-                sync_external_data_job_workflow(active_schema, create=True)
+                sync_external_data_job_workflow(active_schema, create=True, should_sync=active_schema.should_sync)
         except Exception as e:
             # Log error but don't fail because the source model was already created
             logger.exception("Could not trigger external data job", exc_info=e)

--- a/posthog/warehouse/api/test/conftest.py
+++ b/posthog/warehouse/api/test/conftest.py
@@ -1,6 +1,15 @@
+import logging
+
 import psycopg
+import pytest
 import pytest_asyncio
+from asgiref.sync import async_to_sync
 from psycopg import sql
+from temporalio.client import Client as TemporalClient
+from temporalio.service import RPCError
+
+from posthog.temporal.common.client import sync_connect
+from posthog.warehouse.models import ExternalDataSchema
 
 
 @pytest_asyncio.fixture
@@ -69,3 +78,29 @@ async def setup_postgres_test_db(postgres_config):
         await cursor.execute(sql.SQL("DROP DATABASE {}").format(sql.Identifier(postgres_config["database"])))
 
     await connection.close()
+
+
+@async_to_sync
+async def delete_temporal_schedule(temporal: TemporalClient, schedule_id: str):
+    """Delete a Temporal Schedule with the given id."""
+    handle = temporal.get_schedule_handle(schedule_id)
+    await handle.delete()
+
+
+def cleanup_temporal_schedules(client):
+    """Clean up any Temporal Schedules created during the test."""
+    for schedule in ExternalDataSchema.objects.all():
+        try:
+            delete_temporal_schedule(client, str(schedule.id))
+        except RPCError:
+            # Assume this is fine as we are tearing down, but don't fail silently.
+            logging.warning("Schedule %s has already been deleted, ignoring.", schedule.id)
+            continue
+
+
+@pytest.fixture
+def temporal():
+    """Return a TemporalClient instance."""
+    client = sync_connect()
+    yield client
+    cleanup_temporal_schedules(client)

--- a/posthog/warehouse/api/test/test_external_data_schema.py
+++ b/posthog/warehouse/api/test/test_external_data_schema.py
@@ -64,14 +64,14 @@ class TestExternalDataSchema(APIBaseTest):
         self.temporal = temporal
 
     def test_incremental_fields_stripe(self):
-        soruce = ExternalDataSource.objects.create(
+        source = ExternalDataSource.objects.create(
             team=self.team,
             source_type=ExternalDataSource.Type.STRIPE,
         )
         schema = ExternalDataSchema.objects.create(
             name="BalanceTransaction",
             team=self.team,
-            source=soruce,
+            source=source,
             should_sync=True,
             status=ExternalDataSchema.Status.COMPLETED,
             sync_type=ExternalDataSchema.SyncType.FULL_REFRESH,
@@ -85,14 +85,14 @@ class TestExternalDataSchema(APIBaseTest):
         assert payload == [{"label": "created_at", "type": "datetime", "field": "created", "field_type": "integer"}]
 
     def test_incremental_fields_missing_source_type(self):
-        soruce = ExternalDataSource.objects.create(
+        source = ExternalDataSource.objects.create(
             team=self.team,
             source_type="bad_source",
         )
         schema = ExternalDataSchema.objects.create(
             name="BalanceTransaction",
             team=self.team,
-            source=soruce,
+            source=source,
             should_sync=True,
             status=ExternalDataSchema.Status.COMPLETED,
             sync_type=ExternalDataSchema.SyncType.FULL_REFRESH,
@@ -105,14 +105,14 @@ class TestExternalDataSchema(APIBaseTest):
         assert response.status_code == 400
 
     def test_incremental_fields_missing_table_name(self):
-        soruce = ExternalDataSource.objects.create(
+        source = ExternalDataSource.objects.create(
             team=self.team,
             source_type=ExternalDataSource.Type.STRIPE,
         )
         schema = ExternalDataSchema.objects.create(
             name="Some_other_non_existent_table",
             team=self.team,
-            source=soruce,
+            source=source,
             should_sync=True,
             status=ExternalDataSchema.Status.COMPLETED,
             sync_type=ExternalDataSchema.SyncType.FULL_REFRESH,
@@ -397,7 +397,9 @@ class TestUpdateExternalDataSchema:
         assert response.status_code == 200
 
         schema.refresh_from_db()
-        assert schema.should_sync is True
+        # needed to appease mypy ;-(
+        new_schema = schema
+        assert new_schema.should_sync is True
 
         schedule_desc = describe_schedule(temporal, str(schema.id))
         assert schedule_desc.schedule.state.paused is False

--- a/posthog/warehouse/api/test/test_external_data_schema.py
+++ b/posthog/warehouse/api/test/test_external_data_schema.py
@@ -402,7 +402,7 @@ class TestUpdateExternalDataSchema:
         schedule_desc = describe_schedule(temporal, str(schema.id))
         assert schedule_desc.schedule.state.paused is False
 
-    def test_update_schema_change_should_sync_on_without_sync_type(self, team, user, client: HttpClient):
+    def test_update_schema_change_should_sync_on_without_sync_type(self, team, user, client: HttpClient, temporal):
         """Test that we can turn on a schema that doesn't have a sync type set.
 
         Not sure in which cases this can happen.
@@ -433,7 +433,7 @@ class TestUpdateExternalDataSchema:
 
         assert response.status_code == 400
 
-    def test_update_schema_change_sync_type_with_invalid_type(self, team, user, client: HttpClient):
+    def test_update_schema_change_sync_type_with_invalid_type(self, team, user, client: HttpClient, temporal):
         client.force_login(user)
         source_id = create_external_data_source_ok(client, team.pk)
         schema = ExternalDataSchema.objects.filter(source_id=source_id).first()

--- a/posthog/warehouse/api/test/test_external_data_schema.py
+++ b/posthog/warehouse/api/test/test_external_data_schema.py
@@ -7,8 +7,11 @@ import pytest
 import pytest_asyncio
 from asgiref.sync import sync_to_async
 from django.conf import settings
+from temporalio.service import RPCError
 
+from posthog.temporal.common.schedule import describe_schedule
 from posthog.test.base import APIBaseTest
+from posthog.warehouse.api.test.utils import create_external_data_source_ok
 from posthog.warehouse.models import DataWarehouseTable
 from posthog.warehouse.models.external_data_schema import ExternalDataSchema
 from posthog.warehouse.models.external_data_source import ExternalDataSource
@@ -47,9 +50,10 @@ async def postgres_connection(postgres_config, setup_postgres_test_db):
 @pytest.mark.usefixtures("postgres_connection", "postgres_config")
 class TestExternalDataSchema(APIBaseTest):
     @pytest.fixture(autouse=True)
-    def _setup(self, postgres_connection, postgres_config):
+    def _setup(self, postgres_connection, postgres_config, temporal):
         self.postgres_connection = postgres_connection
         self.postgres_config = postgres_config
+        self.temporal = temporal
 
     def test_incremental_fields_stripe(self):
         soruce = ExternalDataSource.objects.create(
@@ -228,218 +232,247 @@ class TestExternalDataSchema(APIBaseTest):
             assert schema.sync_type_config.get("incremental_field_type") == "integer"
             assert schema.sync_type_config.get("incremental_field_last_value") == 1
 
-    def test_update_schema_change_should_sync_off(self):
-        source = ExternalDataSource.objects.create(
-            team=self.team, source_type=ExternalDataSource.Type.STRIPE, job_inputs={}
-        )
-        schema = ExternalDataSchema.objects.create(
-            name="BalanceTransaction",
-            team=self.team,
-            source=source,
-            should_sync=True,
-            status=ExternalDataSchema.Status.COMPLETED,
-            sync_type=ExternalDataSchema.SyncType.FULL_REFRESH,
-        )
-
-        with (
-            mock.patch(
-                "posthog.warehouse.api.external_data_schema.external_data_workflow_exists"
-            ) as mock_external_data_workflow_exists,
-            mock.patch(
-                "posthog.warehouse.api.external_data_schema.pause_external_data_schedule"
-            ) as mock_pause_external_data_schedule,
-        ):
-            mock_external_data_workflow_exists.return_value = True
-
-            response = self.client.patch(
-                f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
-                data={"should_sync": False},
-            )
-
-            assert response.status_code == 200
-            mock_pause_external_data_schedule.assert_called_once()
-
-            schema.refresh_from_db()
-            assert schema.should_sync is False
-
-    def test_update_schema_change_should_sync_on_with_existing_schedule(self):
-        source = ExternalDataSource.objects.create(
-            team=self.team, source_type=ExternalDataSource.Type.STRIPE, job_inputs={}
-        )
-        schema = ExternalDataSchema.objects.create(
-            name="BalanceTransaction",
-            team=self.team,
-            source=source,
-            should_sync=False,
-            status=ExternalDataSchema.Status.COMPLETED,
-            sync_type=ExternalDataSchema.SyncType.FULL_REFRESH,
-        )
-
-        with (
-            mock.patch(
-                "posthog.warehouse.api.external_data_schema.external_data_workflow_exists"
-            ) as mock_external_data_workflow_exists,
-            mock.patch(
-                "posthog.warehouse.api.external_data_schema.unpause_external_data_schedule"
-            ) as mock_unpause_external_data_schedule,
-        ):
-            mock_external_data_workflow_exists.return_value = True
-
-            response = self.client.patch(
-                f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
-                data={"should_sync": True},
-            )
-
-            assert response.status_code == 200
-            mock_unpause_external_data_schedule.assert_called_once()
-
-            schema.refresh_from_db()
-            assert schema.should_sync is True
-
     def test_update_schema_change_should_sync_on_without_existing_schedule(self):
-        source = ExternalDataSource.objects.create(
-            team=self.team, source_type=ExternalDataSource.Type.STRIPE, job_inputs={}
-        )
-        schema = ExternalDataSchema.objects.create(
-            name="BalanceTransaction",
-            team=self.team,
-            source=source,
-            should_sync=False,
-            status=ExternalDataSchema.Status.COMPLETED,
-            sync_type=ExternalDataSchema.SyncType.FULL_REFRESH,
-        )
+        source_id = create_external_data_source_ok(self.client, self.team.pk)
+        schema = ExternalDataSchema.objects.filter(source_id=source_id, should_sync=False).first()
+        assert schema is not None
 
-        with (
-            mock.patch(
-                "posthog.warehouse.api.external_data_schema.external_data_workflow_exists"
-            ) as mock_external_data_workflow_exists,
-            mock.patch(
-                "posthog.warehouse.api.external_data_schema.sync_external_data_job_workflow"
-            ) as mock_sync_external_data_job_workflow,
-        ):
-            mock_external_data_workflow_exists.return_value = False
-
-            response = self.client.patch(
-                f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
-                data={"should_sync": True},
-            )
-
-            assert response.status_code == 200
-            mock_sync_external_data_job_workflow.assert_called_once()
-
-            schema.refresh_from_db()
-            assert schema.should_sync is True
-
-    def test_update_schema_change_should_sync_on_without_sync_type(self):
-        source = ExternalDataSource.objects.create(
-            team=self.team, source_type=ExternalDataSource.Type.STRIPE, job_inputs={}
-        )
-        schema = ExternalDataSchema.objects.create(
-            name="BalanceTransaction",
-            team=self.team,
-            source=source,
-            should_sync=False,
-            status=ExternalDataSchema.Status.COMPLETED,
-            sync_type=None,
-        )
+        # This is expected to raise an RPCError if the schedule doesn't exist yet
+        with pytest.raises(RPCError):
+            schedule_desc = describe_schedule(self.temporal, str(schema.id))
 
         response = self.client.patch(
             f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
-            data={"should_sync": True},
+            data={
+                "id": str(schema.id),
+                "name": schema.name,
+                "should_sync": True,
+                "incremental": False,
+                "status": "Completed",
+                "sync_type": "full_refresh",
+                "incremental_field": None,
+                "incremental_field_type": None,
+                "sync_frequency": "6hour",
+                "sync_time_of_day": "00:00:00",
+            },
+        )
+
+        assert response.status_code == 200
+
+        schema.refresh_from_db()
+        assert schema.should_sync is True
+
+        schedule_desc = describe_schedule(self.temporal, str(schema.id))
+        assert schedule_desc.schedule.state.paused is False
+
+    def test_update_schema_change_should_sync_off(self):
+        """Test that we can pause a schedule by setting should_sync to false.
+
+        We try to simulate the behaviour in production as close as possible since the previous tests using mocks were
+        not catching issues with us not updating the schedule in Temporal correctly.
+        """
+        source_id = create_external_data_source_ok(self.client, self.team.pk)
+        schema = ExternalDataSchema.objects.filter(source_id=source_id, should_sync=True).first()
+        assert schema is not None
+
+        schedule_desc = describe_schedule(self.temporal, str(schema.id))
+        assert schedule_desc.schedule.state.paused is False
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
+            # here we try to mimic the payload from the frontend, which actually sends all fields, not just should_sync
+            data={
+                "id": str(schema.id),
+                "name": schema.name,
+                "should_sync": False,
+                "incremental": False,
+                "status": "Completed",
+                "sync_type": "full_refresh",
+                "incremental_field": None,
+                "incremental_field_type": None,
+                "sync_frequency": "6hour",
+                "sync_time_of_day": "00:00:00",
+            },
+        )
+        assert response.status_code == 200
+
+        schema.refresh_from_db()
+        assert schema.should_sync is False
+
+        schedule_desc = describe_schedule(self.temporal, str(schema.id))
+        assert schedule_desc.schedule.state.paused is True
+
+    def test_update_schema_change_should_sync_on_with_existing_schedule(self):
+        source_id = create_external_data_source_ok(self.client, self.team.pk)
+        schema = ExternalDataSchema.objects.filter(source_id=source_id, should_sync=True).first()
+        assert schema is not None
+
+        # ensure schedule exists first
+        schedule_desc = describe_schedule(self.temporal, str(schema.id))
+        assert schedule_desc.schedule.state.paused is False
+
+        # pause the schedule
+        response = self.client.patch(
+            f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
+            data={
+                "id": str(schema.id),
+                "name": schema.name,
+                "should_sync": False,
+                "incremental": False,
+                "status": "Completed",
+                "sync_type": "full_refresh",
+                "incremental_field": None,
+                "incremental_field_type": None,
+                "sync_frequency": "6hour",
+                "sync_time_of_day": "00:00:00",
+            },
+        )
+        assert response.status_code == 200
+
+        schema.refresh_from_db()
+        assert schema.should_sync is False
+
+        schedule_desc = describe_schedule(self.temporal, str(schema.id))
+        assert schedule_desc.schedule.state.paused is True
+
+        # now turn it back on
+        response = self.client.patch(
+            f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
+            data={
+                "id": str(schema.id),
+                "name": schema.name,
+                "should_sync": True,
+                "incremental": False,
+                "status": "Completed",
+                "sync_type": "full_refresh",
+                "incremental_field": None,
+                "incremental_field_type": None,
+                "sync_frequency": "6hour",
+                "sync_time_of_day": "00:00:00",
+            },
+        )
+
+        assert response.status_code == 200
+
+        schema.refresh_from_db()
+        assert schema.should_sync is True
+
+        schedule_desc = describe_schedule(self.temporal, str(schema.id))
+        assert schedule_desc.schedule.state.paused is False
+
+    def test_update_schema_change_should_sync_on_without_sync_type(self):
+        """Test that we can turn on a schema that doesn't have a sync type set.
+
+        Not sure in which cases this can happen.
+        """
+        source_id = create_external_data_source_ok(self.client, self.team.pk)
+        schema = ExternalDataSchema.objects.filter(source_id=source_id, should_sync=False).first()
+        assert schema is not None
+        schema.sync_type = None
+        schema.save()
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
+            data={
+                "id": str(schema.id),
+                "name": schema.name,
+                "should_sync": True,
+                "incremental": False,
+                "status": "Completed",
+                "sync_type": None,
+                "incremental_field": None,
+                "incremental_field_type": None,
+                "sync_frequency": "6hour",
+                "sync_time_of_day": "00:00:00",
+            },
         )
 
         assert response.status_code == 400
 
     def test_update_schema_change_sync_type_with_invalid_type(self):
-        source = ExternalDataSource.objects.create(
-            team=self.team, source_type=ExternalDataSource.Type.STRIPE, job_inputs={}
-        )
-        schema = ExternalDataSchema.objects.create(
-            name="BalanceTransaction",
-            team=self.team,
-            source=source,
-            should_sync=False,
-            status=ExternalDataSchema.Status.COMPLETED,
-            sync_type=None,
-        )
+        source_id = create_external_data_source_ok(self.client, self.team.pk)
+        schema = ExternalDataSchema.objects.filter(source_id=source_id).first()
+        assert schema is not None
 
         response = self.client.patch(
             f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
-            data={"sync_type": "blah"},
+            data={
+                "id": str(schema.id),
+                "name": schema.name,
+                "should_sync": True,
+                "incremental": False,
+                "status": "Completed",
+                "sync_type": "blah",
+                "incremental_field": None,
+                "incremental_field_type": None,
+                "sync_frequency": "6hour",
+                "sync_time_of_day": "00:00:00",
+            },
         )
 
         assert response.status_code == 400
 
     def test_update_schema_sync_frequency(self):
-        source = ExternalDataSource.objects.create(
-            team=self.team, source_type=ExternalDataSource.Type.STRIPE, job_inputs={}
+        source_id = create_external_data_source_ok(self.client, self.team.pk)
+        schema = ExternalDataSchema.objects.filter(source_id=source_id).first()
+        assert schema is not None
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
+            data={
+                "id": str(schema.id),
+                "name": schema.name,
+                "should_sync": True,
+                "incremental": False,
+                "status": "Completed",
+                "sync_type": "full_refresh",
+                "incremental_field": None,
+                "incremental_field_type": None,
+                "sync_frequency": "7day",
+                "sync_time_of_day": "00:00:00",
+            },
         )
-        schema = ExternalDataSchema.objects.create(
-            name="BalanceTransaction",
-            team=self.team,
-            source=source,
-            should_sync=True,
-            status=ExternalDataSchema.Status.COMPLETED,
-            sync_type=ExternalDataSchema.SyncType.FULL_REFRESH,
-            sync_frequency_interval=timedelta(hours=24),
-        )
 
-        with (
-            mock.patch(
-                "posthog.warehouse.api.external_data_schema.external_data_workflow_exists"
-            ) as mock_external_data_workflow_exists,
-            mock.patch(
-                "posthog.warehouse.api.external_data_schema.sync_external_data_job_workflow"
-            ) as mock_sync_external_data_job_workflow,
-        ):
-            mock_external_data_workflow_exists.return_value = True
+        assert response.status_code == 200
 
-            response = self.client.patch(
-                f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
-                data={"sync_frequency": "7day"},
-            )
+        schema.refresh_from_db()
+        assert schema.sync_frequency_interval == timedelta(days=7)
 
-            assert response.status_code == 200
-            mock_sync_external_data_job_workflow.assert_called_once()
-
-            schema.refresh_from_db()
-            assert schema.sync_frequency_interval == timedelta(days=7)
+        # TODO - add this back once we have updated the schedules correctly
+        # schedule_desc = describe_schedule(self.temporal, str(schema.id))
+        # assert schedule_desc.schedule.spec.intervals[0].every == "604800s"  # 7 days in seconds
 
     def test_update_schema_sync_time_of_day(self):
-        source = ExternalDataSource.objects.create(
-            team=self.team, source_type=ExternalDataSource.Type.STRIPE, job_inputs={}
+        source_id = create_external_data_source_ok(self.client, self.team.pk)
+        schema = ExternalDataSchema.objects.filter(source_id=source_id).first()
+        assert schema is not None
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
+            data={
+                "id": str(schema.id),
+                "name": schema.name,
+                "should_sync": True,
+                "incremental": False,
+                "status": "Completed",
+                "sync_type": "full_refresh",
+                "incremental_field": None,
+                "incremental_field_type": None,
+                "sync_frequency": "24hour",
+                "sync_time_of_day": "15:30:00",
+            },
         )
-        schema = ExternalDataSchema.objects.create(
-            name="BalanceTransaction",
-            team=self.team,
-            source=source,
-            should_sync=True,
-            status=ExternalDataSchema.Status.COMPLETED,
-            sync_type=ExternalDataSchema.SyncType.FULL_REFRESH,
-            sync_frequency_interval=timedelta(days=1),
-            sync_time_of_day="12:00:00",
-        )
 
-        with (
-            mock.patch(
-                "posthog.warehouse.api.external_data_schema.external_data_workflow_exists"
-            ) as mock_external_data_workflow_exists,
-            mock.patch(
-                "posthog.warehouse.api.external_data_schema.sync_external_data_job_workflow"
-            ) as mock_sync_external_data_job_workflow,
-        ):
-            mock_external_data_workflow_exists.return_value = True
+        assert response.status_code == 200
 
-            response = self.client.patch(
-                f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
-                data={"sync_time_of_day": "15:30:00"},
-            )
+        schema.refresh_from_db()
+        assert schema.sync_time_of_day is not None
+        assert schema.sync_time_of_day.hour == 15
+        assert schema.sync_time_of_day.minute == 30
+        assert schema.sync_time_of_day.second == 0
 
-            assert response.status_code == 200
-            mock_sync_external_data_job_workflow.assert_called_once()
-
-            schema.refresh_from_db()
-            assert schema.sync_time_of_day is not None
-            assert schema.sync_time_of_day.hour == 15
-            assert schema.sync_time_of_day.minute == 30
-            assert schema.sync_time_of_day.second == 0
+        # TODO - add this back once we have updated the schedules correctly
+        # schedule_desc = describe_schedule(self.temporal, str(schema.id))
+        # assert schedule_desc.schedule.spec.intervals[0].at.time.hour == 15
+        # assert schedule_desc.schedule.spec.intervals[0].at.time.minute == 30
+        # assert schedule_desc.schedule.spec.intervals[0].at.time.second == 0

--- a/posthog/warehouse/api/test/utils.py
+++ b/posthog/warehouse/api/test/utils.py
@@ -1,0 +1,27 @@
+from typing import Any
+
+
+def create_external_data_source_ok(client, team_id) -> int:
+    """Create an external data source and return the id."""
+    response = client.post(
+        f"/api/environments/{team_id}/external_data_sources/",
+        data={
+            "source_type": "Stripe",
+            "payload": {
+                "client_secret": "sk_test_123",
+                "schemas": [
+                    {"name": "BalanceTransaction", "should_sync": True, "sync_type": "full_refresh"},
+                    {"name": "Subscription", "should_sync": True, "sync_type": "full_refresh"},
+                    {"name": "Customer", "should_sync": True, "sync_type": "full_refresh"},
+                    {"name": "Product", "should_sync": True, "sync_type": "full_refresh"},
+                    {"name": "Price", "should_sync": True, "sync_type": "full_refresh"},
+                    {"name": "Invoice", "should_sync": True, "sync_type": "full_refresh"},
+                    {"name": "Charge", "should_sync": False, "sync_type": "full_refresh"},
+                ],
+            },
+        },
+    )
+    payload: dict[str, Any] = response.json()
+
+    assert response.status_code == 201
+    return payload["id"]

--- a/posthog/warehouse/api/test/utils.py
+++ b/posthog/warehouse/api/test/utils.py
@@ -1,7 +1,9 @@
 from typing import Any
 
+from django.test.client import Client as HttpClient
 
-def create_external_data_source_ok(client, team_id) -> int:
+
+def create_external_data_source_ok(client: HttpClient, team_id: int) -> int:
     """Create an external data source and return the id."""
     response = client.post(
         f"/api/environments/{team_id}/external_data_sources/",
@@ -16,10 +18,16 @@ def create_external_data_source_ok(client, team_id) -> int:
                     {"name": "Product", "should_sync": True, "sync_type": "full_refresh"},
                     {"name": "Price", "should_sync": True, "sync_type": "full_refresh"},
                     {"name": "Invoice", "should_sync": True, "sync_type": "full_refresh"},
-                    {"name": "Charge", "should_sync": False, "sync_type": "full_refresh"},
+                    {
+                        "name": "Charge",
+                        "should_sync": False,
+                        "sync_type": "full_refresh",
+                        "sync_time_of_day": "01:00:00",
+                    },
                 ],
             },
         },
+        content_type="application/json",
     )
     payload: dict[str, Any] = response.json()
 

--- a/posthog/warehouse/models/external_data_source.py
+++ b/posthog/warehouse/models/external_data_source.py
@@ -88,7 +88,7 @@ class ExternalDataSource(CreatedMetaFields, UpdatedMetaFields, UUIDModel, Delete
                 trigger_external_data_workflow(schema)
             except temporalio.service.RPCError as e:
                 if e.status == temporalio.service.RPCStatusCode.NOT_FOUND:
-                    sync_external_data_job_workflow(schema, create=True)
+                    sync_external_data_job_workflow(schema, create=True, should_sync=True)
 
             except Exception as e:
                 logger.exception(f"Could not trigger external data job for schema {schema.name}", exc_info=e)


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Pausing data import schemas is effectively broken; they will be paused in our DB but not in Temporal, meaning they will keep running indefinitely.

The issue stemmed from the following line:
```
if sync_time_of_day != instance.sync_time_of_day:
```

which always returns true as these two variables are always of different types (first is a string, second is a `datetime.time`). This means we always update the schedule even when pausing a schema, and when we do so, we always update it, overriding whether it is paused or not!

## Changes

- Add some tests to properly cover this. Our current tests didn't pick up this regression since they only inspect the data in the database and not in Temporal.
- Compare sync times of the day correctly
- Add a `should_sync` argument to functions that update schedules, to ensure we always respect the desired state


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

New tests.

Also tested locally.

## Other considerations

We will need to update schedules in Temporal once deployed
