### PR TITLE
feat(propdefs): prototype property definitions filter builder service

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2234,6 +2234,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
+name = "fastrange-rs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e90a1392cd6ec5ebe42ccaf251f2b7ba6be654c377f05c913f3898bfb2172512"
+
+[[package]]
 name = "feature-flags"
 version = "0.1.0"
 dependencies = [
@@ -2540,6 +2546,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -4636,6 +4651,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "property_filter"
+version = "0.1.0"
+dependencies = [
+ "axum 0.7.5",
+ "chrono",
+ "envconfig",
+ "futures",
+ "fxhash",
+ "health",
+ "metrics",
+ "rand",
+ "sbbf-rs-safe",
+ "serde",
+ "serve-metrics",
+ "sqlx",
+ "time",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "prost"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5322,6 +5359,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "sbbf-rs"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5525db49c7719816ac719ea8ffd0d0b4586db1a3f5d3e7751593230dacc642fd"
+dependencies = [
+ "cpufeatures",
+ "fastrange-rs",
+]
+
+[[package]]
+name = "sbbf-rs-safe"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9902ffeb2cff3f8c072c60c7d526ac9560fc9a66fe1dfc3c240eba5e2151ba3c"
+dependencies = [
+ "sbbf-rs",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "cymbal",
     "common/geoip",
     "common/hogvm",
+    "property_filter",
 ]
 
 [workspace.lints.rust]
@@ -109,6 +110,8 @@ moka = { version = "0.12.8", features = ["sync", "future"] }
 posthog-rs = { version = "0.3.5", features = ["async-client"] }
 regex = "1.11.1"
 lz-str = "0.2.1"
+sbbf-rs-safe = "0.3.2"
+fxhash =  "0.2.1"
 
 # Used for decrypting django encrypted fields
 fernet = "0.2"

--- a/rust/property_filter/Cargo.toml
+++ b/rust/property_filter/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "property_filter"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+health = { path = "../common/health" }
+serve-metrics = { path = "../common/serve_metrics" }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+futures = { workspace = true }
+time = { workspace = true }
+serde = { workspace = true }
+sbbf-rs-safe = { workspace = true }
+fxhash = { workspace = true }
+sqlx = { workspace = true }
+metrics = { workspace = true }
+tokio = { workspace = true }
+axum = { workspace = true }
+envconfig = { workspace = true }
+rand = { workspace = true }
+chrono = { workspace = true }
+
+[lints]
+workspace = true

--- a/rust/property_filter/src/app.rs
+++ b/rust/property_filter/src/app.rs
@@ -1,0 +1,30 @@
+use crate::config::Config;
+use health::{HealthHandle, HealthRegistry};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+use sqlx::PgPool;
+
+pub struct Context {
+    pub config: Config,
+    pub pool: PgPool,
+    pub liveness: HealthRegistry,
+    pub worker_liveness: HealthHandle,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, FromRow, PartialEq, Eq, Hash)]
+pub struct FilterRow {
+    // the team this filter represents
+    pub team_id: i64,
+    // the raw bytes (from Postgres BYTEA cols) of the serialized bloom filters
+    pub fwd_bloom: Option<Vec<u8>>,
+    pub rev_bloom: Option<Vec<u8>>,
+    // number of property definitions recorded in the filters
+    pub property_count: i32,
+    // is this team prohibited from defining any more properties?
+    pub blocked: bool,
+    // timestamps for the filter update cron to use to know which teams
+    // need the filter to be crawled and updated with new records
+    pub last_updated_at: DateTime<Utc>,
+}

--- a/rust/property_filter/src/config.rs
+++ b/rust/property_filter/src/config.rs
@@ -1,0 +1,16 @@
+use envconfig::Envconfig;
+
+#[derive(Envconfig, Clone)]
+pub struct Config {
+    #[envconfig(default = "postgres://posthog:posthog@localhost:5432/test_posthog")]
+    pub database_url: String,
+
+    #[envconfig(default = "8")]
+    pub max_pg_connections: u32,
+
+    #[envconfig(from = "BIND_HOST", default = "::")]
+    pub host: String,
+
+    #[envconfig(from = "BIND_PORT", default = "3301")]
+    pub port: u16,
+}

--- a/rust/property_filter/src/lib.rs
+++ b/rust/property_filter/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod app;
+pub mod config;
+pub mod worker;

--- a/rust/property_filter/src/main.rs
+++ b/rust/property_filter/src/main.rs
@@ -1,0 +1,108 @@
+use property_filter::{
+    app::{Context, FilterRow},
+    config::Config,
+    worker::filter_builder,
+};
+
+use health::{HealthHandle, HealthRegistry};
+use serve_metrics::{serve, setup_metrics_routes};
+
+use axum::{routing::get, Router};
+use chrono::Utc;
+use envconfig::Envconfig;
+use futures::future::ready;
+use sqlx::postgres::PgPoolOptions;
+use time::Duration;
+use tokio::task::JoinHandle;
+use tracing::{info, warn};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
+
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // bootstrap logging infra
+    setup_tracing();
+    info!("starting filter builder service");
+
+    // build app context
+    let config = Config::init_from_env().unwrap();
+    let options = PgPoolOptions::new().max_connections(config.max_pg_connections);
+    let pool = options
+        .connect(&config.database_url)
+        .await
+        .expect("failed to connect to database");
+    let liveness: HealthRegistry = HealthRegistry::new("liveness");
+    let worker_liveness: HealthHandle = liveness
+        .register("worker".to_string(), Duration::seconds(60))
+        .await;
+    let ctx = Arc::new(Context {
+        config,
+        pool,
+        liveness,
+        worker_liveness,
+    });
+
+    // start health, metrics server
+    start_server(ctx.clone());
+
+    // start filter builder worker (TODO: parallelize this via chunked table scan)
+    let mut handles = Vec::new();
+
+    // TODO(eli): just for demo, construct a synthetic team entry to scan.
+    // next up, we'll fetch batches of team IDs to fan out into worker threads
+    let team_id = 2;
+    let filter_row = FilterRow {
+        team_id,
+        fwd_bloom: None,
+        rev_bloom: None,
+        property_count: 0,
+        blocked: false,
+        last_updated_at: Utc::now(),
+    };
+
+    let filter_builder_handle = tokio::spawn(filter_builder(ctx, filter_row));
+    handles.push(filter_builder_handle);
+
+    // if any handle returns, abort the other ones, and then return an error
+    let (result, _, others) = futures::future::select_all(handles).await;
+    warn!("workers shutting down with result: {:?}", result);
+
+    for handle in others {
+        handle.abort();
+    }
+    Ok(result?)
+}
+
+async fn index() -> &'static str {
+    "property definitions filter builder service"
+}
+
+fn start_server(ctx: Arc<Context>) -> JoinHandle<()> {
+    let bind = format!("{}:{}", ctx.config.host, ctx.config.port);
+
+    let context = ctx.clone();
+    let router = Router::new()
+        .route("/", get(index))
+        .route("/_readiness", get(index))
+        .route(
+            "/_liveness",
+            get(move || ready(context.liveness.get_status())),
+        );
+    let router = setup_metrics_routes(router);
+
+    tokio::task::spawn(async move {
+        serve(router, &bind)
+            .await
+            .expect("failed to start serving metrics");
+    })
+}
+
+fn setup_tracing() {
+    let log_layer: tracing_subscriber::filter::Filtered<
+        tracing_subscriber::fmt::Layer<tracing_subscriber::Registry>,
+        EnvFilter,
+        tracing_subscriber::Registry,
+    > = tracing_subscriber::fmt::layer().with_filter(EnvFilter::from_default_env());
+    tracing_subscriber::registry().with(log_layer).init();
+}

--- a/rust/property_filter/src/worker.rs
+++ b/rust/property_filter/src/worker.rs
@@ -165,16 +165,16 @@ pub async fn filter_builder(ctx: Arc<Context>, mut filter_row: FilterRow) {
 
                     // only add the key to a filter if it's missing, and
                     // only update the prop count once for this step
-                    let mut exists = false;
+                    let mut exists = true;
                     if !fwd_filter.contains_hash(fwd_hash) {
-                        exists = true;
+                        exists = false;
                         fwd_filter.insert_hash(fwd_hash);
                     }
                     if !rev_filter.contains_hash(rev_hash) {
-                        exists = true;
+                        exists = false;
                         rev_filter.insert_hash(rev_hash);
                     }
-                    if exists {
+                    if !exists {
                         insert_count += 1;
                         filter_row.property_count += 1;
                     }

--- a/rust/property_filter/src/worker.rs
+++ b/rust/property_filter/src/worker.rs
@@ -1,0 +1,353 @@
+use std::fmt;
+use std::hash::Hasher;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::app::{Context, FilterRow};
+
+use chrono::Utc;
+use fxhash::FxHasher64;
+use sbbf_rs_safe::Filter;
+use serde::{Deserialize, Serialize};
+use sqlx::{
+    postgres::{PgQueryResult, PgRow},
+    FromRow,
+};
+use tracing::{error, info, warn};
+
+// metrics keys
+const PROPDEFS_BATCH_FETCH_ATTEMPT: &str = "propfilter_batch_fetch_attempt";
+const PROPFILTER_STORE_ATTEMPT: &str = "propfilter_store_attempt";
+const PROPFILTER_TEAMS_PROCESSED: &str = "propfilter_teams_processed";
+const PROPFILTER_TEAMS_FAILED: &str = "propfilter_teams_failed";
+const PROPFILTER_PROPS_INSERTED: &str = "propfilter_props_inserted";
+const PROPFILTER_DEFS_SCANNED: &str = "propfilter_definitions_scanned";
+
+// teams with more than this many property definitions are outliers
+// and should be skipped for further property defs processing anyway.
+// looking at the distribution of propdefs to teams in the database,
+// this feels like reasonable, but we can make final decisions later.
+const TEAM_PROPDEFS_CAP: i32 = 100_000;
+const _TEAM_PROPDEFS_FILTER_SIZE_CAP: usize = 8192; // 8k as initial limit
+
+// batch size & retry params
+const BATCH_FETCH_SIZE: i64 = 1_000;
+const BATCH_RETRY_DELAY_MS: u64 = 100;
+const MAX_BATCH_FETCH_ATTEMPTS: u64 = 5;
+const MAX_PROPFILTER_STORE_ATTEMPTS: u64 = 5;
+
+// bloom filter params DO NOT CHANGE ONCE DECIDED :)
+const BITS_PER_KEY: usize = 64;
+const NUM_KEYS: usize = 1_000_000;
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct PropEntry {
+    property_type: char,
+    group_type_index: char,
+    property_name: String,
+}
+
+// property def hash key for insertion or lookup in Bloom filters.
+// contains all the values needed to determine a unique property
+// on the parent Team
+impl PropEntry {
+    pub fn new(property_name: String, property_type: char, group_type_index: char) -> Self {
+        Self {
+            property_type,
+            group_type_index,
+            property_name,
+        }
+    }
+
+    pub fn from_row(row: PropertyRow) -> Self {
+        let group_type_index_resolved: char = row
+            .group_type_index
+            .map_or('X', |gti| char::from_digit(gti as u32, 10).unwrap());
+
+        Self::new(
+            row.name,
+            char::from_digit(row.r#type as u32, 10).unwrap(),
+            group_type_index_resolved,
+        )
+    }
+}
+
+// used to build hash input for Bloom filter insertion/lookup
+impl fmt::Display for PropEntry {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}{}{}",
+            self.property_type, self.group_type_index, self.property_name
+        )
+    }
+}
+
+#[derive(Deserialize, FromRow, PartialEq, Eq)]
+pub struct PropertyRow {
+    team_id: i64,
+    name: String,
+    r#type: i8,
+    group_type_index: Option<i8>,
+}
+
+// Builds or updates the Bloom filters for the specified FilterRow (team ID)
+// which may be brand new, or fetched from posthog_propertyfilter by the
+// caller. This function is will be spawned in a thread and fanned out in
+// a fixed-size worker pool (Tokio runtime) to control DB R/W load.
+pub async fn filter_builder(ctx: Arc<Context>, mut filter_row: FilterRow) {
+    let mut offset: i64 = 0;
+    let mut fwd_filter = filter_row
+        .fwd_bloom
+        .as_ref()
+        .map_or(Filter::new(BITS_PER_KEY, NUM_KEYS), |bs| {
+            Filter::from_bytes(bs).expect("failed to deserialize bloom filter")
+        });
+    let mut rev_filter = filter_row
+        .rev_bloom
+        .as_ref()
+        .map_or(Filter::new(BITS_PER_KEY, NUM_KEYS), |bs| {
+            Filter::from_bytes(bs).expect("failed to deserialize bloom filter")
+        });
+
+    loop {
+        if filter_row.property_count >= TEAM_PROPDEFS_CAP {
+            warn!(
+                "Filter construction for team {} has exceeded {} properties; marking as blocked",
+                filter_row.team_id, TEAM_PROPDEFS_CAP
+            );
+
+            // mark as blocked along with other partial updates before persisting
+            filter_row.blocked = true;
+            filter_row = update_prop_filter(filter_row, &fwd_filter, &rev_filter);
+
+            match store_team_filter(&ctx, &filter_row).await {
+                Ok(result) => {
+                    metrics::counter!(PROPFILTER_TEAMS_PROCESSED, &[("result", "blocked")])
+                        .increment(1);
+                    info!(
+                        "persisted blocked filter for team {} ({} rows affected)",
+                        filter_row.team_id,
+                        result.rows_affected()
+                    );
+                }
+                Err(e) => {
+                    metrics::counter!(PROPFILTER_TEAMS_FAILED, &[("reason", "store_blocked")])
+                        .increment(1);
+                    error!(
+                        "failed to store blocked filter for team {}, got: {}",
+                        filter_row.team_id, e
+                    );
+                    return;
+                }
+            }
+            return;
+        }
+
+        match get_next_batch(&ctx, filter_row.team_id, offset).await {
+            Ok(rows) => {
+                let mut insert_count: usize = 0;
+                for row in &rows {
+                    let pd_row = PropertyRow::from_row(row).unwrap();
+
+                    // build a hash for each bloom filter and insert
+                    // into the corresponding filter if missing
+                    let fwd_entry = PropEntry::from_row(pd_row).to_string();
+                    let mut fwd_hasher = FxHasher64::default();
+                    fwd_hasher.write(fwd_entry.as_bytes());
+                    let fwd_hash = fwd_hasher.finish();
+
+                    let rev_entry = fwd_entry.chars().rev().collect::<String>();
+                    let mut rev_hasher = FxHasher64::default();
+                    rev_hasher.write(rev_entry.as_bytes());
+                    let rev_hash = rev_hasher.finish();
+
+                    // only add the key to a filter if it's missing, and
+                    // only update the prop count once for this step
+                    let mut exists = false;
+                    if !fwd_filter.contains_hash(fwd_hash) {
+                        exists = true;
+                        fwd_filter.insert_hash(fwd_hash);
+                    }
+                    if !rev_filter.contains_hash(rev_hash) {
+                        exists = true;
+                        rev_filter.insert_hash(rev_hash);
+                    }
+                    if exists {
+                        insert_count += 1;
+                        filter_row.property_count += 1;
+                    }
+                }
+
+                // if we've processed all the rows, we're done
+                if rows.is_empty() {
+                    filter_row = update_prop_filter(filter_row, &fwd_filter, &rev_filter);
+                    match store_team_filter(&ctx, &filter_row).await {
+                        Ok(result) => {
+                            metrics::counter!(PROPFILTER_TEAMS_PROCESSED, &[("result", "success")])
+                                .increment(1);
+                            info!(
+                                "persisted updated filter for team {} ({} rows affected)",
+                                filter_row.team_id,
+                                result.rows_affected()
+                            );
+                            return;
+                        }
+                        Err(e) => {
+                            metrics::counter!(
+                                PROPFILTER_TEAMS_FAILED,
+                                &[("reason", "store_filter")]
+                            )
+                            .increment(1);
+                            error!(
+                                "failed to store updated filter for team {}, got: {}",
+                                filter_row.team_id, e
+                            );
+                            return;
+                        }
+                    }
+                }
+
+                // report and proceed to the next batch
+                offset += rows.len() as i64;
+                info!(
+                    "Added {} property definitions to filter from batch of {} rows for team {}",
+                    insert_count,
+                    rows.len(),
+                    filter_row.team_id
+                );
+                metrics::counter!(PROPFILTER_PROPS_INSERTED).increment(insert_count as u64);
+                metrics::counter!(PROPFILTER_DEFS_SCANNED).increment(rows.len() as u64);
+            }
+
+            Err(e) => {
+                error!(
+                    "Failed fetching posthog_propertydefinition row batch: {}",
+                    e
+                );
+                filter_row = update_prop_filter(filter_row, &fwd_filter, &rev_filter);
+                metrics::counter!(PROPFILTER_TEAMS_FAILED, &[("reason", "batch_fetch")])
+                    .increment(1);
+                match store_team_filter(&ctx, &filter_row).await {
+                    Ok(result) => {
+                        info!("persisted filter for team {} after batch fetch error ({} rows affected)",
+                            filter_row.team_id, result.rows_affected());
+                    }
+                    Err(e) => {
+                        error!(
+                            "failed to store filter after batch fetch error for team {}, got: {}",
+                            filter_row.team_id, e
+                        );
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn update_prop_filter(mut filter_row: FilterRow, fwd: &Filter, rev: &Filter) -> FilterRow {
+    filter_row.fwd_bloom = Some(fwd.as_bytes().into());
+    filter_row.rev_bloom = Some(rev.as_bytes().into());
+    filter_row.last_updated_at = Utc::now();
+    filter_row
+}
+
+async fn store_team_filter(
+    ctx: &Arc<Context>,
+    filter_row: &FilterRow,
+) -> Result<PgQueryResult, sqlx::Error> {
+    let mut attempt = 1;
+    loop {
+        match sqlx::query(
+            r#"
+            INSERT INTO posthog_propertyfilter
+                (team_id, fwd_bloom, rev_bloom, property_count, blocked, last_updated_at)
+                VALUES ($1, $2, $3, $4, $5, $6)
+            ON CONFLICT (team_id) DO UPDATE SET
+                fwd_bloom=$2, rev_bloom=$3, property_count=$4, blocked=$5, last_updated_at=$6"#,
+        )
+        .bind(filter_row.team_id)
+        .bind(&filter_row.fwd_bloom)
+        .bind(&filter_row.rev_bloom)
+        .bind(filter_row.property_count)
+        .bind(filter_row.blocked)
+        .bind(filter_row.last_updated_at)
+        .execute(&ctx.pool)
+        .await
+        {
+            Ok(result) => {
+                metrics::counter!(PROPFILTER_STORE_ATTEMPT, &[("result", "success")]).increment(1);
+                return Ok(result);
+            }
+            Err(e) => {
+                if attempt >= MAX_PROPFILTER_STORE_ATTEMPTS {
+                    metrics::counter!(PROPFILTER_STORE_ATTEMPT, &[("result", "failed")])
+                        .increment(1);
+                    error!(
+                        "failed to store filter record for team_id {} with: {:?}",
+                        filter_row.team_id, e
+                    );
+                    return Err(e);
+                }
+
+                // within retry budget, try again
+                metrics::counter!(PROPFILTER_STORE_ATTEMPT, &[("result", "retry")]).increment(1);
+                let jitter = rand::random::<u64>() % 50;
+                let delay: u64 = attempt * BATCH_RETRY_DELAY_MS + jitter;
+                tokio::time::sleep(Duration::from_millis(delay)).await;
+                attempt += 1;
+            }
+        }
+    }
+}
+
+async fn get_next_batch(
+    ctx: &Arc<Context>,
+    team_id: i64,
+    offset: i64,
+) -> Result<Vec<PgRow>, sqlx::Error> {
+    let mut attempt = 1;
+    // note: I measured this (EXPLAIN, example executions etc.) against several outlier teams
+    // that have created millions of hash-based unique property keys and if we cap fetches to
+    // 1k and stop iterating at first 100k propdefs, using LIMIT/OFFSET here seems acceptable
+    loop {
+        match sqlx::query(
+            r#"
+            SELECT property_type, name, type, group_type_index FROM posthog_propertydefinition
+            WHERE team_id = $1
+            LIMIT $2 OFFSET $3"#,
+        )
+        .bind(team_id)
+        .bind(BATCH_FETCH_SIZE)
+        .bind(offset)
+        .fetch_all(&ctx.pool)
+        .await
+        {
+            Ok(rows) => {
+                metrics::counter!(PROPDEFS_BATCH_FETCH_ATTEMPT, &[("result", "success")])
+                    .increment(1);
+                return Ok(rows);
+            }
+            Err(e) => {
+                if attempt >= MAX_BATCH_FETCH_ATTEMPTS {
+                    metrics::counter!(PROPDEFS_BATCH_FETCH_ATTEMPT, &[("result", "failed")])
+                        .increment(1);
+                    error!(
+                        "failed to fetch next batch for team_id {} at offset {} with: {:?}",
+                        team_id, offset, e
+                    );
+                    return Err(e);
+                }
+
+                // within retry budget, try again
+                metrics::counter!(PROPDEFS_BATCH_FETCH_ATTEMPT, &[("result", "retry")])
+                    .increment(1);
+                let jitter = rand::random::<u64>() % 50;
+                let delay: u64 = attempt * BATCH_RETRY_DELAY_MS + jitter;
+                tokio::time::sleep(Duration::from_millis(delay)).await;
+                attempt += 1;
+            }
+        }
+    }
+}


### PR DESCRIPTION
⚠️  **WIP do not merge yet!** ⚠️ 

## Problem
Property definitions dataset is extremely duplicative. It is drawn from the event stream, where once a new event type and/or custom properties are submitted, they are resubmitted regularly.

The service only needs to observe and persist them once, barring occasional manual edits performed by users and admins. Writing the same data optimistically to Postgres at this level of duplication is causing performance degradation on the database for no reason.

## Changes
This service will scan the known property definitions of selected teams, and build a set of serializable Bloom filters for each team. It will persist a row in the new `posthog_propertyfilter` table for each team, which can be fetched and cached by the `property-defs-rs` service.

If the prototype is successful (serialized filters are of reasonable size, caching is effective, and false positive rate is suitable low) these filters can be used to cheaply deduplicate properties found in the event stream, and minimize database writes from `property-defs-rs`.

In production, once a full static (all teams) filter set has been populated, a crawler process adapted from this prototype will track teams that have written previously-unseen property and event definitions recently, and update the corresponding Bloom filters offline in a cronjob.

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally, CI, and test deploy in `dev` env