### PR TITLE
fix: remove person join from funnel breakdowns

### DIFF
--- a/posthog/hogql_queries/insights/funnels/base.py
+++ b/posthog/hogql_queries/insights/funnels/base.py
@@ -559,7 +559,7 @@ class FunnelBase(ABC):
 
         for cohort in self.breakdown_cohorts:
             query = parse_select(
-                f"select id as cohort_person_id, {cohort.pk} as value from cohort_people where person_id in cohort {cohort.pk}"
+                f"select person_id as cohort_person_id, {cohort.pk} as value from cohort_people where person_id in cohort {cohort.pk}"
             )
             assert isinstance(query, ast.SelectQuery)
             cohort_queries.append(query)

--- a/posthog/hogql_queries/insights/funnels/base.py
+++ b/posthog/hogql_queries/insights/funnels/base.py
@@ -559,7 +559,7 @@ class FunnelBase(ABC):
 
         for cohort in self.breakdown_cohorts:
             query = parse_select(
-                f"select id as cohort_person_id, {cohort.pk} as value from persons where id in cohort {cohort.pk}"
+                f"select id as cohort_person_id, {cohort.pk} as value from cohort_people where person_id in cohort {cohort.pk}"
             )
             assert isinstance(query, ast.SelectQuery)
             cohort_queries.append(query)


### PR DESCRIPTION
## Problem
We're requiring a person join in funnel breakdowns, but not in normal filters. This makes unidentified people not show up in the funnel.

## Changes
Remove this join

## How did you test this code?
Looked at the queries, ran tests.
