### PR TITLE
chore(data-warehouse): Add command for updating data import Temporal schedules

### DIFF
--- a/posthog/management/commands/test/test_update_data_import_schedules.py
+++ b/posthog/management/commands/test/test_update_data_import_schedules.py
@@ -1,0 +1,282 @@
+import datetime as dt
+import logging
+
+import pytest
+from asgiref.sync import async_to_sync
+from django.core.management import CommandError, call_command
+from temporalio.client import Client as TemporalClient
+from temporalio.service import RPCError
+
+from posthog.api.test.test_organization import create_organization
+from posthog.api.test.test_team import create_team
+from posthog.management.commands.update_data_import_schedules import (
+    _get_external_data_schemas,
+)
+from posthog.temporal.common.client import sync_connect
+from posthog.temporal.common.schedule import describe_schedule, update_schedule
+from posthog.warehouse.data_load.service import sync_external_data_job_workflow
+from posthog.warehouse.models.external_data_schema import ExternalDataSchema
+from posthog.warehouse.models.external_data_source import ExternalDataSource
+
+pytestmark = [pytest.mark.django_db]
+
+
+@pytest.fixture
+def organization():
+    return create_organization("test org")
+
+
+@pytest.fixture
+def team(organization):
+    return create_team(organization=organization)
+
+
+@pytest.fixture
+def team_2(organization):
+    return create_team(organization=organization)
+
+
+def _create_external_data_source(team, source_type):
+    return ExternalDataSource.objects.create(team=team, source_type=source_type, job_inputs={})
+
+
+def _create_external_data_schema(
+    external_data_source,
+    sync_frequency_interval,
+    sync_time_of_day,
+    should_sync=True,
+    updated_at=None,
+    create_schedule=True,
+    sync_type=ExternalDataSchema.SyncType.FULL_REFRESH,
+):
+    external_data_schema = ExternalDataSchema.objects.create(
+        name="TestSchema",
+        team=external_data_source.team,
+        source=external_data_source,
+        should_sync=should_sync,
+        sync_type=sync_type,
+        sync_frequency_interval=sync_frequency_interval,
+        sync_time_of_day=sync_time_of_day,
+    )
+    if create_schedule:
+        # create the schedule in Temporal
+        sync_external_data_job_workflow(external_data_schema, create=True, should_sync=should_sync)
+    # simulate the updated_at field being set to a different value
+    if updated_at:
+        ExternalDataSchema.objects.filter(id=external_data_schema.id).update(updated_at=updated_at)
+    return external_data_schema
+
+
+@async_to_sync
+async def delete_temporal_schedule(temporal: TemporalClient, schedule_id: str):
+    """Delete a Temporal Schedule with the given id."""
+    handle = temporal.get_schedule_handle(schedule_id)
+    await handle.delete()
+
+
+def cleanup_temporal_schedules(client):
+    """Clean up any Temporal Schedules created during the test."""
+    for schedule in ExternalDataSchema.objects.all():
+        try:
+            delete_temporal_schedule(client, str(schedule.id))
+        except RPCError:
+            # Assume this is fine as we are tearing down, but don't fail silently.
+            logging.warning("Schedule %s has already been deleted, ignoring.", schedule.id)
+            continue
+
+
+@pytest.fixture(autouse=True)
+def temporal():
+    """Return a TemporalClient instance and cleanup any schedules created during the test."""
+    client = sync_connect()
+    yield client
+    cleanup_temporal_schedules(client)
+
+
+def _assert_schedule(temporal: TemporalClient, external_data_schema: ExternalDataSchema, paused: bool | None = None):
+    schedule = describe_schedule(temporal, str(external_data_schema.id))
+    if paused is not None:
+        assert schedule.schedule.state.paused == paused
+    else:
+        assert schedule.schedule.state.paused != external_data_schema.should_sync
+
+
+def _update_schedule(temporal: TemporalClient, external_data_schema: ExternalDataSchema, paused: bool):
+    schedule = describe_schedule(temporal, str(external_data_schema.id))
+    new_schedule = schedule.schedule
+    new_schedule.state.paused = paused
+    update_schedule(temporal, str(external_data_schema.id), new_schedule)
+    schedule = describe_schedule(temporal, str(external_data_schema.id))
+    assert schedule.schedule.state.paused == paused
+
+
+def test_command_updates_all_schedules_for_a_given_source(team, temporal):
+    source = _create_external_data_source(team, "Stripe")
+    # create a couple of schemas for the source (to ensure that the command updates all schemas for the source)
+    external_data_schema_1 = _create_external_data_schema(source, dt.timedelta(hours=6), "00:00:00", should_sync=True)
+    external_data_schema_2 = _create_external_data_schema(source, dt.timedelta(hours=1), "00:00:00", should_sync=True)
+    # assert that the schedules are created in Temporal
+    _assert_schedule(temporal, external_data_schema_1)
+    _assert_schedule(temporal, external_data_schema_2)
+
+    # create another source with another schema to ensure that the command only updates the correct source
+    source_2 = _create_external_data_source(team, "BigQuery")
+    external_data_schema_3 = _create_external_data_schema(source_2, dt.timedelta(hours=6), "00:00:00", should_sync=True)
+    _assert_schedule(temporal, external_data_schema_3)
+
+    # Manually update the schedules so we can check that the command updates (or doesn't update) them
+    _update_schedule(temporal, external_data_schema_1, paused=True)
+    _update_schedule(temporal, external_data_schema_2, paused=True)
+    _update_schedule(temporal, external_data_schema_3, paused=True)
+
+    call_command(
+        "update_data_import_schedules",
+        f"--external-data-source-id={source.id}",
+    )
+
+    _assert_schedule(temporal, external_data_schema_1)
+    _assert_schedule(temporal, external_data_schema_2)
+    # this one should still be paused
+    _assert_schedule(temporal, external_data_schema_3, paused=True)
+
+
+def test_command_updates_all_schedules_for_a_given_source_since_a_given_updated_at(team, temporal):
+    source = _create_external_data_source(team, "Stripe")
+    # create a couple of schemas for the source (to ensure that the command updates all schemas for the source)
+    external_data_schema_1 = _create_external_data_schema(source, dt.timedelta(hours=6), "00:00:00", should_sync=True)
+    external_data_schema_2 = _create_external_data_schema(
+        source, dt.timedelta(hours=1), "00:00:00", updated_at=dt.datetime(2020, 1, 1), should_sync=True
+    )
+    # assert that the schedules are created in Temporal
+    _assert_schedule(temporal, external_data_schema_1)
+    _assert_schedule(temporal, external_data_schema_2)
+
+    # Manually update the schedules so we can check that the command updates (or doesn't update) them
+    _update_schedule(temporal, external_data_schema_1, paused=True)
+    _update_schedule(temporal, external_data_schema_2, paused=True)
+
+    call_command(
+        "update_data_import_schedules",
+        f"--external-data-source-id={source.id}",
+        f"--updated-at-gt=2020-01-02",
+    )
+
+    _assert_schedule(temporal, external_data_schema_1)
+    # this one should still be paused
+    _assert_schedule(temporal, external_data_schema_2, paused=True)
+
+
+def test_get_external_data_schemas(
+    team,
+    team_2,
+):
+    """Tests the filtering logic of the command.
+
+    The above tests ensure that the command updates the schedules correctly, so here we just test that the filtering
+    logic works for various cases.
+    """
+    # create several different external data sources and schemas with different properties
+    stripe_source = _create_external_data_source(team, "Stripe")
+    bigquery_source = _create_external_data_source(team, "BigQuery")
+    stripe_source_team_2 = _create_external_data_source(team_2, "Stripe")
+
+    # create a couple of schemas for the source (to ensure that the command updates all schemas for the source)
+    stripe_schema_1 = _create_external_data_schema(
+        stripe_source, dt.timedelta(hours=6), "00:00:00", should_sync=True, create_schedule=False
+    )
+    stripe_schema_2 = _create_external_data_schema(
+        stripe_source, dt.timedelta(hours=1), "00:00:00", should_sync=True, create_schedule=False
+    )
+    bigquery_schema_paused = _create_external_data_schema(
+        bigquery_source, dt.timedelta(hours=6), "00:00:00", should_sync=False, create_schedule=False
+    )
+    bigquery_schema_incremental = _create_external_data_schema(
+        bigquery_source,
+        dt.timedelta(hours=1),
+        "00:00:00",
+        should_sync=True,
+        sync_type=ExternalDataSchema.SyncType.INCREMENTAL,
+        create_schedule=False,
+    )
+    stripe_schema_team_2 = _create_external_data_schema(
+        stripe_source_team_2,
+        dt.timedelta(hours=24),
+        "00:00:00",
+        should_sync=True,
+        sync_type=ExternalDataSchema.SyncType.INCREMENTAL,
+        create_schedule=False,
+    )
+    old_stripe_schema = _create_external_data_schema(
+        stripe_source,
+        dt.timedelta(hours=12),
+        "00:00:00",
+        should_sync=True,
+        updated_at=dt.datetime(2020, 1, 1),
+        create_schedule=False,
+    )
+
+    # test using external_data_source_id
+    schemas = _get_external_data_schemas(external_data_source_id=stripe_source.id)
+    assert len(schemas) == 3
+    assert stripe_schema_1 in schemas
+    assert stripe_schema_2 in schemas
+    assert old_stripe_schema in schemas
+
+    # test using team_id
+    schemas = _get_external_data_schemas(team_id=team_2.id)
+    assert len(schemas) == 1
+    assert stripe_schema_team_2 in schemas
+
+    # test using source_type
+    schemas = _get_external_data_schemas(source_type="Stripe")
+    assert len(schemas) == 4
+    assert stripe_schema_1 in schemas
+    assert stripe_schema_2 in schemas
+    assert stripe_schema_team_2 in schemas
+    assert old_stripe_schema in schemas
+
+    # test using sync_type
+    schemas = _get_external_data_schemas(sync_type=ExternalDataSchema.SyncType.INCREMENTAL)
+    assert len(schemas) == 2
+    assert bigquery_schema_incremental in schemas
+    assert stripe_schema_team_2 in schemas
+
+    # test using sync_frequency
+    schemas = _get_external_data_schemas(sync_frequency="1hour")
+    assert len(schemas) == 2
+    assert stripe_schema_2 in schemas
+    assert bigquery_schema_incremental in schemas
+
+    # test using should_sync
+    schemas = _get_external_data_schemas(should_sync=False)
+    assert len(schemas) == 1
+    assert bigquery_schema_paused in schemas
+
+    # test using updated_at_gt
+    schemas = _get_external_data_schemas(updated_at_gt="2020-01-02")
+    assert len(schemas) == 5
+    assert old_stripe_schema not in schemas
+
+    # test using updated_at_lt
+    schemas = _get_external_data_schemas(updated_at_lt="2020-01-02")
+    assert len(schemas) == 1
+    assert old_stripe_schema in schemas
+
+
+def test_update_data_import_schedules_raises_error_if_no_args():
+    """Test that the command raises an error if no arguments are provided.
+
+    This is more of a safety net than anything else, so could remove in future if we want to.
+    """
+    with pytest.raises(CommandError, match="Must call this command with at least one filter"):
+        call_command("update_data_import_schedules")
+
+
+def test_update_data_import_schedules_raises_error_if_no_schemas_found(team):
+    source = _create_external_data_source(team, "Stripe")
+    _create_external_data_schema(source, dt.timedelta(hours=6), "00:00:00", should_sync=True)
+    with pytest.raises(CommandError, match="No external data schemas found"):
+        call_command(
+            "update_data_import_schedules",
+            f"--source-type=NonExistentType",
+        )

--- a/posthog/management/commands/update_batch_export_schedules.py
+++ b/posthog/management/commands/update_batch_export_schedules.py
@@ -11,7 +11,7 @@ logger = structlog.get_logger(__name__)
 
 
 class Command(BaseCommand):
-    help = "Updates the Temporal schedules for batch exports"
+    help = "Updates the Temporal schedules for batch exports to ensure they are up to date"
 
     def add_arguments(self, parser):
         parser.add_argument("--batch-export-id", default=None, type=str, help="Single batch export ID to update")

--- a/posthog/management/commands/update_batch_export_schedules.py
+++ b/posthog/management/commands/update_batch_export_schedules.py
@@ -11,7 +11,7 @@ logger = structlog.get_logger(__name__)
 
 
 class Command(BaseCommand):
-    help = "Updates the Temporal schedule for a batch export"
+    help = "Updates the Temporal schedules for batch exports"
 
     def add_arguments(self, parser):
         parser.add_argument("--batch-export-id", default=None, type=str, help="Single batch export ID to update")

--- a/posthog/management/commands/update_data_import_schedules.py
+++ b/posthog/management/commands/update_data_import_schedules.py
@@ -1,0 +1,140 @@
+import datetime as dt
+import logging
+
+import structlog
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from posthog.warehouse.data_load.service import sync_external_data_job_workflow
+from posthog.warehouse.models.external_data_schema import (
+    ExternalDataSchema,
+    sync_frequency_to_sync_frequency_interval,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+def _update_external_data_schema_schedule(external_data_schema: ExternalDataSchema):
+    logger.info("Updating external data schema schedule...", external_data_schema_id=str(external_data_schema.id))
+
+    try:
+        sync_external_data_job_workflow(
+            external_data_schema, create=False, should_sync=external_data_schema.should_sync
+        )
+    except Exception:
+        logger.exception(
+            "Error updating external data schema schedule", external_data_schema_id=str(external_data_schema.id)
+        )
+
+
+def _get_external_data_schemas(**options) -> list[ExternalDataSchema]:
+    filters_applied = False
+    queryset = ExternalDataSchema.objects.filter(deleted=False)
+
+    if options.get("external_data_source_id") is not None:
+        queryset = queryset.filter(source_id=options["external_data_source_id"])
+        filters_applied = True
+
+    if options.get("team_id") is not None:
+        queryset = queryset.filter(team_id=options["team_id"])
+        filters_applied = True
+
+    if options.get("source_type") is not None:
+        queryset = queryset.filter(source__source_type=options["source_type"])
+        filters_applied = True
+
+    if options.get("sync_type") is not None:
+        queryset = queryset.filter(sync_type=options["sync_type"])
+        filters_applied = True
+
+    if options.get("sync_frequency") is not None:
+        sync_frequency_interval = sync_frequency_to_sync_frequency_interval(options["sync_frequency"])
+        queryset = queryset.filter(sync_frequency_interval=sync_frequency_interval)
+        filters_applied = True
+
+    if options.get("should_sync") is not None:
+        queryset = queryset.filter(should_sync=options["should_sync"])
+        filters_applied = True
+
+    if options.get("updated_at_gt") is not None:
+        try:
+            updated_at_gt = dt.datetime.strptime(options["updated_at_gt"], "%Y-%m-%d").replace(tzinfo=dt.UTC)
+        except ValueError:
+            raise CommandError("updated_at_gt must be in the format YYYY-MM-DD")
+        queryset = queryset.filter(updated_at__gt=updated_at_gt)
+        filters_applied = True
+
+    if options.get("updated_at_lt") is not None:
+        try:
+            updated_at_lt = dt.datetime.strptime(options["updated_at_lt"], "%Y-%m-%d").replace(tzinfo=dt.UTC)
+        except ValueError:
+            raise CommandError("updated_at_lt must be in the format YYYY-MM-DD")
+        queryset = queryset.filter(updated_at__lt=updated_at_lt)
+        filters_applied = True
+
+    if not filters_applied:
+        raise CommandError("Must call this command with at least one filter")
+
+    return list(queryset)
+
+
+class Command(BaseCommand):
+    help = "Updates the Temporal schedules for data imports to ensure they are up to date"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--external-data-source-id", default=None, type=str, help="Single external data source ID to update"
+        )
+        parser.add_argument(
+            "--team-id", default=None, type=int, help="Team ID for which to update all external data sources"
+        )
+        parser.add_argument(
+            "--source-type", default=None, type=str, help="Update all external data sources for a given source type"
+        )
+        parser.add_argument(
+            "--sync-type",
+            default=None,
+            type=str,
+            choices=["full_refresh", "incremental"],
+            help="Filter data schemas by sync type (full_refresh or incremental)",
+        )
+        parser.add_argument(
+            "--sync-frequency",
+            default=None,
+            type=str,
+            choices=["never", "5min", "30min", "1hour", "6hour", "12hour", "24hour", "7day", "30day"],
+            help="Filter data schemas by sync frequency interval",
+        )
+        parser.add_argument(
+            "--should-sync", default=None, type=bool, help="Filter data schemas by should sync value (True or False)"
+        )
+        parser.add_argument(
+            "--updated-at-gt",
+            default=None,
+            type=str,
+            help="Filter data schemas by updated at greater than (YYYY-MM-DD)",
+        )
+        parser.add_argument(
+            "--updated-at-lt", default=None, type=str, help="Filter data schemas by updated at less than (YYYY-MM-DD)"
+        )
+
+    def handle(self, **options):
+        logger.setLevel(logging.INFO)
+
+        external_data_schemas = _get_external_data_schemas(**options)
+
+        if len(external_data_schemas) == 0:
+            raise CommandError("No external data schemas found")
+
+        if not settings.TEST:
+            confirm = input(
+                f"\n\tWill update schedules for {len(external_data_schemas)} external data schemas. Proceed? (y/n) "
+            )
+            if confirm.strip().lower() != "y":
+                logger.info("Aborting")
+                return
+
+        for external_data_schema in external_data_schemas:
+            _update_external_data_schema_schedule(external_data_schema)
+
+        logger.info("Done!")


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Sometimes we need to apply updates to the schedules in Temporal to reflect changes we've applied to the models.

## Changes

Create a Django command to do this, similar to the one we have for batch exports.

## How did you test this code?

Added tests.

Tested on a local data source.
