### PR TITLE
fix: better min duration name when saving team setting

### DIFF
--- a/frontend/src/scenes/teamLogic.tsx
+++ b/frontend/src/scenes/teamLogic.tsx
@@ -23,13 +23,18 @@ import { projectLogic } from './projectLogic'
 import type { teamLogicType } from './teamLogicType'
 import { userLogic } from './userLogic'
 
-const parseUpdatedAttributeName = (attr: string | null): string => {
+const parseUpdatedAttributeName = (attr: keyof TeamType | null): string => {
     if (attr === 'slack_incoming_webhook') {
         return 'Webhook'
     }
     if (attr === 'app_urls') {
         return 'Authorized URLs'
     }
+
+    if (attr === 'session_recording_minimum_duration_milliseconds') {
+        return 'Session recording minimum duration'
+    }
+
     return attr ? identifierToHuman(attr) : 'Project'
 }
 
@@ -115,7 +120,8 @@ export const teamLogic = kea<teamLogicType>([
                     actions.loadUser()
 
                     /* Notify user the update was successful  */
-                    const updatedAttribute = Object.keys(payload).length === 1 ? Object.keys(payload)[0] : null
+                    const updatedAttribute =
+                        Object.keys(payload).length === 1 ? (Object.keys(payload)[0] as keyof TeamType) : null
 
                     let message: string
                     if (updatedAttribute === 'slack_incoming_webhook') {

--- a/frontend/src/scenes/teamLogic.tsx
+++ b/frontend/src/scenes/teamLogic.tsx
@@ -140,7 +140,9 @@ export const teamLogic = kea<teamLogicType>([
                     }
 
                     Object.keys(payload).map((property) => {
-                        eventUsageLogic.findMounted()?.actions?.reportTeamSettingChange(property, payload[property])
+                        eventUsageLogic
+                            .findMounted()
+                            ?.actions?.reportTeamSettingChange(property, payload[property as keyof TeamType])
                     })
 
                     const isUpdatingOnboardingTasks = Object.keys(payload).every((key) => key === 'onboarding_tasks')


### PR DESCRIPTION
see https://posthoghelp.zendesk.com/agent/tickets/29820 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/31626)

we present min duration to humans as seconds, because humans understand seconds

but we present it to the computer as milliseconds, because we should just always tell computers about milliseconds

that makes the confirmation toast look broken

well, not any more

| before | after | 
| - | - |
|![Screenshot 2025-05-06 at 13 56 53](https://github.com/user-attachments/assets/c83632a1-a778-4d33-b959-ee1df5d27cf6) | ![Screenshot 2025-05-06 at 13 54 33](https://github.com/user-attachments/assets/816cc252-ce94-4565-84f9-6cbb3ff807cf)|

