### PR TITLE
fix(batch-exports): BigQuery destination test uses list_dataset

### DIFF
--- a/posthog/temporal/batch_exports/destination_tests.py
+++ b/posthog/temporal/batch_exports/destination_tests.py
@@ -278,6 +278,11 @@ class BigQueryProjectTestStep(DestinationTestStep):
     This test could not be broken into two as the project not existing and us not
     having permissions to access it looks the same from our perspective.
 
+    Permissions could be granted at the project level, or at the dataset level.
+    To account for this, we check that the project exists by listing projects
+    (`list_projects` call) and by listing datasets (with `list_datasets`) and
+    inspecting the project associated with each dataset.
+
     Attributes:
         project_id: ID of the BigQuery project we are checking.
         service_account_info: Service account credentials used to access the
@@ -320,6 +325,11 @@ class BigQueryProjectTestStep(DestinationTestStep):
         projects = {p.project_id for p in client.list_projects()}
 
         if self.project_id in projects:
+            return DestinationTestStepResult(status=Status.PASSED)
+
+        dataset_projects = {d.project for d in client.list_datasets()}
+
+        if self.project_id in dataset_projects:
             return DestinationTestStepResult(status=Status.PASSED)
         else:
             return DestinationTestStepResult(


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

If the service account provided does not have a role at the project level assigned, but does at the dataset level, the batch export still works, but the test fails. This is because `list_projects` requires a role at the project level. We can use `list_datasets` with a role at the dataset level though.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

If checking `list_projects` fails, look up the project in `list_datasets` too.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
