### PR TITLE
remove setting query_id via Clickhouse http interface

### DIFF
--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -93,8 +93,8 @@ class ProxyClient:
         types_check=False,
         columnar=False,
     ):
-        if query_id:
-            settings["query_id"] = query_id
+        # if query_id:
+        #     settings["query_id"] = query_id # setting query_id via HTTP interface is not supported, see https://github.com/ClickHouse/ClickHouse/issues/11987
         result = self._client.query(query=query, parameters=params, settings=settings, column_oriented=columnar)
 
         # we must play with result summary here


### PR DESCRIPTION
## Problem

Lots of errors in clickhouse log:
```
2025.05.16 09:15:50.813220 [ 1020 ] {} <Warning> Settings: Unknown setting 'query_id', skipping
2025.05.16 09:15:52.814900 [ 1020 ] {} <Warning> Settings: Unknown setting 'query_id', skipping
2025.05.16 09:15:54.820942 [ 1020 ] {} <Warning> Settings: Unknown setting 'query_id', skipping
2025.05.16 09:15:56.822479 [ 1020 ] {} <Warning> Settings: Unknown setting 'query_id', skipping
2025.05.16 09:15:58.825072 [ 1020 ] {} <Warning> Settings: Unknown setting 'query_id', skipping
  ```

I think, the culprit is here: 
https://github.com/PostHog/posthog/blob/master/posthog/clickhouse/client/connection.py#L97

Checking CH repo, turns out setting `query_id` is impossible via HTTP interface:
https://github.com/ClickHouse/ClickHouse/issues/11987

@orian , can you make sure it does not work here and can be removed safely to avoid excessive error logging?


## Does this work well for both Cloud and self-hosted?

should affect both

