### PR TITLE
fix(properties): fix updating/deleting properties when group keys share substrings

### DIFF
--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -186,6 +186,12 @@ class ClickhouseTestGroupsApi(ClickhouseTestMixin, APIBaseTest):
             group_key="org:5",
             properties={"name": "Mr. Krabs"},
         )
+        create_group(
+            team_id=self.team.pk,
+            group_type_index=group_type_mapping.group_type_index,
+            group_key="org:55",
+            properties={"name": "Mr. Krabs"},
+        )
 
         response = self.client.post(
             f"/api/projects/{self.team.id}/groups/update_property?group_key=org:5&group_type_index=0",


### PR DESCRIPTION
## Problem

Groups where the group key is a substring of another group's key can't be update/deleted. 

https://posthoghelp.zendesk.com/agent/tickets/30442 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/32294)

Error tracking:
- update_property https://us.posthog.com/project/2/error_tracking/3a15308a-990e-4fed-8e4c-9216dc249984
- delete_property https://us.posthog.com/project/2/error_tracking/bea106f2-bf51-441c-9096-cfbb1420f03e
- activity https://us.posthog.com/project/2/error_tracking/3326e659-d233-426c-964a-464ae84af5e2

## Changes

This is because the `safely_get_queryset` method is overwritten with am `__icontains` operator for a `find` endpoint. We're now using `get_object` with an analog `safely_get_object` method.

## How did you test this code?

Adapted a test case and tried manually