### PR TITLE
chore: add email and user id to org member removal

### DIFF
--- a/posthog/api/organization_member.py
+++ b/posthog/api/organization_member.py
@@ -157,6 +157,8 @@ class OrganizationMemberViewSet(
                 "organization_id": instance.organization_id,
                 "organization_name": instance.organization.name,
                 "removal_type": "self_removal" if is_self_removal else "removed_by_other",
+                "removed_email": removed_user.email,
+                "removed_user_id": removed_user.id,
             },
             groups=groups(instance.organization),
         )

--- a/posthog/api/test/test_organization_members.py
+++ b/posthog/api/test/test_organization_members.py
@@ -77,6 +77,8 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
                 "organization_id": self.organization.id,
                 "organization_name": self.organization.name,
                 "removal_type": "removed_by_other",
+                "removed_email": user.email,
+                "removed_user_id": user.id,
             },
             groups={"instance": "http://localhost:8010", "organization": str(self.organization.id)},
         )

--- a/posthog/api/test/test_organization_members.py
+++ b/posthog/api/test/test_organization_members.py
@@ -230,6 +230,8 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
                 "organization_id": self.organization.id,
                 "organization_name": self.organization.name,
                 "removal_type": "self_removal",
+                "removed_email": self.user.email,
+                "removed_user_id": self.user.id,
             },
             groups={"instance": ANY, "organization": str(self.organization.id)},
         )


### PR DESCRIPTION
## Problem

We have the `organization member removed` but it only has the member id so it's not possible to look up more info on the removed user after the fact because the org membership gets deleted.

## Changes

Adding email and user id so it helps with understanding who was removed. 

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
