### PR TITLE
chore(plugin-server): adds person latency metrics by version 

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/measuring-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/measuring-person-store.ts
@@ -7,6 +7,7 @@ import { DB } from '../../../utils/db/db'
 import { PostgresUse, TransactionClient } from '../../../utils/db/postgres'
 import { logger } from '../../../utils/logger'
 import {
+    observeLatencyByVersion,
     personCacheOperationsCounter,
     personDatabaseOperationsPerBatchHistogram,
     personMethodCallsPerBatchHistogram,
@@ -171,7 +172,9 @@ export class MeasuringPersonsStoreForDistinctIdBatch implements PersonsStoreForD
         }
 
         this.incrementDatabaseOperation('fetchForChecking')
+        const start = performance.now()
         const person = await this.db.fetchPerson(teamId, distinctId, { useReadReplica: true })
+        observeLatencyByVersion(person, start, 'fetchForChecking')
         this.setCheckCachedPerson(teamId, distinctId, person ?? null)
         return person ?? null
     }
@@ -185,7 +188,9 @@ export class MeasuringPersonsStoreForDistinctIdBatch implements PersonsStoreForD
         }
 
         this.incrementDatabaseOperation('fetchForUpdate')
+        const start = performance.now()
         const person = await this.db.fetchPerson(teamId, distinctId, { useReadReplica: false })
+        observeLatencyByVersion(person, start, 'fetchForUpdate')
         this.setCachedPerson(teamId, distinctId, person ?? null)
         return person ?? null
     }
@@ -227,14 +232,20 @@ export class MeasuringPersonsStoreForDistinctIdBatch implements PersonsStoreForD
         this.incrementCount('updatePersonDeprecated')
         this.clearCache()
         this.incrementDatabaseOperation('updatePersonDeprecated')
-        return await this.db.updatePersonDeprecated(person, update, tx)
+        const start = performance.now()
+        const messages = await this.db.updatePersonDeprecated(person, update, tx)
+        observeLatencyByVersion(person, start, 'updatePersonDeprecated')
+        return messages
     }
 
     async deletePerson(person: InternalPerson, tx?: TransactionClient): Promise<TopicMessage[]> {
         this.incrementCount('deletePerson')
         this.clearCache()
         this.incrementDatabaseOperation('deletePerson')
-        return await this.db.deletePerson(person, tx)
+        const start = performance.now()
+        const messages = await this.db.deletePerson(person, tx)
+        observeLatencyByVersion(person, start, 'deletePerson')
+        return messages
     }
 
     async addDistinctId(
@@ -246,7 +257,10 @@ export class MeasuringPersonsStoreForDistinctIdBatch implements PersonsStoreForD
         this.incrementCount('addDistinctId')
         this.clearCache()
         this.incrementDatabaseOperation('addDistinctId')
-        return await this.db.addDistinctId(person, distinctId, version, tx)
+        const start = performance.now()
+        const message = await this.db.addDistinctId(person, distinctId, version, tx)
+        observeLatencyByVersion(person, start, 'addDistinctId')
+        return message
     }
 
     async moveDistinctIds(
@@ -257,7 +271,10 @@ export class MeasuringPersonsStoreForDistinctIdBatch implements PersonsStoreForD
         this.incrementCount('moveDistinctIds')
         this.clearCache()
         this.incrementDatabaseOperation('moveDistinctIds')
-        return await this.db.moveDistinctIds(source, target, tx)
+        const start = performance.now()
+        const messages = await this.db.moveDistinctIds(source, target, tx)
+        observeLatencyByVersion(target, start, 'moveDistinctIds')
+        return messages
     }
 
     async updateCohortsAndFeatureFlagsForMerge(

--- a/plugin-server/src/worker/ingestion/persons/measuring-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/measuring-person-store.ts
@@ -233,9 +233,9 @@ export class MeasuringPersonsStoreForDistinctIdBatch implements PersonsStoreForD
         this.clearCache()
         this.incrementDatabaseOperation('updatePersonDeprecated')
         const start = performance.now()
-        const messages = await this.db.updatePersonDeprecated(person, update, tx)
+        const response = await this.db.updatePersonDeprecated(person, update, tx)
         observeLatencyByVersion(person, start, 'updatePersonDeprecated')
-        return messages
+        return response
     }
 
     async deletePerson(person: InternalPerson, tx?: TransactionClient): Promise<TopicMessage[]> {
@@ -243,9 +243,9 @@ export class MeasuringPersonsStoreForDistinctIdBatch implements PersonsStoreForD
         this.clearCache()
         this.incrementDatabaseOperation('deletePerson')
         const start = performance.now()
-        const messages = await this.db.deletePerson(person, tx)
+        const response = await this.db.deletePerson(person, tx)
         observeLatencyByVersion(person, start, 'deletePerson')
-        return messages
+        return response
     }
 
     async addDistinctId(
@@ -258,9 +258,9 @@ export class MeasuringPersonsStoreForDistinctIdBatch implements PersonsStoreForD
         this.clearCache()
         this.incrementDatabaseOperation('addDistinctId')
         const start = performance.now()
-        const message = await this.db.addDistinctId(person, distinctId, version, tx)
+        const response = await this.db.addDistinctId(person, distinctId, version, tx)
         observeLatencyByVersion(person, start, 'addDistinctId')
-        return message
+        return response
     }
 
     async moveDistinctIds(
@@ -272,9 +272,9 @@ export class MeasuringPersonsStoreForDistinctIdBatch implements PersonsStoreForD
         this.clearCache()
         this.incrementDatabaseOperation('moveDistinctIds')
         const start = performance.now()
-        const messages = await this.db.moveDistinctIds(source, target, tx)
+        const response = await this.db.moveDistinctIds(source, target, tx)
         observeLatencyByVersion(target, start, 'moveDistinctIds')
-        return messages
+        return response
     }
 
     async updateCohortsAndFeatureFlagsForMerge(

--- a/plugin-server/src/worker/ingestion/persons/metrics.ts
+++ b/plugin-server/src/worker/ingestion/persons/metrics.ts
@@ -1,4 +1,6 @@
-import { Counter, Histogram } from 'prom-client'
+import { Counter, Histogram, Summary } from 'prom-client'
+
+import { InternalPerson } from '~/src/types'
 
 export const personMethodCallsPerBatchHistogram = new Histogram({
     name: 'person_method_calls_per_batch',
@@ -19,3 +21,43 @@ export const personCacheOperationsCounter = new Counter({
     help: 'Total number of cache hits and misses',
     labelNames: ['cache', 'operation'],
 })
+
+export const personOperationLatencyByVersionSummary = new Summary({
+    name: 'person_operation_latency_by_version',
+    help: 'Latency distribution of person',
+})
+
+export function getVersionBucketLabel(version: number): string {
+    if (version === 0) {
+        return 'v0'
+    }
+    if (version <= 50) {
+        return 'v1-50'
+    }
+    if (version <= 100) {
+        return 'v51-100'
+    }
+    if (version <= 1000) {
+        return 'v101-1000'
+    }
+    if (version <= 10000) {
+        return 'v1001-10000'
+    }
+    if (version <= 100000) {
+        return 'v10001-100000'
+    }
+    if (version <= 1000000) {
+        return 'v100001-1000000'
+    }
+    return 'v1000001+'
+}
+
+export function observeLatencyByVersion(person: InternalPerson | undefined, start: number, operation: string) {
+    if (!person) {
+        return
+    }
+    const versionBucket = getVersionBucketLabel(person.version)
+    personOperationLatencyByVersionSummary
+        .labels({ operation, version_bucket: versionBucket })
+        .observe(performance.now() - start)
+}

--- a/plugin-server/src/worker/ingestion/persons/metrics.ts
+++ b/plugin-server/src/worker/ingestion/persons/metrics.ts
@@ -24,7 +24,8 @@ export const personCacheOperationsCounter = new Counter({
 
 export const personOperationLatencyByVersionSummary = new Summary({
     name: 'person_operation_latency_by_version',
-    help: 'Latency distribution of person',
+    help: 'Latency distribution of person by version',
+    labelNames: ['operation', 'version_bucket'],
 })
 
 export function getVersionBucketLabel(version: number): string {
@@ -57,7 +58,5 @@ export function observeLatencyByVersion(person: InternalPerson | undefined, star
         return
     }
     const versionBucket = getVersionBucketLabel(person.version)
-    personOperationLatencyByVersionSummary
-        .labels({ operation, version_bucket: versionBucket })
-        .observe(performance.now() - start)
+    personOperationLatencyByVersionSummary.labels(operation, versionBucket).observe(performance.now() - start)
 }


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

A metric to help undestand which person queries slow down as the version number of a person we are processing increases.

## Changes

Another Summary metric for persons latencies, with an extra label that indicates a "bucket" of version numbers the person falls within..

## Does this work well for both Cloud and self-hosted?

Added metrics

## How did you test this code?
Ran locally