### PR TITLE
fix: Dagster webserver going OOM due to huge logs

### DIFF
--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -406,6 +406,13 @@ class Query:
     def __call__(self, client: Client):
         return client.execute(self.query, self.parameters, settings=self.settings)
 
+    def __repr__(self) -> str:
+        if self.parameters and isinstance(self.parameters, list):
+            params_repr = f"{self.parameters[:50]!r} (showing first 50 out of {len(self.parameters)} parameters)"
+        else:
+            params_repr = f"{self.parameters!r}"
+        return f"Query(query={self.query!r}, parameters={params_repr}, settings={self.settings!r})"
+
 
 @dataclass
 class ExponentialBackoff:


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

When we run steps that pass thousands of parameters to the query (for `load_pending_deletions`, that would be all data that is going to be inserted), Dagster server just goes out of memory trying to load the run in the UI.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Show only the first 50 elements in the log.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
Locally.
