### PR TITLE
chore: do not retry API queries from offline in the online cluster

### DIFF
--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -24,7 +24,6 @@ from posthog.clickhouse.client.escape import substitute_params
 from posthog.clickhouse.query_tagging import tag_queries, get_query_tag_value, get_query_tags
 from posthog.cloud_utils import is_cloud
 from posthog.errors import wrap_query_error, ch_error_type
-from posthog.exceptions import ClickhouseAtCapacity
 from posthog.settings import TEST
 from posthog.utils import generate_short_id, patchable
 
@@ -206,11 +205,6 @@ def sync_execute(
                 exception_type=exception_type, query_type=query_type, workload=workload.value, chargeable=chargeable
             ).inc()
             err = wrap_query_error(e)
-            if isinstance(err, ClickhouseAtCapacity) and is_personal_api_key and workload == Workload.OFFLINE:
-                workload = Workload.ONLINE
-                tags["clickhouse_exception_type"] = exception_type
-                tags["workload"] = str(workload)
-                continue
             raise err from e
         finally:
             execution_time = perf_counter() - start_time

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -1,10 +1,8 @@
 import json
 from typing import Any
 
-from clickhouse_driver.errors import ServerException
 
 from posthog.clickhouse.client.async_task_chain import task_chain_context
-from posthog.clickhouse.client.connection import Workload, ClickHouseUser
 import uuid
 
 from django.test import TestCase, SimpleTestCase
@@ -340,7 +338,6 @@ class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):
         Note I'm not really testing much complexity, I trust that those will
         come out as failures in other tests.
         """
-        from posthog.clickhouse.query_tagging import tag_queries
 
         # First add in the request information that should be added to the sql.
         # We check this to make sure it is not removed by the comment stripping
@@ -360,33 +357,3 @@ class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):
             # Make sure it still includes the "annotation" comment that includes
             # request routing information for debugging purposes
             self.assertIn(f"/* user_id:{self.user_id} request:1 */", first_query)
-
-    @patch("posthog.clickhouse.client.execute.get_client_from_pool")
-    def test_offline_workload_if_personal_api_key_and_retries_online(self, mock_get_client):
-        # Create mock clients
-        mock_client1 = MagicMock()
-        mock_client2 = MagicMock()
-
-        # First client raises 202 ServerException
-        mock_client1.__enter__.return_value.execute.side_effect = ServerException("Test error", code=202)
-
-        # Second client succeeds
-        mock_client2.__enter__.return_value.execute.return_value = "success"
-
-        # Return different clients on consecutive calls
-        mock_get_client.side_effect = [mock_client1, mock_client2]
-
-        # Execute query with personal_api_key access method
-        query = "SELECT 1"
-        # tag_queries = {"access_method": "personal_api_key"}
-        tag_queries(access_method="personal_api_key")
-        result = sync_execute(query)
-
-        # Verify first call was with OFFLINE workload
-        mock_get_client.assert_any_call(Workload.OFFLINE, None, False, ClickHouseUser.API)
-
-        # Verify second call was with ONLINE workload
-        mock_get_client.assert_any_call(Workload.ONLINE, None, False, ClickHouseUser.API)
-
-        # Verify final result
-        self.assertEqual(result, "success")


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

If a query fails in the offline cluster, it goes to the online one.

In situations where the offline cluster is saturated, it could saturate the online cluster too.

## Changes

Remove the retry logic.


## Does this work well for both Cloud and self-hosted?

Yes

