### PR TITLE
feat(database): UUID mapping field for HogQL

### DIFF
--- a/posthog/hogql/database/models.py
+++ b/posthog/hogql/database/models.py
@@ -44,6 +44,13 @@ class IntegerDatabaseField(DatabaseField):
         return IntegerType(nullable=self.is_nullable())
 
 
+class UUIDDatabaseField(DatabaseField):
+    def get_constant_type(self) -> "ConstantType":
+        from posthog.hogql.ast import UUIDType
+
+        return UUIDType(nullable=self.is_nullable())
+
+
 class FloatDatabaseField(DatabaseField):
     def get_constant_type(self) -> "ConstantType":
         from posthog.hogql.ast import FloatType

--- a/posthog/warehouse/models/util.py
+++ b/posthog/warehouse/models/util.py
@@ -1,6 +1,7 @@
 import re
 
 from posthog.hogql.database.models import (
+    UUIDDatabaseField,
     BooleanDatabaseField,
     DateDatabaseField,
     DateTimeDatabaseField,
@@ -70,7 +71,7 @@ def clean_type(column_type: str) -> str:
 
 
 CLICKHOUSE_HOGQL_MAPPING = {
-    "UUID": StringDatabaseField,
+    "UUID": UUIDDatabaseField,
     "String": StringDatabaseField,
     "Nothing": UnknownDatabaseField,
     "DateTime64": DateTimeDatabaseField,

--- a/posthog/warehouse/models/util.py
+++ b/posthog/warehouse/models/util.py
@@ -100,6 +100,7 @@ CLICKHOUSE_HOGQL_MAPPING = {
 }
 
 STR_TO_HOGQL_MAPPING = {
+    "UUIDDatabaseField": UUIDDatabaseField,
     "BooleanDatabaseField": BooleanDatabaseField,
     "DateDatabaseField": DateDatabaseField,
     "DateTimeDatabaseField": DateTimeDatabaseField,


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
UUID is becoming a string and not working with joins for a few people using the feature.

## Changes
- [x] Adds `UUID` field as mapping
- [] Add test 

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
For now, checking this running against CI
