### PR TITLE
fix: be able to edit survey submit text

### DIFF
--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -403,7 +403,11 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                     name="buttonText"
                     label="Submit button text"
                     className="flex-1 flex gap-1 justify-center"
-                    info="When the 'Automatically submit on selection' option is enabled, users won't need to click a submit button - their response will be submitted immediately after selecting an option. The submit button will be hidden. Requires at least version 1.244.0 of posthog-js. Not available for the mobile SDKs at the moment."
+                    info={
+                        canSkipSubmitButton
+                            ? "When the 'Automatically submit on selection' option is enabled, users won't need to click a submit button - their response will be submitted immediately after selecting an option. The submit button will be hidden. Requires at least version 1.244.0 of posthog-js. Not available for the mobile SDKs at the moment."
+                            : undefined
+                    }
                 >
                     <>
                         {(!canSkipSubmitButton || (canSkipSubmitButton && !question.skipSubmitButton)) && (

--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -413,6 +413,11 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                                         ? survey.appearance?.submitButtonText ?? 'Submit'
                                         : question.buttonText
                                 }
+                                onChange={(val) => {
+                                    const newQuestions = [...survey.questions]
+                                    newQuestions[index] = { ...question, buttonText: val }
+                                    setSurveyValue('questions', newQuestions)
+                                }}
                             />
                         )}
                         {canSkipSubmitButton && (

--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -417,11 +417,7 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                                         ? survey.appearance?.submitButtonText ?? 'Submit'
                                         : question.buttonText
                                 }
-                                onChange={(val) => {
-                                    const newQuestions = [...survey.questions]
-                                    newQuestions[index] = { ...question, buttonText: val }
-                                    setSurveyValue('questions', newQuestions)
-                                }}
+                                onChange={(val) => handleQuestionValueChange('buttonText', val)}
                             />
                         )}
                         {canSkipSubmitButton && (


### PR DESCRIPTION
Closes https://github.com/PostHog/posthog/issues/32525.

This bug was introduced [on this PR](https://github.com/PostHog/posthog/pull/32228) because the LemonInput is no longer the only direct child of LemonField.Pure.