### PR TITLE
fix(project-tree): pinned folder nits

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -400,7 +400,7 @@ export function ProjectTree({
             contentRef={mainContentRef as RefObject<HTMLElement>}
             className="px-0 py-1"
             data={fullFileSystemFiltered}
-            mode={projectTreeMode as TreeMode}
+            mode={onlyTree ? 'tree' : (projectTreeMode as TreeMode)}
             selectMode={selectMode}
             tableViewKeys={treeTableKeys}
             defaultSelectedFolderOrNodeId={lastViewedId || undefined}
@@ -412,6 +412,7 @@ export function ProjectTree({
             }}
             onItemChecked={onItemChecked}
             checkedItemCount={checkedItemCountNumeric}
+            disableScroll={onlyTree ? true : false}
             onItemClick={(item) => {
                 if (item?.type === 'empty-folder' || item?.type === 'loading-indicator') {
                     return

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -184,6 +184,8 @@ export type LemonTreeProps = LemonTreeBaseProps & {
     onDragEnd?: (dragEvent: DragEndEvent) => void
     /** Whether the item is checked. */
     isItemChecked?: (item: TreeDataItem, checked: boolean) => boolean | undefined
+    /** Whether to disable the scrollable shadows. */
+    disableScroll?: boolean
 }
 
 export type LemonTreeNodeProps = LemonTreeBaseProps & {
@@ -660,6 +662,7 @@ const LemonTree = forwardRef<LemonTreeRef, LemonTreeProps>(
             tableModeHeader,
             tableModeRow,
             size = 'default',
+            disableScroll = false,
             ...props
         },
         ref: ForwardedRef<LemonTreeRef>
@@ -1289,7 +1292,9 @@ const LemonTree = forwardRef<LemonTreeRef, LemonTreeProps>(
                     aria-label="Tree navigation"
                     onKeyDown={handleKeyDown}
                     className="flex-1"
-                    innerClassName="relative overflow-x-auto"
+                    innerClassName={cn('relative overflow-x-auto', {
+                        'overflow-hidden': disableScroll,
+                    })}
                     styledScrollbars
                     style={
                         {


### PR DESCRIPTION

## Problem
* Changing tree view mode => "table" also changed all tree (including pinned folder's tree)
* Pinned folder's tree had it's own scroll bar

## Changes
* Add prop to lemon tree to disable scrolling
* Block pinned folder's tree from inheriting tree mode by checking `onlyTree` prop is true

## How did you test this code?
Manually