### PR TITLE
fix(capture-rs): quiet chatty error log on hot path

### DIFF
--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -34,7 +34,7 @@ pub const MAX_PAYLOAD_SNIPPET_SIZE: usize = 20;
 pub const FORM_MIME_TYPE: &str = "application/x-www-form-urlencoded";
 
 #[derive(PartialEq, Eq)]
-enum Base64Option {
+pub enum Base64Option {
     // hasn't been decoded from urlencoded payload; won't include spaces
     Strict,
     // input might have been urlencoded; might include spaces that need touching up
@@ -322,7 +322,7 @@ fn is_likely_urlencoded_form(payload: &[u8]) -> bool {
 
 // relatively cheap check for base64 encoded payload since these can show up at
 // various decoding layers in requests from different PostHog SDKs and versions
-fn is_likely_base64(payload: &[u8], opt: Base64Option) -> bool {
+pub fn is_likely_base64(payload: &[u8], opt: Base64Option) -> bool {
     if payload.is_empty() {
         return false;
     }
@@ -342,7 +342,7 @@ fn is_likely_base64(payload: &[u8], opt: Base64Option) -> bool {
     prefix_chars_b64_compatible && is_b64_aligned
 }
 
-fn decode_base64(payload: &[u8], location: &str) -> Result<Vec<u8>, CaptureError> {
+pub fn decode_base64(payload: &[u8], location: &str) -> Result<Vec<u8>, CaptureError> {
     match base64::engine::general_purpose::STANDARD.decode(payload) {
         Ok(decoded_payload) => Ok(decoded_payload),
         Err(e) => {

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -189,8 +189,8 @@ impl RawRequest {
 
             let s = String::from_utf8(bytes.into()).map_err(|e| {
                 error!(
-                    "from_bytes: failed to convert request payload to UTF8: {:?}",
-                    e
+                    valid_up_to = &e.utf8_error().valid_up_to(),
+                    "from_bytes: failed to convert request payload to UTF8: {}", e
                 );
                 CaptureError::RequestDecodingError(String::from("invalid UTF8 in request payload"))
             })?;

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -10,8 +10,10 @@ use time::OffsetDateTime;
 use tracing::{debug, error, instrument, warn, Span};
 
 use crate::{
-    api::CaptureError, prometheus::report_dropped_events, token::validate_token,
-    v0_endpoint::MAX_PAYLOAD_SNIPPET_SIZE,
+    api::CaptureError,
+    prometheus::report_dropped_events,
+    token::validate_token,
+    v0_endpoint::{decode_base64, is_likely_base64, Base64Option, MAX_PAYLOAD_SNIPPET_SIZE},
 };
 
 #[derive(Deserialize, Default, Clone, Copy, PartialEq, Eq)]
@@ -121,7 +123,7 @@ impl RawRequest {
             warn!(len = bytes.len(), "from_bytes: decoding new event");
         }
 
-        let payload = if (is_mirror_deploy && cmp_hint == Compression::Gzip)
+        let mut payload = if (is_mirror_deploy && cmp_hint == Compression::Gzip)
             || bytes.starts_with(&GZIP_MAGIC_NUMBERS)
         {
             let len = bytes.len();
@@ -204,6 +206,29 @@ impl RawRequest {
             }
             s
         };
+
+        if is_mirror_deploy {
+            if is_likely_base64(payload.as_bytes(), Base64Option::Strict) {
+                warn!("from_bytes: payload still base64 after decoding step");
+                payload = match decode_base64(payload.as_bytes(), "from_bytes_after_decoding") {
+                    Ok(out) => {
+                        match String::from_utf8(out) {
+                            Ok(unwrapped_payload) => unwrapped_payload,
+                            Err(e) => {
+                                error!("from_bytes: failed UTF8 conversion after post-decode base64: {}", e);
+                                payload
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        error!("from_bytes: failed post-decode base64 unwrap: {}", e);
+                        payload
+                    }
+                }
+            } else {
+                warn!("from_bytes: payload may be LZ64 or other after decoding step");
+            }
+        }
 
         if is_mirror_deploy {
             let truncate_at: usize = payload


### PR DESCRIPTION
## Problem
Debug `{:?}` logging of UTF8 conversion errors is chattier than I hoped, and is sometimes exposed in the hot path in `capture-rs` 

## Changes
* Just log the error and where in the buffer it hit decoding trouble.
* Adds exploratory check (mirror codepath only) for additional post-decode base64 unwrap, looking to map an error I'm seeing to one of the `capture.py` "kludge warnings" 

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally + CI; soon, mirror deploy test