### PR TITLE
chore: Add RequestInfo to hold request properties

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1500,6 +1500,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "common-request"
+version = "0.1.0"
+dependencies = [
+ "axum 0.7.5",
+ "bytes",
+ "serde",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "common-types"
 version = "0.1.0"
 dependencies = [
@@ -2249,6 +2260,7 @@ dependencies = [
  "common-geoip",
  "common-metrics",
  "common-redis",
+ "common-request",
  "common-types",
  "dateparser",
  "envconfig",

--- a/rust/common/request/Cargo.toml
+++ b/rust/common/request/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "common-request"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+tracing = { workspace = true }
+serde = { workspace = true }
+bytes = { workspace = true }
+axum = { workspace = true }
+uuid = { workspace = true }
+
+[lints]
+workspace = true

--- a/rust/common/request/src/lib.rs
+++ b/rust/common/request/src/lib.rs
@@ -1,0 +1,75 @@
+use axum::http::{HeaderMap, Method};
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+use std::net::IpAddr;
+use uuid::Uuid;
+
+#[derive(Clone, Deserialize, Default)]
+pub struct FlagsQueryParams {
+    /// Optional API version identifier
+    #[serde(alias = "v")]
+    pub version: Option<String>,
+
+    /// Compression type for the incoming request
+    pub compression: Option<Compression>,
+
+    /// Library version (alias: "ver")
+    #[serde(alias = "ver")]
+    pub lib_version: Option<String>,
+
+    /// Optional timestamp indicating when the request was sent
+    #[serde(alias = "_")]
+    pub sent_at: Option<i64>,
+
+    /// Optional personal API key.
+    pub personal_api_key: Option<String>,
+
+    /// Optional secret API key.
+    pub secret_api_key: Option<String>,
+
+    /// Whether to send cohorts to the client. Only applies to the flags definition endpoint.
+    pub send_cohorts: Option<bool>,
+}
+
+/// Represents information about the request.
+pub struct RequestInfo {
+    /// Request ID
+    pub id: Uuid,
+
+    /// Client IP
+    pub ip: IpAddr,
+
+    /// HTTP headers
+    pub headers: HeaderMap,
+
+    /// Query params (contains compression, library version, etc.)
+    pub meta: FlagsQueryParams,
+
+    /// Raw request body
+    pub body: Bytes,
+
+    /// HTTP method
+    pub method: Method,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Compression {
+    #[serde(rename = "gzip", alias = "gzip-js")]
+    Gzip,
+    #[serde(rename = "base64")]
+    Base64,
+    #[default]
+    #[serde(other)]
+    Unsupported,
+}
+
+impl Compression {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Compression::Gzip => "gzip",
+            Compression::Base64 => "base64",
+            Compression::Unsupported => "unsupported",
+        }
+    }
+}

--- a/rust/feature-flags/Cargo.toml
+++ b/rust/feature-flags/Cargo.toml
@@ -14,6 +14,7 @@ chrono = { workspace = true }
 common-cookieless = { path = "../common/cookieless" }
 common-database = { path = "../common/database" }
 common-redis = { path = "../common/redis" }
+common-request = { path = "../common/request" }
 common-types = { path = "../common/types" }
 envconfig = { workspace = true }
 limiters = { path = "../common/limiters" }

--- a/rust/feature-flags/src/api/test_endpoint.rs
+++ b/rust/feature-flags/src/api/test_endpoint.rs
@@ -9,11 +9,8 @@ use bytes::Bytes;
 use tracing::error;
 use uuid::Uuid;
 
-use crate::api::{
-    errors::FlagError,
-    request_handler::{decode_request, FlagsQueryParams},
-    types::LegacyFlagsResponse,
-};
+use crate::api::{errors::FlagError, request_handler::decode_request, types::LegacyFlagsResponse};
+use common_request::FlagsQueryParams;
 
 // Metrics constants for test endpoint
 pub const REQUEST_SEEN: &str = "flags_test_request_seen";


### PR DESCRIPTION
This'll make code that only works on the request info easier to test.> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

This is another rust refactoring that does 2 things.

1. Creates a new `RequestInfo` type that contains the information about the request, rather than making each of these properties part of `RequestContext`. It makes methods that only need this info easier to test.
2. Moves `RequestInfo` into a common lib so it can be used by the upcoming `flag_definitions`

## Changes

No visible changes. Just code refactoring.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Unit tests
Manual testing