### PR TITLE
refactor: Make it easier to detect proper revenue analytics views

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -7337,6 +7337,9 @@
                 "id": {
                     "type": "string"
                 },
+                "kind": {
+                    "$ref": "#/definitions/DatabaseSchemaManagedViewTableKind"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -7346,13 +7349,20 @@
                 "row_count": {
                     "type": "number"
                 },
+                "source_id": {
+                    "type": "string"
+                },
                 "type": {
                     "const": "managed_view",
                     "type": "string"
                 }
             },
-            "required": ["fields", "id", "name", "query", "type"],
+            "required": ["fields", "id", "kind", "name", "query", "type"],
             "type": "object"
+        },
+        "DatabaseSchemaManagedViewTableKind": {
+            "const": "revenue_analytics",
+            "type": "string"
         },
         "DatabaseSchemaMaterializedViewTable": {
             "additionalProperties": false,

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2407,9 +2407,15 @@ export interface DatabaseSchemaViewTable extends DatabaseSchemaTableCommon {
     query: HogQLQuery
 }
 
+export enum DatabaseSchemaManagedViewTableKind {
+    REVENUE_ANALYTICS = 'revenue_analytics',
+}
+
 export interface DatabaseSchemaManagedViewTable extends DatabaseSchemaTableCommon {
-    type: 'managed_view'
     query: HogQLQuery
+    type: 'managed_view'
+    kind: DatabaseSchemaManagedViewTableKind
+    source_id?: string
 }
 
 export interface DatabaseSchemaMaterializedViewTable extends DatabaseSchemaTableCommon {

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -497,11 +497,13 @@ def create_hogql_database(
                     views[view.name] = view
                     create_nested_table_group(view.name.split("."), views, view)
 
-        # No need to call `create_nested_table_group` because these arent using dot notation
+        # Similar to the above, these will be in the format revenue_analytics.<event_name>.events_revenue_view
+        # so let's make sure we have the proper nested queries
         with timings.measure("for_events"):
             revenue_views = RevenueAnalyticsBaseView.for_events(team)
             for view in revenue_views:
                 views[view.name] = view
+                create_nested_table_group(view.name.split("."), views, view)
 
     with timings.measure("data_warehouse_tables"):
         with timings.measure("select"):
@@ -980,6 +982,8 @@ def serialize_database(
                 fields=fields_dict,
                 id=view.name,  # We don't have a UUID for revenue views because they're not saved, just reuse the name
                 name=view.name,
+                kind="revenue_analytics",
+                source_id=view.source_id,
                 query=HogQLQuery(query=view.query),
             )
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -8666,9 +8666,11 @@ class DatabaseSchemaManagedViewTable(BaseModel):
     )
     fields: dict[str, DatabaseSchemaField]
     id: str
+    kind: Literal["revenue_analytics"] = "revenue_analytics"
     name: str
     query: HogQLQuery
     row_count: Optional[float] = None
+    source_id: Optional[str] = None
     type: Literal["managed_view"] = "managed_view"
 
 

--- a/products/revenue_analytics/backend/hogql_queries/revenue_example_events_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_example_events_query_runner.py
@@ -10,7 +10,8 @@ from posthog.schema import (
     RevenueExampleEventsQueryResponse,
     CachedRevenueExampleEventsQueryResponse,
 )
-from ..views.revenue_analytics_charge_view import EVENTS_VIEW_SUFFIX
+
+from ..views.revenue_analytics_base_view import RevenueAnalyticsBaseView
 
 
 class RevenueExampleEventsQueryRunner(QueryRunnerWithHogQLContext):
@@ -26,59 +27,74 @@ class RevenueExampleEventsQueryRunner(QueryRunnerWithHogQLContext):
         )
 
     def to_query(self) -> ast.SelectQuery:
-        if not self.database.has_table(EVENTS_VIEW_SUFFIX):
+        view_names = self.database.get_views()
+        all_views = [self.database.get_table(view_name) for view_name in view_names]
+        views = [view for view in all_views if isinstance(view, RevenueAnalyticsBaseView) and view.source_id is None]
+        if not views:
             return ast.SelectQuery.empty()
 
-        select = ast.SelectQuery(
-            select=[
-                ast.Call(
-                    name="tuple",
-                    args=[
-                        ast.Field(chain=["events", "uuid"]),
-                        ast.Field(chain=["events", "event"]),
-                        ast.Field(chain=["events", "distinct_id"]),
-                        ast.Field(chain=["events", "properties"]),
+        queries: list[ast.SelectQuery] = []
+        for view in views:
+            queries.append(
+                ast.SelectQuery(
+                    select=[
+                        ast.Call(
+                            name="tuple",
+                            args=[
+                                ast.Field(chain=["events", "uuid"]),
+                                ast.Field(chain=["events", "event"]),
+                                ast.Field(chain=["events", "distinct_id"]),
+                                ast.Field(chain=["events", "properties"]),
+                            ],
+                        ),
+                        ast.Field(chain=["view", "event_name"]),
+                        ast.Field(chain=["view", "original_amount"]),
+                        ast.Field(chain=["view", "currency_aware_amount"]),
+                        ast.Field(chain=["view", "original_currency"]),
+                        ast.Field(chain=["view", "amount"]),
+                        ast.Field(chain=["view", "currency"]),
+                        ast.Call(
+                            name="tuple",
+                            args=[
+                                ast.Field(chain=["events", "person", "id"]),
+                                ast.Field(chain=["events", "person", "created_at"]),
+                                ast.Field(chain=["events", "distinct_id"]),
+                                ast.Field(chain=["events", "person", "properties"]),
+                            ],
+                        ),
+                        ast.Field(chain=["view", "session_id"]),
+                        ast.Alias(alias="timestamp", expr=ast.Field(chain=["view", "timestamp"])),
                     ],
-                ),
-                ast.Field(chain=["view", "event_name"]),
-                ast.Field(chain=["view", "original_amount"]),
-                ast.Field(chain=["view", "currency_aware_amount"]),
-                ast.Field(chain=["view", "original_currency"]),
-                ast.Field(chain=["view", "amount"]),
-                ast.Field(chain=["view", "currency"]),
-                ast.Call(
-                    name="tuple",
-                    args=[
-                        ast.Field(chain=["events", "person", "id"]),
-                        ast.Field(chain=["events", "person", "created_at"]),
-                        ast.Field(chain=["events", "distinct_id"]),
-                        ast.Field(chain=["events", "person", "properties"]),
-                    ],
-                ),
-                ast.Field(chain=["view", "session_id"]),
-                ast.Field(chain=["view", "timestamp"]),
-            ],
-            select_from=ast.JoinExpr(
-                alias="view",
-                table=ast.Field(chain=[EVENTS_VIEW_SUFFIX]),
-                next_join=ast.JoinExpr(
-                    join_type="INNER JOIN",
-                    table=ast.Field(chain=["events"]),
-                    alias="events",
-                    constraint=ast.JoinConstraint(
-                        constraint_type="ON",
-                        expr=ast.CompareOperation(
-                            op=CompareOperationOp.Eq,
-                            left=ast.Field(chain=["events", "event"]),
-                            right=ast.Field(chain=["view", "event_name"]),
+                    select_from=ast.JoinExpr(
+                        alias="view",
+                        table=ast.Field(chain=[view.name]),
+                        next_join=ast.JoinExpr(
+                            join_type="INNER JOIN",
+                            alias="events",
+                            table=ast.Field(chain=["events"]),
+                            constraint=ast.JoinConstraint(
+                                constraint_type="ON",
+                                expr=ast.CompareOperation(
+                                    op=CompareOperationOp.Eq,
+                                    left=ast.Field(chain=["events", "event"]),
+                                    right=ast.Field(chain=["view", "event_name"]),
+                                ),
+                            ),
                         ),
                     ),
-                ),
-            ),
-            order_by=[ast.OrderExpr(expr=ast.Field(chain=["view", "timestamp"]), order="DESC")],
-        )
+                    order_by=[ast.OrderExpr(expr=ast.Field(chain=["timestamp"]), order="DESC")],
+                )
+            )
 
-        return select
+        if len(queries) == 1:
+            return queries[0]
+
+        # Reorder by timestamp to ensure the most recent events are at the top across all event views
+        return ast.SelectQuery(
+            select=[ast.Field(chain=["*"])],
+            select_from=ast.JoinExpr(table=ast.SelectSetQuery.create_from_queries(queries, "UNION ALL")),
+            order_by=[ast.OrderExpr(expr=ast.Field(chain=["timestamp"]), order="DESC")],
+        )
 
     def calculate(self):
         response = self.paginator.execute_hogql_query(

--- a/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_growth_rate_query_runner.ambr
+++ b/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_growth_rate_query_runner.ambr
@@ -175,35 +175,35 @@
        (SELECT toStartOfMonth(timestamp) AS month,
                sum(amount) AS revenue
         FROM
-          (SELECT events_revenue_view.id AS id,
-                  events_revenue_view.timestamp AS timestamp,
-                  events_revenue_view.customer_id AS customer_id,
-                  events_revenue_view.session_id AS session_id,
-                  events_revenue_view.event_name AS event_name,
-                  events_revenue_view.original_currency AS original_currency,
-                  events_revenue_view.original_amount AS original_amount,
-                  events_revenue_view.enable_currency_aware_divider AS enable_currency_aware_divider,
-                  events_revenue_view.currency_aware_divider AS currency_aware_divider,
-                  events_revenue_view.currency_aware_amount AS currency_aware_amount,
-                  events_revenue_view.currency AS currency,
-                  events_revenue_view.amount AS amount
+          (SELECT `revenue_analytics.purchase.events_revenue_view`.id AS id,
+                  `revenue_analytics.purchase.events_revenue_view`.timestamp AS timestamp,
+                  `revenue_analytics.purchase.events_revenue_view`.customer_id AS customer_id,
+                  `revenue_analytics.purchase.events_revenue_view`.session_id AS session_id,
+                  `revenue_analytics.purchase.events_revenue_view`.event_name AS event_name,
+                  `revenue_analytics.purchase.events_revenue_view`.original_currency AS original_currency,
+                  `revenue_analytics.purchase.events_revenue_view`.original_amount AS original_amount,
+                  `revenue_analytics.purchase.events_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                  `revenue_analytics.purchase.events_revenue_view`.currency_aware_divider AS currency_aware_divider,
+                  `revenue_analytics.purchase.events_revenue_view`.currency_aware_amount AS currency_aware_amount,
+                  `revenue_analytics.purchase.events_revenue_view`.currency AS currency,
+                  `revenue_analytics.purchase.events_revenue_view`.amount AS amount
            FROM
              (SELECT events.uuid AS id,
                      toTimeZone(events.created_at, 'UTC') AS timestamp,
                      events.distinct_id AS customer_id,
                      toString(events.`$session_id`) AS session_id,
                      events.event AS event_name,
-                     multiIf(equals(events.event, 'purchase'), upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), NULL) AS original_currency,
-                     multiIf(equals(events.event, 'purchase'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS original_amount,
+                     upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+                     accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
                      1 AS enable_currency_aware_divider,
                      if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
                      divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
                      'GBP' AS currency,
-                     multiIf(equals(events.event, 'purchase'), if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))), NULL) AS amount
+                     if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
               FROM events
               WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
-              ORDER BY timestamp DESC) AS events_revenue_view
-           WHERE in(events_revenue_view.event_name,
+              ORDER BY timestamp DESC) AS `revenue_analytics.purchase.events_revenue_view`
+           WHERE in(`revenue_analytics.purchase.events_revenue_view`.event_name,
                     ['purchase']))
         WHERE and(ifNull(greaterOrEquals(timestamp, assumeNotNull(toDateTime('2015-01-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(timestamp, assumeNotNull(toDateTime('2025-04-21 23:59:59', 'UTC'))), 0))
         GROUP BY month
@@ -240,35 +240,36 @@
        (SELECT toStartOfMonth(timestamp) AS month,
                sum(amount) AS revenue
         FROM
-          (SELECT events_revenue_view.id AS id,
-                  events_revenue_view.timestamp AS timestamp,
-                  events_revenue_view.customer_id AS customer_id,
-                  events_revenue_view.session_id AS session_id,
-                  events_revenue_view.event_name AS event_name,
-                  events_revenue_view.original_currency AS original_currency,
-                  events_revenue_view.original_amount AS original_amount,
-                  events_revenue_view.enable_currency_aware_divider AS enable_currency_aware_divider,
-                  events_revenue_view.currency_aware_divider AS currency_aware_divider,
-                  events_revenue_view.currency_aware_amount AS currency_aware_amount,
-                  events_revenue_view.currency AS currency,
-                  events_revenue_view.amount AS amount
+          (SELECT `revenue_analytics.purchase.events_revenue_view`.id AS id,
+                  `revenue_analytics.purchase.events_revenue_view`.timestamp AS timestamp,
+                  `revenue_analytics.purchase.events_revenue_view`.customer_id AS customer_id,
+                  `revenue_analytics.purchase.events_revenue_view`.session_id AS session_id,
+                  `revenue_analytics.purchase.events_revenue_view`.event_name AS event_name,
+                  `revenue_analytics.purchase.events_revenue_view`.original_currency AS original_currency,
+                  `revenue_analytics.purchase.events_revenue_view`.original_amount AS original_amount,
+                  `revenue_analytics.purchase.events_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                  `revenue_analytics.purchase.events_revenue_view`.currency_aware_divider AS currency_aware_divider,
+                  `revenue_analytics.purchase.events_revenue_view`.currency_aware_amount AS currency_aware_amount,
+                  `revenue_analytics.purchase.events_revenue_view`.currency AS currency,
+                  `revenue_analytics.purchase.events_revenue_view`.amount AS amount
            FROM
              (SELECT events.uuid AS id,
                      toTimeZone(events.created_at, 'UTC') AS timestamp,
                      events.distinct_id AS customer_id,
                      toString(events.`$session_id`) AS session_id,
                      events.event AS event_name,
-                     multiIf(equals(events.event, 'purchase'), upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), NULL) AS original_currency,
-                     multiIf(equals(events.event, 'purchase'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS original_amount,
-                     if(in(event_name, ['purchase']), in(original_currency, ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']), 1) AS enable_currency_aware_divider,
-                     if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                     divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                     'GBP' AS currency,
-                     multiIf(equals(events.event, 'purchase'), if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))), NULL) AS amount
+                     upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+                     accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                     in(original_currency,
+                        ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                       if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                       divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                       'GBP' AS currency,
+                       if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
               FROM events
               WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
-              ORDER BY timestamp DESC) AS events_revenue_view
-           WHERE in(events_revenue_view.event_name,
+              ORDER BY timestamp DESC) AS `revenue_analytics.purchase.events_revenue_view`
+           WHERE in(`revenue_analytics.purchase.events_revenue_view`.event_name,
                     ['purchase']))
         WHERE and(ifNull(greaterOrEquals(timestamp, assumeNotNull(toDateTime('2015-01-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(timestamp, assumeNotNull(toDateTime('2025-04-21 23:59:59', 'UTC'))), 0))
         GROUP BY month

--- a/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_overview_query_runner.ambr
+++ b/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_overview_query_runner.ambr
@@ -67,35 +67,35 @@
          count(DISTINCT customer_id) AS paying_customer_count,
          ifNull(divideDecimal(revenue, accurateCastOrNull(paying_customer_count, 'Decimal64(10)')), 0) AS avg_revenue_per_customer
   FROM
-    (SELECT events_revenue_view.id AS id,
-            events_revenue_view.timestamp AS timestamp,
-            events_revenue_view.customer_id AS customer_id,
-            events_revenue_view.session_id AS session_id,
-            events_revenue_view.event_name AS event_name,
-            events_revenue_view.original_currency AS original_currency,
-            events_revenue_view.original_amount AS original_amount,
-            events_revenue_view.enable_currency_aware_divider AS enable_currency_aware_divider,
-            events_revenue_view.currency_aware_divider AS currency_aware_divider,
-            events_revenue_view.currency_aware_amount AS currency_aware_amount,
-            events_revenue_view.currency AS currency,
-            events_revenue_view.amount AS amount
+    (SELECT `revenue_analytics.purchase.events_revenue_view`.id AS id,
+            `revenue_analytics.purchase.events_revenue_view`.timestamp AS timestamp,
+            `revenue_analytics.purchase.events_revenue_view`.customer_id AS customer_id,
+            `revenue_analytics.purchase.events_revenue_view`.session_id AS session_id,
+            `revenue_analytics.purchase.events_revenue_view`.event_name AS event_name,
+            `revenue_analytics.purchase.events_revenue_view`.original_currency AS original_currency,
+            `revenue_analytics.purchase.events_revenue_view`.original_amount AS original_amount,
+            `revenue_analytics.purchase.events_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
+            `revenue_analytics.purchase.events_revenue_view`.currency_aware_divider AS currency_aware_divider,
+            `revenue_analytics.purchase.events_revenue_view`.currency_aware_amount AS currency_aware_amount,
+            `revenue_analytics.purchase.events_revenue_view`.currency AS currency,
+            `revenue_analytics.purchase.events_revenue_view`.amount AS amount
      FROM
        (SELECT events.uuid AS id,
                toTimeZone(events.created_at, 'UTC') AS timestamp,
                events.distinct_id AS customer_id,
                toString(events.`$session_id`) AS session_id,
                events.event AS event_name,
-               multiIf(equals(events.event, 'purchase'), upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), NULL) AS original_currency,
-               multiIf(equals(events.event, 'purchase'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS original_amount,
+               upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+               accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
                1 AS enable_currency_aware_divider,
                if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
                divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
                'GBP' AS currency,
-               multiIf(equals(events.event, 'purchase'), if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))), NULL) AS amount
+               if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
-        ORDER BY timestamp DESC) AS events_revenue_view
-     WHERE in(events_revenue_view.event_name,
+        ORDER BY timestamp DESC) AS `revenue_analytics.purchase.events_revenue_view`
+     WHERE in(`revenue_analytics.purchase.events_revenue_view`.event_name,
               ['purchase']))
   WHERE and(ifNull(greaterOrEquals(timestamp, assumeNotNull(toDateTime('2023-11-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(timestamp, assumeNotNull(toDateTime('2024-01-31 23:59:59', 'UTC'))), 0))
   LIMIT 100 SETTINGS readonly=2,
@@ -115,35 +115,36 @@
          count(DISTINCT customer_id) AS paying_customer_count,
          ifNull(divideDecimal(revenue, accurateCastOrNull(paying_customer_count, 'Decimal64(10)')), 0) AS avg_revenue_per_customer
   FROM
-    (SELECT events_revenue_view.id AS id,
-            events_revenue_view.timestamp AS timestamp,
-            events_revenue_view.customer_id AS customer_id,
-            events_revenue_view.session_id AS session_id,
-            events_revenue_view.event_name AS event_name,
-            events_revenue_view.original_currency AS original_currency,
-            events_revenue_view.original_amount AS original_amount,
-            events_revenue_view.enable_currency_aware_divider AS enable_currency_aware_divider,
-            events_revenue_view.currency_aware_divider AS currency_aware_divider,
-            events_revenue_view.currency_aware_amount AS currency_aware_amount,
-            events_revenue_view.currency AS currency,
-            events_revenue_view.amount AS amount
+    (SELECT `revenue_analytics.purchase.events_revenue_view`.id AS id,
+            `revenue_analytics.purchase.events_revenue_view`.timestamp AS timestamp,
+            `revenue_analytics.purchase.events_revenue_view`.customer_id AS customer_id,
+            `revenue_analytics.purchase.events_revenue_view`.session_id AS session_id,
+            `revenue_analytics.purchase.events_revenue_view`.event_name AS event_name,
+            `revenue_analytics.purchase.events_revenue_view`.original_currency AS original_currency,
+            `revenue_analytics.purchase.events_revenue_view`.original_amount AS original_amount,
+            `revenue_analytics.purchase.events_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
+            `revenue_analytics.purchase.events_revenue_view`.currency_aware_divider AS currency_aware_divider,
+            `revenue_analytics.purchase.events_revenue_view`.currency_aware_amount AS currency_aware_amount,
+            `revenue_analytics.purchase.events_revenue_view`.currency AS currency,
+            `revenue_analytics.purchase.events_revenue_view`.amount AS amount
      FROM
        (SELECT events.uuid AS id,
                toTimeZone(events.created_at, 'UTC') AS timestamp,
                events.distinct_id AS customer_id,
                toString(events.`$session_id`) AS session_id,
                events.event AS event_name,
-               multiIf(equals(events.event, 'purchase'), upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), NULL) AS original_currency,
-               multiIf(equals(events.event, 'purchase'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS original_amount,
-               if(in(event_name, ['purchase']), in(original_currency, ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']), 1) AS enable_currency_aware_divider,
-               if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-               divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-               'GBP' AS currency,
-               multiIf(equals(events.event, 'purchase'), if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))), NULL) AS amount
+               upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+               accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+               in(original_currency,
+                  ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                 if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                 divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                 'GBP' AS currency,
+                 if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
-        ORDER BY timestamp DESC) AS events_revenue_view
-     WHERE in(events_revenue_view.event_name,
+        ORDER BY timestamp DESC) AS `revenue_analytics.purchase.events_revenue_view`
+     WHERE in(`revenue_analytics.purchase.events_revenue_view`.event_name,
               ['purchase']))
   WHERE and(ifNull(greaterOrEquals(timestamp, assumeNotNull(toDateTime('2023-11-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(timestamp, assumeNotNull(toDateTime('2024-01-31 23:59:59', 'UTC'))), 0))
   LIMIT 100 SETTINGS readonly=2,

--- a/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_top_customers_query_runner.ambr
+++ b/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_top_customers_query_runner.ambr
@@ -280,35 +280,35 @@
             toStartOfMonth(timestamp) AS month,
             sum(amount) AS amount
      FROM
-       (SELECT events_revenue_view.id AS id,
-               events_revenue_view.timestamp AS timestamp,
-               events_revenue_view.customer_id AS customer_id,
-               events_revenue_view.session_id AS session_id,
-               events_revenue_view.event_name AS event_name,
-               events_revenue_view.original_currency AS original_currency,
-               events_revenue_view.original_amount AS original_amount,
-               events_revenue_view.enable_currency_aware_divider AS enable_currency_aware_divider,
-               events_revenue_view.currency_aware_divider AS currency_aware_divider,
-               events_revenue_view.currency_aware_amount AS currency_aware_amount,
-               events_revenue_view.currency AS currency,
-               events_revenue_view.amount AS amount
+       (SELECT `revenue_analytics.purchase.events_revenue_view`.id AS id,
+               `revenue_analytics.purchase.events_revenue_view`.timestamp AS timestamp,
+               `revenue_analytics.purchase.events_revenue_view`.customer_id AS customer_id,
+               `revenue_analytics.purchase.events_revenue_view`.session_id AS session_id,
+               `revenue_analytics.purchase.events_revenue_view`.event_name AS event_name,
+               `revenue_analytics.purchase.events_revenue_view`.original_currency AS original_currency,
+               `revenue_analytics.purchase.events_revenue_view`.original_amount AS original_amount,
+               `revenue_analytics.purchase.events_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
+               `revenue_analytics.purchase.events_revenue_view`.currency_aware_divider AS currency_aware_divider,
+               `revenue_analytics.purchase.events_revenue_view`.currency_aware_amount AS currency_aware_amount,
+               `revenue_analytics.purchase.events_revenue_view`.currency AS currency,
+               `revenue_analytics.purchase.events_revenue_view`.amount AS amount
         FROM
           (SELECT events.uuid AS id,
                   toTimeZone(events.created_at, 'UTC') AS timestamp,
                   events.distinct_id AS customer_id,
                   toString(events.`$session_id`) AS session_id,
                   events.event AS event_name,
-                  multiIf(equals(events.event, 'purchase'), upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), NULL) AS original_currency,
-                  multiIf(equals(events.event, 'purchase'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS original_amount,
+                  upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
                   1 AS enable_currency_aware_divider,
                   if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
                   divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
                   'GBP' AS currency,
-                  multiIf(equals(events.event, 'purchase'), if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))), NULL) AS amount
+                  if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
            FROM events
            WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
-           ORDER BY timestamp DESC) AS events_revenue_view
-        WHERE in(events_revenue_view.event_name,
+           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.events_revenue_view`
+        WHERE in(`revenue_analytics.purchase.events_revenue_view`.event_name,
                  ['purchase']))
      WHERE and(ifNull(greaterOrEquals(timestamp, assumeNotNull(toDateTime('2023-11-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(timestamp, assumeNotNull(toDateTime('2024-01-31 23:59:59', 'UTC'))), 0))
      GROUP BY customer_id,
@@ -338,35 +338,36 @@
             toStartOfMonth(timestamp) AS month,
             sum(amount) AS amount
      FROM
-       (SELECT events_revenue_view.id AS id,
-               events_revenue_view.timestamp AS timestamp,
-               events_revenue_view.customer_id AS customer_id,
-               events_revenue_view.session_id AS session_id,
-               events_revenue_view.event_name AS event_name,
-               events_revenue_view.original_currency AS original_currency,
-               events_revenue_view.original_amount AS original_amount,
-               events_revenue_view.enable_currency_aware_divider AS enable_currency_aware_divider,
-               events_revenue_view.currency_aware_divider AS currency_aware_divider,
-               events_revenue_view.currency_aware_amount AS currency_aware_amount,
-               events_revenue_view.currency AS currency,
-               events_revenue_view.amount AS amount
+       (SELECT `revenue_analytics.purchase.events_revenue_view`.id AS id,
+               `revenue_analytics.purchase.events_revenue_view`.timestamp AS timestamp,
+               `revenue_analytics.purchase.events_revenue_view`.customer_id AS customer_id,
+               `revenue_analytics.purchase.events_revenue_view`.session_id AS session_id,
+               `revenue_analytics.purchase.events_revenue_view`.event_name AS event_name,
+               `revenue_analytics.purchase.events_revenue_view`.original_currency AS original_currency,
+               `revenue_analytics.purchase.events_revenue_view`.original_amount AS original_amount,
+               `revenue_analytics.purchase.events_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
+               `revenue_analytics.purchase.events_revenue_view`.currency_aware_divider AS currency_aware_divider,
+               `revenue_analytics.purchase.events_revenue_view`.currency_aware_amount AS currency_aware_amount,
+               `revenue_analytics.purchase.events_revenue_view`.currency AS currency,
+               `revenue_analytics.purchase.events_revenue_view`.amount AS amount
         FROM
           (SELECT events.uuid AS id,
                   toTimeZone(events.created_at, 'UTC') AS timestamp,
                   events.distinct_id AS customer_id,
                   toString(events.`$session_id`) AS session_id,
                   events.event AS event_name,
-                  multiIf(equals(events.event, 'purchase'), upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), NULL) AS original_currency,
-                  multiIf(equals(events.event, 'purchase'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS original_amount,
-                  if(in(event_name, ['purchase']), in(original_currency, ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']), 1) AS enable_currency_aware_divider,
-                  if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-                  divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-                  'GBP' AS currency,
-                  multiIf(equals(events.event, 'purchase'), if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))), NULL) AS amount
+                  upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')) AS original_currency,
+                  accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+                  in(original_currency,
+                     ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                    if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                    divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                    'GBP' AS currency,
+                    if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
            FROM events
            WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
-           ORDER BY timestamp DESC) AS events_revenue_view
-        WHERE in(events_revenue_view.event_name,
+           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.events_revenue_view`
+        WHERE in(`revenue_analytics.purchase.events_revenue_view`.event_name,
                  ['purchase']))
      WHERE and(ifNull(greaterOrEquals(timestamp, assumeNotNull(toDateTime('2023-11-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(timestamp, assumeNotNull(toDateTime('2024-01-31 23:59:59', 'UTC'))), 0))
      GROUP BY customer_id,

--- a/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_example_events_query_runner.ambr
+++ b/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_example_events_query_runner.ambr
@@ -1,53 +1,112 @@
 # serializer version: 1
 # name: TestRevenueExampleEventsQueryRunner.test_multiple_events
   '''
-  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(events.uuid, events.event, events.distinct_id, events.properties)`,
-         view.event_name AS event_name,
-         view.original_amount AS original_amount,
-         view.currency_aware_amount AS currency_aware_amount,
-         view.original_currency AS original_currency,
-         view.amount AS amount,
-         view.currency AS currency,
-         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(events.person.id, events.person.created_at, events.distinct_id, events.person.properties)`,
-         view.session_id AS session_id,
-         view.timestamp AS timestamp
+  SELECT `tuple(events.uuid, events.event, events.distinct_id, events.properties)` AS `tuple(events.uuid, events.event, events.distinct_id, events.properties)`,
+         event_name AS event_name,
+         original_amount AS original_amount,
+         currency_aware_amount AS currency_aware_amount,
+         original_currency AS original_currency,
+         amount AS amount,
+         currency AS currency,
+         `tuple(events.person.id, events.person.created_at, events.distinct_id, events.person.properties)` AS `tuple(events.person.id, events.person.created_at, events.distinct_id, events.person.properties)`,
+         session_id AS session_id,
+         timestamp AS timestamp
   FROM
-    (SELECT events.uuid AS id,
-            toTimeZone(events.created_at, 'UTC') AS timestamp,
-            events.distinct_id AS customer_id,
-            toString(events.`$session_id`) AS session_id,
-            events.event AS event_name,
-            multiIf(equals(events.event, 'purchase_a'), 'USD', equals(events.event, 'purchase_b'), 'USD', NULL) AS original_currency,
-            multiIf(equals(events.event, 'purchase_a'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), equals(events.event, 'purchase_b'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS original_amount,
-            1 AS enable_currency_aware_divider,
-            if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-            divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-            'USD' AS currency,
-            multiIf(equals(events.event, 'purchase_a'), if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))), equals(events.event, 'purchase_b'), if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))), NULL) AS amount
-     FROM events
-     WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, 'purchase_a'), equals(events.event, 'purchase_b')), isNotNull(amount)))
-     ORDER BY timestamp DESC) AS view
-  INNER JOIN events ON equals(events.event, view.event_name)
-  LEFT OUTER JOIN
-    (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-            person_distinct_id_overrides.distinct_id AS distinct_id
-     FROM person_distinct_id_overrides
-     WHERE equals(person_distinct_id_overrides.team_id, 99999)
-     GROUP BY person_distinct_id_overrides.distinct_id
-     HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-  LEFT JOIN
-    (SELECT person.id AS id,
-            toTimeZone(person.created_at, 'UTC') AS created_at,
-            person.properties AS properties
-     FROM person
-     WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                   (SELECT person.id AS id, max(person.version) AS version
-                                                    FROM person
-                                                    WHERE equals(person.team_id, 99999)
-                                                    GROUP BY person.id
-                                                    HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
-  WHERE equals(events.team_id, 99999)
-  ORDER BY view.timestamp DESC
+    (SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(events.uuid, events.event, events.distinct_id, events.properties)`,
+            view.event_name AS event_name,
+            view.original_amount AS original_amount,
+            view.currency_aware_amount AS currency_aware_amount,
+            view.original_currency AS original_currency,
+            view.amount AS amount,
+            view.currency AS currency,
+            tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(events.person.id, events.person.created_at, events.distinct_id, events.person.properties)`,
+            view.session_id AS session_id,
+            view.timestamp AS timestamp
+     FROM
+       (SELECT events.uuid AS id,
+               toTimeZone(events.created_at, 'UTC') AS timestamp,
+               events.distinct_id AS customer_id,
+               toString(events.`$session_id`) AS session_id,
+               events.event AS event_name,
+               'USD' AS original_currency,
+               accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+               1 AS enable_currency_aware_divider,
+               if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+               divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+               'USD' AS currency,
+               if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+        FROM events
+        WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_a'), isNotNull(amount)))
+        ORDER BY timestamp DESC) AS view
+     INNER JOIN events ON equals(events.event, view.event_name)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     LEFT JOIN
+       (SELECT person.id AS id,
+               toTimeZone(person.created_at, 'UTC') AS created_at,
+               person.properties AS properties
+        FROM person
+        WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                       FROM person
+                                                       WHERE equals(person.team_id, 99999)
+                                                       GROUP BY person.id
+                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+     WHERE equals(events.team_id, 99999)
+     ORDER BY timestamp DESC
+     UNION ALL SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(events.uuid, events.event, events.distinct_id, events.properties)`,
+                      view.event_name AS event_name,
+                      view.original_amount AS original_amount,
+                      view.currency_aware_amount AS currency_aware_amount,
+                      view.original_currency AS original_currency,
+                      view.amount AS amount,
+                      view.currency AS currency,
+                      tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(events.person.id, events.person.created_at, events.distinct_id, events.person.properties)`,
+                      view.session_id AS session_id,
+                      view.timestamp AS timestamp
+     FROM
+       (SELECT events.uuid AS id,
+               toTimeZone(events.created_at, 'UTC') AS timestamp,
+               events.distinct_id AS customer_id,
+               toString(events.`$session_id`) AS session_id,
+               events.event AS event_name,
+               'USD' AS original_currency,
+               accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+               1 AS enable_currency_aware_divider,
+               if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+               divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+               'USD' AS currency,
+               if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+        FROM events
+        WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_b'), isNotNull(amount)))
+        ORDER BY timestamp DESC) AS view
+     INNER JOIN events ON equals(events.event, view.event_name)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     LEFT JOIN
+       (SELECT person.id AS id,
+               toTimeZone(person.created_at, 'UTC') AS created_at,
+               person.properties AS properties
+        FROM person
+        WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                       FROM person
+                                                       WHERE equals(person.team_id, 99999)
+                                                       GROUP BY person.id
+                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+     WHERE equals(events.team_id, 99999)
+     ORDER BY timestamp DESC)
+  ORDER BY timestamp DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -78,53 +137,162 @@
 # ---
 # name: TestRevenueExampleEventsQueryRunner.test_revenue_currency_property
   '''
-  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(events.uuid, events.event, events.distinct_id, events.properties)`,
-         view.event_name AS event_name,
-         view.original_amount AS original_amount,
-         view.currency_aware_amount AS currency_aware_amount,
-         view.original_currency AS original_currency,
-         view.amount AS amount,
-         view.currency AS currency,
-         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(events.person.id, events.person.created_at, events.distinct_id, events.person.properties)`,
-         view.session_id AS session_id,
-         view.timestamp AS timestamp
+  SELECT `tuple(events.uuid, events.event, events.distinct_id, events.properties)` AS `tuple(events.uuid, events.event, events.distinct_id, events.properties)`,
+         event_name AS event_name,
+         original_amount AS original_amount,
+         currency_aware_amount AS currency_aware_amount,
+         original_currency AS original_currency,
+         amount AS amount,
+         currency AS currency,
+         `tuple(events.person.id, events.person.created_at, events.distinct_id, events.person.properties)` AS `tuple(events.person.id, events.person.created_at, events.distinct_id, events.person.properties)`,
+         session_id AS session_id,
+         timestamp AS timestamp
   FROM
-    (SELECT events.uuid AS id,
-            toTimeZone(events.created_at, 'UTC') AS timestamp,
-            events.distinct_id AS customer_id,
-            toString(events.`$session_id`) AS session_id,
-            events.event AS event_name,
-            multiIf(equals(events.event, 'purchase_a'), 'GBP', equals(events.event, 'purchase_b'), upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), equals(events.event, 'purchase_c'), upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', '')), NULL) AS original_currency,
-            multiIf(equals(events.event, 'purchase_a'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), equals(events.event, 'purchase_b'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), equals(events.event, 'purchase_c'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_c'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS original_amount,
-            if(in(event_name, ['purchase_a', 'purchase_b', 'purchase_c']), in(original_currency, ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']), 1) AS enable_currency_aware_divider,
-            if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-            divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-            'EUR' AS currency,
-            multiIf(equals(events.event, 'purchase_a'), if(isNull('GBP'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('GBP', 'EUR'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'EUR', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))), equals(events.event, 'purchase_b'), if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), 'EUR'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'EUR', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))), equals(events.event, 'purchase_c'), if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', '')), 'EUR'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'EUR', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))), NULL) AS amount
-     FROM events
-     WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, 'purchase_a'), equals(events.event, 'purchase_b'), equals(events.event, 'purchase_c')), isNotNull(amount)))
-     ORDER BY timestamp DESC) AS view
-  INNER JOIN events ON equals(events.event, view.event_name)
-  LEFT OUTER JOIN
-    (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-            person_distinct_id_overrides.distinct_id AS distinct_id
-     FROM person_distinct_id_overrides
-     WHERE equals(person_distinct_id_overrides.team_id, 99999)
-     GROUP BY person_distinct_id_overrides.distinct_id
-     HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-  INNER JOIN
-    (SELECT person.id AS id,
-            toTimeZone(person.created_at, 'UTC') AS created_at,
-            person.properties AS properties
-     FROM person
-     WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                   (SELECT person.id AS id, max(person.version) AS version
-                                                    FROM person
-                                                    WHERE equals(person.team_id, 99999)
-                                                    GROUP BY person.id
-                                                    HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
-  WHERE equals(events.team_id, 99999)
-  ORDER BY view.timestamp DESC
+    (SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(events.uuid, events.event, events.distinct_id, events.properties)`,
+            view.event_name AS event_name,
+            view.original_amount AS original_amount,
+            view.currency_aware_amount AS currency_aware_amount,
+            view.original_currency AS original_currency,
+            view.amount AS amount,
+            view.currency AS currency,
+            tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(events.person.id, events.person.created_at, events.distinct_id, events.person.properties)`,
+            view.session_id AS session_id,
+            view.timestamp AS timestamp
+     FROM
+       (SELECT events.uuid AS id,
+               toTimeZone(events.created_at, 'UTC') AS timestamp,
+               events.distinct_id AS customer_id,
+               toString(events.`$session_id`) AS session_id,
+               events.event AS event_name,
+               'GBP' AS original_currency,
+               accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+               in(original_currency,
+                  ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                 if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                 divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                 'EUR' AS currency,
+                 if(isNull('GBP'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('GBP', 'EUR'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'EUR', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+        FROM events
+        WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_a'), isNotNull(amount)))
+        ORDER BY timestamp DESC) AS view
+     INNER JOIN events ON equals(events.event, view.event_name)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     INNER JOIN
+       (SELECT person.id AS id,
+               toTimeZone(person.created_at, 'UTC') AS created_at,
+               person.properties AS properties
+        FROM person
+        WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                       FROM person
+                                                       WHERE equals(person.team_id, 99999)
+                                                       GROUP BY person.id
+                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+     WHERE equals(events.team_id, 99999)
+     ORDER BY timestamp DESC
+     UNION ALL SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(events.uuid, events.event, events.distinct_id, events.properties)`,
+                      view.event_name AS event_name,
+                      view.original_amount AS original_amount,
+                      view.currency_aware_amount AS currency_aware_amount,
+                      view.original_currency AS original_currency,
+                      view.amount AS amount,
+                      view.currency AS currency,
+                      tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(events.person.id, events.person.created_at, events.distinct_id, events.person.properties)`,
+                      view.session_id AS session_id,
+                      view.timestamp AS timestamp
+     FROM
+       (SELECT events.uuid AS id,
+               toTimeZone(events.created_at, 'UTC') AS timestamp,
+               events.distinct_id AS customer_id,
+               toString(events.`$session_id`) AS session_id,
+               events.event AS event_name,
+               upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')) AS original_currency,
+               accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+               in(original_currency,
+                  ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                 if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                 divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                 'EUR' AS currency,
+                 if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), 'EUR'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'EUR', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+        FROM events
+        WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_b'), isNotNull(amount)))
+        ORDER BY timestamp DESC) AS view
+     INNER JOIN events ON equals(events.event, view.event_name)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     INNER JOIN
+       (SELECT person.id AS id,
+               toTimeZone(person.created_at, 'UTC') AS created_at,
+               person.properties AS properties
+        FROM person
+        WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                       FROM person
+                                                       WHERE equals(person.team_id, 99999)
+                                                       GROUP BY person.id
+                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+     WHERE equals(events.team_id, 99999)
+     ORDER BY timestamp DESC
+     UNION ALL SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(events.uuid, events.event, events.distinct_id, events.properties)`,
+                      view.event_name AS event_name,
+                      view.original_amount AS original_amount,
+                      view.currency_aware_amount AS currency_aware_amount,
+                      view.original_currency AS original_currency,
+                      view.amount AS amount,
+                      view.currency AS currency,
+                      tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(events.person.id, events.person.created_at, events.distinct_id, events.person.properties)`,
+                      view.session_id AS session_id,
+                      view.timestamp AS timestamp
+     FROM
+       (SELECT events.uuid AS id,
+               toTimeZone(events.created_at, 'UTC') AS timestamp,
+               events.distinct_id AS customer_id,
+               toString(events.`$session_id`) AS session_id,
+               events.event AS event_name,
+               upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', '')) AS original_currency,
+               accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_c'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+               in(original_currency,
+                  ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                 if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                 divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                 'EUR' AS currency,
+                 if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', '')), 'EUR'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'EUR', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+        FROM events
+        WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_c'), isNotNull(amount)))
+        ORDER BY timestamp DESC) AS view
+     INNER JOIN events ON equals(events.event, view.event_name)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     INNER JOIN
+       (SELECT person.id AS id,
+               toTimeZone(person.created_at, 'UTC') AS created_at,
+               person.properties AS properties
+        FROM person
+        WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                       FROM person
+                                                       WHERE equals(person.team_id, 99999)
+                                                       GROUP BY person.id
+                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+     WHERE equals(events.team_id, 99999)
+     ORDER BY timestamp DESC)
+  ORDER BY timestamp DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -139,53 +307,162 @@
 # ---
 # name: TestRevenueExampleEventsQueryRunner.test_revenue_currency_property_without_feature_flag
   '''
-  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(events.uuid, events.event, events.distinct_id, events.properties)`,
-         view.event_name AS event_name,
-         view.original_amount AS original_amount,
-         view.currency_aware_amount AS currency_aware_amount,
-         view.original_currency AS original_currency,
-         view.amount AS amount,
-         view.currency AS currency,
-         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(events.person.id, events.person.created_at, events.distinct_id, events.person.properties)`,
-         view.session_id AS session_id,
-         view.timestamp AS timestamp
+  SELECT `tuple(events.uuid, events.event, events.distinct_id, events.properties)` AS `tuple(events.uuid, events.event, events.distinct_id, events.properties)`,
+         event_name AS event_name,
+         original_amount AS original_amount,
+         currency_aware_amount AS currency_aware_amount,
+         original_currency AS original_currency,
+         amount AS amount,
+         currency AS currency,
+         `tuple(events.person.id, events.person.created_at, events.distinct_id, events.person.properties)` AS `tuple(events.person.id, events.person.created_at, events.distinct_id, events.person.properties)`,
+         session_id AS session_id,
+         timestamp AS timestamp
   FROM
-    (SELECT events.uuid AS id,
-            toTimeZone(events.created_at, 'UTC') AS timestamp,
-            events.distinct_id AS customer_id,
-            toString(events.`$session_id`) AS session_id,
-            events.event AS event_name,
-            multiIf(equals(events.event, 'purchase_a'), 'GBP', equals(events.event, 'purchase_b'), upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), equals(events.event, 'purchase_c'), upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', '')), NULL) AS original_currency,
-            multiIf(equals(events.event, 'purchase_a'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), equals(events.event, 'purchase_b'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), equals(events.event, 'purchase_c'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_c'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS original_amount,
-            if(in(event_name, ['purchase_a', 'purchase_b', 'purchase_c']), in(original_currency, ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']), 1) AS enable_currency_aware_divider,
-            if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-            divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-            'EUR' AS currency,
-            multiIf(equals(events.event, 'purchase_a'), if(isNull('GBP'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('GBP', 'EUR'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'EUR', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))), equals(events.event, 'purchase_b'), if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), 'EUR'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'EUR', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))), equals(events.event, 'purchase_c'), if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', '')), 'EUR'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'EUR', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))), NULL) AS amount
-     FROM events
-     WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, 'purchase_a'), equals(events.event, 'purchase_b'), equals(events.event, 'purchase_c')), isNotNull(amount)))
-     ORDER BY timestamp DESC) AS view
-  INNER JOIN events ON equals(events.event, view.event_name)
-  LEFT OUTER JOIN
-    (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-            person_distinct_id_overrides.distinct_id AS distinct_id
-     FROM person_distinct_id_overrides
-     WHERE equals(person_distinct_id_overrides.team_id, 99999)
-     GROUP BY person_distinct_id_overrides.distinct_id
-     HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-  LEFT JOIN
-    (SELECT person.id AS id,
-            toTimeZone(person.created_at, 'UTC') AS created_at,
-            person.properties AS properties
-     FROM person
-     WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                   (SELECT person.id AS id, max(person.version) AS version
-                                                    FROM person
-                                                    WHERE equals(person.team_id, 99999)
-                                                    GROUP BY person.id
-                                                    HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
-  WHERE equals(events.team_id, 99999)
-  ORDER BY view.timestamp DESC
+    (SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(events.uuid, events.event, events.distinct_id, events.properties)`,
+            view.event_name AS event_name,
+            view.original_amount AS original_amount,
+            view.currency_aware_amount AS currency_aware_amount,
+            view.original_currency AS original_currency,
+            view.amount AS amount,
+            view.currency AS currency,
+            tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(events.person.id, events.person.created_at, events.distinct_id, events.person.properties)`,
+            view.session_id AS session_id,
+            view.timestamp AS timestamp
+     FROM
+       (SELECT events.uuid AS id,
+               toTimeZone(events.created_at, 'UTC') AS timestamp,
+               events.distinct_id AS customer_id,
+               toString(events.`$session_id`) AS session_id,
+               events.event AS event_name,
+               'GBP' AS original_currency,
+               accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+               in(original_currency,
+                  ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                 if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                 divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                 'EUR' AS currency,
+                 if(isNull('GBP'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('GBP', 'EUR'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'EUR', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+        FROM events
+        WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_a'), isNotNull(amount)))
+        ORDER BY timestamp DESC) AS view
+     INNER JOIN events ON equals(events.event, view.event_name)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     LEFT JOIN
+       (SELECT person.id AS id,
+               toTimeZone(person.created_at, 'UTC') AS created_at,
+               person.properties AS properties
+        FROM person
+        WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                       FROM person
+                                                       WHERE equals(person.team_id, 99999)
+                                                       GROUP BY person.id
+                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+     WHERE equals(events.team_id, 99999)
+     ORDER BY timestamp DESC
+     UNION ALL SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(events.uuid, events.event, events.distinct_id, events.properties)`,
+                      view.event_name AS event_name,
+                      view.original_amount AS original_amount,
+                      view.currency_aware_amount AS currency_aware_amount,
+                      view.original_currency AS original_currency,
+                      view.amount AS amount,
+                      view.currency AS currency,
+                      tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(events.person.id, events.person.created_at, events.distinct_id, events.person.properties)`,
+                      view.session_id AS session_id,
+                      view.timestamp AS timestamp
+     FROM
+       (SELECT events.uuid AS id,
+               toTimeZone(events.created_at, 'UTC') AS timestamp,
+               events.distinct_id AS customer_id,
+               toString(events.`$session_id`) AS session_id,
+               events.event AS event_name,
+               upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')) AS original_currency,
+               accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+               in(original_currency,
+                  ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                 if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                 divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                 'EUR' AS currency,
+                 if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), 'EUR'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'EUR', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+        FROM events
+        WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_b'), isNotNull(amount)))
+        ORDER BY timestamp DESC) AS view
+     INNER JOIN events ON equals(events.event, view.event_name)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     LEFT JOIN
+       (SELECT person.id AS id,
+               toTimeZone(person.created_at, 'UTC') AS created_at,
+               person.properties AS properties
+        FROM person
+        WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                       FROM person
+                                                       WHERE equals(person.team_id, 99999)
+                                                       GROUP BY person.id
+                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+     WHERE equals(events.team_id, 99999)
+     ORDER BY timestamp DESC
+     UNION ALL SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(events.uuid, events.event, events.distinct_id, events.properties)`,
+                      view.event_name AS event_name,
+                      view.original_amount AS original_amount,
+                      view.currency_aware_amount AS currency_aware_amount,
+                      view.original_currency AS original_currency,
+                      view.amount AS amount,
+                      view.currency AS currency,
+                      tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(events.person.id, events.person.created_at, events.distinct_id, events.person.properties)`,
+                      view.session_id AS session_id,
+                      view.timestamp AS timestamp
+     FROM
+       (SELECT events.uuid AS id,
+               toTimeZone(events.created_at, 'UTC') AS timestamp,
+               events.distinct_id AS customer_id,
+               toString(events.`$session_id`) AS session_id,
+               events.event AS event_name,
+               upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', '')) AS original_currency,
+               accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_c'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+               in(original_currency,
+                  ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+                 if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+                 divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+                 'EUR' AS currency,
+                 if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', '')), 'EUR'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'EUR', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+        FROM events
+        WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_c'), isNotNull(amount)))
+        ORDER BY timestamp DESC) AS view
+     INNER JOIN events ON equals(events.event, view.event_name)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     LEFT JOIN
+       (SELECT person.id AS id,
+               toTimeZone(person.created_at, 'UTC') AS created_at,
+               person.properties AS properties
+        FROM person
+        WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                       FROM person
+                                                       WHERE equals(person.team_id, 99999)
+                                                       GROUP BY person.id
+                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+     WHERE equals(events.team_id, 99999)
+     ORDER BY timestamp DESC)
+  ORDER BY timestamp DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -200,53 +477,159 @@
 # ---
 # name: TestRevenueExampleEventsQueryRunner.test_revenue_currency_property_without_smallest_unit_divider
   '''
-  SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(events.uuid, events.event, events.distinct_id, events.properties)`,
-         view.event_name AS event_name,
-         view.original_amount AS original_amount,
-         view.currency_aware_amount AS currency_aware_amount,
-         view.original_currency AS original_currency,
-         view.amount AS amount,
-         view.currency AS currency,
-         tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(events.person.id, events.person.created_at, events.distinct_id, events.person.properties)`,
-         view.session_id AS session_id,
-         view.timestamp AS timestamp
+  SELECT `tuple(events.uuid, events.event, events.distinct_id, events.properties)` AS `tuple(events.uuid, events.event, events.distinct_id, events.properties)`,
+         event_name AS event_name,
+         original_amount AS original_amount,
+         currency_aware_amount AS currency_aware_amount,
+         original_currency AS original_currency,
+         amount AS amount,
+         currency AS currency,
+         `tuple(events.person.id, events.person.created_at, events.distinct_id, events.person.properties)` AS `tuple(events.person.id, events.person.created_at, events.distinct_id, events.person.properties)`,
+         session_id AS session_id,
+         timestamp AS timestamp
   FROM
-    (SELECT events.uuid AS id,
-            toTimeZone(events.created_at, 'UTC') AS timestamp,
-            events.distinct_id AS customer_id,
-            toString(events.`$session_id`) AS session_id,
-            events.event AS event_name,
-            multiIf(equals(events.event, 'purchase_a'), 'GBP', equals(events.event, 'purchase_b'), upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), equals(events.event, 'purchase_c'), upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', '')), NULL) AS original_currency,
-            multiIf(equals(events.event, 'purchase_a'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), equals(events.event, 'purchase_b'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), equals(events.event, 'purchase_c'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_c'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS original_amount,
-            1 AS enable_currency_aware_divider,
-            if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-            divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-            'EUR' AS currency,
-            multiIf(equals(events.event, 'purchase_a'), if(isNull('GBP'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('GBP', 'EUR'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'EUR', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))), equals(events.event, 'purchase_b'), if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), 'EUR'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'EUR', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))), equals(events.event, 'purchase_c'), if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', '')), 'EUR'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'EUR', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))), NULL) AS amount
-     FROM events
-     WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, 'purchase_a'), equals(events.event, 'purchase_b'), equals(events.event, 'purchase_c')), isNotNull(amount)))
-     ORDER BY timestamp DESC) AS view
-  INNER JOIN events ON equals(events.event, view.event_name)
-  LEFT OUTER JOIN
-    (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-            person_distinct_id_overrides.distinct_id AS distinct_id
-     FROM person_distinct_id_overrides
-     WHERE equals(person_distinct_id_overrides.team_id, 99999)
-     GROUP BY person_distinct_id_overrides.distinct_id
-     HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-  INNER JOIN
-    (SELECT person.id AS id,
-            toTimeZone(person.created_at, 'UTC') AS created_at,
-            person.properties AS properties
-     FROM person
-     WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                   (SELECT person.id AS id, max(person.version) AS version
-                                                    FROM person
-                                                    WHERE equals(person.team_id, 99999)
-                                                    GROUP BY person.id
-                                                    HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
-  WHERE equals(events.team_id, 99999)
-  ORDER BY view.timestamp DESC
+    (SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(events.uuid, events.event, events.distinct_id, events.properties)`,
+            view.event_name AS event_name,
+            view.original_amount AS original_amount,
+            view.currency_aware_amount AS currency_aware_amount,
+            view.original_currency AS original_currency,
+            view.amount AS amount,
+            view.currency AS currency,
+            tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(events.person.id, events.person.created_at, events.distinct_id, events.person.properties)`,
+            view.session_id AS session_id,
+            view.timestamp AS timestamp
+     FROM
+       (SELECT events.uuid AS id,
+               toTimeZone(events.created_at, 'UTC') AS timestamp,
+               events.distinct_id AS customer_id,
+               toString(events.`$session_id`) AS session_id,
+               events.event AS event_name,
+               'GBP' AS original_currency,
+               accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_a'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+               1 AS enable_currency_aware_divider,
+               if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+               divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+               'EUR' AS currency,
+               if(isNull('GBP'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('GBP', 'EUR'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'EUR', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+        FROM events
+        WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_a'), isNotNull(amount)))
+        ORDER BY timestamp DESC) AS view
+     INNER JOIN events ON equals(events.event, view.event_name)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     INNER JOIN
+       (SELECT person.id AS id,
+               toTimeZone(person.created_at, 'UTC') AS created_at,
+               person.properties AS properties
+        FROM person
+        WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                       FROM person
+                                                       WHERE equals(person.team_id, 99999)
+                                                       GROUP BY person.id
+                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+     WHERE equals(events.team_id, 99999)
+     ORDER BY timestamp DESC
+     UNION ALL SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(events.uuid, events.event, events.distinct_id, events.properties)`,
+                      view.event_name AS event_name,
+                      view.original_amount AS original_amount,
+                      view.currency_aware_amount AS currency_aware_amount,
+                      view.original_currency AS original_currency,
+                      view.amount AS amount,
+                      view.currency AS currency,
+                      tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(events.person.id, events.person.created_at, events.distinct_id, events.person.properties)`,
+                      view.session_id AS session_id,
+                      view.timestamp AS timestamp
+     FROM
+       (SELECT events.uuid AS id,
+               toTimeZone(events.created_at, 'UTC') AS timestamp,
+               events.distinct_id AS customer_id,
+               toString(events.`$session_id`) AS session_id,
+               events.event AS event_name,
+               upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')) AS original_currency,
+               accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_b'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+               1 AS enable_currency_aware_divider,
+               if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+               divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+               'EUR' AS currency,
+               if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), 'EUR'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_b'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'EUR', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+        FROM events
+        WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_b'), isNotNull(amount)))
+        ORDER BY timestamp DESC) AS view
+     INNER JOIN events ON equals(events.event, view.event_name)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     INNER JOIN
+       (SELECT person.id AS id,
+               toTimeZone(person.created_at, 'UTC') AS created_at,
+               person.properties AS properties
+        FROM person
+        WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                       FROM person
+                                                       WHERE equals(person.team_id, 99999)
+                                                       GROUP BY person.id
+                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+     WHERE equals(events.team_id, 99999)
+     ORDER BY timestamp DESC
+     UNION ALL SELECT tuple(events.uuid, events.event, events.distinct_id, events.properties) AS `tuple(events.uuid, events.event, events.distinct_id, events.properties)`,
+                      view.event_name AS event_name,
+                      view.original_amount AS original_amount,
+                      view.currency_aware_amount AS currency_aware_amount,
+                      view.original_currency AS original_currency,
+                      view.amount AS amount,
+                      view.currency AS currency,
+                      tuple(events__person.id, events__person.created_at, events.distinct_id, events__person.properties) AS `tuple(events.person.id, events.person.created_at, events.distinct_id, events.person.properties)`,
+                      view.session_id AS session_id,
+                      view.timestamp AS timestamp
+     FROM
+       (SELECT events.uuid AS id,
+               toTimeZone(events.created_at, 'UTC') AS timestamp,
+               events.distinct_id AS customer_id,
+               toString(events.`$session_id`) AS session_id,
+               events.event AS event_name,
+               upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', '')) AS original_currency,
+               accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue_c'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+               1 AS enable_currency_aware_divider,
+               if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+               divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+               'EUR' AS currency,
+               if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', '')), 'EUR'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency_c'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'EUR', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
+        FROM events
+        WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_c'), isNotNull(amount)))
+        ORDER BY timestamp DESC) AS view
+     INNER JOIN events ON equals(events.event, view.event_name)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     INNER JOIN
+       (SELECT person.id AS id,
+               toTimeZone(person.created_at, 'UTC') AS created_at,
+               person.properties AS properties
+        FROM person
+        WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                       FROM person
+                                                       WHERE equals(person.team_id, 99999)
+                                                       GROUP BY person.id
+                                                       HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+     WHERE equals(events.team_id, 99999)
+     ORDER BY timestamp DESC)
+  ORDER BY timestamp DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -277,13 +660,13 @@
             events.distinct_id AS customer_id,
             toString(events.`$session_id`) AS session_id,
             events.event AS event_name,
-            multiIf(equals(events.event, 'purchase'), 'USD', NULL) AS original_currency,
-            multiIf(equals(events.event, 'purchase'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS original_amount,
+            'USD' AS original_currency,
+            accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
             1 AS enable_currency_aware_divider,
             if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
             divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
             'USD' AS currency,
-            multiIf(equals(events.event, 'purchase'), if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))), NULL) AS amount
+            if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
      FROM events
      WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
      ORDER BY timestamp DESC) AS view
@@ -307,7 +690,7 @@
                                                     GROUP BY person.id
                                                     HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
   WHERE equals(events.team_id, 99999)
-  ORDER BY view.timestamp DESC
+  ORDER BY timestamp DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -338,13 +721,14 @@
             events.distinct_id AS customer_id,
             toString(events.`$session_id`) AS session_id,
             events.event AS event_name,
-            multiIf(equals(events.event, 'purchase'), 'USD', NULL) AS original_currency,
-            multiIf(equals(events.event, 'purchase'), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)'), NULL) AS original_amount,
-            if(in(event_name, ['purchase']), in(original_currency, ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']), 1) AS enable_currency_aware_divider,
-            if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
-            divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
-            'USD' AS currency,
-            multiIf(equals(events.event, 'purchase'), if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))), NULL) AS amount
+            'USD' AS original_currency,
+            accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'revenue'), ''), 'null'), '^"|"$', ''), 'Decimal64(10)') AS original_amount,
+            in(original_currency,
+               ['BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF']) AS enable_currency_aware_divider,
+              if(enable_currency_aware_divider, accurateCastOrNull(1, 'Decimal64(10)'), accurateCastOrNull(100, 'Decimal64(10)')) AS currency_aware_divider,
+              divideDecimal(original_amount, currency_aware_divider) AS currency_aware_amount,
+              'USD' AS currency,
+              if(isNull('USD'), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals('USD', 'USD'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'USD', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
      FROM events
      WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
      ORDER BY timestamp DESC) AS view
@@ -368,7 +752,7 @@
                                                     GROUP BY person.id
                                                     HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
   WHERE equals(events.team_id, 99999)
-  ORDER BY view.timestamp DESC
+  ORDER BY timestamp DESC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,

--- a/products/revenue_analytics/backend/test/test_revenue_analytics_base_view.py
+++ b/products/revenue_analytics/backend/test/test_revenue_analytics_base_view.py
@@ -1,0 +1,35 @@
+import pytest
+from posthog.warehouse.models.external_data_source import ExternalDataSource
+from products.revenue_analytics.backend.views.revenue_analytics_base_view import RevenueAnalyticsBaseView
+
+
+@pytest.mark.parametrize(
+    "source_type,prefix,view_name,expected",
+    [
+        ("stripe", None, "charges", "stripe.charges"),
+        ("stripe", "prod", "charges", "stripe.prod.charges"),
+        ("stripe", "prod_", "charges", "stripe.prod.charges"),
+        ("stripe", "_prod", "charges", "stripe.prod.charges"),
+        ("stripe", "_prod_", "charges", "stripe.prod.charges"),
+    ],
+)
+def test_get_view_name_for_source(source_type, prefix, view_name, expected):
+    source = ExternalDataSource(source_type=source_type, prefix=prefix)
+    result = RevenueAnalyticsBaseView.get_view_name_for_source(source, view_name)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "event,view_name,expected",
+    [
+        ("charge_succeeded", "charges", "revenue_analytics.charge_succeeded.charges"),
+        ("charge.succeeded", "charges", "revenue_analytics.charge_succeeded.charges"),
+        ("charge-succeeded", "charges", "revenue_analytics.charge_succeeded.charges"),
+        ("charge$succeeded", "charges", "revenue_analytics.charge_succeeded.charges"),
+        ("charge123succeeded", "charges", "revenue_analytics.charge123succeeded.charges"),
+        ("charge*!@#%^#$succeeded", "charges", "revenue_analytics.charge________succeeded.charges"),
+    ],
+)
+def test_get_view_name_for_event(event, view_name, expected):
+    result = RevenueAnalyticsBaseView.get_view_name_for_event(event, view_name)
+    assert result == expected

--- a/products/revenue_analytics/backend/views/revenue_analytics_base_view.py
+++ b/products/revenue_analytics/backend/views/revenue_analytics_base_view.py
@@ -2,6 +2,7 @@ from typing import Optional
 from posthog.models.team.team import Team
 from posthog.hogql.database.models import SavedQuery
 from posthog.warehouse.models.external_data_source import ExternalDataSource
+import re
 
 
 class RevenueAnalyticsBaseView(SavedQuery):
@@ -27,7 +28,7 @@ class RevenueAnalyticsBaseView(SavedQuery):
             *RevenueAnalyticsCustomerView.for_schema_source(source),
         ]
 
-    # Used in child classes to generate the view name
+    # Used in child classes to generate view names
     @staticmethod
     def get_view_name_for_source(source: ExternalDataSource, view_name: str) -> str:
         if not source.prefix:
@@ -35,3 +36,7 @@ class RevenueAnalyticsBaseView(SavedQuery):
         else:
             prefix = source.prefix.strip("_")
             return f"{source.source_type.lower()}.{prefix}.{view_name}"
+
+    @staticmethod
+    def get_view_name_for_event(event: str, view_name: str) -> str:
+        return f"revenue_analytics.{re.sub(r'[^a-zA-Z0-9]', '_', event)}.{view_name}"

--- a/products/revenue_analytics/backend/views/revenue_analytics_charge_view.py
+++ b/products/revenue_analytics/backend/views/revenue_analytics_charge_view.py
@@ -120,7 +120,7 @@ class RevenueAnalyticsChargeView(RevenueAnalyticsBaseView):
 
         revenue_config = team.revenue_analytics_config
 
-        queries: tuple[str, list[ast.SelectQuery]] = []
+        queries: list[tuple[str, ast.SelectQuery]] = []
         for event in revenue_config.events:
             comparison_expr, value_expr = revenue_comparison_and_value_exprs_for_events(
                 revenue_config, event, do_currency_conversion=False

--- a/products/revenue_analytics/backend/views/revenue_analytics_charge_view.py
+++ b/products/revenue_analytics/backend/views/revenue_analytics_charge_view.py
@@ -15,17 +15,15 @@ from posthog.hogql.database.models import (
     FieldOrTable,
 )
 from posthog.hogql.database.schema.exchange_rate import (
-    revenue_expression_for_events,
-    revenue_where_expr_for_events,
+    revenue_comparison_and_value_exprs_for_events,
     convert_currency_call,
-    currency_expression_for_all_events,
+    currency_expression_for_events,
 )
 from .revenue_analytics_base_view import RevenueAnalyticsBaseView
 from posthog.temporal.data_imports.pipelines.stripe.constants import (
     CHARGE_RESOURCE_NAME as STRIPE_CHARGE_RESOURCE_NAME,
 )
 
-# Keep in sync with `revenueAnalyticsLogic.ts`
 SOURCE_VIEW_SUFFIX = "charge_revenue_view"
 EVENTS_VIEW_SUFFIX = "events_revenue_view"
 STRIPE_CHARGE_SUCCEEDED_STATUS = "succeeded"
@@ -122,75 +120,66 @@ class RevenueAnalyticsChargeView(RevenueAnalyticsBaseView):
 
         revenue_config = team.revenue_analytics_config
 
-        currency_aware_event_names = [event.eventName for event in revenue_config.events if event.currencyAwareDecimal]
+        queries: tuple[str, list[ast.SelectQuery]] = []
+        for event in revenue_config.events:
+            comparison_expr, value_expr = revenue_comparison_and_value_exprs_for_events(
+                revenue_config, event, do_currency_conversion=False
+            )
+            _, currency_aware_amount_expr = revenue_comparison_and_value_exprs_for_events(
+                revenue_config,
+                event,
+                amount_expr=ast.Field(chain=["currency_aware_amount"]),
+            )
 
-        query = ast.SelectQuery(
-            select=[
-                ast.Alias(alias="id", expr=ast.Field(chain=["uuid"])),
-                ast.Alias(alias="timestamp", expr=ast.Field(chain=["created_at"])),
-                ast.Alias(alias="customer_id", expr=ast.Field(chain=["distinct_id"])),
-                ast.Alias(alias="session_id", expr=ast.Call(name="toString", args=[ast.Field(chain=["$session_id"])])),
-                ast.Alias(alias="event_name", expr=ast.Field(chain=["event"])),
-                ast.Alias(alias="original_currency", expr=currency_expression_for_all_events(revenue_config)),
-                ast.Alias(
-                    alias="original_amount",
-                    expr=revenue_expression_for_events(revenue_config, do_currency_conversion=False),
-                ),
-                # Being zero-decimal implies we will NOT divide the original amount by 100
-                # We should only do that if we've tagged the event with `currencyAwareDecimal`
-                # Otherwise, we'll just assume it's a non-zero-decimal currency
-                # There's a small optimization here in case NONE of the events have `currencyAwareDecimal`
-                # in which case we can just return True for all rows
-                ast.Alias(
-                    alias="enable_currency_aware_divider",
-                    expr=ast.Constant(value=True)
-                    if not currency_aware_event_names
-                    else ast.Call(
-                        name="if",
-                        args=[
-                            ast.Call(
-                                name="in",
-                                args=[
-                                    ast.Field(chain=["event_name"]),
-                                    ast.Constant(value=currency_aware_event_names),
-                                ],
-                            ),
-                            is_zero_decimal_in_stripe(ast.Field(chain=["original_currency"])),
-                            ast.Constant(value=True),
-                        ],
+            query = ast.SelectQuery(
+                select=[
+                    ast.Alias(alias="id", expr=ast.Field(chain=["uuid"])),
+                    ast.Alias(alias="timestamp", expr=ast.Field(chain=["created_at"])),
+                    ast.Alias(alias="customer_id", expr=ast.Field(chain=["distinct_id"])),
+                    ast.Alias(
+                        alias="session_id", expr=ast.Call(name="toString", args=[ast.Field(chain=["$session_id"])])
                     ),
-                ),
-                currency_aware_divider(),
-                currency_aware_amount(),
-                ast.Alias(alias="currency", expr=ast.Constant(value=revenue_config.base_currency)),
-                ast.Alias(
-                    alias="amount",
-                    expr=revenue_expression_for_events(
-                        revenue_config, amount_expr=ast.Field(chain=["currency_aware_amount"])
+                    ast.Alias(alias="event_name", expr=ast.Field(chain=["event"])),
+                    ast.Alias(alias="original_currency", expr=currency_expression_for_events(revenue_config, event)),
+                    ast.Alias(alias="original_amount", expr=value_expr),
+                    # Being zero-decimal implies we will NOT divide the original amount by 100
+                    # We should only do that if we've tagged the event with `currencyAwareDecimal`
+                    # Otherwise, we'll just assume it's a non-zero-decimal currency
+                    ast.Alias(
+                        alias="enable_currency_aware_divider",
+                        expr=is_zero_decimal_in_stripe(ast.Field(chain=["original_currency"]))
+                        if event.currencyAwareDecimal
+                        else ast.Constant(value=True),
                     ),
+                    currency_aware_divider(),
+                    currency_aware_amount(),
+                    ast.Alias(alias="currency", expr=ast.Constant(value=revenue_config.base_currency)),
+                    ast.Alias(alias="amount", expr=currency_aware_amount_expr),
+                ],
+                select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+                where=ast.And(
+                    exprs=[
+                        comparison_expr,
+                        ast.CompareOperation(
+                            op=ast.CompareOperationOp.NotEq,
+                            left=ast.Field(chain=["amount"]),  # refers to the Alias above
+                            right=ast.Constant(value=None),
+                        ),
+                    ]
                 ),
-            ],
-            select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
-            where=ast.And(
-                exprs=[
-                    revenue_where_expr_for_events(revenue_config),
-                    ast.CompareOperation(
-                        op=ast.CompareOperationOp.NotEq,
-                        left=ast.Field(chain=["amount"]),  # refers to the Alias above
-                        right=ast.Constant(value=None),
-                    ),
-                ]
-            ),
-            order_by=[ast.OrderExpr(expr=ast.Field(chain=["timestamp"]), order="DESC")],
-        )
+                order_by=[ast.OrderExpr(expr=ast.Field(chain=["timestamp"]), order="DESC")],
+            )
+
+            queries.append((event.eventName, query))
 
         return [
             RevenueAnalyticsChargeView(
-                id=EVENTS_VIEW_SUFFIX,
-                name=EVENTS_VIEW_SUFFIX,
+                id=RevenueAnalyticsBaseView.get_view_name_for_event(event_name, EVENTS_VIEW_SUFFIX),
+                name=RevenueAnalyticsBaseView.get_view_name_for_event(event_name, EVENTS_VIEW_SUFFIX),
                 query=query.to_hogql(),
                 fields=FIELDS,
             )
+            for event_name, query in queries
         ]
 
     @staticmethod

--- a/products/revenue_analytics/frontend/RevenueAnalyticsScene.tsx
+++ b/products/revenue_analytics/frontend/RevenueAnalyticsScene.tsx
@@ -158,7 +158,7 @@ export function RevenueAnalyticsSceneContent(): JSX.Element {
         <div>
             <LemonBanner
                 type="info"
-                dismissKey="revenue-analytics-beta"
+                dismissKey="revenue-analytics-beta-banner"
                 className="mb-2"
                 action={{ children: 'Send feedback', id: 'revenue-analytics-feedback-button' }}
             >

--- a/products/revenue_analytics/frontend/revenueAnalyticsLogic.ts
+++ b/products/revenue_analytics/frontend/revenueAnalyticsLogic.ts
@@ -1,4 +1,4 @@
-import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
+import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { getDefaultInterval } from 'lib/utils'
 import { getCurrencySymbol } from 'lib/utils/geography/currency'
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
@@ -301,4 +301,14 @@ export const revenueAnalyticsLogic = kea<revenueAnalyticsLogicType>([
             })
         },
     })),
+    afterMount(({ actions, values }) => {
+        if (values.allEvents !== null && values.allDataWarehouseSources !== null) {
+            actions.setRevenueSources({
+                events: values.allEvents,
+                dataWarehouseSources: values.allDataWarehouseSources.results.filter(
+                    (source) => source.revenue_analytics_enabled
+                ),
+            })
+        }
+    }),
 ])

--- a/products/revenue_analytics/frontend/revenueAnalyticsLogic.ts
+++ b/products/revenue_analytics/frontend/revenueAnalyticsLogic.ts
@@ -7,9 +7,9 @@ import { dataWarehouseSettingsLogic } from 'scenes/data-warehouse/settings/dataW
 import { urls } from 'scenes/urls'
 
 import {
+    DatabaseSchemaManagedViewTable,
+    DatabaseSchemaManagedViewTableKind,
     DataTableNode,
-    DataWarehouseNode,
-    EventsNode,
     NodeKind,
     QuerySchema,
     RevenueAnalyticsEventItem,
@@ -19,9 +19,6 @@ import { Breadcrumb, ChartDisplayType, ExternalDataSource, InsightLogicProps, Pr
 
 import type { revenueAnalyticsLogicType } from './revenueAnalyticsLogicType'
 import { revenueEventsSettingsLogic } from './settings/revenueEventsSettingsLogic'
-
-// Keep in sync with `revenue_analytics/backend/models.py`
-const CHARGE_REVENUE_VIEW_SUFFIX = 'charge_revenue_view'
 
 export enum RevenueAnalyticsQuery {
     OVERVIEW,
@@ -81,7 +78,7 @@ export const revenueAnalyticsLogic = kea<revenueAnalyticsLogicType>([
             dataWarehouseSceneLogic,
             ['dataWarehouseTablesBySourceType'],
             databaseTableListLogic,
-            ['database'],
+            ['database', 'managedViews'],
             revenueEventsSettingsLogic,
             ['baseCurrency', 'events as allEvents', 'dataWarehouseSources as allDataWarehouseSources'],
         ],
@@ -182,10 +179,35 @@ export const revenueAnalyticsLogic = kea<revenueAnalyticsLogicType>([
             },
         ],
 
+        chargeRevenueViews: [
+            (s) => [s.managedViews, s.rawRevenueSources],
+            (managedViews, rawRevenueSources): DatabaseSchemaManagedViewTable[] => {
+                if (!managedViews) {
+                    return []
+                }
+
+                const dataWarehouseSourceIds = rawRevenueSources.dataWarehouseSources.map((source) => source.id)
+                const eventNames = rawRevenueSources.events.map((e) => e.eventName)
+
+                return managedViews
+                    .filter((view) => view.kind === DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS)
+                    .filter((view) => {
+                        // Comes from a Data Warehouse source
+                        if (view.source_id) {
+                            return dataWarehouseSourceIds.includes(view.source_id)
+                        }
+
+                        // Comes from events
+                        return eventNames.includes(view.name)
+                    })
+            },
+        ],
+
         queries: [
             (s) => [
                 s.dateFilter,
                 s.rawRevenueSources,
+                s.chargeRevenueViews,
                 s.topCustomersDisplayMode,
                 s.growthRateDisplayMode,
                 s.baseCurrency,
@@ -193,6 +215,7 @@ export const revenueAnalyticsLogic = kea<revenueAnalyticsLogicType>([
             (
                 dateFilter,
                 rawRevenueSources,
+                chargeRevenueViews,
                 topCustomersDisplayMode,
                 growthRateDisplayMode,
                 baseCurrency
@@ -204,12 +227,6 @@ export const revenueAnalyticsLogic = kea<revenueAnalyticsLogicType>([
                     topCustomersDisplayMode === 'table' ? 'all' : 'month'
 
                 const { isPrefix, symbol: currencySymbol } = getCurrencySymbol(baseCurrency)
-
-                const chargeViews = rawRevenueSources.dataWarehouseSources.map((source) => {
-                    return source.prefix
-                        ? `${source.source_type.toLocaleLowerCase()}.${source.prefix}.${CHARGE_REVENUE_VIEW_SUFFIX}`
-                        : `${source.source_type.toLocaleLowerCase()}.${CHARGE_REVENUE_VIEW_SUFFIX}`
-                })
 
                 // Convert from the raw revenue sources (events and data warehouse sources) to the revenue sources
                 // that the RevenueAnalyticsOverviewQuery expects which is just a list of event names and data warehouse source IDs
@@ -231,34 +248,24 @@ export const revenueAnalyticsLogic = kea<revenueAnalyticsLogicType>([
                         hideTooltipOnScroll: true,
                         source: {
                             kind: NodeKind.TrendsQuery,
-                            series: [
-                                ...chargeViews.map((view) => ({
-                                    kind: NodeKind.DataWarehouseNode,
-                                    id: view,
-                                    name: view,
-                                    custom_name: chargeViews.length > 1 ? `Gross revenue for ${view}` : 'Gross revenue',
-                                    id_field: 'id',
-                                    timestamp_field: 'timestamp',
-                                    distinct_id_field: 'id',
-                                    table_name: view,
-                                    math: PropertyMathType.Sum,
-                                    math_property: 'amount',
-                                })),
-                                ...rawRevenueSources.events.map((e) => ({
-                                    name: e.eventName,
-                                    event: e.eventName,
-                                    custom_name: e.eventName,
-                                    math: PropertyMathType.Sum,
-                                    kind: NodeKind.EventsNode,
-                                    math_property: e.revenueProperty,
-                                    math_property_revenue_currency: e.revenueCurrencyProperty,
-                                })),
-                            ] as (EventsNode | DataWarehouseNode)[],
+                            series: chargeRevenueViews.map((view) => ({
+                                kind: NodeKind.DataWarehouseNode,
+                                id: view.name,
+                                name: view.name,
+                                custom_name:
+                                    chargeRevenueViews.length > 1 ? `Gross revenue for ${view.name}` : 'Gross revenue',
+                                id_field: 'id',
+                                distinct_id_field: 'id',
+                                timestamp_field: 'timestamp',
+                                table_name: view.name,
+                                math: PropertyMathType.Sum,
+                                math_property: 'amount',
+                            })),
                             interval,
                             dateRange,
                             trendsFilter: {
                                 display:
-                                    chargeViews.length > 1
+                                    chargeRevenueViews.length > 1
                                         ? ChartDisplayType.ActionsAreaGraph
                                         : ChartDisplayType.ActionsLineGraph,
                                 aggregationAxisFormat: 'numeric',
@@ -290,7 +297,7 @@ export const revenueAnalyticsLogic = kea<revenueAnalyticsLogicType>([
         loadSourcesSuccess: ({ dataWarehouseSources }) => {
             actions.setRevenueSources({
                 events: values.allEvents,
-                dataWarehouseSources: dataWarehouseSources.results,
+                dataWarehouseSources: dataWarehouseSources.results.filter((source) => source.revenue_analytics_enabled),
             })
         },
     })),

--- a/products/revenue_analytics/frontend/settings/RevenueEventsSettings.tsx
+++ b/products/revenue_analytics/frontend/settings/RevenueEventsSettings.tsx
@@ -91,7 +91,9 @@ export function RevenueEventsSettings(): JSX.Element {
             <BaseCurrency />
 
             <EventConfiguration buttonRef={eventsButtonRef} />
-            <ExternalDataSourceConfiguration buttonRef={dataWarehouseTablesButtonRef} />
+            {featureFlags[FEATURE_FLAGS.REVENUE_ANALYTICS] && (
+                <ExternalDataSourceConfiguration buttonRef={dataWarehouseTablesButtonRef} />
+            )}
 
             {featureFlags[FEATURE_FLAGS.REVENUE_ANALYTICS] ? (
                 <LemonTabs


### PR DESCRIPTION
Our code to generate trends from revenue analytics views was kinda crazy. We were doing a lot of work in the UI to figure out what the name of each individual view looked like, and then sent it to the backend. We can make that slightly easier by appending a new `kind` value to our managed views and filter on them. We can also create one view per kind of revenue event to make our lifes slightly easier - tests are covering that, see snapshots