### PR TITLE
fix: make it so all replicas can become leader of pending_deletes tables

### DIFF
--- a/dags/deletes.py
+++ b/dags/deletes.py
@@ -118,6 +118,7 @@ class PendingDeletesTable:
             )
             ENGINE = ReplicatedReplacingMergeTree('{self.zk_path}', '{{shard}}-{{replica}}')
             ORDER BY (team_id, deletion_type, key)
+            SETTINGS replicated_can_become_leader = 1
         """
 
     @property


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

When the `pending_deletes_reporting` table is created and then truncated, coordinators cannot truncate it because they cannot become leaders of the replica.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Make it so all can become leaders.

This is an deletes ad-hoc, small table, with inserts once per week. Shouldn't be an issue that coordinators schedule merges for it.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Verified that it can be truncated after becoming leaders.
