### PR TITLE
feat(project-tree): data management items via manifest

### DIFF
--- a/common/esbuilder/utils.mjs
+++ b/common/esbuilder/utils.mjs
@@ -564,6 +564,7 @@ export function gatherProductManifests(__dirname) {
     const fileSystemTypes = []
     const treeItemsNew = {}
     const treeItemsGames = {}
+    const treeItemsDataManagement = {}
     const treeItemsProducts = {}
     const fileSystemFilterTypes = []
 
@@ -680,7 +681,7 @@ export function gatherProductManifests(__dirname) {
             } else if (
                 ts.isPropertyAssignment(node) &&
                 ts.isArrayLiteralExpression(node.initializer) &&
-                (node.name.text === 'treeItemsProducts' || node.name.text === 'treeItemsGames')
+                (node.name.text === 'treeItemsProducts' || node.name.text === 'treeItemsDataManagement' || node.name.text === 'treeItemsGames')
             ) {
                 for (const element of node.initializer.elements) {
                     if (ts.isObjectLiteralExpression(element)) {
@@ -689,6 +690,8 @@ export function gatherProductManifests(__dirname) {
                         if (path) {
                             if (node.name.text === 'treeItemsProducts') {
                                 treeItemsProducts[path] = cloneNode(element)
+                            } else if (node.name.text === 'treeItemsDataManagement') {
+                                treeItemsDataManagement[path] = cloneNode(element)
                             } else {
                                 treeItemsGames[path] = cloneNode(element)
                             }
@@ -767,6 +770,15 @@ export function gatherProductManifests(__dirname) {
         ),
         sourceFile
     )
+    const manifestTreeItemsDataManagement = printer.printNode(
+        ts.EmitHint.Unspecified,
+        ts.factory.createArrayLiteralExpression(
+            Object.keys(treeItemsDataManagement)
+                .sort()
+                .map((key) => treeItemsDataManagement[key])
+        ),
+        sourceFile
+    )
     const manifestTreeFilterTypes = printer.printNode(
         ts.EmitHint.Unspecified,
         ts.factory.createObjectLiteralExpression(fileSystemFilterTypes),
@@ -812,6 +824,8 @@ export function gatherProductManifests(__dirname) {
         export const getTreeItemsProducts = (): FileSystemImport[] => ${manifestTreeItemsProducts}\n
         ${autogenComment}
         export const getTreeItemsGames = (): FileSystemImport[] => ${manifestTreeItemsGames}\n
+        ${autogenComment}
+        export const getTreeItemsDataManagement = (): FileSystemImport[] => ${manifestTreeItemsDataManagement}\n
         ${autogenComment}
         export const getTreeFilterTypes = (): Record<string, FileSystemFilterType> => (${manifestTreeFilterTypes})\n
     `

--- a/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
@@ -85,11 +85,6 @@ export const getDefaultTreeNew = (): FileSystemImport[] =>
 export const getDefaultTreeDataManagement = (): FileSystemImport[] => [
     ...getTreeItemsDataManagement(),
     {
-        path: 'Actions',
-        iconType: 'rocket',
-        href: urls.actions(),
-    },
-    {
         path: 'Event definitions',
         iconType: 'database',
         href: urls.eventDefinitions(),
@@ -103,11 +98,6 @@ export const getDefaultTreeDataManagement = (): FileSystemImport[] => [
         path: 'Annotations',
         iconType: 'notification',
         href: urls.annotations(),
-    },
-    {
-        path: 'Cohorts',
-        type: 'cohort',
-        href: urls.cohorts(),
     },
     {
         path: 'Ingestion warnings',

--- a/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
@@ -16,7 +16,13 @@ import {
 import { FEATURE_FLAGS } from 'lib/constants'
 import { urls } from 'scenes/urls'
 
-import { fileSystemTypes, getTreeItemsGames, getTreeItemsNew, getTreeItemsProducts } from '~/products'
+import {
+    fileSystemTypes,
+    getTreeItemsDataManagement,
+    getTreeItemsGames,
+    getTreeItemsNew,
+    getTreeItemsProducts,
+} from '~/products'
 import { FileSystemImport } from '~/queries/schema/schema-general'
 import { ActivityTab, PipelineStage } from '~/types'
 
@@ -77,6 +83,7 @@ export const getDefaultTreeNew = (): FileSystemImport[] =>
     ].sort((a, b) => a.path.localeCompare(b.path, undefined, { sensitivity: 'accent' }))
 
 export const getDefaultTreeDataManagement = (): FileSystemImport[] => [
+    ...getTreeItemsDataManagement(),
     {
         path: 'Actions',
         iconType: 'rocket',

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -395,7 +395,6 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
     { path: 'Persons', iconType: 'cohort', href: urls.persons() },
     { path: 'Product analytics', type: 'insight', href: urls.insights() },
     { path: 'Revenue analytics', iconType: 'piggyBank', href: urls.revenueAnalytics() },
-    { path: 'Revenue settings', iconType: 'handMoney', href: urls.revenueSettings() },
     { path: 'Session replay', href: urls.replay(ReplayTabs.Home), type: 'session_recording_playlist' },
     { path: 'Surveys', type: 'survey', href: urls.surveys() },
     { path: 'User interviews', href: urls.userInterviews(), type: 'user_interview' },
@@ -404,6 +403,11 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
 
 /** This const is auto-generated, as is the whole file */
 export const getTreeItemsGames = (): FileSystemImport[] => [{ path: '368 Hedgehogs', href: urls.game368hedgehogs() }]
+
+/** This const is auto-generated, as is the whole file */
+export const getTreeItemsDataManagement = (): FileSystemImport[] => [
+    { path: 'Revenue settings', iconType: 'handMoney', href: urls.revenueSettings() },
+]
 
 /** This const is auto-generated, as is the whole file */
 export const getTreeFilterTypes = (): Record<string, FileSystemFilterType> => ({

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -406,6 +406,8 @@ export const getTreeItemsGames = (): FileSystemImport[] => [{ path: '368 Hedgeho
 
 /** This const is auto-generated, as is the whole file */
 export const getTreeItemsDataManagement = (): FileSystemImport[] => [
+    { path: 'Actions', iconType: 'rocket', href: urls.actions() },
+    { path: 'Cohorts', type: 'cohort', href: urls.cohorts() },
     { path: 'Revenue settings', iconType: 'handMoney', href: urls.revenueSettings() },
 ]
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5402,6 +5402,7 @@ export interface ProductManifest {
     treeItemsNew?: FileSystemImport[]
     treeItemsProducts?: FileSystemImport[]
     treeItemsGames?: FileSystemImport[]
+    treeItemsDataManagement?: FileSystemImport[]
     fileSystemFilterTypes?: Record<string, FileSystemFilterType>
 }
 

--- a/products/actions/manifest.tsx
+++ b/products/actions/manifest.tsx
@@ -30,4 +30,11 @@ export const manifest: ProductManifest = {
             href: urls.createAction(),
         },
     ],
+    treeItemsDataManagement: [
+        {
+            path: 'Actions',
+            iconType: 'rocket',
+            href: urls.actions(),
+        },
+    ],
 }

--- a/products/cohorts/manifest.tsx
+++ b/products/cohorts/manifest.tsx
@@ -23,4 +23,11 @@ export const manifest: ProductManifest = {
         },
     ],
     treeItemsProducts: [],
+    treeItemsDataManagement: [
+        {
+            path: 'Cohorts',
+            type: 'cohort',
+            href: urls.cohorts(),
+        },
+    ],
 }

--- a/products/revenue_analytics/manifest.tsx
+++ b/products/revenue_analytics/manifest.tsx
@@ -25,6 +25,8 @@ export const manifest: ProductManifest = {
             iconType: 'piggyBank',
             href: urls.revenueAnalytics(),
         },
+    ],
+    treeItemsDataManagement: [
         {
             path: 'Revenue settings',
             iconType: 'handMoney',


### PR DESCRIPTION
## Changes

You can now add items like "revenue settings", "actions" and "cohorts" under "data management" via manifest files.

![image](https://github.com/user-attachments/assets/38eaadd5-0757-4979-a5a2-8360d35201c2)