### PR TITLE
fix: Fix firefox barfing on 204s

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -720,7 +720,6 @@ class Fix204Middleware:
 
         response.content = b""
         for h in ["Content-Type", "X-Content-Type-Options"]:
-            if h in response.headers:
-                del response.headers[h]
+            response.headers.pop(h, None)
 
         return response

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -715,11 +715,9 @@ class Fix204Middleware:
     def __call__(self, request):
         response = self.get_response(request)
 
-        if response.status_code != 204:
-            return response
-
-        response.content = b""
-        for h in ["Content-Type", "X-Content-Type-Options"]:
-            response.headers.pop(h, None)
+        if response.status_code == 204:
+            response.content = b""
+            for h in ["Content-Type", "X-Content-Type-Options"]:
+                response.headers.pop(h, None)
 
         return response

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -718,14 +718,9 @@ class Fix204Middleware:
         if response.status_code != 204:
             return response
 
-        # Remove the 'Content-Type' and 'X-Content-Type-Options: nosniff' headers
+        response.content = b""
         for h in ["Content-Type", "X-Content-Type-Options"]:
             if h in response.headers:
                 del response.headers[h]
-
-        response.headers["Content-Length"] = "0"
-
-        # Set content to empty string
-        response.content = b""
 
         return response

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -68,6 +68,7 @@ MIDDLEWARE = [
     "posthog.middleware.per_request_logging_context_middleware",
     "django_structlog.middlewares.RequestMiddleware",
     "django_structlog.middlewares.CeleryMiddleware",
+    "posthog.middleware.Fix204Middleware",
     "django.middleware.security.SecurityMiddleware",
     "posthog.middleware.CaptureMiddleware",
     # NOTE: we need healthcheck high up to avoid hitting middlewares that may be


### PR DESCRIPTION


## Problem

Firefox really does not like content-type or X-Content-Type-Options="nosniff" on http 204 responses. Sadly, django will add these things by default. Let's remove them

## Changes

Add a middleware to remove these headers. Also ensure that the body is empty, just to be defensive.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
Before:
<img width="1546" alt="Screenshot 2025-05-15 at 17 16 13" src="https://github.com/user-attachments/assets/697e9a54-b34c-4cfc-8c05-38d12f0a0cde" />

After:
<img width="664" alt="Screenshot 2025-05-15 at 17 15 43" src="https://github.com/user-attachments/assets/065d0a8f-c435-4d21-b739-5ea34b06b1d7" />

