### PR TITLE
fix(file-system): use strong references

### DIFF
--- a/posthog/models/file_system/file_system_mixin.py
+++ b/posthog/models/file_system/file_system_mixin.py
@@ -77,7 +77,7 @@ class FileSystemSyncMixin(Model):
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
 
-        @receiver(post_save, sender=cls)
+        @receiver(post_save, sender=cls, weak=False)
         def _file_system_post_save(sender, instance: FileSystemSyncMixin, created, **kwargs):
             from posthog.models.file_system.file_system import create_or_update_file, delete_file
 
@@ -101,7 +101,7 @@ class FileSystemSyncMixin(Model):
                 # Don't raise exceptions in signals
                 capture_exception(e, additional_properties=dataclasses.asdict(fs_data))
 
-        @receiver(post_delete, sender=cls)
+        @receiver(post_delete, sender=cls, weak=False)
         def _file_system_post_delete(sender, instance: FileSystemSyncMixin, **kwargs):
             from posthog.models.file_system.file_system import delete_file
 


### PR DESCRIPTION
## Problem

There have been cases when the post-save callbacks defined in the file system mixins don't fire. The [django docs](https://docs.djangoproject.com/en/5.2/topics/signals/#listening-to-signals) say:

> Django stores signal handlers as weak references by default. Thus, if your receiver is a local function, it may be garbage collected. To prevent this, pass weak=False when you call the signal’s connect() method.

## Changes

Makes the signals strong 💪 

## How did you test this code?

Nothing broke (nor changed) locally. Let's see if this fixes it in production.