### PR TITLE
feat: Move /csp endpoint to /report

### DIFF
--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -2386,7 +2386,7 @@ class TestCapture(BaseTest):
         }
 
         response = self.client.post(
-            f"/csp/?token={self.team.api_token}",
+            f"/report/?token={self.team.api_token}",
             data=json.dumps(csp_report),
             content_type="application/csp-report",
         )
@@ -2431,7 +2431,7 @@ class TestCapture(BaseTest):
 
     def test_capture_csp_invalid_json_gives_invalid_csp_payload(self):
         response = self.client.post(
-            f"/csp/?token={self.team.api_token}",
+            f"/report/?token={self.team.api_token}",
             data="this is not valid json",
             content_type="application/csp-report",
         )
@@ -2444,7 +2444,7 @@ class TestCapture(BaseTest):
         invalid_csp_report = {"not-a-csp-report": "invalid format"}
 
         response = self.client.post(
-            f"/csp/?token={self.team.api_token}",
+            f"/report/?token={self.team.api_token}",
             data=json.dumps(invalid_csp_report),
             content_type="application/csp-report",
         )
@@ -2455,7 +2455,7 @@ class TestCapture(BaseTest):
 
     def test_integration_csp_report_invalid_json_gives_invalid_csp_payload(self):
         response = self.client.post(
-            f"/csp/?token={self.team.api_token}",
+            f"/report/?token={self.team.api_token}",
             data="this is not valid json}",
             content_type="application/csp-report",
         )
@@ -2472,7 +2472,7 @@ class TestCapture(BaseTest):
         }
 
         response = self.client.post(
-            f"/csp/?token={self.team.api_token}",
+            f"/report/?token={self.team.api_token}",
             data=json.dumps(invalid_format),
             content_type="application/csp-report",
         )
@@ -2491,7 +2491,7 @@ class TestCapture(BaseTest):
         }
 
         response = self.client.post(
-            f"/csp/?token={self.team.api_token}",
+            f"/report/?token={self.team.api_token}",
             data=json.dumps(valid_csp_report),
             content_type="application/json",  # Not application/csp-report
         )
@@ -2520,7 +2520,7 @@ class TestCapture(BaseTest):
         ]
 
         response = self.client.post(
-            f"/csp/?token={self.team.api_token}",
+            f"/report/?token={self.team.api_token}",
             data=json.dumps(report_to_format),
             content_type="application/reports+json",
         )
@@ -2572,7 +2572,7 @@ class TestCapture(BaseTest):
         ]
 
         response = self.client.post(
-            f"/csp/?token={self.team.api_token}",
+            f"/report/?token={self.team.api_token}",
             data=json.dumps(report_to_format),
             content_type="application/reports+json",
         )

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -2422,7 +2422,7 @@ class TestCapture(BaseTest):
         }
 
         response = self.client.post(
-            f"/csp?token={self.team.api_token}",
+            f"/report?token={self.team.api_token}",
             data=json.dumps(csp_report),
             content_type="application/csp-report",
         )

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -148,7 +148,11 @@ def format_paginated_url(request: request.Request, offset: int, page_size: int, 
 
 
 def is_csp_report(request) -> bool:
-    return request.path == "/report" or request.path == "/report/"
+    return (
+        request.path == "/report"
+        or request.path == "/report/"
+        or request.headers.get("Content-Type") == "application/reports+json"
+    )
 
 
 def get_token(data, request) -> Optional[str]:

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -151,7 +151,7 @@ def is_csp_report(request) -> bool:
     return (
         request.path == "/report"
         or request.path == "/report/"
-        or request.headers.get("Content-Type") == "application/reports+json"
+        or request.headers.get("Content-Type") in {"application/reports+json", "application/csp-report"}
     )
 
 

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -148,7 +148,7 @@ def format_paginated_url(request: request.Request, offset: int, page_size: int, 
 
 
 def is_csp_report(request) -> bool:
-    return request.path == "/csp" or request.path == "/csp/"
+    return request.path == "/report" or request.path == "/report/"
 
 
 def get_token(data, request) -> Optional[str]:

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -229,7 +229,7 @@ urlpatterns = [
     opt_slash_path("capture", capture.get_event),
     opt_slash_path("batch", capture.get_event),
     opt_slash_path("s", capture.get_event),  # session recordings
-    opt_slash_path("csp", capture.get_csp_event),  # CSP violation reports
+    opt_slash_path("report", capture.get_csp_event),  # CSP violation reports
     opt_slash_path("robots.txt", robots_txt),
     opt_slash_path(".well-known/security.txt", security_txt),
     # auth


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
The /csp endpoint will eventually be able to handle other kinds of reports, to rename it to /report


## Changes

Rename the endpoint to /report

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Existing tests still pass :)
