### PR TITLE
fix: show x25 in yc form

### DIFF
--- a/frontend/src/scenes/startups/startupProgramLogic.ts
+++ b/frontend/src/scenes/startups/startupProgramLogic.ts
@@ -41,7 +41,7 @@ export const RAISED_OPTIONS = [
 
 export const YC_BATCH_OPTIONS = [
     { label: 'Select your batch', value: '' },
-    // { label: 'Summer 2025', value: 'S25' }, # Too early to show, X25 only starting in April 2025
+    { label: 'Spring 2025', value: 'X25' },
     { label: 'Winter 2025', value: 'W25' },
     { label: 'Fall 2024', value: 'F24' },
     { label: 'Summer 2024', value: 'S24' },


### PR DESCRIPTION
## Problem

I've added it to the `billing` already but forgot to add to the form options.

## Changes

Adds `X25` to YC batch options in YC form

## Does this work well for both Cloud and self-hosted?

Cloud only

## How did you test this code?

n/a
