### PR TITLE
fix: Allow `WHERE {column} IS NOT NULL` in index creation

### DIFF
--- a/posthog/management/commands/test/test_migrations_are_safe.py
+++ b/posthog/management/commands/test/test_migrations_are_safe.py
@@ -56,3 +56,13 @@ COMMIT;
     """
     should_fail = validate_migration_sql(sql_for_model_with_uuid)
     assert should_fail is False
+
+
+def test_unique_indexes_can_apply_only_to_not_null_values() -> None:
+    sql_for_model_with_uuid = """
+BEGIN;
+CREATE UNIQUE INDEX CONCURRENTLY team_secret_api_token_unique_idx ON posthog_team (secret_api_token) WHERE secret_api_token IS NOT NULL;
+COMMIT;
+    """
+    should_fail = validate_migration_sql(sql_for_model_with_uuid)
+    assert should_fail is False

--- a/posthog/management/commands/test/test_migrations_are_safe.py
+++ b/posthog/management/commands/test/test_migrations_are_safe.py
@@ -59,10 +59,10 @@ COMMIT;
 
 
 def test_unique_indexes_can_apply_only_to_not_null_values() -> None:
-    sql_for_model_with_uuid = """
+    sql_for_unique_index_with_where = """
 BEGIN;
 CREATE UNIQUE INDEX CONCURRENTLY team_secret_api_token_unique_idx ON posthog_team (secret_api_token) WHERE secret_api_token IS NOT NULL;
 COMMIT;
     """
-    should_fail = validate_migration_sql(sql_for_model_with_uuid)
+    should_fail = validate_migration_sql(sql_for_unique_index_with_where)
     assert should_fail is False

--- a/posthog/management/commands/test_migrations_are_safe.py
+++ b/posthog/management/commands/test_migrations_are_safe.py
@@ -38,9 +38,8 @@ def validate_migration_sql(sql) -> bool:
                 return True
 
         if (
-            re.findall(r"(?<!DROP) (NOT NULL|DEFAULT .* NOT NULL)", operation_sql, re.M & re.I)
-            and "CREATE TABLE" not in operation_sql
-            and "ADD CONSTRAINT" not in operation_sql
+            "ALTER TABLE" in operation_sql  # Only check ALTER TABLE operations
+            and re.findall(r"(?<!DROP) (NOT NULL|DEFAULT .* NOT NULL)", operation_sql, re.M & re.I)
             and "-- not-null-ignore" not in operation_sql
             # Ignore for brand-new tables
             and (table_being_altered not in tables_created_so_far or table_being_altered not in new_tables)


### PR DESCRIPTION
This check is trying to protect against adding a column with a non-null constraint to a table OR adding a non-null constraint to an existing column.

However, the only way such a thing can occur is if we're altering a table. So it seems changing the condition to look for the existence of "ALTER TABLE" should be safe and more robust.

> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
