### PR TITLE
fix(mssql): Support datetimeoffset as pa.timestamp("us")

### DIFF
--- a/posthog/temporal/data_imports/pipelines/mssql/mssql.py
+++ b/posthog/temporal/data_imports/pipelines/mssql/mssql.py
@@ -140,7 +140,7 @@ class MSSQLColumn(Column):
                 arrow_type = pa.string()
             case "date":
                 arrow_type = pa.date32()
-            case "datetime" | "datetime2" | "smalldatetime":
+            case "datetime" | "datetime2" | "smalldatetime" | "datetimeoffset":
                 arrow_type = pa.timestamp("us")
             case "time":
                 arrow_type = pa.time64("us")


### PR DESCRIPTION
# Problem

The python MSSQLServer driver returns `datetimeoffset` types as python
`datetime.datetime` objects. However, our schema resolution resolves
these types to the fallback `pa.string()`. This causes parsing to fail
as we try to cast a `pa.timestamp("us", tz="+10:00")` to a `pa.string()`,
and pyarrow doesn't like that for some reason.

# Changes

I think arrow is a bit bugged here, but we should also be treating
`datetimeoffset` types the same we treat other datetime types anyways.
So, I've added that type to the type resolution function so they resolve
as `pa.timestamp("us")` like other datetime types.