### PR TITLE
fix(project-tree): shortcut nits

### DIFF
--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -413,7 +413,9 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
                                 <div className="border-b border-primary h-px my-1" />
 
                                 {featureFlags[FEATURE_FLAGS.TREE_VIEW_PRODUCTS] ? (
-                                    <div className={!isLayoutNavCollapsed ? 'pt-1' : ''}>
+                                    <div
+                                        className={!isLayoutNavCollapsed ? 'pt-1' : 'flex flex-col gap-px items-center'}
+                                    >
                                         <Shortcuts />
                                     </div>
                                 ) : (

--- a/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
@@ -46,7 +46,7 @@ export function wrapWithShortcutIcon(icon: React.ReactNode): JSX.Element {
     return (
         <div className="relative">
             {icon}
-            <IconShortcut className="absolute bottom-[-0.15rem] left-[-0.25rem] size-3 [&_path]:fill-white " />
+            <IconShortcut className="absolute bottom-[-0.15rem] left-[-0.25rem] size-3 [&_path]:fill-white" />
         </div>
     )
 }

--- a/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
@@ -1,4 +1,4 @@
-import { IconArrowUpRight, IconPlus } from '@posthog/icons'
+import { IconPlus, IconShortcut } from '@posthog/icons'
 import { Spinner } from '@posthog/lemon-ui'
 import { TreeDataItem } from 'lib/lemon-ui/LemonTree/LemonTree'
 
@@ -46,7 +46,7 @@ export function wrapWithShortcutIcon(icon: React.ReactNode): JSX.Element {
     return (
         <div className="relative">
             {icon}
-            <IconArrowUpRight className="absolute bottom-[-0.25rem] left-[-0.25rem] scale-66 bg-white border border-black" />
+            <IconShortcut className="absolute bottom-[-0.15rem] left-[-0.25rem] size-3 [&_path]:fill-white " />
         </div>
     )
 }

--- a/frontend/src/layout/panel-layout/Shortcuts/Shortcuts.tsx
+++ b/frontend/src/layout/panel-layout/Shortcuts/Shortcuts.tsx
@@ -71,11 +71,18 @@ export function Shortcuts(): JSX.Element {
                 </div>
             )}
 
-            {shortcuts.length === 0 ? (
-                <div className="pl-3 text-muted">{shortcutsLoading ? <Spinner /> : 'No shortcuts added'}</div>
+            {isLayoutNavCollapsed && (
+                <ButtonPrimitive onClick={showModal} iconOnly tooltip="Add shortcut" tooltipPlacement="right">
+                    <IconPlus className="size-3 text-secondary" />
+                </ButtonPrimitive>
+            )}
+
+            {!isLayoutNavCollapsed && shortcuts.length === 0 ? (
+                <div className="pl-3 text-secondary">{shortcutsLoading ? <Spinner /> : 'No shortcuts added'}</div>
             ) : null}
 
             <div className="mt-[-0.25rem]">
+                {/* TODO: move this tree into popover if isLayoutNavCollapsed is true */}
                 <LemonTree
                     ref={treeRef}
                     contentRef={mainContentRef as RefObject<HTMLElement>}

--- a/frontend/src/layout/panel-layout/Shortcuts/Shortcuts.tsx
+++ b/frontend/src/layout/panel-layout/Shortcuts/Shortcuts.tsx
@@ -65,7 +65,7 @@ export function Shortcuts(): JSX.Element {
                         <span className="text-xs font-semibold text-quaternary">Shortcuts</span>
                         {shortcutsLoading && shortcuts.length > 0 ? <Spinner /> : null}
                     </div>
-                    <ButtonPrimitive onClick={showModal}>
+                    <ButtonPrimitive onClick={showModal} iconOnly>
                         <IconPlus className="size-3 text-secondary" />
                     </ButtonPrimitive>
                 </div>

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTreeUtils.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTreeUtils.tsx
@@ -100,7 +100,7 @@ export const TreeNodeDisplayIcon = ({
     }
 
     return (
-        <div className="h-[var(--lemon-tree-button-height)] flex gap-1 relative [&_svg]:size-4 items-start -ml-px">
+        <div className="h-[var(--lemon-tree-button-height)] flex gap-1 relative items-start -ml-px">
             {isFolder && (
                 <div
                     className={cn(

--- a/frontend/src/lib/lemon-ui/icons/categories.ts
+++ b/frontend/src/lib/lemon-ui/icons/categories.ts
@@ -214,6 +214,7 @@ export const ELEMENTS = {
         'IconTriangleDownFilled',
         'IconTriangleUp',
         'IconTriangleUpFilled',
+        'IconShortcut',
         'IconStar',
         'IconStarFilled',
         'IconStarHalfFilled',

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "overrides": {
             "playwright": "1.45.0",
             "typescript": "~4.9.5",
-            "@posthog/icons": "0.13.1"
+            "@posthog/icons": "0.14"
         },
         "patchedDependencies": {
             "node-rdkafka@2.17.0": "patches/node-rdkafka@2.17.0.patch",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   playwright: 1.45.0
   typescript: ~4.9.5
-  '@posthog/icons': 0.13.1
+  '@posthog/icons': '0.14'
 
 patchedDependencies:
   dayjs@1.11.11:
@@ -564,8 +564,8 @@ importers:
         specifier: workspace:*
         version: link:../common/hogvm/typescript
       '@posthog/icons':
-        specifier: 0.13.1
-        version: 0.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: '0.14'
+        version: 0.14.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@posthog/plugin-scaffold':
         specifier: ^1.4.4
         version: 1.4.4
@@ -1560,8 +1560,8 @@ importers:
   products/actions:
     dependencies:
       '@posthog/icons':
-        specifier: 0.13.1
-        version: 0.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: '0.14'
+        version: 0.14.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -1587,8 +1587,8 @@ importers:
   products/cohorts:
     dependencies:
       '@posthog/icons':
-        specifier: 0.13.1
-        version: 0.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: '0.14'
+        version: 0.14.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -1614,8 +1614,8 @@ importers:
   products/dashboards:
     dependencies:
       '@posthog/icons':
-        specifier: 0.13.1
-        version: 0.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: '0.14'
+        version: 0.14.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -1641,8 +1641,8 @@ importers:
   products/early_access_features:
     dependencies:
       '@posthog/icons':
-        specifier: 0.13.1
-        version: 0.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: '0.14'
+        version: 0.14.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/react':
         specifier: '*'
         version: 7.6.4(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@4.9.5)
@@ -1673,8 +1673,8 @@ importers:
   products/experiments:
     dependencies:
       '@posthog/icons':
-        specifier: 0.13.1
-        version: 0.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: '0.14'
+        version: 0.14.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -1700,8 +1700,8 @@ importers:
   products/feature_flags:
     dependencies:
       '@posthog/icons':
-        specifier: 0.13.1
-        version: 0.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: '0.14'
+        version: 0.14.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -1727,8 +1727,8 @@ importers:
   products/games:
     dependencies:
       '@posthog/icons':
-        specifier: 0.13.1
-        version: 0.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: '0.14'
+        version: 0.14.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -1754,8 +1754,8 @@ importers:
   products/groups:
     dependencies:
       '@posthog/icons':
-        specifier: 0.13.1
-        version: 0.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: '0.14'
+        version: 0.14.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -1781,8 +1781,8 @@ importers:
   products/llm_observability:
     dependencies:
       '@posthog/icons':
-        specifier: 0.13.1
-        version: 0.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: '0.14'
+        version: 0.14.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/react':
         specifier: '*'
         version: 7.6.4(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@4.9.5)
@@ -1829,8 +1829,8 @@ importers:
   products/logs:
     dependencies:
       '@posthog/icons':
-        specifier: 0.13.1
-        version: 0.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: '0.14'
+        version: 0.14.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/react':
         specifier: '*'
         version: 7.6.4(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@4.9.5)
@@ -1877,8 +1877,8 @@ importers:
   products/messaging:
     dependencies:
       '@posthog/icons':
-        specifier: 0.13.1
-        version: 0.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: '0.14'
+        version: 0.14.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -1907,8 +1907,8 @@ importers:
   products/notebooks:
     dependencies:
       '@posthog/icons':
-        specifier: 0.13.1
-        version: 0.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: '0.14'
+        version: 0.14.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -1934,8 +1934,8 @@ importers:
   products/persons:
     dependencies:
       '@posthog/icons':
-        specifier: 0.13.1
-        version: 0.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: '0.14'
+        version: 0.14.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -1961,8 +1961,8 @@ importers:
   products/product_analytics:
     dependencies:
       '@posthog/icons':
-        specifier: 0.13.1
-        version: 0.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: '0.14'
+        version: 0.14.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -1988,8 +1988,8 @@ importers:
   products/replay:
     dependencies:
       '@posthog/icons':
-        specifier: 0.13.1
-        version: 0.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: '0.14'
+        version: 0.14.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -2015,8 +2015,8 @@ importers:
   products/revenue_analytics:
     dependencies:
       '@posthog/icons':
-        specifier: 0.13.1
-        version: 0.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: '0.14'
+        version: 0.14.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/react':
         specifier: '*'
         version: 7.6.4(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@4.9.5)
@@ -2045,8 +2045,8 @@ importers:
   products/surveys:
     dependencies:
       '@posthog/icons':
-        specifier: 0.13.1
-        version: 0.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: '0.14'
+        version: 0.14.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -2072,8 +2072,8 @@ importers:
   products/user_interviews:
     dependencies:
       '@posthog/icons':
-        specifier: 0.13.1
-        version: 0.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: '0.14'
+        version: 0.14.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -2099,8 +2099,8 @@ importers:
   products/web_analytics:
     dependencies:
       '@posthog/icons':
-        specifier: 0.13.1
-        version: 0.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: '0.14'
+        version: 0.14.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: '*'
         version: 17.0.52
@@ -4622,8 +4622,8 @@ packages:
     resolution: {integrity: sha512-B8hZ8Dh2EoJoDb7Gx38ylBQM92oON/X2IxXCb7BfYStk3m17nStcAyaCsc2zbvxC0fFfTMU8lFRiFSEJmijkyg==}
     engines: {node: '>=12'}
 
-  '@posthog/icons@0.13.1':
-    resolution: {integrity: sha512-A/feFWVvdBpbDEyxzJzRZUuM+w3UlgNXpRfIGu3BS04PJrlhdh7V5LfsIBe9H/qirMt92I4z4117U+SUilC9FQ==}
+  '@posthog/icons@0.14.0':
+    resolution: {integrity: sha512-kv4PQD9O7y7a1i8ahpqjLNdIvKDP8Mh/g9JmegzwMyRa6SFEcYkrDrMyxpREzlYws9W9q7E2WDvhamU3htGFLA==}
     peerDependencies:
       react: '>=16.14.0'
       react-dom: '>=16.14.0'
@@ -19557,7 +19557,7 @@ snapshots:
 
   '@posthog/clickhouse@1.7.0': {}
 
-  '@posthog/icons@0.13.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@posthog/icons@0.14.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)


### PR DESCRIPTION
## Problem
* Shortcut icon wasn't fit for purpose and took up too much visual space
* Shortcut (+) button/icon wasn't square
* Shortcuts, when `nav is collapsed`:
    * empty state "No shortcuts added" wasn't styled 
    * didn't have any method to "add shortcut"

## Changes
New icon for shortcut
Added prop to (+) button to make square
Remove empty state from shortcuts if `nav is collapsed`
Add new (+) button if `nav is collapsed`

<img width="82" alt="image" src="https://github.com/user-attachments/assets/0e9bc706-14b6-4bb6-bbe5-c56008b37dfb" />
<img width="75" alt="image" src="https://github.com/user-attachments/assets/12e06d42-58d5-48b2-b324-ce62fd048f90" />


<img width="255" alt="image" src="https://github.com/user-attachments/assets/b4cf7b79-96f7-404d-bba4-47560d7c3f86" />

<img width="224" alt="image" src="https://github.com/user-attachments/assets/62d794f1-219d-4b98-ba92-4de83a513d5d" />

## Todo
if nav is collapsed, move shortcuts under a popover (we don't show tree items correctly at such a small width

## How did you test this code?
Manually