### PR TITLE
fix(data-modeling): Fix materializing pascal cased views

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -263,9 +263,7 @@ class PipelineNonDLT:
 
         file_uris = delta_table.file_uris()
         self._logger.debug(f"Preparing S3 files - total parquet files: {len(file_uris)}")
-        prepare_s3_files_for_querying(
-            self._job.folder_path(), self._resource_name, file_uris, ExternalDataJob.PipelineVersion.V2
-        )
+        prepare_s3_files_for_querying(self._job.folder_path(), self._resource_name, file_uris)
 
         self._logger.debug("Updating last synced at timestamp on schema")
         _update_last_synced_at_sync(self._schema, self._job)

--- a/posthog/temporal/data_imports/util.py
+++ b/posthog/temporal/data_imports/util.py
@@ -5,7 +5,6 @@ from dlt.common.normalizers.naming.snake_case import NamingConvention
 
 from posthog.settings.utils import get_from_env
 from posthog.utils import str_to_bool
-from posthog.warehouse.models import ExternalDataJob
 from posthog.warehouse.s3 import get_s3_client
 
 
@@ -13,7 +12,7 @@ def prepare_s3_files_for_querying(
     folder_path: str,
     table_name: str,
     file_uris: list[str],
-    pipeline_version: Optional[ExternalDataJob.PipelineVersion] = None,
+    preserve_table_name_casing: Optional[bool] = False,
 ):
     s3 = get_s3_client()
 
@@ -21,7 +20,12 @@ def prepare_s3_files_for_querying(
 
     s3_folder_for_job = f"{settings.BUCKET_URL}/{folder_path}"
 
-    s3_folder_for_schema = f"{s3_folder_for_job}/{normalized_table_name}"
+    # Dont use the normalized table name when renaming files when called from the data modeling job
+    s3_folder_for_schema = (
+        f"{s3_folder_for_job}/{table_name}"
+        if preserve_table_name_casing is True
+        else f"{s3_folder_for_job}/{normalized_table_name}"
+    )
 
     s3_folder_for_querying = f"{s3_folder_for_job}/{normalized_table_name}__query"
 

--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -13,7 +13,6 @@ import os
 import dlt
 import dlt.common.data_types as dlt_data_types
 import dlt.common.schema.typing as dlt_typing
-import dlt.extract
 import structlog
 import temporalio.activity
 import temporalio.common
@@ -447,7 +446,7 @@ async def materialize_model(
 
         file_uris = table.file_uris()
 
-        prepare_s3_files_for_querying(saved_query.folder_path, saved_query.name, file_uris)
+        prepare_s3_files_for_querying(saved_query.folder_path, saved_query.name, file_uris, True)
 
     if not tables:
         saved_query.latest_error = f"No tables were created by pipeline for model {model_label}"
@@ -933,6 +932,7 @@ class RunWorkflow(PostHogWorkflow):
 
             temporalio.workflow.logger.error(f"Activity failed during model run: {str(e)}")
             return Results(set(), set(), set())
+
         completed, failed, ancestor_failed = results
 
         # publish metrics

--- a/posthog/temporal/tests/data_modeling/test_run_workflow.py
+++ b/posthog/temporal/tests/data_modeling/test_run_workflow.py
@@ -9,8 +9,8 @@ import aioboto3
 import dlt
 import pytest
 import pytest_asyncio
+from asgiref.sync import sync_to_async
 import temporalio.common
-import temporalio.testing
 import temporalio.worker
 from django.conf import settings
 from django.test import override_settings
@@ -21,6 +21,7 @@ from freezegun.api import freeze_time
 
 from posthog import constants
 from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.query import execute_hogql_query
 from posthog.models import Team
 from posthog.warehouse.models.data_modeling_job import DataModelingJob
 from posthog.temporal.data_modeling.run_workflow import (
@@ -377,6 +378,81 @@ async def test_materialize_model(ateam, bucket_name, minio_client, pageview_even
     assert len(s3_objects["Contents"]) != 0
     assert key == saved_query.name
     assert sorted(table.to_pylist(), key=lambda d: (d["distinct_id"], d["timestamp"])) == expected_events
+
+    # Ensure we can query the table
+    await sync_to_async(execute_hogql_query)(f"SELECT * FROM {saved_query.name}", ateam)
+
+
+async def test_materialize_model_with_pascal_cased_name(ateam, bucket_name, minio_client, pageview_events):
+    query = """\
+    select
+      event as event,
+      if(distinct_id != '0', distinct_id, null) as distinct_id,
+      timestamp as timestamp
+    from events
+    where event = '$pageview'
+    """
+    saved_query = await DataWarehouseSavedQuery.objects.acreate(
+        team=ateam,
+        name="PascalCasedView",
+        query={"query": query, "kind": "HogQLQuery"},
+    )
+
+    with (
+        override_settings(
+            BUCKET_URL=f"s3://{bucket_name}",
+            AIRBYTE_BUCKET_KEY=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
+            AIRBYTE_BUCKET_SECRET=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
+            AIRBYTE_BUCKET_REGION="us-east-1",
+            AIRBYTE_BUCKET_DOMAIN="objectstorage:19000",
+        ),
+        unittest.mock.patch.object(AwsCredentials, "to_session_credentials", mock_to_session_credentials),
+        unittest.mock.patch.object(
+            AwsCredentials, "to_object_store_rs_credentials", mock_to_object_store_rs_credentials
+        ),
+    ):
+        job = await database_sync_to_async(DataModelingJob.objects.create)(
+            team=ateam,
+            status=DataModelingJob.Status.RUNNING,
+            workflow_id="test_workflow",
+        )
+
+        key, delta_table, job_id = await materialize_model(
+            saved_query.id.hex,
+            ateam,
+            saved_query,
+            job,
+        )
+
+    s3_objects = await minio_client.list_objects_v2(
+        Bucket=bucket_name, Prefix=f"team_{ateam.pk}_model_{saved_query.id.hex}/"
+    )
+    table = delta_table.to_pyarrow_table(columns=["event", "distinct_id", "timestamp"])
+    events, _ = pageview_events
+    expected_events = sorted(
+        [
+            {
+                k: dt.datetime.fromisoformat(v).replace(tzinfo=dt.UTC) if k == "timestamp" else v
+                for k, v in event.items()
+                if k in ("event", "distinct_id", "timestamp")
+            }
+            for event in events
+        ],
+        key=lambda d: (d["distinct_id"], d["timestamp"]),
+    )
+
+    normalized_table_name = NamingConvention().normalize_identifier(saved_query.name)
+
+    assert any(f"{normalized_table_name}__query" in obj["Key"] for obj in s3_objects["Contents"])
+    assert table.num_rows == len(expected_events)
+    assert table.num_columns == 3
+    assert table.column_names == ["event", "distinct_id", "timestamp"]
+    assert len(s3_objects["Contents"]) != 0
+    assert key == saved_query.name
+    assert sorted(table.to_pylist(), key=lambda d: (d["distinct_id"], d["timestamp"])) == expected_events
+
+    # Ensure we can query the table
+    await sync_to_async(execute_hogql_query)(f"SELECT * FROM {saved_query.name}", ateam)
 
 
 @pytest_asyncio.fixture

--- a/posthog/warehouse/api/saved_query.py
+++ b/posthog/warehouse/api/saved_query.py
@@ -11,7 +11,6 @@ from rest_framework.decorators import action
 from loginas.utils import is_impersonated_session
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
-from posthog.constants import DATA_MODELING_TASK_QUEUE
 from posthog.models import Team
 from posthog.models.activity_logging.activity_log import (
     Detail,
@@ -29,7 +28,6 @@ from posthog.hogql.parser import parse_select
 from posthog.hogql.placeholders import FindPlaceholders
 from posthog.hogql.printer import print_ast
 from posthog.temporal.common.client import sync_connect
-from posthog.temporal.data_modeling.run_workflow import RunWorkflowInputs, Selector
 from temporalio.client import ScheduleActionExecutionStartWorkflow
 from posthog.warehouse.models import (
     CLICKHOUSE_HOGQL_MAPPING,
@@ -46,6 +44,7 @@ from posthog.warehouse.data_load.saved_query_service import (
     saved_query_workflow_exists,
     sync_saved_query_workflow,
     delete_saved_query_schedule,
+    trigger_saved_query_schedule,
 )
 from rest_framework.response import Response
 import uuid
@@ -378,27 +377,9 @@ class DataWarehouseSavedQueryViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewS
     @action(methods=["POST"], detail=True)
     def run(self, request: request.Request, *args, **kwargs) -> response.Response:
         """Run this saved query."""
-        ancestors = request.data.get("ancestors", 0)
-        descendants = request.data.get("descendants", 0)
-
         saved_query = self.get_object()
 
-        temporal = sync_connect()
-
-        inputs = RunWorkflowInputs(
-            team_id=saved_query.team_id,
-            select=[Selector(label=saved_query.id.hex, ancestors=ancestors, descendants=descendants)],
-        )
-        workflow_id = f"data-modeling-run-{saved_query.id.hex}"
-        saved_query.status = DataWarehouseSavedQuery.Status.RUNNING
-        saved_query.save()
-
-        async_to_sync(temporal.start_workflow)(  # type: ignore
-            "data-modeling-run",  # type: ignore
-            inputs,  # type: ignore
-            id=workflow_id,
-            task_queue=DATA_MODELING_TASK_QUEUE,
-        )
+        trigger_saved_query_schedule(saved_query)
 
         return response.Response(status=status.HTTP_200_OK)
 


### PR DESCRIPTION
## Problem
- Materializing views with a Pascal-cased name would break the S3 file copying logic since we no longer normalize table names due to https://github.com/PostHog/posthog/pull/31927
- Reported here https://posthog.slack.com/archives/C0862M4NJHG/p1746591906321369

## Changes
- Ensure we copy the files over correctly to S3
  - Added a test for this and enhanced our current tests to ensure we can actually query the table after its been materialized
- Updated how we trigger runs - instead of kicking off a new workflow, I've got it to trigger the schedule, which helps give us visibility on temporal runs for a view from a single page in temporal

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
tested locally a bunch