### PR TITLE
fix(ingestion): only shows restriction msg if dropping data

### DIFF
--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -123,12 +123,11 @@ export const navigationLogic = kea<navigationLogicType>([
                     return 'internet_connection_issue'
                 } else if (user?.is_impersonated) {
                     return 'is_impersonated'
-                    /*} else if (currentTeam?.is_demo && !preflight?.demo) {
+                } else if (currentTeam?.is_demo && !preflight?.demo) {
                     // If the project is a demo one, show a project-level warning
                     // Don't show this project-level warning in the PostHog demo environemnt though,
                     // as then Announcement is shown instance-wide
                     return 'demo_project'
-                */
                 } else if (!user?.is_email_verified && !user?.has_social_auth && preflight?.email_service_available) {
                     return 'unverified_email'
                 } else if (

--- a/frontend/src/layout/navigation/navigationLogic.ts
+++ b/frontend/src/layout/navigation/navigationLogic.ts
@@ -104,7 +104,7 @@ export const navigationLogic = kea<navigationLogicType>([
                 s.memberCount,
                 apiStatusLogic.selectors.internetConnectionIssue,
                 s.projectNoticesAcknowledged,
-                eventIngestionRestrictionLogic.selectors.hasAnyRestriction,
+                eventIngestionRestrictionLogic.selectors.hasProjectNoticeRestriction,
             ],
             (
                 organization,
@@ -123,11 +123,12 @@ export const navigationLogic = kea<navigationLogicType>([
                     return 'internet_connection_issue'
                 } else if (user?.is_impersonated) {
                     return 'is_impersonated'
-                } else if (currentTeam?.is_demo && !preflight?.demo) {
+                    /*} else if (currentTeam?.is_demo && !preflight?.demo) {
                     // If the project is a demo one, show a project-level warning
                     // Don't show this project-level warning in the PostHog demo environemnt though,
                     // as then Announcement is shown instance-wide
                     return 'demo_project'
+                */
                 } else if (!user?.is_email_verified && !user?.has_social_auth && preflight?.email_service_available) {
                     return 'unverified_email'
                 } else if (

--- a/frontend/src/lib/logic/eventIngestionRestrictionLogic.test.ts
+++ b/frontend/src/lib/logic/eventIngestionRestrictionLogic.test.ts
@@ -40,7 +40,53 @@ describe('eventIngestionRestrictionLogic', () => {
                         distinct_ids: ['user1', 'user2'],
                     },
                 ],
-                hasAnyRestriction: true,
+                hasProjectNoticeRestriction: true,
+            })
+    })
+
+    it('handles SKIP_PERSON_PROCESSING restriction', async () => {
+        jest.spyOn(api, 'get').mockResolvedValue([
+            {
+                restriction_type: RestrictionType.SKIP_PERSON_PROCESSING,
+                distinct_ids: ['user3'],
+            },
+        ])
+
+        logic.mount()
+
+        await expectLogic(logic)
+            .toDispatchActions(['loadEventIngestionRestrictions', 'loadEventIngestionRestrictionsSuccess'])
+            .toMatchValues({
+                eventIngestionRestrictions: [
+                    {
+                        restriction_type: RestrictionType.SKIP_PERSON_PROCESSING,
+                        distinct_ids: ['user3'],
+                    },
+                ],
+                hasProjectNoticeRestriction: true,
+            })
+    })
+
+    it('handles FORCE_OVERFLOW_FROM_INGESTION restriction (should not trigger project notice)', async () => {
+        jest.spyOn(api, 'get').mockResolvedValue([
+            {
+                restriction_type: RestrictionType.FORCE_OVERFLOW_FROM_INGESTION,
+                distinct_ids: ['user4'],
+            },
+        ])
+
+        logic.mount()
+
+        await expectLogic(logic)
+            .toDispatchActions(['loadEventIngestionRestrictions', 'loadEventIngestionRestrictionsSuccess'])
+            .toMatchValues({
+                eventIngestionRestrictions: [
+                    {
+                        restriction_type: RestrictionType.FORCE_OVERFLOW_FROM_INGESTION,
+                        distinct_ids: ['user4'],
+                    },
+                ],
+                hasProjectNoticeRestriction: false,
             })
     })
 
@@ -53,7 +99,7 @@ describe('eventIngestionRestrictionLogic', () => {
             .toDispatchActions(['loadEventIngestionRestrictions', 'loadEventIngestionRestrictionsSuccess'])
             .toMatchValues({
                 eventIngestionRestrictions: [],
-                hasAnyRestriction: false,
+                hasProjectNoticeRestriction: false,
             })
     })
 })

--- a/frontend/src/lib/logic/eventIngestionRestrictionLogic.ts
+++ b/frontend/src/lib/logic/eventIngestionRestrictionLogic.ts
@@ -34,10 +34,14 @@ export const eventIngestionRestrictionLogic = kea<eventIngestionRestrictionLogic
     })),
 
     selectors({
-        hasAnyRestriction: [
+        hasProjectNoticeRestriction: [
             (s) => [s.eventIngestionRestrictions],
-            (eventIngestionRestrictions): boolean => {
-                return eventIngestionRestrictions.length > 0
+            (eventIngestionRestrictions: EventIngestionRestriction[]): boolean => {
+                return eventIngestionRestrictions.some(
+                    (r: EventIngestionRestriction) =>
+                        r.restriction_type === RestrictionType.DROP_EVENT_FROM_INGESTION ||
+                        r.restriction_type === RestrictionType.SKIP_PERSON_PROCESSING
+                )
             },
         ],
     }),


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

If an ingestion restriction is only forcing events to overflow, the project notice is too heavy handed. Only show it when the restriction is either dropping events or skipping person processing.

## Changes

Changes to the logic of how we show a ingestion restriction logic. We do not want to show when the events are just being forced to overflow

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Tested locally by applying different restriction tokens to my account through django admin, and ensuring the banner only shows up when a skip person processing or drop events token is in place.
