### PR TITLE
fix: trial banner width

### DIFF
--- a/frontend/src/scenes/billing/Billing.tsx
+++ b/frontend/src/scenes/billing/Billing.tsx
@@ -150,7 +150,7 @@ export function Billing(): JSX.Element {
             )}
 
             {billing?.trial ? (
-                <LemonBanner type="info" hideIcon className="mb-2">
+                <LemonBanner type="info" hideIcon className="max-w-300 mb-2">
                     <div className="flex items-center gap-4">
                         <JudgeHog className="w-20 h-20 flex-shrink-0" />
                         <div>


### PR DESCRIPTION
## Problem

<img width="1794" alt="SCR-20250506-ibxu" src="https://github.com/user-attachments/assets/adf491bf-189e-4ade-94d9-cfd7ea13ddce" />

## Changes

<img width="1543" alt="SCR-20250506-ibtk" src="https://github.com/user-attachments/assets/b0787e6b-b20b-4a72-a561-424aca80c0bb" />

## Does this work well for both Cloud and self-hosted?

Cloud only

## How did you test this code?

Manually
