### PR TITLE
feat: duplicate shared metric

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -198,7 +198,8 @@ export const productUrls = {
     ): string => `/experiments/${id}${options ? `?${toParams(options)}` : ''}`,
     experiments: (): string => '/experiments',
     experimentsSharedMetrics: (): string => '/experiments/shared-metrics',
-    experimentsSharedMetric: (id: string | number): string => `/experiments/shared-metrics/${id}`,
+    experimentsSharedMetric: (id: string | number, action?: string): string =>
+        action ? `/experiments/shared-metrics/${id}/${action}` : `/experiments/shared-metrics/${id}`,
     featureFlags: (tab?: string): string => `/feature_flags${tab ? `?tab=${tab}` : ''}`,
     featureFlag: (id: string | number): string => `/feature_flags/${id}`,
     featureFlagDuplicate: (sourceId: number | string | null): string => `/feature_flags/new?sourceId=${sourceId}`,

--- a/frontend/src/scenes/experiments/SharedMetrics/SharedMetric.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/SharedMetric.tsx
@@ -18,13 +18,14 @@ import { sharedMetricLogic } from './sharedMetricLogic'
 export const scene: SceneExport = {
     component: SharedMetric,
     logic: sharedMetricLogic,
-    paramsToProps: ({ params: { id } }) => ({
-        sharedMetricId: id === 'new' ? 'new' : parseInt(id),
+    paramsToProps: ({ params: { id, action } }) => ({
+        sharedMetricId: id === 'new' ? null : parseInt(id),
+        action: action || (id === 'new' ? 'create' : 'update'),
     }),
 }
 
 export function SharedMetric(): JSX.Element {
-    const { sharedMetricId, sharedMetric } = useValues(sharedMetricLogic)
+    const { sharedMetric, action } = useValues(sharedMetricLogic)
     const { setSharedMetric, createSharedMetric, updateSharedMetric, deleteSharedMetric } =
         useActions(sharedMetricLogic)
     const { isDarkModeOn } = useValues(themeLogic)
@@ -147,7 +148,7 @@ export function SharedMetric(): JSX.Element {
                 )}
             </div>
             <div className="flex justify-between mt-4">
-                {sharedMetricId !== 'new' && (
+                {action === 'update' && (
                     <LemonButton
                         size="medium"
                         type="primary"
@@ -179,11 +180,12 @@ export function SharedMetric(): JSX.Element {
                     size="medium"
                     type="primary"
                     onClick={() => {
-                        if (sharedMetricId === 'new') {
+                        if (['create', 'duplicate'].includes(action)) {
                             createSharedMetric()
-                        } else {
-                            updateSharedMetric()
+                            return
                         }
+
+                        updateSharedMetric()
                     }}
                 >
                     Save

--- a/frontend/src/scenes/experiments/SharedMetrics/SharedMetrics.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/SharedMetrics.tsx
@@ -1,4 +1,4 @@
-import { IconArrowLeft, IconPencil } from '@posthog/icons'
+import { IconArrowLeft, IconCopy, IconPencil } from '@posthog/icons'
 import { LemonBanner, LemonButton, LemonTable, LemonTableColumn, LemonTableColumns, LemonTag } from '@posthog/lemon-ui'
 import { useValues } from 'kea'
 import { router } from 'kea-router'
@@ -82,15 +82,26 @@ export function SharedMetrics(): JSX.Element {
             title: 'Actions',
             render: (_, sharedMetric) => {
                 return (
-                    <LemonButton
-                        className="max-w-72"
-                        type="secondary"
-                        size="xsmall"
-                        icon={<IconPencil />}
-                        onClick={() => {
-                            router.actions.push(urls.experimentsSharedMetric(sharedMetric.id))
-                        }}
-                    />
+                    <div className="flex gap-1">
+                        <LemonButton
+                            className="max-w-72"
+                            type="secondary"
+                            size="xsmall"
+                            icon={<IconPencil />}
+                            onClick={() => {
+                                router.actions.push(urls.experimentsSharedMetric(sharedMetric.id))
+                            }}
+                        />
+                        <LemonButton
+                            className="max-w-72"
+                            type="secondary"
+                            size="xsmall"
+                            icon={<IconCopy />}
+                            onClick={() => {
+                                router.actions.push(urls.experimentsSharedMetric(sharedMetric.id, 'duplicate'))
+                            }}
+                        />
+                    </div>
                 )
             },
         },

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
@@ -70,7 +70,19 @@ export const sharedMetricLogic = kea<sharedMetricLogicType>([
         },
     })),
 
-    listeners(({ actions, values }) => ({
+    listeners(({ actions, props, values }) => ({
+        /**
+         * we need to wait for the metric to load to check if we need to modify the name and id
+         */
+        loadSharedMetricSuccess: () => {
+            if (props.action === 'duplicate' && values.sharedMetric) {
+                actions.setSharedMetric({
+                    ...values.sharedMetric,
+                    name: `${values.sharedMetric.name} (Duplicate)`,
+                    id: undefined,
+                })
+            }
+        },
         createSharedMetric: async () => {
             const response = await api.create(`api/projects/@current/experiment_saved_metrics/`, values.sharedMetric)
             if (response.id) {

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -622,6 +622,7 @@ export const routes: Record<string, [Scene | string, string]> = {
     [urls.experiments()]: [Scene.Experiments, 'experiments'],
     [urls.experimentsSharedMetrics()]: [Scene.ExperimentsSharedMetrics, 'experimentsSharedMetrics'],
     [urls.experimentsSharedMetric(':id')]: [Scene.ExperimentsSharedMetric, 'experimentsSharedMetric'],
+    [urls.experimentsSharedMetric(':id', ':action')]: [Scene.ExperimentsSharedMetric, 'experimentsSharedMetric'],
     [urls.experiment(':id')]: [Scene.Experiment, 'experiment'],
     [urls.errorTracking()]: [Scene.ErrorTracking, 'errorTracking'],
     [urls.errorTrackingConfiguration()]: [Scene.ErrorTrackingConfiguration, 'errorTrackingConfiguration'],

--- a/products/experiments/manifest.tsx
+++ b/products/experiments/manifest.tsx
@@ -18,7 +18,8 @@ export const manifest: ProductManifest = {
         ): string => `/experiments/${id}${options ? `?${toParams(options)}` : ''}`,
         experiments: (): string => '/experiments',
         experimentsSharedMetrics: (): string => '/experiments/shared-metrics',
-        experimentsSharedMetric: (id: string | number): string => `/experiments/shared-metrics/${id}`,
+        experimentsSharedMetric: (id: string | number, action?: string): string =>
+            action ? `/experiments/shared-metrics/${id}/${action}` : `/experiments/shared-metrics/${id}`,
     },
     fileSystemTypes: {
         experiment: {


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Part of #31862

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

In this initial change, we are adding a new _Duplicate_ action to the list of shared metrics. This opens the _Shared Metric_ form with all the original metric values preloaded.

https://github.com/user-attachments/assets/3538fe78-94ff-487b-a583-1946899eede0

To accomplish this, we are adding a new `/duplicate` route for the metric, and updated the logic and form to handle different `actions`. We also did a bit of a cleanup to remove unused variables.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

Docs update PR: https://github.com/PostHog/posthog.com/pull/11557

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [x] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
