### PR TITLE
feat(log-capture): add trace stub, grpc-web and fix http routing

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1112,7 +1112,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -3891,6 +3891,8 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tonic 0.12.3",
+ "tonic-web",
+ "tower",
  "tracing",
  "tracing-subscriber",
 ]
@@ -7198,6 +7200,26 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-web"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5299dd20801ad736dccb4a5ea0da7376e59cd98f213bf1c3d478cf53f4834b58"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "pin-project",
+ "tokio-stream",
+ "tonic 0.12.3",
+ "tower-http",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -113,6 +113,7 @@ regex = "1.11.1"
 lz-str = "0.2.1"
 opentelemetry-proto = "0.29.0"
 tonic = "0.12.3"
+tonic-web = "0.12.3"
 clickhouse = { version = "0.13.2", features = [
     "uuid",
     "time",

--- a/rust/log-capture/Cargo.toml
+++ b/rust/log-capture/Cargo.toml
@@ -15,6 +15,8 @@ common-metrics = { path = "../common/metrics" }
 common-alloc = { path = "../common/alloc" }
 opentelemetry-proto = { workspace = true }
 tonic = { workspace = true }
+tonic-web = { workspace = true }
+tower = { workspace = true }
 jsonwebtoken = "8.3"
 serde = { workspace = true }
 serde_derive = { workspace = true }

--- a/rust/log-capture/src/clickhouse.rs
+++ b/rust/log-capture/src/clickhouse.rs
@@ -9,6 +9,7 @@ use tracing::info;
 
 use crate::{config::Config, log_record::LogRow};
 
+#[derive(Clone)]
 pub struct ClickHouseWriter {
     pub client: Client,
     _sink: mpsc::Sender<InsertTask>,

--- a/rust/log-capture/src/config.rs
+++ b/rust/log-capture/src/config.rs
@@ -5,7 +5,7 @@ pub struct Config {
     #[envconfig(from = "BIND_HOST", default = "::")]
     pub host: String,
 
-    #[envconfig(from = "BIND_PORT", default = "3305")]
+    #[envconfig(from = "BIND_PORT", default = "4317")]
     pub port: u16,
 
     #[envconfig(from = "JWT_SECRET")]

--- a/rust/log-capture/src/main.rs
+++ b/rust/log-capture/src/main.rs
@@ -1,8 +1,8 @@
 use opentelemetry_proto::tonic::collector::logs::v1::logs_service_server::LogsServiceServer;
-use std::net::SocketAddr;
-use tonic::transport::Server;
+use tonic_web::GrpcWebLayer;
+use tower::Layer as TowerLayer;
 
-use axum::{routing::get, Router};
+use axum::routing::get;
 use common_metrics::{serve, setup_metrics_routes};
 use log_capture::config::Config;
 use log_capture::service::Service;
@@ -40,20 +40,7 @@ async fn main() {
 
     let config = Config::init_with_defaults().unwrap();
     let health_registry = HealthRegistry::new("liveness");
-
-    let router = Router::new()
-        .route("/", get(index))
-        .route("/_readiness", get(index))
-        .route(
-            "/_liveness",
-            get(move || ready(health_registry.get_status())),
-        );
-    let router = setup_metrics_routes(router);
     let bind = format!("{}:{}", config.host, config.port);
-    info!("Healthcheck listening on {}", bind);
-    let server = serve(router, &bind);
-
-    let addr = SocketAddr::from(([0, 0, 0, 0], 4317)); // Standard OTLP gRPC port
 
     // Initialize ClickHouse writer and logs service
     let logs_service = match Service::new(config).await {
@@ -64,11 +51,18 @@ async fn main() {
         }
     };
 
-    Server::builder()
-        .add_service(LogsServiceServer::new(logs_service))
-        .serve(addr)
-        .await
-        .unwrap();
+    let router = tonic::service::Routes::new(
+        GrpcWebLayer::new().layer(tonic_web::enable(LogsServiceServer::new(logs_service))),
+    )
+    .prepare()
+    .into_axum_router()
+    .route("/", get(index))
+    .route("/_readiness", get(index))
+    .route(
+        "/_liveness",
+        get(move || ready(health_registry.get_status())),
+    );
+    let router = setup_metrics_routes(router);
 
-    server.await.unwrap();
+    serve(router, &bind).await.unwrap();
 }

--- a/rust/log-capture/src/service.rs
+++ b/rust/log-capture/src/service.rs
@@ -3,10 +3,15 @@ use crate::{auth::authenticate_request, clickhouse::ClickHouseWriter, config::Co
 use opentelemetry_proto::tonic::collector::logs::v1::{
     logs_service_server::LogsService, ExportLogsServiceRequest, ExportLogsServiceResponse,
 };
+use opentelemetry_proto::tonic::collector::trace::v1::trace_service_server::TraceService;
+use opentelemetry_proto::tonic::collector::trace::v1::{
+    ExportTraceServiceRequest, ExportTraceServiceResponse,
+};
 
 use tonic::{Request, Response, Status};
 use tracing::error;
 
+#[derive(Clone)]
 pub struct Service {
     config: Config,
     clickhouse_writer: ClickHouseWriter,
@@ -89,6 +94,19 @@ impl LogsService for Service {
 
         // A successful OTLP export expects an ExportLogsServiceResponse.
         let response = ExportLogsServiceResponse {
+            partial_success: None,
+        };
+        Ok(Response::new(response))
+    }
+}
+
+#[tonic::async_trait]
+impl TraceService for Service {
+    async fn export(
+        &self,
+        _request: Request<ExportTraceServiceRequest>,
+    ) -> Result<Response<ExportTraceServiceResponse>, Status> {
+        let response = ExportTraceServiceResponse {
             partial_success: None,
         };
         Ok(Response::new(response))


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
we can now use grpc-web to access the service, as well as serving the /metrics and /liveness endpoints via http

also dummy tracing capture service

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
