### PR TITLE
chore(data-modeling): Update the UI to show the last run time

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryInfo.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryInfo.tsx
@@ -123,7 +123,7 @@ export function QueryInfo({ codeEditorKey }: QueryInfoProps): JSX.Element {
                                                 savedQuery?.status !== 'Running' && 'Materialization is not running',
                                         }}
                                     >
-                                        Sync now
+                                        {savedQuery?.status === 'Running' ? 'Running...' : 'Sync now'}
                                     </LemonButton>
                                     <LemonSelect
                                         className="h-9"

--- a/posthog/warehouse/api/saved_query.py
+++ b/posthog/warehouse/api/saved_query.py
@@ -1,10 +1,11 @@
+from datetime import datetime
 from typing import Any
 from django.conf import settings
 
 import structlog
 from asgiref.sync import async_to_sync
 from django.db import transaction
-from django.db.models import Q, OuterRef, Subquery, TextField
+from django.db.models import Prefetch, Q, OuterRef, Subquery, TextField
 from django.db.models.functions import Cast
 from rest_framework import exceptions, filters, request, response, serializers, status, viewsets
 from rest_framework.decorators import action
@@ -33,6 +34,7 @@ from posthog.temporal.data_modeling.run_workflow import RunWorkflowInputs, Selec
 from temporalio.client import ScheduleActionExecutionStartWorkflow
 from posthog.warehouse.models import (
     CLICKHOUSE_HOGQL_MAPPING,
+    DataModelingJob,
     DataWarehouseJoin,
     DataWarehouseModelPath,
     DataWarehouseSavedQuery,
@@ -58,6 +60,7 @@ class DataWarehouseSavedQuerySerializer(serializers.ModelSerializer):
     columns = serializers.SerializerMethodField(read_only=True)
     sync_frequency = serializers.SerializerMethodField()
     latest_history_id = serializers.SerializerMethodField(read_only=True)
+    last_run_at = serializers.SerializerMethodField(read_only=True)
     edited_history_id = serializers.CharField(write_only=True, required=False, allow_null=True)
 
     class Meta:
@@ -87,6 +90,16 @@ class DataWarehouseSavedQuerySerializer(serializers.ModelSerializer):
             "latest_error",
             "latest_history_id",
         ]
+
+    def get_last_run_at(self, view: DataWarehouseSavedQuery) -> datetime | None:
+        try:
+            jobs = view.jobs  # type: ignore
+            if len(jobs) > 0:
+                return jobs[0].last_run_at
+        except:
+            pass
+
+        return view.last_run_at
 
     def get_columns(self, view: DataWarehouseSavedQuery) -> list[SerializedField]:
         team_id = self.context["team_id"]
@@ -337,7 +350,16 @@ class DataWarehouseSavedQueryViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewS
         return context
 
     def safely_get_queryset(self, queryset):
-        base_queryset = queryset.prefetch_related("created_by").exclude(deleted=True).order_by(self.ordering)
+        base_queryset = (
+            queryset.prefetch_related(
+                "created_by",
+                Prefetch(
+                    "datamodelingjob_set", queryset=DataModelingJob.objects.order_by("-last_run_at")[:1], to_attr="jobs"
+                ),
+            )
+            .exclude(deleted=True)
+            .order_by(self.ordering)
+        )
 
         # Only annotate with latest activity ID for list operations, not for single object retrieves
         # This avoids the annotation when we're getting a single object for update/create/etc.


### PR DESCRIPTION
## Problem
- https://posthog.slack.com/archives/C0862M4NJHG/p1746591906321369
- Having a different timestamp between the last run statement and the table of runs was confusing for people

## Changes
- Use the same timestamp as the last run
- Updated the copy of the "Sync now" button when there's a run in-progress

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Tested locally