### PR TITLE
fix: previous period actors modal on bold number

### DIFF
--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -201,6 +201,7 @@ function BoldNumberComparison({
                                     query: {
                                         kind: NodeKind.InsightActorsQuery,
                                         source: querySource!,
+                                        includeRecordings: true,
                                     },
                                     additionalSelect: {
                                         value_at_data_point: 'event_count',


### PR DESCRIPTION
Previous period actors modal wasn't working (follow up to: https://github.com/PostHog/posthog/pull/22288)