### PR TITLE
fix: Fix InfiniteList logic when using `showNumericalPropsOnly`

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -131,6 +131,7 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                         offset,
                         excluded_properties: JSON.stringify(excludedProperties),
                         properties: propertyAllowList ? propertyAllowList.join(',') : undefined,
+                        ...(props.showNumericalPropsOnly ? { is_numerical: 'true' } : {}),
                         // TODO: remove this filter once we can support behavioral cohorts for feature flags, it's only
                         // used in the feature flag property filter UI
                         ...(props.hideBehavioralCohorts ? { hide_behavioral_cohorts: 'true' } : {}),
@@ -343,6 +344,9 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
         items: [
             (s, p) => [s.remoteItems, s.localItems, p.showNumericalPropsOnly ?? (() => false)],
             (remoteItems, localItems, showNumericalPropsOnly) => {
+                // NOTE: This might not be needed because we're filtering on the backend to improve loading performance
+                // That said, there might be some edge cases where the backend is NOT filtering on the same way
+                // as we are here in the frontend, so let's keep this here
                 const results = [...localItems.results, ...remoteItems.results].filter((result) => {
                     if (!showNumericalPropsOnly) {
                         return true


### PR DESCRIPTION
Because of the way we do filtering + rendering in our UI we had an inconsistent loading state for lists using `showNumericalPropsOnly`. The backend would return a very high count of rows - which we always render in the frontend - and we would not tag them as "void" when we filter them out, causing us some troubles - people thought we were still loading when we weren't anymore.


https://github.com/user-attachments/assets/06ae9ad5-a93e-4a8b-a769-e32dd77df49d



Let's fix this by simply querying the DB/backend directly rather than filtering in the UI.

A follow-up PR will introduce a FF to remove the filtering in the frontend, it might be unnecessary - need some testing in production.