### PR TITLE
fix: Add project API token resets to activity log

### DIFF
--- a/frontend/src/scenes/teamActivityDescriber.tsx
+++ b/frontend/src/scenes/teamActivityDescriber.tsx
@@ -21,6 +21,15 @@ const teamActionsMapping: Record<
     keyof TeamType,
     (change?: ActivityChange, logItem?: ActivityLogItem) => ChangeMapping | null
 > = {
+    api_token: (change) => {
+        if (change === undefined || change.after === undefined) {
+            return null
+        }
+        const prefix = change.action === 'created' ? 'set' : 'reset'
+        return {
+            description: [<>{prefix} the project API key</>],
+        }
+    },
     // session replay
     session_recording_minimum_duration_milliseconds: (change) => {
         const after = change?.after
@@ -457,7 +466,6 @@ const teamActionsMapping: Record<
 
     // should never come from the backend
     created_at: () => null,
-    api_token: () => null,
     id: () => null,
     updated_at: () => null,
     uuid: () => null,

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -572,8 +572,8 @@ def team_api_test_factory():
                             "changes": [
                                 {
                                     "action": "changed",
-                                    "after": None,
-                                    "before": None,
+                                    "after": self.team.api_token,
+                                    "before": "xyz",
                                     "field": "api_token",
                                     "type": "Team",
                                 },

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -246,7 +246,7 @@ field_exclusions: dict[ActivityScope, list[str]] = {
         "post_to_slack",
         "property_type_format",
     ],
-    "Team": ["uuid", "updated_at", "api_token", "created_at", "id"],
+    "Team": ["uuid", "updated_at", "created_at", "id"],
     "Project": ["id", "created_at"],
     "DataWarehouseSavedQuery": [
         "name",

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -527,6 +527,8 @@ class Team(UUIDClassicModel):
                         type="Team",
                         action="changed",
                         field="api_token",
+                        before=old_token,
+                        after=self.api_token,
                     )
                 ],
             ),


### PR DESCRIPTION
Log changes to the project API token in the activity log.

> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

If someone resets the project API key, that could break a lot of things. And right now, we _attempt_ to log who changed it in the activity log, but nothing shows up in the actual log because we don't pass the before and after `api_token` to the changes list. We pass `None` which means our activity logger sees no changes and ignores showing it.

Project API tokens are not secrets. They are public to the website when used by customers.

They are especially not secret to the team because they're clearly visible on the project settings.

## Changes

We now log project API key resets in the activity log.

<img width="588" alt="Screenshot 2025-05-03 at 1 54 59 PM" src="https://github.com/user-attachments/assets/50194267-8f16-46b0-a1eb-e0d1be73eac4" />

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Unit tests and manual testing.