### PR TITLE
fix: Keep focus in support form field after selected for typing.

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
@@ -33,7 +33,7 @@ const Section = ({ title, children }: { title: string; children: React.ReactNode
 //Support offsite messaging
 const SUPPORT_MESSAGE_OVERRIDE_TITLE = "We're making improvements:"
 const SUPPORT_MESSAGE_OVERRIDE_BODY =
-    "Many of our support engineers are attending an offsite (from 12th to 16th May) so we can make long-term enhancements. We're working different hours, so non-urgent inquiries without priority support may experience a slight delay. We’ll be back to full speed from the 19th!"
+    "Many of our support engineers are attending an offsite (from 12th to 16th May) so we can make long-term enhancements. We're working different hours, so non-urgent inquiries without priority support may experience a slight delay. We'll be back to full speed from the 19th!"
 
 //Support Christmas messaging
 //const SUPPORT_MESSAGE_OVERRIDE_TITLE = '🎄 🎅 Support during the holidays 🎁 ⛄'

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -355,6 +355,7 @@ export const supportLogic = kea<supportLogicType>([
         updateUrlParams: true,
         openEmailForm: true,
         closeEmailForm: true,
+        setFocusedField: (field: string | null) => ({ field }),
     })),
     reducers(() => ({
         isSupportFormOpen: [
@@ -369,6 +370,14 @@ export const supportLogic = kea<supportLogicType>([
             {
                 openEmailForm: () => true,
                 closeEmailForm: () => false,
+            },
+        ],
+        focusedField: [
+            null as string | null,
+            {
+                setFocusedField: (_, { field }) => field,
+                // Reset focused field when form is closed
+                closeSupportForm: () => null,
             },
         ],
     })),
@@ -413,11 +422,14 @@ export const supportLogic = kea<supportLogicType>([
     }),
     listeners(({ actions, props, values }) => ({
         updateUrlParams: async () => {
+            // Only include non-text fields in the URL parameters
+            // This prevents focus loss when typing in text fields
             const panelOptions = [
                 values.sendSupportRequest.kind ?? '',
                 values.sendSupportRequest.target_area ?? '',
                 values.sendSupportRequest.severity_level ?? '',
                 values.isEmailFormOpen ?? 'false',
+                // Explicitly exclude message, name, and email fields
             ].join(':')
 
             if (panelOptions !== ':') {
@@ -579,8 +591,11 @@ export const supportLogic = kea<supportLogicType>([
             props.onClose?.()
         },
 
-        setSendSupportRequestValue: () => {
-            actions.updateUrlParams()
+        setSendSupportRequestValue: ({ name }) => {
+            // Only update URL params for non-text fields to prevent focus loss during typing
+            if (name !== 'message' && name !== 'name' && name !== 'email') {
+                actions.updateUrlParams()
+            }
         },
     })),
 


### PR DESCRIPTION
## Problem

Something was causing the focus to be pulled away from the support form when the user started typing, so after typing 1 character, the cursor was removed from the form field.

## Changes

- Added a `focusedField` state to the supportLogic to track which field has focus
- Added refs to the input fields (name, email, message)
- Added focus/blur event handlers to update the focusedField state
- Added an effect to restore focus to the appropriate field after re-renders
- Modified the useEffect to not only restore focus but also set the cursor position to the end of the text using setSelectionRange

## Does this work well for both Cloud and self-hosted?

Cloud only

## How did you test this code?

In my browser on my local. Also sent a test ticket to ZD to make sure it still works.