### PR TITLE
chore: Run backend CI on hobby

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -81,9 +81,9 @@ jobs:
                         - .github/workflows/ci-backend.yml
                         - .github/actions/run-backend-tests/action.yml
                         # We use docker compose for tests, make sure we rerun on
-                        # changes to docker-compose.dev.yml e.g. dependency
+                        # changes to docker-compose.hobby.yml e.g. dependency
                         # version changes
-                        - docker-compose.dev.yml
+                        - docker-compose.hobby.yml
                         - docker-compose.base.yml
                         - frontend/public/email/*
                         # These scripts are used in the CI
@@ -127,8 +127,8 @@ jobs:
 
             - name: Stop/Start stack with Docker Compose
               run: |
-                  docker compose -f docker-compose.dev.yml down
-                  docker compose -f docker-compose.dev.yml up -d
+                  docker compose -f docker-compose.hobby.yml down
+                  docker compose -f docker-compose.hobby.yml up -d
 
             - name: Set up Python
               uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
@@ -305,8 +305,8 @@ jobs:
             - name: Start stack with Docker Compose
               run: |
                   export CLICKHOUSE_SERVER_IMAGE_VERSION=${{ matrix.clickhouse-server-image }}
-                  docker compose -f docker-compose.dev.yml down
-                  docker compose -f docker-compose.dev.yml up -d
+                  docker compose -f docker-compose.hobby.yml down
+                  docker compose -f docker-compose.hobby.yml up -d
 
             - name: Set up Python
               uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -81,9 +81,9 @@ jobs:
                         - .github/workflows/ci-backend.yml
                         - .github/actions/run-backend-tests/action.yml
                         # We use docker compose for tests, make sure we rerun on
-                        # changes to docker-compose.hobby.yml e.g. dependency
+                        # changes to docker-compose.dev.yml e.g. dependency
                         # version changes
-                        - docker-compose.hobby.yml
+                        - docker-compose.dev.yml
                         - docker-compose.base.yml
                         - frontend/public/email/*
                         # These scripts are used in the CI
@@ -127,8 +127,8 @@ jobs:
 
             - name: Stop/Start stack with Docker Compose
               run: |
-                  docker compose -f docker-compose.hobby.yml down
-                  docker compose -f docker-compose.hobby.yml up -d
+                  docker compose -f docker-compose.dev.yml down
+                  docker compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
               uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
@@ -305,8 +305,8 @@ jobs:
             - name: Start stack with Docker Compose
               run: |
                   export CLICKHOUSE_SERVER_IMAGE_VERSION=${{ matrix.clickhouse-server-image }}
-                  docker compose -f docker-compose.hobby.yml down
-                  docker compose -f docker-compose.hobby.yml up -d
+                  docker compose -f docker-compose.dev.yml down
+                  docker compose -f docker-compose.dev.yml up -d
 
             - name: Set up Python
               uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -44,9 +44,9 @@ jobs:
                         - .github/workflows/ci-e2e-playwright.yml
                         - .github/actions/build-n-cache-image/action.yml
                         # We use docker compose for tests, make sure we rerun on
-                        # changes to docker-compose.dev.yml e.g. dependency
+                        # changes to docker-compose.hobby.yml e.g. dependency
                         # version changes
-                        - docker-compose.dev.yml
+                        - docker-compose.hobby.yml
                         - Dockerfile
                         - playwright/**
 
@@ -127,8 +127,8 @@ jobs:
               # these are required checks so, we can't skip entire sections
               if: needs.changes.outputs.shouldRun == 'true'
               run: |
-                  docker compose -f docker-compose.dev.yml down
-                  docker compose -f docker-compose.dev.yml up -d
+                  docker compose -f docker-compose.hobby.yml down
+                  docker compose -f docker-compose.hobby.yml up -d
 
             - name: Wait for ClickHouse
               # these are required checks so, we can't skip entire sections

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -231,6 +231,7 @@ services:
             SKIP_READS: 'false'
 
     plugins:
+        build: .
         command: ./bin/plugin-server --no-restart-loop
         restart: on-failure
         environment:

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -89,7 +89,7 @@ services:
             SESSION_RECORDING_V2_S3_ENDPOINT: http://objectstorage:19000
             OBJECT_STORAGE_ENABLED: true
             ENCRYPTION_SALT_KEYS: $ENCRYPTION_SALT_KEYS
-        image: $REGISTRY_URL:$POSTHOG_APP_TAG
+        # image: $REGISTRY_URL:$POSTHOG_APP_TAG
     web:
         extends:
             file: docker-compose.base.yml
@@ -97,7 +97,7 @@ services:
         command: /compose/start
         volumes:
             - ./compose:/compose
-        image: $REGISTRY_URL:$POSTHOG_APP_TAG
+        # image: $REGISTRY_URL:$POSTHOG_APP_TAG
         environment:
             SENTRY_DSN: $SENTRY_DSN
             SITE_URL: https://$DOMAIN
@@ -120,7 +120,7 @@ services:
         extends:
             file: docker-compose.base.yml
             service: plugins
-        image: $REGISTRY_URL:$POSTHOG_APP_TAG
+        # image: $REGISTRY_URL:$POSTHOG_APP_TAG
         environment:
             SENTRY_DSN: $SENTRY_DSN
             SITE_URL: https://$DOMAIN
@@ -169,7 +169,7 @@ services:
         extends:
             file: docker-compose.base.yml
             service: asyncmigrationscheck
-        image: $REGISTRY_URL:$POSTHOG_APP_TAG
+        # image: $REGISTRY_URL:$POSTHOG_APP_TAG
         environment:
             SENTRY_DSN: $SENTRY_DSN
             SITE_URL: https://$DOMAIN
@@ -215,7 +215,7 @@ services:
             service: temporal-django-worker
         volumes:
             - ./compose:/compose
-        image: $REGISTRY_URL:$POSTHOG_APP_TAG
+        # image: $REGISTRY_URL:$POSTHOG_APP_TAG
         environment:
             SENTRY_DSN: $SENTRY_DSN
             SITE_URL: https://$DOMAIN

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -90,6 +90,7 @@ services:
             OBJECT_STORAGE_ENABLED: true
             ENCRYPTION_SALT_KEYS: $ENCRYPTION_SALT_KEYS
         # image: $REGISTRY_URL:$POSTHOG_APP_TAG
+
     web:
         extends:
             file: docker-compose.base.yml
@@ -154,6 +155,7 @@ services:
             - caddy-config:/config
         depends_on:
             - web
+
     objectstorage:
         extends:
             file: docker-compose.base.yml


### PR DESCRIPTION
Hobby is always broken, just run CI on it rather than dev (we're running that locally anyway) to guarantee we dont break it