### PR TITLE
chore: update license to 2025

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2020-2024 PostHog Inc.
+Copyright (c) 2020-2025 PostHog Inc.
 
 Portions of this software are licensed as follows:
 


### PR DESCRIPTION
Saw this while checking the license for CSP Evaluator.

