### PR TITLE
fix(do-not-normalize-dlt): Fix materialized view casing switches

### DIFF
--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -1,5 +1,4 @@
 import asyncio
-import collections
 import collections.abc
 import dataclasses
 import datetime as dt
@@ -10,6 +9,7 @@ import re
 import typing
 import uuid
 
+import os
 import dlt
 import dlt.common.data_types as dlt_data_types
 import dlt.common.schema.typing as dlt_typing
@@ -39,6 +39,9 @@ from posthog.warehouse.models.data_modeling_job import DataModelingJob
 from posthog.warehouse.util import database_sync_to_async
 
 logger = structlog.get_logger()
+
+# preserve casing since we are already coming from a sql dialect, we don't need to worry about normalizing
+os.environ["SCHEMA__NAMING"] = "direct"
 
 CLICKHOUSE_DLT_MAPPING: dict[str, dlt_data_types.TDataType] = {
     "UUID": "text",


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
Users that have non camel cased names we're getting surprised when suddenly their column names changed upon materializing a view.

## Changes

- [x] Providing config
- [x] Adds test 

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Materialized View 
<img width="991" alt="image" src="https://github.com/user-attachments/assets/ac715d39-1eab-485e-9e56-d3a6a6c1ef1f" />

camelCase preserved
<img width="995" alt="image" src="https://github.com/user-attachments/assets/16a0dfa6-7413-426c-b23f-ca8d47dc3c1f" />


