### PR TITLE
feat: Added requeue method for onevent processor

### DIFF
--- a/plugin-server/src/cdp/consumers/cdp-legacy-event.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-legacy-event.consumer.ts
@@ -1,10 +1,12 @@
 import { Message } from 'node-rdkafka'
 
 import { KAFKA_EVENTS_JSON } from '../../config/kafka-topics'
+import { parseKafkaHeaders } from '../../kafka/consumer'
 import { runInstrumentedFunction } from '../../main/utils'
 import { Hub, ISOTimestamp, PostIngestionEvent, ProjectId, RawClickHouseEvent } from '../../types'
 import { parseJSON } from '../../utils/json-parse'
 import { logger } from '../../utils/logger'
+import { PromiseScheduler } from '../../utils/promise-scheduler'
 import { runOnEvent } from '../../worker/plugins/run'
 import { HogFunctionInvocation, HogFunctionInvocationGlobals } from '../types'
 import { convertToHogFunctionInvocationGlobals } from '../utils'
@@ -17,6 +19,7 @@ import { CdpEventsConsumer, counterParseError } from './cdp-events.consumer'
  */
 export class CdpLegacyEventsConsumer extends CdpEventsConsumer {
     protected name = 'CdpLegacyEventsConsumer'
+    protected promiseScheduler = new PromiseScheduler()
 
     constructor(hub: Hub) {
         super(hub, KAFKA_EVENTS_JSON, 'clickhouse-plugin-server-async-onevent')
@@ -47,22 +50,17 @@ export class CdpLegacyEventsConsumer extends CdpEventsConsumer {
     public async processBatch(
         invocationGlobals: HogFunctionInvocationGlobals[]
     ): Promise<{ backgroundTask: Promise<any>; invocations: HogFunctionInvocation[] }> {
-        if (!invocationGlobals.length) {
-            return { backgroundTask: Promise.resolve(), invocations: [] }
+        if (invocationGlobals.length) {
+            await Promise.all(
+                invocationGlobals.map((x) => {
+                    return this.runInstrumented('cdpLegacyEventsConsumer.processEvent', () => this.processEvent(x))
+                })
+            )
         }
-
-        await Promise.all(
-            invocationGlobals.map((x) => {
-                return this.runInstrumented('cdpLegacyEventsConsumer.processEvent', () => this.processEvent(x))
-            })
-        )
-
-        // NOTE: We _could_ consider moving this to a background task to improve throughput with a max concurrency of 2 for example
-        // but we should avoid it if possible
 
         return {
             // This is all IO so we can set them off in the background and start processing the next batch
-            backgroundTask: Promise.resolve(),
+            backgroundTask: this.promiseScheduler.waitForAll(),
             invocations: [],
         }
     }
@@ -90,6 +88,13 @@ export class CdpLegacyEventsConsumer extends CdpEventsConsumer {
                                 if (pluginConfigs.length === 0) {
                                     return
                                 }
+
+                                if (this.hub.CDP_LEGACY_EVENT_REDIRECT_TOPIC) {
+                                    void this.promiseScheduler.schedule(this.emitToReplicaTopic([message]))
+
+                                    return
+                                }
+
                                 events.push(
                                     convertToHogFunctionInvocationGlobals(
                                         clickHouseEvent,
@@ -106,6 +111,24 @@ export class CdpLegacyEventsConsumer extends CdpEventsConsumer {
 
                     return events
                 },
+            })
+        )
+    }
+
+    private async emitToReplicaTopic(kafkaMessages: Message[]) {
+        const redirectTopic = this.hub.CDP_LEGACY_EVENT_REDIRECT_TOPIC
+        if (!redirectTopic) {
+            throw new Error('No redirect topic configured')
+        }
+
+        await Promise.all(
+            kafkaMessages.map((message) => {
+                return this.kafkaProducer!.produce({
+                    topic: redirectTopic,
+                    value: message.value,
+                    key: message.key ?? null,
+                    headers: parseKafkaHeaders(message.headers),
+                })
             })
         )
     }

--- a/plugin-server/src/cdp/consumers/cdp-legacy-event.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-legacy-event.consumer.ts
@@ -1,6 +1,5 @@
 import { Message } from 'node-rdkafka'
 
-import { KAFKA_EVENTS_JSON } from '../../config/kafka-topics'
 import { parseKafkaHeaders } from '../../kafka/consumer'
 import { runInstrumentedFunction } from '../../main/utils'
 import { Hub, ISOTimestamp, PostIngestionEvent, ProjectId, RawClickHouseEvent } from '../../types'

--- a/plugin-server/src/cdp/consumers/cdp-legacy-event.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-legacy-event.consumer.ts
@@ -22,7 +22,7 @@ export class CdpLegacyEventsConsumer extends CdpEventsConsumer {
     protected promiseScheduler = new PromiseScheduler()
 
     constructor(hub: Hub) {
-        super(hub, KAFKA_EVENTS_JSON, 'clickhouse-plugin-server-async-onevent')
+        super(hub, hub.CDP_LEGACY_EVENT_CONSUMER_TOPIC, hub.CDP_LEGACY_EVENT_CONSUMER_GROUP_ID)
 
         logger.info('🔁', `CdpLegacyEventsConsumer setup`, {
             pluginConfigs: Array.from(this.hub.pluginConfigsPerTeam.keys()),

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -196,6 +196,8 @@ export function getDefaultConfig(): PluginsServerConfig {
         CDP_FETCH_BACKOFF_BASE_MS: 1000,
         CDP_FETCH_BACKOFF_MAX_MS: 30000,
 
+        CDP_LEGACY_EVENT_CONSUMER_GROUP_ID: 'clickhouse-plugin-server-async-onevent',
+        CDP_LEGACY_EVENT_CONSUMER_TOPIC: KAFKA_EVENTS_JSON,
         CDP_LEGACY_EVENT_REDIRECT_TOPIC: '',
 
         // Destination Migration Diffing

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -196,6 +196,8 @@ export function getDefaultConfig(): PluginsServerConfig {
         CDP_FETCH_BACKOFF_BASE_MS: 1000,
         CDP_FETCH_BACKOFF_MAX_MS: 30000,
 
+        CDP_LEGACY_EVENT_REDIRECT_TOPIC: '',
+
         // Destination Migration Diffing
         DESTINATION_MIGRATION_DIFFING_ENABLED: false,
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -110,6 +110,8 @@ export type CdpConfig = {
     CDP_CYCLOTRON_JOB_QUEUE_PRODUCER_TEAM_MAPPING: string // Like the above but with a team check too
     CDP_CYCLOTRON_JOB_QUEUE_PRODUCER_FORCE_SCHEDULED_TO_POSTGRES: boolean // If true then scheduled jobs will be routed to postgres even if they are mapped to kafka
 
+    CDP_LEGACY_EVENT_CONSUMER_GROUP_ID: string
+    CDP_LEGACY_EVENT_CONSUMER_TOPIC: string
     CDP_LEGACY_EVENT_REDIRECT_TOPIC: string // If set then this consumer will emit to this topic instead of processing
 
     CDP_CYCLOTRON_BATCH_SIZE: number

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -110,6 +110,8 @@ export type CdpConfig = {
     CDP_CYCLOTRON_JOB_QUEUE_PRODUCER_TEAM_MAPPING: string // Like the above but with a team check too
     CDP_CYCLOTRON_JOB_QUEUE_PRODUCER_FORCE_SCHEDULED_TO_POSTGRES: boolean // If true then scheduled jobs will be routed to postgres even if they are mapped to kafka
 
+    CDP_LEGACY_EVENT_REDIRECT_TOPIC: string // If set then this consumer will emit to this topic instead of processing
+
     CDP_CYCLOTRON_BATCH_SIZE: number
     CDP_CYCLOTRON_BATCH_DELAY_MS: number
     CDP_CYCLOTRON_INSERT_MAX_BATCH_SIZE: number

--- a/plugin-server/src/utils/promise-scheduler.ts
+++ b/plugin-server/src/utils/promise-scheduler.ts
@@ -1,0 +1,13 @@
+export class PromiseScheduler {
+    public readonly promises: Set<Promise<any>> = new Set()
+
+    public schedule<T>(promise: Promise<T>): Promise<T> {
+        this.promises.add(promise)
+        void promise.finally(() => this.promises.delete(promise))
+        return promise
+    }
+
+    public async waitForAll() {
+        await Promise.all(this.promises)
+    }
+}


### PR DESCRIPTION
## Problem

Prepped if we need it. Would allow us to run the consumer in a different processing mode with a different topic /consumer group ID

## Changes

* As on tin

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
