### PR TITLE
fix: table already exists on dagster materialization

### DIFF
--- a/posthog/models/web_preaggregated/sql.py
+++ b/posthog/models/web_preaggregated/sql.py
@@ -10,7 +10,7 @@ def TABLE_TEMPLATE(table_name, columns, order_by, on_cluster=True):
     engine = AggregatingMergeTree(table_name, replication_scheme=ReplicationScheme.REPLICATED)
     on_cluster_clause = f"ON CLUSTER '{CLICKHOUSE_CLUSTER}'" if on_cluster else ""
     return f"""
-    CREATE OR REPLACE TABLE {table_name} {on_cluster_clause}
+    CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     (
         day_bucket DateTime,
         team_id UInt64,
@@ -25,7 +25,7 @@ def TABLE_TEMPLATE(table_name, columns, order_by, on_cluster=True):
 
 def DISTRIBUTED_TABLE_TEMPLATE(dist_table_name, base_table_name, columns):
     return f"""
-    CREATE OR REPLACE TABLE {dist_table_name} ON CLUSTER '{CLICKHOUSE_CLUSTER}'
+    CREATE TABLE IF NOT EXISTS {dist_table_name} ON CLUSTER '{CLICKHOUSE_CLUSTER}'
     (
         day_bucket DateTime,
         team_id UInt64,


### PR DESCRIPTION
## Problem

Those tables are intended for internal use to test the pre-aggregation approach for web analytics queries. 

The integration of the query runners is behind an FF and query modifier, so I assumed replacing them every time on the dagster jobs would be ok, but apparently... it is not?

I saw that the [person_overrides](https://github.com/PostHog/posthog/blob/6eba7faefc15f6fbee99a35b2101ee9b055bff0b/dags/person_overrides.py#L36-L42) does that, but I can move this to a regular migration if that's better.

## Changes

- "IF NOT EXISTS" instead of "CREATE OR REPLACE"

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

I did not 😅 
