### PR TITLE
feat(project-tree): add back dashboards

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -353,6 +353,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
     { path: 'Broadcasts', href: urls.messagingBroadcasts(), type: 'hog_function/broadcast' },
     { path: 'Campaigns', href: urls.messagingCampaigns(), type: 'hog_function/campaign' },
     { path: 'Cohorts', type: 'cohort', href: urls.cohorts() },
+    { path: 'Dashboards', type: 'dashboard', href: urls.dashboards() },
     { path: 'Early access features', type: 'early_access_feature', href: urls.earlyAccessFeatures() },
     { path: `Experiments`, type: 'experiment', href: urls.experiments() },
     { path: `Feature flags`, type: 'feature_flag', href: urls.featureFlags() },

--- a/products/dashboards/manifest.tsx
+++ b/products/dashboards/manifest.tsx
@@ -32,6 +32,13 @@ export const manifest: ProductManifest = {
             href: urls.dashboards() + '#newDashboard=modal',
         },
     ],
+    treeItemsProducts: [
+        {
+            path: 'Dashboards',
+            type: 'dashboard',
+            href: urls.dashboards(),
+        },
+    ],
     fileSystemFilterTypes: {
         dashboard: { name: 'Dashboards' },
     },


### PR DESCRIPTION
## Problem

There's no way to access dashboards in the `tree-view-products` flag.

## Changes

Quickly add them back as a product. I'll rework the tree and add "data management" in a separate PR next... and maybe move this around even more.

<img width="598" alt="image" src="https://github.com/user-attachments/assets/d6a46d95-2820-45dc-8b89-859a358d2859" />
