### PR TITLE
fix(flags): Fix pagination for flags on persons page

### DIFF
--- a/frontend/src/scenes/persons/RelatedFeatureFlags.tsx
+++ b/frontend/src/scenes/persons/RelatedFeatureFlags.tsx
@@ -35,10 +35,10 @@ const featureFlagMatchMapping = {
 }
 
 export function RelatedFeatureFlags({ distinctId, groupTypeIndex, groups }: Props): JSX.Element {
-    const { filteredMappedFlags, relatedFeatureFlagsLoading, searchTerm, filters } = useValues(
-        relatedFeatureFlagsLogic({ distinctId, groupTypeIndex, groups })
-    )
-    const { setSearchTerm, setFilters } = useActions(relatedFeatureFlagsLogic({ distinctId, groupTypeIndex, groups }))
+    const relatedFlagsLogic = relatedFeatureFlagsLogic({ distinctId, groupTypeIndex, groups })
+    const { filteredMappedFlags, relatedFeatureFlagsLoading, searchTerm, filters, pagination } =
+        useValues(relatedFlagsLogic)
+    const { setSearchTerm, setFilters } = useActions(relatedFlagsLogic)
 
     const columns: LemonTableColumns<RelatedFeatureFlag> = [
         {
@@ -232,7 +232,12 @@ export function RelatedFeatureFlags({ distinctId, groupTypeIndex, groups }: Prop
                     />
                 </div>
             </div>
-            <LemonTable columns={columns} loading={relatedFeatureFlagsLoading} dataSource={filteredMappedFlags} />
+            <LemonTable
+                columns={columns}
+                loading={relatedFeatureFlagsLoading}
+                dataSource={filteredMappedFlags}
+                pagination={pagination}
+            />
         </>
     )
 }

--- a/frontend/src/scenes/persons/relatedFeatureFlagsLogic.ts
+++ b/frontend/src/scenes/persons/relatedFeatureFlagsLogic.ts
@@ -1,10 +1,11 @@
-import Fuse from 'fuse.js'
 import { actions, connect, events, kea, key, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
+import { urlToAction } from 'kea-router'
 import api from 'lib/api'
 import { toParams } from 'lib/utils'
 import { featureFlagsLogic } from 'scenes/feature-flags/featureFlagsLogic'
 import { projectLogic } from 'scenes/projectLogic'
+import { urls } from 'scenes/urls'
 
 import { FeatureFlagReleaseType, FeatureFlagType } from '~/types'
 
@@ -29,14 +30,13 @@ export interface RelatedFeatureFlagResponse {
 }
 
 export interface RelatedFlagsFilters {
-    type: string
-    active: string
-    reason: string
+    type?: FeatureFlagReleaseType
+    active?: 'true' | 'false'
+    reason?: 'matched' | 'not matched'
 }
 
 export const relatedFeatureFlagsLogic = kea<relatedFeatureFlagsLogicType>([
     path(['scenes', 'persons', 'relatedFeatureFlagsLogic']),
-    connect(() => ({ values: [projectLogic, ['currentProjectId'], featureFlagsLogic, ['featureFlags']] })),
     props(
         {} as {
             distinctId: string | null
@@ -45,8 +45,15 @@ export const relatedFeatureFlagsLogic = kea<relatedFeatureFlagsLogicType>([
         }
     ),
     key((props) => `${props.distinctId}`),
+    connect(() => ({
+        values: [projectLogic, ['currentProjectId'], featureFlagsLogic, ['featureFlags', 'pagination']],
+        actions: [featureFlagsLogic, ['setFeatureFlagsFilters']],
+    })),
     actions({
-        setSearchTerm: (searchTerm: string) => ({ searchTerm }),
+        setSearchTerm: (searchTerm: string) => {
+            featureFlagsLogic.actions.setFeatureFlagsFilters({ search: searchTerm })
+            return { searchTerm }
+        },
         setFilters: (filters: Partial<RelatedFlagsFilters>, replace?: boolean) => ({ filters, replace }),
         loadRelatedFeatureFlags: true,
     }),
@@ -116,44 +123,45 @@ export const relatedFeatureFlagsLogic = kea<relatedFeatureFlagsLogicType>([
             },
         ],
         filteredMappedFlags: [
-            (selectors) => [selectors.mappedRelatedFeatureFlags, selectors.searchTerm, selectors.filters],
-            (featureFlags, searchTerm, filters) => {
-                if (!searchTerm && Object.keys(filters).length === 0) {
+            (selectors) => [selectors.mappedRelatedFeatureFlags, selectors.filters],
+            (featureFlags, filters: Partial<RelatedFlagsFilters>) => {
+                if (Object.keys(filters).length === 0) {
                     return featureFlags
-                }
-                let searchedFlags: RelatedFeatureFlag[] = featureFlags
-                if (searchTerm) {
-                    searchedFlags = new Fuse(featureFlags, {
-                        keys: ['key', 'name'],
-                        threshold: 0.3,
-                    })
-                        .search(searchTerm)
-                        .map((result) => result.item)
                 }
 
                 const { type, active, reason } = filters
+                let filteredFlags = featureFlags
+
                 if (type) {
-                    searchedFlags = searchedFlags.filter((flag) =>
+                    filteredFlags = filteredFlags.filter((flag) =>
                         type === FeatureFlagReleaseType.Variants
                             ? flag.filters.multivariate
                             : !flag.filters.multivariate
                     )
                 }
                 if (active) {
-                    searchedFlags = searchedFlags.filter((flag) => (active === 'true' ? flag.active : !flag.active))
+                    filteredFlags = filteredFlags.filter((flag) => (active === 'true' ? flag.active : !flag.active))
                 }
                 if (reason) {
-                    searchedFlags = searchedFlags.filter((flag) =>
+                    filteredFlags = filteredFlags.filter((flag) =>
                         reason === 'not matched'
                             ? flag.evaluation.reason !== FeatureFlagMatchReason.ConditionMatch
                             : flag.evaluation.reason === FeatureFlagMatchReason.ConditionMatch
                     )
                 }
-                return searchedFlags
+                return filteredFlags
             },
         ],
     })),
     events(({ actions }) => ({
         afterMount: actions.loadRelatedFeatureFlags,
+    })),
+    urlToAction(({ actions }) => ({
+        [urls.personByUUID('*', false)]: async (_, searchParams) => {
+            const page = searchParams['page']
+            if (page !== undefined) {
+                actions.setFeatureFlagsFilters({ page: parseInt(page) })
+            }
+        },
     })),
 ])

--- a/frontend/src/scenes/persons/relatedFeatureFlagsLogic.ts
+++ b/frontend/src/scenes/persons/relatedFeatureFlagsLogic.ts
@@ -30,9 +30,9 @@ export interface RelatedFeatureFlagResponse {
 }
 
 export interface RelatedFlagsFilters {
-    type?: FeatureFlagReleaseType
-    active?: 'true' | 'false'
-    reason?: 'matched' | 'not matched'
+    type?: string
+    active?: string
+    reason?: string
 }
 
 export const relatedFeatureFlagsLogic = kea<relatedFeatureFlagsLogicType>([


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

When viewing the feature flags tab on a person page AND the org has over 100 flags, only 100 flags are displayed and there's no way to paginate. On top of that, using the search filter only filters on the client side.

## Changes

This changes `relatedFeatureFlagsLogic.ts` to leverage the pagination and filtering within `featureFlagsLogic.ts`. It then updates `RelatedFeatureFlags.tsx` to use pagination for the flags list.

Note that this doesn't add pagination to the `/evaluation_reasons` endpoint as that would be a much bigger change and is not really necessary as it's much less data than the `feature_flags` endpoint.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manually.

[screen-capture.webm](https://github.com/user-attachments/assets/6a3501a7-6853-4718-b5ab-de12919da919)
