### PR TITLE
fix: Filter different types of revenue analytics views

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -7370,7 +7370,7 @@
             "type": "object"
         },
         "DatabaseSchemaManagedViewTableKind": {
-            "const": "revenue_analytics",
+            "enum": ["revenue_analytics_charge", "revenue_analytics_customer"],
             "type": "string"
         },
         "DatabaseSchemaMaterializedViewTable": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2408,7 +2408,8 @@ export interface DatabaseSchemaViewTable extends DatabaseSchemaTableCommon {
 }
 
 export enum DatabaseSchemaManagedViewTableKind {
-    REVENUE_ANALYTICS = 'revenue_analytics',
+    REVENUE_ANALYTICS_CHARGE = 'revenue_analytics_charge',
+    REVENUE_ANALYTICS_CUSTOMER = 'revenue_analytics_customer',
 }
 
 export interface DatabaseSchemaManagedViewTable extends DatabaseSchemaTableCommon {

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -103,6 +103,7 @@ from posthog.schema import (
     DatabaseSchemaDataWarehouseTable,
     DatabaseSchemaField,
     DatabaseSchemaManagedViewTable,
+    DatabaseSchemaManagedViewTableKind,
     DatabaseSchemaPostHogTable,
     DatabaseSchemaSchema,
     DatabaseSchemaSource,
@@ -119,6 +120,9 @@ from posthog.warehouse.models.external_data_source import ExternalDataSource
 from posthog.warehouse.models.table import DataWarehouseTable, DataWarehouseTableColumns
 from products.revenue_analytics.backend.views.revenue_analytics_base_view import (
     RevenueAnalyticsBaseView,
+)
+from products.revenue_analytics.backend.views.revenue_analytics_charge_view import (
+    RevenueAnalyticsChargeView,
 )
 
 if TYPE_CHECKING:
@@ -982,7 +986,9 @@ def serialize_database(
                 fields=fields_dict,
                 id=view.name,  # We don't have a UUID for revenue views because they're not saved, just reuse the name
                 name=view.name,
-                kind="revenue_analytics",
+                kind=DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_CHARGE
+                if isinstance(view, RevenueAnalyticsChargeView)
+                else DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_CUSTOMER,
                 source_id=view.source_id,
                 query=HogQLQuery(query=view.query),
             )

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -743,6 +743,11 @@ class DataWarehouseEventsModifier(BaseModel):
     timestamp_field: str
 
 
+class DatabaseSchemaManagedViewTableKind(StrEnum):
+    REVENUE_ANALYTICS_CHARGE = "revenue_analytics_charge"
+    REVENUE_ANALYTICS_CUSTOMER = "revenue_analytics_customer"
+
+
 class DatabaseSchemaSchema(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -8669,7 +8674,7 @@ class DatabaseSchemaManagedViewTable(BaseModel):
     )
     fields: dict[str, DatabaseSchemaField]
     id: str
-    kind: Literal["revenue_analytics"] = "revenue_analytics"
+    kind: DatabaseSchemaManagedViewTableKind
     name: str
     query: HogQLQuery
     row_count: Optional[float] = None

--- a/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_growth_rate_query_runner.ambr
+++ b/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_growth_rate_query_runner.ambr
@@ -175,18 +175,18 @@
        (SELECT toStartOfMonth(timestamp) AS month,
                sum(amount) AS revenue
         FROM
-          (SELECT `revenue_analytics.purchase.events_revenue_view`.id AS id,
-                  `revenue_analytics.purchase.events_revenue_view`.timestamp AS timestamp,
-                  `revenue_analytics.purchase.events_revenue_view`.customer_id AS customer_id,
-                  `revenue_analytics.purchase.events_revenue_view`.session_id AS session_id,
-                  `revenue_analytics.purchase.events_revenue_view`.event_name AS event_name,
-                  `revenue_analytics.purchase.events_revenue_view`.original_currency AS original_currency,
-                  `revenue_analytics.purchase.events_revenue_view`.original_amount AS original_amount,
-                  `revenue_analytics.purchase.events_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
-                  `revenue_analytics.purchase.events_revenue_view`.currency_aware_divider AS currency_aware_divider,
-                  `revenue_analytics.purchase.events_revenue_view`.currency_aware_amount AS currency_aware_amount,
-                  `revenue_analytics.purchase.events_revenue_view`.currency AS currency,
-                  `revenue_analytics.purchase.events_revenue_view`.amount AS amount
+          (SELECT `revenue_analytics.purchase.charge_events_revenue_view`.id AS id,
+                  `revenue_analytics.purchase.charge_events_revenue_view`.timestamp AS timestamp,
+                  `revenue_analytics.purchase.charge_events_revenue_view`.customer_id AS customer_id,
+                  `revenue_analytics.purchase.charge_events_revenue_view`.session_id AS session_id,
+                  `revenue_analytics.purchase.charge_events_revenue_view`.event_name AS event_name,
+                  `revenue_analytics.purchase.charge_events_revenue_view`.original_currency AS original_currency,
+                  `revenue_analytics.purchase.charge_events_revenue_view`.original_amount AS original_amount,
+                  `revenue_analytics.purchase.charge_events_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                  `revenue_analytics.purchase.charge_events_revenue_view`.currency_aware_divider AS currency_aware_divider,
+                  `revenue_analytics.purchase.charge_events_revenue_view`.currency_aware_amount AS currency_aware_amount,
+                  `revenue_analytics.purchase.charge_events_revenue_view`.currency AS currency,
+                  `revenue_analytics.purchase.charge_events_revenue_view`.amount AS amount
            FROM
              (SELECT events.uuid AS id,
                      toTimeZone(events.created_at, 'UTC') AS timestamp,
@@ -202,8 +202,8 @@
                      if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
               FROM events
               WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
-              ORDER BY timestamp DESC) AS `revenue_analytics.purchase.events_revenue_view`
-           WHERE in(`revenue_analytics.purchase.events_revenue_view`.event_name,
+              ORDER BY timestamp DESC) AS `revenue_analytics.purchase.charge_events_revenue_view`
+           WHERE in(`revenue_analytics.purchase.charge_events_revenue_view`.event_name,
                     ['purchase']))
         WHERE and(ifNull(greaterOrEquals(timestamp, assumeNotNull(toDateTime('2015-01-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(timestamp, assumeNotNull(toDateTime('2025-04-21 23:59:59', 'UTC'))), 0))
         GROUP BY month
@@ -240,18 +240,18 @@
        (SELECT toStartOfMonth(timestamp) AS month,
                sum(amount) AS revenue
         FROM
-          (SELECT `revenue_analytics.purchase.events_revenue_view`.id AS id,
-                  `revenue_analytics.purchase.events_revenue_view`.timestamp AS timestamp,
-                  `revenue_analytics.purchase.events_revenue_view`.customer_id AS customer_id,
-                  `revenue_analytics.purchase.events_revenue_view`.session_id AS session_id,
-                  `revenue_analytics.purchase.events_revenue_view`.event_name AS event_name,
-                  `revenue_analytics.purchase.events_revenue_view`.original_currency AS original_currency,
-                  `revenue_analytics.purchase.events_revenue_view`.original_amount AS original_amount,
-                  `revenue_analytics.purchase.events_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
-                  `revenue_analytics.purchase.events_revenue_view`.currency_aware_divider AS currency_aware_divider,
-                  `revenue_analytics.purchase.events_revenue_view`.currency_aware_amount AS currency_aware_amount,
-                  `revenue_analytics.purchase.events_revenue_view`.currency AS currency,
-                  `revenue_analytics.purchase.events_revenue_view`.amount AS amount
+          (SELECT `revenue_analytics.purchase.charge_events_revenue_view`.id AS id,
+                  `revenue_analytics.purchase.charge_events_revenue_view`.timestamp AS timestamp,
+                  `revenue_analytics.purchase.charge_events_revenue_view`.customer_id AS customer_id,
+                  `revenue_analytics.purchase.charge_events_revenue_view`.session_id AS session_id,
+                  `revenue_analytics.purchase.charge_events_revenue_view`.event_name AS event_name,
+                  `revenue_analytics.purchase.charge_events_revenue_view`.original_currency AS original_currency,
+                  `revenue_analytics.purchase.charge_events_revenue_view`.original_amount AS original_amount,
+                  `revenue_analytics.purchase.charge_events_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
+                  `revenue_analytics.purchase.charge_events_revenue_view`.currency_aware_divider AS currency_aware_divider,
+                  `revenue_analytics.purchase.charge_events_revenue_view`.currency_aware_amount AS currency_aware_amount,
+                  `revenue_analytics.purchase.charge_events_revenue_view`.currency AS currency,
+                  `revenue_analytics.purchase.charge_events_revenue_view`.amount AS amount
            FROM
              (SELECT events.uuid AS id,
                      toTimeZone(events.created_at, 'UTC') AS timestamp,
@@ -268,8 +268,8 @@
                        if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
               FROM events
               WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
-              ORDER BY timestamp DESC) AS `revenue_analytics.purchase.events_revenue_view`
-           WHERE in(`revenue_analytics.purchase.events_revenue_view`.event_name,
+              ORDER BY timestamp DESC) AS `revenue_analytics.purchase.charge_events_revenue_view`
+           WHERE in(`revenue_analytics.purchase.charge_events_revenue_view`.event_name,
                     ['purchase']))
         WHERE and(ifNull(greaterOrEquals(timestamp, assumeNotNull(toDateTime('2015-01-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(timestamp, assumeNotNull(toDateTime('2025-04-21 23:59:59', 'UTC'))), 0))
         GROUP BY month

--- a/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_overview_query_runner.ambr
+++ b/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_overview_query_runner.ambr
@@ -67,18 +67,18 @@
          count(DISTINCT customer_id) AS paying_customer_count,
          ifNull(divideDecimal(revenue, accurateCastOrNull(paying_customer_count, 'Decimal64(10)')), 0) AS avg_revenue_per_customer
   FROM
-    (SELECT `revenue_analytics.purchase.events_revenue_view`.id AS id,
-            `revenue_analytics.purchase.events_revenue_view`.timestamp AS timestamp,
-            `revenue_analytics.purchase.events_revenue_view`.customer_id AS customer_id,
-            `revenue_analytics.purchase.events_revenue_view`.session_id AS session_id,
-            `revenue_analytics.purchase.events_revenue_view`.event_name AS event_name,
-            `revenue_analytics.purchase.events_revenue_view`.original_currency AS original_currency,
-            `revenue_analytics.purchase.events_revenue_view`.original_amount AS original_amount,
-            `revenue_analytics.purchase.events_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
-            `revenue_analytics.purchase.events_revenue_view`.currency_aware_divider AS currency_aware_divider,
-            `revenue_analytics.purchase.events_revenue_view`.currency_aware_amount AS currency_aware_amount,
-            `revenue_analytics.purchase.events_revenue_view`.currency AS currency,
-            `revenue_analytics.purchase.events_revenue_view`.amount AS amount
+    (SELECT `revenue_analytics.purchase.charge_events_revenue_view`.id AS id,
+            `revenue_analytics.purchase.charge_events_revenue_view`.timestamp AS timestamp,
+            `revenue_analytics.purchase.charge_events_revenue_view`.customer_id AS customer_id,
+            `revenue_analytics.purchase.charge_events_revenue_view`.session_id AS session_id,
+            `revenue_analytics.purchase.charge_events_revenue_view`.event_name AS event_name,
+            `revenue_analytics.purchase.charge_events_revenue_view`.original_currency AS original_currency,
+            `revenue_analytics.purchase.charge_events_revenue_view`.original_amount AS original_amount,
+            `revenue_analytics.purchase.charge_events_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
+            `revenue_analytics.purchase.charge_events_revenue_view`.currency_aware_divider AS currency_aware_divider,
+            `revenue_analytics.purchase.charge_events_revenue_view`.currency_aware_amount AS currency_aware_amount,
+            `revenue_analytics.purchase.charge_events_revenue_view`.currency AS currency,
+            `revenue_analytics.purchase.charge_events_revenue_view`.amount AS amount
      FROM
        (SELECT events.uuid AS id,
                toTimeZone(events.created_at, 'UTC') AS timestamp,
@@ -94,8 +94,8 @@
                if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
-        ORDER BY timestamp DESC) AS `revenue_analytics.purchase.events_revenue_view`
-     WHERE in(`revenue_analytics.purchase.events_revenue_view`.event_name,
+        ORDER BY timestamp DESC) AS `revenue_analytics.purchase.charge_events_revenue_view`
+     WHERE in(`revenue_analytics.purchase.charge_events_revenue_view`.event_name,
               ['purchase']))
   WHERE and(ifNull(greaterOrEquals(timestamp, assumeNotNull(toDateTime('2023-11-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(timestamp, assumeNotNull(toDateTime('2024-01-31 23:59:59', 'UTC'))), 0))
   LIMIT 100 SETTINGS readonly=2,
@@ -115,18 +115,18 @@
          count(DISTINCT customer_id) AS paying_customer_count,
          ifNull(divideDecimal(revenue, accurateCastOrNull(paying_customer_count, 'Decimal64(10)')), 0) AS avg_revenue_per_customer
   FROM
-    (SELECT `revenue_analytics.purchase.events_revenue_view`.id AS id,
-            `revenue_analytics.purchase.events_revenue_view`.timestamp AS timestamp,
-            `revenue_analytics.purchase.events_revenue_view`.customer_id AS customer_id,
-            `revenue_analytics.purchase.events_revenue_view`.session_id AS session_id,
-            `revenue_analytics.purchase.events_revenue_view`.event_name AS event_name,
-            `revenue_analytics.purchase.events_revenue_view`.original_currency AS original_currency,
-            `revenue_analytics.purchase.events_revenue_view`.original_amount AS original_amount,
-            `revenue_analytics.purchase.events_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
-            `revenue_analytics.purchase.events_revenue_view`.currency_aware_divider AS currency_aware_divider,
-            `revenue_analytics.purchase.events_revenue_view`.currency_aware_amount AS currency_aware_amount,
-            `revenue_analytics.purchase.events_revenue_view`.currency AS currency,
-            `revenue_analytics.purchase.events_revenue_view`.amount AS amount
+    (SELECT `revenue_analytics.purchase.charge_events_revenue_view`.id AS id,
+            `revenue_analytics.purchase.charge_events_revenue_view`.timestamp AS timestamp,
+            `revenue_analytics.purchase.charge_events_revenue_view`.customer_id AS customer_id,
+            `revenue_analytics.purchase.charge_events_revenue_view`.session_id AS session_id,
+            `revenue_analytics.purchase.charge_events_revenue_view`.event_name AS event_name,
+            `revenue_analytics.purchase.charge_events_revenue_view`.original_currency AS original_currency,
+            `revenue_analytics.purchase.charge_events_revenue_view`.original_amount AS original_amount,
+            `revenue_analytics.purchase.charge_events_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
+            `revenue_analytics.purchase.charge_events_revenue_view`.currency_aware_divider AS currency_aware_divider,
+            `revenue_analytics.purchase.charge_events_revenue_view`.currency_aware_amount AS currency_aware_amount,
+            `revenue_analytics.purchase.charge_events_revenue_view`.currency AS currency,
+            `revenue_analytics.purchase.charge_events_revenue_view`.amount AS amount
      FROM
        (SELECT events.uuid AS id,
                toTimeZone(events.created_at, 'UTC') AS timestamp,
@@ -143,8 +143,8 @@
                  if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
-        ORDER BY timestamp DESC) AS `revenue_analytics.purchase.events_revenue_view`
-     WHERE in(`revenue_analytics.purchase.events_revenue_view`.event_name,
+        ORDER BY timestamp DESC) AS `revenue_analytics.purchase.charge_events_revenue_view`
+     WHERE in(`revenue_analytics.purchase.charge_events_revenue_view`.event_name,
               ['purchase']))
   WHERE and(ifNull(greaterOrEquals(timestamp, assumeNotNull(toDateTime('2023-11-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(timestamp, assumeNotNull(toDateTime('2024-01-31 23:59:59', 'UTC'))), 0))
   LIMIT 100 SETTINGS readonly=2,

--- a/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_top_customers_query_runner.ambr
+++ b/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_analytics_top_customers_query_runner.ambr
@@ -280,18 +280,18 @@
             toStartOfMonth(timestamp) AS month,
             sum(amount) AS amount
      FROM
-       (SELECT `revenue_analytics.purchase.events_revenue_view`.id AS id,
-               `revenue_analytics.purchase.events_revenue_view`.timestamp AS timestamp,
-               `revenue_analytics.purchase.events_revenue_view`.customer_id AS customer_id,
-               `revenue_analytics.purchase.events_revenue_view`.session_id AS session_id,
-               `revenue_analytics.purchase.events_revenue_view`.event_name AS event_name,
-               `revenue_analytics.purchase.events_revenue_view`.original_currency AS original_currency,
-               `revenue_analytics.purchase.events_revenue_view`.original_amount AS original_amount,
-               `revenue_analytics.purchase.events_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
-               `revenue_analytics.purchase.events_revenue_view`.currency_aware_divider AS currency_aware_divider,
-               `revenue_analytics.purchase.events_revenue_view`.currency_aware_amount AS currency_aware_amount,
-               `revenue_analytics.purchase.events_revenue_view`.currency AS currency,
-               `revenue_analytics.purchase.events_revenue_view`.amount AS amount
+       (SELECT `revenue_analytics.purchase.charge_events_revenue_view`.id AS id,
+               `revenue_analytics.purchase.charge_events_revenue_view`.timestamp AS timestamp,
+               `revenue_analytics.purchase.charge_events_revenue_view`.customer_id AS customer_id,
+               `revenue_analytics.purchase.charge_events_revenue_view`.session_id AS session_id,
+               `revenue_analytics.purchase.charge_events_revenue_view`.event_name AS event_name,
+               `revenue_analytics.purchase.charge_events_revenue_view`.original_currency AS original_currency,
+               `revenue_analytics.purchase.charge_events_revenue_view`.original_amount AS original_amount,
+               `revenue_analytics.purchase.charge_events_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
+               `revenue_analytics.purchase.charge_events_revenue_view`.currency_aware_divider AS currency_aware_divider,
+               `revenue_analytics.purchase.charge_events_revenue_view`.currency_aware_amount AS currency_aware_amount,
+               `revenue_analytics.purchase.charge_events_revenue_view`.currency AS currency,
+               `revenue_analytics.purchase.charge_events_revenue_view`.amount AS amount
         FROM
           (SELECT events.uuid AS id,
                   toTimeZone(events.created_at, 'UTC') AS timestamp,
@@ -307,8 +307,8 @@
                   if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
            FROM events
            WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
-           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.events_revenue_view`
-        WHERE in(`revenue_analytics.purchase.events_revenue_view`.event_name,
+           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.charge_events_revenue_view`
+        WHERE in(`revenue_analytics.purchase.charge_events_revenue_view`.event_name,
                  ['purchase']))
      WHERE and(ifNull(greaterOrEquals(timestamp, assumeNotNull(toDateTime('2023-11-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(timestamp, assumeNotNull(toDateTime('2024-01-31 23:59:59', 'UTC'))), 0))
      GROUP BY customer_id,
@@ -338,18 +338,18 @@
             toStartOfMonth(timestamp) AS month,
             sum(amount) AS amount
      FROM
-       (SELECT `revenue_analytics.purchase.events_revenue_view`.id AS id,
-               `revenue_analytics.purchase.events_revenue_view`.timestamp AS timestamp,
-               `revenue_analytics.purchase.events_revenue_view`.customer_id AS customer_id,
-               `revenue_analytics.purchase.events_revenue_view`.session_id AS session_id,
-               `revenue_analytics.purchase.events_revenue_view`.event_name AS event_name,
-               `revenue_analytics.purchase.events_revenue_view`.original_currency AS original_currency,
-               `revenue_analytics.purchase.events_revenue_view`.original_amount AS original_amount,
-               `revenue_analytics.purchase.events_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
-               `revenue_analytics.purchase.events_revenue_view`.currency_aware_divider AS currency_aware_divider,
-               `revenue_analytics.purchase.events_revenue_view`.currency_aware_amount AS currency_aware_amount,
-               `revenue_analytics.purchase.events_revenue_view`.currency AS currency,
-               `revenue_analytics.purchase.events_revenue_view`.amount AS amount
+       (SELECT `revenue_analytics.purchase.charge_events_revenue_view`.id AS id,
+               `revenue_analytics.purchase.charge_events_revenue_view`.timestamp AS timestamp,
+               `revenue_analytics.purchase.charge_events_revenue_view`.customer_id AS customer_id,
+               `revenue_analytics.purchase.charge_events_revenue_view`.session_id AS session_id,
+               `revenue_analytics.purchase.charge_events_revenue_view`.event_name AS event_name,
+               `revenue_analytics.purchase.charge_events_revenue_view`.original_currency AS original_currency,
+               `revenue_analytics.purchase.charge_events_revenue_view`.original_amount AS original_amount,
+               `revenue_analytics.purchase.charge_events_revenue_view`.enable_currency_aware_divider AS enable_currency_aware_divider,
+               `revenue_analytics.purchase.charge_events_revenue_view`.currency_aware_divider AS currency_aware_divider,
+               `revenue_analytics.purchase.charge_events_revenue_view`.currency_aware_amount AS currency_aware_amount,
+               `revenue_analytics.purchase.charge_events_revenue_view`.currency AS currency,
+               `revenue_analytics.purchase.charge_events_revenue_view`.amount AS amount
         FROM
           (SELECT events.uuid AS id,
                   toTimeZone(events.created_at, 'UTC') AS timestamp,
@@ -366,8 +366,8 @@
                     if(isNull(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', ''))), accurateCastOrNull(currency_aware_amount, 'Decimal64(10)'), if(equals(upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), 'GBP'), toDecimal64(currency_aware_amount, 10), if(dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)) = 0, toDecimal64(0, 10), multiplyDecimal(divideDecimal(toDecimal64(currency_aware_amount, 10), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', upper(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'currency'), ''), 'null'), '^"|"$', '')), toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10))), dictGetOrDefault(`posthog_test`.`exchange_rate_dict`, 'rate', 'GBP', toDate(toTimeZone(events.timestamp, 'UTC')), toDecimal64(0, 10)))))) AS amount
            FROM events
            WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
-           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.events_revenue_view`
-        WHERE in(`revenue_analytics.purchase.events_revenue_view`.event_name,
+           ORDER BY timestamp DESC) AS `revenue_analytics.purchase.charge_events_revenue_view`
+        WHERE in(`revenue_analytics.purchase.charge_events_revenue_view`.event_name,
                  ['purchase']))
      WHERE and(ifNull(greaterOrEquals(timestamp, assumeNotNull(toDateTime('2023-11-01 00:00:00', 'UTC'))), 0), ifNull(lessOrEquals(timestamp, assumeNotNull(toDateTime('2024-01-31 23:59:59', 'UTC'))), 0))
      GROUP BY customer_id,

--- a/products/revenue_analytics/backend/views/revenue_analytics_charge_view.py
+++ b/products/revenue_analytics/backend/views/revenue_analytics_charge_view.py
@@ -25,7 +25,7 @@ from posthog.temporal.data_imports.pipelines.stripe.constants import (
 )
 
 SOURCE_VIEW_SUFFIX = "charge_revenue_view"
-EVENTS_VIEW_SUFFIX = "events_revenue_view"
+EVENTS_VIEW_SUFFIX = "charge_events_revenue_view"
 STRIPE_CHARGE_SUCCEEDED_STATUS = "succeeded"
 
 # Stripe represents most currencies with integer amounts multiplied by 100,

--- a/products/revenue_analytics/frontend/revenueAnalyticsLogic.ts
+++ b/products/revenue_analytics/frontend/revenueAnalyticsLogic.ts
@@ -190,7 +190,7 @@ export const revenueAnalyticsLogic = kea<revenueAnalyticsLogicType>([
                 const eventNames = rawRevenueSources.events.map((e) => e.eventName)
 
                 return managedViews
-                    .filter((view) => view.kind === DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS)
+                    .filter((view) => view.kind === DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_CHARGE)
                     .filter((view) => {
                         // Comes from a Data Warehouse source
                         if (view.source_id) {


### PR DESCRIPTION
Let's guarantee we're including only charge views when querying by them in the UI