### PR TITLE
feat(web-analytics): add web_bounces_daily materialization

### DIFF
--- a/dags/definitions.py
+++ b/dags/definitions.py
@@ -56,6 +56,7 @@ defs = dagster.Definitions(
         web_preaggregated_internal.web_analytics_preaggregated_tables,
         web_preaggregated_internal.web_overview_daily,
         web_preaggregated_internal.web_stats_daily,
+        web_preaggregated_internal.web_bounces_daily,
     ],
     jobs=[
         deletes.deletes_job,

--- a/dags/web_preaggregated_internal.py
+++ b/dags/web_preaggregated_internal.py
@@ -114,6 +114,7 @@ def web_overview_daily(
     config_schema=WEB_ANALYTICS_CONFIG_SCHEMA,
     deps=["web_analytics_preaggregated_tables"],
     metadata={"table": "web_bounces_daily"},
+    tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
 )
 def web_bounces_daily(
     context: dagster.AssetExecutionContext,

--- a/posthog/models/web_preaggregated/sql.py
+++ b/posthog/models/web_preaggregated/sql.py
@@ -68,7 +68,6 @@ WEB_BOUNCES_COLUMNS = """
     entry_path String,
     persons_uniq_state AggregateFunction(uniq, UUID),
     sessions_uniq_state AggregateFunction(uniq, String),
-    total_session_duration_state AggregateFunction(sum, Int64),
     pageviews_count_state AggregateFunction(sum, UInt64),
     bounces_count_state AggregateFunction(sum, UInt64)
 """
@@ -333,50 +332,43 @@ def WEB_BOUNCES_INSERT_SQL(
         host,
         device_type,
         entry_path,
-        uniqState(assumeNotNull(session_person_id)) AS persons_uniq_state,
+        uniqState(assumeNotNull(person_id)) AS persons_uniq_state,
         uniqState(assumeNotNull(session_id)) AS sessions_uniq_state,
-        sumState(session_duration) AS total_session_duration_state,
         sumState(pageview_count) AS pageviews_count_state,
         sumState(toUInt64(ifNull(is_bounce, 0))) AS bounces_count_state
     FROM
     (
         SELECT
-            any(if(NOT empty(events__override.distinct_id), events__override.person_id, events.person_id)) AS session_person_id,
-            events__session.session_id AS session_id,
+            any(if(NOT empty(events__override.distinct_id), events__override.person_id, events.person_id)) AS person_id,
+            countIf(e.event IN ('$pageview', '$screen')) AS pageview_count,
             events__session.entry_path AS entry_path,
+            events__session.session_id AS session_id,
+            any(events__session.is_bounce) AS is_bounce,
             e.mat_$host AS host,
             e.mat_$device_type AS device_type,
-            any(events__session.`$session_duration`) AS session_duration,
-            countIf(e.event IN ('$pageview', '$screen')) AS pageview_count,
-            any(events__session.is_bounce) AS is_bounce,
             e.team_id AS team_id,
             min(events__session.start_timestamp) AS start_timestamp
         FROM events AS e
         LEFT JOIN
         (
             SELECT
-                toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-                min(toTimeZone(raw_sessions.min_timestamp, '{timezone}')) AS start_timestamp,
                 path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS entry_path,
-                raw_sessions.session_id_v7 AS session_id_v7,
-                dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, '{timezone}')), max(toTimeZone(raw_sessions.max_timestamp, '{timezone}'))) AS `$session_duration`,
-                /* Bounce calculation logic */
-                if(
-                    ifNull(equals(uniqUpToMerge(1)(raw_sessions.page_screen_autocapture_uniq_up_to), 0), 0),
-                    NULL,
+                toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL,
                     NOT(or(
-                        ifNull(greater(uniqUpToMerge(1)(raw_sessions.page_screen_autocapture_uniq_up_to), 1), 0),
-                        greaterOrEquals(dateDiff('second',
-                            min(toTimeZone(raw_sessions.min_timestamp, '{timezone}')),
-                            max(toTimeZone(raw_sessions.max_timestamp, '{timezone}'))), 10)
+                        ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0),
+                        ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0),
+                        -- This can be configured so we need to de-opt-the query if it is different
+                        greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, '{timezone}')), max(toTimeZone(raw_sessions.max_timestamp, '{timezone}'))), 10)
                     ))
-                ) AS is_bounce
+                ) AS is_bounce,
+                min(toTimeZone(raw_sessions.min_timestamp, '{timezone}')) AS start_timestamp,
+                raw_sessions.session_id_v7 AS session_id_v7
             FROM raw_sessions
             WHERE {team_filter}
                 AND toTimeZone(raw_sessions.min_timestamp, '{timezone}') >= toDateTime('{date_start}', '{timezone}')
                 AND toTimeZone(raw_sessions.min_timestamp, '{timezone}') < toDateTime('{date_end}', '{timezone}')
             GROUP BY raw_sessions.session_id_v7
-            SETTINGS {settings}
         ) AS events__session ON toUInt128(accurateCastOrNull(e.`$session_id`, 'UUID')) = events__session.session_id_v7
         LEFT JOIN
         (
@@ -387,7 +379,6 @@ def WEB_BOUNCES_INSERT_SQL(
             WHERE {person_team_filter}
             GROUP BY person_distinct_id_overrides.distinct_id
             HAVING ifNull(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version) = 0, 0)
-            SETTINGS {settings}
         ) AS events__override ON e.distinct_id = events__override.distinct_id
         WHERE {events_team_filter}
             AND ((e.event = '$pageview') OR (e.event = '$screen'))
@@ -395,18 +386,17 @@ def WEB_BOUNCES_INSERT_SQL(
             AND toTimeZone(e.timestamp, '{timezone}') >= toDateTime('{date_start}', '{timezone}')
             AND toTimeZone(e.timestamp, '{timezone}') < toDateTime('{date_end}', '{timezone}')
         GROUP BY
-            events__session.session_id,
-            e.team_id,
+            session_id,
+            entry_path,
+            team_id,
             host,
-            device_type,
-            entry_path
-        SETTINGS {settings}
+            device_type
     )
     GROUP BY
         day_bucket,
         team_id,
+        entry_path,
         host,
-        device_type,
-        entry_path
+        device_type
     SETTINGS {settings}
     """

--- a/posthog/models/web_preaggregated/sql.py
+++ b/posthog/models/web_preaggregated/sql.py
@@ -352,14 +352,14 @@ def WEB_BOUNCES_INSERT_SQL(
         LEFT JOIN
         (
             SELECT
-                path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS entry_path,
+                path(coalesce(argMinMerge(raw_sessions.entry_url), '')) AS entry_path,
                 toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-                if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL,
+                if(ifNull(equals(uniqUpToMerge(1)(raw_sessions.page_screen_autocapture_uniq_up_to), 0), 0), NULL,
                     NOT(or(
-                        ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0),
-                        ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0),
-                        -- This can be configured so we need to de-opt-the query if it is different
-                        greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, '{timezone}')), max(toTimeZone(raw_sessions.max_timestamp, '{timezone}'))), 10)
+                        ifNull(greater(uniqUpToMerge(1)(raw_sessions.page_screen_autocapture_uniq_up_to), 1), 0),
+                        greaterOrEquals(dateDiff('second',
+                        min(toTimeZone(raw_sessions.min_timestamp, '{timezone}')),
+                        max(toTimeZone(raw_sessions.max_timestamp, '{timezone}'))), 10)
                     ))
                 ) AS is_bounce,
                 min(toTimeZone(raw_sessions.min_timestamp, '{timezone}')) AS start_timestamp,


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We need to be very careful about bounce rate counts and will require this table to build the path breakdown, which currently includes bounce rate calculations as an inner query. At least now they won't time out :) 

## Changes

- Added a new Dagster asset so we can have a pre-aggregated table for daily bounce rates per path. By using the raw paths we can still enable Path cleaning when running this query.

## Did you write or update any docs for this change?

- [x] No docs needed for this change

## How did you test this code?

Double-checked against prod data on the us offline cluster.

