### PR TITLE
Increase Kafka retention on hoppy install

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -69,12 +69,21 @@ services:
         depends_on:
             - zookeeper
         environment:
-            KAFKA_LOG_RETENTION_MS: 3600000
+            KAFKA_LOG_RETENTION_MS: 86400000
             KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS: 300000
-            KAFKA_LOG_RETENTION_HOURS: 1
+            KAFKA_LOG_RETENTION_HOURS: 24
         volumes:
             - kafka-data:/bitnami/kafka
-
+    
+    kafka_ui:
+        extends:
+            file: docker-compose.base.yml
+            service: kafka_ui
+        ports:
+            - '8088:8080'
+        depends_on:
+            - kafka 
+    
     worker:
         extends:
             file: docker-compose.base.yml


### PR DESCRIPTION
## Problem

Under heavy load (>150k events per hour) self-hosted posthog began losing chunks of events every 30 min. We figured this was happening due to the worker not able to catch up with ingestion during busy hours, and Kafka's low retention was deleting events before they were consumed by ingestion pipelines. 

Increasing retention to 24h fixes that and allows to worker time to catch up.

Also, adding kafka-ui service is very useful to hunt down problems like this.

## Changes

            KAFKA_LOG_RETENTION* env vars and kafka-ui service



## Does this work well for both Cloud and self-hosted?

self-hosted 

## How did you test this code?

running it live now