### PR TITLE
fix: add api/app users to hobby setup

### DIFF
--- a/docker/clickhouse/users.xml
+++ b/docker/clickhouse/users.xml
@@ -32,6 +32,14 @@
             <readonly>1</readonly>
         </readonly>
 
+        <api>
+            <profile>default</profile>
+        </api>
+
+        <app>
+            <profile>default</profile>
+        </app>
+
     </profiles>
 
     <!-- Users and ACL. -->
@@ -118,6 +126,30 @@
             <!-- User can create other users and grant rights to them. -->
             <!-- <access_management>1</access_management> -->
         </default>
+
+        <api>
+            <password>apipass</password>
+
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+
+            <profile>api</profile>
+
+            <quota>default</quota>
+        </api>
+
+        <app>
+            <password>apppass</password>
+
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+
+            <profile>app</profile>
+
+            <quota>default</quota>
+        </app>
     </users>
 
     <!-- Quotas. -->


### PR DESCRIPTION
## Problem

hobby setup does does not have app/api ClickHouse users

## Changes

add required users

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

start setup