### PR TITLE
chore(messaging): add Messaging to support product dropdown

### DIFF
--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -258,6 +258,7 @@ export type SupportTicketTargetArea =
     | 'cdp_destinations'
     | 'data_ingestion'
     | 'batch_exports'
+    | 'messaging'
 export type SupportTicketSeverityLevel = keyof typeof SEVERITY_LEVEL_TO_NAME
 export type SupportTicketKind = keyof typeof SUPPORT_KIND_TO_SUBJECT
 
@@ -297,6 +298,7 @@ export const URL_PATH_TO_TARGET_AREA: Record<string, SupportTicketTargetArea> = 
     transformations: 'cdp_destinations',
     source: 'data_warehouse',
     sources: 'data_warehouse',
+    messaging: 'messaging',
 }
 
 export const SUPPORT_TICKET_TEMPLATES = {

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -216,6 +216,11 @@ export const TARGET_AREA_TO_NAME = [
                 'data-attr': `support-form-target-area-llm-observability`,
                 label: 'LLM observability',
             },
+            {
+                value: 'messaging',
+                'data-attr': `support-form-target-area-messaging`,
+                label: 'Messaging',
+            },
         ],
     },
 ]


### PR DESCRIPTION

## Problem

Users have sent back messaging alpha feedback through the Help and had to select an irrelevant topics, adding messaging so that they get routed correctly now


## Changes


<img width="464" alt="Screenshot 2025-05-17 at 10 47 19 AM" src="https://github.com/user-attachments/assets/a1cddeb0-ae84-48fa-b5fc-bec83a72413e" />

Yes



## How did you test this code?

Checked that form works
