### PR TITLE
fix(flags): Fix support for timestamp values for date comparisons

### DIFF
--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -175,7 +175,7 @@ def match_property(property: Property, override_property_values: dict[str, Any])
         else:
             return compare(str(override_value), str(value), operator)
 
-    if operator in ["is_date_before", "is_date_after"]:
+    if operator in ["is_date_before", "is_date_after", "is_date_exact"]:
         parsed_date = determine_parsed_date_for_property_matching(value)
 
         if not parsed_date:
@@ -188,8 +188,10 @@ def match_property(property: Property, override_property_values: dict[str, Any])
 
         if operator == "is_date_before":
             return parsed_override_date < parsed_date
-        else:
+        elif operator == "is_date_after":
             return parsed_override_date > parsed_date
+        elif operator == "is_date_exact":
+            return parsed_override_date == parsed_date
 
     return False
 

--- a/posthog/queries/test/test_base.py
+++ b/posthog/queries/test/test_base.py
@@ -258,10 +258,21 @@ class TestMatchProperties(TestCase):
         self.assertTrue(match_property(property_a, {"key": 1836277747.867530}))
         self.assertFalse(match_property(property_a, {"key": 1747794128}))
 
+        property_b = Property(key="key", value="2027-03-21T00:00:00Z", operator="is_date_before")
+        self.assertFalse(match_property(property_b, {"key": 1836277747}))
+        self.assertFalse(match_property(property_b, {"key": 1836277747.867530}))
+        self.assertTrue(match_property(property_b, {"key": 1747794128}))
+
+        property_e = Property(key="key", value="2028-03-10T05:09:07Z", operator="is_date_exact")
+        self.assertTrue(match_property(property_e, {"key": 1836277747}))
+
     def test_match_property_date_operators_with_string_timestamps(self):
         property_a = Property(key="key", value="2027-03-21T00:00:00Z", operator="is_date_after")
         self.assertTrue(match_property(property_a, {"key": "1836277747"}))
         self.assertFalse(match_property(property_a, {"key": "1747794128"}))
+
+        property_e = Property(key="key", value="2028-03-10T05:09:07Z", operator="is_date_exact")
+        self.assertTrue(match_property(property_e, {"key": "1836277747"}))
 
     def test_determine_parsed_incoming_date_with_int_timestamp(self):
         self.assertEqual(

--- a/posthog/queries/test/test_base.py
+++ b/posthog/queries/test/test_base.py
@@ -2,6 +2,7 @@ import datetime
 import re
 import unittest
 from unittest.mock import patch
+from zoneinfo import ZoneInfo
 
 from dateutil import parser, tz
 from django.test import TestCase
@@ -12,6 +13,7 @@ from rest_framework.exceptions import ValidationError
 from posthog.models.filters.path_filter import PathFilter
 from posthog.models.property.property import Property
 from posthog.queries.base import (
+    determine_parsed_incoming_date,
     match_property,
     relative_date_parse_for_feature_flag_matching,
     sanitize_property_key,
@@ -221,9 +223,6 @@ class TestMatchProperties(TestCase):
         self.assertTrue(match_property(property_a, {"key": parser.parse("2022-04-30")}))
         self.assertFalse(match_property(property_a, {"key": "2022-05-30"}))
 
-        # Can't be a number
-        self.assertFalse(match_property(property_a, {"key": 1}))
-
         # can't be invalid string
         self.assertFalse(match_property(property_a, {"key": "abcdef"}))
 
@@ -253,14 +252,55 @@ class TestMatchProperties(TestCase):
 
         self.assertFalse(match_property(property_d, {"key": "2022-04-05 12:34:13 CET"}))
 
+    def test_match_property_date_operators_with_numeric_timestamps(self):
+        property_a = Property(key="key", value="2027-03-21T00:00:00Z", operator="is_date_after")
+        self.assertTrue(match_property(property_a, {"key": 1836277747}))
+        self.assertTrue(match_property(property_a, {"key": 1836277747.867530}))
+        self.assertFalse(match_property(property_a, {"key": 1747794128}))
+
+    def test_match_property_date_operators_with_string_timestamps(self):
+        property_a = Property(key="key", value="2027-03-21T00:00:00Z", operator="is_date_after")
+        self.assertTrue(match_property(property_a, {"key": "1836277747"}))
+        self.assertFalse(match_property(property_a, {"key": "1747794128"}))
+
+    def test_determine_parsed_incoming_date_with_int_timestamp(self):
+        self.assertEqual(
+            determine_parsed_incoming_date(1836277747), datetime.datetime(2028, 3, 10, 5, 9, 7, tzinfo=ZoneInfo("UTC"))
+        )
+
+    def test_determine_parsed_incoming_date_with_float_timestamp(self):
+        timestamp = 1836277747.867530
+        expected = datetime.datetime(2028, 3, 10, 5, 9, 7, 867530, tzinfo=ZoneInfo("UTC"))
+        self.assertEqual(determine_parsed_incoming_date(timestamp), expected)
+
+    def test_determine_parsed_incoming_date_with_string_timestamp(self):
+        parsed_date = determine_parsed_incoming_date("1836277747")
+        expected = datetime.datetime(2028, 3, 10, 5, 9, 7, tzinfo=ZoneInfo("UTC"))
+        self.assertEqual(parsed_date, expected)
+
+    def test_determine_parsed_incoming_date_with_datetime(self):
+        parsed_date = determine_parsed_incoming_date(datetime.datetime(2028, 3, 10, 5, 9, 7, tzinfo=ZoneInfo("UTC")))
+        expected = datetime.datetime(2028, 3, 10, 5, 9, 7, tzinfo=ZoneInfo("UTC"))
+        self.assertEqual(parsed_date, expected)
+
+    def test_determine_parsed_incoming_date_with_string_date(self):
+        parsed_date = determine_parsed_incoming_date("2028-03-10T05:09:07Z")
+        expected = datetime.datetime(2028, 3, 10, 5, 9, 7, tzinfo=ZoneInfo("UTC"))
+        self.assertEqual(parsed_date, expected)
+
+    def test_determine_parsed_date_for_property_matching_with_string_fractional_timestamp(self):
+        timestamp = "1836277747.867530"
+        expected = datetime.datetime(2028, 3, 10, 5, 9, 7, 867530, tzinfo=ZoneInfo("UTC"))
+        self.assertEqual(determine_parsed_incoming_date(timestamp), expected)
+
     @freeze_time("2022-05-01")
     def test_match_property_relative_date_operators(self):
         property_a = Property(key="key", value="6h", operator="is_date_before")
         self.assertTrue(match_property(property_a, {"key": "2022-03-01"}))
         self.assertTrue(match_property(property_a, {"key": "2022-04-30"}))
         self.assertTrue(match_property(property_a, {"key": datetime.datetime(2022, 4, 30, 1, 2, 3)}))
-        # false because date comparison, instead of datetime, so reduces to same date
-        self.assertFalse(match_property(property_a, {"key": datetime.date(2022, 4, 30)}))
+        # The date gets converted to datetime at midnight UTC, which is before 6 hours ago
+        self.assertTrue(match_property(property_a, {"key": datetime.date(2022, 4, 30)}))
 
         self.assertFalse(match_property(property_a, {"key": datetime.datetime(2022, 4, 30, 19, 2, 3)}))
         self.assertTrue(
@@ -271,9 +311,6 @@ class TestMatchProperties(TestCase):
         )
         self.assertTrue(match_property(property_a, {"key": parser.parse("2022-04-30")}))
         self.assertFalse(match_property(property_a, {"key": "2022-05-30"}))
-
-        # Can't be a number
-        self.assertFalse(match_property(property_a, {"key": 1}))
 
         # can't be invalid string
         self.assertFalse(match_property(property_a, {"key": "abcdef"}))
@@ -291,7 +328,6 @@ class TestMatchProperties(TestCase):
         # Invalid flag property
         property_c = Property(key="key", value=1234, operator="is_date_after")
 
-        self.assertFalse(match_property(property_c, {"key": 1}))
         self.assertTrue(match_property(property_c, {"key": "2022-05-30"}))
 
         # # Timezone aware property

--- a/rust/feature-flags/src/properties/property_matching.rs
+++ b/rust/feature-flags/src/properties/property_matching.rs
@@ -304,15 +304,7 @@ fn determine_parsed_date_for_property_matching(value: Option<&Value>) -> Option<
             return Some(parse_float_timestamp(num)?);
         }
         // Then try relative date parsing
-        let return_value = parse_date_string(date_str);
-        if return_value.is_none() {
-            // Maybe the value is a timestamp passed as a string.
-            // First we try a float.
-            if let Some(num) = value.as_f64() {
-                return Some(parse_float_timestamp(num)?);
-            }
-        }
-        return return_value;
+        return parse_date_string(date_str);
     }
 
     if let Some(num) = value.as_number() {

--- a/rust/feature-flags/src/properties/property_matching.rs
+++ b/rust/feature-flags/src/properties/property_matching.rs
@@ -1515,6 +1515,20 @@ mod test_match_properties {
         )
         .expect("expected match to exist"));
 
+        assert!(match_property(
+            &property_exact,
+            &HashMap::from([("date".to_string(), json!(1710979200))]),
+            true
+        )
+        .expect("expected match to exist"));
+
+        assert!(match_property(
+            &property_exact,
+            &HashMap::from([("date".to_string(), json!("1710979200"))]),
+            true
+        )
+        .expect("expected match to exist"));
+
         // Test with invalid date format
         assert!(!match_property(
             &property_exact,

--- a/rust/feature-flags/src/properties/property_matching.rs
+++ b/rust/feature-flags/src/properties/property_matching.rs
@@ -299,19 +299,35 @@ fn determine_parsed_date_for_property_matching(value: Option<&Value>) -> Option<
     let value = value?;
 
     if let Some(date_str) = value.as_str() {
-        return parse_date_string(date_str);
+        // First try parsing as a float timestamp
+        if let Ok(num) = date_str.parse::<f64>() {
+            return Some(parse_float_timestamp(num)?);
+        }
+        // Then try relative date parsing
+        let return_value = parse_date_string(date_str);
+        if return_value.is_none() {
+            // Maybe the value is a timestamp passed as a string.
+            // First we try a float.
+            if let Some(num) = value.as_f64() {
+                return Some(parse_float_timestamp(num)?);
+            }
+        }
+        return return_value;
     }
 
     if let Some(num) = value.as_number() {
-        // Convert to f64 first to handle both integer and float timestamps
-        let ms = num.as_f64()?;
-        let seconds = (ms / 1000.0).floor() as i64;
-        let nanos = ((ms % 1000.0) * 1_000_000.0) as u32;
-
-        return DateTime::from_timestamp(seconds, nanos);
+        // Unix timestamps are the number of seconds since epoch (January 1, 1970, at 00:00:00 UTC)
+        let seconds_f = num.as_f64()?;
+        return Some(parse_float_timestamp(seconds_f)?);
     }
 
     None
+}
+
+fn parse_float_timestamp(value: f64) -> Option<DateTime<Utc>> {
+    let whole_seconds = value.floor() as i64;
+    let nanos = ((value % 1.0) * 1_000_000_000.0).round() as u32;
+    DateTime::from_timestamp(whole_seconds, nanos)
 }
 
 /// Copy of https://github.com/PostHog/posthog/blob/master/posthog/queries/test/test_base.py#L35
@@ -321,6 +337,7 @@ fn determine_parsed_date_for_property_matching(value: Option<&Value>) -> Option<
 mod test_match_properties {
     use super::*;
     use serde_json::json;
+    use test_case::test_case;
 
     #[test]
     fn test_match_properties_exact_with_partial_props() {
@@ -1509,10 +1526,33 @@ mod test_match_properties {
         // Test with timestamp
         assert!(match_property(
             &property_exact,
-            &HashMap::from([("date".to_string(), json!(1710979200000.0))]), // 2024-03-21 00:00:00 UTC
+            &HashMap::from([("date".to_string(), json!(1710979200.0))]), // 2024-03-21 00:00:00 UTC
             true
         )
         .expect("expected match to exist"));
+    }
+
+    #[test_case(json!(1836277747) => true; "numeric timestamp after target date")] // 2028-03-10 05:09:07
+    #[test_case(json!("1836277747") => true; "string timestamp after target date")] // 2028-03-10 05:09:07
+    #[test_case(json!(1747793088) => false; "numeric timestamp before target date")] // 2025-05-21 02:04:48
+    #[test_case(json!("1747793088") => false; "string timestamp before target date")] // 2025-05-21 02:04:48
+    fn test_match_properties_date_after_with_timestamp(input_value: Value) -> bool {
+        let target_date = "2027-03-21T00:00:00Z";
+        let property = PropertyFilter {
+            key: "date".to_string(),
+            value: Some(json!(target_date)),
+            operator: Some(OperatorType::IsDateAfter),
+            prop_type: "person".to_string(),
+            group_type_index: None,
+            negation: None,
+        };
+
+        match_property(
+            &property,
+            &HashMap::from([("date".to_string(), input_value)]),
+            true,
+        )
+        .expect("expected match to exist")
     }
 
     #[test]
@@ -1552,7 +1592,7 @@ mod test_match_properties {
             &property_relative,
             &HashMap::from([(
                 "joined_at".to_string(),
-                json!(four_days_ago.timestamp_millis() as f64)
+                json!(four_days_ago.timestamp() as f64)
             )]),
             true
         )
@@ -1576,5 +1616,32 @@ mod test_match_properties {
 
         // Test with missing property
         assert!(match_property(&property_relative, &HashMap::from([]), true).is_err());
+    }
+
+    #[test]
+    fn test_parse_timestamp_in_seconds_as_date() {
+        let expected_date = DateTime::parse_from_rfc3339("2028-03-10T05:09:07Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let timestamp_number = 1836277747;
+        let timestamp_string = timestamp_number.to_string();
+        let date = determine_parsed_date_for_property_matching(Some(&json!(timestamp_number)));
+        assert_eq!(date, Some(expected_date));
+        let date = determine_parsed_date_for_property_matching(Some(&json!(timestamp_string)));
+        assert_eq!(date, Some(expected_date));
+    }
+
+    #[test]
+    fn test_parse_timestamp_with_fractional_milliseconds_as_date() {
+        let expected_date = DateTime::parse_from_rfc3339("2028-03-10T05:09:07.867530107Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let timestamp_number = 1836277747.867530;
+        let date = determine_parsed_date_for_property_matching(Some(&json!(timestamp_number)));
+        assert_eq!(date, Some(expected_date));
+
+        let timestamp_string = "1836277747.867530";
+        let date = determine_parsed_date_for_property_matching(Some(&json!(timestamp_string)));
+        assert_eq!(date, Some(expected_date));
     }
 }

--- a/rust/feature-flags/src/properties/property_matching.rs
+++ b/rust/feature-flags/src/properties/property_matching.rs
@@ -301,7 +301,7 @@ fn determine_parsed_date_for_property_matching(value: Option<&Value>) -> Option<
     if let Some(date_str) = value.as_str() {
         // First try parsing as a float timestamp
         if let Ok(num) = date_str.parse::<f64>() {
-            return Some(parse_float_timestamp(num)?);
+            return parse_float_timestamp(num);
         }
         // Then try relative date parsing
         return parse_date_string(date_str);
@@ -310,7 +310,7 @@ fn determine_parsed_date_for_property_matching(value: Option<&Value>) -> Option<
     if let Some(num) = value.as_number() {
         // Unix timestamps are the number of seconds since epoch (January 1, 1970, at 00:00:00 UTC)
         let seconds_f = num.as_f64()?;
-        return Some(parse_float_timestamp(seconds_f)?);
+        return parse_float_timestamp(seconds_f);
     }
 
     None
@@ -1642,11 +1642,11 @@ mod test_match_properties {
         let expected_date = DateTime::parse_from_rfc3339("2028-03-10T05:09:07.867530107Z")
             .unwrap()
             .with_timezone(&Utc);
-        let timestamp_number = 1836277747.867530;
+        let timestamp_number = 1836277747.86753;
         let date = determine_parsed_date_for_property_matching(Some(&json!(timestamp_number)));
         assert_eq!(date, Some(expected_date));
 
-        let timestamp_string = "1836277747.867530";
+        let timestamp_string = "1836277747.86753";
         let date = determine_parsed_date_for_property_matching(Some(&json!(timestamp_string)));
         assert_eq!(date, Some(expected_date));
     }


### PR DESCRIPTION
## Problem

Given a feature flag named `date-comparison` with a filter condition like so:

```json
{
  "key": "org_created_at_timestamp",
  "type": "person",
  "value": "2025-05-12 11:38:00",
  "operator": "is_date_after"
}
```

It would be reasonable to expect this code to evaluate to true:

```js
posthog.setPersonPropertiesForFlags({org_created_at_timestamp: 1836277747});
let result = posthog.featureFlags.getFeatureFlagDetails('date-comparison');
console.log(result); // should be 'true' but is 'false'
```

Where `1836277747` is a unix timestamp equivalent to `2028-03-10 05:09:07 UTC` which is definitely after `2025-05-12 11:38:00 UTC`.

> [!NOTE]  
> A unix timestamp is the number of seconds since the Unix epoch (aka `1970-01-01 00:00:00 UTC`)

Interestingly enough, it works with `/flags` when the timestamp is the string `"1836277747"` which gets translated to a unix timestamp, but not when you pass `1836277747` because `/flags` interprets that as milliseconds and not seconds.

Neither of these values works for `/decide` because `/decide` doesn't support timestamp values.

I think this is confusing and that we should support unix timestamps both in `/decide` and `/flags`.

See https://posthoghelp.zendesk.com/agent/tickets/29062 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/32559) for more context.

## Changes

This PR changes `/flags` to interpret numeric values as Unix timestamps rather than millisecond timestamps.
It also adds support to `/decide` for unit timestamps in both string and numeric formats.

This supports fractional timestamps such as `1836277747.867530` which is probably an unnecessary level of precision, but the precedence was set in the original `/flags` implementation so I made sure it carried over when passing a string value such as `"1836277747.867530"`.

Note that this conversion of timestamps to dates _only_ occurs when the filter comparison operator is a date operator such as `is_after_date`. 

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manual testing
Unit tests