### PR TITLE
fix: remove opt_slash_path from progress stub

### DIFF
--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -174,7 +174,8 @@ urlpatterns = [
     *ee_urlpatterns,
     # api
     path("api/environments/<int:team_id>/progress/", progress),
-    opt_slash_path("api/environments/<int:team_id>/query/<str:query_uuid>/progress", progress),
+    path("api/environments/<int:team_id>/query/<str:query_uuid>/progress/", progress),
+    path("api/environments/<int:team_id>/query/<str:query_uuid>/progress", progress),
     path("api/unsubscribe", unsubscribe.unsubscribe),
     path("api/", include(router.urls)),
     path("", include(tf_urls)),


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

opt_slash_path requires regex path params

still issues with 406 responses from old progress endpoint
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
