### PR TITLE
fix: no clicky when no thingy

### DIFF
--- a/frontend/src/scenes/session-recordings/components/ReplayActiveHoursHeatMap.tsx
+++ b/frontend/src/scenes/session-recordings/components/ReplayActiveHoursHeatMap.tsx
@@ -4,7 +4,7 @@ import { CalendarHeatMap } from 'scenes/web-analytics/CalendarHeatMap/CalendarHe
 import { getOnClickTooltip, onCellClick, replayActiveHoursHeatMapLogic } from './replayActiveHoursHeatMapLogic'
 
 export const ReplayActiveHoursHeatMap = (): JSX.Element => {
-    const { calendarHeatmapProps, recordingsPerHourLoading } = useValues(
+    const { calendarHeatmapProps, recordingsPerHourLoading, isClickable } = useValues(
         replayActiveHoursHeatMapLogic({ scene: 'templates' })
     )
 
@@ -22,6 +22,7 @@ export const ReplayActiveHoursHeatMap = (): JSX.Element => {
                 getOverallAggregationTooltip={() => ''}
                 getOnClickTooltip={getOnClickTooltip}
                 onClick={onCellClick}
+                isClickable={isClickable}
                 showColumnAggregations={false}
                 showRowAggregations={false}
             />

--- a/frontend/src/scenes/session-recordings/components/replayActiveHoursHeatMapLogic.ts
+++ b/frontend/src/scenes/session-recordings/components/replayActiveHoursHeatMapLogic.ts
@@ -174,6 +174,16 @@ export const replayActiveHoursHeatMapLogic = kea<replayActiveHoursHeatMapLogicTy
                 }
             },
         ],
+        isClickable: [
+            (s) => [s.calendarHeatmapProps],
+            (calendarHeatmapProps) => (colIndex: number, rowIndex?: number) => {
+                const valueSource =
+                    rowIndex == undefined
+                        ? calendarHeatmapProps?.processedData.columnsAggregations
+                        : calendarHeatmapProps?.processedData.matrix[rowIndex]
+                return (valueSource[colIndex] ?? 0) > 0
+            },
+        ],
     })),
     listeners(() => ({
         loadRecordingsPerHourFailed: async () => {

--- a/frontend/src/scenes/session-recordings/components/replayActiveHoursHeatMapLogic.ts
+++ b/frontend/src/scenes/session-recordings/components/replayActiveHoursHeatMapLogic.ts
@@ -4,6 +4,7 @@ import { router } from 'kea-router'
 import api from 'lib/api'
 import { Dayjs, now } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
+import posthog from 'posthog-js'
 import { urls } from 'scenes/urls'
 import { CalendarHeatMapProps } from 'scenes/web-analytics/CalendarHeatMap/CalendarHeatMap'
 
@@ -51,6 +52,11 @@ export const onCellClick = (colIndex: number, rowIndex: number | undefined): voi
     } else {
         endDate = endDate.add(1, 'day')
     }
+
+    posthog.capture('clicked_replay_active_hours_heatmap_cell', {
+        isColumnHeader: rowIndex == undefined,
+        isIndividualCell: rowIndex != undefined,
+    })
 
     router.actions.push(
         urls.replay(ReplayTabs.Home, {


### PR DESCRIPTION
first change for replay active heatmaps
don't offer a clickthough to filters of there are no recordings in a slot

and send custom event when customer clicks on a cell

![2025-05-19 10 35 02](https://github.com/user-attachments/assets/05f30139-e90b-47a4-8084-5a06b16184ab)
