### PR TITLE
fix(messaging): backwards compat for setting up email integration with mailjet creds

### DIFF
--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -53,14 +53,16 @@ class IntegrationSerializer(serializers.ModelSerializer):
         elif validated_data["kind"] == "email":
             config = validated_data.get("config", {})
 
-            if config.get("vendor") == "mailjet" and not (config.get("api_key") and config.get("secret_key")):
-                raise ValidationError("Both api_key and secret_key are required for Mail integration")
-            instance = EmailIntegration.integration_from_keys(
-                config["api_key"],
-                config["secret_key"],
-                team_id,
-                request.user,
-            )
+            if config.get("vendor") == "mailjet":
+                if not (config.get("api_key") and config.get("secret_key")):
+                    raise ValidationError("Both api_key and secret_key are required for Mail integration")
+                instance = EmailIntegration.integration_from_keys(
+                    config["api_key"],
+                    config["secret_key"],
+                    team_id,
+                    request.user,
+                )
+                return instance
 
             if not (config.get("domain")):
                 raise ValidationError("Domain is required for email integration")

--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -52,6 +52,16 @@ class IntegrationSerializer(serializers.ModelSerializer):
 
         elif validated_data["kind"] == "email":
             config = validated_data.get("config", {})
+
+            if config.get("vendor") == "mailjet" and not (config.get("api_key") and config.get("secret_key")):
+                raise ValidationError("Both api_key and secret_key are required for Mail integration")
+            instance = EmailIntegration.integration_from_keys(
+                config["api_key"],
+                config["secret_key"],
+                team_id,
+                request.user,
+            )
+
             if not (config.get("domain")):
                 raise ValidationError("Domain is required for email integration")
             instance = EmailIntegration.integration_from_domain(

--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -53,7 +53,7 @@ class IntegrationSerializer(serializers.ModelSerializer):
         elif validated_data["kind"] == "email":
             config = validated_data.get("config", {})
 
-            if config.get("vendor") == "mailjet":
+            if config.get("api_key") is not None:
                 if not (config.get("api_key") and config.get("secret_key")):
                     raise ValidationError("Both api_key and secret_key are required for Mail integration")
                 instance = EmailIntegration.integration_from_keys(

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -830,6 +830,31 @@ class EmailIntegration:
 
         return integration
 
+    @classmethod
+    def integration_from_keys(
+        cls, api_key: str, secret_key: str, team_id: int, created_by: Optional[User] = None
+    ) -> Integration:
+        integration, created = Integration.objects.update_or_create(
+            team_id=team_id,
+            kind="email",
+            integration_id=api_key,
+            defaults={
+                "config": {
+                    "api_key": api_key,
+                    "vendor": "mailjet",
+                },
+                "sensitive_config": {
+                    "secret_key": secret_key,
+                },
+                "created_by": created_by,
+            },
+        )
+        if integration.errors:
+            integration.errors = ""
+            integration.save()
+
+        return integration
+
     def verify(self):
         domain = self.integration.config.get("domain")
 


### PR DESCRIPTION



## Problem

Adding back a bit of code around email integration setup that was removed from https://github.com/PostHog/posthog/pull/31543

This needs to stay in place just until https://github.com/PostHog/posthog/pull/31936 and https://github.com/PostHog/posthog/pull/31935 land

## Changes

No changes just backwards compat via the integrations API

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Verified cred-based integration setup works
