### PR TITLE
fix(project-tree): nits

### DIFF
--- a/frontend/src/layout/panel-layout/PanelLayoutPanel.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutPanel.tsx
@@ -28,6 +28,7 @@ interface PanelLayoutPanelProps {
     searchPlaceholder?: string
     panelActions?: React.ReactNode
     children: React.ReactNode
+    showFilterDropdown?: boolean
 }
 
 const panelLayoutPanelVariants = cva({
@@ -155,7 +156,12 @@ export function FiltersDropdown({ setSearchTerm, searchTerm }: FiltersDropdownPr
     )
 }
 
-export function PanelLayoutPanel({ searchPlaceholder, panelActions, children }: PanelLayoutPanelProps): JSX.Element {
+export function PanelLayoutPanel({
+    searchPlaceholder,
+    panelActions,
+    children,
+    showFilterDropdown = false,
+}: PanelLayoutPanelProps): JSX.Element {
     const { clearSearch, setSearchTerm, toggleLayoutPanelPinned, setPanelWidth } = useActions(panelLayoutLogic)
     const {
         isLayoutPanelPinned,
@@ -238,7 +244,7 @@ export function PanelLayoutPanel({ searchPlaceholder, panelActions, children }: 
                             }
                         }}
                     />
-                    <FiltersDropdown setSearchTerm={setSearchTerm} searchTerm={searchTerm} />
+                    {showFilterDropdown && <FiltersDropdown setSearchTerm={setSearchTerm} searchTerm={searchTerm} />}
                 </div>
                 <div className="border-b border-primary h-px" />
                 {children}

--- a/frontend/src/layout/panel-layout/PanelLayoutPanel.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutPanel.tsx
@@ -130,7 +130,7 @@ export function FiltersDropdown({ setSearchTerm, searchTerm }: FiltersDropdownPr
                     </DropdownMenuItem>
                     <DropdownMenuSeparator />
                     {types
-                        .filter(([_, { flag }]) => !flag || featureFlags[flag])
+                        .filter(([_, { flag }]) => !flag || featureFlags[flag as keyof typeof featureFlags])
                         .map(([obj, { name }]) => (
                             <DropdownMenuItem
                                 key={obj}

--- a/frontend/src/layout/panel-layout/ProductTree/ProductTree.tsx
+++ b/frontend/src/layout/panel-layout/ProductTree/ProductTree.tsx
@@ -15,9 +15,9 @@ import { projectTreeLogic } from '../ProjectTree/projectTreeLogic'
 
 export function ProductTree(): JSX.Element {
     const { treeItemsProducts } = useValues(projectTreeLogic)
-    const { mainContentRef } = useValues(panelLayoutLogic)
     const { addShortcutItem } = useActions(shortcutsLogic)
-
+    const { mainContentRef, isLayoutPanelPinned } = useValues(panelLayoutLogic)
+    const { showLayoutPanel, clearActivePanelIdentifier } = useActions(panelLayoutLogic)
     const treeRef = useRef<LemonTreeRef>(null)
     const [expandedFolders, setExpandedFolders] = useState<string[]>(['/'])
 
@@ -87,6 +87,11 @@ export function ProductTree(): JSX.Element {
                                 : node.record.href
                         )
                     }
+                    if (!isLayoutPanelPinned) {
+                        clearActivePanelIdentifier()
+                        showLayoutPanel(false)
+                    }
+
                     node?.onClick?.(true)
                 }}
                 expandedItemIds={expandedFolders}

--- a/frontend/src/layout/panel-layout/ProductTree/ProductTree.tsx
+++ b/frontend/src/layout/panel-layout/ProductTree/ProductTree.tsx
@@ -58,7 +58,7 @@ export function ProductTree(): JSX.Element {
     }
 
     return (
-        <PanelLayoutPanel>
+        <PanelLayoutPanel searchPlaceholder="Search products">
             <LemonTree
                 ref={treeRef}
                 contentRef={mainContentRef as RefObject<HTMLElement>}

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -372,6 +372,7 @@ export function ProjectTree({ sortMethod }: ProjectTreeProps): JSX.Element {
 
     return (
         <PanelLayoutPanel
+            showFilterDropdown={true}
             searchPlaceholder={sortMethod === 'recent' ? 'Search recent items' : 'Search your project'}
             panelActions={
                 <>

--- a/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
+++ b/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
@@ -1,4 +1,4 @@
-import { actions, connect, kea, path, reducers, selectors } from 'kea'
+import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { LemonTreeRef, TreeMode } from 'lib/lemon-ui/LemonTree/LemonTree'
 
 import { navigation3000Logic } from '../navigation-3000/navigationLogic'
@@ -130,6 +130,12 @@ export const panelLayoutLogic = kea<panelLayoutLogicType>([
             },
         ],
     }),
+    listeners(({ actions }) => ({
+        setActivePanelIdentifier: () => {
+            // clear search term when changing panel
+            actions.clearSearch()
+        },
+    })),
     selectors({
         isLayoutNavCollapsed: [
             (s) => [s.isLayoutNavCollapsedDesktop, s.mobileLayout],


### PR DESCRIPTION
## Problem
* Product tree items when clicked didn't close the panel
* Some trees had filtering when they shouldn't
* Search was persisting across panel switching

![2025-05-16 20 27 58](https://github.com/user-attachments/assets/0cc2a2ec-adf9-4b55-aea5-ea99aa120d6d)

## Changes
Close (product tree) panel (if open) on click 
Hide filter in panel via prop.
Remove search term on panel identifier change.

## How did you test this code?
Manually