### PR TITLE
fix(materialization): Materialization select set query

### DIFF
--- a/posthog/warehouse/models/modeling.py
+++ b/posthog/warehouse/models/modeling.py
@@ -137,6 +137,7 @@ def get_parents_from_model_query(model_query: str) -> set[str]:
                 break
             elif isinstance(join.table, ast.SelectSetQuery):
                 queries.extend(list(extract_select_queries(join.table)))
+                break
 
             parent_name = join.table.chain[0]  # type: ignore
 

--- a/posthog/warehouse/models/test/test_modeling.py
+++ b/posthog/warehouse/models/test/test_modeling.py
@@ -39,6 +39,17 @@ from posthog.warehouse.models.modeling import (
             {"events", "numbers"},
         ),
         ("select * from (select * from (select * from (select * from events)))", {"events"}),
+        (
+            """
+            select *
+            from (
+              select number from numbers(5)
+              union all
+              select number from numbers(5)
+            )
+            """,
+            {"numbers"},
+        ),
     ],
 )
 def test_get_parents_from_model_query(query: str, parents: set[str]):

--- a/posthog/warehouse/models/test/test_modeling.py
+++ b/posthog/warehouse/models/test/test_modeling.py
@@ -45,10 +45,10 @@ from posthog.warehouse.models.modeling import (
             from (
               select number from numbers(5)
               union all
-              select number from numbers(5)
+              select event from events
             )
             """,
-            {"numbers"},
+            {"numbers", "events"},
         ),
     ],
 )


### PR DESCRIPTION
## Problem

- materialization doesn't accept queries like `SELECT * FROM (SELECT ... UNION ALL SELECT ...)`

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- add break statement which resolves this

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
