### PR TITLE
fix(cdp): Start both job producers if percentage weighting

### DIFF
--- a/plugin-server/src/cdp/services/hog-function-monitoring.service.ts
+++ b/plugin-server/src/cdp/services/hog-function-monitoring.service.ts
@@ -15,7 +15,7 @@ import {
 import { fixLogDeduplication } from '../utils'
 import { convertToCaptureEvent } from '../utils'
 
-export const counterHogFunctionMetric = new Counter({
+const counterHogFunctionMetric = new Counter({
     name: 'cdp_hog_function_metric',
     help: 'A function invocation was evaluated with an outcome',
     labelNames: ['metric_kind', 'metric_name'],

--- a/plugin-server/src/cdp/services/job-queue/job-queue.test.ts
+++ b/plugin-server/src/cdp/services/job-queue/job-queue.test.ts
@@ -38,6 +38,45 @@ describe('CyclotronJobQueue', () => {
             expect(queue['consumerMode']).toBe('kafka')
         })
     })
+
+    describe('producer setup', () => {
+        const buildQueue = (mapping: string) => {
+            config.CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_MODE = 'kafka'
+            config.CDP_CYCLOTRON_JOB_QUEUE_PRODUCER_MAPPING = mapping
+            const queue = new CyclotronJobQueue(config, 'hog', mockHogFunctionManager, mockConsumeBatch)
+            queue['jobQueuePostgres'].startAsProducer = jest.fn()
+            queue['jobQueueKafka'].startAsProducer = jest.fn()
+            return queue
+        }
+
+        it('should start only kafka producer if only kafka is mapped', async () => {
+            const queue = buildQueue('*:kafka,fetch:kafka')
+            await queue.startAsProducer()
+            expect(queue['jobQueuePostgres'].startAsProducer).not.toHaveBeenCalled()
+            expect(queue['jobQueueKafka'].startAsProducer).toHaveBeenCalled()
+        })
+
+        it('should start only postgres producer if only postgres is mapped', async () => {
+            const queue = buildQueue('*:postgres,fetch:postgres')
+            await queue.startAsProducer()
+            expect(queue['jobQueuePostgres'].startAsProducer).toHaveBeenCalled()
+            expect(queue['jobQueueKafka'].startAsProducer).not.toHaveBeenCalled()
+        })
+
+        it('should start both producers if both are mapped', async () => {
+            const queue = buildQueue('*:postgres,fetch:kafka')
+            await queue.startAsProducer()
+            expect(queue['jobQueuePostgres'].startAsProducer).toHaveBeenCalled()
+            expect(queue['jobQueueKafka'].startAsProducer).toHaveBeenCalled()
+        })
+
+        it('should start both producers if a percentage is mapped', async () => {
+            const queue = buildQueue('*:postgres:0.5')
+            await queue.startAsProducer()
+            expect(queue['jobQueuePostgres'].startAsProducer).toHaveBeenCalled()
+            expect(queue['jobQueueKafka'].startAsProducer).toHaveBeenCalled()
+        })
+    })
 })
 
 describe('getProducerMapping', () => {
@@ -71,7 +110,7 @@ describe('getProducerMapping', () => {
             'wrong_queue:kafka',
             'Invalid mapping: wrong_queue:kafka - queue wrong_queue must be one of *, hog, fetch, plugin',
         ],
-        ['hog:kafka:1.1', 'Invalid mapping: hog:kafka:1.1 - percentage 1.1 must be a number between 0 and 1'],
+        ['hog:kafka:1.1', 'Invalid mapping: hog:kafka:1.1 - percentage 1.1 must be 0 < x <= 1'],
         ['hog:kafka', 'No mapping for the default queue for example: *:postgres'],
     ])('should throw for bad values for %s', (mapping, error) => {
         expect(() => getProducerMapping(mapping)).toThrow(error)


### PR DESCRIPTION
## Problem

The logic was a bit too simple and didn't account for if a weighting of `0.5` was used as it only checked the keys. Now it checks if any routing has a percentage split and starts both

## Changes

* As it says

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

* With tests!
