### PR TITLE
chore(ingestion): group FOR UPDATE behind env var

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -257,6 +257,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         PERSON_CACHE_ENABLED_FOR_UPDATES: true,
         PERSON_CACHE_ENABLED_FOR_CHECKS: true,
         USE_DYNAMIC_EVENT_INGESTION_RESTRICTION_CONFIG: false,
+        DISABLE_GROUP_SELECT_FOR_UPDATE: false,
     }
 }
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -336,6 +336,8 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
     // for enablement/sampling of expensive person JSONB sizes; value in [0,1]
     PERSON_JSONB_SIZE_ESTIMATE_ENABLE: number
     USE_DYNAMIC_EVENT_INGESTION_RESTRICTION_CONFIG: boolean
+    // Control whether group FOR UPDATE queries are disabled or not
+    DISABLE_GROUP_SELECT_FOR_UPDATE: boolean
 }
 
 export interface Hub extends PluginsServerConfig {

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -336,7 +336,6 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
     // for enablement/sampling of expensive person JSONB sizes; value in [0,1]
     PERSON_JSONB_SIZE_ESTIMATE_ENABLE: number
     USE_DYNAMIC_EVENT_INGESTION_RESTRICTION_CONFIG: boolean
-    // Control whether group FOR UPDATE queries are disabled or not
     DISABLE_GROUP_SELECT_FOR_UPDATE: boolean
 }
 

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -1274,7 +1274,6 @@ export class DB {
         createdAt: DateTime,
         propertiesLastUpdatedAt: PropertiesLastUpdatedAt,
         propertiesLastOperation: PropertiesLastOperation,
-        version: number,
         tx?: TransactionClient
     ): Promise<number | undefined> {
         const result = await this.postgres.query<{ version: string }>(

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -1235,7 +1235,6 @@ export class DB {
         createdAt: DateTime,
         propertiesLastUpdatedAt: PropertiesLastUpdatedAt,
         propertiesLastOperation: PropertiesLastOperation,
-        version: number,
         tx?: TransactionClient
     ): Promise<number> {
         const result = await this.postgres.query<{ version: string }>(
@@ -1254,7 +1253,7 @@ export class DB {
                 createdAt.toISO(),
                 JSON.stringify(propertiesLastUpdatedAt),
                 JSON.stringify(propertiesLastOperation),
-                version,
+                1,
             ],
             'upsertGroup'
         )

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -1285,7 +1285,7 @@ export class DB {
             group_properties = $5,
             properties_last_updated_at = $6,
             properties_last_operation = $7,
-            version = $8
+            version = COALESCE(version, 0)::numeric + 1
             WHERE team_id = $1 AND group_key = $2 AND group_type_index = $3
             RETURNING version
             `,
@@ -1297,7 +1297,6 @@ export class DB {
                 JSON.stringify(groupProperties),
                 JSON.stringify(propertiesLastUpdatedAt),
                 JSON.stringify(propertiesLastOperation),
-                version,
             ],
             'upsertGroup'
         )

--- a/plugin-server/src/utils/db/metrics.ts
+++ b/plugin-server/src/utils/db/metrics.ts
@@ -5,6 +5,12 @@ export const personUpdateVersionMismatchCounter = new Counter({
     help: 'Person update version mismatch',
 })
 
+export const groupUpdateVersionMismatchCounter = new Counter({
+    name: 'group_update_version_mismatch',
+    help: 'Group update version mismatch',
+    labelNames: ['type'],
+})
+
 export const pluginLogEntryCounter = new Counter({
     name: 'plugin_log_entry',
     help: 'Plugin log entry created by plugin',

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -301,7 +301,8 @@ export class EventsProcessor {
                 groupTypeIndex,
                 groupKey.toString(),
                 groupPropertiesToSet || {},
-                timestamp
+                timestamp,
+                !this.hub.DISABLE_GROUP_SELECT_FOR_UPDATE
             )
         }
     }

--- a/plugin-server/src/worker/ingestion/properties-updater.ts
+++ b/plugin-server/src/worker/ingestion/properties-updater.ts
@@ -88,7 +88,6 @@ export async function upsertGroup(
                             createdAt,
                             {},
                             {},
-                            expectedVersion,
                             tx
                         )
                         actualVersion = insertedVersion

--- a/plugin-server/src/worker/ingestion/properties-updater.ts
+++ b/plugin-server/src/worker/ingestion/properties-updater.ts
@@ -54,7 +54,6 @@ export async function upsertGroup(
                             createdAt,
                             {},
                             {},
-                            expectedVersion,
                             tx
                         )
                         if (updatedVersion !== undefined) {

--- a/plugin-server/src/worker/ingestion/properties-updater.ts
+++ b/plugin-server/src/worker/ingestion/properties-updater.ts
@@ -20,7 +20,8 @@ export async function upsertGroup(
     groupTypeIndex: GroupTypeIndex,
     groupKey: string,
     properties: Properties,
-    timestamp: DateTime
+    timestamp: DateTime,
+    forUpdate: boolean = true
 ): Promise<void> {
     try {
         const [propertiesUpdate, createdAt, version] = await db.postgres.transaction(
@@ -28,7 +29,7 @@ export async function upsertGroup(
             'upsertGroup',
             async (tx) => {
                 const group: Group | undefined = await db.fetchGroup(teamId, groupTypeIndex, groupKey, tx, {
-                    forUpdate: true,
+                    forUpdate,
                 })
                 const createdAt = DateTime.min(group?.created_at || DateTime.now(), timestamp)
                 const version = (group?.version || 0) + 1

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -554,8 +554,7 @@ describe('DB', () => {
                 { prop: 'val' },
                 TIMESTAMP,
                 { prop: ISO_TIMESTAMP },
-                { prop: PropertyUpdateOperation.Set },
-                1
+                { prop: PropertyUpdateOperation.Set }
             )
 
             expect(await db.fetchGroup(3, 0, 'group_key')).toEqual(undefined)
@@ -571,8 +570,7 @@ describe('DB', () => {
                 { prop: 'val' },
                 TIMESTAMP,
                 { prop: ISO_TIMESTAMP },
-                { prop: PropertyUpdateOperation.Set },
-                1
+                { prop: PropertyUpdateOperation.Set }
             )
 
             expect(await db.fetchGroup(2, 0, 'group_key')).toEqual({
@@ -596,8 +594,7 @@ describe('DB', () => {
                 { prop: 'val' },
                 TIMESTAMP,
                 { prop: ISO_TIMESTAMP },
-                { prop: PropertyUpdateOperation.Set },
-                1
+                { prop: PropertyUpdateOperation.Set }
             )
 
             await expect(
@@ -608,8 +605,7 @@ describe('DB', () => {
                     { prop: 'newval' },
                     TIMESTAMP,
                     { prop: ISO_TIMESTAMP },
-                    { prop: PropertyUpdateOperation.Set },
-                    1
+                    { prop: PropertyUpdateOperation.Set }
                 )
             ).rejects.toEqual(new RaceConditionError('Parallel posthog_group inserts, retry'))
         })
@@ -622,8 +618,7 @@ describe('DB', () => {
                 { prop: 'val' },
                 TIMESTAMP,
                 { prop: ISO_TIMESTAMP },
-                { prop: PropertyUpdateOperation.Set },
-                1
+                { prop: PropertyUpdateOperation.Set }
             )
 
             const originalGroup = await db.fetchGroup(2, 0, 'group_key')

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -636,8 +636,7 @@ describe('DB', () => {
                 { prop: 'newVal', prop2: 2 },
                 TIMESTAMP,
                 { prop: timestamp2.toISO()!, prop2: timestamp2.toISO()! },
-                { prop: PropertyUpdateOperation.Set, prop2: PropertyUpdateOperation.Set },
-                2
+                { prop: PropertyUpdateOperation.Set, prop2: PropertyUpdateOperation.Set }
             )
 
             expect(await db.fetchGroup(2, 0, 'group_key')).toEqual({

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -1928,7 +1928,7 @@ test('$groupidentify updating properties', async () => {
     const next: DateTime = now.plus({ minutes: 1 })
 
     await createPerson(hub, team, ['distinct_id1'])
-    await hub.db.insertGroup(team.id, 0, 'org::5', { a: 1, b: 2 }, now, {}, {}, 1)
+    await hub.db.insertGroup(team.id, 0, 'org::5', { a: 1, b: 2 }, now, {}, {})
 
     await processEvent(
         'distinct_id1',


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

The consistency gained for the SELECT FOR UPDATE on Group table is not necessary and is causing resource contention on the DB

## Changes

Put the FOR UPDATE part of the Select behind an env var that can be controlled

## Does this work well for both Cloud and self-hosted?


## How did you test this code?

local tests, it is behind env var
