### PR TITLE
feat(cdp): add option to view log event in testing

### DIFF
--- a/frontend/src/scenes/hog-functions/configuration/HogFunctionTest.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/HogFunctionTest.tsx
@@ -263,7 +263,7 @@ export function HogFunctionTest({ configurable }: { configurable: boolean }): JS
                                                         <LemonDivider />
                                                         <LemonButton
                                                             fullWidth
-                                                            onClick={loadSampleGlobals}
+                                                            onClick={() => loadSampleGlobals()}
                                                             loading={sampleGlobalsLoading && !fetchCancelled}
                                                             tooltip="Find the last event matching filters, and use it to populate the globals below."
                                                         >

--- a/frontend/src/scenes/hog-functions/logs/HogFunctionLogs.tsx
+++ b/frontend/src/scenes/hog-functions/logs/HogFunctionLogs.tsx
@@ -1,12 +1,16 @@
 import { IconEllipsis } from '@posthog/icons'
 import { LemonButton, LemonCheckbox, LemonDialog, LemonMenu, LemonTag } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
 import { PageHeader } from 'lib/components/PageHeader'
 import { LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { useMemo } from 'react'
 import { urls } from 'scenes/urls'
 
+import { PipelineNodeTab, PipelineStage } from '~/types'
+
+import { hogFunctionTestLogic } from '../configuration/hogFunctionTestLogic'
 import { hogFunctionLogsLogic } from './hogFunctionLogsLogic'
 import { LogsViewer } from './LogsViewer'
 import { GroupedLogEntry, LogsViewerLogicProps } from './logsViewerLogic'
@@ -108,6 +112,7 @@ function HogFunctionLogsStatus({
         sourceType: 'hog_function',
         sourceId: hogFunctionId,
     }
+    const { loadSampleGlobals, toggleExpanded } = useActions(hogFunctionTestLogic({ id: hogFunctionId }))
 
     const { retries, selectingMany, selectedForRetry, eventIdByInvocationId } = useValues(
         hogFunctionLogsLogic(logicProps)
@@ -168,6 +173,20 @@ function HogFunctionLogsStatus({
                             setSelectedForRetry({
                                 [record.instanceId]: true,
                             })
+                        },
+                    },
+                    {
+                        label: 'View event in configuration tab',
+                        onClick: () => {
+                            loadSampleGlobals({ eventId })
+                            toggleExpanded(true)
+                            router.actions.push(
+                                urls.pipelineNode(
+                                    PipelineStage.Destination,
+                                    'hog-' + hogFunctionId,
+                                    PipelineNodeTab.Configuration
+                                )
+                            )
                         },
                     },
                 ]}

--- a/frontend/src/scenes/hog-functions/logs/HogFunctionLogs.tsx
+++ b/frontend/src/scenes/hog-functions/logs/HogFunctionLogs.tsx
@@ -8,8 +8,6 @@ import { capitalizeFirstLetter } from 'lib/utils'
 import { useMemo } from 'react'
 import { urls } from 'scenes/urls'
 
-import { PipelineNodeTab, PipelineStage } from '~/types'
-
 import { hogFunctionTestLogic } from '../configuration/hogFunctionTestLogic'
 import { hogFunctionLogsLogic } from './hogFunctionLogsLogic'
 import { LogsViewer } from './LogsViewer'
@@ -176,17 +174,11 @@ function HogFunctionLogsStatus({
                         },
                     },
                     {
-                        label: 'View event in configuration tab',
+                        label: 'Test with this event in configuration',
                         onClick: () => {
                             loadSampleGlobals({ eventId })
                             toggleExpanded(true)
-                            router.actions.push(
-                                urls.pipelineNode(
-                                    PipelineStage.Destination,
-                                    'hog-' + hogFunctionId,
-                                    PipelineNodeTab.Configuration
-                                )
-                            )
+                            router.actions.push(urls.hogFunction(hogFunctionId) + '?tab=configuration')
                         },
                     },
                 ]}

--- a/frontend/src/scenes/hog-functions/testing/HogFunctionTesting.tsx
+++ b/frontend/src/scenes/hog-functions/testing/HogFunctionTesting.tsx
@@ -29,15 +29,7 @@ import { InsightEmptyState } from 'scenes/insights/EmptyStates'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 import { urls } from 'scenes/urls'
 
-import {
-    AvailableFeature,
-    GroupType,
-    GroupTypeIndex,
-    HogFunctionInvocationGlobals,
-    LogEntry,
-    PipelineNodeTab,
-    PipelineStage,
-} from '~/types'
+import { AvailableFeature, GroupType, GroupTypeIndex, HogFunctionInvocationGlobals, LogEntry } from '~/types'
 
 import {
     convertToHogFunctionInvocationGlobals,
@@ -492,7 +484,7 @@ function TestingEventsList({ id }: { id: string }): JSX.Element | null {
                                             },
                                         },
                                         {
-                                            label: 'View event in configuration tab',
+                                            label: 'Test with this event in configuration',
                                             onClick: () => {
                                                 const globals = buildGlobals(
                                                     row,
@@ -501,13 +493,7 @@ function TestingEventsList({ id }: { id: string }): JSX.Element | null {
                                                 )
                                                 setSampleGlobals(globals)
                                                 toggleExpanded(true)
-                                                router.actions.push(
-                                                    urls.pipelineNode(
-                                                        PipelineStage.Destination,
-                                                        'hog-' + id,
-                                                        PipelineNodeTab.Configuration
-                                                    )
-                                                )
+                                                router.actions.push(urls.hogFunction(id) + '?tab=configuration')
                                             },
                                         },
                                     ]}


### PR DESCRIPTION
## Changes

![2025-05-19 at 13 38 28](https://github.com/user-attachments/assets/b9e9e519-8a5f-4497-8cfd-a90353ae8ab3)

Similar to what we have in the testing tab, add a `View event in configuration tab` option to make debugging easier

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
