### PR TITLE
chore(sql-editor): Force the user to run the query before saving

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
@@ -94,6 +94,22 @@ export function QueryWindow({ onSetMonacoAndEditor }: QueryWindowProps): JSX.Ele
         </LemonButton>
     )
 
+    const editingViewDisabledReason = useMemo(() => {
+        if (updatingDataWarehouseSavedQuery) {
+            return 'Saving...'
+        }
+
+        if (!response) {
+            return 'Run query to update'
+        }
+
+        if (!changesToSave) {
+            return 'No changes to save'
+        }
+
+        return undefined
+    }, [updatingDataWarehouseSavedQuery, changesToSave, response])
+
     return (
         <div className="flex flex-1 flex-col h-full overflow-hidden">
             <div className="flex flex-row overflow-x-auto">
@@ -145,13 +161,7 @@ export function QueryWindow({ onSetMonacoAndEditor }: QueryWindowProps): JSX.Ele
                                     edited_history_id: inProgressViewEdits[editingView.id],
                                 })
                             }
-                            disabledReason={
-                                updatingDataWarehouseSavedQuery
-                                    ? 'Saving...'
-                                    : !changesToSave
-                                    ? 'No changes to save'
-                                    : ''
-                            }
+                            disabledReason={editingViewDisabledReason}
                             icon={<IconDownload />}
                             type="tertiary"
                             size="xsmall"


### PR DESCRIPTION
## Problem
- When saving a view, we pass the query response types to the backend so that we don't have to execute the query again to get the column types. But if a user doesn't run the query in the frontend, then we have no types to pass through, causing the backend to run the query which often hits the 60 second timeout and gives users a very unhelpful error message 
- Spurred on by https://posthog.slack.com/archives/C0862M4NJHG/p1746588257045479

## Changes
- Force users to run the query before saving the view - lesser of two evils here, at least the user has some form of progress bar etc before saving the query and not just say waiting for the spinning wheel of death. Still, it's not an ideal solution to us needing the column types 

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Tested locally