### PR TITLE
feat(capture-rs): refactor utils; defensive payload size check in post-decode b64 codepath

### DIFF
--- a/rust/capture/src/utils.rs
+++ b/rust/capture/src/utils.rs
@@ -1,6 +1,27 @@
+use axum::http::HeaderMap;
+use base64::Engine;
 use rand::RngCore;
+use tracing::error;
 use uuid::Uuid;
 
+use crate::{
+    api::CaptureError,
+    v0_request::{Compression, EventFormData, EventQuery},
+};
+
+// used to limit test scans and extract loggable snippets from potentially large strings/buffers
+pub const MAX_CHARS_TO_CHECK: usize = 128;
+pub const MAX_PAYLOAD_SNIPPET_SIZE: usize = 20;
+
+pub const FORM_MIME_TYPE: &str = "application/x-www-form-urlencoded";
+
+#[derive(PartialEq, Eq)]
+pub enum Base64Option {
+    // hasn't been decoded from urlencoded payload; won't include spaces
+    Strict,
+    // input might have been urlencoded; might include spaces that need touching up
+    Loose,
+}
 pub fn random_bytes<const N: usize>() -> [u8; N] {
     let mut ret = [0u8; N];
     rand::thread_rng().fill_bytes(&mut ret);
@@ -35,4 +56,118 @@ pub fn uuid_v7() -> Uuid {
     let now_millis: u64 = now.unix_timestamp() as u64 * 1_000 + now.millisecond() as u64;
 
     encode_unix_timestamp_millis(now_millis, &bytes)
+}
+
+pub fn extract_lib_version(form: &EventFormData, params: &EventQuery) -> Option<String> {
+    let form_lv = form.lib_version.as_ref();
+    let params_lv = params.lib_version.as_ref();
+    if form_lv.is_some_and(|lv| !lv.is_empty()) {
+        return Some(form_lv.unwrap().clone());
+    }
+    if params_lv.is_some_and(|lv| !lv.is_empty()) {
+        return Some(params_lv.unwrap().clone());
+    }
+
+    None
+}
+
+// the compression hint can be tucked away any number of places depending on the SDK submitting the request...
+pub fn extract_compression(
+    form: &EventFormData,
+    params: &EventQuery,
+    headers: &HeaderMap,
+) -> Compression {
+    if params
+        .compression
+        .is_some_and(|c| c != Compression::Unsupported)
+    {
+        params.compression.unwrap()
+    } else if form
+        .compression
+        .is_some_and(|c| c != Compression::Unsupported)
+    {
+        form.compression.unwrap()
+    } else if let Some(ct) = headers.get("content-encoding") {
+        match ct.to_str().unwrap_or("UNKNOWN") {
+            "gzip" | "gzip-js" => Compression::Gzip,
+            "lz64" | "lz-string" => Compression::LZString,
+            _ => Compression::Unsupported,
+        }
+    } else {
+        Compression::Unsupported
+    }
+}
+
+pub fn decode_form(payload: &[u8]) -> Result<EventFormData, CaptureError> {
+    match serde_urlencoded::from_bytes::<EventFormData>(payload) {
+        Ok(form) => Ok(form),
+
+        Err(e) => {
+            let max_chars: usize = std::cmp::min(payload.len(), MAX_PAYLOAD_SNIPPET_SIZE);
+            let form_data_snippet = String::from_utf8(payload[..max_chars].to_vec())
+                .unwrap_or(String::from("INVALID_UTF8"));
+            error!(
+                form_data = form_data_snippet,
+                "failed to decode urlencoded form body: {}", e
+            );
+            Err(CaptureError::RequestDecodingError(String::from(
+                "invalid urlencoded form data",
+            )))
+        }
+    }
+}
+
+// have we decoded sufficiently have a urlencoded data payload of the expected form yet?
+pub fn is_likely_urlencoded_form(payload: &[u8]) -> bool {
+    [
+        &b"data="[..],
+        &b"ver="[..],
+        &b"_="[..],
+        &b"ip="[..],
+        &b"compression="[..],
+    ]
+    .iter()
+    .any(|target: &&[u8]| payload.starts_with(target))
+}
+
+// relatively cheap check for base64 encoded payload since these can show up at
+// various decoding layers in requests from different PostHog SDKs and versions
+pub fn is_likely_base64(payload: &[u8], opt: Base64Option) -> bool {
+    if payload.is_empty() {
+        return false;
+    }
+
+    let prefix_chars_b64_compatible = payload.iter().take(MAX_CHARS_TO_CHECK).all(|b| {
+        (*b >= b'A' && *b <= b'Z')
+            || (*b >= b'a' && *b <= b'z')
+            || (*b >= b'0' && *b <= b'9')
+            || *b == b'+'
+            || *b == b'/'
+            || *b == b'='
+            || (opt == Base64Option::Loose && *b == b' ')
+    });
+
+    let is_b64_aligned = payload.len() % 4 == 0;
+
+    prefix_chars_b64_compatible && is_b64_aligned
+}
+
+pub fn decode_base64(payload: &[u8], location: &str) -> Result<Vec<u8>, CaptureError> {
+    match base64::engine::general_purpose::STANDARD.decode(payload) {
+        Ok(decoded_payload) => Ok(decoded_payload),
+        Err(e) => {
+            let max_chars = std::cmp::min(payload.len(), MAX_PAYLOAD_SNIPPET_SIZE);
+            let data_snippet = String::from_utf8(payload[..max_chars].to_vec())
+                .unwrap_or(String::from("INVALID_UTF8"));
+            error!(
+                location = location,
+                data_snippet = data_snippet,
+                "decode_base64 failure: {}",
+                e
+            );
+            Err(CaptureError::RequestDecodingError(String::from(
+                "attempting to decode base64",
+            )))
+        }
+    }
 }

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -13,7 +13,7 @@ use crate::{
     api::CaptureError,
     prometheus::report_dropped_events,
     token::validate_token,
-    v0_endpoint::{decode_base64, is_likely_base64, Base64Option, MAX_PAYLOAD_SNIPPET_SIZE},
+    utils::{decode_base64, is_likely_base64, Base64Option, MAX_PAYLOAD_SNIPPET_SIZE},
 };
 
 #[derive(Deserialize, Default, Clone, Copy, PartialEq, Eq)]
@@ -200,20 +200,32 @@ impl RawRequest {
                 error!("from_bytes: request size limit reached");
                 report_dropped_events("event_too_big", 1);
                 return Err(CaptureError::EventTooBig(format!(
-                    "Event or batch wasn't compressed, size exceeded {}",
-                    limit
+                    "Uncompressed payload size limit {} exceeded: {}",
+                    limit,
+                    s.len(),
                 )));
             }
             s
         };
 
+        // TODO(eli): remove special casing and additional logging after migration is completed
         if is_mirror_deploy {
             if is_likely_base64(payload.as_bytes(), Base64Option::Strict) {
                 warn!("from_bytes: payload still base64 after decoding step");
                 payload = match decode_base64(payload.as_bytes(), "from_bytes_after_decoding") {
                     Ok(out) => {
                         match String::from_utf8(out) {
-                            Ok(unwrapped_payload) => unwrapped_payload,
+                            Ok(unwrapped_payload) => {
+                                if unwrapped_payload.len() > limit {
+                                    error!("from_bytes: request size limit exceeded after post-decode base64 unwrap");
+                                    report_dropped_events("event_too_big", 1);
+                                    return Err(CaptureError::EventTooBig(format!(
+                                        "from_bytes: payload size limit {} exceeded after post-decode base64 unwrap: {}",
+                                        limit, unwrapped_payload.len(),
+                                    )));
+                                }
+                                unwrapped_payload
+                            }
                             Err(e) => {
                                 error!("from_bytes: failed UTF8 conversion after post-decode base64: {}", e);
                                 payload


### PR DESCRIPTION
## Problem
Moving some of the new utility functions out of the legacy codepath lets us share them as we plan to unite the old `/i/v0/e` and legacy event handling after migration off `capture.py`.

A defensive size check on decoded payloads is required as part of the new post-decode base64 double-wrap codepath in test in the mirror deploy.

## Changes
* Refactor utility functions we're sharing across modules into the `utils` module
* param base64 detection to include URL-safe variant as we prep to test `/engage` (can include `GET` req w/query param payload)
* Add defensive check to new (temporarily mirror-only) base64 double-unwrap codepath

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally, CI; next - mirror test deploy