### PR TITLE
chore(handle-unstarted-materializations): Handle non-started Materialization runs

### DIFF
--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -879,7 +879,7 @@ async def fail_jobs_activity(inputs: FailJobsActivityInputs) -> None:
             workflow_id=inputs.workflow_id,
             workflow_run_id=inputs.workflow_run_id,
             status=DataModelingJob.Status.FAILED,
-            error=inputs.error,
+            error="Materialization could not start",
         )
 
 

--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -875,11 +875,12 @@ async def fail_jobs_activity(inputs: FailJobsActivityInputs) -> None:
         await logger.ainfo(
             "No job record found to fail", workflow_id=inputs.workflow_id, workflow_run_id=inputs.workflow_run_id
         )
-        DataModelingJob.objects.create(
+        await database_sync_to_async(DataModelingJob.objects.create)(
             workflow_id=inputs.workflow_id,
             workflow_run_id=inputs.workflow_run_id,
             status=DataModelingJob.Status.FAILED,
             error="Materialization could not start",
+            team_id=inputs.team_id,
         )
 
 

--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -835,6 +835,7 @@ class CancelJobsActivityInputs:
 class FailJobsActivityInputs:
     workflow_id: str
     workflow_run_id: str
+    team_id: int
     error: str
 
 

--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -986,7 +986,9 @@ class RunWorkflow(PostHogWorkflow):
 
             await temporalio.workflow.execute_activity(
                 fail_jobs_activity,
-                FailJobsActivityInputs(workflow_id=workflow_id, workflow_run_id=workflow_run_id, error=str(e)),
+                FailJobsActivityInputs(
+                    workflow_id=workflow_id, workflow_run_id=workflow_run_id, team_id=inputs.team_id, error=str(e)
+                ),
                 start_to_close_timeout=dt.timedelta(minutes=5),
                 retry_policy=temporalio.common.RetryPolicy(
                     maximum_attempts=3,


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
Sometimes our queue winds up as empty when starting materialization runs and we never wind up executing the code that starts a modeling run. We can protect ourselves from this exception by creating the record in the event it was not found.

## What happens now
<img width="627" alt="image" src="https://github.com/user-attachments/assets/4368269e-6e19-411c-b717-37f82d2a422a" />

> Note: I changed the error message to be more readable and less mapped to the actual model names.


```py
    if queue.empty():
        raise asyncio.QueueEmpty()

    running_tasks = set()

    async with Heartbeater():
        while True:
            message = await queue.get()
            match message:
                case QueueMessage(status=ModelStatus.READY, label=label):
                    model = inputs.dag[label]
                    # run started in here...
                    task = asyncio.create_task(handle_model_ready(model, inputs.team_id, queue))
                    running_tasks.add(task)
                    task.add_done_callback(running_tasks.discard)
```

## Does this work well for both Cloud and self-hosted?
Yes

