### PR TITLE
feat(lemon-tree): delete folders again

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -295,31 +295,7 @@ export function ProjectTree({ sortMethod }: ProjectTreeProps): JSX.Element {
                     </MenuItem>
                 ) : null}
 
-                {item.record?.path && item.record?.shortcut ? (
-                    <MenuItem
-                        asChild
-                        onClick={(e) => {
-                            e.stopPropagation()
-                            assureVisibility({ type: item.record?.type, ref: item.record?.ref })
-                        }}
-                    >
-                        <ButtonPrimitive menuItem>Show original</ButtonPrimitive>
-                    </MenuItem>
-                ) : null}
-
-                {item.record?.path && item.record?.type === 'folder' ? (
-                    <MenuItem
-                        asChild
-                        onClick={(e) => {
-                            e.stopPropagation()
-                            setEditingItemId(item.id)
-                        }}
-                    >
-                        <ButtonPrimitive menuItem>Rename</ButtonPrimitive>
-                    </MenuItem>
-                ) : null}
-
-                {item.record?.shortcut && (
+                {item.record?.shortcut ? (
                     <MenuItem
                         asChild
                         onClick={(e) => {
@@ -329,7 +305,17 @@ export function ProjectTree({ sortMethod }: ProjectTreeProps): JSX.Element {
                     >
                         <ButtonPrimitive menuItem>Delete shortcut</ButtonPrimitive>
                     </MenuItem>
-                )}
+                ) : item.record?.path && item.record?.type === 'folder' ? (
+                    <MenuItem
+                        asChild
+                        onClick={(e) => {
+                            e.stopPropagation()
+                            deleteItem(item.record as unknown as FileSystemEntry)
+                        }}
+                    >
+                        <ButtonPrimitive menuItem>Delete folder</ButtonPrimitive>
+                    </MenuItem>
+                ) : null}
 
                 <MenuItem
                     asChild
@@ -345,6 +331,29 @@ export function ProjectTree({ sortMethod }: ProjectTreeProps): JSX.Element {
                 >
                     <ButtonPrimitive menuItem>Move to...</ButtonPrimitive>
                 </MenuItem>
+                {item.record?.path && item.record?.type === 'folder' ? (
+                    <MenuItem
+                        asChild
+                        onClick={(e) => {
+                            e.stopPropagation()
+                            setEditingItemId(item.id)
+                        }}
+                    >
+                        <ButtonPrimitive menuItem>Rename</ButtonPrimitive>
+                    </MenuItem>
+                ) : null}
+
+                {item.record?.path && item.record?.shortcut ? (
+                    <MenuItem
+                        asChild
+                        onClick={(e) => {
+                            e.stopPropagation()
+                            assureVisibility({ type: item.record?.type, ref: item.record?.ref })
+                        }}
+                    >
+                        <ButtonPrimitive menuItem>Show original</ButtonPrimitive>
+                    </MenuItem>
+                ) : null}
             </>
         )
     }

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
@@ -303,7 +303,9 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                             const response = await api.fileSystem.count(action.item.id)
                             actions.removeQueuedAction(action)
                             if (response && response.count > DELETE_ALERT_LIMIT) {
-                                const confirmMessage = `You're about to move ${response.count} items into 'Unfiled'. Are you sure?`
+                                const confirmMessage = `Delete the folder "${splitPath(
+                                    action.item.path
+                                ).pop()}" and move ${response.count} items back into "Unfiled"?`
                                 if (!confirm(confirmMessage)) {
                                     return false
                                 }


### PR DESCRIPTION
## Problem

We had earlier confusion about "deleting" vs "unfiling" and thus we removed the delete option altogether. You must now delete each object from their respective in-page delete buttons.

However there was no way to delete folders, including ones you might accidentally create. These untitled folders started littering up the tree:

![image](https://github.com/user-attachments/assets/d91b18b0-0c1e-48b3-bf11-8cee7d43ad96)

## Changes

You can now delete folders!

If the folder has any files inside, we give a warning that they will be moved back to "Unfiled".

![2025-05-07 11 28 36](https://github.com/user-attachments/assets/79753202-ee34-4397-a2cc-9da3b90ca810)


## How did you test this code?

👀 