### PR TITLE
fix: experiment creation won't override feature flag.

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm.tsx
@@ -62,6 +62,11 @@ const ExperimentFormFields = (): JSX.Element => {
                             placeholder="Pricing page conversion"
                             data-attr="experiment-name"
                             onBlur={() => {
+                                // bail if feature flag key is already set
+                                if (experiment.feature_flag_key) {
+                                    return
+                                }
+
                                 setExperiment({
                                     feature_flag_key: generateFeatureFlagKey(
                                         experiment.name,


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

If the user writes or links to a feature flag _before_ setting up the experiment name, the selection gets overwritten with an auto-generated flag.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

A simple check if the `experiment` has a feature flag already set prevents this problem to happen.

> [!NOTE]
> If you are asking _well, where is the feature flag input validation and `onChange`_, it is hidden behind the veil of the Kea logic. Do not despair.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
