### PR TITLE
fix: fix attribute error in proxy record error handling

### DIFF
--- a/posthog/temporal/proxy_service/create.py
+++ b/posthog/temporal/proxy_service/create.py
@@ -362,7 +362,7 @@ class CreateManagedProxyWorkflow(PostHogWorkflow):
                 type(e),
             )
 
-            if hasattr(e, "cause") and e.cause.type == "RecordDeletedException":
+            if hasattr(e, "cause") and hasattr(e.cause, "type") and e.cause.type == "RecordDeletedException":
                 logger.info(
                     "Record was deleted before completing provisioning for id %s (%s)",
                     inputs.proxy_record_id,


### PR DESCRIPTION
e.cause doesn't always have "type" attribute

> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
