### PR TITLE
feat(project-tree): align user icons

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
@@ -84,7 +84,6 @@ export function convertFileSystemEntryToTreeDataItem({
                             - {dayjs(item.meta?.created_at).fromNow()}
                         </span>
                     ) : null}
-                    {user ? <ProfilePicture user={user} size="sm" className="ml-1" /> : null}
                 </>
             ),
             icon: item._loading ? (
@@ -92,6 +91,7 @@ export function convertFileSystemEntryToTreeDataItem({
             ) : (
                 wrapWithShortcutIcon(item, ('icon' in item && item.icon) || iconForType(item.type))
             ),
+            preIcon: user ? <ProfilePicture user={user} size="sm" className="mr-1" /> : null,
             record: item,
             checked: checkedItems[nodeId],
             onClick: () => {

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -43,6 +43,8 @@ export type TreeDataItem = {
     itemSideAction?: (item: TreeDataItem) => SideAction
     /** The icon to use for the item. */
     icon?: React.ReactNode
+    /** The icon to use before the item. */
+    preIcon?: React.ReactNode
     /** The children of the item. */
     children?: TreeDataItem[]
     /** Disabled: The reason the item is disabled. */
@@ -51,8 +53,6 @@ export type TreeDataItem = {
     disableSelect?: boolean
     /** Is the item selected */
     checked?: boolean | 'indeterminate'
-    /** The icon to use for the side action. */
-    sideIcon?: React.ReactNode
 
     /** The type of item.
      *
@@ -359,7 +359,7 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                                 className="h-full bg-transparent pointer-events-none flex-shrink-0 transition-[width] duration-50"
                                 // eslint-disable-next-line react/forbid-dom-props
                                 style={{
-                                    width: `${firstColumnOffset}px`,
+                                    width: `${firstColumnOffset + (item.preIcon ? 24 : 0)}px`,
                                 }}
                             />
 

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTreeUtils.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTreeUtils.tsx
@@ -7,7 +7,7 @@ import { CSSProperties, useEffect, useRef } from 'react'
 import { LemonCheckbox } from '../LemonCheckbox'
 import { LemonTreeSelectMode, TreeDataItem } from './LemonTree'
 
-export const ICON_CLASSES = 'text-tertiary size-5 flex items-center justify-center'
+export const ICON_CLASSES = 'text-tertiary flex items-center justify-center'
 
 type TreeNodeDisplayIconWrapperProps = {
     item: TreeDataItem
@@ -182,6 +182,20 @@ export const TreeNodeDisplayIcon = ({
                     <IconChevronRight className={cn('transition-transform size-4', isOpen ? 'rotate-90' : '')} />
                 </div>
             )}
+            {item.preIcon ? (
+                <div
+                    className={cn(
+                        ICON_CLASSES,
+                        {
+                            'text-tertiary': item.disabledReason,
+                            'group-hover/lemon-tree-button-group:opacity-0': isFolder,
+                        },
+                        'transition-opacity duration-150'
+                    )}
+                >
+                    {item.preIcon}
+                </div>
+            ) : null}
             <div
                 className={cn(
                     ICON_CLASSES,


### PR DESCRIPTION
## Problem

There are a couple of questions I want to reach a consensus on:

- Do we want "created by" user icons in the project tree? Do they add value or noise?
- Where do we place them? Left? Right?

## Changes

I had a go at adding them to the left however the DOM/CSS changes I made are **horrible**:

![2025-05-05 13 17 22](https://github.com/user-attachments/assets/6be7d6ce-9113-4236-b3c2-33ed2b29e57c)

---

We currently show them just to the right of the title, which isn't very clean or useful as they get cut off:

<img width="414" alt="image" src="https://github.com/user-attachments/assets/e4fc40d7-d343-4761-91a2-b6cc8603cf34" />

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
