### PR TITLE
feat(hogql): Support modifying csv allow double quotes settings

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -10827,6 +10827,9 @@
                     "enum": ["count_pageviews", "uniq_urls", "uniq_page_screen_autocaptures"],
                     "type": "string"
                 },
+                "csvAllowDoubleQuotes": {
+                    "type": "boolean"
+                },
                 "customChannelTypeRules": {
                     "items": {
                         "$ref": "#/definitions/CustomChannelRule"

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -10827,9 +10827,6 @@
                     "enum": ["count_pageviews", "uniq_urls", "uniq_page_screen_autocaptures"],
                     "type": "string"
                 },
-                "csvAllowDoubleQuotes": {
-                    "type": "boolean"
-                },
                 "customChannelTypeRules": {
                     "items": {
                         "$ref": "#/definitions/CustomChannelRule"
@@ -10843,6 +10840,9 @@
                     "type": "array"
                 },
                 "debug": {
+                    "type": "boolean"
+                },
+                "formatCsvAllowDoubleQuotes": {
                     "type": "boolean"
                 },
                 "inCohortVia": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -302,6 +302,7 @@ export interface HogQLQueryModifiers {
     customChannelTypeRules?: CustomChannelRule[]
     usePresortedEventsTable?: boolean
     useWebAnalyticsPreAggregatedTables?: boolean
+    csvAllowDoubleQuotes?: boolean
 }
 
 export interface DataWarehouseEventsModifier {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -302,7 +302,7 @@ export interface HogQLQueryModifiers {
     customChannelTypeRules?: CustomChannelRule[]
     usePresortedEventsTable?: boolean
     useWebAnalyticsPreAggregatedTables?: boolean
-    csvAllowDoubleQuotes?: boolean
+    formatCsvAllowDoubleQuotes?: boolean
 }
 
 export interface DataWarehouseEventsModifier {

--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -177,6 +177,10 @@ class HogQLQueryExecutor:
             LimitContext.SAVED_QUERY,
         ):
             settings.max_execution_time = max(settings.max_execution_time or 0, HOGQL_INCREASED_MAX_EXECUTION_TIME)
+
+        if self.query_modifiers.csvAllowDoubleQuotes is not None:
+            settings.format_csv_allow_double_quotes = self.query_modifiers.csvAllowDoubleQuotes
+
         try:
             self.clickhouse_context = dataclasses.replace(
                 self.context,

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -2797,10 +2797,10 @@ class HogQLQueryModifiers(BaseModel):
     )
     bounceRateDurationSeconds: Optional[float] = None
     bounceRatePageViewMode: Optional[BounceRatePageViewMode] = None
-    csvAllowDoubleQuotes: Optional[bool] = None
     customChannelTypeRules: Optional[list[CustomChannelRule]] = None
     dataWarehouseEventsModifiers: Optional[list[DataWarehouseEventsModifier]] = None
     debug: Optional[bool] = None
+    formatCsvAllowDoubleQuotes: Optional[bool] = None
     inCohortVia: Optional[InCohortVia] = None
     materializationMode: Optional[MaterializationMode] = None
     optimizeJoinedFilters: Optional[bool] = None

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -2813,6 +2813,7 @@ class HogQLQueryModifiers(BaseModel):
     useMaterializedViews: Optional[bool] = None
     usePresortedEventsTable: Optional[bool] = None
     useWebAnalyticsPreAggregatedTables: Optional[bool] = None
+    csvAllowDoubleQuotes: Optional[bool] = None
 
 
 class HogQuery(BaseModel):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -2797,6 +2797,7 @@ class HogQLQueryModifiers(BaseModel):
     )
     bounceRateDurationSeconds: Optional[float] = None
     bounceRatePageViewMode: Optional[BounceRatePageViewMode] = None
+    csvAllowDoubleQuotes: Optional[bool] = None
     customChannelTypeRules: Optional[list[CustomChannelRule]] = None
     dataWarehouseEventsModifiers: Optional[list[DataWarehouseEventsModifier]] = None
     debug: Optional[bool] = None
@@ -2813,7 +2814,6 @@ class HogQLQueryModifiers(BaseModel):
     useMaterializedViews: Optional[bool] = None
     usePresortedEventsTable: Optional[bool] = None
     useWebAnalyticsPreAggregatedTables: Optional[bool] = None
-    csvAllowDoubleQuotes: Optional[bool] = None
 
 
 class HogQuery(BaseModel):


### PR DESCRIPTION
## Problem

The format_csv_allow_double_quotes ClickHouse setting is defaulted to
0. But, as CSV is a very shaky format, this can cause lots of trouble
when CSVs are not formatted in certain ways, particularly when JSON
values are nested in CSVs.

## Changes

We should ultimately allow users to customize how do their CSV files
look like, but it seemed faster for now to allow configuring this on a
team by team basis.

So, I've added a new HogQLModifier that when set will update the
aforementioned setting.

The plan is to then set this modifier for teams who request it.

Looking for more seasoned HogQL developers to tell me if this is the
right approach! My thought was that eventually this modifier could be
somewhat set at the `ExternalDataSource` level, and the user can be 
prompted to customize their CSV experience when syncing one. But that
seemed quite involved and I wasn't sure how to achieve that. So, I've 
left it as an enhancement for later.