### PR TITLE
feat(data-warehouse): Track rows synced via redis for in-progress syncs

### DIFF
--- a/posthog/temporal/data_imports/external_data_job.py
+++ b/posthog/temporal/data_imports/external_data_job.py
@@ -10,9 +10,11 @@ from temporalio import activity, exceptions, workflow
 from temporalio.common import RetryPolicy
 
 # TODO: remove dependency
+from posthog.exceptions_capture import capture_exception
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.logger import bind_temporal_worker_logger_sync
 from posthog.temporal.data_imports.metrics import get_data_import_finished_metric
+from posthog.temporal.data_imports.row_tracking import finish_row_tracking, get_rows
 from posthog.temporal.data_imports.workflow_activities.check_billing_limits import (
     CheckBillingLimitsActivityInputs,
     check_billing_limits_activity,
@@ -113,6 +115,14 @@ def update_external_data_job_model(inputs: UpdateExternalDataJobStatusInputs) ->
     logger = bind_temporal_worker_logger_sync(team_id=inputs.team_id)
 
     close_old_connections()
+
+    rows_tracked = get_rows(inputs.team_id, inputs.schema_id)
+    if rows_tracked > 0 and inputs.status == ExternalDataJob.Status.COMPLETED:
+        msg = f"Rows tracked is greater than 0 on a COMPLETED job. rows_tracked={rows_tracked}"
+        logger.debug(msg)
+        capture_exception(Exception(msg))
+
+    finish_row_tracking(inputs.team_id, inputs.schema_id)
 
     if inputs.job_id is None:
         job: ExternalDataJob | None = (

--- a/posthog/temporal/data_imports/pipelines/mssql/mssql.py
+++ b/posthog/temporal/data_imports/pipelines/mssql/mssql.py
@@ -346,6 +346,32 @@ def _get_table_stats(cursor: Cursor, schema: str, table_name: str) -> tuple[int,
     return total_rows, total_bytes
 
 
+def _get_rows_to_sync(
+    cursor: Cursor, inner_query: str, inner_query_args: dict[str, Any], logger: FilteringBoundLogger
+) -> int:
+    try:
+        query = f"SELECT COUNT(*) FROM ({inner_query}) as t"
+
+        cursor.execute(query, inner_query_args)
+        row = cursor.fetchone()
+
+        if row is None:
+            logger.debug(f"_get_rows_to_sync: No results returned. Using 0 as rows to sync")
+            return 0
+
+        rows_to_sync = row[0] or 0
+        rows_to_sync_int = int(rows_to_sync)
+
+        logger.debug(f"_get_rows_to_sync: rows_to_sync_int={rows_to_sync_int}")
+
+        return int(rows_to_sync)
+    except Exception as e:
+        logger.debug(f"_get_rows_to_sync: Error: {e}. Using 0 as rows to sync", exc_info=e)
+        capture_exception(e)
+
+        return 0
+
+
 def _get_partition_settings(
     cursor: Cursor, schema: str, table_name: str, logger: FilteringBoundLogger
 ) -> PartitionSettings | None:
@@ -397,8 +423,18 @@ def mssql_source(
         login_timeout=5,
     ) as connection:
         with connection.cursor() as cursor:
+            inner_query, inner_query_args = _build_query(
+                schema,
+                table_name,
+                is_incremental,
+                incremental_field,
+                incremental_field_type,
+                db_incremental_field_last_value,
+            )
+
             primary_keys = _get_primary_keys(cursor, schema, table_name)
             table = _get_table(cursor, schema, table_name)
+            rows_to_sync = _get_rows_to_sync(cursor, inner_query, inner_query_args, logger)
             chunk_size = _get_table_chunk_size(
                 cursor,
                 schema,
@@ -463,4 +499,5 @@ def mssql_source(
         primary_keys=primary_keys,
         partition_count=partition_settings.partition_count if partition_settings else None,
         partition_size=partition_settings.partition_size if partition_settings else None,
+        rows_to_sync=rows_to_sync,
     )

--- a/posthog/temporal/data_imports/pipelines/mysql/mysql.py
+++ b/posthog/temporal/data_imports/pipelines/mysql/mysql.py
@@ -12,6 +12,7 @@ from django.conf import settings
 from dlt.common.normalizers.naming.snake_case import NamingConvention
 from pymysql.cursors import Cursor, SSCursor
 
+from posthog.exceptions_capture import capture_exception
 from posthog.temporal.common.logger import FilteringBoundLogger
 from posthog.temporal.data_imports.pipelines.helpers import (
     incremental_type_to_initial_value,
@@ -72,6 +73,32 @@ def _build_query(
     return query, {
         "incremental_value": db_incremental_field_last_value,
     }
+
+
+def _get_rows_to_sync(
+    cursor: Cursor, inner_query: str, inner_query_args: dict[str, Any], logger: FilteringBoundLogger
+) -> int:
+    try:
+        query = f"SELECT COUNT(*) FROM ({inner_query}) as t"
+
+        cursor.execute(query, inner_query_args)
+        row = cursor.fetchone()
+
+        if row is None:
+            logger.debug(f"_get_rows_to_sync: No results returned. Using 0 as rows to sync")
+            return 0
+
+        rows_to_sync = row[0] or 0
+        rows_to_sync_int = int(rows_to_sync)
+
+        logger.debug(f"_get_rows_to_sync: rows_to_sync_int={rows_to_sync_int}")
+
+        return int(rows_to_sync)
+    except Exception as e:
+        logger.debug(f"_get_rows_to_sync: Error: {e}. Using 0 as rows to sync", exc_info=e)
+        capture_exception(e)
+
+        return 0
 
 
 def _get_partition_settings(
@@ -322,8 +349,18 @@ def mysql_source(
         ssl_ca=ssl_ca,
     ) as connection:
         with connection.cursor() as cursor:
+            inner_query, inner_query_args = _build_query(
+                schema,
+                table_name,
+                is_incremental,
+                incremental_field,
+                incremental_field_type,
+                db_incremental_field_last_value,
+            )
+
             primary_keys = _get_primary_keys(cursor, schema, table_name)
             table = _get_table(cursor, schema, table_name)
+            rows_to_sync = _get_rows_to_sync(cursor, inner_query, inner_query_args, logger)
             partition_settings = _get_partition_settings(cursor, schema, table_name) if is_incremental else None
 
             # Fallback on checking for an `id` field on the table
@@ -376,4 +413,5 @@ def mysql_source(
         primary_keys=primary_keys,
         partition_count=partition_settings.partition_count if partition_settings else None,
         partition_size=partition_settings.partition_size if partition_settings else None,
+        rows_to_sync=rows_to_sync,
     )

--- a/posthog/temporal/data_imports/pipelines/pipeline/typings.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/typings.py
@@ -17,6 +17,7 @@ class SourceResponse:
     partition_size: Optional[int] = None
     # our source typically return data in ascending timestamp order, but some (eg Stripe) do not
     sort_mode: Optional[SortMode] = "asc"
+    rows_to_sync: Optional[int] = None
 
 
 PartitionMode = Literal["md5", "numerical", "datetime"]

--- a/posthog/temporal/data_imports/pipelines/postgres/postgres.py
+++ b/posthog/temporal/data_imports/pipelines/postgres/postgres.py
@@ -129,6 +129,32 @@ def _get_table_chunk_size(
         return DEFAULT_CHUNK_SIZE
 
 
+def _get_rows_to_sync(cursor: psycopg.Cursor, inner_query: sql.Composed, logger: FilteringBoundLogger) -> int:
+    try:
+        query = sql.SQL("""
+            SELECT COUNT(t.*) FROM ({}) as t
+        """).format(inner_query)
+
+        cursor.execute(query)
+        row = cursor.fetchone()
+
+        if row is None:
+            logger.debug(f"_get_rows_to_sync: No results returned. Using 0 as rows to sync")
+            return 0
+
+        rows_to_sync = row[0] or 0
+        rows_to_sync_int = int(rows_to_sync)
+
+        logger.debug(f"_get_rows_to_sync: rows_to_sync_int={rows_to_sync_int}")
+
+        return int(rows_to_sync)
+    except Exception as e:
+        logger.debug(f"_get_rows_to_sync: Error: {e}. Using 0 as rows to sync", exc_info=e)
+        capture_exception(e)
+
+        return 0
+
+
 def _get_partition_settings(cursor: psycopg.Cursor, schema: str, table_name: str) -> PartitionSettings | None:
     query = sql.SQL("""
         SELECT
@@ -329,6 +355,7 @@ def postgres_source(
             primary_keys = _get_primary_keys(cursor, schema, table_name)
             table = _get_table(cursor, schema, table_name)
             chunk_size = _get_table_chunk_size(cursor, inner_query, schema, table_name, logger)
+            rows_to_sync = _get_rows_to_sync(cursor, inner_query, logger)
             partition_settings = _get_partition_settings(cursor, schema, table_name) if is_incremental else None
 
             # Fallback on checking for an `id` field on the table
@@ -384,4 +411,5 @@ def postgres_source(
         primary_keys=primary_keys,
         partition_count=partition_settings.partition_count if partition_settings else None,
         partition_size=partition_settings.partition_size if partition_settings else None,
+        rows_to_sync=rows_to_sync,
     )

--- a/posthog/temporal/data_imports/row_tracking.py
+++ b/posthog/temporal/data_imports/row_tracking.py
@@ -1,0 +1,62 @@
+from contextlib import contextmanager
+import uuid
+from posthog.exceptions_capture import capture_exception
+from posthog.redis import get_client
+
+
+def _get_hash_key(team_id: int) -> str:
+    return f"posthog:data_warehouse_row_tracking:{team_id}"
+
+
+@contextmanager
+def _get_redis():
+    try:
+        # Ensure redis is up and alive
+        redis = get_client()
+        redis.ping()
+
+        yield redis
+    except Exception as e:
+        capture_exception(e)
+
+
+def setup_row_tracking(team_id: int, schema_id: uuid.UUID | str) -> None:
+    with _get_redis() as redis:
+        redis.hset(_get_hash_key(team_id), str(schema_id), 0)
+        redis.expire(_get_hash_key(team_id), 60 * 60 * 24 * 7)  # 7 day expire
+
+
+def increment_rows(team_id: int, schema_id: uuid.UUID | str, rows: int) -> None:
+    with _get_redis() as redis:
+        redis.hincrby(_get_hash_key(team_id), str(schema_id), rows)
+
+
+def decrement_rows(team_id: int, schema_id: uuid.UUID | str, rows: int) -> None:
+    with _get_redis() as redis:
+        if not redis.hexists(_get_hash_key(team_id), str(schema_id)):
+            return
+
+        value = redis.hget(_get_hash_key(team_id), str(schema_id))
+        if not value:
+            return
+
+        value_int = int(value)
+        if value_int - rows < 0:
+            redis.hset(_get_hash_key(team_id), str(schema_id), 0)
+        else:
+            redis.hincrby(_get_hash_key(team_id), str(schema_id), -rows)
+
+
+def finish_row_tracking(team_id: int, schema_id: uuid.UUID | str) -> None:
+    with _get_redis() as redis:
+        redis.hdel(_get_hash_key(team_id), str(schema_id))
+
+
+def get_rows(team_id: int, schema_id: uuid.UUID | str) -> int:
+    with _get_redis() as redis:
+        if redis.hexists(_get_hash_key(team_id), str(schema_id)):
+            value = redis.hget(_get_hash_key(team_id), str(schema_id))
+            if value:
+                return int(value)
+
+        return 0

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -1932,7 +1932,7 @@ async def test_row_tracking_incrementing(team, postgres_config, postgres_connect
 
     schema_id = inputs.external_data_schema_id
 
-    mock_decrement_rows.assert_called_once_with(team.id, schema_id)
+    mock_decrement_rows.assert_called_once_with(team.id, schema_id, 1)
     mock_finish_row_tracking.assert_called_once()
 
     assert schema_id is not None

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -1930,10 +1930,11 @@ async def test_row_tracking_incrementing(team, postgres_config, postgres_connect
             mock_data_response=[],
         )
 
+    schema_id = inputs.external_data_schema_id
+
     mock_decrement_rows.assert_called_once_with(team.id, schema_id)
     mock_finish_row_tracking.assert_called_once()
 
-    schema_id = inputs.external_data_schema_id
     assert schema_id is not None
     row_count_in_redis = get_rows(team.id, schema_id)
 

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -1930,7 +1930,7 @@ async def test_row_tracking_incrementing(team, postgres_config, postgres_connect
             mock_data_response=[],
         )
 
-    mock_decrement_rows.assert_called_once()
+    mock_decrement_rows.assert_called_once_with(team.id, schema_id)
     mock_finish_row_tracking.assert_called_once()
 
     schema_id = inputs.external_data_schema_id

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -38,6 +38,7 @@ from posthog.schema import (
     PersonsOnEventsMode,
 )
 from posthog.temporal.data_imports.pipelines.pipeline.consts import PARTITION_KEY
+from posthog.temporal.data_imports.row_tracking import get_rows
 from posthog.temporal.data_imports.settings import ACTIVITIES
 from posthog.temporal.data_imports.external_data_job import ExternalDataJobWorkflow
 from posthog.temporal.data_imports.pipelines.pipeline.pipeline import PipelineNonDLT
@@ -1895,3 +1896,52 @@ async def test_partition_folders_delta_merge_called_with_partition_predicate(
         "predicate": f"source.id = target.id AND source.{PARTITION_KEY} = target.{PARTITION_KEY} AND target.{PARTITION_KEY} = '0'",
         "streamed_exec": True,
     }
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_row_tracking_incrementing(team, postgres_config, postgres_connection):
+    await postgres_connection.execute(
+        "CREATE TABLE IF NOT EXISTS {schema}.row_tracking (id integer)".format(schema=postgres_config["schema"])
+    )
+    await postgres_connection.execute(
+        "INSERT INTO {schema}.row_tracking (id) VALUES (1)".format(schema=postgres_config["schema"])
+    )
+    await postgres_connection.commit()
+
+    with (
+        mock.patch("posthog.temporal.data_imports.pipelines.pipeline.pipeline.decrement_rows") as mock_decrement_rows,
+        mock.patch("posthog.temporal.data_imports.external_data_job.finish_row_tracking") as mock_finish_row_tracking,
+    ):
+        _, inputs = await _run(
+            team=team,
+            schema_name="row_tracking",
+            table_name="postgres_row_tracking",
+            source_type="Postgres",
+            job_inputs={
+                "host": postgres_config["host"],
+                "port": postgres_config["port"],
+                "database": postgres_config["database"],
+                "user": postgres_config["user"],
+                "password": postgres_config["password"],
+                "schema": postgres_config["schema"],
+                "ssh_tunnel_enabled": "False",
+            },
+            mock_data_response=[],
+        )
+
+    mock_decrement_rows.assert_called_once()
+    mock_finish_row_tracking.assert_called_once()
+
+    schema_id = inputs.external_data_schema_id
+    assert schema_id is not None
+    row_count_in_redis = get_rows(team.id, schema_id)
+
+    assert row_count_in_redis == 1
+
+    res = await sync_to_async(execute_hogql_query)(f"SELECT * FROM postgres_row_tracking", team)
+    columns = res.columns
+
+    assert columns is not None
+    assert len(columns) == 1
+    assert any(x == "id" for x in columns)


### PR DESCRIPTION
## Problem
- Users often run over their free tier limit of data warehouse rows because we don't check ahead of time whether their sync will overrun the usage limit, we only check at the beginning of the sync whether they have hit the limit yet

## Changes
- The first step to implement a system to track this live and stop users from syncing data above their limits
- Adds tracking of in-progress syncs via redis
  - We store a hashmap in redis keyed on the team with fields of in-progress syncs
  - Wrapped the redis code so that the pipeline will continue to function even if redis is down
- Updated a bunch of sources to enable the tracking feature - we need to know how many rows we're planning on syncing ahead of time. I've updated:
  - postgres
  - mssql
  - mysql
  - snowflake
  - bigquery
- The idea here is we want to know our how far away from the limit we are and ensure all in-progress syncs + the current sync won't go over the limit - this logic is to come in a follow-up PR. @PostHog/team-billing I'll likely need a hand to figure out the best way to get the teams current `rows_synced` value

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
- Tested all the sources independently (except for mssql - @rossgray could you either send me your azure db credentials, or test this bit for me please?)
- Added a unit test for the redis stuff
- Confirmed locally that redis gets updated throughout the sync