### PR TITLE
feat(query): rate limit org concurrent queries

### DIFF
--- a/posthog/clickhouse/client/limit.py
+++ b/posthog/clickhouse/client/limit.py
@@ -92,7 +92,7 @@ class RateLimit:
         current_time = self.get_time()
 
         max_concurrency = self.max_concurrency
-        in_beta = team_id in settings.API_QUERIES_PER_TEAM
+        in_beta = kwargs.get("is_api") and (team_id in settings.API_QUERIES_PER_TEAM)
         if in_beta:
             max_concurrency = settings.API_QUERIES_PER_TEAM[team_id]  # type: ignore
         elif "limit" in kwargs:
@@ -138,6 +138,7 @@ class RateLimit:
 
 
 __API_CONCURRENT_QUERY_PER_TEAM: Optional[RateLimit] = None
+__APP_CONCURRENT_QUERY_PER_ORG: Optional[RateLimit] = None
 
 
 def get_api_personal_rate_limiter():
@@ -148,13 +149,31 @@ def get_api_personal_rate_limiter():
             applicable=lambda *args, **kwargs: not TEST and kwargs.get("org_id") and kwargs.get("is_api"),
             limit_name="api_per_org",
             get_task_name=lambda *args, **kwargs: f"api:query:per-org:{kwargs.get('org_id')}",
-            get_task_id=lambda *args, **kwargs: current_task.request.id
-            if current_task
-            else (kwargs.get("task_id") or generate_short_id()),
+            get_task_id=lambda *args, **kwargs: (
+                current_task.request.id if current_task else (kwargs.get("task_id") or generate_short_id())
+            ),
             ttl=600,
             bypass_all=(not settings.API_QUERIES_ENABLED),
         )
     return __API_CONCURRENT_QUERY_PER_TEAM
+
+
+def get_app_org_rate_limiter():
+    """
+    Limits the number of concurrent queries (running outside celery) per organization.
+    """
+    global __APP_CONCURRENT_QUERY_PER_ORG
+    if __APP_CONCURRENT_QUERY_PER_ORG is None:
+        __APP_CONCURRENT_QUERY_PER_ORG = RateLimit(
+            max_concurrency=10,
+            limit_name="app_per_org",
+            get_task_name=lambda *args, **kwargs: f"app:query:per-org:{kwargs.get('org_id')}",
+            get_task_id=lambda *args, **kwargs: (
+                current_task.request.id if current_task else (kwargs.get("task_id") or generate_short_id())
+            ),
+            ttl=600,
+        )
+    return __APP_CONCURRENT_QUERY_PER_ORG
 
 
 class ConcurrencyLimitExceeded(Exception):

--- a/posthog/clickhouse/client/limit.py
+++ b/posthog/clickhouse/client/limit.py
@@ -168,9 +168,7 @@ def get_app_org_rate_limiter():
             max_concurrency=10,
             limit_name="app_per_org",
             get_task_name=lambda *args, **kwargs: f"app:query:per-org:{kwargs.get('org_id')}",
-            get_task_id=lambda *args, **kwargs: (
-                current_task.request.id if current_task else (kwargs.get("task_id") or generate_short_id())
-            ),
+            get_task_id=lambda *args, **kwargs: kwargs.get("task_id") or generate_short_id(),
             ttl=600,
         )
     return __APP_CONCURRENT_QUERY_PER_ORG

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -861,8 +861,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                 tag_queries(chargeable=1)
 
             with get_app_org_rate_limiter().run(
-                org_id=self.team.organization_id,
-                task_id=self.query_id,
+                org_id=self.team.organization_id, task_id=self.query_id, team_id=self.team.id
             ):
                 fresh_response_dict = {
                     **self.calculate().model_dump(),

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -12,7 +12,7 @@ from sentry_sdk import get_traceparent, push_scope, set_tag
 from posthog import settings
 from posthog.caching.utils import ThresholdMode, cache_target_age, is_stale, last_refresh_from_cached_result
 from posthog.clickhouse.client.execute_async import QueryNotFoundError, enqueue_process_query_task, get_query_status
-from posthog.clickhouse.client.limit import get_api_personal_rate_limiter
+from posthog.clickhouse.client.limit import get_api_personal_rate_limiter, get_app_org_rate_limiter
 from posthog.clickhouse.query_tagging import get_query_tag_value, tag_queries
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql import ast
@@ -860,15 +860,19 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             if self.is_query_service:
                 tag_queries(chargeable=1)
 
-            fresh_response_dict = {
-                **self.calculate().model_dump(),
-                "is_cached": False,
-                "last_refresh": last_refresh,
-                "next_allowed_client_refresh": last_refresh + self._refresh_frequency(),
-                "cache_key": cache_key,
-                "timezone": self.team.timezone,
-                "cache_target_age": target_age,
-            }
+            with get_app_org_rate_limiter().run(
+                org_id=self.team.organization_id,
+                task_id=self.query_id,
+            ):
+                fresh_response_dict = {
+                    **self.calculate().model_dump(),
+                    "is_cached": False,
+                    "last_refresh": last_refresh,
+                    "next_allowed_client_refresh": last_refresh + self._refresh_frequency(),
+                    "cache_key": cache_key,
+                    "timezone": self.team.timezone,
+                    "cache_target_age": target_age,
+                }
         if get_query_tag_value("trigger"):
             fresh_response_dict["calculation_trigger"] = get_query_tag_value("trigger")
         fresh_response = CachedResponse(**fresh_response_dict)


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
No protection for concurrent queries once we roll out [this ff](https://us.posthog.com/project/2/feature_flags/134816)
As only celery tasks had concurrency protection

## Changes
Reuse the RateLimit class (Redis lock) to create a limit on org level concurrent queries.
Currently setting it to 10 queries per org.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?
Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
