### PR TITLE
feat(capture-rs): support /engage event shape

### DIFF
--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -1,8 +1,7 @@
-use std::collections::HashSet;
 use std::io::prelude::*;
 
 use bytes::{Buf, Bytes};
-use common_types::{CapturedEvent, RawEvent};
+use common_types::{CapturedEvent, RawEngageEvent, RawEvent};
 use flate2::read::GzDecoder;
 use serde::Deserialize;
 use time::format_description::well_known::Iso8601;
@@ -12,13 +11,8 @@ use tracing::{debug, error, instrument, warn, Span};
 use crate::{
     api::CaptureError,
     prometheus::report_dropped_events,
-    token::validate_token,
     utils::{
-        decode_base64,
-        decompress_lz64,
-        is_likely_base64,
-        Base64Option,
-        MAX_PAYLOAD_SNIPPET_SIZE,
+        decode_base64, decompress_lz64, is_likely_base64, Base64Option, MAX_PAYLOAD_SNIPPET_SIZE,
     },
 };
 
@@ -109,6 +103,8 @@ pub enum RawRequest {
     Batch(BatchedRequest),
     /// Single event (/capture)
     One(Box<RawEvent>),
+    /// Single person-props update event w/o name (/engage)
+    Engage(Box<RawEngageEvent>),
 }
 
 #[derive(Deserialize)]
@@ -278,22 +274,38 @@ impl RawRequest {
         Ok(serde_json::from_str::<RawRequest>(&payload)?)
     }
 
-    pub fn events(self) -> Vec<RawEvent> {
-        match self {
-            RawRequest::Array(events) => events,
-            RawRequest::One(event) => vec![*event],
-            RawRequest::Batch(req) => req.batch,
+    pub fn get_batch_token(&self) -> Option<String> {
+        if let RawRequest::Batch(req) = self {
+            return Some(req.token.clone());
         }
+        None
     }
 
-    pub fn extract_and_verify_token(&self) -> Result<String, CaptureError> {
-        let token = match self {
-            RawRequest::Batch(req) => req.token.to_string(),
-            RawRequest::One(event) => event.extract_token().ok_or(CaptureError::NoTokenError)?,
-            RawRequest::Array(events) => extract_token(events)?,
-        };
-        validate_token(&token)?;
-        Ok(token)
+    pub fn events(self, path: &str) -> Result<Vec<RawEvent>, CaptureError> {
+        match self {
+            RawRequest::Array(events) => Ok(events),
+            RawRequest::One(event) => Ok(vec![*event]),
+            RawRequest::Batch(req) => Ok(req.batch),
+            RawRequest::Engage(engage_event) => {
+                if path.starts_with("/engage") {
+                    Ok(vec![RawEvent {
+                        event: String::from("$identify"),
+                        token: engage_event.token,
+                        distinct_id: engage_event.distinct_id,
+                        uuid: engage_event.uuid,
+                        timestamp: engage_event.timestamp,
+                        offset: engage_event.offset,
+                        set: engage_event.set,
+                        set_once: engage_event.set_once,
+                        properties: engage_event.properties,
+                    }])
+                } else {
+                    Err(CaptureError::RequestParsingError(String::from(
+                        "non-engage event submitted without name",
+                    )))
+                }
+            }
+        }
     }
 
     pub fn historical_migration(&self) -> bool {
@@ -313,25 +325,6 @@ impl RawRequest {
         }
         None
     }
-}
-
-#[instrument(skip_all, fields(events = events.len()))]
-pub fn extract_token(events: &[RawEvent]) -> Result<String, CaptureError> {
-    let distinct_tokens: HashSet<Option<String>> = HashSet::from_iter(
-        events
-            .iter()
-            .map(RawEvent::extract_token)
-            .filter(Option::is_some),
-    );
-
-    return match distinct_tokens.len() {
-        0 => Err(CaptureError::NoTokenError),
-        1 => match distinct_tokens.iter().last() {
-            Some(Some(token)) => Ok(token.clone()),
-            _ => Err(CaptureError::NoTokenError),
-        },
-        _ => Err(CaptureError::MultipleTokensError),
-    };
 }
 
 #[derive(Debug)]
@@ -372,6 +365,7 @@ pub struct ProcessedEventMetadata {
 #[cfg(test)]
 mod tests {
     use crate::token::InvalidTokenReason;
+    use crate::utils::extract_and_verify_token;
     use base64::Engine as _;
     use bytes::Bytes;
     use common_types::util::empty_string_is_none;
@@ -412,7 +406,8 @@ mod tests {
             false,
         )
         .expect("failed to parse")
-        .events();
+        .events("/i/v0/e")
+        .unwrap();
         assert_eq!(1, events.len());
         assert_eq!(Some("my_token1".to_string()), events[0].extract_token());
         assert_eq!("my_event1".to_string(), events[0].event);
@@ -440,7 +435,8 @@ mod tests {
             false,
         )
         .expect("failed to parse")
-        .events();
+        .events("/i/v0/e")
+        .unwrap();
         assert_eq!(1, events.len());
         assert_eq!(Some("my_token2".to_string()), events[0].extract_token());
         assert_eq!("my_event2".to_string(), events[0].event);
@@ -463,7 +459,8 @@ mod tests {
                 false,
             )
             .expect("failed to parse")
-            .events();
+            .events("/i/v0/e")
+            .unwrap();
             parsed[0]
                 .extract_distinct_id()
                 .ok_or(CaptureError::MissingDistinctId)
@@ -539,7 +536,8 @@ mod tests {
             false,
         )
         .expect("failed to parse")
-        .events();
+        .events("/i/v0/e")
+        .unwrap();
         assert_eq!(
             parsed[0].extract_distinct_id().expect("failed to extract"),
             expected_distinct_id
@@ -547,17 +545,24 @@ mod tests {
     }
 
     #[test]
-    fn extract_and_verify_token() {
+    fn test_extract_and_verify_token() {
         let parse_and_extract = |input: &'static str| -> Result<String, CaptureError> {
-            RawRequest::from_bytes(
+            let raw_req = RawRequest::from_bytes(
                 input.into(),
                 Compression::Unsupported,
                 "extract_and_verify_token",
                 2048,
                 false,
             )
-            .expect("failed to parse")
-            .extract_and_verify_token()
+            .expect("failed to parse");
+
+            let maybe_batch_token = raw_req.get_batch_token();
+
+            let events = raw_req
+                .events("/i/v0/e")
+                .expect("failed to hydrate Vec<RawEvent>");
+
+            extract_and_verify_token(&events, maybe_batch_token)
         };
 
         let assert_extracted_token = |input: &'static str, expected: &str| {

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -461,7 +461,7 @@ mod tests {
                     false,
                 )
                 .expect("failed to parse")
-                .events("/e")
+                .events("/e/?ip=192.0.0.1&ver=2.3.4")
             };
 
         // since we're not extracting events against the /engage endpoint path,
@@ -486,7 +486,7 @@ mod tests {
                     false,
                 )
                 .expect("failed to parse")
-                .events("/engage")
+                .events("/engage/?ip=10.0.0.1&ver=1.2.3")
             };
 
         let got = parse_and_extract_events(

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -18,7 +18,7 @@ use crate::{
         decompress_lz64,
         is_likely_base64,
         Base64Option,
-        //MAX_PAYLOAD_SNIPPET_SIZE,
+        MAX_PAYLOAD_SNIPPET_SIZE,
     },
 };
 
@@ -264,8 +264,7 @@ impl RawRequest {
         if is_mirror_deploy {
             let truncate_at: usize = payload
                 .char_indices()
-                //.nth(MAX_PAYLOAD_SNIPPET_SIZE)
-                .nth(1024) // TODO(eli): temporary for odd /engage payload inspection
+                .nth(MAX_PAYLOAD_SNIPPET_SIZE)
                 .map(|(n, _)| n)
                 .unwrap_or(0);
             let payload_snippet = &payload[0..truncate_at];

--- a/rust/common/types/src/event.rs
+++ b/rust/common/types/src/event.rs
@@ -33,6 +33,33 @@ pub struct RawEvent {
     pub set_once: Option<HashMap<String, Value>>,
 }
 
+#[derive(Default, Debug, Deserialize, Serialize)]
+pub struct RawEngageEvent {
+    #[serde(
+        alias = "$token",
+        alias = "api_key",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub token: Option<String>,
+    #[serde(alias = "$distinct_id", skip_serializing_if = "Option::is_none")]
+    pub distinct_id: Option<Value>, // posthog-js accepts arbitrary values as distinct_id
+    #[serde(default, deserialize_with = "empty_string_is_none")]
+    pub uuid: Option<Uuid>,
+    // NOTE: missing event name is the only difference between RawEvent and RawEngageEvent
+    // when the event name is missing, we need fill in $identify as capture.py does:
+    // https://github.com/PostHog/posthog/blob/70ce86a73f6c3d3ee6f44e1ac0acd695e2f78682/posthog/api/capture.py#L501-L502
+    #[serde(default)]
+    pub properties: HashMap<String, Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>, // Passed through if provided, parsed by ingestion
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<i64>, // Passed through if provided, parsed by ingestion
+    #[serde(rename = "$set", skip_serializing_if = "Option::is_none")]
+    pub set: Option<HashMap<String, Value>>,
+    #[serde(rename = "$set_once", skip_serializing_if = "Option::is_none")]
+    pub set_once: Option<HashMap<String, Value>>,
+}
+
 // The event type that capture produces
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct CapturedEvent {

--- a/rust/common/types/src/lib.rs
+++ b/rust/common/types/src/lib.rs
@@ -7,6 +7,7 @@ pub use event::CapturedEvent;
 pub use event::ClickHouseEvent;
 pub use event::InternallyCapturedEvent;
 pub use event::PersonMode;
+pub use event::RawEngageEvent;
 pub use event::RawEvent;
 
 // Teams


### PR DESCRIPTION
## Problem
Events submitted through the legacy `/engage` endpoint are special - they are not named and always involve Person property updates.

Due to the fact that `capture-rs` currently consumes the `RawRequest` when hydrating events, some of this is a bit awkward to implement without a larger refactor.

## Changes
* Adds to support `RawEngageRequest` payloads in `capture-rs`
* Numerous (fairly ugly) defensive refactors to ensure we handle unnamed events safely on:
    * The hot path 🔥 
    * The legacy path (currently only live in mirror deploys)
    * Unit test suites and utility functions
* New unit tests to exercise the new extraction behavior on the hot path

⚠️ Once these changes are landed, I will add this mess to my list of larger-scale refactors I want to make in `capture-rs` once the migration off `capture.py` is completed.

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally + CI