### PR TITLE
fix(persons): Change update latency metric to be in seconds

### DIFF
--- a/plugin-server/src/worker/ingestion/persons/metrics.ts
+++ b/plugin-server/src/worker/ingestion/persons/metrics.ts
@@ -17,7 +17,7 @@ export const personDatabaseOperationsPerBatchHistogram = new Histogram({
 })
 
 export const totalPersonUpdateLatencyPerBatchHistogram = new Histogram({
-    name: 'total_person_update_latency_per_batch',
+    name: 'total_person_update_latency_per_batch_seconds',
     help: 'Total latency of person update per distinct ID per batch',
     labelNames: ['update_type'],
     buckets: exponentialBuckets(0.025, 4, 7),

--- a/plugin-server/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/__snapshots__/runner.test.ts.snap
@@ -106,7 +106,7 @@ exports[`EventPipelineRunner runEventPipeline() runs steps starting from populat
         "personCache": {},
         "personCheckCache": {},
         "token": "token1",
-        "updateLatencyPerDistinctId": {},
+        "updateLatencyPerDistinctIdSeconds": {},
       },
     ],
   ],


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Mistakenly publish the metric in milliseconds instead of seconds

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
