### PR TITLE
feat: Add ability to override query settings on a per-team basis

### DIFF
--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -218,9 +218,7 @@ except Exception:
 
 # Per-team settings used for query execution. Keys should be strings, not numbers.
 try:
-    CLICKHOUSE_PER_TEAM_QUERY_SETTINGS: dict[str, str] = json.loads(
-        os.getenv("CLICKHOUSE_PER_TEAM_QUERY_SETTINGS", "{}")
-    )
+    CLICKHOUSE_PER_TEAM_QUERY_SETTINGS: dict = json.loads(os.getenv("CLICKHOUSE_PER_TEAM_QUERY_SETTINGS", "{}"))
 except Exception:
     CLICKHOUSE_PER_TEAM_QUERY_SETTINGS = {}
 

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -209,10 +209,20 @@ CLICKHOUSE_LOGS_CLUSTER_SECURE: bool = get_from_env(
     "CLICKHOUSE_LOGS_CLUSTER_SECURE", not TEST and not DEBUG, type_cast=str_to_bool
 )
 
+# Per-team settings used for client/pool connection parameters. Note that this takes precedence over any workload-based
+# routing.
 try:
     CLICKHOUSE_PER_TEAM_SETTINGS: dict = json.loads(os.getenv("CLICKHOUSE_PER_TEAM_SETTINGS", "{}"))
 except Exception:
     CLICKHOUSE_PER_TEAM_SETTINGS = {}
+
+# Per-team settings used for query execution.
+try:
+    CLICKHOUSE_PER_TEAM_QUERY_SETTINGS: dict[str, str] = json.loads(
+        os.getenv("CLICKHOUSE_PER_TEAM_QUERY_SETTINGS", "{}")
+    )
+except Exception:
+    CLICKHOUSE_PER_TEAM_QUERY_SETTINGS = {}
 
 API_QUERIES_PER_TEAM: dict[int, int] = {}
 with suppress(Exception):

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -210,13 +210,13 @@ CLICKHOUSE_LOGS_CLUSTER_SECURE: bool = get_from_env(
 )
 
 # Per-team settings used for client/pool connection parameters. Note that this takes precedence over any workload-based
-# routing.
+# routing. Keys should be strings, not numbers.
 try:
     CLICKHOUSE_PER_TEAM_SETTINGS: dict = json.loads(os.getenv("CLICKHOUSE_PER_TEAM_SETTINGS", "{}"))
 except Exception:
     CLICKHOUSE_PER_TEAM_SETTINGS = {}
 
-# Per-team settings used for query execution.
+# Per-team settings used for query execution. Keys should be strings, not numbers.
 try:
     CLICKHOUSE_PER_TEAM_QUERY_SETTINGS: dict[str, str] = json.loads(
         os.getenv("CLICKHOUSE_PER_TEAM_QUERY_SETTINGS", "{}")


### PR DESCRIPTION
## Problem

We want to be able to give some teams custom query settings (execution time limits, max memory usage, etc) if they require either preferential treatment (i.e. more resources) or penalization (fewer resources, throttling, etc.)

## Changes

Adds `CLICKHOUSE_PER_TEAM_QUERY_SETTINGS` setting that can be used for providing an additional layer of settings. These settings take precedence over the default settings (those defined in the cluster or application) but may be overridden by custom settings provided on a per-call basis to `sync_execute`.

## Did you write or update any docs for this change?

No docs needed for this change

## How did you test this code?

```
ted@revuelto posthog % DEBUG=1 CLICKHOUSE_PER_TEAM_QUERY_SETTINGS='{"1":{"max_memory_usage":"123456789"}}' python manage.py shell
>>> from posthog.settings import CLICKHOUSE_PER_TEAM_QUERY_SETTINGS
>>> CLICKHOUSE_PER_TEAM_QUERY_SETTINGS
{'1': {'max_memory_usage': '123456789'}}
>>> from posthog.clickhouse.client.execute import sync_execute
>>> [[query_id]] = sync_execute("SELECT queryID()", team_id=1)
>>> sync_execute("SELECT Settings['max_memory_usage'] FROM system.query_log WHERE query_id = %(query_id)s", {'query_id': query_id})
[('123456789',)]
```