### PR TITLE
feat: allow using person properties in survey links

### DIFF
--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -202,8 +202,16 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                     </LemonField>
                 )}
                 {question.type === SurveyQuestionType.Link && (
-                    <LemonField name="link" label="Link" info="Only https:// or mailto: links are supported.">
-                        <LemonInput value={question.link || ''} placeholder="https://posthog.com" />
+                    <LemonField
+                        name="link"
+                        label="Link"
+                        info="Only https:// or mailto: links are supported. Embedding person properties in links requires posthog-js version at least XXX."
+                        help="Use {'{{property}}'} embedding person properties in links, e.g., 'https://posthog.com?email={{distinct_id}}'."
+                    >
+                        <LemonInput
+                            value={question.link || ''}
+                            placeholder="https://posthog.com?email={{distinct_id}}"
+                        />
                     </LemonField>
                 )}
                 {question.type === SurveyQuestionType.Rating && (


### PR DESCRIPTION
Requires https://github.com/PostHog/posthog-js/pull/1963 before merging

Closes https://github.com/PostHog/posthog/issues/26620

## Changes

add info about embedding person properties in survey links.

## How did you test this code?

Tested string replacement extensively on the SDK part