### PR TITLE
feat: Enhancements to ClickHouse property_definitions ingestion

### DIFF
--- a/dags/property_definitions.py
+++ b/dags/property_definitions.py
@@ -14,7 +14,7 @@ class TimeRange:
     end_time: datetime
 
     def get_expression(self, column: str) -> str:
-        return f"{column} BETWEEN '{self.start_time.isoformat()}' AND '{self.end_time.isoformat()}'"
+        return f"{column} >= '{self.start_time.isoformat()}' AND {column} < '{self.end_time.isoformat()}'"
 
 
 class PropertyDefinitionsConfig(dagster.Config):

--- a/dags/property_definitions.py
+++ b/dags/property_definitions.py
@@ -102,14 +102,10 @@ def ingest_event_properties(
     context.log.info("Executing insert query...")
     cluster.any_host(Query(query)).result()
 
-    # Parse the time range for the count query
-    count_time_range = time_filter.split("BETWEEN ")[1]
-    start_time, end_time = count_time_range.split(" AND ")
-
     # Get the number of rows inserted for this specific time window
     count_query = f"""
     SELECT count() FROM property_definitions
-    WHERE type = 1 AND last_seen_at BETWEEN {start_time} AND {end_time}
+    WHERE type = 1 AND {config.get_time_filter_expression("last_seen_at")}
     """
 
     rows = cluster.any_host(Query(count_query)).result()[0][0]
@@ -168,14 +164,10 @@ def ingest_person_properties(
     context.log.info("Executing insert query...")
     cluster.any_host(Query(query)).result()
 
-    # Parse the time range for the count query
-    count_time_range = time_filter.split("BETWEEN ")[1]
-    start_time, end_time = count_time_range.split(" AND ")
-
     # Get the number of rows inserted for this specific time window
     count_query = f"""
     SELECT count() FROM property_definitions
-    WHERE type = 2 AND last_seen_at BETWEEN {start_time} AND {end_time}
+    WHERE type = 2 AND {config.get_time_filter_expression("last_seen_at")}
     """
 
     rows = cluster.any_host(Query(count_query)).result()[0][0]

--- a/dags/property_definitions.py
+++ b/dags/property_definitions.py
@@ -153,7 +153,7 @@ def ingest_person_properties(
     context.log.info(f"Ingesting person properties for {time_range!r}")
 
     # Query to insert person properties into property_definitions table
-    # NOTE: this is a different data source from current, assuming ok? https://github.com/PostHog/posthog/blob/052f4ea40c5043909115f835f09445e18dd9727c/rust/property-defs-rs/src/types.rs#L250-L26
+    # NOTE: this is a different data source from current, see https://github.com/PostHog/product-internal/pull/748/files#diff-78e7399938cb790eae10d5c5769f7edcb531972f33a32e0655872bded13f4977R165-R170
     insert_query = f"""
     INSERT INTO property_definitions (* EXCEPT(version))
     SELECT

--- a/dags/property_definitions.py
+++ b/dags/property_definitions.py
@@ -2,13 +2,12 @@ import datetime
 from typing import Optional
 
 import dagster
-from dagster import schedule, job, Config
 
 from dags.common import JobOwners
 from posthog.clickhouse.cluster import ClickhouseCluster, Query
 
 
-class PropertyDefinitionsConfig(Config):
+class PropertyDefinitionsConfig(dagster.Config):
     """Configuration for property definitions ingestion job."""
 
     # Process a specific hour (ISO format) instead of lookback
@@ -206,7 +205,7 @@ def optimize_property_definitions(
     return total
 
 
-@job(
+@dagster.job(
     name="property_definitions_ingestion",
     tags={"owner": JobOwners.TEAM_CLICKHOUSE.value},
 )
@@ -224,7 +223,7 @@ def property_definitions_ingestion_job():
     optimize_property_definitions(event_count, person_count)
 
 
-@schedule(
+@dagster.schedule(
     job=property_definitions_ingestion_job,
     cron_schedule="5 * * * *",  # Run 5 minutes after the hour
     execution_timezone="UTC",

--- a/dags/property_definitions.py
+++ b/dags/property_definitions.py
@@ -107,7 +107,12 @@ def ingest_event_properties(
         {int(PropertyDefinition.Type.EVENT)} as type,
         max(timestamp) as last_seen_at
     FROM events_recent
-    WHERE {time_range.get_expression("timestamp")}
+    WHERE
+        {time_range.get_expression("timestamp")}
+        -- https://github.com/PostHog/posthog/blob/052f4ea40c5043909115f835f09445e18dd9727c/rust/property-defs-rs/src/types.rs#L13-L14C52
+        AND event NOT IN ('$$plugin_metrics')
+        -- https://github.com/PostHog/posthog/blob/052f4ea40c5043909115f835f09445e18dd9727c/rust/property-defs-rs/src/types.rs#L17-L28
+        AND name NOT IN ('$set', '$set_once', '$unset', '$group_0', '$group_1', '$group_2', '$group_3', '$group_4', '$groups')
     GROUP BY team_id, event, name, property_type
     ORDER BY team_id, event, name, property_type NULLS LAST
     LIMIT 1 by team_id, event, name

--- a/dags/property_definitions.py
+++ b/dags/property_definitions.py
@@ -38,6 +38,7 @@ def format_datetime_for_clickhouse(dt: datetime.datetime) -> str:
 def ingest_event_properties(
     context: dagster.OpExecutionContext,
     cluster: dagster.ResourceParam[ClickhouseCluster],
+    config: PropertyDefinitionsConfig,
 ) -> tuple[int, tuple[str, str]]:
     """
     Ingest event properties from events_recent table into property_definitions table.
@@ -45,16 +46,6 @@ def ingest_event_properties(
     Uses the JSONExtractKeysAndValuesRaw function to extract property keys and values,
     then determines the property type using JSONType.
     """
-    # Get config from context
-    config_dict = getattr(context, "op_config", {}) or {}
-
-    # Convert to PropertyDefinitionsConfig
-    config = PropertyDefinitionsConfig(
-        target_hour=config_dict.get("target_hour"),
-        start_date=config_dict.get("start_date"),
-        end_date=config_dict.get("end_date"),
-    )
-
     # Build the time filter based on config
     if config.start_date and config.end_date:
         # For backfill runs - these should already be in the right format
@@ -135,6 +126,7 @@ def ingest_event_properties(
 def ingest_person_properties(
     context: dagster.OpExecutionContext,
     cluster: dagster.ResourceParam[ClickhouseCluster],
+    config: PropertyDefinitionsConfig,
     event_time_window: tuple[str, str],
 ) -> tuple[int, tuple[str, str]]:
     """
@@ -143,16 +135,6 @@ def ingest_person_properties(
     Uses the JSONExtractKeysAndValuesRaw function to extract property keys and values,
     then determines the property type using JSONType.
     """
-    # Get config from context
-    config_dict = getattr(context, "op_config", {}) or {}
-
-    # Convert to PropertyDefinitionsConfig
-    config = PropertyDefinitionsConfig(
-        target_hour=config_dict.get("target_hour"),
-        start_date=config_dict.get("start_date"),
-        end_date=config_dict.get("end_date"),
-    )
-
     # Build the time filter based on config
     if config.start_date and config.end_date:
         # For backfill runs - these should already be in the right format

--- a/dags/property_definitions.py
+++ b/dags/property_definitions.py
@@ -122,8 +122,7 @@ def ingest_event_properties(
         team_id as project_id,
         (arrayJoin({DetectPropertyTypeExpression('properties')}) as property).1 as name,
         property.2 as property_type,
-        -- NOTE: event not sanitized, need to check if needed https://github.com/PostHog/posthog/blob/052f4ea40c5043909115f835f09445e18dd9727c/rust/property-defs-rs/src/types.rs#L172
-        event,
+        replaceAll(event, '\\0', '\ufffd') as event,  -- https://github.com/PostHog/posthog/blob/052f4ea40c5043909115f835f09445e18dd9727c/rust/property-defs-rs/src/types.rs#L172
         NULL as group_type_index,
         {int(PropertyDefinition.Type.EVENT)} as type,
         -- NOTE: not floored, need to check if needed https://github.com/PostHog/posthog/blob/052f4ea40c5043909115f835f09445e18dd9727c/rust/property-defs-rs/src/types.rs#L175

--- a/dags/property_definitions.py
+++ b/dags/property_definitions.py
@@ -5,6 +5,7 @@ import dagster
 
 from dags.common import JobOwners
 from posthog.clickhouse.cluster import ClickhouseCluster, Query
+from posthog.models.property_definition import PropertyDefinition
 
 
 @dataclass(frozen=True)
@@ -103,7 +104,7 @@ def ingest_event_properties(
         property.2 as property_type,
         event,
         NULL as group_type_index,
-        1 as type,
+        {int(PropertyDefinition.Type.EVENT)} as type,
         max(timestamp) as last_seen_at
     FROM events_recent
     WHERE {time_range.get_expression("timestamp")}
@@ -149,7 +150,7 @@ def ingest_person_properties(
         property.2 as property_type,
         NULL as event,
         NULL as group_type_index,
-        2 as type,
+        {int(PropertyDefinition.Type.PERSON)} as type,
         max(_timestamp) as last_seen_at
     FROM person
     WHERE {time_range.get_expression("_timestamp")}

--- a/dags/property_definitions.py
+++ b/dags/property_definitions.py
@@ -112,7 +112,7 @@ def ingest_event_properties(
     Ingest event properties from events_recent table into property_definitions table.
     """
     # Log the execution parameters
-    context.log.info(f"Ingesting person properties for {time_range!r}")
+    context.log.info(f"Ingesting event properties for {time_range!r}")
 
     # Query to insert event properties into property_definitions table
     insert_query = f"""

--- a/dags/property_definitions.py
+++ b/dags/property_definitions.py
@@ -95,7 +95,7 @@ def ingest_event_properties(
     context.log.info(f"Ingesting person properties for {time_range!r}")
 
     # Query to insert event properties into property_definitions table
-    query = f"""
+    insert_query = f"""
     INSERT INTO property_definitions (* EXCEPT(version))
     SELECT
         team_id,
@@ -114,7 +114,7 @@ def ingest_event_properties(
     """
 
     context.log.info("Executing insert query...")
-    cluster.any_host(Query(query)).result()
+    cluster.any_host(Query(insert_query)).result()
 
     # Get the number of rows inserted for this specific time window
     count_query = f"""
@@ -141,7 +141,7 @@ def ingest_person_properties(
     context.log.info(f"Ingesting person properties for {time_range!r}")
 
     # Query to insert person properties into property_definitions table
-    query = f"""
+    insert_query = f"""
     INSERT INTO property_definitions (* EXCEPT(version))
     SELECT
         team_id,
@@ -160,7 +160,7 @@ def ingest_person_properties(
     """
 
     context.log.info("Executing insert query...")
-    cluster.any_host(Query(query)).result()
+    cluster.any_host(Query(insert_query)).result()
 
     # Get the number of rows inserted for this specific time window
     count_query = f"""

--- a/dags/property_definitions.py
+++ b/dags/property_definitions.py
@@ -46,6 +46,7 @@ class DetectPropertyTypeExpression:
     source_column: str
 
     def __str__(self) -> str:
+        # largely derived from https://github.com/PostHog/posthog/blob/052f4ea40c5043909115f835f09445e18dd9727c/rust/property-defs-rs/src/types.rs#L314-L373
         return f"""
             arrayMap(
                 (name, value) -> (name, multiIf(

--- a/dags/property_definitions.py
+++ b/dags/property_definitions.py
@@ -107,7 +107,7 @@ def ingest_event_properties(
 
     # Query to insert event properties into property_definitions table
     insert_query = f"""
-    INSERT INTO property_definitions (* EXCEPT(version))
+    INSERT INTO property_definitions
     SELECT
         team_id,
         team_id as project_id,
@@ -162,7 +162,7 @@ def ingest_person_properties(
     # Query to insert person properties into property_definitions table
     # NOTE: this is a different data source from current, see https://github.com/PostHog/product-internal/pull/748/files#diff-78e7399938cb790eae10d5c5769f7edcb531972f33a32e0655872bded13f4977R165-R170
     insert_query = f"""
-    INSERT INTO property_definitions (* EXCEPT(version))
+    INSERT INTO property_definitions
     SELECT
         team_id,
         team_id as project_id,

--- a/dags/property_definitions.py
+++ b/dags/property_definitions.py
@@ -115,6 +115,8 @@ def ingest_event_properties(
         AND name NOT IN ('$set', '$set_once', '$unset', '$group_0', '$group_1', '$group_2', '$group_3', '$group_4', '$groups')
         -- https://github.com/PostHog/posthog/blob/052f4ea40c5043909115f835f09445e18dd9727c/rust/property-defs-rs/src/types.rs#L187-L191
         AND length(event) <= 200
+        -- https://github.com/PostHog/posthog/blob/052f4ea40c5043909115f835f09445e18dd9727c/rust/property-defs-rs/src/types.rs#L279-L286
+        AND length(name) <= 200
     GROUP BY team_id, event, name, property_type
     ORDER BY team_id, event, name, property_type NULLS LAST
     LIMIT 1 by team_id, event, name

--- a/dags/property_definitions.py
+++ b/dags/property_definitions.py
@@ -16,8 +16,6 @@ class PropertyDefinitionsConfig(Config):
     # For backfill runs, we can specify a start and end date
     start_date: Optional[str] = None
     end_date: Optional[str] = None
-    # Batch size for inserts to control memory usage
-    batch_size: int = 10000
     # Timeout for query execution in seconds
     max_execution_time: int = 6000
 
@@ -55,7 +53,6 @@ def ingest_event_properties(context) -> tuple[int, tuple[str, str]]:
         target_hour=config_dict.get("target_hour"),
         start_date=config_dict.get("start_date"),
         end_date=config_dict.get("end_date"),
-        batch_size=config_dict.get("batch_size", 10000),
         max_execution_time=config_dict.get("max_execution_time", 6000),
     )
 
@@ -153,7 +150,6 @@ def ingest_person_properties(context, event_time_window: tuple[str, str]) -> tup
         target_hour=config_dict.get("target_hour"),
         start_date=config_dict.get("start_date"),
         end_date=config_dict.get("end_date"),
-        batch_size=config_dict.get("batch_size", 10000),
         max_execution_time=config_dict.get("max_execution_time", 6000),
     )
 

--- a/dags/property_definitions.py
+++ b/dags/property_definitions.py
@@ -86,8 +86,6 @@ class DetectPropertyTypeExpression:
 COMMON_PROPERTY_FILTERS = """
 -- https://github.com/PostHog/posthog/blob/052f4ea40c5043909115f835f09445e18dd9727c/rust/property-defs-rs/src/types.rs#L17-L28
 name NOT IN ('$set', '$set_once', '$unset', '$group_0', '$group_1', '$group_2', '$group_3', '$group_4', '$groups')
--- https://github.com/PostHog/posthog/blob/052f4ea40c5043909115f835f09445e18dd9727c/rust/property-defs-rs/src/types.rs#L187-L191
-AND length(event) <= 200
 -- https://github.com/PostHog/posthog/blob/052f4ea40c5043909115f835f09445e18dd9727c/rust/property-defs-rs/src/types.rs#L279-L286
 AND length(name) <= 200
 """
@@ -124,6 +122,8 @@ def ingest_event_properties(
         {time_range.get_expression("timestamp")}
         -- https://github.com/PostHog/posthog/blob/052f4ea40c5043909115f835f09445e18dd9727c/rust/property-defs-rs/src/types.rs#L13-L14C52
         AND event NOT IN ('$$plugin_metrics')
+        -- https://github.com/PostHog/posthog/blob/052f4ea40c5043909115f835f09445e18dd9727c/rust/property-defs-rs/src/types.rs#L187-L191
+        AND length(event) <= 200
         AND {COMMON_PROPERTY_FILTERS}
     GROUP BY team_id, event, name, property_type
     ORDER BY team_id, event, name, property_type NULLS LAST

--- a/dags/property_definitions.py
+++ b/dags/property_definitions.py
@@ -16,8 +16,6 @@ class PropertyDefinitionsConfig(Config):
     # For backfill runs, we can specify a start and end date
     start_date: Optional[str] = None
     end_date: Optional[str] = None
-    # Timeout for query execution in seconds
-    max_execution_time: int = 6000
 
 
 def format_datetime_for_clickhouse(dt: datetime.datetime) -> str:
@@ -55,7 +53,6 @@ def ingest_event_properties(
         target_hour=config_dict.get("target_hour"),
         start_date=config_dict.get("start_date"),
         end_date=config_dict.get("end_date"),
-        max_execution_time=config_dict.get("max_execution_time", 6000),
     )
 
     # Build the time filter based on config
@@ -109,7 +106,6 @@ def ingest_event_properties(
     GROUP BY team_id, event, name, property_type
     ORDER BY team_id, event, name, property_type NULLS LAST
     LIMIT 1 by team_id, event, name
-    SETTINGS max_execution_time = {config.max_execution_time}
     """
 
     context.log.info("Executing insert query...")
@@ -155,7 +151,6 @@ def ingest_person_properties(
         target_hour=config_dict.get("target_hour"),
         start_date=config_dict.get("start_date"),
         end_date=config_dict.get("end_date"),
-        max_execution_time=config_dict.get("max_execution_time", 6000),
     )
 
     # Build the time filter based on config
@@ -209,7 +204,6 @@ def ingest_person_properties(
     GROUP BY team_id, name, property_type
     ORDER BY team_id, name, property_type NULLS LAST
     LIMIT 1 by team_id, name
-    SETTINGS max_execution_time = {config.max_execution_time}
     """
 
     context.log.info("Executing insert query...")

--- a/dags/property_definitions.py
+++ b/dags/property_definitions.py
@@ -239,4 +239,4 @@ def property_definitions_hourly_schedule(context):
     target_hour = previous_hour.isoformat()
 
     config = PropertyDefinitionsConfig(start_at=target_hour, duration="1 hour")
-    return {"ops": {"setup_job": config}}
+    return {"ops": {setup_job.name: config}}

--- a/dags/property_definitions.py
+++ b/dags/property_definitions.py
@@ -131,7 +131,9 @@ def ingest_event_properties(
     # Get the number of rows inserted for this specific time window
     count_query = f"""
     SELECT count() FROM property_definitions
-    WHERE type = 1 AND {time_range.get_expression("last_seen_at")}
+    WHERE
+        type = {int(PropertyDefinition.Type.EVENT)}
+        AND {time_range.get_expression("last_seen_at")}
     """
 
     rows = cluster.any_host(Query(count_query)).result()[0][0]
@@ -178,7 +180,9 @@ def ingest_person_properties(
     # Get the number of rows inserted for this specific time window
     count_query = f"""
     SELECT count() FROM property_definitions
-    WHERE type = 2 AND {time_range.get_expression("last_seen_at")}
+    WHERE
+        type = {int(PropertyDefinition.Type.PERSON)}
+        AND {time_range.get_expression("last_seen_at")}
     """
 
     rows = cluster.any_host(Query(count_query)).result()[0][0]

--- a/dags/property_definitions.py
+++ b/dags/property_definitions.py
@@ -22,10 +22,13 @@ class PropertyDefinitionsConfig(dagster.Config):
     """Configuration for property definitions ingestion job."""
 
     start_at: str = pydantic.Field(
-        description="The lower bound (inclusive) timestamp to be used when selecting rows to be included within the ingestion window. The value can be provided in any format that can be parsed by ClickHouse best-effort date parsing."
+        description="The lower bound (inclusive) timestamp to be used when selecting rows to be included within the "
+        "ingestion window. The value can be provided in any format that can be parsed by ClickHouse best-effort date "
+        "parsing."
     )
     duration: str = pydantic.Field(
-        description="The size of the ingestion window, used to determine the upper bound (non-inclusive) of the time range. The value can be provided in any format that can be parsed as a ClickHouse interval.",
+        description="The size of the ingestion window, used to determine the upper bound (non-inclusive) of the time "
+        "range. The value can be provided in any format that can be parsed as a ClickHouse interval.",
         default="1 hour",
     )
 

--- a/dags/property_definitions.py
+++ b/dags/property_definitions.py
@@ -103,9 +103,11 @@ def ingest_event_properties(
         team_id as project_id,
         (arrayJoin({DetectPropertyTypeExpression('properties')}) as property).1 as name,
         property.2 as property_type,
+        -- NOTE: event not sanitized, need to check if needed https://github.com/PostHog/posthog/blob/052f4ea40c5043909115f835f09445e18dd9727c/rust/property-defs-rs/src/types.rs#L172
         event,
         NULL as group_type_index,
         {int(PropertyDefinition.Type.EVENT)} as type,
+        -- NOTE: not floored, need to check if needed https://github.com/PostHog/posthog/blob/052f4ea40c5043909115f835f09445e18dd9727c/rust/property-defs-rs/src/types.rs#L175
         max(timestamp) as last_seen_at
     FROM events_recent
     WHERE

--- a/dags/property_definitions.py
+++ b/dags/property_definitions.py
@@ -1,6 +1,7 @@
 import datetime
 from typing import Optional
 
+import dagster
 from dagster import schedule, job, op, Config, In, Out
 from dagster_slack import slack_resource
 
@@ -38,7 +39,7 @@ def format_datetime_for_clickhouse(dt: datetime.datetime) -> str:
     required_resource_keys={"cluster"},
     out={"inserted_count": Out(int), "time_window": Out(tuple[str, str])},
 )
-def ingest_event_properties(context) -> tuple[int, tuple[str, str]]:
+def ingest_event_properties(context: dagster.OpExecutionContext) -> tuple[int, tuple[str, str]]:
     """
     Ingest event properties from events_recent table into property_definitions table.
 
@@ -135,7 +136,9 @@ def ingest_event_properties(context) -> tuple[int, tuple[str, str]]:
     ins={"event_time_window": In(tuple[str, str])},
     out={"inserted_count": Out(int), "time_window": Out(tuple[str, str])},
 )
-def ingest_person_properties(context, event_time_window: tuple[str, str]) -> tuple[int, tuple[str, str]]:
+def ingest_person_properties(
+    context: dagster.OpExecutionContext, event_time_window: tuple[str, str]
+) -> tuple[int, tuple[str, str]]:
     """
     Ingest person properties from person table into property_definitions table.
 
@@ -232,7 +235,9 @@ def ingest_person_properties(context, event_time_window: tuple[str, str]) -> tup
     ins={"event_count": In(int), "person_count": In(int), "time_window": In(tuple[str, str])},
     out={"total_count": Out(int)},
 )
-def optimize_property_definitions(context, event_count: int, person_count: int, time_window: tuple[str, str]) -> int:
+def optimize_property_definitions(
+    context: dagster.OpExecutionContext, event_count: int, person_count: int, time_window: tuple[str, str]
+) -> int:
     """
     Run OPTIMIZE on property_definitions table to deduplicate inserted data.
 

--- a/dags/property_definitions.py
+++ b/dags/property_definitions.py
@@ -113,6 +113,8 @@ def ingest_event_properties(
         AND event NOT IN ('$$plugin_metrics')
         -- https://github.com/PostHog/posthog/blob/052f4ea40c5043909115f835f09445e18dd9727c/rust/property-defs-rs/src/types.rs#L17-L28
         AND name NOT IN ('$set', '$set_once', '$unset', '$group_0', '$group_1', '$group_2', '$group_3', '$group_4', '$groups')
+        -- https://github.com/PostHog/posthog/blob/052f4ea40c5043909115f835f09445e18dd9727c/rust/property-defs-rs/src/types.rs#L187-L191
+        AND length(event) <= 200
     GROUP BY team_id, event, name, property_type
     ORDER BY team_id, event, name, property_type NULLS LAST
     LIMIT 1 by team_id, event, name

--- a/dags/property_definitions.py
+++ b/dags/property_definitions.py
@@ -148,6 +148,7 @@ def ingest_person_properties(
     context.log.info(f"Ingesting person properties for {time_range!r}")
 
     # Query to insert person properties into property_definitions table
+    # NOTE: this is a different data source from current, assuming ok? https://github.com/PostHog/posthog/blob/052f4ea40c5043909115f835f09445e18dd9727c/rust/property-defs-rs/src/types.rs#L250-L26
     insert_query = f"""
     INSERT INTO property_definitions (* EXCEPT(version))
     SELECT
@@ -227,6 +228,7 @@ def property_definitions_ingestion_job():
     time_range = setup_job()
     event_count = ingest_event_properties(time_range)
     person_count = ingest_person_properties(time_range)
+    # TODO: handle group properties: https://github.com/PostHog/posthog/blob/052f4ea40c5043909115f835f09445e18dd9727c/rust/property-defs-rs/src/types.rs#L224-L245
     optimize_property_definitions(time_range, event_count, person_count)
 
 

--- a/dags/tests/test_property_definitions.py
+++ b/dags/tests/test_property_definitions.py
@@ -1,8 +1,18 @@
-from dags.property_definitions import property_definitions_ingestion_job
+import dagster
+
+from dags.property_definitions import PropertyDefinitionsConfig, property_definitions_ingestion_job
 from posthog.clickhouse.cluster import ClickhouseCluster
 
 
 def test_ingestion_job(cluster: ClickhouseCluster) -> None:
+    config = PropertyDefinitionsConfig(start_at="2025-05-07T00:00:00", duration="1 hour")
     property_definitions_ingestion_job.execute_in_process(
+        run_config=dagster.RunConfig(
+            {
+                "ingest_event_properties": config,
+                "ingest_person_properties": config,
+                "optimize_property_definitions": config,
+            }
+        ),
         resources={"cluster": cluster},
     )

--- a/dags/tests/test_property_definitions.py
+++ b/dags/tests/test_property_definitions.py
@@ -3,4 +3,6 @@ from posthog.clickhouse.cluster import ClickhouseCluster
 
 
 def test_ingestion_job(cluster: ClickhouseCluster) -> None:
-    property_definitions_ingestion_job.execute_in_process()
+    property_definitions_ingestion_job.execute_in_process(
+        resources={"cluster": cluster},
+    )

--- a/dags/tests/test_property_definitions.py
+++ b/dags/tests/test_property_definitions.py
@@ -10,6 +10,7 @@ from dags.property_definitions import (
     DetectPropertyTypeExpression,
     PropertyDefinitionsConfig,
     property_definitions_ingestion_job,
+    setup_job,
 )
 from posthog.clickhouse.cluster import ClickhouseCluster, Query
 
@@ -114,6 +115,6 @@ def test_detect_property_type_expression(cluster: ClickhouseCluster) -> None:
 def test_ingestion_job(cluster: ClickhouseCluster) -> None:
     config = PropertyDefinitionsConfig(start_at="2025-05-07T00:00:00", duration="1 hour")
     property_definitions_ingestion_job.execute_in_process(
-        run_config=dagster.RunConfig({"setup_job": config}),
+        run_config=dagster.RunConfig({setup_job.name: config}),
         resources={"cluster": cluster},
     )

--- a/dags/tests/test_property_definitions.py
+++ b/dags/tests/test_property_definitions.py
@@ -1,7 +1,114 @@
+import json
+import time
+from dataclasses import dataclass
+from datetime import timedelta
+from uuid import UUID
+
 import dagster
 
-from dags.property_definitions import PropertyDefinitionsConfig, property_definitions_ingestion_job
-from posthog.clickhouse.cluster import ClickhouseCluster
+from dags.property_definitions import (
+    DetectPropertyTypeExpression,
+    PropertyDefinitionsConfig,
+    property_definitions_ingestion_job,
+)
+from posthog.clickhouse.cluster import ClickhouseCluster, Query
+
+
+@dataclass
+class PropertyTypeTestData:
+    properties: str
+    expected: list[tuple[str, str | None]]
+
+
+def test_detect_property_type_expression(cluster: ClickhouseCluster) -> None:
+    cases = {
+        UUID(int=i): case
+        for i, case in enumerate(
+            [
+                PropertyTypeTestData("{}", []),
+                # special cases: key patterns
+                PropertyTypeTestData('{"utm_source": 123}', [("utm_source", "String")]),
+                PropertyTypeTestData('{"$feature/a": false}', [("$feature/a", "String")]),
+                PropertyTypeTestData(
+                    '{"$survey_response": 1, "$survey_response_2": 2}',
+                    [("$survey_response", "String"), ("$survey_response_2", "String")],
+                ),
+                # special cases: timestamp detection
+                PropertyTypeTestData(
+                    json.dumps({"timestamp": time.time()}),
+                    [("timestamp", "DateTime")],  # XXX: can't be parsed back out correctly!
+                ),
+                PropertyTypeTestData(json.dumps({"timestamp": int(time.time())}), [("timestamp", "DateTime")]),
+                PropertyTypeTestData(
+                    json.dumps({"timestamp": time.time() - timedelta(days=365).total_seconds()}),
+                    [("timestamp", "Numeric")],  # "too old"
+                ),
+                # special cases: string values
+                PropertyTypeTestData('{"a": "true"}', [("a", "Boolean")]),
+                PropertyTypeTestData('{"a": "TRUE"}', [("a", "Boolean")]),
+                PropertyTypeTestData('{"a": "false"}', [("a", "Boolean")]),
+                PropertyTypeTestData('{"a": "FALSE"}', [("a", "Boolean")]),
+                PropertyTypeTestData('{"a": " true "}', [("a", "Boolean")]),
+                PropertyTypeTestData(
+                    '{"a": "true\\n"}',
+                    [("a", "String")],  # XXX: inconsistent with existing implementation
+                ),
+                PropertyTypeTestData(  # weird formats clickhouse allows
+                    '{"a": "23:21:04", "b": "September", "c": "2024", "d": "1"}',
+                    [("a", "String"), ("b", "String"), ("c", "String"), ("d", "String")],
+                ),
+                PropertyTypeTestData('{"a": "2025-04-24"}', [("a", "DateTime")]),
+                PropertyTypeTestData('{"a": "04/24/2025"}', [("a", "DateTime")]),
+                PropertyTypeTestData(
+                    '{"a": "2025-04-24 23:21:04"}',  # ISO-8601, space separator, no tz
+                    [("a", "DateTime")],
+                ),
+                PropertyTypeTestData(
+                    '{"a": "2025-04-24T23:21:04+0000"}',  # ISO-8601, t separator, with tz
+                    [("a", "DateTime")],
+                ),
+                PropertyTypeTestData(
+                    '{"a": "2025-04-24T23:21:04+00:00"}',  # RFC 3339
+                    [("a", "DateTime")],
+                ),
+                PropertyTypeTestData(
+                    '{"a": "Thu, 24 Apr 2025 23:21:04 +0000"}',  # RFC 2822
+                    [("a", "DateTime")],
+                ),
+                PropertyTypeTestData(
+                    json.dumps({"a": str(time.time())}),
+                    [("a", "String")],  # skip timestamp-like formats
+                ),
+                PropertyTypeTestData(
+                    json.dumps({"a": str(int(time.time()))}),
+                    [("a", "String")],  # skip timestamp-like formats
+                ),
+                # primitive types
+                PropertyTypeTestData('{"a": true}', [("a", "Boolean")]),
+                PropertyTypeTestData('{"a": false}', [("a", "Boolean")]),
+                PropertyTypeTestData('{"a": 0}', [("a", "Numeric")]),
+                PropertyTypeTestData('{"a": 1}', [("a", "Numeric")]),
+                PropertyTypeTestData('{"a": -1}', [("a", "Numeric")]),
+                PropertyTypeTestData('{"a": 3.14}', [("a", "Numeric")]),
+                PropertyTypeTestData('{"a": "x"}', [("a", "String")]),
+                PropertyTypeTestData('{"a": [1,2,3]}', [("a", None)]),
+                PropertyTypeTestData('{"a": {"k": "v"}}', [("a", None)]),
+                PropertyTypeTestData('{"a": null}', [("a", None)]),
+            ]
+        )
+    }
+
+    cluster.any_host(
+        Query(
+            f"INSERT INTO writable_events (uuid, properties) VALUES",
+            [(uuid, case.properties) for uuid, case in cases.items()],
+        )
+    ).result()
+
+    results = cluster.any_host(Query(f"SELECT uuid, {DetectPropertyTypeExpression('properties')} FROM events")).result()
+    for uuid, actual in results:
+        case = cases[uuid]
+        assert actual == case.expected, f"expected {case.expected} for {case.properties}, got {actual}"
 
 
 def test_ingestion_job(cluster: ClickhouseCluster) -> None:

--- a/dags/tests/test_property_definitions.py
+++ b/dags/tests/test_property_definitions.py
@@ -1,0 +1,6 @@
+from dags.property_definitions import property_definitions_ingestion_job
+from posthog.clickhouse.cluster import ClickhouseCluster
+
+
+def test_ingestion_job(cluster: ClickhouseCluster) -> None:
+    property_definitions_ingestion_job.execute_in_process()

--- a/dags/tests/test_property_definitions.py
+++ b/dags/tests/test_property_definitions.py
@@ -128,6 +128,7 @@ def test_ingestion_job(cluster: ClickhouseCluster) -> None:
                         ("event", start_at - timedelta(minutes=30), {"too_old": "1"}),  # out of range (too old)
                         ("event", start_at, {"property": 1}),  # lower bound, should be included
                         ("a" * 201, start_at, {"event_name_too_long": 1}),  # event name too long, should be skipped
+                        ("event", start_at, {"p" * 201: 1}),  # property name too long, should be skipped
                         ("$$plugin_metrics", start_at, {"property": 1}),  # skipped event
                         (
                             "event",

--- a/dags/tests/test_property_definitions.py
+++ b/dags/tests/test_property_definitions.py
@@ -7,12 +7,6 @@ from posthog.clickhouse.cluster import ClickhouseCluster
 def test_ingestion_job(cluster: ClickhouseCluster) -> None:
     config = PropertyDefinitionsConfig(start_at="2025-05-07T00:00:00", duration="1 hour")
     property_definitions_ingestion_job.execute_in_process(
-        run_config=dagster.RunConfig(
-            {
-                "ingest_event_properties": config,
-                "ingest_person_properties": config,
-                "optimize_property_definitions": config,
-            }
-        ),
+        run_config=dagster.RunConfig({"setup_job": config}),
         resources={"cluster": cluster},
     )

--- a/dags/tests/test_property_definitions.py
+++ b/dags/tests/test_property_definitions.py
@@ -147,6 +147,8 @@ def test_ingestion_job(cluster: ClickhouseCluster) -> None:
         )
     ).result()
 
+    # TODO: insert person test data
+
     # run job
     config = PropertyDefinitionsConfig(
         start_at=start_at.isoformat(),

--- a/dags/tests/test_property_definitions.py
+++ b/dags/tests/test_property_definitions.py
@@ -125,11 +125,11 @@ def test_ingestion_job(cluster: ClickhouseCluster) -> None:
                 (UUID(int=i), 1, "event", timestamp, json.dumps(properties))
                 for i, (timestamp, properties) in enumerate(
                     [
-                        (start_at - timedelta(minutes=30), {"property": "1"}),
-                        (start_at, {"property": 1}),
-                        (start_at + duration / 2, {"property": 1}),
-                        (start_at + duration, {"property": 1}),
-                        (start_at + duration + timedelta(minutes=30), {"property": 1}),
+                        (start_at - timedelta(minutes=30), {"too_old": "1"}),  # out of range (too old)
+                        (start_at, {"property": 1}),  # lower bound, should be inclkuded
+                        (start_at + duration / 2, {"property": 1}),  # midpoint
+                        (start_at + duration, {"too_new": 1}),  # upper bound, should be excluded
+                        (start_at + duration + timedelta(minutes=30), {"too_new": 1}),  # out of range (too new)
                     ]
                 )
             ],
@@ -157,6 +157,6 @@ def test_ingestion_job(cluster: ClickhouseCluster) -> None:
         ),
     ).result() == sorted(
         [
-            (1, 1, "property", "Numeric", "event", None, int(PropertyDefinition.Type.EVENT), start_at + duration),
+            (1, 1, "property", "Numeric", "event", None, int(PropertyDefinition.Type.EVENT), start_at + duration / 2),
         ]
     )

--- a/dags/tests/test_property_definitions.py
+++ b/dags/tests/test_property_definitions.py
@@ -132,9 +132,14 @@ def test_ingestion_job(cluster: ClickhouseCluster) -> None:
                         ("$$plugin_metrics", start_at, {"property": 1}),  # skipped event
                         (
                             "event",
-                            start_at + duration / 2,  # midpoint
+                            start_at + duration * 0.5,  # midpoint
                             {"property": 1, "$set": {}},  # includes skipped property
                         ),
+                        (
+                            "event",
+                            start_at + duration / 0.75,
+                            {"property": None},
+                        ),  # prior updates with detected types should take precedence
                         ("event", start_at + duration, {"too_new": 1}),  # upper bound, should be excluded
                         (
                             "event",

--- a/dags/tests/test_property_definitions.py
+++ b/dags/tests/test_property_definitions.py
@@ -128,6 +128,7 @@ def test_ingestion_job(cluster: ClickhouseCluster) -> None:
                         ("event", start_at - timedelta(minutes=30), {"too_old": "1"}),  # out of range (too old)
                         ("event", start_at, {"property": 1}),  # lower bound, should be included
                         ("a" * 201, start_at, {"event_name_too_long": 1}),  # event name too long, should be skipped
+                        ("\u0000", start_at, {"property": 1}),  # null byte should be sanitized
                         ("event", start_at, {"p" * 201: 1}),  # property name too long, should be skipped
                         ("$$plugin_metrics", start_at, {"property": 1}),  # skipped event
                         (
@@ -228,6 +229,7 @@ def test_ingestion_job(cluster: ClickhouseCluster) -> None:
         ),
     ).result() == [
         (1, 1, "property", "Numeric", "event", None, int(PropertyDefinition.Type.EVENT), start_at + duration / 2),
+        (1, 1, "property", "Numeric", "\ufffd", None, int(PropertyDefinition.Type.EVENT), start_at),
         (1, 1, "property", "Numeric", None, 1, int(PropertyDefinition.Type.GROUP), start_at + duration / 2),
         (1, 1, "property", "Numeric", None, 2, int(PropertyDefinition.Type.GROUP), start_at),
         (1, 1, "property", "Numeric", None, None, int(PropertyDefinition.Type.PERSON), start_at + duration / 2),

--- a/dags/tests/test_property_definitions.py
+++ b/dags/tests/test_property_definitions.py
@@ -152,7 +152,31 @@ def test_ingestion_job(cluster: ClickhouseCluster) -> None:
         )
     ).result()
 
-    # TODO: insert person test data
+    cluster.any_host(
+        Query(
+            f"INSERT INTO person (team_id, id, _timestamp, properties) VALUES",
+            [
+                (1, UUID(int=i), timestamp, json.dumps(properties))
+                for i, (timestamp, properties) in enumerate(
+                    [
+                        (start_at - timedelta(minutes=30), {"too_old": "1"}),  # out of range (too old)
+                        (start_at, {"property": 1}),  # lower bound, should be included
+                        (start_at, {"p" * 201: 1}),  # property name too long, should be skipped
+                        (
+                            start_at + duration * 0.5,  # midpoint
+                            {"property": 1},  # includes skipped property
+                        ),
+                        (
+                            start_at + duration / 0.75,
+                            {"property": None},
+                        ),  # prior updates with detected types should take precedence
+                        (start_at + duration, {"too_new": 1}),  # upper bound, should be excluded
+                        (start_at + duration + timedelta(minutes=30), {"too_new": 1}),  # out of range (too new)
+                    ]
+                )
+            ],
+        )
+    ).result()
 
     # run job
     config = PropertyDefinitionsConfig(
@@ -173,8 +197,7 @@ def test_ingestion_job(cluster: ClickhouseCluster) -> None:
             ORDER BY ALL
             """
         ),
-    ).result() == sorted(
-        [
-            (1, 1, "property", "Numeric", "event", None, int(PropertyDefinition.Type.EVENT), start_at + duration / 2),
-        ]
-    )
+    ).result() == [
+        (1, 1, "property", "Numeric", "event", None, int(PropertyDefinition.Type.EVENT), start_at + duration / 2),
+        (1, 1, "property", "Numeric", None, None, int(PropertyDefinition.Type.PERSON), start_at + duration / 2),
+    ]

--- a/dags/tests/test_property_definitions.py
+++ b/dags/tests/test_property_definitions.py
@@ -127,6 +127,7 @@ def test_ingestion_job(cluster: ClickhouseCluster) -> None:
                     [
                         ("event", start_at - timedelta(minutes=30), {"too_old": "1"}),  # out of range (too old)
                         ("event", start_at, {"property": 1}),  # lower bound, should be included
+                        ("a" * 201, start_at, {"event_name_too_long": 1}),  # event name too long, should be skipped
                         ("$$plugin_metrics", start_at, {"property": 1}),  # skipped event
                         (
                             "event",

--- a/dags/tests/test_property_definitions.py
+++ b/dags/tests/test_property_definitions.py
@@ -182,22 +182,25 @@ def test_ingestion_job(cluster: ClickhouseCluster) -> None:
         Query(
             f"INSERT INTO groups (team_id, group_key, group_type_index, _timestamp, group_properties) VALUES",
             [
-                (1, UUID(int=i).hex, 1, timestamp, json.dumps(properties))
-                for i, (timestamp, properties) in enumerate(
+                (1, UUID(int=i).hex, group_type_index, timestamp, json.dumps(properties))
+                for i, (group_type_index, timestamp, properties) in enumerate(
                     [
-                        (start_at - timedelta(minutes=30), {"too_old": "1"}),  # out of range (too old)
-                        (start_at, {"property": 1}),  # lower bound, should be included
-                        (start_at, {"p" * 201: 1}),  # property name too long, should be skipped
+                        (1, start_at - timedelta(minutes=30), {"too_old": "1"}),  # out of range (too old)
+                        (1, start_at, {"property": 1}),  # lower bound, should be included
+                        (1, start_at, {"p" * 201: 1}),  # property name too long, should be skipped
                         (
+                            1,
                             start_at + duration * 0.5,  # midpoint
                             {"property": 1},  # includes skipped property
                         ),
                         (
+                            1,
                             start_at + duration / 0.75,
                             {"property": None},
                         ),  # prior updates with detected types should take precedence
-                        (start_at + duration, {"too_new": 1}),  # upper bound, should be excluded
-                        (start_at + duration + timedelta(minutes=30), {"too_new": 1}),  # out of range (too new)
+                        (1, start_at + duration, {"too_new": 1}),  # upper bound, should be excluded
+                        (1, start_at + duration + timedelta(minutes=30), {"too_new": 1}),  # out of range (too new)
+                        (2, start_at, {"property": 1}),  # lower bound, should be included
                     ]
                 )
             ],
@@ -226,5 +229,6 @@ def test_ingestion_job(cluster: ClickhouseCluster) -> None:
     ).result() == [
         (1, 1, "property", "Numeric", "event", None, int(PropertyDefinition.Type.EVENT), start_at + duration / 2),
         (1, 1, "property", "Numeric", None, 1, int(PropertyDefinition.Type.GROUP), start_at + duration / 2),
+        (1, 1, "property", "Numeric", None, 2, int(PropertyDefinition.Type.GROUP), start_at),
         (1, 1, "property", "Numeric", None, None, int(PropertyDefinition.Type.PERSON), start_at + duration / 2),
     ]

--- a/posthog/clickhouse/migrations/0111_property_definitions_table.py
+++ b/posthog/clickhouse/migrations/0111_property_definitions_table.py
@@ -1,35 +1,8 @@
-from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
 from posthog.clickhouse.client.connection import NodeRole
-from posthog.settings.data_stores import POSTHOG_MIGRATION_CLUSTER
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.models.property_definition import PROPERTY_DEFINITIONS_TABLE_SQL
 
-PROPERTY_DEFINITIONS_TABLE_SQL = f"""
-CREATE TABLE property_definitions
-(
-    -- Team and project relationships
-    team_id UInt32,
-    project_id UInt32 NULL,
-
-    -- Core property fields
-    name String,
-    property_type String NULL,
-    event String NULL, -- Only null for non-event types
-    group_type_index UInt8 NULL,
-
-    -- Type enum (1=event, 2=person, 3=group, 4=session)
-    type UInt8 DEFAULT 1,
-
-    -- Metadata
-    last_seen_at DateTime,
-
-    -- A composite version number that prioritizes property_type presence over timestamp
-    -- We negate isNull() so rows WITH property_type get higher preference
-    version UInt64 MATERIALIZED (bitShiftLeft(toUInt64(NOT isNull(property_type)), 48) + toUInt64(toUnixTimestamp(last_seen_at)))
-)
-ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/posthog_migrations.property_definitions', '{{replica}}-{{shard}}', version)
-ORDER BY (team_id, type, COALESCE(event, ''), name, COALESCE(group_type_index, 255))
-SETTINGS index_granularity = 8192
-"""
 
 operations = [
-    run_sql_with_exceptions(PROPERTY_DEFINITIONS_TABLE_SQL, node_role=NodeRole.ALL),
+    run_sql_with_exceptions(PROPERTY_DEFINITIONS_TABLE_SQL, node_role=NodeRole.ALL),  # TODO: check me
 ]

--- a/posthog/clickhouse/migrations/0111_property_definitions_table.py
+++ b/posthog/clickhouse/migrations/0111_property_definitions_table.py
@@ -4,5 +4,5 @@ from posthog.models.property_definition import PROPERTY_DEFINITIONS_TABLE_SQL
 
 
 operations = [
-    run_sql_with_exceptions(PROPERTY_DEFINITIONS_TABLE_SQL, node_role=NodeRole.ALL),  # TODO: check me
+    run_sql_with_exceptions(PROPERTY_DEFINITIONS_TABLE_SQL(), node_role=NodeRole.ALL),  # TODO: check me
 ]

--- a/posthog/clickhouse/migrations/0111_property_definitions_table.py
+++ b/posthog/clickhouse/migrations/0111_property_definitions_table.py
@@ -4,5 +4,5 @@ from posthog.models.property_definition import PROPERTY_DEFINITIONS_TABLE_SQL
 
 
 operations = [
-    run_sql_with_exceptions(PROPERTY_DEFINITIONS_TABLE_SQL(), node_role=NodeRole.ALL),  # TODO: check me
+    run_sql_with_exceptions(PROPERTY_DEFINITIONS_TABLE_SQL(), node_role=NodeRole.ALL),
 ]

--- a/posthog/models/property_definition.py
+++ b/posthog/models/property_definition.py
@@ -133,7 +133,8 @@ class PropertyDefinition(UUIDModel):
 
 # ClickHouse Table DDL
 
-PROPERTY_DEFINITIONS_TABLE_SQL = f"""
+PROPERTY_DEFINITIONS_TABLE_SQL = (
+    lambda: f"""
 CREATE TABLE IF NOT EXISTS `{CLICKHOUSE_DATABASE}`.`property_definitions`
 (
     -- Team and project relationships
@@ -160,5 +161,6 @@ ENGINE = {ReplacingMergeTree("property_definitions", replication_scheme=Replicat
 ORDER BY (team_id, type, COALESCE(event, ''), name, COALESCE(group_type_index, 255))
 SETTINGS index_granularity = 8192
 """
+)
 
-DROP_PROPERTY_DEFINITIONS_TABLE_SQL = "DROP TABLE IF EXISTS `{CLICKHOUSE_DATABASE}`.`property_definitions`"
+DROP_PROPERTY_DEFINITIONS_TABLE_SQL = lambda: f"DROP TABLE IF EXISTS `{CLICKHOUSE_DATABASE}`.`property_definitions`"

--- a/posthog/models/property_definition.py
+++ b/posthog/models/property_definition.py
@@ -3,8 +3,10 @@ from django.db import models
 from django.db.models.expressions import F
 from django.db.models.functions import Coalesce
 
+from posthog.clickhouse.table_engines import ReplacingMergeTree, ReplicationScheme
 from posthog.models.team import Team
 from posthog.models.utils import UniqueConstraintByExpression, UUIDModel
+from posthog.settings.data_stores import CLICKHOUSE_DATABASE
 
 
 class PropertyType(models.TextChoices):
@@ -127,3 +129,36 @@ class PropertyDefinition(UUIDModel):
     # This is a dynamically calculated field in api/property_definition.py. Defaults to `True` here to help serializers.
     def is_seen_on_filtered_events(self) -> None:
         return None
+
+
+# ClickHouse Table DDL
+
+PROPERTY_DEFINITIONS_TABLE_SQL = f"""
+CREATE TABLE IF NOT EXISTS `{CLICKHOUSE_DATABASE}`.`property_definitions`
+(
+    -- Team and project relationships
+    team_id UInt32,
+    project_id UInt32 NULL,
+
+    -- Core property fields
+    name String,
+    property_type String NULL,
+    event String NULL, -- Only null for non-event types
+    group_type_index UInt8 NULL,
+
+    -- Type enum (1=event, 2=person, 3=group, 4=session)
+    type UInt8 DEFAULT 1,
+
+    -- Metadata
+    last_seen_at DateTime,
+
+    -- A composite version number that prioritizes property_type presence over timestamp
+    -- We negate isNull() so rows WITH property_type get higher preference
+    version UInt64 MATERIALIZED (bitShiftLeft(toUInt64(NOT isNull(property_type)), 48) + toUInt64(toUnixTimestamp(last_seen_at)))
+)
+ENGINE = {ReplacingMergeTree("property_definitions", replication_scheme=ReplicationScheme.REPLICATED, ver="version")}
+ORDER BY (team_id, type, COALESCE(event, ''), name, COALESCE(group_type_index, 255))
+SETTINGS index_granularity = 8192
+"""
+
+DROP_PROPERTY_DEFINITIONS_TABLE_SQL = "DROP TABLE IF EXISTS `{CLICKHOUSE_DATABASE}`.`property_definitions`"

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -63,6 +63,10 @@ from posthog.models.person.sql import (
 )
 from posthog.models.person.util import bulk_create_persons, create_person
 from posthog.models.project import Project
+from posthog.models.property_definition import (
+    DROP_PROPERTY_DEFINITIONS_TABLE_SQL,
+    PROPERTY_DEFINITIONS_TABLE_SQL,
+)
 from posthog.models.sessions.sql import (
     DISTRIBUTED_SESSIONS_TABLE_SQL,
     DROP_SESSION_MATERIALIZED_VIEW_SQL,
@@ -1074,6 +1078,7 @@ def reset_clickhouse_database() -> None:
             DROP_DISTRIBUTED_EVENTS_TABLE_SQL,
             DROP_EVENTS_TABLE_SQL(),
             DROP_PERSON_TABLE_SQL,
+            DROP_PROPERTY_DEFINITIONS_TABLE_SQL,
             DROP_RAW_SESSION_TABLE_SQL(),
             DROP_SESSION_RECORDING_EVENTS_TABLE_SQL(),
             DROP_SESSION_REPLAY_EVENTS_TABLE_SQL(),
@@ -1094,6 +1099,7 @@ def reset_clickhouse_database() -> None:
             EXCHANGE_RATE_TABLE_SQL(),
             EVENTS_TABLE_SQL(),
             PERSONS_TABLE_SQL(),
+            PROPERTY_DEFINITIONS_TABLE_SQL,
             RAW_SESSIONS_TABLE_SQL(),
             SESSIONS_TABLE_SQL(),
             SESSION_RECORDING_EVENTS_TABLE_SQL(),

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -47,6 +47,7 @@ from posthog.models.event.sql import (
     DROP_EVENTS_TABLE_SQL,
     DROP_DISTRIBUTED_EVENTS_TABLE_SQL,
     EVENTS_TABLE_SQL,
+    TRUNCATE_EVENTS_RECENT_TABLE_SQL,
 )
 from posthog.models.event.util import bulk_create_events
 from posthog.models.group.sql import TRUNCATE_GROUPS_TABLE_SQL
@@ -1078,13 +1079,14 @@ def reset_clickhouse_database() -> None:
             DROP_DISTRIBUTED_EVENTS_TABLE_SQL,
             DROP_EVENTS_TABLE_SQL(),
             DROP_PERSON_TABLE_SQL,
-            DROP_PROPERTY_DEFINITIONS_TABLE_SQL,
+            DROP_PROPERTY_DEFINITIONS_TABLE_SQL(),
             DROP_RAW_SESSION_TABLE_SQL(),
             DROP_SESSION_RECORDING_EVENTS_TABLE_SQL(),
             DROP_SESSION_REPLAY_EVENTS_TABLE_SQL(),
             DROP_SESSION_REPLAY_EVENTS_V2_TEST_TABLE_SQL(),
             DROP_SESSION_TABLE_SQL(),
             TRUNCATE_COHORTPEOPLE_TABLE_SQL,
+            TRUNCATE_EVENTS_RECENT_TABLE_SQL(),
             TRUNCATE_GROUPS_TABLE_SQL,
             TRUNCATE_PERSON_DISTINCT_ID2_TABLE_SQL,
             TRUNCATE_PERSON_DISTINCT_ID_OVERRIDES_TABLE_SQL,
@@ -1099,7 +1101,7 @@ def reset_clickhouse_database() -> None:
             EXCHANGE_RATE_TABLE_SQL(),
             EVENTS_TABLE_SQL(),
             PERSONS_TABLE_SQL(),
-            PROPERTY_DEFINITIONS_TABLE_SQL,
+            PROPERTY_DEFINITIONS_TABLE_SQL(),
             RAW_SESSIONS_TABLE_SQL(),
             SESSIONS_TABLE_SQL(),
             SESSION_RECORDING_EVENTS_TABLE_SQL(),


### PR DESCRIPTION
## Problem

Extends #30807 with fixes, improvements, and adds some missing functionality.

## Changes

- Cleans up job configuration so that it only is defined in run configuration once, consolidates methods of specifying time range bounds, uses ClickHouse functions for more flexible format parsing, changes from fully open time interval to half-open
- Switches queries to `ClickhouseCluster` as it provides default retry policy, consistent configuration, and simplifies test integration
- Aligns property type detection and filtering with [existing implementation](https://github.com/PostHog/posthog/blob/master/rust/property-defs-rs/src/types.rs) and adds unit tests
- Adds group property type ingestion
- Adds end to end test for job, updates migrations to support test setup and teardown

## Does this work well for both Cloud and self-hosted?

Yes, currently off any critical paths

## How did you test this code?

Added them