### PR TITLE
test(max): Use Braintrust project per experiment, fixing comparison

### DIFF
--- a/.github/workflows/ci-ai.yml
+++ b/.github/workflows/ci-ai.yml
@@ -95,7 +95,7 @@ jobs:
                                   let baselineComparison = null
                                   const diffHighlight = Math.abs(value.diff) > 0.01 ? "**" : ""
                                   let diffEmoji = "🆕"
-                                  if (result.comparison_experiment_name) {
+                                  if (result.comparison_experiment_name?.startsWith("master-")) {
                                       baselineComparison = `${diffHighlight}${value.diff > 0 ? "+" : value.diff < 0 ? "" : "±"}${(
                                           value.diff * 100
                                       ).toFixed(2)}%${diffHighlight} versus [baseline (master)](${result.project_url}/experiments/${

--- a/.github/workflows/ci-ai.yml
+++ b/.github/workflows/ci-ai.yml
@@ -103,7 +103,6 @@ jobs:
                                       }) (improvements: ${value.improvements}, regressions: ${value.regressions})`
                                       diffEmoji = value.diff > 0.01 ? "🟢" : value.diff < -0.01 ? "🔴" : "🔵"
                                   }
-                                  }
                                   return `${diffEmoji} **${key}**: **${score}**${baselineComparison ? `, ${baselineComparison}` : ""}`
                               })
                               .join("\n")

--- a/.github/workflows/ci-ai.yml
+++ b/.github/workflows/ci-ai.yml
@@ -28,6 +28,10 @@ jobs:
 
         steps:
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+              with:
+                  # Check out the actual branch instead of merge commit with master,
+                  # because we want the Braintrust experiment to have accurate git metadata
+                  ref: ${{ github.event.pull_request.head.ref }}
 
             - name: Stop/Start stack with Docker Compose
               run: |
@@ -64,8 +68,6 @@ jobs:
                   GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
             - name: Post eval summary to PR
-              # Don't run on forks
-              if: github.event.pull_request.head.repo.full_name == github.repository
               uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
               with:
                   github-token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
@@ -85,62 +87,48 @@ jobs:
                       }
 
                       // Generate concise experiment summaries
-                      const experimentSummaries = evalResults
-                          .map((result) => {
-                              const experimentName = result.experiment_name.split("-")[0]
-                              const experimentUrl = result.experiment_url
-                              let comparedTo = result.comparison_experiment_name
-                              if (comparedTo !== `${experimentName}-master`) {
-                                  // This experiment hasn't ran on master yet, so we aren't able to compare to baseline
-                                  comparedTo = null
-                              }
+                      const experimentSummaries = evalResults.map((result) => {
+                          // Format scores as bullet points with improvements/regressions and baseline comparison
+                          const scoresList = Object.entries(result.scores || {})
+                              .map(([key, value]) => {
+                                  const score = typeof value.score === "number" ? `${(value.score * 100).toFixed(2)}%` : value.score
+                                  let baselineComparison = null
+                                  const diffHighlight = Math.abs(value.diff) > 0.01 ? "**" : ""
+                                  const diffEmoji = "🆕"
+                                  if (result.comparison_experiment_name) {
+                                      baselineComparison = `${diffHighlight}${value.diff > 0 ? "+" : value.diff < 0 ? "" : "±"}${(
+                                          value.diff * 100
+                                      ).toFixed(2)}%${diffHighlight} versus [baseline (master)](${result.project_url}/experiments/${
+                                          result.comparison_experiment_name
+                                      }) (improvements: ${value.improvements}, regressions: ${value.regressions})`
+                                      diffEmoji = value.diff > 0.01 ? "🟢" : value.diff < -0.01 ? "🔴" : "🔵"
+                                  }
+                                  return `${diffEmoji} **${key}**: **${score}**${baselineComparison ? `, ${baselineComparison}` : ""}`
+                              })
+                              .join("\n")
 
-                              // Format scores as bullet points with improvements/regressions and baseline comparison
-                              const scoresList = Object.entries(result.scores || {})
-                                  .map(([key, value]) => {
-                                      const score = typeof value.score === "number" ? `${(value.score * 100).toFixed(2)}%` : value.score
-                                      let baselineComparison = null
-                                      const diffHighlight = Math.abs(value.diff) > 0.01 ? "**" : ""
-                                      if (comparedTo) {
-                                          baselineComparison = `${diffHighlight}${value.diff > 0 ? "+" : value.diff < 0 ? "" : "±"}${(
-                                              value.diff * 100
-                                          ).toFixed(2)}%${diffHighlight} versus [baseline (master)](${
-                                              result.project_url
-                                          }/experiments/${comparedTo}) (improvements: ${value.improvements}, regressions: ${
-                                              value.regressions
-                                          })`
-                                      }
-                                      return `${
-                                          !comparedTo ? "🆕" : value.diff > 0.01 ? "🟢" : value.diff < -0.01 ? "🔴" : "🔵"
-                                      } **${key}**: **${score}**${baselineComparison ? `, ${baselineComparison}` : ""}`
-                                  })
-                                  .join("\n")
+                          // Format key metrics concisely
+                          const metrics = result.metrics || {}
+                          const duration = metrics.duration ? `⏱️ ${metrics.duration.metric.toFixed(2)} s` : null
+                          const totalTokens = metrics.total_tokens ? `🔢 ${Math.floor(metrics.total_tokens.metric)} tokens` : null
+                          const cost = metrics.estimated_cost ? `💵 $${metrics.estimated_cost.metric.toFixed(4)} in tokens` : null
+                          const metricsText = [duration, totalTokens, cost].filter(Boolean).join(", ")
 
-                              // Format key metrics concisely
-                              const metrics = result.metrics || {}
-                              const duration = metrics.duration ? `⏱️ ${metrics.duration.metric.toFixed(2)} s` : null
-                              const totalTokens = metrics.total_tokens ? `🔢 ${Math.floor(metrics.total_tokens.metric)} tokens` : null
-                              const cost = metrics.estimated_cost ? `💵 $${metrics.estimated_cost.metric.toFixed(4)} in tokens` : null
-                              const metricsText = [duration, totalTokens, cost].filter(Boolean).join(", ")
+                          // Create concise experiment summary with header only showing experiment name
+                          const experimentName = result.project_name.replace(/^max-ai-/, "")
 
-                              // Create concise experiment summary with header only showing experiment name
-                              return `### [${experimentName}](${experimentUrl})\n\n${scoresList}\n\nAvg. case performance: ${metricsText}`
-                          })
-                          .join("\n\n")
+                          return `### [${experimentName}](${result.experiment_url})\n\n${scoresList}\n\nAvg. case performance: ${metricsText}`
+                      })
 
                       const totalExperiments = evalResults.length
                       const totalMetrics = evalResults.reduce((acc, result) => acc + Object.keys(result.scores || {}).length, 0)
-                      const totalImprovements = evalResults.reduce((acc, result) => {
-                          return acc + Object.values(result.scores || {}).reduce((sum, value) => sum + (value.improvements || 0), 0)
-                      }, 0)
-                      const totalRegressions = evalResults.reduce((acc, result) => {
-                          return acc + Object.values(result.scores || {}).reduce((sum, value) => sum + (value.regressions || 0), 0)
-                      }, 0)
 
-                      let body = `## 🧠 AI eval results\n\n`
-                      body += `Evaluated **${totalMetrics}** metrics across **${totalExperiments}** experiments.\n\n`
-                      body += `${experimentSummaries}\n\n`
-                      body += `_Triggered by [this commit](https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${context.payload.pull_request.number}/commits/${context.payload.pull_request.head.sha})._`
+                      const body = [
+                          `## 🧠 AI eval results`,
+                          `Evaluated **${totalMetrics}** metrics across **${totalExperiments}** experiments.`,
+                          ...experimentSummaries,
+                          `_Triggered by [this commit](https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${context.payload.pull_request.number}/commits/${context.payload.pull_request.head.sha})._`,
+                      ].join("\n\n")
 
                       // Post comment on PR
                       if (context.payload.pull_request) {

--- a/.github/workflows/ci-ai.yml
+++ b/.github/workflows/ci-ai.yml
@@ -94,7 +94,7 @@ jobs:
                                   const score = typeof value.score === "number" ? `${(value.score * 100).toFixed(2)}%` : value.score
                                   let baselineComparison = null
                                   const diffHighlight = Math.abs(value.diff) > 0.01 ? "**" : ""
-                                  const diffEmoji = "🆕"
+                                  let diffEmoji = "🆕"
                                   if (result.comparison_experiment_name) {
                                       baselineComparison = `${diffHighlight}${value.diff > 0 ? "+" : value.diff < 0 ? "" : "±"}${(
                                           value.diff * 100
@@ -102,6 +102,7 @@ jobs:
                                           result.comparison_experiment_name
                                       }) (improvements: ${value.improvements}, regressions: ${value.regressions})`
                                       diffEmoji = value.diff > 0.01 ? "🟢" : value.diff < -0.01 ? "🔴" : "🔵"
+                                  }
                                   }
                                   return `${diffEmoji} **${key}**: **${score}**${baselineComparison ? `, ${baselineComparison}` : ""}`
                               })

--- a/.github/workflows/ci-ai.yml
+++ b/.github/workflows/ci-ai.yml
@@ -125,7 +125,7 @@ jobs:
 
                       const body = [
                           `## 🧠 AI eval results`,
-                          `Evaluated **${totalMetrics}** metrics across **${totalExperiments}** experiments.`,
+                          `Evaluated **${totalExperiments}** experiments, comprising **${totalMetrics}** metrics.`,
                           ...experimentSummaries,
                           `_Triggered by [this commit](https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${context.payload.pull_request.number}/commits/${context.payload.pull_request.head.sha})._`,
                       ].join("\n\n")


### PR DESCRIPTION
## Problem

Eval comparisons to baseline have been borked, because the logic for using `master` as baseline in Braintrust assumes one experiment suite _per project_. Basically in Braintrust a project means something different than in PostHog or Sentry, and is designed to comprise one suite of evals, rather than evals for the whole product. Chatted in depth about this with Braintrust's @ankrgyl. 🙏 

## Changes

Let's do things as the makers of the tool intended. This gives us very clean eval comparisons to previous Max iterations.

## How did you test this code?

Ran the evals.