### PR TITLE
fix: do not run AI CI on draft PRs

### DIFF
--- a/.github/workflows/ci-ai.yml
+++ b/.github/workflows/ci-ai.yml
@@ -24,7 +24,7 @@ jobs:
         timeout-minutes: 30
         name: Run AI evals
         runs-on: ubuntu-latest
-        if: github.repository == 'PostHog/posthog' # Braintrust credentials not available on forks
+        if: github.repository == 'PostHog/posthog' && (github.event_name == 'push' || (github.event.pull_request.draft == false)) # Braintrust credentials not available on forks
 
         steps:
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
Braintrust CI currently runs on all PRs, even draft ones. We don't have to run it on draft PRs.

## Changes
- Fix the CI yaml to avoid running Braintrust on draft PRs.

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
An LLM double checked it for me.
