### PR TITLE
fix(devex): fix custom scrollable styles 

### DIFF
--- a/frontend/src/lib/components/ScrollableShadows/ScrollableShadows.tsx
+++ b/frontend/src/lib/components/ScrollableShadows/ScrollableShadows.tsx
@@ -48,7 +48,11 @@ export const ScrollableShadows = React.forwardRef<HTMLDivElement, ScrollableShad
             {...props}
         >
             <div
-                className={clsx('ScrollableShadows__inner', styledScrollbars && 'styled-scrollbars', innerClassName)}
+                className={clsx(
+                    'ScrollableShadows__inner',
+                    styledScrollbars && 'show-scrollbar-on-hover',
+                    innerClassName
+                )}
                 ref={(refValue) => {
                     scrollRefScrollable.current = refValue
                     if (scrollRef) {

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -375,6 +375,9 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
 ]
 
 /** This const is auto-generated, as is the whole file */
+export const getTreeItemsGames = (): FileSystemImport[] => [{ path: '368 Hedgehogs', href: urls.game368hedgehogs() }]
+
+/** This const is auto-generated, as is the whole file */
 export const getTreeFilterTypes = (): Record<string, FileSystemFilterType> => ({
     action: { name: 'Actions' },
     dashboard: { name: 'Dashboards' },

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -375,9 +375,6 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
 ]
 
 /** This const is auto-generated, as is the whole file */
-export const getTreeItemsGames = (): FileSystemImport[] => [{ path: '368 Hedgehogs', href: urls.game368hedgehogs() }]
-
-/** This const is auto-generated, as is the whole file */
 export const getTreeFilterTypes = (): Record<string, FileSystemFilterType> => ({
     action: { name: 'Actions' },
     dashboard: { name: 'Dashboards' },

--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -1070,12 +1070,9 @@
             }
         }
 
-        .styled-scrollbars {
-            --scrollbar-background: transparent transparent;
-
+        .show-scrollbar-on-hover {
             scrollbar-color: transparent transparent;
             scrollbar-width: thin;
-            scrollbar-gutter: stable;
 
             &::-webkit-scrollbar {
                 width: 0.5rem;


### PR DESCRIPTION

## Problem
If i user had OS level setting of "scrollbar: always show" and when we use `scrollbar-gutter: stable;` forced the spacing even when an element isn't scrollable.

We cannot detect if a user set this at the browser level, we can atleast hid the space when the element isn't scrollable at that time.

Before:
<img width="265" alt="image" src="https://github.com/user-attachments/assets/3a423f7f-910d-4118-b802-19f97904dc7a" />

After:
<img width="264" alt="image" src="https://github.com/user-attachments/assets/730ef1f8-c784-4aa1-ae47-9018d45ef834" />

As you can see, the div isn't scrollable, and this fix removes the space when it's not scrollable.

## Changes
Rename class
Remove `scrollbar-gutter: stable;` declaration

## How did you test this code?
Locally 