### PR TITLE
fix: Stop the plugin server on unhandledRejection

### DIFF
--- a/plugin-server/src/server.ts
+++ b/plugin-server/src/server.ts
@@ -314,6 +314,8 @@ export class PluginServer {
             captureException(error, {
                 extra: { detected_at: `pluginServer.ts on unhandledRejection` },
             })
+
+            void this.stop(error)
         })
 
         process.on('uncaughtException', async (error: Error) => {


### PR DESCRIPTION
## Problem

Fixes #32342 

Plugin server does not shutdown (preventing reboot / restart) when unhandledRejections occur.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

Self-hosted

## How did you test this code?

I manually changed this line on my instance, and have now watched it successfully reboot. This fixes an issue I was having with the v2 session recorder... I do not know if it will introduce issues to other plugins (I was running the v2 session recorder consumer in it's own instance, so this change has only been tested in that context).

See my [comment here](https://github.com/PostHog/posthog/issues/32342#issuecomment-2891800840) for an alternative, possibly safer, means to do this if there's some reason we don't want unhandledRejections to cause a shutdown.
