### PR TITLE
chore: fix missing config for hobby setup

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -290,7 +290,7 @@ services:
         ports:
             - '8666:8080'
         volumes:
-            - ./posthog/docker/livestream/configs-dev.yml:/configs/configs.yml
+            - ./docker/livestream/configs-dev.yml:/configs/configs.yml
 
 volumes:
     zookeeper-data:


### PR DESCRIPTION
## Problem

no config for livestream on hobby setup

## Changes

fix the config location path

## Does this work well for both Cloud and self-hosted?

yes.

## How did you test this code?

yes.