### PR TITLE
feat: link to changelog not npm docs

### DIFF
--- a/frontend/src/lib/components/VersionChecker/VersionCheckerBanner.tsx
+++ b/frontend/src/lib/components/VersionChecker/VersionCheckerBanner.tsx
@@ -18,8 +18,8 @@ export function VersionCheckerBanner(): JSX.Element | null {
             type={versionWarning.level}
             dismissKey={dismissKey}
             action={{
-                children: 'Update now',
-                to: 'https://posthog.com/docs/libraries/js#option-2-install-via-npm',
+                children: 'View the changelog',
+                to: 'https://github.com/PostHog/posthog-js/blob/main/CHANGELOG.md',
                 targetBlank: true,
             }}
             className="mb-4"


### PR DESCRIPTION
when we show you the version checker banner we link to the docs on installing via NPM as the action

but you probably already know how to do that, since that's how you got an old version in production

instead, let's link to the changelog so you can see what you're missing