### PR TITLE
chore(max): Don't use $identify events in new insights

### DIFF
--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -1647,7 +1647,7 @@
         },
         "$identify": {
             "description": "A user has been identified with properties.",
-            "description_llm": "Identifies an anonymous user. The event shows how many users used an account, so do not use it for active users metrics because a user may skip identification.",
+            "ignored_in_assistant": true,
             "label": "Identify"
         },
         "$merge_dangerously": {


### PR DESCRIPTION
## Problem

I've seen Max use the $identify event as a measure of active users, even though the description says this event shouldn't be used for this purpose. 🤔 Generally $identify almost never is an event you should be using in _analytics_, basically no reliable meaning can ever be assigned to it in an analytics context – _typically_ it's fired on login, but also in lots of different context.

## Changes

Proposing we have Max just ignore $identify for taxonomy purposes.