### PR TITLE
feat(data-warehouse): Data imports: make partial data available for querying

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -304,7 +304,7 @@ class PipelineNonDLT:
             table_name=self._resource_name,
             file_uris=new_file_uris,
             # delete existing files if it's the first chunk, otherwise we'll just append to the existing files
-            delete_existing=False if chunk_index > 0 else True,
+            delete_existing=chunk_index == 0,
         )
         self._logger.debug("Validating schema and updating table")
         validate_schema_and_update_table_sync(

--- a/posthog/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/utils.py
@@ -402,11 +402,6 @@ def _get_incremental_field_last_value(schema: ExternalDataSchema | None, table: 
     return last_value
 
 
-def _update_last_synced_at_sync(schema: ExternalDataSchema, job: ExternalDataJob) -> None:
-    schema.last_synced_at = job.created_at
-    schema.save()
-
-
 def _notify_revenue_analytics_that_sync_has_completed(schema: ExternalDataSchema, logger: FilteringBoundLogger) -> None:
     try:
         if (

--- a/posthog/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/utils.py
@@ -789,4 +789,4 @@ def supports_partial_data_loading(schema: ExternalDataSchema) -> bool:
     We should be able to roll this out to all source types but initially we only support it for Stripe so we can verify
     the approach.
     """
-    return schema.source.type == ExternalDataSource.Type.STRIPE
+    return schema.source.source_type == ExternalDataSource.Type.STRIPE

--- a/posthog/temporal/data_imports/pipelines/pipeline_sync.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_sync.py
@@ -52,15 +52,9 @@ class PipelineInputs:
 
 
 def update_last_synced_at_sync(job_id: str, schema_id: str, team_id: int) -> None:
-    job = ExternalDataJob.objects.prefetch_related(
-        "pipeline", Prefetch("schema", queryset=ExternalDataSchema.objects.prefetch_related("source"))
-    ).get(pk=job_id)
-
-    schema = (
-        ExternalDataSchema.objects.prefetch_related("source").exclude(deleted=True).get(id=schema_id, team_id=team_id)
-    )
+    job = ExternalDataJob.objects.get(pk=job_id)
+    schema = ExternalDataSchema.objects.exclude(deleted=True).get(id=schema_id, team_id=team_id)
     schema.last_synced_at = job.created_at
-
     schema.save()
 
 
@@ -128,7 +122,7 @@ def validate_schema_and_update_table_sync(
         }
 
         # create or update
-        table_created: DataWarehouseTable | None = ExternalDataSchema.objects.get(id=_schema_id, team_id=team_id).table
+        table_created: DataWarehouseTable | None = external_data_schema.table
         if table_created:
             table_created.credential = table_params["credential"]
             table_created.format = table_params["format"]

--- a/posthog/temporal/data_imports/pipelines/pipeline_sync.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_sync.py
@@ -1,11 +1,9 @@
-from dataclasses import dataclass
-from datetime import datetime, date
-from typing import Any, Optional
 import uuid
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any, Optional
 
 import dlt
-from django.conf import settings
-from django.db.models import Prefetch
 import dlt.common
 import dlt.common.libs
 import dlt.common.libs.pyarrow
@@ -14,10 +12,10 @@ import dlt.extract.incremental
 import dlt.extract.incremental.transform
 import pendulum
 import pyarrow
-
-from dlt.common.normalizers.naming.snake_case import NamingConvention
-from dlt.common.schema.typing import TSchemaTables
 from clickhouse_driver.errors import ServerException
+from django.conf import settings
+from django.db.models import Prefetch
+from dlt.common.normalizers.naming.snake_case import NamingConvention
 
 from posthog.exceptions_capture import capture_exception
 from posthog.temporal.common.logger import bind_temporal_worker_logger_sync
@@ -70,7 +68,6 @@ def validate_schema_and_update_table_sync(
     run_id: str,
     team_id: int,
     schema_id: uuid.UUID,
-    table_schema: TSchemaTables,
     row_count: int,
     table_format: DataWarehouseTable.TableFormat,
     table_schema_dict: Optional[dict[str, str]] = None,
@@ -84,8 +81,9 @@ def validate_schema_and_update_table_sync(
         run_id: The id of the external data job
         team_id: The id of the team
         schema_id: The schema for which the data job relates to
-        table_schema: The DLT schema from the data load stage
-        table_row_counts: The count of synced rows from DLT
+        row_count: The count of synced rows
+        table_format: The format of the table
+        table_schema_dict: The schema of the table
     """
 
     logger = bind_temporal_worker_logger_sync(team_id=team_id)

--- a/posthog/temporal/data_imports/util.py
+++ b/posthog/temporal/data_imports/util.py
@@ -13,6 +13,7 @@ def prepare_s3_files_for_querying(
     table_name: str,
     file_uris: list[str],
     preserve_table_name_casing: Optional[bool] = False,
+    delete_existing: bool = True,
 ):
     s3 = get_s3_client()
 
@@ -29,8 +30,11 @@ def prepare_s3_files_for_querying(
 
     s3_folder_for_querying = f"{s3_folder_for_job}/{normalized_table_name}__query"
 
-    if s3.exists(s3_folder_for_querying):
-        s3.delete(s3_folder_for_querying, recursive=True)
+    # TODO - maybe we should move these to a separate place and then delete them after the copy is done, to avoid any
+    # downtime?
+    if delete_existing:
+        if s3.exists(s3_folder_for_querying):
+            s3.delete(s3_folder_for_querying, recursive=True)
 
     for file in file_uris:
         file_name = file.replace(f"{s3_folder_for_schema}/", "")


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Currently as a user, you sometimes need to wait a long time for the initial sync of a data source to finish before you can start playing with the data.

## Changes

Load partial data into the data warehouse table on first syncs (initially for Stripe only, but can expand to other sources if it proves to work well)

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manual local testing by testing that the functionality works on new schemas, but also doesn't break on existing ones
