### PR TITLE
fix: Use hedged requests instead of retry logic in python

### DIFF
--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -184,7 +184,10 @@ def sync_execute(
         # these disruptions
         settings["use_hedged_requests"] = "0"
     elif workload == Workload.OFFLINE and is_personal_api_key:
-        # personal api keys are allowed to use hedged requests that can spill into the online resource pool
+        # Personal API keys are allowed to use hedged requests, which can spill into the online resource pool.
+        # This ensures faster and more reliable query execution for personal API key users, even at the cost of
+        # potentially impacting online workloads. This behavior differs from the previous retry logic, which
+        # would retry queries only after a failure, leading to higher latency for personal API key users.
         settings["use_hedged_requests"] = "1"
     start_time = perf_counter()
     try:


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Refine retry logic here - clickhouse should manage it, not python

Clickhouse has all of the facilities required to push a failed query over to the online cluster.
https://clickhouse.com/docs/operations/settings/settings#use_hedged_requests

In general we should be setting this on every category of offline workload because some should fail if the offline cluster is not healthy, other queries like API requests should speculatively be executed on the online cluster if the offline cluster is unresponsive or too slow.

## Changes

remove the while loop and retry logic - enable hedged requests for api calls to offline cluster

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
