### PR TITLE
chore(data-modeling): Capture modeling errors in error tracking

### DIFF
--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -13,7 +13,6 @@ import os
 import dlt
 import dlt.common.data_types as dlt_data_types
 import dlt.common.schema.typing as dlt_typing
-import dlt.extract
 import structlog
 import temporalio.activity
 import temporalio.common
@@ -24,6 +23,7 @@ from django.conf import settings
 from dlt.common.libs.deltalake import get_delta_tables
 
 from posthog.clickhouse.client.connection import Workload
+from posthog.exceptions_capture import capture_exception
 from posthog.hogql.constants import HogQLGlobalSettings, LimitContext
 from posthog.hogql.database.database import create_hogql_database
 from posthog.hogql.query import execute_hogql_query
@@ -498,8 +498,12 @@ async def update_table_row_count(saved_query: DataWarehouseSavedQuery, row_count
             await database_sync_to_async(table.save)()
             await logger.ainfo("Updated row count for table %s to %d", saved_query.name, row_count)
         else:
+            capture_exception(
+                ValueError(f"Could not find DataWarehouseTable record for saved query {saved_query.name}")
+            )
             await logger.aexception("Could not find DataWarehouseTable record for saved query %s", saved_query.name)
     except Exception as e:
+        capture_exception(e)
         await logger.aexception("Failed to update row count for table %s: %s", saved_query.name, str(e))
 
 
@@ -929,8 +933,10 @@ class RunWorkflow(PostHogWorkflow):
                         ),
                     )
                 except Exception as cancel_err:
+                    capture_exception(cancel_err)
                     temporalio.workflow.logger.error(f"Failed to cancel jobs: {str(cancel_err)}")
 
+            capture_exception(e)
             temporalio.workflow.logger.error(f"Activity failed during model run: {str(e)}")
             return Results(set(), set(), set())
         completed, failed, ancestor_failed = results


### PR DESCRIPTION
## Problem
- We're a bit blind to exceptions being raised in temporal from the data modeling workflow, we log to the temporal logger but that's not so helpful 

## Changes
- Capture caught exceptions to our error tracking product
