### PR TITLE
refactor: tag person update queries better

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -672,7 +672,8 @@ export class DB {
     public async updatePersonDeprecated(
         person: InternalPerson,
         update: Partial<InternalPerson>,
-        tx?: TransactionClient
+        tx?: TransactionClient,
+        tag?: string
     ): Promise<[InternalPerson, TopicMessage[]]> {
         let versionString = 'COALESCE(version, 0)::numeric + 1'
         if (update.version) {
@@ -699,7 +700,7 @@ export class DB {
             tx ?? PostgresUse.PERSONS_WRITE,
             queryString,
             values,
-            'updatePerson'
+            `updatePerson${tag ? `-${tag}` : ''}`
         )
         if (rows.length == 0) {
             throw new NoRowsUpdatedError(

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -694,7 +694,8 @@ export class DB {
         const queryString = `UPDATE posthog_person SET version = ${versionString}, ${Object.keys(update).map(
             (field, index) => `"${sanitizeSqlIdentifier(field)}" = $${index + 1}`
         )} WHERE id = $${Object.values(update).length + 1}
-        RETURNING *`
+        RETURNING *
+        /* operation='updatePerson',purpose='${tag || 'update'}' */`
 
         const { rows } = await this.postgres.query<RawPerson>(
             tx ?? PostgresUse.PERSONS_WRITE,

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -342,7 +342,7 @@ export class PersonState {
         }
 
         if (Object.keys(update).length > 0) {
-            const [updatedPerson, kafkaMessages] = await this.personStore.updatePersonDeprecated(person, update)
+            const [updatedPerson, kafkaMessages] = await this.personStore.updatePersonForUpdate(person, update)
             const kafkaAck = this.kafkaProducer.queueMessages(kafkaMessages)
             return [updatedPerson, kafkaAck]
         }
@@ -760,7 +760,7 @@ export class PersonState {
             .inc()
 
         const [mergedPerson, kafkaMessages] = await this.personStore.inTransaction('mergePeople', async (tx) => {
-            const [person, updatePersonMessages] = await this.personStore.updatePersonDeprecated(
+            const [person, updatePersonMessages] = await this.personStore.updatePersonForMerge(
                 mergeInto,
                 {
                     created_at: createdAt,

--- a/plugin-server/src/worker/ingestion/persons/measuring-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/measuring-person-store.ts
@@ -231,13 +231,7 @@ export class MeasuringPersonsStoreForDistinctIdBatch implements PersonsStoreForD
         update: Partial<InternalPerson>,
         tx?: TransactionClient
     ): Promise<[InternalPerson, TopicMessage[]]> {
-        this.incrementCount('updatePersonForUpdate')
-        this.clearCache()
-        this.incrementDatabaseOperation('updatePersonForUpdate')
-        const start = performance.now()
-        const response = await this.db.updatePersonDeprecated(person, update, tx, 'forUpdate')
-        observeLatencyByVersion(person, start, 'updatePersonForUpdate')
-        return response
+        return this.updatePerson(person, update, tx, 'updatePersonForUpdate', 'forUpdate')
     }
 
     async updatePersonForMerge(
@@ -245,12 +239,22 @@ export class MeasuringPersonsStoreForDistinctIdBatch implements PersonsStoreForD
         update: Partial<InternalPerson>,
         tx?: TransactionClient
     ): Promise<[InternalPerson, TopicMessage[]]> {
-        this.incrementCount('updatePersonForMerge')
+        return this.updatePerson(person, update, tx, 'updatePersonForMerge', 'forMerge')
+    }
+
+    private async updatePerson(
+        person: InternalPerson,
+        update: Partial<InternalPerson>,
+        tx: TransactionClient | undefined,
+        methodName: MethodName,
+        updateType: 'forUpdate' | 'forMerge'
+    ): Promise<[InternalPerson, TopicMessage[]]> {
+        this.incrementCount(methodName)
         this.clearCache()
-        this.incrementDatabaseOperation('updatePersonForMerge')
+        this.incrementDatabaseOperation(methodName)
         const start = performance.now()
-        const response = await this.db.updatePersonDeprecated(person, update, tx, 'forMerge')
-        observeLatencyByVersion(person, start, 'updatePersonForMerge')
+        const response = await this.db.updatePersonDeprecated(person, update, tx, updateType)
+        observeLatencyByVersion(person, start, methodName)
         return response
     }
 

--- a/plugin-server/src/worker/ingestion/persons/measuring-person-store.ts
+++ b/plugin-server/src/worker/ingestion/persons/measuring-person-store.ts
@@ -20,7 +20,8 @@ type MethodName =
     | 'fetchForChecking'
     | 'fetchForUpdate'
     | 'createPerson'
-    | 'updatePersonDeprecated'
+    | 'updatePersonForUpdate'
+    | 'updatePersonForMerge'
     | 'deletePerson'
     | 'addDistinctId'
     | 'moveDistinctIds'
@@ -32,7 +33,8 @@ const ALL_METHODS: MethodName[] = [
     'fetchForChecking',
     'fetchForUpdate',
     'createPerson',
-    'updatePersonDeprecated',
+    'updatePersonForUpdate',
+    'updatePersonForMerge',
     'deletePerson',
     'addDistinctId',
     'moveDistinctIds',
@@ -224,17 +226,31 @@ export class MeasuringPersonsStoreForDistinctIdBatch implements PersonsStoreForD
         )
     }
 
-    async updatePersonDeprecated(
+    async updatePersonForUpdate(
         person: InternalPerson,
         update: Partial<InternalPerson>,
         tx?: TransactionClient
     ): Promise<[InternalPerson, TopicMessage[]]> {
-        this.incrementCount('updatePersonDeprecated')
+        this.incrementCount('updatePersonForUpdate')
         this.clearCache()
-        this.incrementDatabaseOperation('updatePersonDeprecated')
+        this.incrementDatabaseOperation('updatePersonForUpdate')
         const start = performance.now()
-        const response = await this.db.updatePersonDeprecated(person, update, tx)
-        observeLatencyByVersion(person, start, 'updatePersonDeprecated')
+        const response = await this.db.updatePersonDeprecated(person, update, tx, 'forUpdate')
+        observeLatencyByVersion(person, start, 'updatePersonForUpdate')
+        return response
+    }
+
+    async updatePersonForMerge(
+        person: InternalPerson,
+        update: Partial<InternalPerson>,
+        tx?: TransactionClient
+    ): Promise<[InternalPerson, TopicMessage[]]> {
+        this.incrementCount('updatePersonForMerge')
+        this.clearCache()
+        this.incrementDatabaseOperation('updatePersonForMerge')
+        const start = performance.now()
+        const response = await this.db.updatePersonDeprecated(person, update, tx, 'forMerge')
+        observeLatencyByVersion(person, start, 'updatePersonForMerge')
         return response
     }
 

--- a/plugin-server/src/worker/ingestion/persons/persons-store-for-distinct-id-batch.ts
+++ b/plugin-server/src/worker/ingestion/persons/persons-store-for-distinct-id-batch.ts
@@ -42,9 +42,18 @@ export interface PersonsStoreForDistinctIdBatch {
     ): Promise<[InternalPerson, TopicMessage[]]>
 
     /**
-     * Updates an existing person
+     * Updates an existing person for regular updates
      */
-    updatePersonDeprecated(
+    updatePersonForUpdate(
+        person: InternalPerson,
+        update: Partial<InternalPerson>,
+        tx?: TransactionClient
+    ): Promise<[InternalPerson, TopicMessage[]]>
+
+    /**
+     * Updates an existing person for merge operations
+     */
+    updatePersonForMerge(
         person: InternalPerson,
         update: Partial<InternalPerson>,
         tx?: TransactionClient


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

In Postgres monitoring tools it's hard to see whether the person update queries are triggered by person updates or merges.

## Changes

Adds a suffix to postgres update person queries, so that it's easier to distinguish them in performance insights.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Plenty of integration tests.