### PR TITLE
feat: prefilter dashboard templates

### DIFF
--- a/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplatesLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplatesLogic.tsx
@@ -1,5 +1,8 @@
 import { actions, afterMount, connect, kea, key, listeners, path, props, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
+import { router } from 'kea-router'
+import { actionToUrl } from 'kea-router'
+import { urlToAction } from 'kea-router'
 import api from 'lib/api'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
@@ -61,4 +64,21 @@ export const dashboardTemplatesLogic = kea<dashboardTemplatesLogicType>([
     afterMount(({ actions }) => {
         actions.getAllTemplates()
     }),
+    urlToAction(({ actions }) => ({
+        '/dashboard': (_, searchParams) => {
+            if (searchParams.templateFilter) {
+                actions.setTemplateFilter(searchParams.templateFilter)
+            }
+        },
+    })),
+    actionToUrl(({ values }) => ({
+        setTemplateFilter: () => {
+            const searchParams = { ...router.values.searchParams }
+            searchParams.templateFilter = values.templateFilter
+            if (!values.templateFilter) {
+                delete searchParams.templateFilter
+            }
+            return ['/dashboard', searchParams, router.values.hashParams, { replace: true }]
+        },
+    })),
 ])


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We want to [deeplink the custom CSP dashboard template](https://posthog.slack.com/archives/C08S18PDPUN/p1747670638619289?thread_ts=1747670490.603689&cid=C08S18PDPUN) to people. This is a quick way to prefilter the templates so we can send them a link.

e.g: http://localhost:8010/project/1/dashboard?templateFilter=csp#newDashboard=modal

ps: you need to have a dashboard template with "csp" in the name created locally

## Changes

- Added a `templateFilter` query parameter to prefilter templates on the `newDashboard` modal. I didn't want for a get request to actually create a new dashboard. 

In the future we can probably use a template id to show up the detailed description instead of the list, but for now it works.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manually.
