### PR TITLE
feat(capture): add offset property type enforcement and unit test

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -21,6 +21,10 @@ posthog/admin/inlines/plugin_attachment_inline.py:0: error: Signature of "has_ch
 posthog/admin/inlines/plugin_attachment_inline.py:0: error: Signature of "has_delete_permission" incompatible with supertype "BaseModelAdmin"  [override]
 posthog/admin/inlines/plugin_attachment_inline.py:0: error: Signature of "has_delete_permission" incompatible with supertype "InlineModelAdmin"  [override]
 posthog/api/action.py:0: error: Argument 1 to <tuple> has incompatible type "*tuple[str, ...]"; expected "type[BaseRenderer]"  [arg-type]
+<<<<<<< HEAD
+=======
+posthog/api/capture.py:0: error: Function "builtins.any" is not valid as a type  [valid-type]
+>>>>>>> 805022e74f (update mypy baseline)
 posthog/api/cohort.py:0: error: Incompatible type for lookup 'pk': (got "str | int | list[str]", expected "str | int")  [misc]
 posthog/api/dashboards/dashboard.py:0: error: Argument 1 to "dashboard_queryset" of "DashboardTile" has incompatible type "DashboardTile_RelatedManager"; expected "QuerySet[Any, Any]"  [arg-type]
 posthog/api/documentation.py:0: error: Signature of "run_validation" incompatible with supertype "Field"  [override]

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -21,7 +21,6 @@ posthog/admin/inlines/plugin_attachment_inline.py:0: error: Signature of "has_ch
 posthog/admin/inlines/plugin_attachment_inline.py:0: error: Signature of "has_delete_permission" incompatible with supertype "BaseModelAdmin"  [override]
 posthog/admin/inlines/plugin_attachment_inline.py:0: error: Signature of "has_delete_permission" incompatible with supertype "InlineModelAdmin"  [override]
 posthog/api/action.py:0: error: Argument 1 to <tuple> has incompatible type "*tuple[str, ...]"; expected "type[BaseRenderer]"  [arg-type]
-posthog/api/capture.py:0: error: Function "builtins.any" is not valid as a type  [valid-type]
 posthog/api/cohort.py:0: error: Incompatible type for lookup 'pk': (got "str | int | list[str]", expected "str | int")  [misc]
 posthog/api/dashboards/dashboard.py:0: error: Argument 1 to "dashboard_queryset" of "DashboardTile" has incompatible type "DashboardTile_RelatedManager"; expected "QuerySet[Any, Any]"  [arg-type]
 posthog/api/documentation.py:0: error: Signature of "run_validation" incompatible with supertype "Field"  [override]

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -21,10 +21,7 @@ posthog/admin/inlines/plugin_attachment_inline.py:0: error: Signature of "has_ch
 posthog/admin/inlines/plugin_attachment_inline.py:0: error: Signature of "has_delete_permission" incompatible with supertype "BaseModelAdmin"  [override]
 posthog/admin/inlines/plugin_attachment_inline.py:0: error: Signature of "has_delete_permission" incompatible with supertype "InlineModelAdmin"  [override]
 posthog/api/action.py:0: error: Argument 1 to <tuple> has incompatible type "*tuple[str, ...]"; expected "type[BaseRenderer]"  [arg-type]
-<<<<<<< HEAD
-=======
 posthog/api/capture.py:0: error: Function "builtins.any" is not valid as a type  [valid-type]
->>>>>>> 805022e74f (update mypy baseline)
 posthog/api/cohort.py:0: error: Incompatible type for lookup 'pk': (got "str | int | list[str]", expected "str | int")  [misc]
 posthog/api/dashboards/dashboard.py:0: error: Argument 1 to "dashboard_queryset" of "DashboardTile" has incompatible type "DashboardTile_RelatedManager"; expected "QuerySet[Any, Any]"  [arg-type]
 posthog/api/documentation.py:0: error: Signature of "run_validation" incompatible with supertype "Field"  [override]

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -347,7 +347,7 @@ def get_distinct_id(data: dict[str, Any]) -> str:
     return str(raw_value)[0:200]
 
 
-def enforce_numeric_offset(properties: dict[str, any]):
+def enforce_numeric_offset(properties: dict[str, Any]):
     try:
         raw_offset = properties["offset"]
     except KeyError:

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -347,6 +347,16 @@ def get_distinct_id(data: dict[str, Any]) -> str:
     return str(raw_value)[0:200]
 
 
+def enforce_numeric_offset(properties: dict[str, any]):
+    try:
+        raw_offset = properties["offset"]
+    except KeyError:
+        return
+
+    if not isinstance(raw_offset, int):
+        raise ValueError(f'Event field "offset" must be numeric, received {type(properties["offset"]).__name__}!')
+
+
 def drop_performance_events(events: list[Any]) -> list[Any]:
     cleaned_list = [event for event in events if event.get("event") != "$performance_event"]
     return cleaned_list
@@ -891,6 +901,8 @@ def parse_event(event):
 
     if not event.get("properties"):
         event["properties"] = {}
+
+    enforce_numeric_offset(event["properties"])
 
     with configure_scope() as scope:
         scope.set_tag("library", event["properties"].get("$lib", "unknown"))

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -446,7 +446,6 @@ class TestCapture(BaseTest):
                 HTTP_ORIGIN="https://localhost",
             )
 
-        # TODO(eli): catch error bubbled up when this fails in more detailed way?
         assert response.status_code == 400
 
     @patch("posthog.kafka_client.client._KafkaProducer.produce")


### PR DESCRIPTION
## Problem
Error tracking reports unenforced non-integer `offset` property values are being ingested in events, causing downstream trouble. The `capture-rs` service enforces an `i64` type on this property if set, but `capture.py` does not.

## Changes
* `capture.py`: check for `offset` property, and if present, enforce it's value is of type `int`
* `test_capture.py` new unit test to exercise the enforcement works (tests with a well-typed `offset` already exist)

Leaving this is draft for now as I'll be on PTO for the next week and won't be around to land it, but feel free to proceed if this is needed sooner.

Also open question as to whether we just wait to deprecate `capture.py` vs. patching this, since `capture-rs` already enforces this type 🤷 

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally and in CI