### PR TITLE
feat(cdp): Allow team based routing

### DIFF
--- a/plugin-server/src/cdp/services/job-queue/job-queue.test.ts
+++ b/plugin-server/src/cdp/services/job-queue/job-queue.test.ts
@@ -40,9 +40,10 @@ describe('CyclotronJobQueue', () => {
     })
 
     describe('producer setup', () => {
-        const buildQueue = (mapping: string) => {
+        const buildQueue = (mapping: string, teamMapping?: string) => {
             config.CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_MODE = 'kafka'
             config.CDP_CYCLOTRON_JOB_QUEUE_PRODUCER_MAPPING = mapping
+            config.CDP_CYCLOTRON_JOB_QUEUE_PRODUCER_TEAM_MAPPING = teamMapping
             const queue = new CyclotronJobQueue(config, 'hog', mockHogFunctionManager, mockConsumeBatch)
             queue['jobQueuePostgres'].startAsProducer = jest.fn()
             queue['jobQueueKafka'].startAsProducer = jest.fn()
@@ -72,6 +73,13 @@ describe('CyclotronJobQueue', () => {
 
         it('should start both producers if a percentage is mapped', async () => {
             const queue = buildQueue('*:postgres:0.5')
+            await queue.startAsProducer()
+            expect(queue['jobQueuePostgres'].startAsProducer).toHaveBeenCalled()
+            expect(queue['jobQueueKafka'].startAsProducer).toHaveBeenCalled()
+        })
+
+        it('should account for team mapping', async () => {
+            const queue = buildQueue('*:postgres', '1:*:kafka')
             await queue.startAsProducer()
             expect(queue['jobQueuePostgres'].startAsProducer).toHaveBeenCalled()
             expect(queue['jobQueueKafka'].startAsProducer).toHaveBeenCalled()

--- a/plugin-server/src/cdp/services/job-queue/job-queue.ts
+++ b/plugin-server/src/cdp/services/job-queue/job-queue.ts
@@ -39,9 +39,14 @@ export type CyclotronJobQueueRouting = {
     }
 }
 
+export type CyclotronJobQueueTeamRouting = {
+    [teamId: string]: CyclotronJobQueueRouting
+}
+
 export class CyclotronJobQueue {
     private consumerMode: CyclotronJobQueueKind
     private producerMapping: CyclotronJobQueueRouting
+    private producerTeamMapping: CyclotronJobQueueTeamRouting
     private jobQueuePostgres: CyclotronJobQueuePostgres
     private jobQueueKafka: CyclotronJobQueueKafka
 
@@ -53,6 +58,7 @@ export class CyclotronJobQueue {
     ) {
         this.consumerMode = this.config.CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_MODE
         this.producerMapping = getProducerMapping(this.config.CDP_CYCLOTRON_JOB_QUEUE_PRODUCER_MAPPING)
+        this.producerTeamMapping = getProducerTeamMapping(this.config.CDP_CYCLOTRON_JOB_QUEUE_PRODUCER_TEAM_MAPPING)
 
         this.jobQueueKafka = new CyclotronJobQueueKafka(
             this.config,
@@ -70,6 +76,7 @@ export class CyclotronJobQueue {
         logger.info('🔄', 'CyclotronJobQueue initialized', {
             consumerMode: this.consumerMode,
             producerMapping: this.producerMapping,
+            producerTeamMapping: this.producerTeamMapping,
         })
     }
 
@@ -86,10 +93,27 @@ export class CyclotronJobQueue {
      */
     public async startAsProducer() {
         // We only need to connect to the queue targets that are configured
-        const targets = new Set<CyclotronJobQueueKind>(Object.values(this.producerMapping).map((x) => x.target))
+
+        const allTargets: {
+            target: CyclotronJobQueueKind
+            percentage: number
+        }[] = []
+
+        for (const teamId in this.producerTeamMapping) {
+            allTargets.push(...Object.values(this.producerTeamMapping[teamId]))
+        }
+
+        for (const queue in this.producerMapping) {
+            allTargets.push({
+                target: this.producerMapping[queue].target,
+                percentage: this.producerMapping[queue].percentage,
+            })
+        }
+
+        const targets = new Set<CyclotronJobQueueKind>(allTargets.map((x) => x.target))
 
         // If any target is a non-100% then we need both producers ready
-        const anySplitRouting = Object.values(this.producerMapping).some((x) => x.percentage < 1)
+        const anySplitRouting = allTargets.some((x) => x.percentage < 1)
 
         if (anySplitRouting || targets.has('postgres')) {
             await this.jobQueuePostgres.startAsProducer()
@@ -127,19 +151,27 @@ export class CyclotronJobQueue {
         }
     }
 
+    private getTarget(invocation: HogFunctionInvocation): CyclotronJobQueueKind {
+        const teamId = invocation.teamId
+        const mapping = this.producerTeamMapping[teamId] ?? this.producerMapping
+        const producerConfig = mapping[invocation.queue] ?? mapping['*']
+
+        let target = producerConfig.target
+
+        if (producerConfig.percentage < 1) {
+            const otherTarget = target === 'postgres' ? 'kafka' : 'postgres'
+            target = Math.random() < producerConfig.percentage ? target : otherTarget
+        }
+
+        return target
+    }
+
     public async queueInvocations(invocations: HogFunctionInvocation[]) {
         const postgresInvocations: HogFunctionInvocation[] = []
         const kafkaInvocations: HogFunctionInvocation[] = []
 
         for (const invocation of invocations) {
-            const producerConfig = this.producerMapping[invocation.queue] ?? this.producerMapping['*']
-
-            let target = producerConfig.target
-
-            if (producerConfig.percentage < 1) {
-                const otherTarget = target === 'postgres' ? 'kafka' : 'postgres'
-                target = Math.random() < producerConfig.percentage ? target : otherTarget
-            }
+            const target = this.getTarget(invocation)
 
             if (target === 'postgres') {
                 postgresInvocations.push(invocation)
@@ -165,14 +197,7 @@ export class CyclotronJobQueue {
         const kafkaInvocations: HogFunctionInvocationResult[] = []
 
         for (const invocationResult of invocationResults) {
-            const producerConfig = this.producerMapping[invocationResult.invocation.queue] ?? this.producerMapping['*']
-
-            let target = producerConfig.target
-
-            if (producerConfig.percentage < 1) {
-                const otherTarget = target === 'postgres' ? 'kafka' : 'postgres'
-                target = Math.random() < producerConfig.percentage ? target : otherTarget
-            }
+            const target = this.getTarget(invocationResult.invocation)
 
             if (target === 'postgres') {
                 if (invocationResult.invocation.queueSource === 'postgres') {
@@ -267,6 +292,28 @@ export function getProducerMapping(stringMapping: string): CyclotronJobQueueRout
 
     if (!routing['*']) {
         throw new Error('No mapping for the default queue for example: *:postgres')
+    }
+
+    return routing
+}
+
+/**
+ * Parses a mapping config from a string into a routing object.
+ * Format is like `TEAM:QUEUE:TARGET:PERCENTAGE with percentage being optional and defaulting to 100
+ *
+ * So for example `*:kafka:10,fetch:postgres` would result in all fetch jobs being routed to postgres and 10% of all other jobs being routed to kafka and the rest to postgres
+ */
+export function getProducerTeamMapping(stringMapping?: string): CyclotronJobQueueTeamRouting {
+    if (!stringMapping) {
+        return {}
+    }
+
+    const routing: CyclotronJobQueueTeamRouting = {}
+    const parts = stringMapping.split(',')
+
+    for (const part of parts) {
+        const [team, ...rest] = part.split(':')
+        routing[team] = getProducerMapping(rest.join(':'))
     }
 
     return routing

--- a/plugin-server/src/cdp/services/job-queue/job-queue.ts
+++ b/plugin-server/src/cdp/services/job-queue/job-queue.ts
@@ -298,10 +298,8 @@ export function getProducerMapping(stringMapping: string): CyclotronJobQueueRout
 }
 
 /**
- * Parses a mapping config from a string into a routing object.
- * Format is like `TEAM:QUEUE:TARGET:PERCENTAGE with percentage being optional and defaulting to 100
- *
- * So for example `*:kafka:10,fetch:postgres` would result in all fetch jobs being routed to postgres and 10% of all other jobs being routed to kafka and the rest to postgres
+ * Same as getProducerMapping but with a team check too.
+ * So for example `1:*:kafka,2:*:postgres` would result in team 1 using kafka and team 2 using postgres
  */
 export function getProducerTeamMapping(stringMapping?: string): CyclotronJobQueueTeamRouting {
     if (!stringMapping) {

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -107,6 +107,7 @@ export type CdpConfig = {
     CDP_HOG_FILTERS_TELEMETRY_TEAMS: string
     CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_MODE: CyclotronJobQueueKind
     CDP_CYCLOTRON_JOB_QUEUE_PRODUCER_MAPPING: string // A comma-separated list of queue to mode like `hog:kafka,fetch:postgres,*:kafka` with * being the default
+    CDP_CYCLOTRON_JOB_QUEUE_PRODUCER_TEAM_MAPPING?: string // Like the above but with a team check too
 
     CDP_CYCLOTRON_BATCH_SIZE: number
     CDP_CYCLOTRON_BATCH_DELAY_MS: number


### PR DESCRIPTION
## Problem

We have percentage based routing but i want to be extra careful and test certain production teams first.

## Changes

* Adds team based overrides

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
