### PR TITLE
revert: remove group analytics from usage and spend

### DIFF
--- a/frontend/src/scenes/billing/BillingEarlyAccessBanner.tsx
+++ b/frontend/src/scenes/billing/BillingEarlyAccessBanner.tsx
@@ -36,7 +36,7 @@ export function BillingEarlyAccessBanner(): JSX.Element {
                     <ul className="list-disc list-inside pl-2">
                         <li>Usage data updates daily (UTC) - so today's numbers show up tomorrow</li>
                         <li>
-                            Some product add-ons (like data pipelines) aren't in here{' '}
+                            Some product add-ons (like group analytics and data pipelines) aren't in here{' '}
                             <span className="italic">yet</span>
                         </li>
                     </ul>

--- a/frontend/src/scenes/billing/BillingEarlyAccessBanner.tsx
+++ b/frontend/src/scenes/billing/BillingEarlyAccessBanner.tsx
@@ -36,8 +36,8 @@ export function BillingEarlyAccessBanner(): JSX.Element {
                     <ul className="list-disc list-inside pl-2">
                         <li>Usage data updates daily (UTC) - so today's numbers show up tomorrow</li>
                         <li>
-                            Some product add-ons (like group analytics and data pipelines) aren't in here{' '}
-                            <span className="italic">yet</span>
+                            Some product add-ons (like group analytics and data pipelines) and deleted projects aren't
+                            in here <span className="italic">yet</span>
                         </li>
                     </ul>
                 </div>

--- a/frontend/src/scenes/billing/constants.ts
+++ b/frontend/src/scenes/billing/constants.ts
@@ -7,7 +7,6 @@ export const USAGE_TYPES = [
     { label: 'Rows Synced', value: 'rows_synced_in_period' },
     { label: 'Persons', value: 'enhanced_persons_event_count_in_period' },
     { label: 'Survey Responses', value: 'survey_responses_count_in_period' },
-    { label: 'Group Analytics', value: 'event_count_with_groups_in_period' },
 ] as const
 
 export type UsageTypeOption = (typeof USAGE_TYPES)[number]


### PR DESCRIPTION
## Problem

Turns out that group analytics uses the same usage key in `report` as identified events (same as data pipelines using anonymous events key) so it also doesn't work properly with existing logic.

## Changes

- Remove `group_analytics` from usage and spend dashboards
- (unrelated) Added disclaimer about deleted projects not being included in the data

## Does this work well for both Cloud and self-hosted?

Cloud only

## How did you test this code?

n/a
