### PR TITLE
feat(cdp): Hog watcher only hog functions

### DIFF
--- a/plugin-server/src/cdp/services/hog-watcher.service.test.ts
+++ b/plugin-server/src/cdp/services/hog-watcher.service.test.ts
@@ -32,7 +32,7 @@ const createResult = (options: {
             teamId: 2,
             timings: [
                 {
-                    kind: 'async_function',
+                    kind: 'hog',
                     duration_ms: options.duration ?? 0,
                 },
             ],
@@ -150,7 +150,7 @@ describe('HogWatcher', () => {
             // Replace the default timing with multiple timings
             result.invocation.timings = [
                 { kind: 'hog', duration_ms: 100 }, // Below threshold, should have minimal cost
-                { kind: 'async_function', duration_ms: 100 }, // Below threshold, should have minimal cost
+                { kind: 'hog', duration_ms: 100 }, // Below threshold, should have minimal cost
                 { kind: 'hog', duration_ms: 100 }, // Below threshold, should have minimal cost
             ]
 

--- a/plugin-server/src/cdp/services/hog-watcher.service.test.ts
+++ b/plugin-server/src/cdp/services/hog-watcher.service.test.ts
@@ -44,45 +44,60 @@ const createResult = (options: {
 }
 
 describe('HogWatcher', () => {
-    describe('integration', () => {
-        let now: number
-        let hub: Hub
-        let watcher: HogWatcherService
-        let mockCeleryApplyAsync: jest.Mock
-        let redis: CdpRedis
+    let now: number
+    let hub: Hub
+    let watcher: HogWatcherService
+    let mockCeleryApplyAsync: jest.Mock
+    let redis: CdpRedis
 
-        beforeEach(async () => {
-            hub = await createHub()
-            hub.celery.applyAsync = mockCeleryApplyAsync = jest.fn()
+    beforeEach(async () => {
+        hub = await createHub()
+        hub.celery.applyAsync = mockCeleryApplyAsync = jest.fn()
 
-            now = 1720000000000
-            mockNow.mockReturnValue(now)
+        now = 1720000000000
+        mockNow.mockReturnValue(now)
 
-            redis = createCdpRedisPool(hub)
-            await deleteKeysWithPrefix(redis, BASE_REDIS_KEY)
+        redis = createCdpRedisPool(hub)
+        await deleteKeysWithPrefix(redis, BASE_REDIS_KEY)
 
-            watcher = new HogWatcherService(hub, redis)
-        })
+        watcher = new HogWatcherService(hub, redis)
+    })
 
-        const advanceTime = (ms: number) => {
-            now += ms
-            mockNow.mockReturnValue(now)
-        }
+    const advanceTime = (ms: number) => {
+        now += ms
+        mockNow.mockReturnValue(now)
+    }
 
-        const reallyAdvanceTime = async (ms: number) => {
-            advanceTime(ms)
-            await delay(ms)
-        }
+    const reallyAdvanceTime = async (ms: number) => {
+        advanceTime(ms)
+        await delay(ms)
+    }
 
-        afterEach(async () => {
-            jest.useRealTimers()
-            await closeHub(hub)
-            jest.clearAllMocks()
-        })
+    afterEach(async () => {
+        jest.useRealTimers()
+        await closeHub(hub)
+        jest.clearAllMocks()
+    })
 
-        it('should retrieve empty state', async () => {
-            const res = await watcher.getStates(['id1', 'id2'])
-            expect(res).toMatchInlineSnapshot(`
+    it('should validate the bounds configuration', () => {
+        expect(() => {
+            const _badWatcher = new HogWatcherService(
+                {
+                    ...hub,
+                    CDP_WATCHER_COST_TIMING_LOWER_MS: 100,
+                    CDP_WATCHER_COST_TIMING_UPPER_MS: 100,
+                    CDP_WATCHER_COST_TIMING: 1,
+                },
+                redis
+            )
+        }).toThrow(
+            'Lower bound for kind hog of 100ms must be lower than upper bound of 100ms. This is a configuration error.'
+        )
+    })
+
+    it('should retrieve empty state', async () => {
+        const res = await watcher.getStates(['id1', 'id2'])
+        expect(res).toMatchInlineSnapshot(`
                 {
                   "id1": {
                     "rating": 1,
@@ -96,84 +111,84 @@ describe('HogWatcher', () => {
                   },
                 }
             `)
-        })
+    })
 
-        const cases: [{ cost: number; state: number }, HogFunctionInvocationResult[]][] = [
-            [{ cost: 0, state: 1 }, [createResult({ id: 'id1' })]],
+    const cases: [{ cost: number; state: number }, HogFunctionInvocationResult[]][] = [
+        [{ cost: 0, state: 1 }, [createResult({ id: 'id1' })]],
+        [
+            { cost: 0, state: 1 },
+            [createResult({ id: 'id1' }), createResult({ id: 'id1' }), createResult({ id: 'id1' })],
+        ],
+        [
+            { cost: 0, state: 1 },
             [
-                { cost: 0, state: 1 },
-                [createResult({ id: 'id1' }), createResult({ id: 'id1' }), createResult({ id: 'id1' })],
+                createResult({ id: 'id1', duration: 10 }),
+                createResult({ id: 'id1', duration: 20 }),
+                createResult({ id: 'id1', duration: 100 }),
             ],
+        ],
+        [
+            { cost: 12, state: 1 },
             [
-                { cost: 0, state: 1 },
-                [
-                    createResult({ id: 'id1', duration: 10 }),
-                    createResult({ id: 'id1', duration: 20 }),
-                    createResult({ id: 'id1', duration: 100 }),
-                ],
+                createResult({ id: 'id1', duration: 1000 }),
+                createResult({ id: 'id1', duration: 1000 }),
+                createResult({ id: 'id1', duration: 1000 }),
             ],
+        ],
+        [{ cost: 20, state: 1 }, [createResult({ id: 'id1', duration: 5000 })]],
+        [{ cost: 40, state: 1 }, [createResult({ id: 'id1', duration: 10000 })]],
+        [
+            { cost: 141, state: 1 },
             [
-                { cost: 12, state: 1 },
-                [
-                    createResult({ id: 'id1', duration: 1000 }),
-                    createResult({ id: 'id1', duration: 1000 }),
-                    createResult({ id: 'id1', duration: 1000 }),
-                ],
+                createResult({ id: 'id1', duration: 5000 }),
+                createResult({ id: 'id1', duration: 10000 }),
+                createResult({ id: 'id1', duration: 20000 }),
             ],
-            [{ cost: 20, state: 1 }, [createResult({ id: 'id1', duration: 5000 })]],
-            [{ cost: 40, state: 1 }, [createResult({ id: 'id1', duration: 10000 })]],
-            [
-                { cost: 141, state: 1 },
-                [
-                    createResult({ id: 'id1', duration: 5000 }),
-                    createResult({ id: 'id1', duration: 10000 }),
-                    createResult({ id: 'id1', duration: 20000 }),
-                ],
-            ],
+        ],
 
-            [{ cost: 100, state: 1 }, [createResult({ id: 'id1', error: 'errored!' })]],
+        [{ cost: 100, state: 1 }, [createResult({ id: 'id1', error: 'errored!' })]],
+    ]
+
+    it.each(cases)('should update tokens based on results %s %s', async (expectedScore, results) => {
+        await watcher.observeResults(results)
+        const result = await watcher.getState('id1')
+
+        expect(hub.CDP_WATCHER_BUCKET_SIZE - result.tokens).toEqual(expectedScore.cost)
+        expect(result.state).toEqual(expectedScore.state)
+    })
+
+    it('should calculate costs per individual timing not based on total duration', async () => {
+        // Create a result with multiple timings that would have different costs
+        // if calculated individually vs. summed together
+        const result = createResult({ id: 'id1', finished: true }) as HogFunctionInvocationResult
+
+        // Replace the default timing with multiple timings
+        result.invocation.timings = [
+            { kind: 'hog', duration_ms: 100 }, // Below threshold, should have minimal cost
+            { kind: 'hog', duration_ms: 100 }, // Below threshold, should have minimal cost
+            { kind: 'hog', duration_ms: 100 }, // Below threshold, should have minimal cost
         ]
 
-        it.each(cases)('should update tokens based on results %s %s', async (expectedScore, results) => {
-            await watcher.observeResults(results)
-            const result = await watcher.getState('id1')
+        // If using individual timings (correct): each timing has a small cost
+        // If using total duration (incorrect): 300ms total would have a higher cost
 
-            expect(hub.CDP_WATCHER_BUCKET_SIZE - result.tokens).toEqual(expectedScore.cost)
-            expect(result.state).toEqual(expectedScore.state)
-        })
+        await watcher.observeResults([result])
+        const state = await watcher.getState('id1')
 
-        it('should calculate costs per individual timing not based on total duration', async () => {
-            // Create a result with multiple timings that would have different costs
-            // if calculated individually vs. summed together
-            const result = createResult({ id: 'id1', finished: true }) as HogFunctionInvocationResult
+        // Expected: each 100ms timing has minimal cost since it's below the lower threshold
+        // This is checking that we're not summing them into a 300ms duration
+        const expectedIndividualCost = 0 // Three 100ms timings each have minimal/zero cost
+        const totalCost = hub.CDP_WATCHER_BUCKET_SIZE - state.tokens
 
-            // Replace the default timing with multiple timings
-            result.invocation.timings = [
-                { kind: 'hog', duration_ms: 100 }, // Below threshold, should have minimal cost
-                { kind: 'hog', duration_ms: 100 }, // Below threshold, should have minimal cost
-                { kind: 'hog', duration_ms: 100 }, // Below threshold, should have minimal cost
-            ]
+        expect(totalCost).toEqual(expectedIndividualCost)
+    })
 
-            // If using individual timings (correct): each timing has a small cost
-            // If using total duration (incorrect): 300ms total would have a higher cost
+    it('should max out scores', async () => {
+        let lotsOfResults = Array(10000).fill(createResult({ id: 'id1', error: 'error!' }))
 
-            await watcher.observeResults([result])
-            const state = await watcher.getState('id1')
+        await watcher.observeResults(lotsOfResults)
 
-            // Expected: each 100ms timing has minimal cost since it's below the lower threshold
-            // This is checking that we're not summing them into a 300ms duration
-            const expectedIndividualCost = 0 // Three 100ms timings each have minimal/zero cost
-            const totalCost = hub.CDP_WATCHER_BUCKET_SIZE - state.tokens
-
-            expect(totalCost).toEqual(expectedIndividualCost)
-        })
-
-        it('should max out scores', async () => {
-            let lotsOfResults = Array(10000).fill(createResult({ id: 'id1', error: 'error!' }))
-
-            await watcher.observeResults(lotsOfResults)
-
-            expect(await watcher.getState('id1')).toMatchInlineSnapshot(`
+        expect(await watcher.getState('id1')).toMatchInlineSnapshot(`
                 {
                   "rating": -0.0001,
                   "state": 3,
@@ -181,46 +196,43 @@ describe('HogWatcher', () => {
                 }
             `)
 
-            lotsOfResults = Array(10000).fill(createResult({ id: 'id2' }))
+        lotsOfResults = Array(10000).fill(createResult({ id: 'id2' }))
 
-            await watcher.observeResults(lotsOfResults)
+        await watcher.observeResults(lotsOfResults)
 
-            expect(await watcher.getState('id2')).toMatchInlineSnapshot(`
+        expect(await watcher.getState('id2')).toMatchInlineSnapshot(`
                 {
                   "rating": 1,
                   "state": 1,
                   "tokens": 10000,
                 }
             `)
-        })
+    })
 
-        it('should refill over time', async () => {
-            hub.CDP_WATCHER_REFILL_RATE = 10
-            await watcher.observeResults([
-                createResult({ id: 'id1', duration: 10000 }),
-                createResult({ id: 'id1', duration: 10000 }),
-                createResult({ id: 'id1', duration: 10000 }),
-            ])
+    it('should refill over time', async () => {
+        hub.CDP_WATCHER_REFILL_RATE = 10
+        await watcher.observeResults([
+            createResult({ id: 'id1', duration: 10000 }),
+            createResult({ id: 'id1', duration: 10000 }),
+            createResult({ id: 'id1', duration: 10000 }),
+        ])
 
-            expect((await watcher.getState('id1')).tokens).toMatchInlineSnapshot(`9880`)
-            advanceTime(1000)
-            expect((await watcher.getState('id1')).tokens).toMatchInlineSnapshot(`9890`)
-            advanceTime(10000)
-            expect((await watcher.getState('id1')).tokens).toMatchInlineSnapshot(`9990`)
-        })
+        expect((await watcher.getState('id1')).tokens).toMatchInlineSnapshot(`9880`)
+        advanceTime(1000)
+        expect((await watcher.getState('id1')).tokens).toMatchInlineSnapshot(`9890`)
+        advanceTime(10000)
+        expect((await watcher.getState('id1')).tokens).toMatchInlineSnapshot(`9990`)
+    })
 
-        it('should remain disabled for period', async () => {
-            const badResults = Array(100).fill(createResult({ id: 'id1', error: 'error!' }))
+    it('should remain disabled for period', async () => {
+        const badResults = Array(100).fill(createResult({ id: 'id1', error: 'error!' }))
 
-            await watcher.observeResults(badResults)
+        await watcher.observeResults(badResults)
 
-            expect(mockCeleryApplyAsync).toHaveBeenCalledTimes(1)
-            expect(mockCeleryApplyAsync).toHaveBeenCalledWith(CELERY_TASK_ID, [
-                'id1',
-                HogWatcherState.disabledForPeriod,
-            ])
+        expect(mockCeleryApplyAsync).toHaveBeenCalledTimes(1)
+        expect(mockCeleryApplyAsync).toHaveBeenCalledWith(CELERY_TASK_ID, ['id1', HogWatcherState.disabledForPeriod])
 
-            expect(await watcher.getState('id1')).toMatchInlineSnapshot(`
+        expect(await watcher.getState('id1')).toMatchInlineSnapshot(`
                 {
                   "rating": 0,
                   "state": 3,
@@ -228,109 +240,108 @@ describe('HogWatcher', () => {
                 }
             `)
 
-            advanceTime(10000)
+        advanceTime(10000)
 
-            // Should still be disabled even though tokens have been refilled
-            expect(await watcher.getState('id1')).toMatchInlineSnapshot(`
+        // Should still be disabled even though tokens have been refilled
+        expect(await watcher.getState('id1')).toMatchInlineSnapshot(`
                 {
                   "rating": 0.01,
                   "state": 3,
                   "tokens": 100,
                 }
             `)
-        })
+    })
 
-        describe('forceStateChange', () => {
-            it('should force healthy', async () => {
-                await watcher.forceStateChange('id1', HogWatcherState.healthy)
-                expect(await watcher.getState('id1')).toMatchInlineSnapshot(`
+    describe('forceStateChange', () => {
+        it('should force healthy', async () => {
+            await watcher.forceStateChange('id1', HogWatcherState.healthy)
+            expect(await watcher.getState('id1')).toMatchInlineSnapshot(`
                     {
                       "rating": 1,
                       "state": 1,
                       "tokens": 10000,
                     }
                 `)
-                expect(mockCeleryApplyAsync).toHaveBeenCalledWith(CELERY_TASK_ID, ['id1', HogWatcherState.healthy])
-            })
-            it('should force degraded', async () => {
-                await watcher.forceStateChange('id1', HogWatcherState.degraded)
-                expect(await watcher.getState('id1')).toMatchInlineSnapshot(`
+            expect(mockCeleryApplyAsync).toHaveBeenCalledWith(CELERY_TASK_ID, ['id1', HogWatcherState.healthy])
+        })
+        it('should force degraded', async () => {
+            await watcher.forceStateChange('id1', HogWatcherState.degraded)
+            expect(await watcher.getState('id1')).toMatchInlineSnapshot(`
                     {
                       "rating": 0.8,
                       "state": 1,
                       "tokens": 8000,
                     }
                 `)
-                expect(mockCeleryApplyAsync).toHaveBeenCalledWith(CELERY_TASK_ID, ['id1', HogWatcherState.degraded])
-            })
-            it('should force disabledForPeriod', async () => {
-                await watcher.forceStateChange('id1', HogWatcherState.disabledForPeriod)
-                expect(await watcher.getState('id1')).toMatchInlineSnapshot(`
+            expect(mockCeleryApplyAsync).toHaveBeenCalledWith(CELERY_TASK_ID, ['id1', HogWatcherState.degraded])
+        })
+        it('should force disabledForPeriod', async () => {
+            await watcher.forceStateChange('id1', HogWatcherState.disabledForPeriod)
+            expect(await watcher.getState('id1')).toMatchInlineSnapshot(`
                     {
                       "rating": 0,
                       "state": 3,
                       "tokens": 0,
                     }
                 `)
-                expect(mockCeleryApplyAsync).toHaveBeenCalledWith(CELERY_TASK_ID, [
-                    'id1',
-                    HogWatcherState.disabledForPeriod,
-                ])
-            })
-            it('should force disabledIndefinitely', async () => {
-                await watcher.forceStateChange('id1', HogWatcherState.disabledIndefinitely)
-                expect(await watcher.getState('id1')).toMatchInlineSnapshot(`
+            expect(mockCeleryApplyAsync).toHaveBeenCalledWith(CELERY_TASK_ID, [
+                'id1',
+                HogWatcherState.disabledForPeriod,
+            ])
+        })
+        it('should force disabledIndefinitely', async () => {
+            await watcher.forceStateChange('id1', HogWatcherState.disabledIndefinitely)
+            expect(await watcher.getState('id1')).toMatchInlineSnapshot(`
                     {
                       "rating": 0,
                       "state": 4,
                       "tokens": 0,
                     }
                 `)
-                expect(mockCeleryApplyAsync).toHaveBeenCalledWith(CELERY_TASK_ID, [
-                    'id1',
-                    HogWatcherState.disabledIndefinitely,
-                ])
-            })
+            expect(mockCeleryApplyAsync).toHaveBeenCalledWith(CELERY_TASK_ID, [
+                'id1',
+                HogWatcherState.disabledIndefinitely,
+            ])
+        })
+    })
+
+    describe('disable logic', () => {
+        jest.retryTimes(3) // Timings are flakey and hard to test but we don't need it to be perfect
+        beforeEach(() => {
+            hub.CDP_WATCHER_BUCKET_SIZE = 100
+            hub.CDP_WATCHER_DISABLED_TEMPORARY_TTL = 1 // Shorter ttl to help with testing
+            hub.CDP_WATCHER_DISABLED_TEMPORARY_MAX_COUNT = 3
         })
 
-        describe('disable logic', () => {
-            jest.retryTimes(3) // Timings are flakey and hard to test but we don't need it to be perfect
-            beforeEach(() => {
-                hub.CDP_WATCHER_BUCKET_SIZE = 100
-                hub.CDP_WATCHER_DISABLED_TEMPORARY_TTL = 1 // Shorter ttl to help with testing
-                hub.CDP_WATCHER_DISABLED_TEMPORARY_MAX_COUNT = 3
-            })
-
-            it('count the number of times it has been disabled', async () => {
-                // Trigger the temporary disabled state 3 times
-                for (let i = 0; i < 2; i++) {
-                    await watcher.observeResults([createResult({ id: 'id1', error: 'error!' })])
-                    expect((await watcher.getState('id1')).state).toEqual(HogWatcherState.disabledForPeriod)
-                    await reallyAdvanceTime(1000)
-                    expect((await watcher.getState('id1')).state).toEqual(HogWatcherState.degraded)
-                }
-
-                expect(mockCeleryApplyAsync).toHaveBeenCalledTimes(2)
-                expect(mockCeleryApplyAsync.mock.calls[0]).toEqual([
-                    CELERY_TASK_ID,
-                    ['id1', HogWatcherState.disabledForPeriod],
-                ])
-                expect(mockCeleryApplyAsync.mock.calls[1]).toEqual([
-                    CELERY_TASK_ID,
-                    ['id1', HogWatcherState.disabledForPeriod],
-                ])
-
+        it('count the number of times it has been disabled', async () => {
+            // Trigger the temporary disabled state 3 times
+            for (let i = 0; i < 2; i++) {
                 await watcher.observeResults([createResult({ id: 'id1', error: 'error!' })])
-                expect((await watcher.getState('id1')).state).toEqual(HogWatcherState.disabledIndefinitely)
+                expect((await watcher.getState('id1')).state).toEqual(HogWatcherState.disabledForPeriod)
                 await reallyAdvanceTime(1000)
-                expect((await watcher.getState('id1')).state).toEqual(HogWatcherState.disabledIndefinitely)
+                expect((await watcher.getState('id1')).state).toEqual(HogWatcherState.degraded)
+            }
 
-                expect(mockCeleryApplyAsync).toHaveBeenCalledTimes(3)
-                expect(mockCeleryApplyAsync.mock.calls[2]).toEqual([
-                    CELERY_TASK_ID,
-                    ['id1', HogWatcherState.disabledIndefinitely],
-                ])
-            })
+            expect(mockCeleryApplyAsync).toHaveBeenCalledTimes(2)
+            expect(mockCeleryApplyAsync.mock.calls[0]).toEqual([
+                CELERY_TASK_ID,
+                ['id1', HogWatcherState.disabledForPeriod],
+            ])
+            expect(mockCeleryApplyAsync.mock.calls[1]).toEqual([
+                CELERY_TASK_ID,
+                ['id1', HogWatcherState.disabledForPeriod],
+            ])
+
+            await watcher.observeResults([createResult({ id: 'id1', error: 'error!' })])
+            expect((await watcher.getState('id1')).state).toEqual(HogWatcherState.disabledIndefinitely)
+            await reallyAdvanceTime(1000)
+            expect((await watcher.getState('id1')).state).toEqual(HogWatcherState.disabledIndefinitely)
+
+            expect(mockCeleryApplyAsync).toHaveBeenCalledTimes(3)
+            expect(mockCeleryApplyAsync.mock.calls[2]).toEqual([
+                CELERY_TASK_ID,
+                ['id1', HogWatcherState.disabledIndefinitely],
+            ])
         })
     })
 })

--- a/plugin-server/src/cdp/services/hog-watcher.service.ts
+++ b/plugin-server/src/cdp/services/hog-watcher.service.ts
@@ -59,6 +59,14 @@ export class HogWatcherService {
                 cost: this.hub.CDP_WATCHER_COST_TIMING,
             },
         }
+
+        for (const [kind, mapping] of Object.entries(this.costsMapping)) {
+            if (mapping.lowerBound >= this.hub.CDP_WATCHER_COST_TIMING_UPPER_MS) {
+                throw new Error(
+                    `Lower bound of ${mapping.lowerBound}ms for kind ${kind} is greater than upper bound of ${mapping.upperBound}ms. This is a configuration error.`
+                )
+            }
+        }
     }
 
     private async onStateChange(id: HogFunctionType['id'], state: HogWatcherState) {

--- a/plugin-server/src/cdp/services/hog-watcher.service.ts
+++ b/plugin-server/src/cdp/services/hog-watcher.service.ts
@@ -63,7 +63,7 @@ export class HogWatcherService {
         for (const [kind, mapping] of Object.entries(this.costsMapping)) {
             if (mapping.lowerBound >= this.hub.CDP_WATCHER_COST_TIMING_UPPER_MS) {
                 throw new Error(
-                    `Lower bound of ${mapping.lowerBound}ms for kind ${kind} is greater than upper bound of ${mapping.upperBound}ms. This is a configuration error.`
+                    `Lower bound for kind ${kind} of ${mapping.lowerBound}ms must be lower than upper bound of ${mapping.upperBound}ms. This is a configuration error.`
                 )
             }
         }

--- a/plugin-server/src/cdp/services/hog-watcher.service.ts
+++ b/plugin-server/src/cdp/services/hog-watcher.service.ts
@@ -4,7 +4,7 @@ import { Hub } from '../../types'
 import { now } from '../../utils/now'
 import { UUIDT } from '../../utils/utils'
 import { CdpRedis } from '../redis'
-import { HogFunctionInvocationResult, HogFunctionType } from '../types'
+import { HogFunctionInvocationResult, HogFunctionTiming, HogFunctionType } from '../types'
 
 export const BASE_REDIS_KEY = process.env.NODE_ENV == 'test' ? '@posthog-test/hog-watcher' : '@posthog/hog-watcher'
 const REDIS_KEY_TOKENS = `${BASE_REDIS_KEY}/tokens`
@@ -35,6 +35,14 @@ export const hogFunctionStateChange = new Counter({
     help: 'Number of times a transformation state changed',
     labelNames: ['state', 'kind'],
 })
+
+type HogFunctionTimingCost = {
+    lowerBound: number
+    upperBound: number
+    cost: number
+}
+
+type HogFunctionTimingCosts = Partial<Record<HogFunctionTiming['kind'], HogFunctionTimingCost>>
 
 // TODO: Future follow up - we should swap this to an API call or something.
 // Having it as a celery task ID based on a file path is brittle and hard to test.
@@ -137,6 +145,16 @@ export class HogWatcherService {
     }
 
     public async observeResults(results: HogFunctionInvocationResult[]): Promise<void> {
+        // NOTE: Currently we only monitor hog code timings. We will have a separate config for async functions
+
+        const costsMapping: HogFunctionTimingCosts = {
+            hog: {
+                lowerBound: this.hub.CDP_WATCHER_COST_TIMING_LOWER_MS,
+                upperBound: this.hub.CDP_WATCHER_COST_TIMING_UPPER_MS,
+                cost: this.hub.CDP_WATCHER_COST_TIMING,
+            },
+        }
+
         const costs: Record<HogFunctionType['id'], number> = {}
         // Create a map to store the function types
         const functionTypes: Record<HogFunctionType['id'], HogFunctionType['type']> = {}
@@ -151,17 +169,20 @@ export class HogWatcherService {
                 let costForTimings = 0
 
                 // Calculate cost for this individual timing
-                const lowerBound = this.hub.CDP_WATCHER_COST_TIMING_LOWER_MS
-                const upperBound = this.hub.CDP_WATCHER_COST_TIMING_UPPER_MS
-                const costTiming = this.hub.CDP_WATCHER_COST_TIMING
 
                 for (const timing of result.invocation.timings) {
                     // Record metrics for this timing entry
                     hogFunctionExecutionTimeSummary.labels({ kind: timing.kind }).observe(timing.duration_ms)
-                    const ratio = Math.max(timing.duration_ms - lowerBound, 0) / (upperBound - lowerBound)
 
-                    // Add to the total cost for this result
-                    costForTimings += Math.round(costTiming * ratio)
+                    const costMapping = costsMapping[timing.kind]
+
+                    if (costMapping) {
+                        const ratio =
+                            Math.max(timing.duration_ms - costMapping.lowerBound, 0) /
+                            (costMapping.upperBound - costMapping.lowerBound)
+                        // Add to the total cost for this result
+                        costForTimings += Math.round(costMapping.cost * ratio)
+                    }
                 }
 
                 cost += costForTimings


### PR DESCRIPTION
## Problem

The timings are really focused around hog code and not fetch functions. This makes it explicit and preps for async function monitoring later

## Changes

* As it says

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
