### PR TITLE
fix(csp): prefer trailing slash after proxy change

### DIFF
--- a/frontend/src/scenes/settings/environment/CSPReportingSettings.tsx
+++ b/frontend/src/scenes/settings/environment/CSPReportingSettings.tsx
@@ -85,7 +85,7 @@ export function CSPReportingSettings(): JSX.Element {
                 <p>Set this URL for both the report-to and report-uri endpoints</p>
                 <CodeSnippet language={Language.Text} wrap={true}>
                     {
-                        combineUrl(`${proxyRecord}/report`, {
+                        combineUrl(`${proxyRecord}/report/`, {
                             token: currentTeam?.api_token,
                             v: includeVersion ? 1 : undefined,
                             session_id: includeSessionId ? 'ADD_THE_SESSION_ID' : undefined,


### PR DESCRIPTION
Defaulting to the trailing slash to avoid problems