### PR TITLE
fix: Send a valid 404 response body

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -501,7 +501,7 @@ class CohortViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
 
         item_id = kwargs["pk"]
         if not Cohort.objects.filter(id=item_id, team__project_id=self.project_id).exists():
-            return Response("", status=status.HTTP_404_NOT_FOUND)
+            return Response(status=status.HTTP_404_NOT_FOUND)
 
         activity_page = load_activity(
             scope="Cohort",

--- a/posthog/api/error_tracking.py
+++ b/posthog/api/error_tracking.py
@@ -227,7 +227,7 @@ class ErrorTrackingIssueViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, view
 
         item_id = kwargs["pk"]
         if not ErrorTrackingIssue.objects.filter(id=item_id, team_id=self.team_id).exists():
-            return Response("", status=status.HTTP_404_NOT_FOUND)
+            return Response(status=status.HTTP_404_NOT_FOUND)
 
         activity_page = load_activity(
             scope="ErrorTrackingIssue",

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1201,10 +1201,10 @@ class FeatureFlagViewSet(
                 else FeatureFlag.objects.get(key=kwargs["pk"], team__project_id=self.project_id)
             )
         except FeatureFlag.DoesNotExist:
-            return Response("", status=status.HTTP_404_NOT_FOUND)
+            return Response(status=status.HTTP_404_NOT_FOUND)
 
         if not feature_flag.is_remote_configuration:
-            return Response("", status=status.HTTP_404_NOT_FOUND)
+            return Response(status=status.HTTP_404_NOT_FOUND)
 
         if not feature_flag.has_encrypted_payloads:
             payloads = feature_flag.filters.get("payloads", {})
@@ -1227,7 +1227,7 @@ class FeatureFlagViewSet(
 
         item_id = kwargs["pk"]
         if not FeatureFlag.objects.filter(id=item_id, team__project_id=self.project_id).exists():
-            return Response("", status=status.HTTP_404_NOT_FOUND)
+            return Response(status=status.HTTP_404_NOT_FOUND)
 
         activity_page = load_activity(
             scope="FeatureFlag",

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1139,7 +1139,7 @@ When set, the specified dashboard's filters and date range override will be appl
 
         item_id = kwargs["pk"]
         if not Insight.objects.filter(id=item_id, team__project_id=self.team.project_id).exists():
-            return Response("", status=status.HTTP_404_NOT_FOUND)
+            return Response(status=status.HTTP_404_NOT_FOUND)
 
         activity_page = load_activity(
             scope="Insight",

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -4755,6 +4755,8 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
 
         activity = self.client.get(url)
         self.assertEqual(activity.status_code, expected_status)
+        if activity.status_code == status.HTTP_404_NOT_FOUND:
+            return None
         return activity.json()
 
     def assert_feature_flag_activity(self, flag_id: Optional[int], expected: list[dict]):

--- a/posthog/warehouse/api/saved_query.py
+++ b/posthog/warehouse/api/saved_query.py
@@ -392,7 +392,7 @@ class DataWarehouseSavedQueryViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewS
 
         item_id = kwargs["pk"]
         if not DataWarehouseSavedQuery.objects.filter(id=item_id, team_id=self.team_id).exists():
-            return Response("", status=status.HTTP_404_NOT_FOUND)
+            return Response(status=status.HTTP_404_NOT_FOUND)
 
         activity_page = load_activity(
             scope="DataWarehouseSavedQuery",


### PR DESCRIPTION
These 404 responses were sending an empty string as the body. While it's valid to have a response body for a 404 request, it's unnecessary.

Also, these are `application/json` requests so an empty string is technically not a valid response body for these requests.

> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

I noticed this issue because a client was trying to deserialize the body as JSON. The reason the client was doing this is most of our API errors have a response body that looks like:

```json
{
   "type": "some_error",
   "code": "error_code",
   "detail": "Your code is whack",
}
```

It turns out in this case, the client was wrong. It should not try to parse the response body of a 404 request. At the same time, a 404 response probably shouldn't send an empty string as the body. They should either send some valid JSON or nothing at all.

## Changes

Removes the empty string in the response body for 404 requests.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manually