### PR TITLE
feat(capture-rs): expand decoded payload capture for /engage debugging

### DIFF
--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -13,7 +13,13 @@ use crate::{
     api::CaptureError,
     prometheus::report_dropped_events,
     token::validate_token,
-    utils::{decode_base64, is_likely_base64, Base64Option, MAX_PAYLOAD_SNIPPET_SIZE},
+    utils::{
+        decode_base64,
+        decompress_lz64,
+        is_likely_base64,
+        Base64Option,
+        //MAX_PAYLOAD_SNIPPET_SIZE,
+    },
 };
 
 #[derive(Deserialize, Default, Clone, Copy, PartialEq, Eq)]
@@ -245,7 +251,8 @@ impl RawRequest {
         if is_mirror_deploy {
             let truncate_at: usize = payload
                 .char_indices()
-                .nth(MAX_PAYLOAD_SNIPPET_SIZE)
+                //.nth(MAX_PAYLOAD_SNIPPET_SIZE)
+                .nth(1024) // TODO(eli): temporary for odd /engage payload inspection
                 .map(|(n, _)| n)
                 .unwrap_or(0);
             let payload_snippet = &payload[0..truncate_at];
@@ -294,54 +301,6 @@ impl RawRequest {
         }
         None
     }
-}
-
-fn decompress_lz64(payload: &[u8], limit: usize) -> Result<String, CaptureError> {
-    // with lz64 the payload is a Base64 string that must be decoded prior to decompression
-    let b64_payload = std::str::from_utf8(payload).unwrap_or("INVALID_UTF8");
-    let decomp_utf16 = match lz_str::decompress_from_base64(b64_payload) {
-        Some(v) => v,
-        None => {
-            let max_chars: usize = std::cmp::min(payload.len(), MAX_PAYLOAD_SNIPPET_SIZE);
-            let payload_snippet = String::from_utf8(payload[..max_chars].to_vec())
-                .unwrap_or(String::from("INVALID_UTF8"));
-            error!(
-                payload_snippet = payload_snippet,
-                "decompress_lz64: failed decompress to UTF16"
-            );
-            return Err(CaptureError::RequestDecodingError(String::from(
-                "decompress_lz64: failed decompress to UTF16",
-            )));
-        }
-    };
-
-    // the decompressed data is UTF16 so we need to convert it to UTF8 to
-    // obtain the JSON event batch payload we've come to know and love
-    let decompressed = match String::from_utf16(&decomp_utf16) {
-        Ok(result) => result,
-        Err(e) => {
-            error!(
-                "decompress_lz64: failed UTF16 to UTF8 conversion, got: {}",
-                e
-            );
-            return Err(CaptureError::RequestDecodingError(String::from(
-                "decompress_lz64: failed UTF16 to UTF8 conversion",
-            )));
-        }
-    };
-
-    if decompressed.len() > limit {
-        error!(
-            "lz64 request payload size limit exceeded: {}",
-            decompressed.len()
-        );
-        report_dropped_events("event_too_big", 1);
-        return Err(CaptureError::EventTooBig(String::from(
-            "lz64 request payload size limit exceeded",
-        )));
-    }
-
-    Ok(decompressed)
 }
 
 #[instrument(skip_all, fields(events = events.len()))]


### PR DESCRIPTION
## Problem
Mirroring traffic from `/engage` endpoint is successfully decoding reasonable-looking payloads, but they fail to pattern match onto the [currently supported payload shapes](https://github.com/PostHog/posthog/blob/master/rust/capture/src/v0_request.rs#L84-L93) in `capture-rs`.

So far from the smaller snippets I can view, these look as if they should match the `One` variant, and all seem to include `$set` params for updating person props.

## Changes
* Temporarily expand payload snippet capture for `/engage` testing, to see why the payloads don't match supported event JSON shapes
* Refactor one more shared function into `utils` module

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
