### PR TITLE
feat(max): Allow auto-run links using new ! prefix

### DIFF
--- a/frontend/src/scenes/max/maxLogic.test.ts
+++ b/frontend/src/scenes/max/maxLogic.test.ts
@@ -1,0 +1,61 @@
+import { router } from 'kea-router'
+import { expectLogic } from 'kea-test-utils'
+
+import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
+import { initKeaTests } from '~/test/init'
+
+import { maxLogic } from './maxLogic'
+
+describe('maxLogic', () => {
+    let logic: ReturnType<typeof maxLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        sidePanelStateLogic.unmount()
+        logic?.unmount()
+    })
+
+    it("doesn't mount sidePanelStateLogic if it's not already mounted", async () => {
+        // Mount maxLogic after setting up the sidePanelStateLogic state
+        logic = maxLogic({ conversationId: 'test-id' })
+        logic.mount()
+
+        // Check that sidePanelStateLogic was not mounted
+        expect(sidePanelStateLogic.isMounted()).toBe(false)
+    })
+
+    it('sets the question when URL has hash param #panel=max:Foo', async () => {
+        // Set up router with #panel=max:Foo
+        router.actions.push('', {}, { panel: 'max:Foo' })
+        sidePanelStateLogic.mount()
+
+        // Mount maxLogic after setting up the sidePanelStateLogic state
+        logic = maxLogic({ conversationId: 'test-id' })
+        logic.mount()
+
+        // Check that the question has been set to "Foo" (via sidePanelStateLogic automatically)
+        await expectLogic(logic).toMatchValues({
+            question: 'Foo',
+        })
+    })
+
+    it('calls askMax when URL has hash param #panel=max:!Foo', async () => {
+        // Set up router with #panel=max:!Foo
+        router.actions.push('', {}, { panel: 'max:!Foo' })
+        sidePanelStateLogic.mount()
+
+        // Spy on askMax action
+        // Must create the logic first to spy on its actions
+        logic = maxLogic({ conversationId: 'test-id' })
+        const askMaxSpy = jest.spyOn(logic.actions, 'askMax')
+
+        // Only mount maxLogic after setting up the router and sidePanelStateLogic
+        logic.mount()
+
+        // Check that askMax has been called with "Foo" (via sidePanelStateLogic automatically)
+        expect(askMaxSpy).toHaveBeenCalledWith('Foo')
+    })
+})

--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -488,7 +488,12 @@ export const maxLogic = kea<maxLogicType>([
             sidePanelStateLogic.values.selectedTab === SidePanelTab.Max &&
             sidePanelStateLogic.values.selectedTabOptions
         ) {
-            actions.setQuestion(sidePanelStateLogic.values.selectedTabOptions)
+            const cleanedQuestion = sidePanelStateLogic.values.selectedTabOptions.replace(/^!/, '')
+            if (sidePanelStateLogic.values.selectedTabOptions.startsWith('!')) {
+                actions.askMax(cleanedQuestion)
+            } else {
+                actions.setQuestion(cleanedQuestion)
+            }
         }
     }),
     permanentlyMount(), // Prevent state from being reset when Max is unmounted, especially key in the side panel


### PR DESCRIPTION
## Changes

Growth hack proposed by @joethreepwood: [Links that immediately run a Max question from the website directly.](https://posthog.slack.com/archives/C0351B1DMUY/p1745927314213979?thread_ts=1745927191.884219&cid=C0351B1DMUY)

This PR is a dream come true then. It adds a new feature, where prefixing the prompt with "!" makes it run immediately:
- `https://app.posthog.com#panel=max:Hello` – will just display "Hello", for the user to edit before sending
- `https://app.posthog.com#panel=max:!Hello` – will send "Hello" right away, without letting the user edit it

## How did you test this code?

Added logic tests.