### PR TITLE
fix(cohorts): was noticing that our new cohort filter validation was getting mad about static cohorts

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -278,6 +278,9 @@ class CohortSerializer(serializers.ModelSerializer):
         1. structural/schema check → pydantic
         2. domain rules (feature-flag gotchas) → bespoke fn
         """
+        # Skip validation for static cohorts
+        if self.initial_data.get("is_static") or getattr(self.instance, "is_static", False):
+            return raw
         if not isinstance(raw, dict) or "properties" not in raw:
             raise ValidationError(
                 {"detail": "Must contain a 'properties' key with type and values", "type": "validation_error"}


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Issue: https://posthoghelp.zendesk.com/agent/tickets/30192 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/31823)

## Changes

Don't attempt to validate cohort filters for static cohorts (which have no filters); we already handle static cohorts in the `create` API.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manually tested
