### PR TITLE
fix(data-warehouse): Dont push sensitive ssh tunnel settings to the client

### DIFF
--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -242,9 +242,9 @@ class ExternalDataSourceSerializers(serializers.ModelSerializer):
                     "auth_type": {
                         "selection": job_inputs.pop("ssh_tunnel_auth_type", None),
                         "username": job_inputs.pop("ssh_tunnel_auth_type_username", None),
-                        "password": job_inputs.pop("ssh_tunnel_auth_type_password", None),
-                        "passphrase": job_inputs.pop("ssh_tunnel_auth_type_passphrase", None),
-                        "private_key": job_inputs.pop("ssh_tunnel_auth_type_private_key", None),
+                        "password": None,
+                        "passphrase": None,
+                        "private_key": None,
                     },
                 }
                 job_inputs["ssh-tunnel"] = ssh_tunnel

--- a/posthog/warehouse/api/test/test_external_data_source.py
+++ b/posthog/warehouse/api/test/test_external_data_source.py
@@ -1053,9 +1053,9 @@ class TestExternalDataSource(APIBaseTest):
         assert "auth_type" in ssh_tunnel
         assert ssh_tunnel["auth_type"]["selection"] == "username_password"
         assert ssh_tunnel["auth_type"]["username"] == "testuser"
-        assert ssh_tunnel["auth_type"]["password"] == "testpass"
-        assert ssh_tunnel["auth_type"]["passphrase"] == "testphrase"
-        assert ssh_tunnel["auth_type"]["private_key"] == "testkey"
+        assert ssh_tunnel["auth_type"]["password"] is None
+        assert ssh_tunnel["auth_type"]["passphrase"] is None
+        assert ssh_tunnel["auth_type"]["private_key"] is None
 
     def test_snowflake_auth_type_create_and_update(self):
         """Test that we can create and update the auth type for a Snowflake source"""


### PR DESCRIPTION
## Problem
- When editing the ssh tunnel of a source, we push the tunnel password/passphrase/private key down to the client, exposing them
- https://posthoghelp.zendesk.com/agent/tickets/30167 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/31644)

## Changes
- Remove them from the payload
