### PR TITLE
fix: spell right

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerSidebar.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerSidebar.tsx
@@ -81,10 +81,19 @@ export function PlayerSidebar(): JSX.Element {
                         <LemonTabs
                             activeKey={activeTab}
                             onChange={(tabId) => setTab(tabId)}
-                            tabs={sidebarTabs.map((tabId) => ({
-                                key: tabId,
-                                label: capitalizeFirstLetter(splitKebabCase(tabId)),
-                            }))}
+                            tabs={sidebarTabs.map((tabId) => {
+                                if (tabId === SessionRecordingSidebarTab.SESSION_SUMMARY) {
+                                    return {
+                                        key: tabId,
+                                        label: 'AI summary',
+                                    }
+                                }
+
+                                return {
+                                    key: tabId,
+                                    label: capitalizeFirstLetter(splitKebabCase(tabId)),
+                                }
+                            })}
                             barClassName="!mb-0"
                             size="small"
                         />


### PR DESCRIPTION
### before
<img width="130" alt="Screenshot 2025-05-19 at 15 31 42" src="https://github.com/user-attachments/assets/5d50d1f0-29fd-4217-b424-90d51a60f666" />


### after

<img width="139" alt="Screenshot 2025-05-19 at 15 31 26" src="https://github.com/user-attachments/assets/99e832af-67aa-4395-a90a-8a5d1de81b71" />
