### PR TITLE
fix(project-tree): split tree logics into respective logics

### DIFF
--- a/frontend/src/layout/panel-layout/GameTree/GameTree.tsx
+++ b/frontend/src/layout/panel-layout/GameTree/GameTree.tsx
@@ -14,7 +14,7 @@ import { gameTreeLogic } from '../GameTree/gameTreeLogic'
 import { PanelLayoutPanel } from '../PanelLayoutPanel'
 
 export function GameTree(): JSX.Element {
-    const { treeItems } = useValues(gameTreeLogic)
+    const { gameTreeItems } = useValues(gameTreeLogic)
     const { mainContentRef, isLayoutPanelPinned } = useValues(panelLayoutLogic)
     const { showLayoutPanel, clearActivePanelIdentifier } = useActions(panelLayoutLogic)
     const { addShortcutItem } = useActions(shortcutsLogic)
@@ -64,7 +64,7 @@ export function GameTree(): JSX.Element {
                 ref={treeRef}
                 contentRef={mainContentRef as RefObject<HTMLElement>}
                 className="px-0 py-1"
-                data={treeItems}
+                data={gameTreeItems}
                 itemContextMenu={(item) => {
                     return <ContextMenuGroup>{renderMenuItems(item, 'context')}</ContextMenuGroup>
                 }}

--- a/frontend/src/layout/panel-layout/GameTree/GameTree.tsx
+++ b/frontend/src/layout/panel-layout/GameTree/GameTree.tsx
@@ -10,12 +10,13 @@ import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
 import { shortcutsLogic } from '~/layout/panel-layout/Shortcuts/shortcutsLogic'
 import { FileSystemEntry } from '~/queries/schema/schema-general'
 
+import { gameTreeLogic } from '../GameTree/gameTreeLogic'
 import { PanelLayoutPanel } from '../PanelLayoutPanel'
-import { projectTreeLogic } from '../ProjectTree/projectTreeLogic'
 
 export function GameTree(): JSX.Element {
-    const { treeItemsGames } = useValues(projectTreeLogic)
-    const { mainContentRef } = useValues(panelLayoutLogic)
+    const { treeItems } = useValues(gameTreeLogic)
+    const { mainContentRef, isLayoutPanelPinned } = useValues(panelLayoutLogic)
+    const { showLayoutPanel, clearActivePanelIdentifier } = useActions(panelLayoutLogic)
     const { addShortcutItem } = useActions(shortcutsLogic)
 
     const treeRef = useRef<LemonTreeRef>(null)
@@ -63,7 +64,7 @@ export function GameTree(): JSX.Element {
                 ref={treeRef}
                 contentRef={mainContentRef as RefObject<HTMLElement>}
                 className="px-0 py-1"
-                data={treeItemsGames}
+                data={treeItems}
                 itemContextMenu={(item) => {
                     return <ContextMenuGroup>{renderMenuItems(item, 'context')}</ContextMenuGroup>
                 }}
@@ -87,6 +88,11 @@ export function GameTree(): JSX.Element {
                                 : node.record.href
                         )
                     }
+                    if (!isLayoutPanelPinned) {
+                        clearActivePanelIdentifier()
+                        showLayoutPanel(false)
+                    }
+
                     node?.onClick?.(true)
                 }}
                 expandedItemIds={expandedFolders}

--- a/frontend/src/layout/panel-layout/GameTree/gameTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/GameTree/gameTreeLogic.tsx
@@ -14,7 +14,7 @@ export const gameTreeLogic = kea<gameTreeLogicType>([
         actions: [],
     })),
     selectors({
-        treeItems: [
+        gameTreeItems: [
             (s) => [s.featureFlags, s.folderStates, s.users],
             (featureFlags, folderStates, users): TreeDataItem[] =>
                 convertFileSystemEntryToTreeDataItem({

--- a/frontend/src/layout/panel-layout/GameTree/gameTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/GameTree/gameTreeLogic.tsx
@@ -1,0 +1,32 @@
+import { connect, kea, path, selectors } from 'kea'
+import { TreeDataItem } from 'lib/lemon-ui/LemonTree/LemonTree'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+
+import { getDefaultTreeGames } from '../ProjectTree/defaultTree'
+import { projectTreeLogic } from '../ProjectTree/projectTreeLogic'
+import { convertFileSystemEntryToTreeDataItem } from '../ProjectTree/utils'
+import type { gameTreeLogicType } from './gameTreeLogicType'
+
+export const gameTreeLogic = kea<gameTreeLogicType>([
+    path(['layout', 'navigation-3000', 'components', 'gameTreeLogic']),
+    connect(() => ({
+        values: [featureFlagLogic, ['featureFlags'], projectTreeLogic, ['folderStates', 'users']],
+        actions: [],
+    })),
+    selectors({
+        treeItems: [
+            (s) => [s.featureFlags, s.folderStates, s.users],
+            (featureFlags, folderStates, users): TreeDataItem[] =>
+                convertFileSystemEntryToTreeDataItem({
+                    imports: getDefaultTreeGames().filter(
+                        (f) => !f.flag || (featureFlags as Record<string, boolean>)[f.flag]
+                    ),
+                    checkedItems: {},
+                    folderStates,
+                    root: 'explore',
+                    users,
+                    foldersFirst: false,
+                }),
+        ],
+    }),
+])

--- a/frontend/src/layout/panel-layout/ProductTree/ProductTree.tsx
+++ b/frontend/src/layout/panel-layout/ProductTree/ProductTree.tsx
@@ -11,13 +11,12 @@ import { shortcutsLogic } from '~/layout/panel-layout/Shortcuts/shortcutsLogic'
 import { FileSystemEntry } from '~/queries/schema/schema-general'
 
 import { PanelLayoutPanel } from '../PanelLayoutPanel'
-import { projectTreeLogic } from '../ProjectTree/projectTreeLogic'
+import { productTreeLogic } from './productTreeLogic'
 
 export function ProductTree(): JSX.Element {
-    const { treeItemsProducts } = useValues(projectTreeLogic)
-    const { mainContentRef } = useValues(panelLayoutLogic)
+    const { productTreeItems } = useValues(productTreeLogic)
     const { addShortcutItem } = useActions(shortcutsLogic)
-
+    const { mainContentRef } = useValues(panelLayoutLogic)
     const treeRef = useRef<LemonTreeRef>(null)
     const [expandedFolders, setExpandedFolders] = useState<string[]>(['/'])
 
@@ -63,7 +62,7 @@ export function ProductTree(): JSX.Element {
                 ref={treeRef}
                 contentRef={mainContentRef as RefObject<HTMLElement>}
                 className="px-0 py-1"
-                data={treeItemsProducts}
+                data={productTreeItems}
                 itemContextMenu={(item) => {
                     return <ContextMenuGroup>{renderMenuItems(item, 'context')}</ContextMenuGroup>
                 }}

--- a/frontend/src/layout/panel-layout/ProductTree/productTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProductTree/productTreeLogic.tsx
@@ -1,0 +1,31 @@
+import { connect, kea, path, selectors } from 'kea'
+import { TreeDataItem } from 'lib/lemon-ui/LemonTree/LemonTree'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+
+import { getDefaultTreeProducts } from '../ProjectTree/defaultTree'
+import { projectTreeLogic } from '../ProjectTree/projectTreeLogic'
+import { convertFileSystemEntryToTreeDataItem } from '../ProjectTree/utils'
+
+export const productTreeLogic = kea([
+    path(['layout', 'navigation-3000', 'components', 'productTreeLogic']),
+    connect(() => ({
+        values: [featureFlagLogic, ['featureFlags'], projectTreeLogic, ['folderStates', 'users']],
+        actions: [],
+    })),
+    selectors({
+        treeItems: [
+            (s) => [s.featureFlags, s.folderStates, s.users],
+            (featureFlags, folderStates, users): TreeDataItem[] =>
+                convertFileSystemEntryToTreeDataItem({
+                    imports: getDefaultTreeProducts().filter(
+                        (f) => !f.flag || (featureFlags as Record<string, boolean>)[f.flag]
+                    ),
+                    checkedItems: {},
+                    folderStates,
+                    root: 'explore',
+                    users,
+                    foldersFirst: false,
+                }),
+        ],
+    }),
+])

--- a/frontend/src/layout/panel-layout/ProductTree/productTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProductTree/productTreeLogic.tsx
@@ -5,8 +5,9 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { getDefaultTreeProducts } from '../ProjectTree/defaultTree'
 import { projectTreeLogic } from '../ProjectTree/projectTreeLogic'
 import { convertFileSystemEntryToTreeDataItem } from '../ProjectTree/utils'
+import type { productTreeLogicType } from './productTreeLogicType'
 
-export const productTreeLogic = kea([
+export const productTreeLogic = kea<productTreeLogicType>([
     path(['layout', 'navigation-3000', 'components', 'productTreeLogic']),
     connect(() => ({
         values: [featureFlagLogic, ['featureFlags'], projectTreeLogic, ['folderStates', 'users']],

--- a/frontend/src/layout/panel-layout/ProductTree/productTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProductTree/productTreeLogic.tsx
@@ -14,7 +14,7 @@ export const productTreeLogic = kea<productTreeLogicType>([
         actions: [],
     })),
     selectors({
-        treeItems: [
+        productTreeItems: [
             (s) => [s.featureFlags, s.folderStates, s.users],
             (featureFlags, folderStates, users): TreeDataItem[] =>
                 convertFileSystemEntryToTreeDataItem({

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -44,7 +44,7 @@ export interface ProjectTreeProps {
 
 export function ProjectTree({ sortMethod }: ProjectTreeProps): JSX.Element {
     const {
-        treeItemsProject,
+        projectTreeItems,
         treeTableKeys,
         lastViewedId,
         viableItems,
@@ -432,7 +432,7 @@ export function ProjectTree({ sortMethod }: ProjectTreeProps): JSX.Element {
                 ref={treeRef}
                 contentRef={mainContentRef as RefObject<HTMLElement>}
                 className="px-0 py-1"
-                data={treeItemsProject}
+                data={projectTreeItems}
                 mode={projectTreeMode as TreeMode}
                 selectMode={selectMode}
                 tableViewKeys={treeTableKeys}

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
@@ -18,7 +18,7 @@ import { FileSystemEntry, FileSystemImport } from '~/queries/schema/schema-gener
 import { Breadcrumb, ProjectTreeBreadcrumb, ProjectTreeRef, UserBasicType } from '~/types'
 
 import { panelLayoutLogic } from '../panelLayoutLogic'
-import { getDefaultTreeGames, getDefaultTreeNew, getDefaultTreeProducts } from './defaultTree'
+import { getDefaultTreeNew } from './defaultTree'
 import type { projectTreeLogicType } from './projectTreeLogicType'
 import { FolderState, ProjectTreeAction } from './types'
 import {
@@ -898,34 +898,6 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                     foldersFirst: false,
                 }),
         ],
-        treeItemsProducts: [
-            (s) => [s.featureFlags, s.folderStates, s.users],
-            (featureFlags, folderStates, users): TreeDataItem[] =>
-                convertFileSystemEntryToTreeDataItem({
-                    imports: getDefaultTreeProducts().filter(
-                        (f) => !f.flag || (featureFlags as Record<string, boolean>)[f.flag]
-                    ),
-                    checkedItems: {},
-                    folderStates,
-                    root: 'explore',
-                    users,
-                    foldersFirst: false,
-                }),
-        ],
-        treeItemsGames: [
-            (s) => [s.featureFlags, s.folderStates, s.users],
-            (featureFlags, folderStates, users): TreeDataItem[] =>
-                convertFileSystemEntryToTreeDataItem({
-                    imports: getDefaultTreeGames().filter(
-                        (f) => !f.flag || (featureFlags as Record<string, boolean>)[f.flag]
-                    ),
-                    checkedItems: {},
-                    folderStates,
-                    root: 'explore',
-                    users,
-                    foldersFirst: false,
-                }),
-        ],
         recentTreeItems: [
             (s) => [s.recentResults, s.recentResultsLoading, s.folderStates, s.checkedItems, s.users],
             (recentResults, recentResultsLoading, folderStates, checkedItems, users): TreeDataItem[] => {
@@ -995,7 +967,7 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                 return results
             },
         ],
-        treeItemsProject: [
+        projectTreeItems: [
             (s) => [s.searchTerm, s.searchedTreeItems, s.projectTree, s.loadingPaths, s.recentTreeItems, s.sortMethod],
             (searchTerm, searchedTreeItems, projectTree, loadingPaths, recentTreeItems, sortMethod): TreeDataItem[] => {
                 if (searchTerm) {
@@ -1015,45 +987,6 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                     ]
                 }
                 return projectTree
-            },
-        ],
-        treeItemsCombined: [
-            (s) => [s.treeItemsProject, s.treeItemsProducts, s.treeItemsNew],
-            (project, products, allNew): TreeDataItem[] => {
-                function addNewLabel(item: TreeDataItem): TreeDataItem {
-                    if (item.children) {
-                        return { ...item, children: item.children?.map(addNewLabel) }
-                    }
-                    const pathParts = splitPath(item.record?.path ?? '')
-                    const name = `New ${pathParts.pop()?.toLowerCase()}`
-                    const newPath = joinPath([...pathParts, name])
-                    return {
-                        ...item,
-                        name: name,
-                        record: { ...item.record, path: newPath },
-                    }
-                }
-
-                return [
-                    {
-                        id: 'project',
-                        name: 'Project',
-                        record: { type: 'folder', id: null, path: '/' },
-                        children: project,
-                    },
-                    {
-                        id: 'products',
-                        name: 'Products',
-                        record: { type: 'folder', id: null, path: '/' },
-                        children: products,
-                    },
-                    {
-                        id: 'new',
-                        name: 'New',
-                        record: { type: 'folder', id: null, path: '/' },
-                        children: allNew.map(addNewLabel),
-                    },
-                ]
             },
         ],
         // TODO: use treeData + some other logic to determine the keys

--- a/frontend/src/layout/panel-layout/Shortcuts/AddShortcutModal.tsx
+++ b/frontend/src/layout/panel-layout/Shortcuts/AddShortcutModal.tsx
@@ -10,9 +10,8 @@ import { shortcutsLogic } from '~/layout/panel-layout/Shortcuts/shortcutsLogic'
 import { FileSystemEntry } from '~/queries/schema/schema-general'
 
 export function CombinedTree(): JSX.Element {
-    const { treeItemsCombined } = useValues(projectTreeLogic)
     const { mainContentRef } = useValues(panelLayoutLogic)
-    const { selectedItem } = useValues(shortcutsLogic)
+    const { selectedItem, treeItemsCombined } = useValues(shortcutsLogic)
     const { setSelectedItem } = useActions(shortcutsLogic)
     const { loadFolderIfNotLoaded } = useActions(projectTreeLogic)
 

--- a/frontend/src/layout/panel-layout/Shortcuts/shortcutsLogic.tsx
+++ b/frontend/src/layout/panel-layout/Shortcuts/shortcutsLogic.tsx
@@ -4,15 +4,22 @@ import api from 'lib/api'
 import { TreeDataItem } from 'lib/lemon-ui/LemonTree/LemonTree'
 
 import { projectTreeLogic } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
-import { convertFileSystemEntryToTreeDataItem, escapePath, splitPath } from '~/layout/panel-layout/ProjectTree/utils'
+import {
+    convertFileSystemEntryToTreeDataItem,
+    escapePath,
+    joinPath,
+    splitPath,
+} from '~/layout/panel-layout/ProjectTree/utils'
 import { FileSystemEntry } from '~/queries/schema/schema-general'
 
+import { productTreeLogic } from '../ProductTree/productTreeLogic'
 import type { shortcutsLogicType } from './shortcutsLogicType'
 
 export const shortcutsLogic = kea<shortcutsLogicType>([
     path(['layout', 'panel-layout', 'Shortcuts', 'shortcutsLogic']),
     connect(() => ({
         actions: [projectTreeLogic, ['updateSyncedFiles', 'deleteTypeAndRef']],
+        values: [projectTreeLogic, ['projectTreeItems', 'treeItemsNew'], productTreeLogic, ['productTreeItems']],
     })),
     actions({
         showModal: true,
@@ -95,6 +102,45 @@ export const shortcutsLogic = kea<shortcutsLogicType>([
                 }).sort((a, b) => a.name.localeCompare(b.name)),
         ],
         shortcutsLoading: [(s) => [s.shortcutDataLoading], (loading) => loading],
+        treeItemsCombined: [
+            (s) => [s.projectTreeItems, s.productTreeItems, s.treeItemsNew],
+            (project, products, allNew): TreeDataItem[] => {
+                function addNewLabel(item: TreeDataItem): TreeDataItem {
+                    if (item.children) {
+                        return { ...item, children: item.children?.map(addNewLabel) }
+                    }
+                    const pathParts = splitPath(item.record?.path ?? '')
+                    const name = `New ${pathParts.pop()?.toLowerCase()}`
+                    const newPath = joinPath([...pathParts, name])
+                    return {
+                        ...item,
+                        name: name,
+                        record: { ...item.record, path: newPath },
+                    }
+                }
+
+                return [
+                    {
+                        id: 'project',
+                        name: 'Project',
+                        record: { type: 'folder', id: null, path: '/' },
+                        children: project,
+                    },
+                    {
+                        id: 'products',
+                        name: 'Products',
+                        record: { type: 'folder', id: null, path: '/' },
+                        children: products,
+                    },
+                    {
+                        id: 'new',
+                        name: 'New',
+                        record: { type: 'folder', id: null, path: '/' },
+                        children: allNew.map(addNewLabel),
+                    },
+                ]
+            },
+        ],
     }),
     afterMount(({ actions }) => {
         actions.loadShortcuts()


### PR DESCRIPTION
## Problem
`Project tree` logic was a dumping ground for all our trees, some things should exist elsewhere

## Changes
Took out `product`/`games`/`shortcut` tree logic out of `project tree` logic and put into their own logic

## Todo in later PR
- [ ] make `tree logic` and move some stuff out of `project tree logic` (`project tree logic` should be for specific stuff pertaining to project `files`, and project `recent files`(?)

## How did you test this code?
Manually