### PR TITLE
fix(dev): syncing of feature flags

### DIFF
--- a/posthog/management/commands/sync_feature_flags.py
+++ b/posthog/management/commands/sync_feature_flags.py
@@ -95,6 +95,7 @@ class Command(BaseCommand):
                             key=flag,
                             created_by=first_user,
                             active=is_enabled,
+                            filters={"groups": [{"properties": [], "rollout_percentage": 100}], "payloads": {}},
                         )
                     print(
                         f"Created feature flag '{flag} for project {project.id} {' - ' + project.name if project.name else ''}"


### PR DESCRIPTION
## Problem

Syncing of feature flags has stopped working lately. It works if we set "payload" in filters to an empty object.

## Changes

- Set `payload` to an empty object in the script.
-
## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

N/A
