### PR TITLE
fix: persist duplicated metric

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/MetricHeader.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/MetricHeader.tsx
@@ -3,6 +3,8 @@ import { useActions } from 'kea'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonTag } from 'lib/lemon-ui/LemonTag'
 
+import type { ExperimentMetric } from '~/queries/schema/schema-general'
+
 import { experimentLogic } from '../experimentLogic'
 import { MetricTitle } from './MetricTitle'
 import { getMetricTag } from './utils'
@@ -12,11 +14,13 @@ export const MetricHeader = ({
     metric,
     metricType,
     isPrimaryMetric,
+    onDuplicateMetricClick,
 }: {
     metricIndex: number
     metric: any
     metricType: any
     isPrimaryMetric: boolean
+    onDuplicateMetricClick: (metric: ExperimentMetric) => void
 }): JSX.Element => {
     /**
      * This is a bit overkill, since primary and secondary metric dialogs are
@@ -32,7 +36,6 @@ export const MetricHeader = ({
         openSecondaryMetricModal,
         openPrimarySharedMetricModal,
         openSecondarySharedMetricModal,
-        duplicateMetric,
     } = useActions(experimentLogic)
 
     return (
@@ -69,7 +72,7 @@ export const MetricHeader = ({
                             icon={<IconCopy fontSize="12" />}
                             tooltip="Duplicate"
                             onClick={() => {
-                                duplicateMetric(metric, isPrimaryMetric)
+                                onDuplicateMetricClick(metric)
                             }}
                         />
                     </div>

--- a/frontend/src/scenes/experiments/MetricsView/MetricHeader.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/MetricHeader.tsx
@@ -72,6 +72,9 @@ export const MetricHeader = ({
                             icon={<IconCopy fontSize="12" />}
                             tooltip="Duplicate"
                             onClick={() => {
+                                if (metric.isSharedMetric) {
+                                    return
+                                }
                                 onDuplicateMetricClick(metric)
                             }}
                         />

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -72,7 +72,6 @@ import { EXPERIMENT_MIN_EXPOSURES_FOR_RESULTS, MetricInsightId } from './constan
 import type { experimentLogicType } from './experimentLogicType'
 import { experimentsLogic } from './experimentsLogic'
 import { holdoutsLogic } from './holdoutsLogic'
-import { getDefaultMetricTitle } from './MetricsView/utils'
 import { SharedMetric } from './SharedMetrics/sharedMetricLogic'
 import { sharedMetricsLogic } from './SharedMetrics/sharedMetricsLogic'
 import { featureFlagEligibleForExperiment, percentageDistribution, transformFiltersForWinningVariant } from './utils'
@@ -405,10 +404,6 @@ export const experimentLogic = kea<experimentLogicType>([
             sharedMetricIds,
             metadata,
         }),
-        duplicateMetric: (
-            metric: ExperimentMetric | ExperimentTrendsQuery | ExperimentFunnelsQuery,
-            isPrimary: boolean
-        ) => ({ metric, isPrimary }),
         removeSharedMetricFromExperiment: (sharedMetricId: SharedMetric['id']) => ({ sharedMetricId }),
         createExperimentDashboard: true,
         setIsCreatingExperimentDashboard: (isCreating: boolean) => ({ isCreating }),
@@ -426,24 +421,6 @@ export const experimentLogic = kea<experimentLogicType>([
             {
                 setExperiment: (state, { experiment }) => {
                     return { ...state, ...experiment }
-                },
-                duplicateMetric: (state, { metric, isPrimary }) => {
-                    const name = metric.name
-                        ? `${metric.name} (copy)`
-                        : metric.kind === NodeKind.ExperimentMetric
-                        ? `${getDefaultMetricTitle(metric)} (copy)`
-                        : undefined
-
-                    const newMetric = { ...metric, id: undefined, name }
-                    const metricsKey = isPrimary ? 'metrics' : 'metrics_secondary'
-                    const metrics = [...state[metricsKey]]
-                    const originalIndex = metrics.findIndex((m) => m === metric)
-                    metrics.splice(originalIndex + 1, 0, newMetric)
-
-                    return {
-                        ...state,
-                        [metricsKey]: metrics,
-                    }
                 },
                 addVariant: (state) => {
                     if (state?.parameters?.feature_flag_variants) {
@@ -848,13 +825,6 @@ export const experimentLogic = kea<experimentLogicType>([
         ],
     }),
     listeners(({ values, actions }) => ({
-        duplicateMetric: ({ isPrimary }) => {
-            if (isPrimary) {
-                actions.loadMetricResults()
-            } else {
-                actions.loadSecondaryMetricResults()
-            }
-        },
         createExperiment: async ({ draft, folder }) => {
             const { recommendedRunningTime, recommendedSampleSize, minimumDetectableEffect } = values
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

The duplicate button for metrics on the experiment page was not persisting the new metrics, so any changes were lost when refreshing the page.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

To fix this, we performed some refactoring by removing duplicated code from the logic and applying the same pattern used by the metric form on the DeltaChart.
The unintended side effect is that we can't persist the experiment without a full re-render of the page. That also triggers the metric load actions.

### Before

https://github.com/user-attachments/assets/0730ba08-d637-4f6e-a15e-eacc29bf74b6

### After

https://github.com/user-attachments/assets/f4aa557b-6a12-4edf-8aa0-fb512b8d7060

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
