### PR TITLE
chore: Exclude migrations check from probes for web and workers

### DIFF
--- a/posthog/health.py
+++ b/posthog/health.py
@@ -43,7 +43,8 @@ service_dependencies: dict[ServiceRole, list[str]] = {
         # NOTE: we include Postgres because the way we use django means every request hits the DB
         # https://posthog.slack.com/archives/C02E3BKC78F/p1679669676438729
         "postgres",
-        "postgres_migrations_uptodate",
+        # NOTE: migrations run in a separate job before the version is even deployed. This check is unnecessary
+        # "postgres_migrations_uptodate",
         "cache",
         # NOTE: we do not include clickhouse for web, as even without clickhouse we
         # want to be able to display something to the user.
@@ -58,7 +59,8 @@ service_dependencies: dict[ServiceRole, list[str]] = {
     "worker": [
         "http",
         "postgres",
-        "postgres_migrations_uptodate",
+        # NOTE: migrations run in a separate job before the version is even deployed. This check is unnecessary
+        # "postgres_migrations_uptodate",
         "clickhouse",
         "celery_broker",
     ],


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We check in every readiness and startup probe if the migrations were run. This is unnecessary as we have a central job in kubernetes that handles that for us via argoCD and sync hooks. 

## Changes

Exclude `postgres_migrations_uptodate` from probes for `web` and `worker` role

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
