### PR TITLE
feat: Include cohort name in export filenames

### DIFF
--- a/frontend/src/models/cohortsModel.ts
+++ b/frontend/src/models/cohortsModel.ts
@@ -218,7 +218,7 @@ export const cohortsModel = kea<cohortsModelType>([
             },
         ],
     }),
-    listeners(({ actions }) => ({
+    listeners(({ actions, values }) => ({
         loadCohortsSuccess: async ({ cohorts }: { cohorts: CountedPaginatedResponse<CohortType> }) => {
             const is_calculating = cohorts.results.filter((cohort) => cohort.is_calculating).length > 0
             if (!is_calculating || !router.values.location.pathname.includes(urls.cohorts())) {
@@ -234,12 +234,14 @@ export const cohortsModel = kea<cohortsModelType>([
             actions.setPollTimeout(window.setTimeout(actions.loadAllCohorts, POLL_TIMEOUT))
         },
         exportCohortPersons: async ({ id, columns }) => {
+            const cohort = values.cohortsById[id]
             const exportCommand = {
                 export_format: ExporterFormat.CSV,
                 export_context: {
                     path: `/api/cohort/${id}/persons`,
                     columns,
-                } as { path: string; columns?: string[] },
+                    filename: cohort?.name ? `cohort-${cohort.name}` : 'cohort',
+                } as { path: string; columns?: string[]; filename?: string },
             }
             if (columns && columns.length > 0) {
                 exportCommand.export_context['columns'] = columns


### PR DESCRIPTION
## Problem

Related to https://posthoghelp.zendesk.com/agent/tickets/31166 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/32645)

## Changes

Add the filename to export context for cohort exports.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Tested locally:
![CleanShot 2025-05-21 at 11 39 24](https://github.com/user-attachments/assets/a7d08f81-6f5b-4a47-98aa-a8465b668a3e)