### PR TITLE
feat: Added legacy onevent consumer

### DIFF
--- a/plugin-server/src/capabilities.ts
+++ b/plugin-server/src/capabilities.ts
@@ -19,6 +19,7 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
                 appManagementSingleton: true,
                 cdpProcessedEvents: true,
                 cdpInternalEvents: true,
+                cdpLegacyOnEvent: true,
                 cdpCyclotronWorker: true,
                 cdpCyclotronWorkerPlugins: true,
                 cdpCyclotronWorkerFetch: true,
@@ -76,6 +77,10 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
         case PluginServerMode.cdp_cyclotron_worker_fetch:
             return {
                 cdpCyclotronWorkerFetch: true,
+            }
+        case PluginServerMode.cdp_legacy_on_event:
+            return {
+                cdpLegacyOnEvent: true,
             }
         case PluginServerMode.cdp_api:
             return {

--- a/plugin-server/src/cdp/consumers/cdp-legacy-event.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-legacy-event.consumer.ts
@@ -54,6 +54,9 @@ export class CdpLegacyEventsConsumer extends CdpEventsConsumer {
             })
         )
 
+        // NOTE: We _could_ consider moving this to a background task to improve throughput with a max concurrency of 2 for example
+        // but we should avoid it if possible
+
         return {
             // This is all IO so we can set them off in the background and start processing the next batch
             backgroundTask: Promise.resolve(),

--- a/plugin-server/src/cdp/consumers/cdp-legacy-event.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-legacy-event.consumer.ts
@@ -1,12 +1,11 @@
 import { Message } from 'node-rdkafka'
 
-import { runOnEvent } from '~/src/worker/plugins/run'
-
 import { KAFKA_EVENTS_JSON } from '../../config/kafka-topics'
 import { runInstrumentedFunction } from '../../main/utils'
 import { Hub, ISOTimestamp, PostIngestionEvent, ProjectId, RawClickHouseEvent } from '../../types'
 import { parseJSON } from '../../utils/json-parse'
 import { logger } from '../../utils/logger'
+import { runOnEvent } from '../../worker/plugins/run'
 import { HogFunctionInvocation, HogFunctionInvocationGlobals } from '../types'
 import { convertToHogFunctionInvocationGlobals } from '../utils'
 import { CdpEventsConsumer, counterParseError } from './cdp-events.consumer'

--- a/plugin-server/src/cdp/consumers/cdp-legacy-event.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-legacy-event.consumer.ts
@@ -12,7 +12,7 @@ import { convertToHogFunctionInvocationGlobals } from '../utils'
 import { CdpEventsConsumer, counterParseError } from './cdp-events.consumer'
 
 /**
- * This isa temporary consumer that hooks into the existing onevent consumer group
+ * This is a temporary consumer that hooks into the existing onevent consumer group
  * It currently just runs the same logic as the old one but with noderdkafka as the consumer tech which should improve things
  * We can then use this to gradually move over to the new hog functions
  */

--- a/plugin-server/src/cdp/consumers/cdp-legacy-event.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-legacy-event.consumer.ts
@@ -13,8 +13,8 @@ import { CdpEventsConsumer, counterParseError } from './cdp-events.consumer'
 
 /**
  * This isa temporary consumer that hooks into the existing onevent consumer group
- * It takes care of handling "plugin" hog function types, ensuring we don't do duplicate processing
- * Once we have fully migrated away from all legacy plugins we can remove this and allow the normal event consumer to handle all events
+ * It currently just runs the same logic as the old one but with noderdkafka as the consumer tech which should improve things
+ * We can then use this to gradually move over to the new hog functions
  */
 export class CdpLegacyEventsConsumer extends CdpEventsConsumer {
     protected name = 'CdpLegacyEventsConsumer'

--- a/plugin-server/src/cdp/consumers/cdp-legacy-event.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-legacy-event.consumer.ts
@@ -1,0 +1,101 @@
+import { Message } from 'node-rdkafka'
+
+import { runOnEvent } from '~/src/worker/plugins/run'
+
+import { KAFKA_EVENTS_JSON } from '../../config/kafka-topics'
+import { runInstrumentedFunction } from '../../main/utils'
+import { Hub, ISOTimestamp, PostIngestionEvent, ProjectId, RawClickHouseEvent } from '../../types'
+import { parseJSON } from '../../utils/json-parse'
+import { logger } from '../../utils/logger'
+import { HogFunctionInvocation, HogFunctionInvocationGlobals } from '../types'
+import { convertToHogFunctionInvocationGlobals } from '../utils'
+import { CdpEventsConsumer, counterParseError } from './cdp-events.consumer'
+
+/**
+ * This isa temporary consumer that hooks into the existing onevent consumer group
+ * It takes care of handling "plugin" hog function types, ensuring we don't do duplicate processing
+ * Once we have fully migrated away from all legacy plugins we can remove this and allow the normal event consumer to handle all events
+ */
+export class CdpLegacyEventsConsumer extends CdpEventsConsumer {
+    protected name = 'CdpLegacyEventsConsumer'
+
+    constructor(hub: Hub) {
+        super(hub, KAFKA_EVENTS_JSON, 'clickhouse-plugin-server-async-onevent')
+    }
+
+    public async processEvent(invocation: HogFunctionInvocationGlobals) {
+        const event: PostIngestionEvent = {
+            eventUuid: invocation.event.uuid,
+            event: invocation.event.event,
+            teamId: invocation.project.id,
+            distinctId: invocation.event.distinct_id,
+            properties: invocation.event.properties,
+            timestamp: invocation.event.timestamp as ISOTimestamp,
+            // None of these are actually used by the runOnEvent as it converts it to a PostIngestionEvent
+            projectId: invocation.project.id as ProjectId,
+            person_created_at: null,
+            person_properties: {},
+            person_id: undefined,
+        }
+
+        await runOnEvent(this.hub, event)
+    }
+
+    public async processBatch(
+        invocationGlobals: HogFunctionInvocationGlobals[]
+    ): Promise<{ backgroundTask: Promise<any>; invocations: HogFunctionInvocation[] }> {
+        if (!invocationGlobals.length) {
+            return { backgroundTask: Promise.resolve(), invocations: [] }
+        }
+
+        await Promise.all(
+            invocationGlobals.map((x) => {
+                return this.runInstrumented('cdpLegacyEventsConsumer.processEvent', () => this.processEvent(x))
+            })
+        )
+
+        return {
+            // This is all IO so we can set them off in the background and start processing the next batch
+            backgroundTask: Promise.resolve(),
+            invocations: [],
+        }
+    }
+
+    // This consumer always parses from kafka
+    public async _parseKafkaBatch(messages: Message[]): Promise<HogFunctionInvocationGlobals[]> {
+        return await this.runWithHeartbeat(() =>
+            runInstrumentedFunction({
+                statsKey: `cdpConsumer.handleEachBatch.parseKafkaMessages`,
+                func: async () => {
+                    const events: HogFunctionInvocationGlobals[] = []
+
+                    await Promise.all(
+                        messages.map(async (message) => {
+                            try {
+                                const clickHouseEvent = parseJSON(message.value!.toString()) as RawClickHouseEvent
+
+                                const team = await this.hub.teamManager.getTeam(clickHouseEvent.team_id)
+
+                                if (!team) {
+                                    return
+                                }
+                                events.push(
+                                    convertToHogFunctionInvocationGlobals(
+                                        clickHouseEvent,
+                                        team,
+                                        this.hub.SITE_URL ?? 'http://localhost:8000'
+                                    )
+                                )
+                            } catch (e) {
+                                logger.error('Error parsing message', e)
+                                counterParseError.labels({ error: e.message }).inc()
+                            }
+                        })
+                    )
+
+                    return events
+                },
+            })
+        )
+    }
+}

--- a/plugin-server/src/server.ts
+++ b/plugin-server/src/server.ts
@@ -13,6 +13,7 @@ import { CdpCyclotronWorkerFetch } from './cdp/consumers/cdp-cyclotron-worker-fe
 import { CdpCyclotronWorkerPlugins } from './cdp/consumers/cdp-cyclotron-worker-plugins.consumer'
 import { CdpEventsConsumer } from './cdp/consumers/cdp-events.consumer'
 import { CdpInternalEventsConsumer } from './cdp/consumers/cdp-internal-event.consumer'
+import { CdpLegacyEventsConsumer } from './cdp/consumers/cdp-legacy-event.consumer'
 import { defaultConfig } from './config/config'
 import {
     KAFKA_EVENTS_PLUGIN_INGESTION,
@@ -220,6 +221,14 @@ export class PluginServer {
             if (capabilities.cdpInternalEvents) {
                 serviceLoaders.push(async () => {
                     const consumer = new CdpInternalEventsConsumer(hub)
+                    await consumer.start()
+                    return consumer.service
+                })
+            }
+
+            if (capabilities.cdpLegacyOnEvent) {
+                serviceLoaders.push(async () => {
+                    const consumer = new CdpLegacyEventsConsumer(hub)
                     await consumer.start()
                     return consumer.service
                 })

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -76,6 +76,7 @@ export enum PluginServerMode {
     cdp_cyclotron_worker_plugins = 'cdp-cyclotron-worker-plugins',
     cdp_cyclotron_worker_fetch = 'cdp-cyclotron-worker-fetch',
     cdp_api = 'cdp-api',
+    cdp_legacy_on_event = 'cdp-legacy-on-event',
     functional_tests = 'functional-tests',
 }
 
@@ -393,6 +394,7 @@ export interface PluginServerCapabilities {
     sessionRecordingBlobIngestionV2Overflow?: boolean
     cdpProcessedEvents?: boolean
     cdpInternalEvents?: boolean
+    cdpLegacyOnEvent?: boolean
     cdpCyclotronWorker?: boolean
     cdpCyclotronWorkerPlugins?: boolean
     cdpCyclotronWorkerFetch?: boolean


### PR DESCRIPTION
## Problem

We want to move 1-1 over onevent. To do this we need to hook into the same consumer group. 

This uses exactly the same "onevent" processing code, just with the new consumer design. It should work well enough.

We'll try it on dev first and then move over. This also gives us a cleaner way of switching over to the new hog function model when ready.

## Changes

* Adds the new consumer

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
