### PR TITLE
chore: remove untransformed snapshot tracking and mobile wireframe data export

### DIFF
--- a/ee/frontend/mobile-replay/parsing.test.ts
+++ b/ee/frontend/mobile-replay/parsing.test.ts
@@ -7,13 +7,13 @@ describe('snapshot parsing', () => {
     const numberOfParsedLinesInData = 3
 
     it('handles normal mobile data', async () => {
-        const parsed = await parseEncodedSnapshots(encodedWebSnapshotData, sessionId, true)
+        const parsed = await parseEncodedSnapshots(encodedWebSnapshotData, sessionId)
         expect(parsed.length).toEqual(numberOfParsedLinesInData)
         expect(parsed).toMatchSnapshot()
     })
     it('handles mobile data with no meta event', async () => {
         const withoutMeta = [encodedWebSnapshotData[0], encodedWebSnapshotData[2]]
-        const parsed = await parseEncodedSnapshots(withoutMeta, sessionId, true)
+        const parsed = await parseEncodedSnapshots(withoutMeta, sessionId)
         expect(parsed.length).toEqual(numberOfParsedLinesInData)
         expect(parsed).toMatchSnapshot()
     })

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -167,7 +167,6 @@ export const FEATURE_FLAGS = {
     SURVEYS_ACTIONS: 'surveys-actions', // owner: #team-surveys
     SURVEYS_CUSTOM_FONTS: 'surveys-custom-fonts', // owner: #team-surveys
     SURVEYS_PARTIAL_RESPONSES: 'surveys-partial-responses', // owner: #team-surveys
-    SESSION_REPLAY_EXPORT_MOBILE_DATA: 'session-replay-export-mobile-data', // owner: #team-replay
     DISCUSSIONS: 'discussions', // owner: @daibhin @benjackwhite
     REDIRECT_INSIGHT_CREATION_PRODUCT_ANALYTICS_ONBOARDING: 'redirect-insight-creation-product-analytics-onboarding', // owner: @biancayang
     AI_SESSION_SUMMARY: 'ai-session-summary', // owner: #team-replay

--- a/frontend/src/scenes/session-recordings/file-playback/sessionRecordingFilePlaybackSceneLogic.ts
+++ b/frontend/src/scenes/session-recordings/file-playback/sessionRecordingFilePlaybackSceneLogic.ts
@@ -143,7 +143,6 @@ export const sessionRecordingFilePlaybackSceneLogic = kea<sessionRecordingFilePl
             // Simulate a loaded source and sources so that nothing extra gets loaded
             dataLogic.actions.loadSnapshotsForSourceSuccess({
                 snapshots: snapshots,
-                untransformed_snapshots: snapshots,
                 source: { source: 'file' },
             })
             dataLogic.actions.loadSnapshotSourcesSuccess([{ source: 'file' }])

--- a/frontend/src/scenes/session-recordings/player/player-meta/PlayerMetaLinks.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/PlayerMetaLinks.tsx
@@ -1,7 +1,6 @@
 import { IconDownload, IconEllipsis, IconMinusSmall, IconNotebook, IconPlusSmall, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonButtonProps, LemonDialog, LemonMenu, LemonMenuItems } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { IconComment } from 'lib/lemon-ui/icons'
 import { useMemo } from 'react'
 import { useNotebookNode } from 'scenes/notebooks/Nodes/NotebookNodeContext'
@@ -32,7 +31,7 @@ function PinToPlaylistButton(): JSX.Element {
             size="xsmall"
             onClick={() => {
                 if (nodeLogic) {
-                    // If we are in a node, then pinning should persist the recording
+                    // If we are in a node, then pinning should persist that recording
                     maybePersistRecording()
                 }
 
@@ -142,8 +141,6 @@ const MenuActions = ({ size }: { size: PlayerMetaBreakpoints }): JSX.Element => 
     const { logicProps } = useValues(sessionRecordingPlayerLogic)
     const { deleteRecording, setIsFullScreen, exportRecordingToFile } = useActions(sessionRecordingPlayerLogic)
 
-    const hasMobileExportFlag = useFeatureFlag('SESSION_REPLAY_EXPORT_MOBILE_DATA')
-    const hasMobileExport = window.IMPERSONATED_SESSION || hasMobileExportFlag
     const isStandardMode =
         (logicProps.mode ?? SessionRecordingPlayerMode.Standard) === SessionRecordingPlayerMode.Standard
 
@@ -172,7 +169,7 @@ const MenuActions = ({ size }: { size: PlayerMetaBreakpoints }): JSX.Element => 
                 label: '.json',
                 status: 'default',
                 icon: <IconDownload />,
-                onClick: () => exportRecordingToFile(false),
+                onClick: () => exportRecordingToFile(),
                 tooltip: 'Export recording to a JSON file. This can be loaded later into PostHog for playback.',
             },
         ]
@@ -180,17 +177,6 @@ const MenuActions = ({ size }: { size: PlayerMetaBreakpoints }): JSX.Element => 
             itemsArray.unshift({
                 label: () => <AddToNotebookButton fullWidth={true} />,
             })
-        }
-        if (hasMobileExport) {
-            isStandardMode &&
-                itemsArray.push({
-                    label: 'DEBUG - mobile.json',
-                    status: 'default',
-                    icon: <IconDownload />,
-                    onClick: () => exportRecordingToFile(true),
-                    tooltip:
-                        'DEBUG - ONLY VISIBLE TO POSTHOG STAFF - Export untransformed recording to a file. This can be loaded later into PostHog for playback.',
-                })
         }
         if (logicProps.playerKey !== 'modal') {
             isStandardMode &&
@@ -202,7 +188,7 @@ const MenuActions = ({ size }: { size: PlayerMetaBreakpoints }): JSX.Element => 
                 })
         }
         return itemsArray
-    }, [logicProps.playerKey, onDelete, exportRecordingToFile, hasMobileExport, size])
+    }, [logicProps.playerKey, onDelete, exportRecordingToFile, size])
 
     return (
         <LemonMenu items={items} buttonSize="xsmall">

--- a/frontend/src/scenes/session-recordings/player/player-meta/PlayerMetaLinks.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/PlayerMetaLinks.tsx
@@ -169,7 +169,7 @@ const MenuActions = ({ size }: { size: PlayerMetaBreakpoints }): JSX.Element => 
                 label: '.json',
                 status: 'default',
                 icon: <IconDownload />,
-                onClick: () => exportRecordingToFile(),
+                onClick: exportRecordingToFile,
                 tooltip: 'Export recording to a JSON file. This can be loaded later into PostHog for playback.',
             },
         ]

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.test.ts
@@ -1,7 +1,6 @@
 import { EventType, IncrementalSource, mutationData, NodeType } from '@posthog/rrweb-types'
 import { expectLogic } from 'kea-test-utils'
 import { api, MOCK_TEAM_ID } from 'lib/api.mock'
-import posthog from 'posthog-js'
 import { convertSnapshotsByWindowId } from 'scenes/session-recordings/__mocks__/recording_snapshots'
 import { encodedWebSnapshotData } from 'scenes/session-recordings/player/__mocks__/encoded-snapshot-data'
 import {
@@ -24,8 +23,6 @@ import { sessionRecordingEventUsageLogic } from '../sessionRecordingEventUsageLo
 import { chunkMutationSnapshot } from './snapshot-processing/chunk-large-mutations'
 import { MUTATION_CHUNK_SIZE } from './snapshot-processing/chunk-large-mutations'
 import { deduplicateSnapshots } from './snapshot-processing/deduplicate-snapshots'
-import { patchMetaEventIntoWebData, ViewportResolution } from './snapshot-processing/patch-meta-event'
-import { clearThrottle } from './snapshot-processing/throttle-capturing'
 
 const sortedRecordingSnapshotsJson = sortedRecordingSnapshots()
 
@@ -514,108 +511,5 @@ describe('sessionRecordingDataLogic', () => {
             const chunks = chunkMutationSnapshot(snapshot)
             expect(chunks).toEqual([snapshot])
         })
-    })
-})
-
-describe('patchMetaEventIntoWebData', () => {
-    const mockViewportForTimestamp = (): ViewportResolution => ({
-        width: '1024',
-        height: '768',
-        href: 'https://blah.io',
-    })
-
-    function createFullSnapshot(): RecordingSnapshot {
-        return {
-            type: EventType.FullSnapshot,
-            timestamp: 1000,
-            windowId: 'window1',
-            data: {} as any,
-        }
-    }
-
-    function createMeta(width: number, height: number, href: string = 'https://blah.io'): RecordingSnapshot {
-        return {
-            type: EventType.Meta,
-            timestamp: 1000,
-            windowId: 'window1',
-            data: {
-                width: width,
-                height: height,
-                href: href,
-            },
-        }
-    }
-
-    it('adds meta event before full snapshot when none exists', () => {
-        const snapshots: RecordingSnapshot[] = [createFullSnapshot()]
-
-        const result = patchMetaEventIntoWebData(snapshots, mockViewportForTimestamp, '12345')
-
-        expect(result).toEqual([createMeta(1024, 768), createFullSnapshot()])
-    })
-
-    it('does not add meta event if one already exists before full snapshot', () => {
-        const snapshots: RecordingSnapshot[] = [createMeta(800, 600, 'http://test'), createFullSnapshot()]
-
-        const result = patchMetaEventIntoWebData(snapshots, mockViewportForTimestamp, '12345')
-
-        expect(result).toHaveLength(2)
-        expect(result[0]).toBe(snapshots[0])
-        expect(result[1]).toBe(snapshots[1])
-    })
-
-    it('handles multiple full snapshots correctly', () => {
-        const snapshots: RecordingSnapshot[] = [
-            createFullSnapshot(),
-            {
-                type: EventType.IncrementalSnapshot,
-                timestamp: 1500,
-                windowId: 'window1',
-                data: {},
-            } as RecordingSnapshot,
-            createFullSnapshot(),
-        ]
-
-        const result = patchMetaEventIntoWebData(snapshots, mockViewportForTimestamp, '12345')
-
-        expect(result).toHaveLength(5)
-        expect(result[0].type).toBe(EventType.Meta)
-        expect(result[1].type).toBe(EventType.FullSnapshot)
-        expect(result[2].type).toBe(EventType.IncrementalSnapshot)
-        expect(result[3].type).toBe(EventType.Meta)
-        expect(result[4].type).toBe(EventType.FullSnapshot)
-    })
-
-    it('logs error when viewport dimensions are not available', () => {
-        const mockViewportForTimestampNoData = (): ViewportResolution | undefined => undefined
-        const snapshots: RecordingSnapshot[] = [createFullSnapshot()]
-
-        jest.spyOn(posthog, 'captureException')
-
-        const result = patchMetaEventIntoWebData(snapshots, mockViewportForTimestampNoData, '12345')
-
-        expect(posthog.captureException).toHaveBeenCalledWith(
-            new Error('No event viewport or meta snapshot found for full snapshot'),
-            expect.any(Object)
-        )
-        expect(result).toHaveLength(1)
-        expect(result[0]).toBe(snapshots[0])
-    })
-
-    it('does not log error twice for the same session', () => {
-        clearThrottle()
-
-        const mockViewportForTimestampNoData = (): ViewportResolution | undefined => undefined
-        const snapshots: RecordingSnapshot[] = [createFullSnapshot()]
-
-        jest.spyOn(posthog, 'captureException')
-
-        expect(posthog.captureException).toHaveBeenCalledTimes(0)
-        patchMetaEventIntoWebData(snapshots, mockViewportForTimestampNoData, '12345')
-        expect(posthog.captureException).toHaveBeenCalledTimes(1)
-        patchMetaEventIntoWebData(snapshots, mockViewportForTimestampNoData, '12345')
-        expect(posthog.captureException).toHaveBeenCalledTimes(1)
-        patchMetaEventIntoWebData(snapshots, mockViewportForTimestampNoData, '54321')
-        expect(posthog.captureException).toHaveBeenCalledTimes(2)
     })
 })

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.test.ts
@@ -400,7 +400,7 @@ describe('sessionRecordingDataLogic', () => {
         const sessionId = '12345'
         const numberOfParsedLinesInData = 8
         it('handles normal web data', async () => {
-            const parsed = await parseEncodedSnapshots(encodedWebSnapshotData, sessionId, false)
+            const parsed = await parseEncodedSnapshots(encodedWebSnapshotData, sessionId)
             expect(parsed.length).toEqual(numberOfParsedLinesInData)
             expect(parsed).toMatchSnapshot()
         })
@@ -410,8 +410,7 @@ describe('sessionRecordingDataLogic', () => {
                 encodedWebSnapshotData.map((line, index) => {
                     return index == 0 ? line.substring(0, line.length / 2) : line
                 }),
-                sessionId,
-                false
+                sessionId
             )
 
             // unparseable lines are not returned

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -168,7 +168,7 @@ export interface SessionRecordingDataLogicProps {
 async function processEncodedResponse(
     encodedResponse: (EncodedRecordingSnapshot | string)[],
     props: SessionRecordingDataLogicProps
-): Promise<RecordingSnapshot[] | null> {
+): Promise<RecordingSnapshot[]> {
     return await parseEncodedSnapshots(encodedResponse, props.sessionRecordingId)
 }
 
@@ -350,7 +350,7 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
                         throw e
                     })
 
-                    return { snapshots: (await processEncodedResponse(response, props)) ?? undefined, source }
+                    return { snapshots: await processEncodedResponse(response, props), source }
                 },
             },
         ],

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -344,15 +344,13 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
 
                     const response = await api.recordings.getSnapshots(props.sessionRecordingId, params).catch((e) => {
                         if (source.source === 'realtime' && e.status === 404) {
-                            // Realtime source is not always available so a 404 is expected
+                            // Realtime source is not always available, so a 404 is expected
                             return []
                         }
                         throw e
                     })
 
-                    const transformed = await processEncodedResponse(response, props)
-
-                    return { snapshots: transformed ?? undefined, source }
+                    return { snapshots: (await processEncodedResponse(response, props)) ?? undefined, source }
                 },
             },
         ],

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -41,12 +41,13 @@ import { decompressEvent } from './snapshot-processing/decompress'
 import { deduplicateSnapshots } from './snapshot-processing/deduplicate-snapshots'
 import {
     getHrefFromSnapshot,
+    patchMetaEventIntoMobileData,
     patchMetaEventIntoWebData,
     ViewportResolution,
 } from './snapshot-processing/patch-meta-event'
-import { patchMetaEventIntoMobileData } from './snapshot-processing/patch-meta-event'
 import { throttleCapture } from './snapshot-processing/throttle-capturing'
 import { createSegments, mapSnapshotsToWindowId } from './utils/segmenter'
+
 const IS_TEST_MODE = process.env.NODE_ENV === 'test'
 const TWENTY_FOUR_HOURS_IN_MS = 24 * 60 * 60 * 1000 // +- before and after start and end of a recording to query for session linked events.
 const FIVE_MINUTES_IN_MS = 5 * 60 * 1000 // +- before and after start and end of a recording to query for events related by person.
@@ -71,18 +72,15 @@ function hasAnyWireframes(snapshotData: Record<string, any>[]): boolean {
  *
  * If it can't be case as eventWithTime by this point then it's probably not a valid event anyway
  */
-function coerceToEventWithTime(d: unknown, withMobileTransformer: boolean, sessionRecordingId: string): eventWithTime {
-    // we decompress first so that we could support partial compression on mobile in future
+function coerceToEventWithTime(d: unknown, sessionRecordingId: string): eventWithTime {
+    // we decompress first so that we could support partial compression on mobile in the future
     const currentEvent = decompressEvent(d, sessionRecordingId)
-    return withMobileTransformer
-        ? postHogEEModule?.mobileReplay?.transformEventToWeb(currentEvent) || (currentEvent as eventWithTime)
-        : (currentEvent as eventWithTime)
+    return postHogEEModule?.mobileReplay?.transformEventToWeb(currentEvent) || (currentEvent as eventWithTime)
 }
 
 export const parseEncodedSnapshots = async (
     items: (RecordingSnapshot | EncodedRecordingSnapshot | string)[],
-    sessionId: string,
-    withMobileTransformer: boolean = true
+    sessionId: string
 ): Promise<RecordingSnapshot[]> => {
     if (!postHogEEModule) {
         postHogEEModule = await posthogEE()
@@ -126,7 +124,7 @@ export const parseEncodedSnapshots = async (
             }
 
             return snapshotData.flatMap((d: unknown) => {
-                const snap = coerceToEventWithTime(d, withMobileTransformer, sessionId)
+                const snap = coerceToEventWithTime(d, sessionId)
 
                 const baseSnapshot: RecordingSnapshot = {
                     windowId: snapshotLine['window_id'] || snapshotLine['windowId'],
@@ -169,22 +167,9 @@ export interface SessionRecordingDataLogicProps {
 
 async function processEncodedResponse(
     encodedResponse: (EncodedRecordingSnapshot | string)[],
-    props: SessionRecordingDataLogicProps,
-    featureFlags: FeatureFlagsSet
-): Promise<{ transformed: RecordingSnapshot[]; untransformed: RecordingSnapshot[] | null }> {
-    let untransformed: RecordingSnapshot[] | null = null
-
-    const transformed = await parseEncodedSnapshots(encodedResponse, props.sessionRecordingId)
-
-    if (featureFlags[FEATURE_FLAGS.SESSION_REPLAY_EXPORT_MOBILE_DATA]) {
-        untransformed = await parseEncodedSnapshots(
-            encodedResponse,
-            props.sessionRecordingId,
-            false // don't transform mobile data
-        )
-    }
-
-    return { transformed, untransformed }
+    props: SessionRecordingDataLogicProps
+): Promise<RecordingSnapshot[] | null> {
+    return await parseEncodedSnapshots(encodedResponse, props.sessionRecordingId)
 }
 
 export type SourceKey = `${SnapshotSourceType}-${string}`
@@ -365,13 +350,9 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
                         throw e
                     })
 
-                    const { transformed, untransformed } = await processEncodedResponse(
-                        response,
-                        props,
-                        values.featureFlags
-                    )
+                    const transformed = await processEncodedResponse(response, props)
 
-                    return { snapshots: transformed, untransformed_snapshots: untransformed ?? undefined, source }
+                    return { snapshots: transformed ?? undefined, source }
                 },
             },
         ],
@@ -913,19 +894,6 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
             },
         ],
 
-        untransformedSnapshots: [
-            (s) => [s.snapshotSources, s.snapshotsBySource],
-            (sources, snapshotsBySource): RecordingSnapshot[] => {
-                const allSnapshots =
-                    sources?.flatMap((source) => {
-                        const sourceKey = getSourceKey(source)
-                        return snapshotsBySource?.[sourceKey]?.untransformed_snapshots || []
-                    }) ?? []
-
-                return deduplicateSnapshots(allSnapshots)
-            },
-        ],
-
         snapshotsByWindowId: [
             (s) => [s.snapshots],
             (snapshots): Record<string, eventWithTime[]> => {
@@ -1005,18 +973,14 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
         ],
 
         createExportJSON: [
-            (s) => [s.sessionPlayerMetaData, s.snapshots, s.untransformedSnapshots],
-            (
-                sessionPlayerMetaData,
-                snapshots,
-                untransformedSnapshots
-            ): ((exportUntransformedMobileSnapshotData: boolean) => ExportedSessionRecordingFileV2) => {
-                return (exportUntransformedMobileSnapshotData: boolean) => ({
+            (s) => [s.sessionPlayerMetaData, s.snapshots],
+            (sessionPlayerMetaData, snapshots): (() => ExportedSessionRecordingFileV2) => {
+                return () => ({
                     version: '2023-04-28',
                     data: {
                         id: sessionPlayerMetaData?.id ?? '',
                         person: sessionPlayerMetaData?.person,
-                        snapshots: exportUntransformedMobileSnapshotData ? untransformedSnapshots : snapshots,
+                        snapshots: snapshots,
                     },
                 })
             },

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -239,7 +239,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
         incrementErrorCount: true,
         incrementWarningCount: (count: number = 1) => ({ count }),
         syncSnapshotsWithPlayer: true,
-        exportRecordingToFile: (exportUntransformedMobileData?: boolean) => ({ exportUntransformedMobileData }),
+        exportRecordingToFile: true,
         deleteRecording: true,
         openExplorer: true,
         takeScreenshot: true,
@@ -1236,7 +1236,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             cache.pausedMediaElements = []
         },
 
-        exportRecordingToFile: async ({ exportUntransformedMobileData }) => {
+        exportRecordingToFile: async () => {
             if (!values.sessionPlayerData) {
                 return
             }
@@ -1261,13 +1261,11 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                     await delay(delayTime)
                 }
 
-                const payload = values.createExportJSON(!!exportUntransformedMobileData)
+                const payload = values.createExportJSON()
 
                 const recordingFile = new File(
                     [JSON.stringify(payload, null, 2)],
-                    `export-${props.sessionRecordingId}.${
-                        exportUntransformedMobileData ? 'mobile.' : ''
-                    }ph-recording.json`,
+                    `export-${props.sessionRecordingId}-ph-recording.json`,
                     { type: 'application/json' }
                 )
 

--- a/frontend/src/scenes/session-recordings/player/snapshot-processing/patch-meta-event.test.ts
+++ b/frontend/src/scenes/session-recordings/player/snapshot-processing/patch-meta-event.test.ts
@@ -1,0 +1,110 @@
+import { EventType } from '@posthog/rrweb-types'
+import posthog from 'posthog-js'
+
+import { RecordingSnapshot } from '~/types'
+
+import { patchMetaEventIntoWebData, ViewportResolution } from './patch-meta-event'
+import { clearThrottle } from './throttle-capturing'
+
+describe('patchMetaEventIntoWebData', () => {
+    const mockViewportForTimestamp = (): ViewportResolution => ({
+        width: '1024',
+        height: '768',
+        href: 'https://blah.io',
+    })
+
+    function createFullSnapshot(): RecordingSnapshot {
+        return {
+            type: EventType.FullSnapshot,
+            timestamp: 1000,
+            windowId: 'window1',
+            data: {} as any,
+        }
+    }
+
+    function createMeta(width: number, height: number, href: string = 'https://blah.io'): RecordingSnapshot {
+        return {
+            type: EventType.Meta,
+            timestamp: 1000,
+            windowId: 'window1',
+            data: {
+                width: width,
+                height: height,
+                href: href,
+            },
+        }
+    }
+
+    it('adds meta event before full snapshot when none exists', () => {
+        const snapshots: RecordingSnapshot[] = [createFullSnapshot()]
+
+        const result = patchMetaEventIntoWebData(snapshots, mockViewportForTimestamp, '12345')
+
+        expect(result).toEqual([createMeta(1024, 768), createFullSnapshot()])
+    })
+
+    it('does not add meta event if one already exists before full snapshot', () => {
+        const snapshots: RecordingSnapshot[] = [createMeta(800, 600, 'http://test'), createFullSnapshot()]
+
+        const result = patchMetaEventIntoWebData(snapshots, mockViewportForTimestamp, '12345')
+
+        expect(result).toHaveLength(2)
+        expect(result[0]).toBe(snapshots[0])
+        expect(result[1]).toBe(snapshots[1])
+    })
+
+    it('handles multiple full snapshots correctly', () => {
+        const snapshots: RecordingSnapshot[] = [
+            createFullSnapshot(),
+            {
+                type: EventType.IncrementalSnapshot,
+                timestamp: 1500,
+                windowId: 'window1',
+                data: {},
+            } as RecordingSnapshot,
+            createFullSnapshot(),
+        ]
+
+        const result = patchMetaEventIntoWebData(snapshots, mockViewportForTimestamp, '12345')
+
+        expect(result).toHaveLength(5)
+        expect(result[0].type).toBe(EventType.Meta)
+        expect(result[1].type).toBe(EventType.FullSnapshot)
+        expect(result[2].type).toBe(EventType.IncrementalSnapshot)
+        expect(result[3].type).toBe(EventType.Meta)
+        expect(result[4].type).toBe(EventType.FullSnapshot)
+    })
+
+    it('logs error when viewport dimensions are not available', () => {
+        const mockViewportForTimestampNoData = (): ViewportResolution | undefined => undefined
+        const snapshots: RecordingSnapshot[] = [createFullSnapshot()]
+
+        jest.spyOn(posthog, 'captureException')
+
+        const result = patchMetaEventIntoWebData(snapshots, mockViewportForTimestampNoData, '12345')
+
+        expect(posthog.captureException).toHaveBeenCalledWith(
+            new Error('No event viewport or meta snapshot found for full snapshot'),
+            expect.any(Object)
+        )
+        expect(result).toHaveLength(1)
+        expect(result[0]).toBe(snapshots[0])
+    })
+
+    it('does not logs error twice for the same session', () => {
+        clearThrottle()
+
+        const mockViewportForTimestampNoData = (): ViewportResolution | undefined => undefined
+        const snapshots: RecordingSnapshot[] = [createFullSnapshot()]
+
+        jest.spyOn(posthog, 'captureException')
+
+        expect(posthog.captureException).toHaveBeenCalledTimes(0)
+        patchMetaEventIntoWebData(snapshots, mockViewportForTimestampNoData, '12345')
+        expect(posthog.captureException).toHaveBeenCalledTimes(1)
+        patchMetaEventIntoWebData(snapshots, mockViewportForTimestampNoData, '12345')
+        expect(posthog.captureException).toHaveBeenCalledTimes(1)
+        patchMetaEventIntoWebData(snapshots, mockViewportForTimestampNoData, '54321')
+        expect(posthog.captureException).toHaveBeenCalledTimes(2)
+    })
+})

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1067,7 +1067,6 @@ export type SessionRecordingSnapshotParams =
 export interface SessionRecordingSnapshotSourceResponse {
     source: Pick<SessionRecordingSnapshotSource, 'source' | 'blob_key'>
     snapshots?: RecordingSnapshot[]
-    untransformed_snapshots?: RecordingSnapshot[]
 }
 
 export interface SessionRecordingSnapshotResponse {
@@ -1083,9 +1082,6 @@ export interface SessionPlayerSnapshotData {
     snapshots?: RecordingSnapshot[]
     sources?: SessionRecordingSnapshotSource[]
     blob_keys?: string[]
-    // used for a debug signal only for PostHog team, controlled by a feature flag
-    // DO NOT RELY ON THIS FOR NON DEBUG PURPOSES
-    untransformed_snapshots?: RecordingSnapshot[]
 }
 
 export interface SessionPlayerData {


### PR DESCRIPTION
we're over processing the snapshot data

part of that is doubling it up in case we want to export mobile replay data for debugging

i have not done that for at least 12 months

and maybe nobody else every did

🪓


(stacked on top of https://github.com/PostHog/posthog/pull/32513)