### PR TITLE
feat(capture-rs): extend mirror-only context logging into even hydration step

### DIFF
--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -188,7 +188,11 @@ where
 
     // run our app with hyper
     tracing::info!("listening on {:?}", listener.local_addr().unwrap());
-    tracing::info!("config: is_mirror_deploy == {:?}", config.is_mirror_deploy);
+    tracing::info!(
+        "config: is_mirror_deploy == {:?} ; log_level == {:?}",
+        config.is_mirror_deploy,
+        config.log_level
+    );
     axum::serve(
         listener,
         app.into_make_service_with_connect_info::<SocketAddr>(),

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -188,6 +188,8 @@ async fn handle_legacy(
     let lib_version = extract_lib_version(&form, query_params);
     Span::current().record("lib_version", &lib_version);
 
+    warn!("payload processed: passing to RawRequest::from_bytes");
+
     // if the payload is populated in the form, process it.
     // otherwise, pass the byte payload
     let data = form.data.map_or(raw_payload, Bytes::from);
@@ -241,7 +243,9 @@ async fn handle_legacy(
         return Err(CaptureError::BillingLimit);
     }
 
-    debug!(context=?context, events=?events, "handle_legacy: decoded request");
+    warn!(context=?context,
+        event_count=?events.len(),
+        "handle_legacy: successfully hydrated events");
     Ok((context, events))
 }
 


### PR DESCRIPTION
## Problem
Now that some of the initial payload processing errors are resolved, we need to surface some logging further into the pipeline where events are hydrated.

## Changes
Adds more logging. Double checks that `LogLevel` is propagating as expected from new config param

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally, CI. Next: mirror deploy test