### PR TITLE
chore: add docs question to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@
 
 ## Did you write or update any docs for this change?
 
-<!-- Engineers are responsible for documenting their features and/or code.  -->
+<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->
 
 - [ ] I've added or updated the docs
 - [ ] I've reached out for help from the docs team

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,9 +13,13 @@
 <!-- If there are frontend changes, please include screenshots. -->
 <!-- If a reference design was involved, include a link to the relevant Figma frame! -->
 
-## Does this work well for both Cloud and self-hosted?
+## Did you write or update any docs for this change?
 
-<!-- Yes / no / it doesn't have an impact. -->
+<!-- Engineers are responsible for documenting their features and/or code.  -->
+
+- [ ] I've added or updated the docs
+- [ ] I've reached out for help from the docs team
+- [ ] No docs needed for this change
 
 ## How did you test this code?
 


### PR DESCRIPTION
We had an [OST session about making devs better at docs](https://github.com/PostHog/company-internal/issues/1923). Adding a section about docs to the PR template has been on my list for a while, so figured I'd just do it!

I think what is missing here is guidance for _when_ docs are required, and we should have a handbook entry for that and link it in the template as well, but since this was on my mind now I figured it was good to put it in and we can add the link after that doc is written.