### PR TITLE
fix: livestream config path for hobby

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -290,7 +290,7 @@ services:
         ports:
             - '8666:8080'
         volumes:
-            - ./docker/livestream/configs-dev.yml:/configs/configs.yml
+            - ./posthog/docker/livestream/configs-dev.yml:/configs/configs.yml
 
 volumes:
     zookeeper-data:


### PR DESCRIPTION
during hobby install we check out posthog into a folder, not the root, so have to change config path accordingly

follow up to https://github.com/PostHog/posthog/pull/31945