### PR TITLE
feat(batch-exports): Monitoring: add check for when no records exported

### DIFF
--- a/posthog/temporal/batch_exports/__init__.py
+++ b/posthog/temporal/batch_exports/__init__.py
@@ -19,7 +19,7 @@ from posthog.temporal.batch_exports.http_batch_export import (
 )
 from posthog.temporal.batch_exports.monitoring import (
     BatchExportMonitoringWorkflow,
-    check_for_missing_batch_export_runs,
+    check_batch_export_runs,
     get_batch_export,
     get_event_counts,
     update_batch_export_runs,
@@ -71,5 +71,5 @@ ACTIVITIES = [
     get_batch_export,
     get_event_counts,
     update_batch_export_runs,
-    check_for_missing_batch_export_runs,
+    check_batch_export_runs,
 ]


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We currently don't have any alerting for when certain batch exports don't export any events.

## Changes

Add alerting for when certain batch exports fail to export records for at least 30 mins (the monitoring workflow only works currently for batch exports with 5 min intervals, so we check for at least 6 intervals with no records exported).


## How did you test this code?

Added a test
