### PR TITLE
fix(lemon-tree): disallow clicking disabled hrefs

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -309,9 +309,13 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                             data-id={item.id}
                             // When dragging, don't allow links to be clicked,
                             // without this drag end would fire this href causing a reload
-                            to={isEmptyFolder ? '#' : item.record?.href || '#'}
-                            onClick={() => {
-                                handleClick(item)
+                            to={item.disabledReason || isEmptyFolder ? '#' : item.record?.href || '#'}
+                            onClick={(e) => {
+                                if (item.disabledReason) {
+                                    e.preventDefault()
+                                } else {
+                                    handleClick(item)
+                                }
                             }}
                             disabled={isDragging}
                             role="treeitem"


### PR DESCRIPTION
## Problem

You could click objects in the "save as" / "move to" dialogs, and watch the page change from under you.

![2025-05-07 11 13 12](https://github.com/user-attachments/assets/531ee564-e966-41d2-b08b-4f268cbb49a8)

## Changes

Prevent clicks on those disabled files.

![2025-05-07 11 12 29](https://github.com/user-attachments/assets/2a3c4bd9-4e58-4b3c-b7d2-12793aef88ad)

## How did you test this code?

👀 