### PR TITLE
fix: Fix some misc browser console warnings

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSwitch/LemonSwitch.tsx
@@ -66,8 +66,11 @@ export const LemonSwitch: React.FunctionComponent<LemonSwitchProps & React.RefAt
         } else if (tooltip) {
             tooltipContent = <span>{tooltip}</span>
         }
+
+        const ButtonHtmlComponent = onChange ? 'button' : 'div'
+
         let buttonComponent = (
-            <button
+            <ButtonHtmlComponent
                 id={id}
                 className={`LemonSwitch__button ${
                     sliderColorOverrideChecked || sliderColorOverrideUnchecked
@@ -89,7 +92,7 @@ export const LemonSwitch: React.FunctionComponent<LemonSwitchProps & React.RefAt
                 {...conditionalProps}
             >
                 <div className="LemonSwitch__handle">{handleContent}</div>
-            </button>
+            </ButtonHtmlComponent>
         )
         if (tooltipContent) {
             buttonComponent = (

--- a/frontend/src/toolbar/actions/ActionsListView.tsx
+++ b/frontend/src/toolbar/actions/ActionsListView.tsx
@@ -16,7 +16,7 @@ export function ActionsListView({ actions }: ActionsListViewProps): JSX.Element 
     const { selectAction } = useActions(actionsTabLogic)
 
     return (
-        <div className="flex flex-col h-full overflow-y-scoll deprecated-space-y-px mb-2">
+        <div className="flex flex-col h-full overflow-y-scroll deprecated-space-y-px mb-2">
             {actions.length ? (
                 actions.map((action, index) => (
                     <Fragment key={action.id}>

--- a/frontend/src/toolbar/actions/ActionsListView.tsx
+++ b/frontend/src/toolbar/actions/ActionsListView.tsx
@@ -22,7 +22,6 @@ export function ActionsListView({ actions }: ActionsListViewProps): JSX.Element 
                     <Fragment key={action.id}>
                         <Link
                             subtle
-                            key={action.id}
                             onClick={() => selectAction(action.id || null)}
                             className="font-medium my-1 w-full"
                         >

--- a/frontend/src/toolbar/actions/ActionsListView.tsx
+++ b/frontend/src/toolbar/actions/ActionsListView.tsx
@@ -1,6 +1,7 @@
 import { Link } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { Spinner } from 'lib/lemon-ui/Spinner'
+import { Fragment } from 'react'
 
 import { actionsLogic } from '~/toolbar/actions/actionsLogic'
 import { actionsTabLogic } from '~/toolbar/actions/actionsTabLogic'
@@ -18,7 +19,7 @@ export function ActionsListView({ actions }: ActionsListViewProps): JSX.Element 
         <div className="flex flex-col h-full overflow-y-scoll deprecated-space-y-px mb-2">
             {actions.length ? (
                 actions.map((action, index) => (
-                    <>
+                    <Fragment key={action.id}>
                         <Link
                             subtle
                             key={action.id}
@@ -30,7 +31,7 @@ export function ActionsListView({ actions }: ActionsListViewProps): JSX.Element 
                                 {action.name || <span className="italic text-secondary">Untitled</span>}
                             </span>
                         </Link>
-                    </>
+                    </Fragment>
                 ))
             ) : allActionsLoading ? (
                 <div className="flex items-center">


### PR DESCRIPTION
## Problem

While debugging some CSP issues with the toolbar, I also noticed these warnings in the browser console.

It's not valid HTML to nest a button with another button, and we do it a fair bit (we'll have a button with a toggle inside it, where the inner toggle is not actually wired up to a change listener, only the outer button is). This PR changes this to valid html without breaking the functionality

## Changes

May as well fix them 🤷 

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?

The browser console warnings didn't show any more, and when I click around in the UI, the toggle still worked
