### PR TITLE
chore: s/JWT.SECRET/LIVESTREAM_JWT_SECRET

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -161,7 +161,7 @@ services:
             file: docker-compose.base.yml
             service: livestream
         environment:
-            - JWT.TOKEN=${SECRET_KEY}
+            - LIVESTREAM_JWT_SECRET=${SECRET_KEY}
         ports:
             - '8666:8080'
         volumes:

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -286,11 +286,11 @@ services:
             file: docker-compose.base.yml
             service: livestream
         environment:
-            - JWT.TOKEN=${POSTHOG_SECRET}
+            - LIVESTREAM_JWT_SECRET=${POSTHOG_SECRET}
         ports:
             - '8666:8080'
         volumes:
-            - ./posthog/docker/livestream/configs-dev.yml:/configs/configs.yml
+            - ./posthog/docker/livestream/configs-hobby.yml:/configs/configs.yml
 
 volumes:
     zookeeper-data:

--- a/docker/livestream/configs-dev.yml
+++ b/docker/livestream/configs-dev.yml
@@ -1,7 +1,4 @@
 debug: true
-tailscale:
-    controlUrl:
-    hostname: 'live-events-dev'
 kafka:
     brokers: 'kafka:9092'
     topic: 'events_plugin_ingestion'

--- a/docker/livestream/configs-hobby.yml
+++ b/docker/livestream/configs-hobby.yml
@@ -1,7 +1,4 @@
 debug: false
-tailscale:
-    controlUrl:
-    hostname: 'live-events'
 kafka:
     brokers: 'kafka:9092'
     topic: 'events_plugin_ingestion'

--- a/docker/livestream/configs-hobby.yml
+++ b/docker/livestream/configs-hobby.yml
@@ -1,0 +1,10 @@
+debug: false
+tailscale:
+    controlUrl:
+    hostname: 'live-events'
+kafka:
+    brokers: 'kafka:9092'
+    topic: 'events_plugin_ingestion'
+    group_id: 'livestream'
+mmdb:
+    path: 'GeoLite2-City.mmdb'


### PR DESCRIPTION
## Problem

livestream jwt token is not passed properly

## Changes

 * s/JWT.SECRET/LIVESTREAM_JWT_SECRET
 * add hobby livestream config
 * remove tailscale leftovers

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

run it
