### PR TITLE
fix: exclude linegraph from toolbar

### DIFF
--- a/frontend/build.mjs
+++ b/frontend/build.mjs
@@ -93,6 +93,7 @@ await buildInParallel(
                             /queries\/QueryEditor\/QueryEditor/,
                             /scenes\/billing/,
                             /scenes\/data-warehouse/,
+                            /LineGraph/,
                         ]
 
                         build.onResolve({ filter: /.*/ }, (args) => {


### PR DESCRIPTION
see: https://posthoghelp.zendesk.com/agent/tickets/30769 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/32038)

I can't replicate this but the toolbar still works with this for me so 🤞 