### PR TITLE
fix: fix chromium CORB error on beacon by responding with 204

### DIFF
--- a/rust/capture/src/api.rs
+++ b/rust/capture/src/api.rs
@@ -146,7 +146,7 @@ mod tests {
     use axum::http::StatusCode;
 
     #[test]
-    fn test_capture_response_into_response() {
+    fn test_capture_response_into_response_ok() {
         // Test Ok response
         let response = CaptureResponse {
             status: CaptureResponseCode::Ok,
@@ -154,7 +154,10 @@ mod tests {
         };
         let response = response.into_response();
         assert_eq!(response.status(), StatusCode::OK);
+    }
 
+    #[test]
+    fn test_capture_response_into_response_no_content() {
         // Test NoContent response
         let response = CaptureResponse {
             status: CaptureResponseCode::NoContent,

--- a/rust/capture/src/api.rs
+++ b/rust/capture/src/api.rs
@@ -1,5 +1,6 @@
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
+use axum::Json;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -8,6 +9,7 @@ use crate::token::InvalidTokenReason;
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub enum CaptureResponseCode {
     Ok = 1,
+    NoContent = 2,
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
@@ -16,6 +18,15 @@ pub struct CaptureResponse {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quota_limited: Option<Vec<String>>,
+}
+
+impl IntoResponse for CaptureResponse {
+    fn into_response(self) -> Response {
+        match self.status {
+            CaptureResponseCode::NoContent => StatusCode::NO_CONTENT.into_response(),
+            CaptureResponseCode::Ok => (StatusCode::OK, Json(self)).into_response(),
+        }
+    }
 }
 
 #[derive(Clone, Error, Debug)]
@@ -126,5 +137,30 @@ impl IntoResponse for CaptureError {
             }
         }
         .into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+
+    #[test]
+    fn test_capture_response_into_response() {
+        // Test Ok response
+        let response = CaptureResponse {
+            status: CaptureResponseCode::Ok,
+            quota_limited: None,
+        };
+        let response = response.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // Test NoContent response
+        let response = CaptureResponse {
+            status: CaptureResponseCode::NoContent,
+            quota_limited: None,
+        };
+        let response = response.into_response();
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
     }
 }

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -388,7 +388,7 @@ pub async fn event_legacy(
     method: Method,
     path: MatchedPath,
     body: Bytes,
-) -> Result<Json<CaptureResponse>, CaptureError> {
+) -> Result<CaptureResponse, CaptureError> {
     let mut params: EventQuery = meta.0;
 
     // TODO(eli): temporary peek at these
@@ -409,10 +409,10 @@ pub async fn event_legacy(
         Err(CaptureError::BillingLimit) => {
             // Short term: return OK here to avoid clients retrying over and over
             // Long term: v1 endpoints will return richer errors, sync w/SDK behavior
-            Ok(Json(CaptureResponse {
+            Ok(CaptureResponse {
                 status: CaptureResponseCode::Ok,
                 quota_limited: None,
-            }))
+            })
         }
 
         Err(err) => {
@@ -437,14 +437,14 @@ pub async fn event_legacy(
                 return Err(err);
             }
 
-            Ok(Json(CaptureResponse {
+            Ok(CaptureResponse {
                 status: if params.beacon {
                     CaptureResponseCode::NoContent
                 } else {
                     CaptureResponseCode::Ok
                 },
                 quota_limited: None,
-            }))
+            })
         }
     }
 }
@@ -467,13 +467,13 @@ pub async fn event_legacy(
 pub async fn event(
     state: State<router::State>,
     ip: InsecureClientIp,
-    meta: Query<EventQuery>,
+    params: Query<EventQuery>,
     headers: HeaderMap,
     method: Method,
     path: MatchedPath,
     body: Bytes,
-) -> Result<Json<CaptureResponse>, CaptureError> {
-    match handle_common(&state, &ip, &meta, &headers, &method, &path, body).await {
+) -> Result<CaptureResponse, CaptureError> {
+    match handle_common(&state, &ip, &params, &headers, &method, &path, body).await {
         Err(CaptureError::BillingLimit) => {
             // for v0 we want to just return ok 🙃
             // this is because the clients are pretty dumb and will just retry over and over and
@@ -481,10 +481,10 @@ pub async fn event(
             //
             // for v1, we'll return a meaningful error code and error, so that the clients can do
             // something meaningful with that error
-            Ok(Json(CaptureResponse {
+            Ok(CaptureResponse {
                 status: CaptureResponseCode::Ok,
                 quota_limited: None,
-            }))
+            })
         }
         Err(err) => {
             report_internal_error_metrics(err.to_metric_tag(), "parsing");
@@ -512,14 +512,14 @@ pub async fn event(
                 return Err(err);
             }
 
-            Ok(Json(CaptureResponse {
-                status: if meta.beacon {
+            Ok(CaptureResponse {
+                status: if params.beacon {
                     CaptureResponseCode::NoContent
                 } else {
                     CaptureResponseCode::Ok
                 },
                 quota_limited: None,
-            }))
+            })
         }
     }
 }

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -438,7 +438,11 @@ pub async fn event_legacy(
             }
 
             Ok(Json(CaptureResponse {
-                status: CaptureResponseCode::Ok,
+                status: if params.beacon {
+                    CaptureResponseCode::NoContent
+                } else {
+                    CaptureResponseCode::Ok
+                },
                 quota_limited: None,
             }))
         }
@@ -509,7 +513,11 @@ pub async fn event(
             }
 
             Ok(Json(CaptureResponse {
-                status: CaptureResponseCode::Ok,
+                status: if meta.beacon {
+                    CaptureResponseCode::NoContent
+                } else {
+                    CaptureResponseCode::Ok
+                },
                 quota_limited: None,
             }))
         }

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -56,6 +56,18 @@ pub struct EventQuery {
 
     #[serde(alias = "_")]
     sent_at: Option<i64>,
+
+    // If true, return 204 No Content on success
+    #[serde(default, deserialize_with = "deserialize_beacon")]
+    pub beacon: bool,
+}
+
+fn deserialize_beacon<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value: Option<i32> = Option::deserialize(deserializer)?;
+    Ok(value.is_some_and(|v| v == 1))
 }
 
 impl EventQuery {

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -67,7 +67,8 @@ where
     D: serde::Deserializer<'de>,
 {
     let value: Option<i32> = Option::deserialize(deserializer)?;
-    Ok(value.is_some_and(|v| v == 1))
+    let result = value.is_some_and(|v| v == 1);
+    Ok(result)
 }
 
 impl EventQuery {

--- a/rust/capture/tests/common.rs
+++ b/rust/capture/tests/common.rs
@@ -80,12 +80,11 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     healthcheck_strategy: HealthStrategy::All,
 });
 
-pub static TRACING_INIT: Once = Once::new();
+static TRACING_INIT: Once = Once::new();
 pub fn setup_tracing() {
     TRACING_INIT.call_once(|| {
         tracing_subscriber::fmt()
             .with_writer(tracing_subscriber::fmt::TestWriter::new())
-            .with_env_filter("capture=debug,info") // Ensure capture crate debug logs are shown, default to info for others
             .init()
     });
 }

--- a/rust/capture/tests/common.rs
+++ b/rust/capture/tests/common.rs
@@ -80,11 +80,12 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     healthcheck_strategy: HealthStrategy::All,
 });
 
-static TRACING_INIT: Once = Once::new();
+pub static TRACING_INIT: Once = Once::new();
 pub fn setup_tracing() {
     TRACING_INIT.call_once(|| {
         tracing_subscriber::fmt()
             .with_writer(tracing_subscriber::fmt::TestWriter::new())
+            .with_env_filter("capture=debug,info") // Ensure capture crate debug logs are shown, default to info for others
             .init()
     });
 }

--- a/rust/capture/tests/events.rs
+++ b/rust/capture/tests/events.rs
@@ -1,4 +1,5 @@
 use std::num::NonZeroU32;
+use std::time::Duration as StdDuration;
 use time::Duration;
 
 use crate::common::*;
@@ -1177,6 +1178,40 @@ async fn it_limits_batch_endpoints_to_20mb() -> Result<()> {
     assert_eq!(StatusCode::PAYLOAD_TOO_LARGE, res.status());
     let res = server.capture_to_batch(nok_event.to_string()).await;
     assert_eq!(StatusCode::PAYLOAD_TOO_LARGE, res.status());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn it_returns_204_when_beacon_is_1() -> Result<()> {
+    setup_tracing();
+    let token = random_string("token", 16);
+    let distinct_id = random_string("id", 16);
+
+    let main_topic = EphemeralTopic::new().await;
+    let histo_topic = EphemeralTopic::new().await;
+    let server = ServerHandle::for_topics(&main_topic, &histo_topic).await;
+
+    let event = json!({
+        "token": token,
+        "event": "testing",
+        "distinct_id": distinct_id
+    });
+    let res = server.capture_events(event.to_string()).await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    // Now test with beacon=1 in the query string
+    let client = reqwest::Client::builder()
+        .timeout(StdDuration::from_millis(3000))
+        .build()
+        .unwrap();
+    let res = client
+        .post(format!("http://{:?}/i/v0/e?beacon=1", server.addr))
+        .body(event.to_string())
+        .send()
+        .await
+        .expect("failed to send request");
+    assert_eq!(StatusCode::NO_CONTENT, res.status());
 
     Ok(())
 }

--- a/rust/capture/tests/events.rs
+++ b/rust/capture/tests/events.rs
@@ -1205,8 +1205,13 @@ async fn it_returns_204_when_beacon_is_1() -> Result<()> {
         .timeout(StdDuration::from_millis(3000))
         .build()
         .unwrap();
+    let timestamp = Utc::now().timestamp_millis();
+    let url = format!(
+        "http://{:?}/i/v0/e/?_={}&ver=1.240.6&compression=gzip-js&beacon=1",
+        server.addr, timestamp
+    );
     let res = client
-        .post(format!("http://{:?}/i/v0/e?beacon=1", server.addr))
+        .post(url)
         .body(event.to_string())
         .send()
         .await

--- a/rust/capture/tests/recordings.rs
+++ b/rust/capture/tests/recordings.rs
@@ -2,12 +2,12 @@ use crate::common::*;
 use anyhow::Result;
 use assert_json_diff::assert_json_include;
 use capture::config::CaptureMode;
+use chrono::Utc;
 use limiters::redis::QuotaResource;
 use reqwest::StatusCode;
 use serde_json::{json, value::Value};
 use time::Duration;
 use uuid::Uuid;
-use chrono::Utc;
 
 mod common;
 
@@ -421,8 +421,7 @@ async fn it_returns_200() -> Result<()> {
     let timestamp = Utc::now().timestamp_millis();
     let beacon_url = format!(
         "http://{:?}/s/?ip=1&_={}&ver=1.240.6&compression=gzip-js",
-        server.addr,
-        timestamp
+        server.addr, timestamp
     );
 
     let res = client
@@ -436,7 +435,6 @@ async fn it_returns_200() -> Result<()> {
 
     Ok(())
 }
-
 
 #[tokio::test]
 async fn it_returns_204_when_beacon_is_1_for_recordings() -> Result<()> {
@@ -472,8 +470,7 @@ async fn it_returns_204_when_beacon_is_1_for_recordings() -> Result<()> {
     let timestamp = Utc::now().timestamp_millis();
     let beacon_url = format!(
         "http://{:?}/s/?ip=1&_={}&ver=1.240.6&compression=gzip-js&beacon=1",
-        server.addr, 
-        timestamp
+        server.addr, timestamp
     );
 
     let res_no_content = client
@@ -483,7 +480,11 @@ async fn it_returns_204_when_beacon_is_1_for_recordings() -> Result<()> {
         .await
         .expect("Failed to send beacon request to /s/");
 
-    assert_eq!(StatusCode::NO_CONTENT, res_no_content.status(), "Expected NO_CONTENT for beacon recording request");
+    assert_eq!(
+        StatusCode::NO_CONTENT,
+        res_no_content.status(),
+        "Expected NO_CONTENT for beacon recording request"
+    );
 
     Ok(())
 }

--- a/rust/capture/tests/recordings.rs
+++ b/rust/capture/tests/recordings.rs
@@ -448,7 +448,6 @@ async fn it_returns_204_when_beacon_is_1_for_recordings() -> Result<()> {
     let server = ServerHandle::for_recordings(&main_topic).await;
 
     let recording_event = json!([{
-
         "token": token,
         "event": "$snapshot",
         "distinct_id": distinct_id,
@@ -456,7 +455,7 @@ async fn it_returns_204_when_beacon_is_1_for_recordings() -> Result<()> {
         "properties": {
             "$session_id": session_id.clone(),
             "$window_id": window_id.clone(),
-             "$snapshot_data": [
+            "$snapshot_data": [
                 {"type": 2, "data": {"source": 0}, "timestamp": Utc::now().timestamp_millis()}
             ]
         }

--- a/rust/capture/tests/recordings.rs
+++ b/rust/capture/tests/recordings.rs
@@ -7,6 +7,7 @@ use reqwest::StatusCode;
 use serde_json::{json, value::Value};
 use time::Duration;
 use uuid::Uuid;
+use chrono::Utc;
 
 mod common;
 
@@ -383,6 +384,106 @@ async fn it_applies_overflow_limits() -> Result<()> {
             },
         })
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn it_returns_200() -> Result<()> {
+    setup_tracing();
+    let token = random_string("token", 16);
+    let distinct_id = random_string("id", 16);
+    let session_id = Uuid::now_v7().to_string();
+    let window_id = Uuid::now_v7().to_string();
+
+    let main_topic = EphemeralTopic::new().await;
+    let server = ServerHandle::for_recordings(&main_topic).await;
+
+    let recording_event = json!([{
+        "token": token,
+        "event": "$snapshot",
+        "distinct_id": distinct_id,
+        "$session_id": session_id.clone(),
+        "properties": {
+            "$session_id": session_id.clone(),
+            "$window_id": window_id.clone(),
+            "$snapshot_data": [
+                {"type": 2, "data": {"source": 0}, "timestamp": Utc::now().timestamp_millis()}
+            ]
+        }
+    }]);
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_millis(3000))
+        .build()
+        .unwrap();
+
+    let timestamp = Utc::now().timestamp_millis();
+    let beacon_url = format!(
+        "http://{:?}/s/?ip=1&_={}&ver=1.240.6&compression=gzip-js",
+        server.addr,
+        timestamp
+    );
+
+    let res = client
+        .post(beacon_url)
+        .body(recording_event.to_string())
+        .send()
+        .await
+        .expect("Failed to send beacon request to /s/");
+
+    assert_eq!(StatusCode::OK, res.status(), "Expected OK");
+
+    Ok(())
+}
+
+
+#[tokio::test]
+async fn it_returns_204_when_beacon_is_1_for_recordings() -> Result<()> {
+    setup_tracing();
+    let token = random_string("token", 16);
+    let distinct_id = random_string("id", 16);
+    let session_id = Uuid::now_v7().to_string();
+    let window_id = Uuid::now_v7().to_string();
+
+    let main_topic = EphemeralTopic::new().await;
+    let server = ServerHandle::for_recordings(&main_topic).await;
+
+    let recording_event = json!([{
+
+        "token": token,
+        "event": "$snapshot",
+        "distinct_id": distinct_id,
+        "$session_id": session_id.clone(),
+        "properties": {
+            "$session_id": session_id.clone(),
+            "$window_id": window_id.clone(),
+             "$snapshot_data": [
+                {"type": 2, "data": {"source": 0}, "timestamp": Utc::now().timestamp_millis()}
+            ]
+        }
+    }]);
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_millis(3000))
+        .build()
+        .unwrap();
+
+    let timestamp = Utc::now().timestamp_millis();
+    let beacon_url = format!(
+        "http://{:?}/s/?ip=1&_={}&ver=1.240.6&compression=gzip-js&beacon=1",
+        server.addr, 
+        timestamp
+    );
+
+    let res_no_content = client
+        .post(beacon_url)
+        .body(recording_event.to_string())
+        .send()
+        .await
+        .expect("Failed to send beacon request to /s/");
+
+    assert_eq!(StatusCode::NO_CONTENT, res_no_content.status(), "Expected NO_CONTENT for beacon recording request");
 
     Ok(())
 }


### PR DESCRIPTION
Fixes https://github.com/PostHog/posthog/issues/32166

## Problem

![image](https://github.com/user-attachments/assets/5e78d319-2bf1-4950-8bf4-5f602b7489ad)

We're running into CORB errors with our requests from posthog-js that use `navigator.sendBeacon`. This happens because `sendBeacon` is write-only, but our endpoint includes a response body, which Chrome has to discard, and warns that it has done so. 

This doesn't actually break anything, but it does mean that a warning appears on our customers' sites.

We need to send an HTTP 204 to silence these warnings, as 204 NO CONTENT signals that there is no response body to discard.

## Changes
Changes /e/ and /s/ in capture-rs to respond with HTTP 204 instead of 200 if the request URL contains `beacon=1`

This doesn't require any changes to posthog-js, which already sends `beacon=1` for these requests.

In theory, we could change these endpoints to always return 204, but there are a lot of clients out there and I didn't want to risk that change, but only posthog-js will send beacon=1.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

For the status code, I added tests to our existing Rust test suite.

For the warning itself, I used the steps to reproduce in the ticket. It's pretty easy to reproduce and can be done in local dev. After this change, refreshing the page did not give these warnings.

* Add `--build --force-recreate` to `docker-compose`, e.g. in `bin/mprocs.yaml` to ensure that the capture API is rebuilt when checking out this branch. Use bin/start
* Run the project in posthog-js/playground/next-js
* Accept cookies and hit refresh
