### PR TITLE
feat: Render replay session into video/GIF from S3 snapshots

### DIFF
--- a/ee/session_recordings/session_recording_extensions.py
+++ b/ee/session_recordings/session_recording_extensions.py
@@ -175,7 +175,7 @@ def _persist_recording_v2_impl(recording_id: str, team_id: int) -> None:
         recording.save()
         return
 
-    blocks = list_blocks(recording)
+    blocks = list_blocks(recording.session_id, recording.team)
     if not blocks:
         logger.info(
             "No v2 metadata found for recording or recording is incomplete, skipping v2 persistence",

--- a/ee/session_recordings/session_summary/input_data.py
+++ b/ee/session_recordings/session_summary/input_data.py
@@ -5,7 +5,7 @@ from typing import cast
 
 from ee.session_recordings.session_summary.local.input_data import (
     _get_production_session_events_locally,
-    _get_production_session_metadata_locally,
+    get_production_session_metadata_locally,
 )
 from ee.session_recordings.session_summary.utils import (
     get_column_index,
@@ -37,7 +37,7 @@ def get_session_metadata(session_id: str, team: Team, local_reads_prod: bool = F
     if not local_reads_prod:
         session_metadata = events_obj.get_metadata(session_id=str(session_id), team=team)
     else:
-        session_metadata = _get_production_session_metadata_locally(events_obj, session_id, team)
+        session_metadata = get_production_session_metadata_locally(events_obj, session_id, team)
     if not session_metadata:
         raise ValueError(f"No session metadata found for session_id {session_id}")
     return session_metadata

--- a/ee/session_recordings/session_summary/local/input_data.py
+++ b/ee/session_recordings/session_summary/local/input_data.py
@@ -28,7 +28,7 @@ def _ch_client_local_reads_prod():
         client.disconnect()
 
 
-def _get_production_session_metadata_locally(
+def get_production_session_metadata_locally(
     events_obj: SessionReplayEvents,
     session_id: str,
     team: Team,

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -710,7 +710,7 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, U
         blob_prefix = ""
 
         if is_v2_enabled:
-            blocks = list_blocks(recording)
+            blocks = list_blocks(recording.session_id, recording.team)
             for i, block in enumerate(blocks):
                 sources.append(
                     {
@@ -927,7 +927,7 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, U
         )
 
         with STREAM_RESPONSE_TO_CLIENT_HISTOGRAM.time():
-            blocks = list_blocks(recording)
+            blocks = list_blocks(recording.session_id, recording.team)
             if not blocks:
                 raise exceptions.NotFound("Session recording not found")
 

--- a/posthog/session_recordings/session_recording_v2_service.py
+++ b/posthog/session_recordings/session_recording_v2_service.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import TypedDict
 import structlog
 
-from posthog.session_recordings.models.session_recording import SessionRecording
+from posthog.models.team.team import Team
 from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
 
 logger = structlog.get_logger(__name__)
@@ -14,13 +14,13 @@ class RecordingBlock(TypedDict):
     url: str
 
 
-def list_blocks(recording: SessionRecording) -> list[RecordingBlock]:
+def list_blocks(session_id: str, team: Team) -> list[RecordingBlock]:
     """
     Returns a list of recording blocks with their timestamps and URLs.
     The blocks are sorted by start time and guaranteed to start from the beginning of the recording.
     Returns empty list if the recording is invalid or incomplete.
     """
-    metadata = SessionReplayEvents().get_metadata(recording.session_id, recording.team)
+    metadata = SessionReplayEvents().get_metadata(session_id, team)
     if not metadata:
         return []
 
@@ -34,8 +34,8 @@ def list_blocks(recording: SessionRecording) -> list[RecordingBlock]:
     ):
         logger.error(
             "session recording metadata arrays length mismatch",
-            session_id=recording.session_id,
-            team_id=recording.team.id,
+            session_id=session_id,
+            team_id=team.id,
             first_timestamps_length=len(first_timestamps) if first_timestamps else 0,
             last_timestamps_length=len(last_timestamps) if last_timestamps else 0,
             urls_length=len(urls) if urls else 0,

--- a/posthog/session_recordings/tests/test_session_recording_v2_service.py
+++ b/posthog/session_recordings/tests/test_session_recording_v2_service.py
@@ -19,7 +19,7 @@ class TestSessionRecordingV2Service(TestCase):
     @patch("posthog.session_recordings.session_recording_v2_service.SessionReplayEvents")
     def test_list_blocks_returns_empty_list_when_no_metadata(self, mock_replay_events):
         mock_replay_events.return_value.get_metadata.return_value = None
-        blocks = list_blocks(self.recording)
+        blocks = list_blocks(self.recording.session_id, self.recording.team)
         self.assertEqual(blocks, [])
 
     @freeze_time("2024-01-01T12:00:00Z")
@@ -31,7 +31,7 @@ class TestSessionRecordingV2Service(TestCase):
             "block_urls": [],  # Different length
             "start_time": datetime(2024, 1, 1, 12, 0),
         }
-        blocks = list_blocks(self.recording)
+        blocks = list_blocks(self.recording.session_id, self.recording.team)
         self.assertEqual(blocks, [])
 
     @freeze_time("2024-01-01T12:00:00Z")
@@ -56,7 +56,7 @@ class TestSessionRecordingV2Service(TestCase):
             ],
             "start_time": datetime(2024, 1, 1, 12, 0),
         }
-        blocks = list_blocks(self.recording)
+        blocks = list_blocks(self.recording.session_id, self.recording.team)
         self.assertEqual(blocks, [])
 
     @freeze_time("2024-01-01T12:00:00Z")
@@ -68,7 +68,7 @@ class TestSessionRecordingV2Service(TestCase):
             "block_urls": ["s3://bucket/key1"],
             "start_time": datetime(2024, 1, 1, 12, 0),
         }
-        blocks = list_blocks(self.recording)
+        blocks = list_blocks(self.recording.session_id, self.recording.team)
         self.assertEqual(blocks, [])
 
     @freeze_time("2024-01-01T12:00:00Z")
@@ -93,7 +93,7 @@ class TestSessionRecordingV2Service(TestCase):
             "start_time": datetime(2024, 1, 1, 12, 0),
         }
 
-        blocks = list_blocks(self.recording)
+        blocks = list_blocks(self.recording.session_id, self.recording.team)
 
         self.assertEqual(len(blocks), 3)
         self.assertEqual(blocks[0]["start_time"], datetime(2024, 1, 1, 12, 0))

--- a/posthog/temporal/session_recordings/compare_recording_events_workflow.py
+++ b/posthog/temporal/session_recordings/compare_recording_events_workflow.py
@@ -53,7 +53,7 @@ async def compare_recording_snapshots_activity(inputs: CompareRecordingSnapshots
 
         # Get v1 and v2 snapshots using the shared utility functions
         v1_snapshots = await asyncio.to_thread(fetch_v1_snapshots, recording)
-        v2_snapshots = await asyncio.to_thread(fetch_v2_snapshots, recording)
+        v2_snapshots = await asyncio.to_thread(fetch_v2_snapshots, recording.session_id, recording.team)
 
         # Compare snapshots
         snapshot_differences = []

--- a/posthog/temporal/session_recordings/compare_sampled_recording_events_workflow.py
+++ b/posthog/temporal/session_recordings/compare_sampled_recording_events_workflow.py
@@ -97,7 +97,7 @@ async def compare_sampled_recording_events_activity(inputs: CompareSampledRecord
                 continue
 
             try:
-                v2_snapshots = await asyncio.to_thread(fetch_v2_snapshots, recording)
+                v2_snapshots = await asyncio.to_thread(fetch_v2_snapshots, recording.session_id, recording.team)
             except Exception as e:
                 await logger.awarn(
                     "Skipping session due to error when fetching v2 snapshots",

--- a/posthog/temporal/session_recordings/snapshot_utils.py
+++ b/posthog/temporal/session_recordings/snapshot_utils.py
@@ -2,6 +2,7 @@ import gzip
 import json
 from typing import Any, cast
 
+from posthog.models.team.team import Team
 from posthog.storage import object_storage
 from posthog.session_recordings.models.session_recording import SessionRecording
 from posthog.session_recordings.session_recording_v2_service import list_blocks
@@ -105,10 +106,10 @@ def fetch_v1_snapshots(recording: SessionRecording) -> list[dict[str, Any]]:
     return v1_snapshots
 
 
-def fetch_v2_snapshots(recording: SessionRecording) -> list[dict[str, Any]]:
+def fetch_v2_snapshots(session_id: str, team: Team) -> list[dict[str, Any]]:
     """Fetch and transform v2 snapshots for a recording."""
     v2_snapshots: list[dict[str, Any]] = []
-    blocks = list_blocks(recording.session_id, recording.team)
+    blocks = list_blocks(session_id, team)
     if blocks:
         for block in blocks:
             try:

--- a/posthog/temporal/session_recordings/snapshot_utils.py
+++ b/posthog/temporal/session_recordings/snapshot_utils.py
@@ -108,7 +108,7 @@ def fetch_v1_snapshots(recording: SessionRecording) -> list[dict[str, Any]]:
 def fetch_v2_snapshots(recording: SessionRecording) -> list[dict[str, Any]]:
     """Fetch and transform v2 snapshots for a recording."""
     v2_snapshots: list[dict[str, Any]] = []
-    blocks = list_blocks(recording)
+    blocks = list_blocks(recording.session_id, recording.team)
     if blocks:
         for block in blocks:
             try:

--- a/posthog/temporal/session_recordings/snapshot_utils.py
+++ b/posthog/temporal/session_recordings/snapshot_utils.py
@@ -106,10 +106,10 @@ def fetch_v1_snapshots(recording: SessionRecording) -> list[dict[str, Any]]:
     return v1_snapshots
 
 
-def fetch_v2_snapshots(session_id: str, team: Team) -> list[dict[str, Any]]:
+def fetch_v2_snapshots(session_id: str, team: Team, local_reads_prod: bool = False) -> list[dict[str, Any]]:
     """Fetch and transform v2 snapshots for a recording."""
     v2_snapshots: list[dict[str, Any]] = []
-    blocks = list_blocks(session_id, team)
+    blocks = list_blocks(session_id, team, local_reads_prod)
     if blocks:
         for block in blocks:
             try:


### PR DESCRIPTION
## Changes

**Current state:** allow accessing S3 snapshots for actual recordings locally.

Requires env variables to be stored in the local `.env` file:
- `SESSION_RECORDING_V2_S3_ENDPOINT`
- `SESSION_RECORDING_V2_S3_REGION`
- `SESSION_RECORDING_V2_S3_BUCKET`
- `SESSION_RECORDING_V2_S3_PREFIX`
- `SESSION_RECORDING_V2_S3_ACCESS_KEY_ID`
- `SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY`

First four can be copied from ArgoCD chars: https://github.com/PostHog/charts/blob/b88c66aab1095f4002303cd97d0ffad856c7ecce/argocd/cdp/config/recordings-blob-ingestion-v2.prod-us.yaml#L31

The last two could be extracted by `aws configure export-credentials --profile prod-us` (using the profile name you picked for production S3).

To work with `rrvideo` on M-chips, you also need to install `chromium` manually and set up env variables (in `~/.zshrc` or any applicable):
- `brew install chromium --no-quarantine`
- `export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true`
- `export PUPPETEER_EXECUTABLE_PATH=`which chromium`

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
