### PR TITLE
chore: drop preagg tables before recreating

### DIFF
--- a/dags/web_preaggregated_internal.py
+++ b/dags/web_preaggregated_internal.py
@@ -70,6 +70,11 @@ def web_analytics_preaggregated_tables(
         client.execute(DISTRIBUTED_WEB_OVERVIEW_METRICS_DAILY_SQL())
         client.execute(DISTRIBUTED_WEB_STATS_DAILY_SQL())
 
+    def drop_tables(client: Client):
+        client.execute("DROP TABLE IF EXISTS web_overview_daily SYNC")
+        client.execute("DROP TABLE IF EXISTS web_stats_daily SYNC")
+
+    cluster.map_all_hosts(drop_tables).result()
     cluster.map_all_hosts(create_tables).result()
     return True
 


### PR DESCRIPTION
## Problem

This is effectively the same approach as [person_overrides](https://github.com/PostHog/posthog/blob/6eba7faefc15f6fbee99a35b2101ee9b055bff0b/dags/person_overrides.py#L52-L53) now so we can keep the job running on automation

## Changes

- Clean tables everytime :)

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Running on clickhouse dev
