### PR TITLE
feat(capture-rs): initial scaffold of new legacy event endpoint and handler

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1243,6 +1243,7 @@ dependencies = [
  "futures",
  "health",
  "limiters",
+ "lz-str",
  "metrics",
  "metrics-exporter-prometheus",
  "once_cell",
@@ -3645,6 +3646,12 @@ checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.0",
 ]
+
+[[package]]
+name = "lz-str"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39f3d72d77227090eed75ea331285a53726e78374a1f357ff5757702c23c70cc"
 
 [[package]]
 name = "mach"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -108,6 +108,7 @@ mockall = "0.13.0"
 moka = { version = "0.12.8", features = ["sync", "future"] }
 posthog-rs = { version = "0.3.5", features = ["async-client"] }
 regex = "1.11.1"
+lz-str = "0.2.1"
 
 # Used for decrypting django encrypted fields
 fernet = "0.2"

--- a/rust/capture/Cargo.toml
+++ b/rust/capture/Cargo.toml
@@ -48,6 +48,7 @@ uuid = { workspace = true }
 aws-config = { workspace = true }
 aws-sdk-s3 = { workspace = true }
 chrono = { workspace = true }
+lz-str = { workspace = true }
 
 [dev-dependencies]
 assert-json-diff = { workspace = true }

--- a/rust/capture/src/api.rs
+++ b/rust/capture/src/api.rs
@@ -27,6 +27,8 @@ pub enum CaptureError {
 
     #[error("request holds no event")]
     EmptyBatch,
+    #[error("request missing data payload")]
+    EmptyPayload,
     #[error("event submitted with an empty event name")]
     MissingEventName,
     #[error("event submitted without a distinct_id")]
@@ -75,6 +77,7 @@ impl IntoResponse for CaptureError {
             CaptureError::RequestDecodingError(_)
             | CaptureError::RequestParsingError(_)
             | CaptureError::EmptyBatch
+            | CaptureError::EmptyPayload
             | CaptureError::MissingEventName
             | CaptureError::MissingDistinctId
             | CaptureError::InvalidCookielessMode

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -81,7 +81,7 @@ async fn handle_legacy(
     let raw_payload: Bytes = match *method {
         Method::POST => {
             if !body.is_empty() {
-                error!("unexpected missing payload on {} request", *method);
+                error!("unexpected missing payload on {:?} request", method);
                 return Err(CaptureError::EmptyPayload);
             }
             body
@@ -94,7 +94,7 @@ async fn handle_legacy(
             } else if !body.is_empty() {
                 body
             } else {
-                error!("unexpected missing payload on {} request", *method);
+                error!("unexpected missing payload on {:?} request", method);
                 return Err(CaptureError::EmptyPayload);
             }
         }

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -34,7 +34,7 @@ pub const MAX_CHARS_TO_CHECK: usize = 128;
 // flexible form schema to accommodate legacy quirks across SDKs/versions
 #[derive(Deserialize)]
 struct LegacyEventForm {
-    pub data: Vec<u8>,
+    pub data: Vec<u8>, // TODO(eli): this should be Option<Vec<u8>>
     pub compression: Option<Compression>,
     #[serde(alias = "ver")]
     pub lib_version: Option<String>,

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -279,7 +279,7 @@ fn decode_form(payload: &[u8], location: &str) -> Result<LegacyEventForm, Captur
         Ok(form) => Ok(form),
 
         Err(e) => {
-            let max_chars = std::cmp::min(payload.len(), MAX_CHARS_TO_CHECK);
+            let max_chars: usize = std::cmp::min(payload.len(), MAX_CHARS_TO_CHECK);
             let form_data_snippet = String::from_utf8(payload[..max_chars].to_vec())
                 .unwrap_or(String::from("INVALID_UTF8"));
             error!(

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -41,7 +41,7 @@ pub struct EventQuery {
     pub compression: Option<Compression>,
 
     // legacy GET requests can include data as query param
-    pub data: Option<String>,
+    pub data: Option<Vec<u8>>,
 
     #[serde(alias = "ver")]
     pub lib_version: Option<String>,

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -253,7 +253,7 @@ fn decompress_lz64(payload: &[u8], limit: usize) -> Result<String, CaptureError>
         }
     };
 
-    if decompressed.len() >= limit {
+    if decompressed.len() > limit {
         error!(
             "lz64 request payload size limit exceeded: {}",
             decompressed.len()

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -7,19 +7,33 @@ use flate2::read::GzDecoder;
 use serde::Deserialize;
 use time::format_description::well_known::Iso8601;
 use time::OffsetDateTime;
-use tracing::instrument;
+use tracing::{error, instrument};
 
-use crate::api::CaptureError;
-use crate::prometheus::report_dropped_events;
-use crate::token::validate_token;
+use crate::{
+    api::CaptureError, prometheus::report_dropped_events, token::validate_token,
+    v0_endpoint::MAX_CHARS_TO_CHECK,
+};
 
-#[derive(Deserialize, Default)]
+#[derive(Deserialize, Default, Clone, Copy, PartialEq, Eq)]
 pub enum Compression {
     #[default]
     Unsupported,
 
     #[serde(rename = "gzip", alias = "gzip-js")]
     Gzip,
+
+    #[serde(rename = "lz64")]
+    LZString,
+}
+
+impl std::fmt::Display for Compression {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Compression::Gzip => write!(f, "gzip"),
+            Compression::LZString => write!(f, "lz64"),
+            Compression::Unsupported => write!(f, "unsupported"),
+        }
+    }
 }
 
 #[derive(Deserialize, Default)]
@@ -54,12 +68,16 @@ impl EventQuery {
     }
 }
 
-#[derive(Debug, Deserialize)]
+// Some SDKs like posthog-js-lite can include metadata in the POST body
+#[derive(Deserialize)]
 pub struct EventFormData {
     pub data: String,
+    pub compression: Option<Compression>,
+    #[serde(alias = "ver")]
+    pub lib_version: Option<String>,
 }
 
-pub static GZIP_MAGIC_NUMBERS: [u8; 3] = [0x1f, 0x8b, 8];
+pub static GZIP_MAGIC_NUMBERS: [u8; 3] = [0x1f, 0x8b, 0x08];
 
 #[derive(Deserialize)]
 #[serde(untagged)]
@@ -88,10 +106,17 @@ impl RawRequest {
     /// Instead of trusting the parameter, we peek at the payload's first three bytes to
     /// detect gzip, fallback to uncompressed utf8 otherwise.
     #[instrument(skip_all)]
-    pub fn from_bytes(bytes: Bytes, limit: usize) -> Result<RawRequest, CaptureError> {
+    pub fn from_bytes(
+        bytes: Bytes,
+        cmp_hint: Compression,
+        limit: usize,
+        is_mirror_deploy: bool,
+    ) -> Result<RawRequest, CaptureError> {
         tracing::debug!(len = bytes.len(), "decoding new event");
 
-        let payload = if bytes.starts_with(&GZIP_MAGIC_NUMBERS) {
+        let payload = if (is_mirror_deploy && cmp_hint == Compression::Gzip)
+            || bytes.starts_with(&GZIP_MAGIC_NUMBERS)
+        {
             let len = bytes.len();
             let mut zipstream = GzDecoder::new(bytes.reader());
             let chunk = &mut [0; 1024];
@@ -128,6 +153,8 @@ impl RawRequest {
                     )));
                 }
             }
+        } else if is_mirror_deploy && cmp_hint == Compression::LZString {
+            decompress_lz64(&bytes, limit)?
         } else {
             let s = String::from_utf8(bytes.into()).map_err(|e| {
                 tracing::error!(
@@ -186,6 +213,53 @@ impl RawRequest {
         }
         None
     }
+}
+
+fn decompress_lz64(payload: &[u8], limit: usize) -> Result<String, CaptureError> {
+    // with lz64 the payload is a Base64 string that must be decoded prior to decompression
+    let b64_payload = std::str::from_utf8(payload).unwrap_or("INVALID_UTF8");
+    let decomp_utf16 = match lz_str::decompress_from_base64(b64_payload) {
+        Some(v) => v,
+        None => {
+            let form_data_snippet = String::from_utf8(payload[..MAX_CHARS_TO_CHECK].to_vec())
+                .unwrap_or(String::from("INVALID_UTF8"));
+            error!(
+                form_data = form_data_snippet,
+                "decompress_lz64: failed decompress to UTF16"
+            );
+            return Err(CaptureError::RequestDecodingError(String::from(
+                "decompress_lz64: failed decompress to UTF16",
+            )));
+        }
+    };
+
+    // the decompressed data is UTF16 so we need to convert it to UTF8 to
+    // obtain the JSON event batch payload we've come to know and love
+    let decompressed = match String::from_utf16(&decomp_utf16) {
+        Ok(result) => result,
+        Err(e) => {
+            error!(
+                "decompress_lz64: failed UTF16 to UTF8 conversion, got: {}",
+                e
+            );
+            return Err(CaptureError::RequestDecodingError(String::from(
+                "decompress_lz64: failed UTF16 to UTF8 conversion",
+            )));
+        }
+    };
+
+    if decompressed.len() >= limit {
+        error!(
+            "lz64 request payload size limit exceeded: {}",
+            decompressed.len()
+        );
+        report_dropped_events("event_too_big", 1);
+        return Err(CaptureError::EventTooBig(String::from(
+            "lz64 request payload size limit exceeded",
+        )));
+    }
+
+    Ok(decompressed)
 }
 
 #[instrument(skip_all, fields(events = events.len()))]
@@ -253,8 +327,7 @@ mod tests {
     use serde_json::Value;
     use uuid::Uuid;
 
-    use super::CaptureError;
-    use super::RawRequest;
+    use super::{CaptureError, Compression, RawRequest};
 
     fn test_deserialize(json: Value) -> Result<Option<Uuid>, serde_json::Error> {
         #[derive(Deserialize)]
@@ -276,9 +349,10 @@ mod tests {
                 .expect("payload is not base64"),
         );
 
-        let events = RawRequest::from_bytes(compressed_bytes, 1024)
-            .expect("failed to parse")
-            .events();
+        let events =
+            RawRequest::from_bytes(compressed_bytes, Compression::Unsupported, 1024, false)
+                .expect("failed to parse")
+                .events();
         assert_eq!(1, events.len());
         assert_eq!(Some("my_token1".to_string()), events[0].extract_token());
         assert_eq!("my_event1".to_string(), events[0].event);
@@ -298,9 +372,10 @@ mod tests {
                 .expect("payload is not base64"),
         );
 
-        let events = RawRequest::from_bytes(compressed_bytes, 2048)
-            .expect("failed to parse")
-            .events();
+        let events =
+            RawRequest::from_bytes(compressed_bytes, Compression::Unsupported, 2048, false)
+                .expect("failed to parse")
+                .events();
         assert_eq!(1, events.len());
         assert_eq!(Some("my_token2".to_string()), events[0].extract_token());
         assert_eq!("my_event2".to_string(), events[0].event);
@@ -315,9 +390,10 @@ mod tests {
     #[test]
     fn extract_distinct_id() {
         let parse_and_extract = |input: &'static str| -> Result<String, CaptureError> {
-            let parsed = RawRequest::from_bytes(input.into(), 2048)
-                .expect("failed to parse")
-                .events();
+            let parsed =
+                RawRequest::from_bytes(input.into(), Compression::Unsupported, 2048, false)
+                    .expect("failed to parse")
+                    .events();
             parsed[0]
                 .extract_distinct_id()
                 .ok_or(CaptureError::MissingDistinctId)
@@ -385,9 +461,14 @@ mod tests {
             "distinct_id": distinct_id
         }]);
 
-        let parsed = RawRequest::from_bytes(input.to_string().into(), 2048)
-            .expect("failed to parse")
-            .events();
+        let parsed = RawRequest::from_bytes(
+            input.to_string().into(),
+            Compression::Unsupported,
+            2048,
+            false,
+        )
+        .expect("failed to parse")
+        .events();
         assert_eq!(
             parsed[0].extract_distinct_id().expect("failed to extract"),
             expected_distinct_id
@@ -397,7 +478,7 @@ mod tests {
     #[test]
     fn extract_and_verify_token() {
         let parse_and_extract = |input: &'static str| -> Result<String, CaptureError> {
-            RawRequest::from_bytes(input.into(), 2048)
+            RawRequest::from_bytes(input.into(), Compression::Unsupported, 2048, false)
                 .expect("failed to parse")
                 .extract_and_verify_token()
         };

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -26,6 +26,9 @@ pub enum Compression {
 pub struct EventQuery {
     pub compression: Option<Compression>,
 
+    // legacy GET requests can include data as query param
+    pub data: Option<String>,
+
     #[serde(alias = "ver")]
     pub lib_version: Option<String>,
 
@@ -36,7 +39,7 @@ pub struct EventQuery {
 impl EventQuery {
     /// Returns the parsed value of the sent_at timestamp if present in the query params.
     /// We only support the format sent by recent posthog-js versions, in milliseconds integer.
-    /// Values in seconds integer (older SDKs will be ignored).
+    /// Values in seconds integer (older SDKs) will be ignored.
     pub fn sent_at(&self) -> Option<OffsetDateTime> {
         if let Some(value) = self.sent_at {
             let value_nanos: i128 = i128::from(value) * 1_000_000; // Assuming the value is in milliseconds, latest posthog-js releases

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -226,7 +226,8 @@ fn decompress_lz64(payload: &[u8], limit: usize) -> Result<String, CaptureError>
     let decomp_utf16 = match lz_str::decompress_from_base64(b64_payload) {
         Some(v) => v,
         None => {
-            let form_data_snippet = String::from_utf8(payload[..MAX_CHARS_TO_CHECK].to_vec())
+            let max_chars: usize = std::cmp::min(payload.len(), MAX_CHARS_TO_CHECK);
+            let form_data_snippet = String::from_utf8(payload[..max_chars].to_vec())
                 .unwrap_or(String::from("INVALID_UTF8"));
             error!(
                 form_data = form_data_snippet,


### PR DESCRIPTION
## Problem
As detailed in the [tracking issue](https://github.com/PostHog/posthog/issues/31844), we need to implement additional request processing and event handling in `capture-rs` to accommodate the various legacy capture endpoints and SDK behaviors, before it can completely replace `posthog-events-django` (`capture.py`.)

## Changes
* Implements new event handler endpoint and processing logic w/insights from `capture.py` and the SDKs that still publish to legacy endpoints
* Implements new richer observability to:
   * Aid in debugging fail modes with more clarity and detail
   * Aid in identification of SDK versions causing specific corner cases

NOTE: this is just round one, to quickly get my eyes on richer error traces and identify additional SDK corner-cases we want to target and/or consider deprecating. Lots more iterations and full test suite are on the way after this lands 👍 

## Does this work well for both Cloud and self-hosted?
Working well is a strong claim at this stage 😂 but let's say it will work equally well in those envs 

## How did you test this code?
Locally, CI; soon mirror deploy for observation
