### PR TITLE
fix(ff): label reflects status

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -897,7 +897,7 @@ function FeatureFlagRollout({ readOnly }: { readOnly?: boolean }): JSX.Element {
                                                                 },
                                                             })
                                                         }}
-                                                        label="Enabled"
+                                                        label={featureFlag.active ? 'Enabled' : 'Disabled'}
                                                         disabledReason={
                                                             accessControlDisabledReason ||
                                                             (!featureFlag.can_edit


### PR DESCRIPTION
A tiny one, but when a flag is disabled, the status toggle shows the text "Status: Enabled", and for people who don't look at this ui a lot (like me lol), this can throw you off

Before:
![image](https://github.com/user-attachments/assets/08ab921e-978a-4fc0-98cf-9ec503d93d41)

After:
<img width="149" alt="image" src="https://github.com/user-attachments/assets/265d473b-ef92-414f-95c0-495c57f6c7a2" />
