### PR TITLE
fix(dashboards): fix filter preview on dashboard sync load

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1440,6 +1440,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     // Create an array of functions that fetch insights synchronously
                     const fetchSyncInsightFunctions = insightsToRefresh.map((insight) => async () => {
                         const queryId = uuid()
+                        const queryStartTime = performance.now()
                         const dashboardId: number = props.id
 
                         // Set insight as refreshing
@@ -1490,6 +1491,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                                     e
                                 )
                                 // Do not set refresh error if cancelled by abort
+                                actions.abortQuery({ queryId, queryStartTime })
                             } else {
                                 actions.setRefreshError(insight.short_id)
                                 console.error('Error loading insight synchronously:', e)
@@ -1732,7 +1734,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
         abortQuery: async ({ queryId, queryStartTime }) => {
             const { currentTeamId } = values
             try {
-                await api.delete(`api/environments/${currentTeamId}/query/${queryId}?dequeue_only=true`)
+                await api.delete(`api/environments/${currentTeamId}/query/${queryId}`)
             } catch (e) {
                 console.warn('Failed cancelling query', e)
             }


### PR DESCRIPTION
## Problem
When you change filters with dashboard sync mode on, the refresh wasn't using cached data

## Changes
- Don't pass filter overrides while previewing as dashboard ID is already passed in.
- Add abort controller to send cancel queries on navigate away

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?
Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Tested locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
