### PR TITLE
fix(register-fail-activity): Register fail activity for modeling jobs

### DIFF
--- a/posthog/temporal/data_modeling/__init__.py
+++ b/posthog/temporal/data_modeling/__init__.py
@@ -6,6 +6,7 @@ from posthog.temporal.data_modeling.run_workflow import (
     run_dag_activity,
     start_run_activity,
     cancel_jobs_activity,
+    fail_jobs_activity,
 )
 
 WORKFLOWS = [RunWorkflow]
@@ -16,4 +17,5 @@ ACTIVITIES = [
     run_dag_activity,
     create_table_activity,
     cancel_jobs_activity,
+    fail_jobs_activity,
 ]


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
We don't seem to have the failing activity task registered for the data modeling runs.

```
Activity function fail_jobs_activity for workflow xxxxxxxxxxxxxxxxxxxxxx-2025-05-08T01:55:28Z is not registered on this worker, available activities: build_dag_activity, cancel_jobs_activity, create_table_activity, finish_run_activity, run_dag_activity, start_run_activity
```
## Changes

- [x] Register the task

## Does this work well for both Cloud and self-hosted?
Yes
