### PR TITLE
feat(web-analytics): swap path cleaning fields order and add example alias

### DIFF
--- a/frontend/src/lib/components/PathCleanFilters/PathRegexModal.tsx
+++ b/frontend/src/lib/components/PathCleanFilters/PathRegexModal.tsx
@@ -44,30 +44,18 @@ export function PathRegexModal({ filter, isOpen, onSave, onClose }: PathRegexMod
                 <div className="px-2 py-1" data-attr="path-regex-modal-content">
                     <div className="deprecated-space-y-2">
                         <div>
-                            <span>Alias</span>
-                            <LemonInput
-                                value={alias}
-                                onChange={(alias) => setAlias(alias)}
-                                onPressEnter={() => false}
-                            />
-                            <div className="text-muted">
-                                We suggest you use <code>&lt;id&gt;</code> or <code>&lt;slug&gt;</code> to indicate a
-                                dynamic part of the path.
-                            </div>
-                        </div>
-                        <div>
                             <span>Regex</span>
                             <LemonInput
                                 value={regex}
                                 onChange={(regex) => setRegex(regex)}
                                 onPressEnter={() => false}
                             />
-                            <p className="text-secondary">
+                            <p className="text-muted">
                                 <span>
                                     Example:{' '}
                                     <span className="font-mono text-accent text-xs">/merchant/\d+/dashboard$</span> (no
                                     need to escape slashes)
-                                </span>{' '}
+                                </span>
                                 <br />
                                 <span>
                                     We use the{' '}
@@ -75,6 +63,22 @@ export function PathRegexModal({ filter, isOpen, onSave, onClose }: PathRegexMod
                                         re2
                                     </Link>{' '}
                                     syntax.
+                                </span>
+                            </p>
+                        </div>
+                        <div>
+                            <span>Alias</span>
+                            <LemonInput
+                                value={alias}
+                                onChange={(alias) => setAlias(alias)}
+                                onPressEnter={() => false}
+                            />
+                            <p className="text-muted">
+                                <span>How the path will appear after path cleaning</span>
+                                <br />
+                                <span>
+                                    Example:{' '}
+                                    <span className="font-mono text-accent text-xs">{'/merchant/<id>/dashboard'}</span>
                                 </span>
                             </p>
                         </div>


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Dealing with this ticket https://posthoghelp.zendesk.com/agent/tickets/29638, (moved to PostHog: https://us.posthog.com/project/2/support/tickets/31978) I found the UI a bit confusing

## Changes

I swapped the order of the fields so that the regex is now first, and added an example alias.

Before:
![image](https://github.com/user-attachments/assets/097de640-fbeb-438d-85f0-496ec54d4311)

After
<img width="493" alt="Screenshot 2025-05-06 at 10 37 01" src="https://github.com/user-attachments/assets/a2e1d08a-537d-408b-8173-d402c138904c" />

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added some path cleaning rules in local dev
