### PR TITLE
feat: switch blob v2 to session_replay_events

### DIFF
--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -2285,6 +2285,10 @@
       distinct_id VARCHAR,
       min_first_timestamp SimpleAggregateFunction(min, DateTime64(6, 'UTC')),
       max_last_timestamp SimpleAggregateFunction(max, DateTime64(6, 'UTC')),
+      -- session recording v2 blocks
+      block_first_timestamps SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
+      block_last_timestamps SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
+      block_urls SimpleAggregateFunction(groupArrayArray, Array(String)),
       -- store the first url of the session so we can quickly show that in playlists
       first_url AggregateFunction(argMin, Nullable(VARCHAR), DateTime64(6, 'UTC')),
       -- but also store each url so we can query by visited page without having to scan all events
@@ -2994,6 +2998,10 @@
       distinct_id VARCHAR,
       min_first_timestamp SimpleAggregateFunction(min, DateTime64(6, 'UTC')),
       max_last_timestamp SimpleAggregateFunction(max, DateTime64(6, 'UTC')),
+      -- session recording v2 blocks
+      block_first_timestamps SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
+      block_last_timestamps SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
+      block_urls SimpleAggregateFunction(groupArrayArray, Array(String)),
       -- store the first url of the session so we can quickly show that in playlists
       first_url AggregateFunction(argMin, Nullable(VARCHAR), DateTime64(6, 'UTC')),
       -- but also store each url so we can query by visited page without having to scan all events
@@ -4277,6 +4285,10 @@
       distinct_id VARCHAR,
       min_first_timestamp SimpleAggregateFunction(min, DateTime64(6, 'UTC')),
       max_last_timestamp SimpleAggregateFunction(max, DateTime64(6, 'UTC')),
+      -- session recording v2 blocks
+      block_first_timestamps SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
+      block_last_timestamps SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
+      block_urls SimpleAggregateFunction(groupArrayArray, Array(String)),
       -- store the first url of the session so we can quickly show that in playlists
       first_url AggregateFunction(argMin, Nullable(VARCHAR), DateTime64(6, 'UTC')),
       -- but also store each url so we can query by visited page without having to scan all events

--- a/posthog/session_recordings/models/metadata.py
+++ b/posthog/session_recordings/models/metadata.py
@@ -52,6 +52,9 @@ class RecordingMetadata(TypedDict):
     duration: int
     active_seconds: int
     snapshot_source: Literal["web", "mobile"]
+    block_first_timestamps: list[datetime]
+    block_last_timestamps: list[datetime]
+    block_urls: list[str]
 
 
 class RecordingMatchingEvents(TypedDict):

--- a/posthog/session_recordings/queries/session_replay_events.py
+++ b/posthog/session_recordings/queries/session_replay_events.py
@@ -93,7 +93,10 @@ class SessionReplayEvents:
                 sum(console_log_count) as console_log_count,
                 sum(console_warn_count) as console_warn_count,
                 sum(console_error_count) as console_error_count,
-                argMinMerge(snapshot_source) as snapshot_source
+                argMinMerge(snapshot_source) as snapshot_source,
+                groupArrayArray(block_first_timestamps) as block_first_timestamps,
+                groupArrayArray(block_last_timestamps) as block_last_timestamps,
+                groupArrayArray(block_urls) as block_urls
             FROM
                 session_replay_events
             PREWHERE
@@ -138,6 +141,9 @@ class SessionReplayEvents:
             console_warn_count=replay[10],
             console_error_count=replay[11],
             snapshot_source=replay[12] or "web",
+            block_first_timestamps=replay[13],
+            block_last_timestamps=replay[14],
+            block_urls=replay[15],
         )
 
     def get_events(

--- a/posthog/session_recordings/queries/test/session_replay_sql.py
+++ b/posthog/session_recordings/queries/test/session_replay_sql.py
@@ -127,6 +127,7 @@ def produce_replay_summary(
     size: Optional[int] = None,
     *,
     ensure_analytics_event_in_session: bool = True,
+    block_url: str | None = None,
 ):
     if log_messages is None:
         log_messages = {}
@@ -152,6 +153,7 @@ def produce_replay_summary(
         "snapshot_source": snapshot_source,
         "snapshot_library": snapshot_library,
         "size": size or 0,
+        "block_url": block_url,
     }
 
     if settings.TEST:

--- a/posthog/session_recordings/queries/test/session_replay_sql.py
+++ b/posthog/session_recordings/queries/test/session_replay_sql.py
@@ -56,8 +56,8 @@ SELECT
     argMinState(cast(%(snapshot_library)s, 'LowCardinality(Nullable(String))'), toDateTime64(%(first_timestamp)s, 6, 'UTC')),
     %(size)s,
     %(block_urls)s,
-    [toDateTime64(%(first_timestamp)s, 6, 'UTC')],
-    [toDateTime64(%(last_timestamp)s, 6, 'UTC')],
+    %(block_first_timestamps)s,
+    %(block_last_timestamps)s,
     %(_timestamp)s
 """
 
@@ -133,7 +133,9 @@ def produce_replay_summary(
     size: Optional[int] = None,
     *,
     ensure_analytics_event_in_session: bool = True,
-    block_url: str | None = None,
+    block_urls: list[str] | None = None,
+    block_first_timestamps: list[datetime] | None = None,
+    block_last_timestamps: list[datetime] | None = None,
 ):
     if log_messages is None:
         log_messages = {}
@@ -159,7 +161,9 @@ def produce_replay_summary(
         "snapshot_source": snapshot_source,
         "snapshot_library": snapshot_library,
         "size": size or 0,
-        "block_urls": [block_url] if block_url else [],
+        "block_urls": block_urls or [],
+        "block_first_timestamps": block_first_timestamps or [],
+        "block_last_timestamps": block_last_timestamps or [],
     }
 
     if settings.TEST:

--- a/posthog/session_recordings/queries/test/session_replay_sql.py
+++ b/posthog/session_recordings/queries/test/session_replay_sql.py
@@ -33,6 +33,9 @@ INSERT INTO sharded_session_replay_events (
     snapshot_source,
     snapshot_library,
     size,
+    block_urls,
+    block_first_timestamps,
+    block_last_timestamps,
     _timestamp
 )
 SELECT
@@ -52,6 +55,9 @@ SELECT
     argMinState(cast(%(snapshot_source)s, 'LowCardinality(Nullable(String))'), toDateTime64(%(first_timestamp)s, 6, 'UTC')),
     argMinState(cast(%(snapshot_library)s, 'LowCardinality(Nullable(String))'), toDateTime64(%(first_timestamp)s, 6, 'UTC')),
     %(size)s,
+    %(block_urls)s,
+    [toDateTime64(%(first_timestamp)s, 6, 'UTC')],
+    [toDateTime64(%(last_timestamp)s, 6, 'UTC')],
     %(_timestamp)s
 """
 
@@ -153,7 +159,7 @@ def produce_replay_summary(
         "snapshot_source": snapshot_source,
         "snapshot_library": snapshot_library,
         "size": size or 0,
-        "block_url": block_url,
+        "block_urls": [block_url] if block_url else [],
     }
 
     if settings.TEST:

--- a/posthog/session_recordings/queries/test/test_session_replay_events.py
+++ b/posthog/session_recordings/queries/test/test_session_replay_events.py
@@ -15,8 +15,8 @@ class SessionReplayEventsQueries(ClickhouseTestMixin, APIBaseTest):
         produce_replay_summary(
             session_id="1",
             team_id=self.team.pk,
-            first_timestamp=self.base_time.isoformat(),
-            last_timestamp=self.base_time.isoformat(),
+            first_timestamp=self.base_time,
+            last_timestamp=self.base_time,
             distinct_id="u1",
             first_url="https://example.io/home",
             click_count=2,
@@ -27,20 +27,50 @@ class SessionReplayEventsQueries(ClickhouseTestMixin, APIBaseTest):
         produce_replay_summary(
             session_id="2",
             team_id=self.team.pk,
-            first_timestamp=self.base_time.isoformat(),
-            last_timestamp=self.base_time.isoformat(),
-            distinct_id="u1",
+            first_timestamp=self.base_time,
+            last_timestamp=self.base_time + relativedelta(seconds=2),
+            distinct_id="u2",
             first_url="https://example.io/home",
-            click_count=2,
+            click_count=100,
+            keypress_count=200,
+            mouse_activity_count=300,
+            active_milliseconds=1234,
+            block_url="s3://block-1",
+        )
+        produce_replay_summary(
+            session_id="3",
+            team_id=self.team.pk,
+            first_timestamp=self.base_time + relativedelta(seconds=1),
+            last_timestamp=self.base_time + relativedelta(seconds=2),
+            distinct_id="u3",
+            first_url="https://example.io/1",
+            click_count=100,
+            keypress_count=200,
+            mouse_activity_count=300,
+            active_milliseconds=1234,
+            block_url="s3://block-x",
+        )
+        produce_replay_summary(
+            session_id="3",
+            team_id=self.team.pk,
+            first_timestamp=self.base_time + relativedelta(seconds=2),
+            last_timestamp=self.base_time + relativedelta(seconds=3),
+            distinct_id="u3",
+            first_url="https://example.io/2",
+            click_count=1,
             keypress_count=2,
-            mouse_activity_count=2,
-            active_milliseconds=50 * 1000 * 0.5,
+            mouse_activity_count=3,
+            active_milliseconds=1000,
+            block_url="s3://block-y",
         )
 
     def test_get_metadata(self) -> None:
         metadata = SessionReplayEvents().get_metadata(session_id="1", team=self.team)
         assert metadata == {
             "active_seconds": 25.0,
+            "block_first_timestamps": [],
+            "block_last_timestamps": [],
+            "block_urls": [],
             "click_count": 2,
             "console_error_count": 0,
             "console_log_count": 0,
@@ -51,6 +81,58 @@ class SessionReplayEventsQueries(ClickhouseTestMixin, APIBaseTest):
             "first_url": "https://example.io/home",
             "keypress_count": 2,
             "mouse_activity_count": 2,
+            "start_time": self.base_time,
+            "snapshot_source": "web",
+        }
+
+    def test_get_metadata_with_block(self) -> None:
+        metadata = SessionReplayEvents().get_metadata(session_id="2", team=self.team)
+        assert metadata == {
+            "active_seconds": 1.234,
+            "start_time": self.base_time,
+            "end_time": self.base_time + relativedelta(seconds=2),
+            "block_first_timestamps": [self.base_time],
+            "block_last_timestamps": [self.base_time + relativedelta(seconds=2)],
+            "block_urls": ["https://example.io/home"],
+            "click_count": 100,
+            "console_error_count": 0,
+            "console_log_count": 0,
+            "console_warn_count": 0,
+            "distinct_id": "u2",
+            "duration": 0,
+            "end_time": self.base_time,
+            "first_url": "https://example.io/home",
+            "keypress_count": 200,
+            "mouse_activity_count": 300,
+            "start_time": self.base_time,
+            "snapshot_source": "web",
+        }
+
+    def test_get_metadata_with_multiple_blocks(self) -> None:
+        metadata = SessionReplayEvents().get_metadata(session_id="3", team=self.team)
+        assert metadata == {
+            "active_seconds": 2.234,
+            "start_time": self.base_time + relativedelta(seconds=1),
+            "end_time": self.base_time + relativedelta(seconds=3),
+            "block_first_timestamps": [
+                self.base_time + relativedelta(seconds=1),
+                self.base_time + relativedelta(seconds=2),
+            ],
+            "block_last_timestamps": [
+                self.base_time + relativedelta(seconds=2),
+                self.base_time + relativedelta(seconds=3),
+            ],
+            "block_urls": ["s3://block-x", "s3://block-y"],
+            "click_count": 101,
+            "console_error_count": 0,
+            "console_log_count": 0,
+            "console_warn_count": 0,
+            "distinct_id": "u3",
+            "duration": 0,
+            "end_time": self.base_time,
+            "first_url": "https://example.io/1",
+            "keypress_count": 202,
+            "mouse_activity_count": 303,
             "start_time": self.base_time,
             "snapshot_source": "web",
         }

--- a/posthog/session_recordings/queries/test/test_session_replay_events.py
+++ b/posthog/session_recordings/queries/test/test_session_replay_events.py
@@ -100,11 +100,9 @@ class SessionReplayEventsQueries(ClickhouseTestMixin, APIBaseTest):
             "console_warn_count": 0,
             "distinct_id": "u2",
             "duration": 0,
-            "end_time": self.base_time,
             "first_url": "https://example.io/home",
             "keypress_count": 200,
             "mouse_activity_count": 300,
-            "start_time": self.base_time,
             "snapshot_source": "web",
         }
 
@@ -129,11 +127,9 @@ class SessionReplayEventsQueries(ClickhouseTestMixin, APIBaseTest):
             "console_warn_count": 0,
             "distinct_id": "u3",
             "duration": 0,
-            "end_time": self.base_time,
             "first_url": "https://example.io/1",
             "keypress_count": 202,
             "mouse_activity_count": 303,
-            "start_time": self.base_time,
             "snapshot_source": "web",
         }
 

--- a/posthog/session_recordings/queries/test/test_session_replay_events.py
+++ b/posthog/session_recordings/queries/test/test_session_replay_events.py
@@ -35,33 +35,30 @@ class SessionReplayEventsQueries(ClickhouseTestMixin, APIBaseTest):
             keypress_count=200,
             mouse_activity_count=300,
             active_milliseconds=1234,
-            block_url="s3://block-1",
+            block_urls=["s3://block-1"],
+            block_first_timestamps=[self.base_time],
+            block_last_timestamps=[self.base_time + relativedelta(seconds=2)],
         )
         produce_replay_summary(
             session_id="3",
             team_id=self.team.pk,
             first_timestamp=self.base_time + relativedelta(seconds=1),
-            last_timestamp=self.base_time + relativedelta(seconds=2),
-            distinct_id="u3",
-            first_url="https://example.io/1",
-            click_count=100,
-            keypress_count=200,
-            mouse_activity_count=300,
-            active_milliseconds=1234,
-            block_url="s3://block-x",
-        )
-        produce_replay_summary(
-            session_id="3",
-            team_id=self.team.pk,
-            first_timestamp=self.base_time + relativedelta(seconds=2),
             last_timestamp=self.base_time + relativedelta(seconds=3),
             distinct_id="u3",
-            first_url="https://example.io/2",
-            click_count=1,
-            keypress_count=2,
-            mouse_activity_count=3,
-            active_milliseconds=1000,
-            block_url="s3://block-y",
+            first_url="https://example.io/1",
+            click_count=10,
+            keypress_count=20,
+            mouse_activity_count=30,
+            active_milliseconds=2345,
+            block_urls=["s3://block-x", "s3://block-y"],
+            block_first_timestamps=[
+                self.base_time + relativedelta(seconds=1),
+                self.base_time + relativedelta(seconds=2),
+            ],
+            block_last_timestamps=[
+                self.base_time + relativedelta(seconds=2),
+                self.base_time + relativedelta(seconds=3),
+            ],
         )
 
     def test_get_metadata(self) -> None:
@@ -93,13 +90,13 @@ class SessionReplayEventsQueries(ClickhouseTestMixin, APIBaseTest):
             "end_time": self.base_time + relativedelta(seconds=2),
             "block_first_timestamps": [self.base_time],
             "block_last_timestamps": [self.base_time + relativedelta(seconds=2)],
-            "block_urls": ["https://example.io/home"],
+            "block_urls": ["s3://block-1"],
             "click_count": 100,
             "console_error_count": 0,
             "console_log_count": 0,
             "console_warn_count": 0,
             "distinct_id": "u2",
-            "duration": 0,
+            "duration": 2,
             "first_url": "https://example.io/home",
             "keypress_count": 200,
             "mouse_activity_count": 300,
@@ -109,7 +106,7 @@ class SessionReplayEventsQueries(ClickhouseTestMixin, APIBaseTest):
     def test_get_metadata_with_multiple_blocks(self) -> None:
         metadata = SessionReplayEvents().get_metadata(session_id="3", team=self.team)
         assert metadata == {
-            "active_seconds": 2.234,
+            "active_seconds": 2.345,
             "start_time": self.base_time + relativedelta(seconds=1),
             "end_time": self.base_time + relativedelta(seconds=3),
             "block_first_timestamps": [
@@ -121,15 +118,15 @@ class SessionReplayEventsQueries(ClickhouseTestMixin, APIBaseTest):
                 self.base_time + relativedelta(seconds=3),
             ],
             "block_urls": ["s3://block-x", "s3://block-y"],
-            "click_count": 101,
+            "click_count": 10,
             "console_error_count": 0,
             "console_log_count": 0,
             "console_warn_count": 0,
             "distinct_id": "u3",
-            "duration": 0,
+            "duration": 2,
             "first_url": "https://example.io/1",
-            "keypress_count": 202,
-            "mouse_activity_count": 303,
+            "keypress_count": 20,
+            "mouse_activity_count": 30,
             "snapshot_source": "web",
         }
 

--- a/posthog/session_recordings/session_recording_v2_service.py
+++ b/posthog/session_recordings/session_recording_v2_service.py
@@ -3,7 +3,7 @@ from typing import TypedDict
 import structlog
 
 from posthog.session_recordings.models.session_recording import SessionRecording
-from posthog.session_recordings.queries.session_replay_events_v2_test import SessionReplayEventsV2Test
+from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
 
 logger = structlog.get_logger(__name__)
 
@@ -20,7 +20,7 @@ def list_blocks(recording: SessionRecording) -> list[RecordingBlock]:
     The blocks are sorted by start time and guaranteed to start from the beginning of the recording.
     Returns empty list if the recording is invalid or incomplete.
     """
-    metadata = SessionReplayEventsV2Test().get_metadata(recording.session_id, recording.team)
+    metadata = SessionReplayEvents().get_metadata(recording.session_id, recording.team)
     if not metadata:
         return []
 

--- a/posthog/session_recordings/sql/session_replay_event_sql.py
+++ b/posthog/session_recordings/sql/session_replay_event_sql.py
@@ -60,6 +60,10 @@ CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     distinct_id VARCHAR,
     min_first_timestamp SimpleAggregateFunction(min, DateTime64(6, 'UTC')),
     max_last_timestamp SimpleAggregateFunction(max, DateTime64(6, 'UTC')),
+    -- session recording v2 blocks
+    block_first_timestamps SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
+    block_last_timestamps SimpleAggregateFunction(groupArrayArray, Array(DateTime64(6, 'UTC'))),
+    block_urls SimpleAggregateFunction(groupArrayArray, Array(String)),
     -- store the first url of the session so we can quickly show that in playlists
     first_url AggregateFunction(argMin, Nullable(VARCHAR), DateTime64(6, 'UTC')),
     -- but also store each url so we can query by visited page without having to scan all events

--- a/posthog/session_recordings/tests/test_session_recording_v2_service.py
+++ b/posthog/session_recordings/tests/test_session_recording_v2_service.py
@@ -16,14 +16,14 @@ class TestSessionRecordingV2Service(TestCase):
         self.recording.team = self.team
 
     @freeze_time("2024-01-01T12:00:00Z")
-    @patch("posthog.session_recordings.session_recording_v2_service.SessionReplayEventsV2Test")
+    @patch("posthog.session_recordings.session_recording_v2_service.SessionReplayEvents")
     def test_list_blocks_returns_empty_list_when_no_metadata(self, mock_replay_events):
         mock_replay_events.return_value.get_metadata.return_value = None
         blocks = list_blocks(self.recording)
         self.assertEqual(blocks, [])
 
     @freeze_time("2024-01-01T12:00:00Z")
-    @patch("posthog.session_recordings.session_recording_v2_service.SessionReplayEventsV2Test")
+    @patch("posthog.session_recordings.session_recording_v2_service.SessionReplayEvents")
     def test_list_blocks_returns_empty_list_when_arrays_have_different_lengths_simple(self, mock_replay_events):
         mock_replay_events.return_value.get_metadata.return_value = {
             "block_first_timestamps": [datetime(2024, 1, 1, 12, 0)],
@@ -35,7 +35,7 @@ class TestSessionRecordingV2Service(TestCase):
         self.assertEqual(blocks, [])
 
     @freeze_time("2024-01-01T12:00:00Z")
-    @patch("posthog.session_recordings.session_recording_v2_service.SessionReplayEventsV2Test")
+    @patch("posthog.session_recordings.session_recording_v2_service.SessionReplayEvents")
     def test_list_blocks_returns_empty_list_when_arrays_have_different_lengths_complex(self, mock_replay_events):
         mock_replay_events.return_value.get_metadata.return_value = {
             "block_first_timestamps": [
@@ -60,7 +60,7 @@ class TestSessionRecordingV2Service(TestCase):
         self.assertEqual(blocks, [])
 
     @freeze_time("2024-01-01T12:00:00Z")
-    @patch("posthog.session_recordings.session_recording_v2_service.SessionReplayEventsV2Test")
+    @patch("posthog.session_recordings.session_recording_v2_service.SessionReplayEvents")
     def test_list_blocks_returns_empty_list_when_first_block_not_at_start_time(self, mock_replay_events):
         mock_replay_events.return_value.get_metadata.return_value = {
             "block_first_timestamps": [datetime(2024, 1, 1, 12, 1)],  # Later than start_time
@@ -72,7 +72,7 @@ class TestSessionRecordingV2Service(TestCase):
         self.assertEqual(blocks, [])
 
     @freeze_time("2024-01-01T12:00:00Z")
-    @patch("posthog.session_recordings.session_recording_v2_service.SessionReplayEventsV2Test")
+    @patch("posthog.session_recordings.session_recording_v2_service.SessionReplayEvents")
     def test_list_blocks_returns_sorted_blocks(self, mock_replay_events):
         mock_replay_events.return_value.get_metadata.return_value = {
             "block_first_timestamps": [


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We're moving blobby v2 to write to `session_replay_events` and we want to fetch the blocks from this table instead.

## Changes

Changes the `list_blocks` method to use `session_replay_events` instead of `session_replay_events_v2`.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Tested locally to see if replays still work.