### PR TITLE
fix: clear lingering rollout_percentage artifact after feature flag is scheduled

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditions.tsx
@@ -353,7 +353,11 @@ export function FeatureFlagReleaseConditions({
                                         onChange={(value): void => {
                                             updateConditionSet(index, value === undefined ? 0 : value)
                                         }}
-                                        value={group.rollout_percentage !== null ? group.rollout_percentage : 100}
+                                        value={
+                                            group.rollout_percentage !== null
+                                                ? group.rollout_percentage ?? Number.NaN
+                                                : 100
+                                        }
                                         min={0}
                                         max={100}
                                         step="any"


### PR DESCRIPTION
## Problem
fixes confusing client-side behavior reported by issue https://github.com/PostHog/posthog/issues/31914
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
Closes https://github.com/PostHog/posthog/issues/31914

## Changes
When the group.rollout_condition is undefined, set the displayed value in the input component to `Number.NaN`

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?
- tested functionality for self-hosted using flox dev environment

## How did you test this code?
- validated behavior (see attached video)

## Observations and Approach
Relevant console logs
- `group.rollout_percentage` changing from `undefined` to a defined value (and vice versa) was logging warnings about the underlying input component changing from uncontrolled to controlled/
- the `undefined` value was recommended to be substituted with `''`

Observed problem: the LemonInput value is set to `undefined` in state but the displayed value is not cleared. The underlying `input` component's flip-flopping between a controlled and uncontrolled component leads to unpredictable behavior.

Potential solutions
- set the [NEW_FLAG](https://github.com/PostHog/posthog/blob/66c912d4ed4a200e4bc05406879f87d115c9ac19/frontend/src/scenes/feature-flags/featureFlagLogic.ts#L93) rollout_percentage to null and avoid the undefined case
  - [ ] this introduces a backwards incompatible change in behavior: the value is set to `100` when rollout_percentage is null
- provide a string fallback after the null check in case the rollout percentage is undefined (`group.rollout_percentage ?? ''`)
  - [ ] this violates the `number` type of the LemonInput component
- add a ref callback and directly modify the DOM to effectively bypass the previous type error 
  - [ ] ...no
- Modify the LemonInput component such that if the value is undefined an empty string is displayed
  - [ ] The LemonInput  component is used throughout; the blast radius in behavior change will be wide.
- bank on `NaN` being a non-parseable value
  - [x] I observed that when `value` is `NaN`, the input cell is cleared. I still don't REALLY like it but it'll have to do. Should NaN have a future displayable value this approach will no longer be viable.

https://github.com/user-attachments/assets/c6b4f56b-c05c-44be-a166-7492d7f07f6b



