### PR TITLE
fix(flags): Set description to None

### DIFF
--- a/rust/feature-flags/src/api/request_handler.rs
+++ b/rust/feature-flags/src/api/request_handler.rs
@@ -859,7 +859,7 @@ mod tests {
                 metadata: FlagDetailsMetadata {
                     id: 1,
                     version: 1,
-                    description: Some("Error Flag".to_string()),
+                    description: None,
                     payload: None,
                 },
             }
@@ -1344,7 +1344,7 @@ mod tests {
                 metadata: FlagDetailsMetadata {
                     id: 1,
                     version: 1,
-                    description: Some("Flag 1".to_string()),
+                    description: None,
                     payload: None,
                 },
             }
@@ -1363,7 +1363,7 @@ mod tests {
                 metadata: FlagDetailsMetadata {
                     id: 2,
                     version: 1,
-                    description: Some("Flag 2".to_string()),
+                    description: None,
                     payload: None,
                 },
             }

--- a/rust/feature-flags/src/api/types.rs
+++ b/rust/feature-flags/src/api/types.rs
@@ -147,7 +147,7 @@ impl FromFeatureAndMatch for FlagDetails {
             metadata: FlagDetailsMetadata {
                 id: flag.id,
                 version: flag.version.unwrap_or(0),
-                description: flag.name.clone(),
+                description: None,
                 payload: flag_match.payload.clone(),
             },
         }
@@ -166,7 +166,7 @@ impl FromFeatureAndMatch for FlagDetails {
             metadata: FlagDetailsMetadata {
                 id: flag.id,
                 version: flag.version.unwrap_or(0),
-                description: flag.name.clone(),
+                description: None,
                 payload: None,
             },
         }


### PR DESCRIPTION
## Problem

The description contains information that's not necessary for flag evaluation and makes the payload larger than it needs to be.

## Changes

Set the description to None for now. When I'm sure it won't break clients, I'll just remove it entirely.

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Manually.