### PR TITLE
fix(project-tree): search for product & project trees 

### DIFF
--- a/frontend/src/layout/panel-layout/GameTree/GameTree.tsx
+++ b/frontend/src/layout/panel-layout/GameTree/GameTree.tsx
@@ -14,7 +14,7 @@ import { gameTreeLogic } from '../GameTree/gameTreeLogic'
 import { PanelLayoutPanel } from '../PanelLayoutPanel'
 
 export function GameTree(): JSX.Element {
-    const { treeItems } = useValues(gameTreeLogic)
+    const { gameTreeItems } = useValues(gameTreeLogic)
     const { mainContentRef, isLayoutPanelPinned } = useValues(panelLayoutLogic)
     const { showLayoutPanel, clearActivePanelIdentifier } = useActions(panelLayoutLogic)
     const { addShortcutItem } = useActions(shortcutsLogic)
@@ -64,7 +64,7 @@ export function GameTree(): JSX.Element {
                 ref={treeRef}
                 contentRef={mainContentRef as RefObject<HTMLElement>}
                 className="px-0 py-1"
-                data={treeItems}
+                data={gameTreeItems}
                 itemContextMenu={(item) => {
                     return <ContextMenuGroup>{renderMenuItems(item, 'context')}</ContextMenuGroup>
                 }}

--- a/frontend/src/layout/panel-layout/GameTree/GameTree.tsx
+++ b/frontend/src/layout/panel-layout/GameTree/GameTree.tsx
@@ -10,12 +10,13 @@ import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
 import { shortcutsLogic } from '~/layout/panel-layout/Shortcuts/shortcutsLogic'
 import { FileSystemEntry } from '~/queries/schema/schema-general'
 
+import { gameTreeLogic } from '../GameTree/gameTreeLogic'
 import { PanelLayoutPanel } from '../PanelLayoutPanel'
-import { projectTreeLogic } from '../ProjectTree/projectTreeLogic'
 
 export function GameTree(): JSX.Element {
-    const { treeItemsGames } = useValues(projectTreeLogic)
-    const { mainContentRef } = useValues(panelLayoutLogic)
+    const { treeItems } = useValues(gameTreeLogic)
+    const { mainContentRef, isLayoutPanelPinned } = useValues(panelLayoutLogic)
+    const { showLayoutPanel, clearActivePanelIdentifier } = useActions(panelLayoutLogic)
     const { addShortcutItem } = useActions(shortcutsLogic)
 
     const treeRef = useRef<LemonTreeRef>(null)
@@ -63,7 +64,7 @@ export function GameTree(): JSX.Element {
                 ref={treeRef}
                 contentRef={mainContentRef as RefObject<HTMLElement>}
                 className="px-0 py-1"
-                data={treeItemsGames}
+                data={treeItems}
                 itemContextMenu={(item) => {
                     return <ContextMenuGroup>{renderMenuItems(item, 'context')}</ContextMenuGroup>
                 }}
@@ -87,6 +88,11 @@ export function GameTree(): JSX.Element {
                                 : node.record.href
                         )
                     }
+                    if (!isLayoutPanelPinned) {
+                        clearActivePanelIdentifier()
+                        showLayoutPanel(false)
+                    }
+
                     node?.onClick?.(true)
                 }}
                 expandedItemIds={expandedFolders}

--- a/frontend/src/layout/panel-layout/GameTree/gameTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/GameTree/gameTreeLogic.tsx
@@ -14,7 +14,7 @@ export const gameTreeLogic = kea<gameTreeLogicType>([
         actions: [],
     })),
     selectors({
-        treeItems: [
+        gameTreeItems: [
             (s) => [s.featureFlags, s.folderStates, s.users],
             (featureFlags, folderStates, users): TreeDataItem[] =>
                 convertFileSystemEntryToTreeDataItem({

--- a/frontend/src/layout/panel-layout/GameTree/gameTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/GameTree/gameTreeLogic.tsx
@@ -1,0 +1,32 @@
+import { connect, kea, path, selectors } from 'kea'
+import { TreeDataItem } from 'lib/lemon-ui/LemonTree/LemonTree'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+
+import { getDefaultTreeGames } from '../ProjectTree/defaultTree'
+import { projectTreeLogic } from '../ProjectTree/projectTreeLogic'
+import { convertFileSystemEntryToTreeDataItem } from '../ProjectTree/utils'
+import type { gameTreeLogicType } from './gameTreeLogicType'
+
+export const gameTreeLogic = kea<gameTreeLogicType>([
+    path(['layout', 'navigation-3000', 'components', 'gameTreeLogic']),
+    connect(() => ({
+        values: [featureFlagLogic, ['featureFlags'], projectTreeLogic, ['folderStates', 'users']],
+        actions: [],
+    })),
+    selectors({
+        treeItems: [
+            (s) => [s.featureFlags, s.folderStates, s.users],
+            (featureFlags, folderStates, users): TreeDataItem[] =>
+                convertFileSystemEntryToTreeDataItem({
+                    imports: getDefaultTreeGames().filter(
+                        (f) => !f.flag || (featureFlags as Record<string, boolean>)[f.flag]
+                    ),
+                    checkedItems: {},
+                    folderStates,
+                    root: 'explore',
+                    users,
+                    foldersFirst: false,
+                }),
+        ],
+    }),
+])

--- a/frontend/src/layout/panel-layout/PanelLayoutPanel.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutPanel.tsx
@@ -28,6 +28,7 @@ interface PanelLayoutPanelProps {
     searchPlaceholder?: string
     panelActions?: React.ReactNode
     children: React.ReactNode
+    showFilterDropdown?: boolean
 }
 
 const panelLayoutPanelVariants = cva({
@@ -155,7 +156,12 @@ export function FiltersDropdown({ setSearchTerm, searchTerm }: FiltersDropdownPr
     )
 }
 
-export function PanelLayoutPanel({ searchPlaceholder, panelActions, children }: PanelLayoutPanelProps): JSX.Element {
+export function PanelLayoutPanel({
+    searchPlaceholder,
+    panelActions,
+    children,
+    showFilterDropdown = false,
+}: PanelLayoutPanelProps): JSX.Element {
     const { clearSearch, setSearchTerm, toggleLayoutPanelPinned, setPanelWidth } = useActions(panelLayoutLogic)
     const {
         isLayoutPanelPinned,
@@ -238,7 +244,7 @@ export function PanelLayoutPanel({ searchPlaceholder, panelActions, children }: 
                             }
                         }}
                     />
-                    <FiltersDropdown setSearchTerm={setSearchTerm} searchTerm={searchTerm} />
+                    {showFilterDropdown && <FiltersDropdown setSearchTerm={setSearchTerm} searchTerm={searchTerm} />}
                 </div>
                 <div className="border-b border-primary h-px" />
                 {children}

--- a/frontend/src/layout/panel-layout/PanelLayoutPanel.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutPanel.tsx
@@ -130,7 +130,7 @@ export function FiltersDropdown({ setSearchTerm, searchTerm }: FiltersDropdownPr
                     </DropdownMenuItem>
                     <DropdownMenuSeparator />
                     {types
-                        .filter(([_, { flag }]) => !flag || featureFlags[flag])
+                        .filter(([_, { flag }]) => !flag || featureFlags[flag as keyof typeof featureFlags])
                         .map(([obj, { name }]) => (
                             <DropdownMenuItem
                                 key={obj}

--- a/frontend/src/layout/panel-layout/PanelLayoutPanel.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutPanel.tsx
@@ -237,6 +237,7 @@ export function PanelLayoutPanel({
                             if (e.key === 'ArrowDown') {
                                 e.preventDefault() // Prevent scrolling
                                 const visibleItems = panelTreeRef?.current?.getVisibleItems()
+
                                 if (visibleItems && visibleItems.length > 0) {
                                     e.currentTarget.blur() // Remove focus from input
                                     panelTreeRef?.current?.focusItem(visibleItems[0].id)

--- a/frontend/src/layout/panel-layout/ProductTree/ProductTree.tsx
+++ b/frontend/src/layout/panel-layout/ProductTree/ProductTree.tsx
@@ -15,9 +15,9 @@ import { projectTreeLogic } from '../ProjectTree/projectTreeLogic'
 
 export function ProductTree(): JSX.Element {
     const { treeItemsProducts } = useValues(projectTreeLogic)
-    const { mainContentRef } = useValues(panelLayoutLogic)
     const { addShortcutItem } = useActions(shortcutsLogic)
-
+    const { mainContentRef, isLayoutPanelPinned } = useValues(panelLayoutLogic)
+    const { showLayoutPanel, clearActivePanelIdentifier } = useActions(panelLayoutLogic)
     const treeRef = useRef<LemonTreeRef>(null)
     const [expandedFolders, setExpandedFolders] = useState<string[]>(['/'])
 
@@ -87,6 +87,11 @@ export function ProductTree(): JSX.Element {
                                 : node.record.href
                         )
                     }
+                    if (!isLayoutPanelPinned) {
+                        clearActivePanelIdentifier()
+                        showLayoutPanel(false)
+                    }
+
                     node?.onClick?.(true)
                 }}
                 expandedItemIds={expandedFolders}

--- a/frontend/src/layout/panel-layout/ProductTree/ProductTree.tsx
+++ b/frontend/src/layout/panel-layout/ProductTree/ProductTree.tsx
@@ -14,9 +14,9 @@ import { PanelLayoutPanel } from '../PanelLayoutPanel'
 import { productTreeLogic } from '../ProductTree/productTreeLogic'
 
 export function ProductTree(): JSX.Element {
-    const { productTreeItems } = useValues(productTreeLogic)
+    const { productTreeItems, searchResults } = useValues(productTreeLogic)
     const { addShortcutItem } = useActions(shortcutsLogic)
-    const { mainContentRef, isLayoutPanelPinned } = useValues(panelLayoutLogic)
+    const { mainContentRef, isLayoutPanelPinned, searchTerm } = useValues(panelLayoutLogic)
     const { showLayoutPanel, clearActivePanelIdentifier } = useActions(panelLayoutLogic)
     const treeRef = useRef<LemonTreeRef>(null)
     const [expandedFolders, setExpandedFolders] = useState<string[]>(['/'])
@@ -63,7 +63,7 @@ export function ProductTree(): JSX.Element {
                 ref={treeRef}
                 contentRef={mainContentRef as RefObject<HTMLElement>}
                 className="px-0 py-1"
-                data={productTreeItems}
+                data={searchTerm ? searchResults : productTreeItems}
                 itemContextMenu={(item) => {
                     return <ContextMenuGroup>{renderMenuItems(item, 'context')}</ContextMenuGroup>
                 }}

--- a/frontend/src/layout/panel-layout/ProductTree/ProductTree.tsx
+++ b/frontend/src/layout/panel-layout/ProductTree/ProductTree.tsx
@@ -11,10 +11,10 @@ import { shortcutsLogic } from '~/layout/panel-layout/Shortcuts/shortcutsLogic'
 import { FileSystemEntry } from '~/queries/schema/schema-general'
 
 import { PanelLayoutPanel } from '../PanelLayoutPanel'
-import { projectTreeLogic } from '../ProjectTree/projectTreeLogic'
+import { productTreeLogic } from '../ProductTree/productTreeLogic'
 
 export function ProductTree(): JSX.Element {
-    const { treeItemsProducts } = useValues(projectTreeLogic)
+    const { treeItems } = useValues(productTreeLogic)
     const { addShortcutItem } = useActions(shortcutsLogic)
     const { mainContentRef, isLayoutPanelPinned } = useValues(panelLayoutLogic)
     const { showLayoutPanel, clearActivePanelIdentifier } = useActions(panelLayoutLogic)
@@ -63,7 +63,7 @@ export function ProductTree(): JSX.Element {
                 ref={treeRef}
                 contentRef={mainContentRef as RefObject<HTMLElement>}
                 className="px-0 py-1"
-                data={treeItemsProducts}
+                data={treeItems}
                 itemContextMenu={(item) => {
                     return <ContextMenuGroup>{renderMenuItems(item, 'context')}</ContextMenuGroup>
                 }}

--- a/frontend/src/layout/panel-layout/ProductTree/ProductTree.tsx
+++ b/frontend/src/layout/panel-layout/ProductTree/ProductTree.tsx
@@ -4,7 +4,7 @@ import { LemonTree, LemonTreeRef, TreeDataItem } from 'lib/lemon-ui/LemonTree/Le
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { ContextMenuGroup, ContextMenuItem } from 'lib/ui/ContextMenu/ContextMenu'
 import { DropdownMenuGroup, DropdownMenuItem } from 'lib/ui/DropdownMenu/DropdownMenu'
-import { RefObject, useRef, useState } from 'react'
+import { RefObject, useEffect, useRef, useState } from 'react'
 
 import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
 import { shortcutsLogic } from '~/layout/panel-layout/Shortcuts/shortcutsLogic'
@@ -17,9 +17,13 @@ export function ProductTree(): JSX.Element {
     const { productTreeItems, searchResults } = useValues(productTreeLogic)
     const { addShortcutItem } = useActions(shortcutsLogic)
     const { mainContentRef, isLayoutPanelPinned, searchTerm } = useValues(panelLayoutLogic)
-    const { showLayoutPanel, clearActivePanelIdentifier } = useActions(panelLayoutLogic)
+    const { showLayoutPanel, setPanelTreeRef, clearActivePanelIdentifier } = useActions(panelLayoutLogic)
     const treeRef = useRef<LemonTreeRef>(null)
     const [expandedFolders, setExpandedFolders] = useState<string[]>(['/'])
+
+    useEffect(() => {
+        setPanelTreeRef(treeRef)
+    }, [treeRef, setPanelTreeRef])
 
     const renderMenuItems = (item: TreeDataItem, type: 'context' | 'dropdown'): JSX.Element => {
         const MenuItem = type === 'context' ? ContextMenuItem : DropdownMenuItem

--- a/frontend/src/layout/panel-layout/ProductTree/ProductTree.tsx
+++ b/frontend/src/layout/panel-layout/ProductTree/ProductTree.tsx
@@ -11,13 +11,12 @@ import { shortcutsLogic } from '~/layout/panel-layout/Shortcuts/shortcutsLogic'
 import { FileSystemEntry } from '~/queries/schema/schema-general'
 
 import { PanelLayoutPanel } from '../PanelLayoutPanel'
-import { projectTreeLogic } from '../ProjectTree/projectTreeLogic'
+import { productTreeLogic } from './productTreeLogic'
 
 export function ProductTree(): JSX.Element {
-    const { treeItemsProducts } = useValues(projectTreeLogic)
-    const { mainContentRef } = useValues(panelLayoutLogic)
+    const { productTreeItems } = useValues(productTreeLogic)
     const { addShortcutItem } = useActions(shortcutsLogic)
-
+    const { mainContentRef } = useValues(panelLayoutLogic)
     const treeRef = useRef<LemonTreeRef>(null)
     const [expandedFolders, setExpandedFolders] = useState<string[]>(['/'])
 
@@ -63,7 +62,7 @@ export function ProductTree(): JSX.Element {
                 ref={treeRef}
                 contentRef={mainContentRef as RefObject<HTMLElement>}
                 className="px-0 py-1"
-                data={treeItemsProducts}
+                data={productTreeItems}
                 itemContextMenu={(item) => {
                     return <ContextMenuGroup>{renderMenuItems(item, 'context')}</ContextMenuGroup>
                 }}

--- a/frontend/src/layout/panel-layout/ProductTree/ProductTree.tsx
+++ b/frontend/src/layout/panel-layout/ProductTree/ProductTree.tsx
@@ -14,7 +14,7 @@ import { PanelLayoutPanel } from '../PanelLayoutPanel'
 import { productTreeLogic } from '../ProductTree/productTreeLogic'
 
 export function ProductTree(): JSX.Element {
-    const { treeItems } = useValues(productTreeLogic)
+    const { productTreeItems } = useValues(productTreeLogic)
     const { addShortcutItem } = useActions(shortcutsLogic)
     const { mainContentRef, isLayoutPanelPinned } = useValues(panelLayoutLogic)
     const { showLayoutPanel, clearActivePanelIdentifier } = useActions(panelLayoutLogic)
@@ -63,7 +63,7 @@ export function ProductTree(): JSX.Element {
                 ref={treeRef}
                 contentRef={mainContentRef as RefObject<HTMLElement>}
                 className="px-0 py-1"
-                data={treeItems}
+                data={productTreeItems}
                 itemContextMenu={(item) => {
                     return <ContextMenuGroup>{renderMenuItems(item, 'context')}</ContextMenuGroup>
                 }}

--- a/frontend/src/layout/panel-layout/ProductTree/ProductTree.tsx
+++ b/frontend/src/layout/panel-layout/ProductTree/ProductTree.tsx
@@ -58,7 +58,7 @@ export function ProductTree(): JSX.Element {
     }
 
     return (
-        <PanelLayoutPanel>
+        <PanelLayoutPanel searchPlaceholder="Search products">
             <LemonTree
                 ref={treeRef}
                 contentRef={mainContentRef as RefObject<HTMLElement>}

--- a/frontend/src/layout/panel-layout/ProductTree/productTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProductTree/productTreeLogic.tsx
@@ -2,6 +2,7 @@ import { connect, kea, path, selectors } from 'kea'
 import { TreeDataItem } from 'lib/lemon-ui/LemonTree/LemonTree'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
+import { panelLayoutLogic } from '../panelLayoutLogic'
 import { getDefaultTreeProducts } from '../ProjectTree/defaultTree'
 import { projectTreeLogic } from '../ProjectTree/projectTreeLogic'
 import { convertFileSystemEntryToTreeDataItem } from '../ProjectTree/utils'
@@ -10,7 +11,14 @@ import type { productTreeLogicType } from './productTreeLogicType'
 export const productTreeLogic = kea<productTreeLogicType>([
     path(['layout', 'navigation-3000', 'components', 'productTreeLogic']),
     connect(() => ({
-        values: [featureFlagLogic, ['featureFlags'], projectTreeLogic, ['folderStates', 'users']],
+        values: [
+            featureFlagLogic,
+            ['featureFlags'],
+            projectTreeLogic,
+            ['folderStates', 'users'],
+            panelLayoutLogic,
+            ['searchTerm'],
+        ],
         actions: [],
     })),
     selectors({
@@ -27,6 +35,12 @@ export const productTreeLogic = kea<productTreeLogicType>([
                     users,
                     foldersFirst: false,
                 }),
+        ],
+        searchResults: [
+            (s) => [s.searchTerm, s.productTreeItems],
+            (searchTerm, productTreeItems): TreeDataItem[] => {
+                return productTreeItems.filter((item) => item.name.toLowerCase().includes(searchTerm.toLowerCase()))
+            },
         ],
     }),
 ])

--- a/frontend/src/layout/panel-layout/ProductTree/productTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProductTree/productTreeLogic.tsx
@@ -1,0 +1,31 @@
+import { connect, kea, path, selectors } from 'kea'
+import { TreeDataItem } from 'lib/lemon-ui/LemonTree/LemonTree'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+
+import { getDefaultTreeProducts } from '../ProjectTree/defaultTree'
+import { projectTreeLogic } from '../ProjectTree/projectTreeLogic'
+import { convertFileSystemEntryToTreeDataItem } from '../ProjectTree/utils'
+
+export const productTreeLogic = kea([
+    path(['layout', 'navigation-3000', 'components', 'productTreeLogic']),
+    connect(() => ({
+        values: [featureFlagLogic, ['featureFlags'], projectTreeLogic, ['folderStates', 'users']],
+        actions: [],
+    })),
+    selectors({
+        treeItems: [
+            (s) => [s.featureFlags, s.folderStates, s.users],
+            (featureFlags, folderStates, users): TreeDataItem[] =>
+                convertFileSystemEntryToTreeDataItem({
+                    imports: getDefaultTreeProducts().filter(
+                        (f) => !f.flag || (featureFlags as Record<string, boolean>)[f.flag]
+                    ),
+                    checkedItems: {},
+                    folderStates,
+                    root: 'explore',
+                    users,
+                    foldersFirst: false,
+                }),
+        ],
+    }),
+])

--- a/frontend/src/layout/panel-layout/ProductTree/productTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProductTree/productTreeLogic.tsx
@@ -5,8 +5,9 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { getDefaultTreeProducts } from '../ProjectTree/defaultTree'
 import { projectTreeLogic } from '../ProjectTree/projectTreeLogic'
 import { convertFileSystemEntryToTreeDataItem } from '../ProjectTree/utils'
+import type { productTreeLogicType } from './productTreeLogicType'
 
-export const productTreeLogic = kea([
+export const productTreeLogic = kea<productTreeLogicType>([
     path(['layout', 'navigation-3000', 'components', 'productTreeLogic']),
     connect(() => ({
         values: [featureFlagLogic, ['featureFlags'], projectTreeLogic, ['folderStates', 'users']],

--- a/frontend/src/layout/panel-layout/ProductTree/productTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProductTree/productTreeLogic.tsx
@@ -14,7 +14,7 @@ export const productTreeLogic = kea<productTreeLogicType>([
         actions: [],
     })),
     selectors({
-        treeItems: [
+        productTreeItems: [
             (s) => [s.featureFlags, s.folderStates, s.users],
             (featureFlags, folderStates, users): TreeDataItem[] =>
                 convertFileSystemEntryToTreeDataItem({

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -44,7 +44,7 @@ export interface ProjectTreeProps {
 
 export function ProjectTree({ sortMethod }: ProjectTreeProps): JSX.Element {
     const {
-        treeItemsProject,
+        projectTreeItems,
         treeTableKeys,
         lastViewedId,
         viableItems,
@@ -433,7 +433,7 @@ export function ProjectTree({ sortMethod }: ProjectTreeProps): JSX.Element {
                 ref={treeRef}
                 contentRef={mainContentRef as RefObject<HTMLElement>}
                 className="px-0 py-1"
-                data={treeItemsProject}
+                data={projectTreeItems}
                 mode={projectTreeMode as TreeMode}
                 selectMode={selectMode}
                 tableViewKeys={treeTableKeys}

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -372,6 +372,7 @@ export function ProjectTree({ sortMethod }: ProjectTreeProps): JSX.Element {
 
     return (
         <PanelLayoutPanel
+            showFilterDropdown={true}
             searchPlaceholder={sortMethod === 'recent' ? 'Search recent items' : 'Search your project'}
             panelActions={
                 <>

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -44,7 +44,7 @@ export interface ProjectTreeProps {
 
 export function ProjectTree({ sortMethod }: ProjectTreeProps): JSX.Element {
     const {
-        treeItemsProject,
+        projectTreeItems,
         treeTableKeys,
         lastViewedId,
         viableItems,
@@ -432,7 +432,7 @@ export function ProjectTree({ sortMethod }: ProjectTreeProps): JSX.Element {
                 ref={treeRef}
                 contentRef={mainContentRef as RefObject<HTMLElement>}
                 className="px-0 py-1"
-                data={treeItemsProject}
+                data={projectTreeItems}
                 mode={projectTreeMode as TreeMode}
                 selectMode={selectMode}
                 tableViewKeys={treeTableKeys}

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
@@ -18,7 +18,7 @@ import { FileSystemEntry, FileSystemImport } from '~/queries/schema/schema-gener
 import { Breadcrumb, ProjectTreeBreadcrumb, ProjectTreeRef, UserBasicType } from '~/types'
 
 import { panelLayoutLogic } from '../panelLayoutLogic'
-import { getDefaultTreeGames, getDefaultTreeNew, getDefaultTreeProducts } from './defaultTree'
+import { getDefaultTreeNew } from './defaultTree'
 import type { projectTreeLogicType } from './projectTreeLogicType'
 import { FolderState, ProjectTreeAction } from './types'
 import {
@@ -898,34 +898,6 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                     foldersFirst: false,
                 }),
         ],
-        treeItemsProducts: [
-            (s) => [s.featureFlags, s.folderStates, s.users],
-            (featureFlags, folderStates, users): TreeDataItem[] =>
-                convertFileSystemEntryToTreeDataItem({
-                    imports: getDefaultTreeProducts().filter(
-                        (f) => !f.flag || (featureFlags as Record<string, boolean>)[f.flag]
-                    ),
-                    checkedItems: {},
-                    folderStates,
-                    root: 'explore',
-                    users,
-                    foldersFirst: false,
-                }),
-        ],
-        treeItemsGames: [
-            (s) => [s.featureFlags, s.folderStates, s.users],
-            (featureFlags, folderStates, users): TreeDataItem[] =>
-                convertFileSystemEntryToTreeDataItem({
-                    imports: getDefaultTreeGames().filter(
-                        (f) => !f.flag || (featureFlags as Record<string, boolean>)[f.flag]
-                    ),
-                    checkedItems: {},
-                    folderStates,
-                    root: 'explore',
-                    users,
-                    foldersFirst: false,
-                }),
-        ],
         recentTreeItems: [
             (s) => [s.recentResults, s.recentResultsLoading, s.folderStates, s.checkedItems, s.users],
             (recentResults, recentResultsLoading, folderStates, checkedItems, users): TreeDataItem[] => {
@@ -995,7 +967,7 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                 return results
             },
         ],
-        treeItemsProject: [
+        projectTreeItems: [
             (s) => [s.searchTerm, s.searchedTreeItems, s.projectTree, s.loadingPaths, s.recentTreeItems, s.sortMethod],
             (searchTerm, searchedTreeItems, projectTree, loadingPaths, recentTreeItems, sortMethod): TreeDataItem[] => {
                 if (searchTerm) {
@@ -1015,45 +987,6 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                     ]
                 }
                 return projectTree
-            },
-        ],
-        treeItemsCombined: [
-            (s) => [s.treeItemsProject, s.treeItemsProducts, s.treeItemsNew],
-            (project, products, allNew): TreeDataItem[] => {
-                function addNewLabel(item: TreeDataItem): TreeDataItem {
-                    if (item.children) {
-                        return { ...item, children: item.children?.map(addNewLabel) }
-                    }
-                    const pathParts = splitPath(item.record?.path ?? '')
-                    const name = `New ${pathParts.pop()?.toLowerCase()}`
-                    const newPath = joinPath([...pathParts, name])
-                    return {
-                        ...item,
-                        name: name,
-                        record: { ...item.record, path: newPath },
-                    }
-                }
-
-                return [
-                    {
-                        id: 'project',
-                        name: 'Project',
-                        record: { type: 'folder', id: null, path: '/' },
-                        children: project,
-                    },
-                    {
-                        id: 'products',
-                        name: 'Products',
-                        record: { type: 'folder', id: null, path: '/' },
-                        children: products,
-                    },
-                    {
-                        id: 'new',
-                        name: 'New',
-                        record: { type: 'folder', id: null, path: '/' },
-                        children: allNew.map(addNewLabel),
-                    },
-                ]
             },
         ],
         // TODO: use treeData + some other logic to determine the keys

--- a/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
@@ -70,7 +70,6 @@ export function convertFileSystemEntryToTreeDataItem({
         const nodeId = getItemId(item)
         const displayName = <SearchHighlightMultiple string={itemName} substring={searchTerm ?? ''} />
         const user: UserBasicType | undefined = item.meta?.created_by ? users?.[item.meta.created_by] : undefined
-
         const icon = iconForType('iconType' in item ? item.iconType : item.type)
         const node: TreeDataItem = {
             id: nodeId,

--- a/frontend/src/layout/panel-layout/Shortcuts/AddShortcutModal.tsx
+++ b/frontend/src/layout/panel-layout/Shortcuts/AddShortcutModal.tsx
@@ -10,9 +10,8 @@ import { shortcutsLogic } from '~/layout/panel-layout/Shortcuts/shortcutsLogic'
 import { FileSystemEntry } from '~/queries/schema/schema-general'
 
 export function CombinedTree(): JSX.Element {
-    const { treeItemsCombined } = useValues(projectTreeLogic)
     const { mainContentRef } = useValues(panelLayoutLogic)
-    const { selectedItem } = useValues(shortcutsLogic)
+    const { selectedItem, treeItemsCombined } = useValues(shortcutsLogic)
     const { setSelectedItem } = useActions(shortcutsLogic)
     const { loadFolderIfNotLoaded } = useActions(projectTreeLogic)
 

--- a/frontend/src/layout/panel-layout/Shortcuts/shortcutsLogic.tsx
+++ b/frontend/src/layout/panel-layout/Shortcuts/shortcutsLogic.tsx
@@ -4,15 +4,22 @@ import api from 'lib/api'
 import { TreeDataItem } from 'lib/lemon-ui/LemonTree/LemonTree'
 
 import { projectTreeLogic } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
-import { convertFileSystemEntryToTreeDataItem, escapePath, splitPath } from '~/layout/panel-layout/ProjectTree/utils'
+import {
+    convertFileSystemEntryToTreeDataItem,
+    escapePath,
+    joinPath,
+    splitPath,
+} from '~/layout/panel-layout/ProjectTree/utils'
 import { FileSystemEntry } from '~/queries/schema/schema-general'
 
+import { productTreeLogic } from '../ProductTree/productTreeLogic'
 import type { shortcutsLogicType } from './shortcutsLogicType'
 
 export const shortcutsLogic = kea<shortcutsLogicType>([
     path(['layout', 'panel-layout', 'Shortcuts', 'shortcutsLogic']),
     connect(() => ({
         actions: [projectTreeLogic, ['updateSyncedFiles', 'deleteTypeAndRef']],
+        values: [projectTreeLogic, ['projectTreeItems', 'treeItemsNew'], productTreeLogic, ['productTreeItems']],
     })),
     actions({
         showModal: true,
@@ -95,6 +102,45 @@ export const shortcutsLogic = kea<shortcutsLogicType>([
                 }).sort((a, b) => a.name.localeCompare(b.name)),
         ],
         shortcutsLoading: [(s) => [s.shortcutDataLoading], (loading) => loading],
+        treeItemsCombined: [
+            (s) => [s.projectTreeItems, s.productTreeItems, s.treeItemsNew],
+            (project, products, allNew): TreeDataItem[] => {
+                function addNewLabel(item: TreeDataItem): TreeDataItem {
+                    if (item.children) {
+                        return { ...item, children: item.children?.map(addNewLabel) }
+                    }
+                    const pathParts = splitPath(item.record?.path ?? '')
+                    const name = `New ${pathParts.pop()?.toLowerCase()}`
+                    const newPath = joinPath([...pathParts, name])
+                    return {
+                        ...item,
+                        name: name,
+                        record: { ...item.record, path: newPath },
+                    }
+                }
+
+                return [
+                    {
+                        id: 'project',
+                        name: 'Project',
+                        record: { type: 'folder', id: null, path: '/' },
+                        children: project,
+                    },
+                    {
+                        id: 'products',
+                        name: 'Products',
+                        record: { type: 'folder', id: null, path: '/' },
+                        children: products,
+                    },
+                    {
+                        id: 'new',
+                        name: 'New',
+                        record: { type: 'folder', id: null, path: '/' },
+                        children: allNew.map(addNewLabel),
+                    },
+                ]
+            },
+        ],
     }),
     afterMount(({ actions }) => {
         actions.loadShortcuts()

--- a/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
+++ b/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
@@ -1,4 +1,4 @@
-import { actions, connect, kea, path, reducers, selectors } from 'kea'
+import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { LemonTreeRef, TreeMode } from 'lib/lemon-ui/LemonTree/LemonTree'
 
 import { navigation3000Logic } from '../navigation-3000/navigationLogic'
@@ -130,6 +130,12 @@ export const panelLayoutLogic = kea<panelLayoutLogicType>([
             },
         ],
     }),
+    listeners(({ actions }) => ({
+        setActivePanelIdentifier: () => {
+            // clear search term when changing panel
+            actions.clearSearch()
+        },
+    })),
     selectors({
         isLayoutNavCollapsed: [
             (s) => [s.isLayoutNavCollapsedDesktop, s.mobileLayout],


### PR DESCRIPTION
[waiting for this [PR](https://github.com/PostHog/posthog/pull/32296) to merge, so i can rebase and clear stacked commits]

## Problem
* Product(s) tree wasn't searchable
* Couldn't search `go/revenue` (searching `go revenue` `revenue go` worked though)
* Couldn't key arrow down from panel search into `ProductTree`

problem: searching products
![2025-05-17 23 03 19](https://github.com/user-attachments/assets/1c708a8f-060f-4101-a6c6-58d27fc19f0e)

problem: Searching `go/revenue`
![2025-05-17 23 02 12](https://github.com/user-attachments/assets/cb11e149-4da6-4ebb-a647-2737a2b8fe20)


## Changes
* Added simple search to product tree
* Added split to plain free text for `/` and searches for each part (regardless of order)
* Added support for arrow down from panel search into `ProductTree` 

changes: searching products
![2025-05-17 23 04 06](https://github.com/user-attachments/assets/966728b7-ede9-4835-a4ad-e797e0c936ec)

changes: Searching `go/revenue`
![2025-05-17 23 05 02](https://github.com/user-attachments/assets/26c86bbd-256e-4c5c-8ee9-b08dc96f1396)


## How did you test this code?
Manually
