### PR TITLE
fix: reduce the total possible playlists that need counting into the cache

### DIFF
--- a/ee/session_recordings/test/__snapshots__/test_recordings_that_match_playlist_filters.ambr
+++ b/ee/session_recordings/test/__snapshots__/test_recordings_that_match_playlist_filters.ambr
@@ -89,22 +89,44 @@
 # ---
 # name: TestRecordingsThatMatchPlaylistFilters.test_sorts_nulls_first_and_then_least_recently_counted.4
   '''
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_sessionrecordingplaylist"
-  WHERE (NOT "posthog_sessionrecordingplaylist"."deleted"
-         AND "posthog_sessionrecordingplaylist"."filters" IS NOT NULL
-         AND ("posthog_sessionrecordingplaylist"."last_counted_at" IS NULL
-              OR "posthog_sessionrecordingplaylist"."last_counted_at" < '2024-01-01 10:00:00+00:00'::timestamptz))
+  SELECT COUNT(*)
+  FROM
+    (SELECT "posthog_sessionrecordingplaylist"."id" AS "col1"
+     FROM "posthog_sessionrecordingplaylist"
+     LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecordingplaylist"."id" = "posthog_sessionrecordingplaylistitem"."playlist_id")
+     WHERE (NOT "posthog_sessionrecordingplaylist"."deleted"
+            AND "posthog_sessionrecordingplaylist"."filters" IS NOT NULL
+            AND ("posthog_sessionrecordingplaylist"."last_counted_at" IS NULL
+                 OR "posthog_sessionrecordingplaylist"."last_counted_at" < '2024-01-01 10:00:00+00:00'::timestamptz)
+            AND NOT ("posthog_sessionrecordingplaylist"."name" IN ('Recordings of Gmail users',
+                                                                   'Mobile device recordings',
+                                                                   'Recordings with Rage Clicks',
+                                                                   'Recordings of people from Google Ads',
+                                                                   'Recordings with 5+ console log errors',
+                                                                   'All recordings')
+                     AND "posthog_sessionrecordingplaylist"."name" IS NOT NULL))
+     GROUP BY 1
+     HAVING COUNT("posthog_sessionrecordingplaylistitem"."id") = 99999) subquery
   '''
 # ---
 # name: TestRecordingsThatMatchPlaylistFilters.test_sorts_nulls_first_and_then_least_recently_counted.5
   '''
   SELECT "posthog_sessionrecordingplaylist"."id"
   FROM "posthog_sessionrecordingplaylist"
+  LEFT OUTER JOIN "posthog_sessionrecordingplaylistitem" ON ("posthog_sessionrecordingplaylist"."id" = "posthog_sessionrecordingplaylistitem"."playlist_id")
   WHERE (NOT "posthog_sessionrecordingplaylist"."deleted"
          AND "posthog_sessionrecordingplaylist"."filters" IS NOT NULL
          AND ("posthog_sessionrecordingplaylist"."last_counted_at" IS NULL
-              OR "posthog_sessionrecordingplaylist"."last_counted_at" < '2024-01-01 10:00:00+00:00'::timestamptz))
+              OR "posthog_sessionrecordingplaylist"."last_counted_at" < '2024-01-01 10:00:00+00:00'::timestamptz)
+         AND NOT ("posthog_sessionrecordingplaylist"."name" IN ('Recordings of Gmail users',
+                                                                'Mobile device recordings',
+                                                                'Recordings with Rage Clicks',
+                                                                'Recordings of people from Google Ads',
+                                                                'Recordings with 5+ console log errors',
+                                                                'All recordings')
+                  AND "posthog_sessionrecordingplaylist"."name" IS NOT NULL))
+  GROUP BY "posthog_sessionrecordingplaylist"."id"
+  HAVING COUNT("posthog_sessionrecordingplaylistitem"."id") = 99999
   ORDER BY "posthog_sessionrecordingplaylist"."last_counted_at" ASC NULLS FIRST
   LIMIT 2500
   '''

--- a/posthog/helpers/session_recording_playlist_templates.py
+++ b/posthog/helpers/session_recording_playlist_templates.py
@@ -112,3 +112,5 @@ DEFAULT_PLAYLISTS = [
         "description": "All session recordings longer than 1 minute",
     },
 ]
+
+DEFAULT_PLAYLIST_NAMES = [p["name"] for p in DEFAULT_PLAYLISTS]


### PR DESCRIPTION
split out of https://github.com/PostHog/posthog/pull/31881

since throttling the celery task we can't keep up with this

but we can reduce the total we need to consider

* no need to consider anything with a pinned item - since that is a collection and has a deterministic count
* no need to consider the templated playlists we create for new teams - they're saved filters but we can present them differently once we've split collections and saved filters