### PR TITLE
fix: Join on event ID rather than name

### DIFF
--- a/products/revenue_analytics/backend/hogql_queries/revenue_example_events_query_runner.py
+++ b/products/revenue_analytics/backend/hogql_queries/revenue_example_events_query_runner.py
@@ -76,8 +76,8 @@ class RevenueExampleEventsQueryRunner(QueryRunnerWithHogQLContext):
                                 constraint_type="ON",
                                 expr=ast.CompareOperation(
                                     op=CompareOperationOp.Eq,
-                                    left=ast.Field(chain=["events", "event"]),
-                                    right=ast.Field(chain=["view", "event_name"]),
+                                    left=ast.Field(chain=["events", "uuid"]),
+                                    right=ast.Field(chain=["view", "id"]),
                                 ),
                             ),
                         ),

--- a/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_example_events_query_runner.ambr
+++ b/products/revenue_analytics/backend/hogql_queries/test/__snapshots__/test_revenue_example_events_query_runner.ambr
@@ -38,7 +38,7 @@
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_a'), isNotNull(amount)))
         ORDER BY timestamp DESC) AS view
-     INNER JOIN events ON equals(events.event, view.event_name)
+     INNER JOIN events ON equals(events.uuid, view.id)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id
@@ -85,7 +85,7 @@
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_b'), isNotNull(amount)))
         ORDER BY timestamp DESC) AS view
-     INNER JOIN events ON equals(events.event, view.event_name)
+     INNER JOIN events ON equals(events.uuid, view.id)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id
@@ -175,7 +175,7 @@
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_a'), isNotNull(amount)))
         ORDER BY timestamp DESC) AS view
-     INNER JOIN events ON equals(events.event, view.event_name)
+     INNER JOIN events ON equals(events.uuid, view.id)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id
@@ -223,7 +223,7 @@
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_b'), isNotNull(amount)))
         ORDER BY timestamp DESC) AS view
-     INNER JOIN events ON equals(events.event, view.event_name)
+     INNER JOIN events ON equals(events.uuid, view.id)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id
@@ -271,7 +271,7 @@
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_c'), isNotNull(amount)))
         ORDER BY timestamp DESC) AS view
-     INNER JOIN events ON equals(events.event, view.event_name)
+     INNER JOIN events ON equals(events.uuid, view.id)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id
@@ -345,7 +345,7 @@
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_a'), isNotNull(amount)))
         ORDER BY timestamp DESC) AS view
-     INNER JOIN events ON equals(events.event, view.event_name)
+     INNER JOIN events ON equals(events.uuid, view.id)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id
@@ -393,7 +393,7 @@
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_b'), isNotNull(amount)))
         ORDER BY timestamp DESC) AS view
-     INNER JOIN events ON equals(events.event, view.event_name)
+     INNER JOIN events ON equals(events.uuid, view.id)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id
@@ -441,7 +441,7 @@
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_c'), isNotNull(amount)))
         ORDER BY timestamp DESC) AS view
-     INNER JOIN events ON equals(events.event, view.event_name)
+     INNER JOIN events ON equals(events.uuid, view.id)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id
@@ -514,7 +514,7 @@
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_a'), isNotNull(amount)))
         ORDER BY timestamp DESC) AS view
-     INNER JOIN events ON equals(events.event, view.event_name)
+     INNER JOIN events ON equals(events.uuid, view.id)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id
@@ -561,7 +561,7 @@
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_b'), isNotNull(amount)))
         ORDER BY timestamp DESC) AS view
-     INNER JOIN events ON equals(events.event, view.event_name)
+     INNER JOIN events ON equals(events.uuid, view.id)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id
@@ -608,7 +608,7 @@
         FROM events
         WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase_c'), isNotNull(amount)))
         ORDER BY timestamp DESC) AS view
-     INNER JOIN events ON equals(events.event, view.event_name)
+     INNER JOIN events ON equals(events.uuid, view.id)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id
@@ -670,7 +670,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
      ORDER BY timestamp DESC) AS view
-  INNER JOIN events ON equals(events.event, view.event_name)
+  INNER JOIN events ON equals(events.uuid, view.id)
   LEFT OUTER JOIN
     (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
             person_distinct_id_overrides.distinct_id AS distinct_id
@@ -732,7 +732,7 @@
      FROM events
      WHERE and(equals(events.team_id, 99999), and(equals(events.event, 'purchase'), isNotNull(amount)))
      ORDER BY timestamp DESC) AS view
-  INNER JOIN events ON equals(events.event, view.event_name)
+  INNER JOIN events ON equals(events.uuid, view.id)
   LEFT OUTER JOIN
     (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
             person_distinct_id_overrides.distinct_id AS distinct_id


### PR DESCRIPTION
I dont know why I did what I did. This was basically a cross-join across all events rather than joining with the relevant event. Big error.