### PR TITLE
fix: only once means only once

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -603,7 +603,9 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
         },
         loadSnapshotSources: () => {
             // We only load events once we actually start loading the recording
-            actions.loadEvents()
+            if (!values.sessionEventsData) {
+                actions.loadEvents()
+            }
         },
         loadRecordingMetaSuccess: () => {
             cache.metadataLoadDuration = Math.round(performance.now() - cache.metaStartTime)


### PR DESCRIPTION
we used `loadSnapshotSources` as a proxy for "things started" because we only called it once

but now we call it more than once

so, let's gate on whether we need to do the thing as well