### PR TITLE
feat(capture-rs): misc. observability and small bugfixes for event handler

### DIFF
--- a/rust/capture/src/test_endpoint.rs
+++ b/rust/capture/src/test_endpoint.rs
@@ -66,7 +66,7 @@ pub async fn test_black_hole(
                     )));
                 }
             };
-            if input.data.is_none() && input.data.as_ref().is_some_and(|d| d.is_empty()) {
+            if input.data.is_none() || input.data.as_ref().is_some_and(|d| d.is_empty()) {
                 error!("unexpected missing EventFormData payload");
                 return Err(CaptureError::EmptyPayload);
             }

--- a/rust/capture/src/test_endpoint.rs
+++ b/rust/capture/src/test_endpoint.rs
@@ -66,12 +66,14 @@ pub async fn test_black_hole(
                     )));
                 }
             };
-            if input.data.is_empty() {
+            if input.data.is_none() && input.data.as_ref().is_some_and(|d| d.is_empty()) {
                 error!("unexpected missing EventFormData payload");
                 return Err(CaptureError::EmptyPayload);
             }
 
-            let payload = match base64::engine::general_purpose::STANDARD.decode(input.data) {
+            let payload = match base64::engine::general_purpose::STANDARD
+                .decode(input.data.unwrap())
+            {
                 Ok(payload) => payload,
                 Err(e) => {
                     error!("failed to decode form data: {}", e);


### PR DESCRIPTION
## Problem
We want to log high-signal metadata from event submission requests while we debug corner cases and map them to SDK versions, but we don't want to be too chatty. We also want to ensure that legacy SDK encoding and compression schemes play nice together

## Changes
* Prune header logging to only high-signal selections
* Fix bug where urlencoded forms garble LZ64 encoded `data` payloads
* Fix bug in form decoding hydration, unify form `struct`
* Simplify collection of req meta and event payload data

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally, CI. Next: live traffic on mirror deploy
