### PR TITLE
fix: start date error when setting exposure criteria on draft experiment

### DIFF
--- a/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
@@ -253,8 +253,11 @@ class ExperimentExposuresQueryRunner(QueryRunner):
         For initial dates with no data, adds entries with zero exposures for each variant.
         """
         date_range = self._get_date_range()
+
+        # for draft experiments, return an empty result
         if not date_range.date_from:
-            raise ValidationError("Start date is required for experiment exposure data")
+            return []
+
         start_date = datetime.fromisoformat(date_range.date_from).date()
         end_date = datetime.fromisoformat(date_range.date_to).date() if date_range.date_to else datetime.now().date()
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

When setting the exposure criteria of a _Draft_ experiment, a _Start date is required for the experiment exposure data_ which is shown. This could be confusing and annoying.

| Screen Shot | Demo |
| - | - |
| <img width="1712" alt="Image" src="https://github.com/user-attachments/assets/c426824f-88d0-415e-86a7-e151b50729a2" /> | ![May-21-2025 14-22-19](https://github.com/user-attachments/assets/0ac03c21-8035-4851-8d4e-4377105e04ff) |

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We've updated the _Experiment Exposures Query Runner_ to return an empty array. This is a stopgap, because the real problem is that the _Experiment Logic_ makes the query when the experiment updates, regardless of the experiment status.

This Closes #32481 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
