### PR TITLE
fix(cohorts): When fetching cohort, process first before updating cohortsModel

### DIFF
--- a/frontend/src/scenes/cohorts/cohortEditLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortEditLogic.ts
@@ -216,9 +216,10 @@ export const cohortEditLogic = kea<cohortEditLogicType>([
                     try {
                         const cohort = await api.cohorts.get(id)
                         breakpoint()
-                        cohortsModel.actions.updateCohort(cohort)
-                        actions.checkIfFinishedCalculating(cohort)
-                        return processCohort(cohort)
+                        const processedCohort = processCohort(cohort)
+                        cohortsModel.actions.updateCohort(processedCohort)
+                        actions.checkIfFinishedCalculating(processedCohort)
+                        return processedCohort
                     } catch (error: any) {
                         lemonToast.error(error.detail || 'Failed to fetch cohort')
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Refer to #32363.

## Changes

I noticed that while the network request is fetching the correct data in, somehow the data displayed in the UI is wrong.

After reading https://github.com/PostHog/posthog/pull/32365 & https://github.com/PostHog/posthog/pull/32349, I realised that `value_property` was undefined in the kea logic:

<img width="415" alt="Screenshot 2025-05-22 at 1 42 10 PM" src="https://github.com/user-attachments/assets/1c9ed872-22c9-4760-84e5-d3678c3e0ae8" />

I'm not 100% sure about this change or whether it works because I haven't been able to setup my localhost, so feel free to close this PR if its not the right solution.


## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Unfortunately, I haven't been able to setup my localhost, so can't test it locally. Do let me know if there is any tests i can add or update, thanks!
