### PR TITLE
fix(cohorts): another corner case for behavioral cohort pydantic models

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -96,6 +96,7 @@ class EventPropFilter(BaseModel, extra="forbid"):
 class HogQLFilter(BaseModel, extra="forbid"):
     type: Literal["hogql"]
     key: str
+    value: Any | None = None
 
 
 class BehavioralFilter(BaseModel, extra="forbid"):

--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -2058,9 +2058,6 @@ email@example.org,
         self.assertEqual(response.status_code, 201, response.json())
         cohort_data = response.json()
         self.assertIsNotNone(cohort_data.get("id"))
-        # You could add more specific assertions here if needed, e.g.:
-        # self.assertEqual(cohort_data["filters"]["properties"]["values"][0]["values"][0]["event_filters"][0]["type"], "hogql")
-        # self.assertIsNone(cohort_data["filters"]["properties"]["values"][0]["values"][0]["event_filters"][0]["value"])
 
 
 def create_cohort(client: Client, team_id: int, name: str, groups: list[dict[str, Any]]):

--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -2012,6 +2012,56 @@ email@example.org,
             "Special Folder/Cohorts" in fs_entry.path
         ), f"Expected path to include 'Special Folder/Cohorts', got '{fs_entry.path}'."
 
+    @patch("posthog.api.cohort.report_user_action")
+    def test_behavioral_filter_with_hogql_event_filter_and_null_value(self, patch_capture):
+        payload = {
+            "name": "Cohort with HogQL Event Filter and Null Value",
+            "filters": {
+                "properties": {  # CohortFilters.properties -> Group
+                    "type": "OR",
+                    "values": [  # Group.values -> list[Union[PropertyFilter, Group]]
+                        {
+                            "type": "OR",  # Inner Group
+                            "values": [
+                                {  # PropertyFilter -> BehavioralFilter
+                                    "type": "behavioral",
+                                    "value": "performed_event",
+                                    "negation": False,
+                                    "key": "PaymentSuccess",
+                                    "event_type": "events",
+                                    "event_filters": [  # BehavioralFilter.event_filters
+                                        {
+                                            "key": "to_date(timestamp) = current_date() - INTERVAL '3 days'",
+                                            "type": "hogql",  # HogQLFilter
+                                            "value": None,  # Testing this null value
+                                        },
+                                        {
+                                            "key": "planId",
+                                            "type": "event",  # EventPropFilter
+                                            "value": ["UPSC26STARTERV1"],
+                                            "operator": "exact",
+                                        },
+                                    ],
+                                    "explicit_datetime": "-30d",
+                                }
+                            ],
+                        }
+                    ],
+                }
+            },
+        }
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/cohorts",
+            data=payload,
+            format="json",
+        )
+        self.assertEqual(response.status_code, 201, response.json())
+        cohort_data = response.json()
+        self.assertIsNotNone(cohort_data.get("id"))
+        # You could add more specific assertions here if needed, e.g.:
+        # self.assertEqual(cohort_data["filters"]["properties"]["values"][0]["values"][0]["event_filters"][0]["type"], "hogql")
+        # self.assertIsNone(cohort_data["filters"]["properties"]["values"][0]["values"][0]["event_filters"][0]["value"])
+
 
 def create_cohort(client: Client, team_id: int, name: str, groups: list[dict[str, Any]]):
     return client.post(f"/api/projects/{team_id}/cohorts", {"name": name, "groups": json.dumps(groups)})


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Issue is described here: https://posthoghelp.zendesk.com/agent/tickets/30554 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/32605)

TL;DR – `hogql` filter types have a null `value` field that has to be present.  TIL.

## Changes

- Fixed the model
- Added a test

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

New unit test to match the customer input
