### PR TITLE
feat: query replay by URL without touching events

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/utils.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.ts
@@ -114,6 +114,7 @@ export const PROPERTY_FILTER_TYPE_TO_TAXONOMIC_FILTER_GROUP_TYPE: Record<Propert
         [PropertyFilterType.DataWarehousePersonProperty]: TaxonomicFilterGroupType.DataWarehousePersonProperties,
         [PropertyFilterType.Recording]: TaxonomicFilterGroupType.Replay,
         [PropertyFilterType.LogEntry]: TaxonomicFilterGroupType.LogEntries,
+        [PropertyFilterType.ReplayURL]: TaxonomicFilterGroupType.Replay,
         [PropertyFilterType.ErrorTrackingIssue]: TaxonomicFilterGroupType.ErrorTrackingIssues,
     }
 

--- a/frontend/src/lib/components/UniversalFilters/utils.ts
+++ b/frontend/src/lib/components/UniversalFilters/utils.ts
@@ -6,6 +6,7 @@ import {
     LogEntryPropertyFilter,
     PropertyFilterType,
     RecordingPropertyFilter,
+    ReplayURLFilter,
     UniversalFiltersGroup,
     UniversalFiltersGroupValue,
     UniversalFilterValue,
@@ -36,6 +37,9 @@ export function isRecordingPropertyFilter(filter: UniversalFilterValue): filter 
 }
 export function isLogEntryPropertyFilter(filter: UniversalFilterValue): filter is LogEntryPropertyFilter {
     return filter.type === 'log_entry'
+}
+export function isReplayURLFilter(filter: UniversalFilterValue): filter is ReplayURLFilter {
+    return filter.type === PropertyFilterType.ReplayURL
 }
 export function isEditableFilter(filter: UniversalFilterValue): boolean {
     return isEntityFilter(filter) ? false : !isCohortPropertyFilter(filter)

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -34,6 +34,7 @@ import {
     PropertyGroupFilterValue,
     PropertyMathType,
     PropertyOperator,
+    ReplayURLFilter,
     RetentionDashboardDisplayType,
     RetentionFilterType,
     SessionPropertyFilter,
@@ -404,6 +405,7 @@ export interface RecordingsQuery extends DataNode<RecordingsQueryResponse> {
     actions?: FilterType['actions']
     properties?: AnyPropertyFilter[]
     console_log_filters?: LogEntryPropertyFilter[]
+    visited_page?: ReplayURLFilter[]
     having_predicates?: AnyPropertyFilter[] // duration and snapshot_source filters
     filter_test_accounts?: boolean
     /**

--- a/frontend/src/scenes/session-recordings/filters/ReplayTaxonomicFilters.tsx
+++ b/frontend/src/scenes/session-recordings/filters/ReplayTaxonomicFilters.tsx
@@ -28,7 +28,7 @@ export function ReplayTaxonomicFilters({ onChange }: ReplayTaxonomicFiltersProps
     const properties = [
         {
             key: 'visited_page',
-            propertyFilterType: PropertyFilterType.Recording,
+            propertyFilterType: PropertyFilterType.ReplayURL,
             taxonomicFilterGroup: TaxonomicFilterGroupType.Replay,
         },
         {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -851,6 +851,7 @@ export enum PropertyFilterType {
     Cohort = 'cohort',
     Recording = 'recording',
     LogEntry = 'log_entry',
+    ReplayURL = 'replay_url',
     Group = 'group',
     HogQL = 'hogql',
     DataWarehouse = 'data_warehouse',
@@ -955,6 +956,7 @@ export type AnyPropertyFilter =
     | CohortPropertyFilter
     | RecordingPropertyFilter
     | LogEntryPropertyFilter
+    | ReplayURLFilter
     | GroupPropertyFilter
     | FeaturePropertyFilter
     | HogQLPropertyFilter
@@ -1157,6 +1159,11 @@ export interface RecordingDurationFilter extends RecordingPropertyFilter {
 
 export interface LogEntryPropertyFilter extends BasePropertyFilter {
     type: PropertyFilterType.LogEntry
+    operator: PropertyOperator
+}
+
+export interface ReplayURLFilter extends BasePropertyFilter {
+    type: PropertyFilterType.ReplayURL
     operator: PropertyOperator
 }
 


### PR DESCRIPTION
we've been gathering URLs onto the session replay table for months now

so it's safe to move the `visited page` filter onto that URL array column