### PR TITLE
feat(capture-rs): add remaining legacy capture endpoints to event_legacy routing

### DIFF
--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -194,8 +194,35 @@ pub fn router<
                 post(v0_endpoint::event_legacy)
                     .get(v0_endpoint::event_legacy)
                     .options(v0_endpoint::options),
+            ),
+            .route(
+                "/track",
+                post(v0_endpoint::event_legacy)
+                    .get(v0_endpoint::event_legacy)
+                    .options(v0_endpoint::options),
+            )
+            .route(
+                "/track/",
+                post(v0_endpoint::event_legacy)
+                    .get(v0_endpoint::event_legacy)
+                    .options(v0_endpoint::options),
+            ),
+            .route(
+                "/capture",
+                post(v0_endpoint::event_legacy)
+                    .get(v0_endpoint::event_legacy)
+                    .options(v0_endpoint::options),
+            )
+            .route(
+                "/capture/",
+                post(v0_endpoint::event_legacy)
+                    .get(v0_endpoint::event_legacy)
+                    .options(v0_endpoint::options),
             );
     } else {
+        // TODO: once mirror testing has validated the legacy endpoints
+        // can be served safely from capture-rs and event_legacy, we may
+        // unite the new and old codepaths and dedup this routing
         event_router = event_router
             .route(
                 "/e",

--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -194,7 +194,7 @@ pub fn router<
                 post(v0_endpoint::event_legacy)
                     .get(v0_endpoint::event_legacy)
                     .options(v0_endpoint::options),
-            ),
+            )
             .route(
                 "/track",
                 post(v0_endpoint::event_legacy)
@@ -206,7 +206,7 @@ pub fn router<
                 post(v0_endpoint::event_legacy)
                     .get(v0_endpoint::event_legacy)
                     .options(v0_endpoint::options),
-            ),
+            )
             .route(
                 "/capture",
                 post(v0_endpoint::event_legacy)


### PR DESCRIPTION
## Problem
We need to test the mirror deploy against all the remaining [legacy capture endpoints](https://github.com/PostHog/posthog/blob/master/posthog/urls.py#L224-L227). We can wire them all up in `capture-rs` safely now, since which we are testing against at the moment is managed upstream in our load balancer 👍 

## Changes
Register the `/track` and `/capture` endpoints for testing now that `/e` traffic is being processed successfully.

The plan is to test each individually at 1% to eliminate noise while identifying corner cases to resolve, then ramp each up individually for confidence before routing all the legacy endpoints into the live `capture-rs` service for final rollout.

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally, CI, mirror deploys