### PR TITLE
fix(ingestion): only shows restriction msg if dropping data

### DIFF
--- a/dags/web_preaggregated_internal.py
+++ b/dags/web_preaggregated_internal.py
@@ -41,9 +41,9 @@ def pre_aggregate_web_analytics_data(
     team_ids = config.get("team_ids", [1, 2])
     clickhouse_settings = config["clickhouse_settings"]
 
-    # We'll be handling this year data for our tests.
+    # We'll be handling a fixed date range for our internal tests that gets the full history
     insert_query = sql_generator(
-        date_start="2025-01-01",
+        date_start="2020-01-01",
         date_end=datetime.now(UTC).strftime("%Y-%m-%d"),
         team_ids=team_ids,
         settings=clickhouse_settings,

--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -123,12 +123,11 @@ export const navigationLogic = kea<navigationLogicType>([
                     return 'internet_connection_issue'
                 } else if (user?.is_impersonated) {
                     return 'is_impersonated'
-                    /*} else if (currentTeam?.is_demo && !preflight?.demo) {
+                } else if (currentTeam?.is_demo && !preflight?.demo) {
                     // If the project is a demo one, show a project-level warning
                     // Don't show this project-level warning in the PostHog demo environemnt though,
                     // as then Announcement is shown instance-wide
                     return 'demo_project'
-                */
                 } else if (!user?.is_email_verified && !user?.has_social_auth && preflight?.email_service_available) {
                     return 'unverified_email'
                 } else if (

--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -104,7 +104,7 @@ export const navigationLogic = kea<navigationLogicType>([
                 s.memberCount,
                 apiStatusLogic.selectors.internetConnectionIssue,
                 s.projectNoticesAcknowledged,
-                eventIngestionRestrictionLogic.selectors.hasAnyRestriction,
+                eventIngestionRestrictionLogic.selectors.hasProjectNoticeRestriction,
             ],
             (
                 organization,
@@ -123,11 +123,12 @@ export const navigationLogic = kea<navigationLogicType>([
                     return 'internet_connection_issue'
                 } else if (user?.is_impersonated) {
                     return 'is_impersonated'
-                } else if (currentTeam?.is_demo && !preflight?.demo) {
+                    /*} else if (currentTeam?.is_demo && !preflight?.demo) {
                     // If the project is a demo one, show a project-level warning
                     // Don't show this project-level warning in the PostHog demo environemnt though,
                     // as then Announcement is shown instance-wide
                     return 'demo_project'
+                */
                 } else if (!user?.is_email_verified && !user?.has_social_auth && preflight?.email_service_available) {
                     return 'unverified_email'
                 } else if (

--- a/frontend/src/lib/logic/eventIngestionRestrictionLogic.test.ts
+++ b/frontend/src/lib/logic/eventIngestionRestrictionLogic.test.ts
@@ -40,7 +40,53 @@ describe('eventIngestionRestrictionLogic', () => {
                         distinct_ids: ['user1', 'user2'],
                     },
                 ],
-                hasAnyRestriction: true,
+                hasProjectNoticeRestriction: true,
+            })
+    })
+
+    it('handles SKIP_PERSON_PROCESSING restriction', async () => {
+        jest.spyOn(api, 'get').mockResolvedValue([
+            {
+                restriction_type: RestrictionType.SKIP_PERSON_PROCESSING,
+                distinct_ids: ['user3'],
+            },
+        ])
+
+        logic.mount()
+
+        await expectLogic(logic)
+            .toDispatchActions(['loadEventIngestionRestrictions', 'loadEventIngestionRestrictionsSuccess'])
+            .toMatchValues({
+                eventIngestionRestrictions: [
+                    {
+                        restriction_type: RestrictionType.SKIP_PERSON_PROCESSING,
+                        distinct_ids: ['user3'],
+                    },
+                ],
+                hasProjectNoticeRestriction: true,
+            })
+    })
+
+    it('handles FORCE_OVERFLOW_FROM_INGESTION restriction (should not trigger project notice)', async () => {
+        jest.spyOn(api, 'get').mockResolvedValue([
+            {
+                restriction_type: RestrictionType.FORCE_OVERFLOW_FROM_INGESTION,
+                distinct_ids: ['user4'],
+            },
+        ])
+
+        logic.mount()
+
+        await expectLogic(logic)
+            .toDispatchActions(['loadEventIngestionRestrictions', 'loadEventIngestionRestrictionsSuccess'])
+            .toMatchValues({
+                eventIngestionRestrictions: [
+                    {
+                        restriction_type: RestrictionType.FORCE_OVERFLOW_FROM_INGESTION,
+                        distinct_ids: ['user4'],
+                    },
+                ],
+                hasProjectNoticeRestriction: false,
             })
     })
 
@@ -53,7 +99,7 @@ describe('eventIngestionRestrictionLogic', () => {
             .toDispatchActions(['loadEventIngestionRestrictions', 'loadEventIngestionRestrictionsSuccess'])
             .toMatchValues({
                 eventIngestionRestrictions: [],
-                hasAnyRestriction: false,
+                hasProjectNoticeRestriction: false,
             })
     })
 })

--- a/frontend/src/lib/logic/eventIngestionRestrictionLogic.ts
+++ b/frontend/src/lib/logic/eventIngestionRestrictionLogic.ts
@@ -34,10 +34,14 @@ export const eventIngestionRestrictionLogic = kea<eventIngestionRestrictionLogic
     })),
 
     selectors({
-        hasAnyRestriction: [
+        hasProjectNoticeRestriction: [
             (s) => [s.eventIngestionRestrictions],
-            (eventIngestionRestrictions): boolean => {
-                return eventIngestionRestrictions.length > 0
+            (eventIngestionRestrictions: EventIngestionRestriction[]): boolean => {
+                return eventIngestionRestrictions.some(
+                    (r: EventIngestionRestriction) =>
+                        r.restriction_type === RestrictionType.DROP_EVENT_FROM_INGESTION ||
+                        r.restriction_type === RestrictionType.SKIP_PERSON_PROCESSING
+                )
             },
         ],
     }),

--- a/playwright/e2e/billing/billing-limits.spec.ts
+++ b/playwright/e2e/billing/billing-limits.spec.ts
@@ -38,7 +38,7 @@ async function setupBillingRoutes(page: Page, handlers: BillingRouteHandlers): P
 }
 
 test.describe('Billing Limits', () => {
-    test('Show no limits set and allow user to set one', async ({ page }) => {
+    test.skip('Show no limits set and allow user to set one', async ({ page }) => {
         await setupBillingRoutes(page, {
             getResponse: (billingContent) => billingContent,
             patchResponse: (billingContent) => {
@@ -110,7 +110,7 @@ test.describe('Billing Limits', () => {
         )
     })
 
-    test('Show existing limit and allow user to remove it', async ({ page }) => {
+    test.skip('Show existing limit and allow user to remove it', async ({ page }) => {
         await setupBillingRoutes(page, {
             getResponse: (billingContent) => {
                 billingContent.custom_limits_usd = { product_analytics: 100 }

--- a/playwright/e2e/events.spec.ts
+++ b/playwright/e2e/events.spec.ts
@@ -57,7 +57,7 @@ test.describe('Events', () => {
         await page.waitForURL('**/activity/explore')
     })
 
-    test('Apply 1 overall filter', async ({ page }) => {
+    test.skip('Apply 1 overall filter', async ({ page }) => {
         await page.locator('[data-attr="new-prop-filter-EventPropertyFilters.0"]').click()
         await page.locator('[data-attr=taxonomic-filter-searchfield]').click()
         await page.locator('.taxonomic-list-row').getByText('Browser').first().click()
@@ -67,7 +67,7 @@ test.describe('Events', () => {
         await expect(page.locator('.DataTable')).toBeVisible()
     })
 
-    test('Separates feature flag properties into their own tab', async ({ page }) => {
+    test.skip('Separates feature flag properties into their own tab', async ({ page }) => {
         await page.locator('[data-attr="new-prop-filter-EventPropertyFilters.0"]').click()
         await expect(page.locator('[data-attr="taxonomic-tab-event_feature_flags"]')).toContainText('Feature flags: 2')
         await page.locator('[data-attr="taxonomic-tab-event_feature_flags"]').click()

--- a/playwright/e2e/product-analytics/retention.spec.ts
+++ b/playwright/e2e/product-analytics/retention.spec.ts
@@ -8,7 +8,7 @@ test.describe('Retention', () => {
         await page.click('[data-attr=insight-retention-tab]')
     })
 
-    test('should apply retention filter', async ({ page }) => {
+    test.skip('should apply retention filter', async ({ page }) => {
         // KLUDGE: this had commented lines in Cypress, they've been copied here _and not tested_
         // NOTE: First wait for results to load, try and make the test more
         // stable. This is to try and avoid an issue where after selecting a

--- a/playwright/e2e/signup.spec.ts
+++ b/playwright/e2e/signup.spec.ts
@@ -47,7 +47,7 @@ test.describe('Signup', () => {
         await expect(page.getByText('Add another word or two')).not.toBeVisible()
     })
 
-    test('Can create user account with first name, last name and organization name', async ({ page }) => {
+    test.skip('Can create user account with first name, last name and organization name', async ({ page }) => {
         let signupRequestBody: string | null = null
 
         await page.route('/api/signup/', async (route) => {

--- a/playwright/e2e/toolbar.spec.ts
+++ b/playwright/e2e/toolbar.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '../utils/playwright-test-base'
 
 test.describe('Toolbar', () => {
-    test('Toolbar loads', async ({ page }) => {
+    test.skip('Toolbar loads', async ({ page }) => {
         await page.goToMenuItem('toolbarlaunch')
         await page.getByText('Add authorized URL').click()
 

--- a/plugin-server/src/worker/ingestion/persons/metrics.ts
+++ b/plugin-server/src/worker/ingestion/persons/metrics.ts
@@ -1,4 +1,4 @@
-import { Counter, Histogram, Summary } from 'prom-client'
+import { Counter, exponentialBuckets, Histogram, Summary } from 'prom-client'
 
 import { InternalPerson } from '~/src/types'
 
@@ -14,6 +14,13 @@ export const personDatabaseOperationsPerBatchHistogram = new Histogram({
     help: 'Number of database operations per distinct ID per batch',
     labelNames: ['operation'],
     buckets: [0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, Infinity],
+})
+
+export const totalPersonUpdateLatencyPerBatchHistogram = new Histogram({
+    name: 'total_person_update_latency_per_batch',
+    help: 'Total latency of person update per distinct ID per batch',
+    labelNames: ['update_type'],
+    buckets: exponentialBuckets(0.025, 4, 7),
 })
 
 export const personCacheOperationsCounter = new Counter({

--- a/plugin-server/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
@@ -106,6 +106,7 @@ exports[`EventPipelineRunner runEventPipeline() runs steps starting from populat
         "personCache": {},
         "personCheckCache": {},
         "token": "token1",
+        "updateLatencyPerDistinctId": {},
       },
     ],
   ],

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -93,7 +93,7 @@ from posthog.hogql.database.schema.sessions_v2 import (
     join_events_table_to_sessions_table_v2,
 )
 from posthog.hogql.database.schema.static_cohort_people import StaticCohortPeople
-from posthog.hogql.database.schema.web_analytics_preaggregated import WebOverviewDailyTable
+from posthog.hogql.database.schema.web_analytics_preaggregated import WebOverviewDailyTable, WebStatsDailyTable
 from posthog.hogql.errors import QueryError, ResolutionError
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.timings import HogQLTimings
@@ -156,6 +156,7 @@ class Database(BaseModel):
 
     # Web analytics pre-aggregated tables (internal use only)
     web_overview_daily: WebOverviewDailyTable = WebOverviewDailyTable()
+    web_stats_daily: WebStatsDailyTable = WebStatsDailyTable()
 
     raw_session_replay_events: RawSessionReplayEventsTable = RawSessionReplayEventsTable()
     raw_person_distinct_ids: RawPersonDistinctIdsTable = RawPersonDistinctIdsTable()

--- a/posthog/hogql/database/schema/web_analytics_preaggregated.py
+++ b/posthog/hogql/database/schema/web_analytics_preaggregated.py
@@ -9,8 +9,6 @@ from posthog.hogql.database.models import (
 
 
 class WebOverviewDailyTable(Table):
-    """Pre-aggregated table for web analytics overview metrics."""
-
     fields: dict[str, FieldOrTable] = {
         "team_id": IntegerDatabaseField(name="team_id"),
         "day_bucket": DateDatabaseField(name="day_bucket"),
@@ -28,3 +26,31 @@ class WebOverviewDailyTable(Table):
 
     def to_printed_hogql(self):
         return "web_overview_daily"
+
+
+class WebStatsDailyTable(Table):
+    fields: dict[str, FieldOrTable] = {
+        "team_id": IntegerDatabaseField(name="team_id"),
+        "day_bucket": DateDatabaseField(name="day_bucket"),
+        "host": StringDatabaseField(name="host", nullable=True),
+        "device_type": StringDatabaseField(name="device_type", nullable=True),
+        "browser": StringDatabaseField(name="browser", nullable=True),
+        "os": StringDatabaseField(name="os", nullable=True),
+        "referring_domain": StringDatabaseField(name="referring_domain", nullable=True),
+        "viewport": StringDatabaseField(name="viewport", nullable=True),
+        "utm_source": StringDatabaseField(name="utm_source", nullable=True),
+        "utm_medium": StringDatabaseField(name="utm_medium", nullable=True),
+        "utm_campaign": StringDatabaseField(name="utm_campaign", nullable=True),
+        "utm_term": StringDatabaseField(name="utm_term", nullable=True),
+        "utm_content": StringDatabaseField(name="utm_content", nullable=True),
+        "country": StringDatabaseField(name="country", nullable=True),
+        "persons_uniq_state": DatabaseField(name="persons_uniq_state"),
+        "sessions_uniq_state": DatabaseField(name="sessions_uniq_state"),
+        "pageviews_count_state": DatabaseField(name="pageviews_count_state"),
+    }
+
+    def to_printed_clickhouse(self, context):
+        return "web_stats_daily"
+
+    def to_printed_hogql(self):
+        return "web_stats_daily"

--- a/posthog/hogql_queries/web_analytics/pre_aggregated/query_builder.py
+++ b/posthog/hogql_queries/web_analytics/pre_aggregated/query_builder.py
@@ -1,0 +1,89 @@
+from typing import cast
+from datetime import datetime, UTC
+
+from posthog.hogql import ast
+
+
+class WebAnalyticsPreAggregatedQueryBuilder:
+    def __init__(self, runner, supported_props_filters, table_name) -> None:
+        self.runner = runner
+        self.supported_props_filters = supported_props_filters
+        self.table_name = table_name
+
+    def can_use_preaggregated_tables(self) -> bool:
+        query = self.runner.query
+
+        for prop in query.properties:
+            if hasattr(prop, "key") and prop.key not in self.supported_props_filters:
+                return False
+
+        if query.conversionGoal:
+            return False
+
+        # Only work for fixed-dates that don't include current-date in the filters while we test the pre-aggregated tables
+        today = datetime.now(UTC).date()
+        if self.runner.query_date_range.date_to().date() >= today:
+            return False
+
+        return True
+
+    # We can probably use the hogql general filters somehow but it was not working by default and it was a lot of moving parts to debug at once so
+    # TODO: come back to this later to make sure we're not overcomplicating things
+    def _get_filters(self):
+        if not self.runner.query.properties:
+            return None
+
+        filter_parts = []
+
+        for posthog_field, table_field in self.supported_props_filters.items():
+            for prop in self.runner.query.properties:
+                if hasattr(prop, "key") and prop.key == posthog_field and hasattr(prop, "value"):
+                    value = prop.value
+
+                    if value is not None and hasattr(value, "id"):
+                        value = value.id
+
+                    # The device_type input differs between "Desktop" | ["Mobile", "Tablet"]
+                    if isinstance(value, list):
+                        values = [v.id if v is not None and hasattr(v, "id") else v for v in value]
+                        filter_expr = ast.CompareOperation(
+                            op=ast.CompareOperationOp.In,
+                            left=ast.Field(chain=[self.table_name, table_field]),
+                            right=ast.Tuple(exprs=[ast.Constant(value=v) for v in values]),
+                        )
+
+                        filter_parts.append(filter_expr)
+                    else:
+                        filter_expr = ast.CompareOperation(
+                            op=ast.CompareOperationOp.Eq,
+                            left=ast.Field(chain=[self.table_name, table_field]),
+                            right=ast.Constant(value=value),
+                        )
+
+                        filter_parts.append(filter_expr)
+
+        if len(filter_parts) > 1:
+            return ast.Call(name="and", args=cast(list[ast.Expr], filter_parts))
+        elif len(filter_parts) == 1:
+            return filter_parts[0]
+
+        return None
+
+    def get_date_ranges(self) -> tuple[str, str]:
+        current_date_from = self.runner.query_date_range.date_from_str
+        current_date_to = self.runner.query_date_range.date_to_str
+
+        if self.runner.query_compare_to_date_range:
+            previous_date_from = self.runner.query_compare_to_date_range.date_from_str
+            previous_date_to = self.runner.query_compare_to_date_range.date_to_str
+        else:
+            # If we don't have a previous period, we can just use the same data as the values won't be used
+            # and our query stays simpler.
+            # TODO: Make sure the frontend handles this correctly for every case
+            previous_date_from = current_date_from
+            previous_date_to = current_date_to
+
+        current_period_filter = f"day_bucket >= '{current_date_from}' AND day_bucket <= '{current_date_to}'"
+        previous_period_filter = f"day_bucket >= '{previous_date_from}' AND day_bucket <= '{previous_date_to}'"
+
+        return (previous_period_filter, current_period_filter)

--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -11,6 +11,7 @@ from posthog.hogql.property import (
     get_property_key,
 )
 from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
+from posthog.hogql_queries.web_analytics.stats_table_pre_aggregated import StatsTablePreAggregatedQueryBuilder
 from posthog.hogql_queries.web_analytics.web_analytics_query_runner import (
     WebAnalyticsQueryRunner,
     map_columns,
@@ -34,14 +35,25 @@ class WebStatsTableQueryRunner(WebAnalyticsQueryRunner):
     response: WebStatsTableQueryResponse
     cached_response: CachedWebStatsTableQueryResponse
     paginator: HogQLHasMorePaginator
+    preaggregated_query_builder: StatsTablePreAggregatedQueryBuilder
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.paginator = HogQLHasMorePaginator.from_limit_context(
             limit_context=LimitContext.QUERY, limit=self.query.limit if self.query.limit else None
         )
+        self.preaggregated_query_builder = StatsTablePreAggregatedQueryBuilder(self)
 
     def to_query(self) -> ast.SelectQuery:
+        should_use_preaggregated = (
+            self.modifiers
+            and self.modifiers.useWebAnalyticsPreAggregatedTables
+            and self.preaggregated_query_builder.can_use_preaggregated_tables()
+        )
+
+        if should_use_preaggregated:
+            return self.preaggregated_query_builder.get_query()
+
         if self.query.breakdownBy == WebStatsBreakdown.PAGE:
             if self.query.conversionGoal:
                 return self.to_main_query(self._counts_breakdown_value())

--- a/posthog/hogql_queries/web_analytics/stats_table_pre_aggregated.py
+++ b/posthog/hogql_queries/web_analytics/stats_table_pre_aggregated.py
@@ -1,0 +1,122 @@
+from typing import TYPE_CHECKING, Literal, cast
+
+from posthog.hogql import ast
+from posthog.hogql.parser import parse_select
+from posthog.hogql_queries.web_analytics.pre_aggregated.query_builder import WebAnalyticsPreAggregatedQueryBuilder
+from posthog.schema import WebAnalyticsOrderByDirection, WebAnalyticsOrderByFields, WebStatsBreakdown
+
+if TYPE_CHECKING:
+    from posthog.hogql_queries.web_analytics.stats_table import WebStatsTableQueryRunner
+
+# We can enable more filters here, but keeping the same as web_overview while we test in
+STATS_TABLE_SUPPORTED_FILTERS = {
+    "$host": "host",
+    "$device_type": "device_type",
+    # "$browser": "browser",
+    # "$os": "os",
+    # "$viewport": "viewport",
+    # "$referring_domain": "referring_domain",
+    # "$utm_source": "utm_source",
+    # "$utm_medium": "utm_medium",
+    # "$utm_campaign": "utm_campaign",
+    # "$utm_term": "utm_term",
+    # "$utm_content": "utm_content",
+    # "$country": "country",
+}
+
+
+class StatsTablePreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder):
+    SUPPORTED_BREAKDOWNS = [
+        WebStatsBreakdown.DEVICE_TYPE,
+        WebStatsBreakdown.BROWSER,
+        WebStatsBreakdown.OS,
+        WebStatsBreakdown.VIEWPORT,
+        WebStatsBreakdown.INITIAL_REFERRING_DOMAIN,
+        WebStatsBreakdown.INITIAL_UTM_SOURCE,
+        WebStatsBreakdown.INITIAL_UTM_MEDIUM,
+        WebStatsBreakdown.INITIAL_UTM_CAMPAIGN,
+        WebStatsBreakdown.INITIAL_UTM_TERM,
+        WebStatsBreakdown.INITIAL_UTM_CONTENT,
+        WebStatsBreakdown.COUNTRY,
+    ]
+
+    def __init__(self, runner: "WebStatsTableQueryRunner") -> None:
+        super().__init__(
+            runner=runner, supported_props_filters=STATS_TABLE_SUPPORTED_FILTERS, table_name="web_stats_daily"
+        )
+
+    def can_use_preaggregated_tables(self) -> bool:
+        if not super().can_use_preaggregated_tables():
+            return False
+
+        return self.runner.query.breakdownBy in self.SUPPORTED_BREAKDOWNS
+
+    def get_query(self) -> ast.SelectQuery:
+        previous_period_filter, current_period_filter = self.get_date_ranges()
+        breakdown_field = self._get_breakdown_field()
+        order_by = self._get_order_by()
+
+        query_str = f"""
+        SELECT
+            {breakdown_field} as `context.columns.breakdown_value`,
+            tuple(
+                uniqMergeIf(persons_uniq_state, {current_period_filter}),
+                uniqMergeIf(persons_uniq_state, {previous_period_filter})
+            ) AS `context.columns.visitors`,
+            tuple(
+                sumMergeIf(pageviews_count_state, {current_period_filter}),
+                sumMergeIf(pageviews_count_state, {previous_period_filter})
+            ) as `context.columns.views`
+        FROM web_stats_daily
+        GROUP BY `context.columns.breakdown_value`
+        {order_by}
+        """
+
+        query = cast(ast.SelectQuery, parse_select(query_str))
+
+        filters = self._get_filters()
+        if filters:
+            query.where = filters
+
+        return query
+
+    def _get_order_by(self):
+        if self.runner.query.orderBy:
+            column = None
+            direction: Literal["ASC", "DESC"] = "DESC"
+            field = cast(WebAnalyticsOrderByFields, self.runner.query.orderBy[0])
+            direction = cast(WebAnalyticsOrderByDirection, self.runner.query.orderBy[1]).value
+
+            if field == WebAnalyticsOrderByFields.VISITORS:
+                column = "context.columns.visitors"
+            elif field == WebAnalyticsOrderByFields.VIEWS:
+                column = "context.columns.views"
+
+            if column:
+                return f"{column} {direction}"
+        return ""
+
+    def _get_breakdown_field(self):
+        match self.runner.query.breakdownBy:
+            case WebStatsBreakdown.DEVICE_TYPE:
+                return "device_type"
+            case WebStatsBreakdown.BROWSER:
+                return "browser"
+            case WebStatsBreakdown.OS:
+                return "os"
+            case WebStatsBreakdown.VIEWPORT:
+                return "viewport"
+            case WebStatsBreakdown.INITIAL_REFERRING_DOMAIN:
+                return "referring_domain"
+            case WebStatsBreakdown.INITIAL_UTM_SOURCE:
+                return "utm_source"
+            case WebStatsBreakdown.INITIAL_UTM_MEDIUM:
+                return "utm_medium"
+            case WebStatsBreakdown.INITIAL_UTM_CAMPAIGN:
+                return "utm_campaign"
+            case WebStatsBreakdown.INITIAL_UTM_TERM:
+                return "utm_term"
+            case WebStatsBreakdown.INITIAL_UTM_CONTENT:
+                return "utm_content"
+            case WebStatsBreakdown.COUNTRY:
+                return "country"

--- a/posthog/hogql_queries/web_analytics/web_overview.py
+++ b/posthog/hogql_queries/web_analytics/web_overview.py
@@ -24,6 +24,7 @@ class WebOverviewQueryRunner(WebAnalyticsQueryRunner):
     query: WebOverviewQuery
     response: WebOverviewQueryResponse
     cached_response: CachedWebOverviewQueryResponse
+    preaggregated_query_builder: WebOverviewPreAggregatedQueryBuilder
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/posthog/hogql_queries/web_analytics/web_overview_pre_aggregated.py
+++ b/posthog/hogql_queries/web_analytics/web_overview_pre_aggregated.py
@@ -1,61 +1,26 @@
 from typing import TYPE_CHECKING, cast
-from datetime import datetime, UTC
 
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_select
+from posthog.hogql_queries.web_analytics.pre_aggregated.query_builder import WebAnalyticsPreAggregatedQueryBuilder
 
 if TYPE_CHECKING:
     from posthog.hogql_queries.web_analytics.web_overview import WebOverviewQueryRunner
 
+SUPPORTED_PROPERTIES = {
+    "$host": "host",
+    "$device_type": "device_type",
+}
 
-class WebOverviewPreAggregatedQueryBuilder:
-    # Supported property keys and their mapping to pre-aggregated table fields
-    SUPPORTED_PROPERTIES = {
-        "$host": "host",
-        "$device_type": "device_type",
-    }
 
+class WebOverviewPreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder):
     def __init__(self, runner: "WebOverviewQueryRunner") -> None:
-        self.runner = runner
-
-    def can_use_preaggregated_tables(self) -> bool:
-        query = self.runner.query
-
-        # Only works for properties we know are in the pre-aggregated tables
-        for prop in query.properties:
-            if hasattr(prop, "key") and prop.key not in self.SUPPORTED_PROPERTIES:
-                return False
-
-        if query.conversionGoal:
-            return False
-
-        # Only work for fixed-dates that don't include current-date in the filters.
-        today = datetime.now(UTC).date()
-        if self.runner.query_date_range.date_to().date() >= today:
-            return False
-
-        return True
+        super().__init__(runner, supported_props_filters=SUPPORTED_PROPERTIES, table_name="web_overview_daily")
 
     def get_query(self) -> ast.SelectQuery:
-        current_date_from = self.runner.query_date_range.date_from_str
-        current_date_to = self.runner.query_date_range.date_to_str
+        previous_period_filter, current_period_filter = self.get_date_ranges()
 
-        # Handle previous period
-        if self.runner.query_compare_to_date_range:
-            previous_date_from = self.runner.query_compare_to_date_range.date_from_str
-            previous_date_to = self.runner.query_compare_to_date_range.date_to_str
-        else:
-            # If we don't have a previous period, we can just use the same data as the values won't be used
-            # and our query stays simpler.
-            previous_date_from = current_date_from
-            previous_date_to = current_date_from
-
-        # Define date filter conditions first
-        current_period_filter = f"day_bucket >= '{current_date_from}' AND day_bucket <= '{current_date_to}'"
-        previous_period_filter = f"day_bucket >= '{previous_date_from}' AND day_bucket <= '{previous_date_to}'"
-
-        # Define common query patterns for averages over sessions
-        def safe_avg_calc(metric, period_filter):
+        def safe_avg_sessions(metric, period_filter):
             sessions = f"uniqMergeIf(sessions_uniq_state, {period_filter})"
             return f"""
             if(
@@ -75,11 +40,11 @@ class WebOverviewPreAggregatedQueryBuilder:
             uniqMergeIf(sessions_uniq_state, {current_period_filter}) AS unique_sessions,
             uniqMergeIf(sessions_uniq_state, {previous_period_filter}) AS previous_unique_sessions,
 
-            {safe_avg_calc("total_session_duration", current_period_filter)} AS avg_session_duration,
-            {safe_avg_calc("total_session_duration", previous_period_filter)} AS previous_avg_session_duration,
+            {safe_avg_sessions("total_session_duration", current_period_filter)} AS avg_session_duration,
+            {safe_avg_sessions("total_session_duration", previous_period_filter)} AS previous_avg_session_duration,
 
-            {safe_avg_calc("total_bounces", current_period_filter)} AS bounce_rate,
-            {safe_avg_calc("total_bounces", previous_period_filter)} AS previous_bounce_rate,
+            {safe_avg_sessions("total_bounces", current_period_filter)} AS bounce_rate,
+            {safe_avg_sessions("total_bounces", previous_period_filter)} AS previous_bounce_rate,
 
             NULL AS revenue,
             NULL AS previous_revenue
@@ -93,50 +58,3 @@ class WebOverviewPreAggregatedQueryBuilder:
             query.where = filters
 
         return query
-
-    # We can probably use the hogql general filters somehow but it was not working by default and it was a lot of moving parts to debug at once so
-    # TODO: come back to this later to make sure we're not overcomplicating things
-    def _get_filters(self):
-        """Generate property filters for pre-aggregated tables"""
-        if not self.runner.query.properties:
-            return None
-
-        # Build filter expressions
-        filter_parts = []
-
-        # Only process properties that we know how to map to pre-aggregated tables
-        for posthog_field, table_field in self.SUPPORTED_PROPERTIES.items():
-            for prop in self.runner.query.properties:
-                if hasattr(prop, "key") and prop.key == posthog_field and hasattr(prop, "value"):
-                    value = prop.value
-
-                    # Extract ID if present
-                    if value is not None and hasattr(value, "id"):
-                        value = value.id
-
-                    # The device_type input differs between "Desktop" | ["Mobile", "Tablet"]
-                    if isinstance(value, list):
-                        values = [v.id if v is not None and hasattr(v, "id") else v for v in value]
-                        filter_expr = ast.CompareOperation(
-                            op=ast.CompareOperationOp.In,
-                            left=ast.Field(chain=["web_overview_daily", table_field]),
-                            right=ast.Tuple(exprs=[ast.Constant(value=v) for v in values]),
-                        )
-
-                        filter_parts.append(filter_expr)
-                    else:
-                        filter_expr = ast.CompareOperation(
-                            op=ast.CompareOperationOp.Eq,
-                            left=ast.Field(chain=["web_overview_daily", table_field]),
-                            right=ast.Constant(value=value),
-                        )
-
-                        filter_parts.append(filter_expr)
-
-        # If we have multiple filters, combine with AND
-        if len(filter_parts) > 1:
-            return ast.Call(name="and", args=cast(list[ast.Expr], filter_parts))
-        elif len(filter_parts) == 1:
-            return filter_parts[0]
-
-        return None

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -476,6 +476,8 @@ def is_truthy_or_falsy_property_value(value: Any) -> bool:
     )
 
 
+# Note: Any changes to this function need to be reflected in the rust version
+# rust/feature-flags/src/properties/relative_date.rs
 def relative_date_parse_for_feature_flag_matching(value: str) -> Optional[datetime.datetime]:
     regex = r"^-?(?P<number>[0-9]+)(?P<interval>[a-z])$"
     match = re.search(regex, value)

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1112,7 +1112,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -2418,6 +2418,7 @@ dependencies = [
  "sha1",
  "sqlx",
  "strum",
+ "test-case",
  "thiserror 1.0.69",
  "tokio",
  "tower",
@@ -6880,6 +6881,39 @@ name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+ "test-case-core",
+]
 
 [[package]]
 name = "thiserror"

--- a/rust/feature-flags/Cargo.toml
+++ b/rust/feature-flags/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow = { workspace = true }
 axum = { workspace = true }
 axum-client-ip = { workspace = true }
-chrono = { workspace = true }
+chrono = { workspace = true, features = ["serde"] }
 common-cookieless = { path = "../common/cookieless" }
 common-database = { path = "../common/database" }
 common-redis = { path = "../common/redis" }
@@ -56,8 +56,8 @@ percent-encoding = "2.3.1"
 workspace = true
 
 [dev-dependencies]
-
 rstest = "0.25.0"
 assert-json-diff = { workspace = true }
 reqwest = { workspace = true }
 futures = "0.3.30"
+test-case = "3.3.1"

--- a/rust/feature-flags/src/properties/mod.rs
+++ b/rust/feature-flags/src/properties/mod.rs
@@ -1,2 +1,3 @@
 pub mod property_matching;
 pub mod property_models;
+pub mod relative_date;

--- a/rust/feature-flags/src/properties/relative_date.rs
+++ b/rust/feature-flags/src/properties/relative_date.rs
@@ -1,0 +1,503 @@
+use chrono::{DateTime, Datelike, Duration, TimeZone, Timelike, Utc};
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+// Compile regex once at startup
+static RELATIVE_DATE_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"^-?(?P<number>[0-9]+)(?P<interval>[hdwmy])$").expect("Invalid regex pattern")
+});
+
+/// Parse a relative date string like "-3d", "3d", "-3h", etc.
+/// Returns None if the string doesn't match the expected format or if the number is too large.
+///
+/// This implementation matches Python's behavior using relativedelta:
+/// - Hours and days use fixed durations
+/// - Weeks are 7 days
+/// - Months and years use calendar-aware calculations
+///
+/// # Examples
+/// ```
+/// use chrono::Utc;
+/// use feature_flags::properties::relative_date::parse_relative_date;
+///
+/// let now = Utc::now();
+/// let three_days_ago = parse_relative_date("-3d").unwrap();
+/// assert!(three_days_ago < now);
+/// ```
+pub fn parse_relative_date(date_str: &str) -> Option<DateTime<Utc>> {
+    parse_relative_date_with_now(date_str, Utc::now())
+}
+
+/// Internal function that takes a specific "now" time for testing
+fn parse_relative_date_with_now(date_str: &str, now: DateTime<Utc>) -> Option<DateTime<Utc>> {
+    let captures = RELATIVE_DATE_REGEX.captures(date_str)?;
+
+    let number: i64 = captures.name("number")?.as_str().parse().ok()?;
+    if number >= 10_000 {
+        // Guard against overflow, disallow numbers greater than 10_000
+        return None;
+    }
+
+    let interval = captures.name("interval")?.as_str();
+
+    match interval {
+        "h" => Some(now - Duration::hours(number)),
+        "d" => Some(now - Duration::days(number)),
+        "w" => Some(now - Duration::weeks(number)),
+        "m" => {
+            // Calendar-aware month calculation
+            let mut result = now;
+            for _ in 0..number {
+                // Go back one month, preserving the day if possible
+                let day = result.day();
+                let month = result.month();
+                let year = result.year();
+
+                // Calculate previous month
+                let (prev_year, prev_month) = if month == 1 {
+                    (year - 1, 12)
+                } else {
+                    (year, month - 1)
+                };
+
+                // Get the last day of the previous month
+                let last_day = if prev_month == 2 {
+                    if prev_year % 4 == 0 && (prev_year % 100 != 0 || prev_year % 400 == 0) {
+                        29 // Leap year
+                    } else {
+                        28 // Non-leap year
+                    }
+                } else if [4, 6, 9, 11].contains(&prev_month) {
+                    30
+                } else {
+                    31
+                };
+
+                // Use the minimum of the original day and the last day of the previous month
+                let new_day = day.min(last_day);
+                result = Utc
+                    .with_ymd_and_hms(
+                        prev_year,
+                        prev_month,
+                        new_day,
+                        result.hour(),
+                        result.minute(),
+                        result.second(),
+                    )
+                    .unwrap()
+                    .with_nanosecond(result.nanosecond())
+                    .unwrap();
+            }
+            Some(result)
+        }
+        "y" => {
+            // Calendar-aware year calculation
+            let mut result = now;
+            for _ in 0..number {
+                let year = result.year() - 1;
+                let month = result.month();
+                let day = result.day();
+
+                // Handle February 29 in leap years
+                let new_day = if month == 2 && day == 29 {
+                    if year % 4 == 0 && (year % 100 != 0 || year % 400 == 0) {
+                        29 // Leap year
+                    } else {
+                        28 // Non-leap year
+                    }
+                } else {
+                    day
+                };
+
+                result = Utc
+                    .with_ymd_and_hms(
+                        year,
+                        month,
+                        new_day,
+                        result.hour(),
+                        result.minute(),
+                        result.second(),
+                    )
+                    .unwrap()
+                    .with_nanosecond(result.nanosecond())
+                    .unwrap();
+            }
+            Some(result)
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+    use test_case::test_case;
+
+    // Helper function to parse relative date with a fixed "now" time
+    fn parse_relative_date_fixed(date_str: &str, now: DateTime<Utc>) -> Option<DateTime<Utc>> {
+        parse_relative_date_with_now(date_str, now)
+    }
+
+    #[test_case("-3d" => true; "negative days")]
+    #[test_case("3d" => true; "positive days")]
+    #[test_case("-3h" => true; "negative hours")]
+    #[test_case("3h" => true; "positive hours")]
+    #[test_case("-3w" => true; "negative weeks")]
+    #[test_case("3w" => true; "positive weeks")]
+    #[test_case("-3m" => true; "negative months")]
+    #[test_case("3m" => true; "positive months")]
+    #[test_case("-3y" => true; "negative years")]
+    #[test_case("3y" => true; "positive years")]
+    #[test_case("invalid" => false; "invalid format")]
+    #[test_case("3x" => false; "invalid interval")]
+    #[test_case("100000d" => false; "too large number")]
+    fn test_parse_relative_date_validity(input: &str) -> bool {
+        parse_relative_date(input).is_some()
+    }
+
+    #[test]
+    fn test_invalid_input() {
+        let now = Utc
+            .with_ymd_and_hms(2020, 1, 1, 12, 1, 20)
+            .unwrap()
+            .with_nanosecond(134000000)
+            .unwrap();
+
+        // Test various invalid inputs
+        assert!(parse_relative_date_fixed("1", now).is_none());
+        assert!(parse_relative_date_fixed("1x", now).is_none());
+        assert!(parse_relative_date_fixed("1.2y", now).is_none());
+        assert!(parse_relative_date_fixed("1z", now).is_none());
+        assert!(parse_relative_date_fixed("1s", now).is_none());
+        assert!(parse_relative_date_fixed("123344000.134m", now).is_none());
+        assert!(parse_relative_date_fixed("bazinga", now).is_none());
+        assert!(parse_relative_date_fixed("000bello", now).is_none());
+        assert!(parse_relative_date_fixed("000hello", now).is_none());
+
+        // Valid inputs with leading zeros
+        assert!(parse_relative_date_fixed("000h", now).is_some());
+        assert!(parse_relative_date_fixed("1000h", now).is_some());
+    }
+
+    #[test]
+    fn test_overflow() {
+        let now = Utc
+            .with_ymd_and_hms(2020, 1, 1, 12, 1, 20)
+            .unwrap()
+            .with_nanosecond(134000000)
+            .unwrap();
+
+        assert!(parse_relative_date_fixed("1000000h", now).is_none());
+        assert!(parse_relative_date_fixed("100000000000000000y", now).is_none());
+    }
+
+    #[test]
+    fn test_hour_parsing() {
+        let now = Utc
+            .with_ymd_and_hms(2020, 1, 1, 12, 1, 20)
+            .unwrap()
+            .with_nanosecond(134000000)
+            .unwrap();
+
+        assert_eq!(
+            parse_relative_date_fixed("1h", now).unwrap(),
+            Utc.with_ymd_and_hms(2020, 1, 1, 11, 1, 20)
+                .unwrap()
+                .with_nanosecond(134000000)
+                .unwrap()
+        );
+        assert_eq!(
+            parse_relative_date_fixed("2h", now).unwrap(),
+            Utc.with_ymd_and_hms(2020, 1, 1, 10, 1, 20)
+                .unwrap()
+                .with_nanosecond(134000000)
+                .unwrap()
+        );
+        assert_eq!(
+            parse_relative_date_fixed("24h", now).unwrap(),
+            Utc.with_ymd_and_hms(2019, 12, 31, 12, 1, 20)
+                .unwrap()
+                .with_nanosecond(134000000)
+                .unwrap()
+        );
+        assert_eq!(
+            parse_relative_date_fixed("30h", now).unwrap(),
+            Utc.with_ymd_and_hms(2019, 12, 31, 6, 1, 20)
+                .unwrap()
+                .with_nanosecond(134000000)
+                .unwrap()
+        );
+        assert_eq!(
+            parse_relative_date_fixed("48h", now).unwrap(),
+            Utc.with_ymd_and_hms(2019, 12, 30, 12, 1, 20)
+                .unwrap()
+                .with_nanosecond(134000000)
+                .unwrap()
+        );
+
+        // 24h should equal 1d
+        assert_eq!(
+            parse_relative_date_fixed("24h", now).unwrap(),
+            parse_relative_date_fixed("1d", now).unwrap()
+        );
+        // 48h should equal 2d
+        assert_eq!(
+            parse_relative_date_fixed("48h", now).unwrap(),
+            parse_relative_date_fixed("2d", now).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_day_parsing() {
+        let now = Utc
+            .with_ymd_and_hms(2020, 1, 1, 12, 1, 20)
+            .unwrap()
+            .with_nanosecond(134000000)
+            .unwrap();
+
+        assert_eq!(
+            parse_relative_date_fixed("1d", now).unwrap(),
+            Utc.with_ymd_and_hms(2019, 12, 31, 12, 1, 20)
+                .unwrap()
+                .with_nanosecond(134000000)
+                .unwrap()
+        );
+        assert_eq!(
+            parse_relative_date_fixed("2d", now).unwrap(),
+            Utc.with_ymd_and_hms(2019, 12, 30, 12, 1, 20)
+                .unwrap()
+                .with_nanosecond(134000000)
+                .unwrap()
+        );
+        assert_eq!(
+            parse_relative_date_fixed("7d", now).unwrap(),
+            Utc.with_ymd_and_hms(2019, 12, 25, 12, 1, 20)
+                .unwrap()
+                .with_nanosecond(134000000)
+                .unwrap()
+        );
+        assert_eq!(
+            parse_relative_date_fixed("14d", now).unwrap(),
+            Utc.with_ymd_and_hms(2019, 12, 18, 12, 1, 20)
+                .unwrap()
+                .with_nanosecond(134000000)
+                .unwrap()
+        );
+        assert_eq!(
+            parse_relative_date_fixed("30d", now).unwrap(),
+            Utc.with_ymd_and_hms(2019, 12, 2, 12, 1, 20)
+                .unwrap()
+                .with_nanosecond(134000000)
+                .unwrap()
+        );
+
+        // 7d should equal 1w
+        assert_eq!(
+            parse_relative_date_fixed("7d", now).unwrap(),
+            parse_relative_date_fixed("1w", now).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_week_parsing() {
+        let now = Utc
+            .with_ymd_and_hms(2020, 1, 1, 12, 1, 20)
+            .unwrap()
+            .with_nanosecond(134000000)
+            .unwrap();
+
+        assert_eq!(
+            parse_relative_date_fixed("1w", now).unwrap(),
+            Utc.with_ymd_and_hms(2019, 12, 25, 12, 1, 20)
+                .unwrap()
+                .with_nanosecond(134000000)
+                .unwrap()
+        );
+        assert_eq!(
+            parse_relative_date_fixed("2w", now).unwrap(),
+            Utc.with_ymd_and_hms(2019, 12, 18, 12, 1, 20)
+                .unwrap()
+                .with_nanosecond(134000000)
+                .unwrap()
+        );
+        assert_eq!(
+            parse_relative_date_fixed("4w", now).unwrap(),
+            Utc.with_ymd_and_hms(2019, 12, 4, 12, 1, 20)
+                .unwrap()
+                .with_nanosecond(134000000)
+                .unwrap()
+        );
+        assert_eq!(
+            parse_relative_date_fixed("8w", now).unwrap(),
+            Utc.with_ymd_and_hms(2019, 11, 6, 12, 1, 20)
+                .unwrap()
+                .with_nanosecond(134000000)
+                .unwrap()
+        );
+
+        // Test month and year relationships
+        assert_eq!(
+            parse_relative_date_fixed("1m", now).unwrap(),
+            Utc.with_ymd_and_hms(2019, 12, 1, 12, 1, 20)
+                .unwrap()
+                .with_nanosecond(134000000)
+                .unwrap()
+        );
+        assert_ne!(
+            parse_relative_date_fixed("4w", now).unwrap(),
+            parse_relative_date_fixed("1m", now).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_month_parsing() {
+        // Test from January
+        let now = Utc
+            .with_ymd_and_hms(2020, 1, 1, 12, 1, 20)
+            .unwrap()
+            .with_nanosecond(134000000)
+            .unwrap();
+
+        assert_eq!(
+            parse_relative_date_fixed("1m", now).unwrap(),
+            Utc.with_ymd_and_hms(2019, 12, 1, 12, 1, 20)
+                .unwrap()
+                .with_nanosecond(134000000)
+                .unwrap()
+        );
+        assert_eq!(
+            parse_relative_date_fixed("2m", now).unwrap(),
+            Utc.with_ymd_and_hms(2019, 11, 1, 12, 1, 20)
+                .unwrap()
+                .with_nanosecond(134000000)
+                .unwrap()
+        );
+        assert_eq!(
+            parse_relative_date_fixed("4m", now).unwrap(),
+            Utc.with_ymd_and_hms(2019, 9, 1, 12, 1, 20)
+                .unwrap()
+                .with_nanosecond(134000000)
+                .unwrap()
+        );
+        assert_eq!(
+            parse_relative_date_fixed("8m", now).unwrap(),
+            Utc.with_ymd_and_hms(2019, 5, 1, 12, 1, 20)
+                .unwrap()
+                .with_nanosecond(134000000)
+                .unwrap()
+        );
+
+        // Test year relationships
+        assert_eq!(
+            parse_relative_date_fixed("1y", now).unwrap(),
+            Utc.with_ymd_and_hms(2019, 1, 1, 12, 1, 20)
+                .unwrap()
+                .with_nanosecond(134000000)
+                .unwrap()
+        );
+        assert_eq!(
+            parse_relative_date_fixed("12m", now).unwrap(),
+            parse_relative_date_fixed("1y", now).unwrap()
+        );
+
+        // Test from April
+        let now = Utc.with_ymd_and_hms(2020, 4, 3, 0, 0, 0).unwrap();
+
+        assert_eq!(
+            parse_relative_date_fixed("1m", now).unwrap(),
+            Utc.with_ymd_and_hms(2020, 3, 3, 0, 0, 0).unwrap()
+        );
+        assert_eq!(
+            parse_relative_date_fixed("2m", now).unwrap(),
+            Utc.with_ymd_and_hms(2020, 2, 3, 0, 0, 0).unwrap()
+        );
+        assert_eq!(
+            parse_relative_date_fixed("4m", now).unwrap(),
+            Utc.with_ymd_and_hms(2019, 12, 3, 0, 0, 0).unwrap()
+        );
+        assert_eq!(
+            parse_relative_date_fixed("8m", now).unwrap(),
+            Utc.with_ymd_and_hms(2019, 8, 3, 0, 0, 0).unwrap()
+        );
+
+        // Test year relationships from April
+        assert_eq!(
+            parse_relative_date_fixed("1y", now).unwrap(),
+            Utc.with_ymd_and_hms(2019, 4, 3, 0, 0, 0).unwrap()
+        );
+        assert_eq!(
+            parse_relative_date_fixed("12m", now).unwrap(),
+            parse_relative_date_fixed("1y", now).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_year_parsing() {
+        let now = Utc
+            .with_ymd_and_hms(2020, 1, 1, 12, 1, 20)
+            .unwrap()
+            .with_nanosecond(134000000)
+            .unwrap();
+
+        assert_eq!(
+            parse_relative_date_fixed("1y", now).unwrap(),
+            Utc.with_ymd_and_hms(2019, 1, 1, 12, 1, 20)
+                .unwrap()
+                .with_nanosecond(134000000)
+                .unwrap()
+        );
+        assert_eq!(
+            parse_relative_date_fixed("2y", now).unwrap(),
+            Utc.with_ymd_and_hms(2018, 1, 1, 12, 1, 20)
+                .unwrap()
+                .with_nanosecond(134000000)
+                .unwrap()
+        );
+        assert_eq!(
+            parse_relative_date_fixed("4y", now).unwrap(),
+            Utc.with_ymd_and_hms(2016, 1, 1, 12, 1, 20)
+                .unwrap()
+                .with_nanosecond(134000000)
+                .unwrap()
+        );
+        assert_eq!(
+            parse_relative_date_fixed("8y", now).unwrap(),
+            Utc.with_ymd_and_hms(2012, 1, 1, 12, 1, 20)
+                .unwrap()
+                .with_nanosecond(134000000)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_edge_cases() {
+        // Test month boundaries
+        let now = Utc.with_ymd_and_hms(2020, 3, 31, 12, 0, 0).unwrap();
+        assert_eq!(
+            parse_relative_date_fixed("1m", now).unwrap(),
+            Utc.with_ymd_and_hms(2020, 2, 29, 12, 0, 0).unwrap() // Leap year
+        );
+
+        let now = Utc.with_ymd_and_hms(2019, 3, 31, 12, 0, 0).unwrap();
+        assert_eq!(
+            parse_relative_date_fixed("1m", now).unwrap(),
+            Utc.with_ymd_and_hms(2019, 2, 28, 12, 0, 0).unwrap() // Non-leap year
+        );
+
+        // Test year boundaries
+        let now = Utc.with_ymd_and_hms(2020, 2, 29, 12, 0, 0).unwrap();
+        assert_eq!(
+            parse_relative_date_fixed("1y", now).unwrap(),
+            Utc.with_ymd_and_hms(2019, 2, 28, 12, 0, 0).unwrap() // Non-leap year
+        );
+
+        // Test large numbers
+        let now = Utc.with_ymd_and_hms(2020, 1, 1, 12, 0, 0).unwrap();
+        assert!(parse_relative_date_fixed("9999d", now).is_some());
+        assert!(parse_relative_date_fixed("9999h", now).is_some());
+        assert!(parse_relative_date_fixed("9999w", now).is_some());
+        assert!(parse_relative_date_fixed("9999m", now).is_some());
+        assert!(parse_relative_date_fixed("9999y", now).is_some());
+    }
+}


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

If an ingestion restriction is only forcing events to overflow, the project notice is too heavy handed. Only show it when the restriction is either dropping events or skipping person processing.

## Changes

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Tested locally by applying different restriction tokens to my account through django admin, and ensuring the banner only shows up when a skip person processing or drop events token is in place.
