### PR TITLE
fix(retention): modal access label from row

### DIFF
--- a/frontend/src/scenes/retention/RetentionModal.tsx
+++ b/frontend/src/scenes/retention/RetentionModal.tsx
@@ -140,7 +140,7 @@ export function RetentionModal(): JSX.Element | null {
                                     {row.values?.map((data: any, index: number) => {
                                         return (
                                             <th key={index}>
-                                                <div>{results[index].label}</div>
+                                                <div>{data.label}</div>
                                                 <div>
                                                     {data.count}
                                                     &nbsp;


### PR DESCRIPTION
## Problem
https://posthoghelp.zendesk.com/agent/tickets/30399 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/32680)

## Changes
Fixed the access to use row, no more index accesses left now!

## Does this work well for both Cloud and self-hosted?
Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Tested locally

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
