### PR TITLE
fix(cdp): Fetch executor logic

### DIFF
--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -20,7 +20,7 @@ import {
     HogFunctionType,
     LogEntry,
 } from './types'
-import { convertToHogFunctionInvocationGlobals } from './utils'
+import { cloneInvocation, convertToHogFunctionInvocationGlobals } from './utils'
 
 export class CdpApi {
     private hogExecutor: HogExecutorService
@@ -222,11 +222,10 @@ export class CdpApi {
                                     )
 
                                 response = {
-                                    invocation: {
-                                        ...invocation,
+                                    invocation: cloneInvocation(invocation, {
                                         queue: 'hog',
                                         queueParameters: { response: { status: 200, headers: {} }, body: '{}' },
-                                    },
+                                    }),
                                     finished: false,
                                     logs: [
                                         {

--- a/plugin-server/src/cdp/cdp-e2e.test.ts
+++ b/plugin-server/src/cdp/cdp-e2e.test.ts
@@ -244,7 +244,7 @@ describe.each(['postgres' as const, 'kafka' as const, 'hybrid' as const])('CDP C
             ])
         })
 
-        it.only('should handle fetch failures with retries', async () => {
+        it('should handle fetch failures with retries', async () => {
             mockFetch.mockImplementation(() => {
                 return Promise.resolve({
                     status: 500,

--- a/plugin-server/src/cdp/cdp-e2e.test.ts
+++ b/plugin-server/src/cdp/cdp-e2e.test.ts
@@ -17,7 +17,6 @@ import { forSnapshot } from '~/tests/helpers/snapshots'
 import { KafkaProducerObserver } from '~/tests/helpers/mocks/producer.spy'
 import { resetKafka } from '~/tests/helpers/kafka'
 import { logger } from '../utils/logger'
-import { errors } from 'undici'
 
 const ActualKafkaProducerWrapper = jest.requireActual('../../src/kafka/producer').KafkaProducerWrapper
 

--- a/plugin-server/src/cdp/services/fetch-executor.service.test.ts
+++ b/plugin-server/src/cdp/services/fetch-executor.service.test.ts
@@ -132,7 +132,11 @@ describe('FetchExecutorService', () => {
         // Should now be complete with failure
         expect(retryResult.invocation.queue).toBe('hog')
         expect(params.trace?.length).toBe(2)
-        expect(params.response).toBeNull()
+        expect(params.response).toEqual({
+            status: 500,
+            headers: expect.objectContaining({ 'content-type': 'text/plain' }),
+        })
+        expect(params.body).toBe('test server error body')
         expect(attempts).toBe(2)
     })
 

--- a/plugin-server/src/cdp/services/fetch-executor.service.ts
+++ b/plugin-server/src/cdp/services/fetch-executor.service.ts
@@ -92,7 +92,6 @@ export class FetchExecutorService {
         }
 
         // If we've exceeded retries, return all failures in trace
-        // TODO: We want to have the full response here too
         return {
             invocation: cloneInvocation(invocation, {
                 queue: 'hog',

--- a/plugin-server/src/cdp/services/fetch-executor.service.ts
+++ b/plugin-server/src/cdp/services/fetch-executor.service.ts
@@ -25,7 +25,7 @@ export class FetchExecutorService {
     private async handleFetchFailure(
         invocation: HogFunctionInvocation,
         response: FetchResponse | null,
-        error: Error | null
+        error: any | null
     ): Promise<HogFunctionInvocationResult> {
         let kind: CyclotronFetchFailureKind = 'requesterror'
 
@@ -113,7 +113,6 @@ export class FetchExecutorService {
     }
 
     async execute(invocation: HogFunctionInvocation): Promise<HogFunctionInvocationResult> {
-        console.log('Executing fetch', invocation.queue, invocation.queueParameters)
         if (invocation.queue !== 'fetch' || !invocation.queueParameters) {
             throw new Error('Bad invocation')
         }
@@ -136,14 +135,14 @@ export class FetchExecutorService {
         try {
             fetchResponse = await fetch(params.url, fetchParams)
         } catch (err) {
-            fetchError = err as Error
+            fetchError = err
         }
 
         const duration = performance.now() - start
         cdpHttpRequests.inc({ status: fetchResponse?.status.toString() ?? 'error' })
 
         // If error - decide if it can be retried and set the values
-        if (!fetchResponse || (fetchResponse?.status && fetchResponse.status > 400)) {
+        if (!fetchResponse || (fetchResponse?.status && fetchResponse.status >= 400)) {
             return await this.handleFetchFailure(invocation, fetchResponse, fetchError)
         }
 

--- a/plugin-server/src/cdp/services/fetch-executor.service.ts
+++ b/plugin-server/src/cdp/services/fetch-executor.service.ts
@@ -3,7 +3,7 @@ import { Counter } from 'prom-client'
 
 import { PluginsServerConfig } from '../../types'
 import { logger } from '../../utils/logger'
-import { fetch, FetchOptions } from '../../utils/request'
+import { fetch, FetchOptions, FetchResponse } from '../../utils/request'
 import {
     CyclotronFetchFailureInfo,
     CyclotronFetchFailureKind,
@@ -11,6 +11,7 @@ import {
     HogFunctionInvocationResult,
     HogFunctionQueueParametersFetchRequest,
 } from '../types'
+import { cloneInvocation } from '../utils'
 
 const cdpHttpRequests = new Counter({
     name: 'cdp_http_requests',
@@ -18,17 +19,39 @@ const cdpHttpRequests = new Counter({
     labelNames: ['status'],
 })
 
-/**
- * This class is only used by the kafka based queuing system. For the Cyclotron system there is no need for this.
- */
 export class FetchExecutorService {
     constructor(private serverConfig: PluginsServerConfig) {}
 
-    private handleFetchFailure(
+    private async handleFetchFailure(
         invocation: HogFunctionInvocation,
-        failure: CyclotronFetchFailureInfo,
-        metadata: { tries: number; trace: CyclotronFetchFailureInfo[] } = { tries: 0, trace: [] }
-    ): HogFunctionInvocationResult {
+        response: FetchResponse | null,
+        error: Error | null
+    ): Promise<HogFunctionInvocationResult> {
+        let kind: CyclotronFetchFailureKind = 'requesterror'
+
+        if (error?.message.toLowerCase().includes('timeout')) {
+            kind = 'timeout'
+        }
+
+        const failure: CyclotronFetchFailureInfo = response
+            ? {
+                  kind: 'failurestatus' as CyclotronFetchFailureKind,
+                  message: `Received failure status: ${response?.status}`,
+                  headers: response?.headers,
+                  status: response?.status,
+                  timestamp: DateTime.utc(),
+              }
+            : {
+                  kind: kind,
+                  message: String(error),
+                  timestamp: DateTime.utc(),
+              }
+
+        // Get existing metadata from previous attempts if any
+        const metadata = (invocation.queueMetadata as { tries: number; trace: CyclotronFetchFailureInfo[] }) || {
+            tries: 0,
+            trace: [],
+        }
         const params = invocation.queueParameters as HogFunctionQueueParametersFetchRequest
         const maxTries = params.max_tries ?? this.serverConfig.CDP_FETCH_RETRIES
         const updatedMetadata = {
@@ -56,113 +79,94 @@ export class FetchExecutorService {
             })
 
             return {
-                invocation: {
-                    ...invocation,
+                invocation: cloneInvocation(invocation, {
                     queue: 'fetch', // Keep in fetch queue for retry
                     queueMetadata: updatedMetadata,
+                    queueParameters: invocation.queueParameters, // Keep the same parameters
                     queuePriority: invocation.queuePriority + 1, // Decrease priority for retries
                     queueScheduledAt: nextScheduledAt,
-                },
+                }),
                 finished: false,
                 logs: [],
             }
         }
 
         // If we've exceeded retries, return all failures in trace
+        // TODO: We want to have the full response here too
         return {
-            invocation: {
-                ...invocation,
+            invocation: cloneInvocation(invocation, {
                 queue: 'hog',
                 queueParameters: {
-                    response: null,
+                    response: response
+                        ? {
+                              status: response?.status,
+                              headers: response?.headers,
+                          }
+                        : null,
+                    body: response ? await response.text() : null,
                     trace: updatedMetadata.trace,
                     timings: [],
                 },
-            },
+            }),
             finished: false,
             logs: [],
         }
     }
 
     async execute(invocation: HogFunctionInvocation): Promise<HogFunctionInvocationResult> {
+        console.log('Executing fetch', invocation.queue, invocation.queueParameters)
         if (invocation.queue !== 'fetch' || !invocation.queueParameters) {
             throw new Error('Bad invocation')
         }
 
+        const start = performance.now()
         const params = invocation.queueParameters as HogFunctionQueueParametersFetchRequest
-
-        // Get existing metadata from previous attempts if any
-        const metadata = (invocation.queueMetadata as { tries: number; trace: CyclotronFetchFailureInfo[] }) || {
-            tries: 0,
-            trace: [],
+        const method = params.method.toUpperCase()
+        const fetchParams: FetchOptions = {
+            method,
+            headers: params.headers,
+            timeoutMs: this.serverConfig.CDP_FETCH_TIMEOUT_MS,
+        }
+        if (!['GET', 'HEAD'].includes(method) && params.body) {
+            fetchParams.body = params.body
         }
 
+        let fetchResponse: FetchResponse | null = null
+        let fetchError: any | undefined = undefined
+
         try {
-            const start = performance.now()
-            const method = params.method.toUpperCase()
-            const fetchParams: FetchOptions = {
-                method,
-                headers: params.headers,
-                timeoutMs: this.serverConfig.CDP_FETCH_TIMEOUT_MS,
-            }
-            if (!['GET', 'HEAD'].includes(method) && params.body) {
-                fetchParams.body = params.body
-            }
-            const fetchResponse = await fetch(params.url, fetchParams)
-            const duration = performance.now() - start
-
-            cdpHttpRequests.inc({ status: fetchResponse.status.toString() })
-
-            // Match Rust implementation: Only return response for success status codes (<400)
-            if (fetchResponse.status && fetchResponse.status < 400) {
-                return {
-                    invocation: {
-                        ...invocation,
-                        queue: 'hog',
-                        queueParameters: {
-                            response: {
-                                status: fetchResponse.status,
-                                headers: fetchResponse.headers,
-                            },
-                            body: await fetchResponse.text(),
-                            timings: [
-                                {
-                                    kind: 'async_function',
-                                    duration_ms: duration,
-                                },
-                            ],
-                        },
-                    },
-                    finished: false,
-                    logs: [],
-                }
-            } else {
-                // For failure status codes, handle retry logic
-                const failure: CyclotronFetchFailureInfo = {
-                    kind: 'failurestatus' as CyclotronFetchFailureKind,
-                    message: `Received failure status: ${fetchResponse.status}`,
-                    headers: fetchResponse.headers,
-                    status: fetchResponse.status,
-                    timestamp: DateTime.utc(),
-                }
-                return this.handleFetchFailure(invocation, failure, metadata)
-            }
+            fetchResponse = await fetch(params.url, fetchParams)
         } catch (err) {
-            cdpHttpRequests.inc({ status: 'error' })
+            fetchError = err as Error
+        }
 
-            let kind: CyclotronFetchFailureKind = 'requesterror'
+        const duration = performance.now() - start
+        cdpHttpRequests.inc({ status: fetchResponse?.status.toString() ?? 'error' })
 
-            if (err.message.toLowerCase().includes('timeout')) {
-                kind = 'timeout'
-            }
+        // If error - decide if it can be retried and set the values
+        if (!fetchResponse || (fetchResponse?.status && fetchResponse.status > 400)) {
+            return await this.handleFetchFailure(invocation, fetchResponse, fetchError)
+        }
 
-            // Match Rust implementation: Create a failure trace for errors
-            const failure: CyclotronFetchFailureInfo = {
-                kind,
-                message: String(err),
-                timestamp: DateTime.utc(),
-            }
-            return this.handleFetchFailure(invocation, failure, metadata)
+        return {
+            invocation: cloneInvocation(invocation, {
+                queue: 'hog',
+                queueParameters: {
+                    response: {
+                        status: fetchResponse?.status,
+                        headers: fetchResponse?.headers,
+                    },
+                    body: await fetchResponse.text(),
+                    timings: [
+                        {
+                            kind: 'async_function',
+                            duration_ms: duration,
+                        },
+                    ],
+                },
+            }),
+            finished: false,
+            logs: [],
         }
     }
 }

--- a/plugin-server/src/cdp/services/fetch-executor.service.ts
+++ b/plugin-server/src/cdp/services/fetch-executor.service.ts
@@ -139,7 +139,7 @@ export class FetchExecutorService {
         }
 
         const duration = performance.now() - start
-        cdpHttpRequests.inc({ status: fetchResponse?.status.toString() ?? 'error' })
+        cdpHttpRequests.inc({ status: fetchResponse?.status?.toString() ?? 'error' })
 
         // If error - decide if it can be retried and set the values
         if (!fetchResponse || (fetchResponse?.status && fetchResponse.status >= 400)) {

--- a/plugin-server/src/cdp/services/job-queue/job-queue-postgres.ts
+++ b/plugin-server/src/cdp/services/job-queue/job-queue-postgres.ts
@@ -246,7 +246,7 @@ function invocationToCyclotronJobInitial(invocation: HogFunctionInvocation): Cyc
         parameters,
         blob,
         metadata: invocation.queueMetadata ?? null,
-        scheduled: invocation.queueScheduledAt?.toISO() ?? null,
+        scheduled: invocation.queueScheduledAt?.toISO() ?? DateTime.now().toISO(),
     }
     return job
 }

--- a/plugin-server/src/cdp/templates/test/test-helpers.ts
+++ b/plugin-server/src/cdp/templates/test/test-helpers.ts
@@ -12,7 +12,7 @@ import {
     HogFunctionQueueParametersFetchResponse,
     HogFunctionType,
 } from '../../types'
-import { createInvocation } from '../../utils'
+import { cloneInvocation, createInvocation } from '../../utils'
 import { compileHog } from '../compiler'
 import { HogFunctionTemplate, HogFunctionTemplateCompiled } from '../types'
 
@@ -163,11 +163,10 @@ export class TemplateTester {
     }
 
     invokeFetchResponse(invocation: HogFunctionInvocation, response: HogFunctionQueueParametersFetchResponse) {
-        const modifiedInvocation = {
-            ...invocation,
+        const modifiedInvocation = cloneInvocation(invocation, {
             queue: 'hog' as const,
             queueParameters: response,
-        }
+        })
 
         return this.executor.execute(modifiedInvocation)
     }

--- a/plugin-server/src/cdp/types.ts
+++ b/plugin-server/src/cdp/types.ts
@@ -197,7 +197,7 @@ export type HogFunctionQueueParametersFetchResponse = {
     } | null
     /** On failure, the fetch worker returns a list of info about the attempts made*/
     trace?: CyclotronFetchFailureInfo[]
-    body?: string // Both results AND failures can have a body
+    body?: string | null // Both results AND failures can have a body
     timings?: HogFunctionTiming[]
     logs?: LogEntry[]
 }
@@ -222,10 +222,10 @@ export type HogFunctionInvocation = {
     timings: HogFunctionTiming[]
     // Params specific to the queueing system
     queue: HogFunctionInvocationJobQueue
-    queueParameters?: HogFunctionInvocationQueueParameters
+    queueParameters?: HogFunctionInvocationQueueParameters | null
     queuePriority: number
     queueScheduledAt?: DateTime
-    queueMetadata?: Record<string, any>
+    queueMetadata?: Record<string, any> | null
     queueSource?: CyclotronJobQueueKind
 }
 

--- a/plugin-server/src/cdp/utils.ts
+++ b/plugin-server/src/cdp/utils.ts
@@ -336,6 +336,28 @@ export function createInvocation(
     }
 }
 
+/**
+ * Clones an invocation, removing all queue related values
+ */
+export function cloneInvocation(
+    invocation: HogFunctionInvocation,
+    params: Pick<
+        Partial<HogFunctionInvocation>,
+        'queuePriority' | 'queueMetadata' | 'queueScheduledAt' | 'queueParameters'
+    > &
+        Pick<HogFunctionInvocation, 'queue'>
+): HogFunctionInvocation {
+    return {
+        ...invocation,
+        queueMetadata: params.queueMetadata ?? undefined,
+        queueScheduledAt: params.queueScheduledAt ?? undefined,
+        queuePriority: params.queuePriority ?? 0,
+        queue: params.queue,
+        queueParameters: params.queueParameters ?? undefined,
+        queueSource: undefined, // This is always set by the consumer
+    }
+}
+
 export function isLegacyPluginHogFunction(hogFunction: HogFunctionType): boolean {
     return hogFunction.template_id?.startsWith('plugin-') ?? false
 }


### PR DESCRIPTION
## Problem

Noticed that the fetch executor behaved slightly differently to expected and wasn't responding with the body of the response if it fails.

## Changes

* Improves the logic and tidies things up a bit
* Adds a helper for the invocation side of things to clear job specific data when cloning it

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
