### PR TITLE
feat: use updated cache value for openai and anthropic

### DIFF
--- a/plugin-server/src/ingestion/ai-costs/process-ai-event.ts
+++ b/plugin-server/src/ingestion/ai-costs/process-ai-event.ts
@@ -24,16 +24,32 @@ const calculateInputCost = (event: PluginEvent, cost: ModelRow) => {
     if (event.properties['$ai_provider'] && event.properties['$ai_provider'].toLowerCase() === 'openai') {
         const cacheReadTokens = event.properties['$ai_cache_read_input_tokens'] || 0
         const inputTokens = event.properties['$ai_input_tokens'] || 0
-        const difference = bigDecimal.subtract(inputTokens, cacheReadTokens)
-        const cachedCost = bigDecimal.multiply(bigDecimal.multiply(cost.cost.prompt_token, 0.5), cacheReadTokens)
-        const uncachedCost = bigDecimal.multiply(cost.cost.prompt_token, difference)
-        return bigDecimal.add(cachedCost, uncachedCost)
+        const regularTokens = bigDecimal.subtract(inputTokens, cacheReadTokens)
+
+        // Use actual cache read cost if available, otherwise fall back to 0.5 multiplier
+        const cacheReadCost =
+            cost.cost.cache_read_token !== undefined
+                ? bigDecimal.multiply(cost.cost.cache_read_token, cacheReadTokens)
+                : bigDecimal.multiply(bigDecimal.multiply(cost.cost.prompt_token, 0.5), cacheReadTokens)
+
+        const regularCost = bigDecimal.multiply(cost.cost.prompt_token, regularTokens)
+        return bigDecimal.add(cacheReadCost, regularCost)
     } else if (event.properties['$ai_provider'] && event.properties['$ai_provider'].toLowerCase() === 'anthropic') {
         const cacheReadTokens = event.properties['$ai_cache_read_input_tokens'] || 0
         const cacheWriteTokens = event.properties['$ai_cache_creation_input_tokens'] || 0
         const inputTokens = event.properties['$ai_input_tokens'] || 0
-        const writeCost = bigDecimal.multiply(bigDecimal.multiply(cost.cost.prompt_token, 1.25), cacheWriteTokens)
-        const cacheReadCost = bigDecimal.multiply(bigDecimal.multiply(cost.cost.prompt_token, 0.1), cacheReadTokens)
+
+        // Use actual cache costs if available, otherwise fall back to multipliers
+        const writeCost =
+            cost.cost.cache_write_token !== undefined
+                ? bigDecimal.multiply(cost.cost.cache_write_token, cacheWriteTokens)
+                : bigDecimal.multiply(bigDecimal.multiply(cost.cost.prompt_token, 1.25), cacheWriteTokens)
+
+        const cacheReadCost =
+            cost.cost.cache_read_token !== undefined
+                ? bigDecimal.multiply(cost.cost.cache_read_token, cacheReadTokens)
+                : bigDecimal.multiply(bigDecimal.multiply(cost.cost.prompt_token, 0.1), cacheReadTokens)
+
         const totalCacheCost = bigDecimal.add(writeCost, cacheReadCost)
         const uncachedCost = bigDecimal.multiply(cost.cost.prompt_token, inputTokens)
         return bigDecimal.add(totalCacheCost, uncachedCost)

--- a/plugin-server/src/ingestion/ai-costs/providers/generated-providers.json
+++ b/plugin-server/src/ingestion/ai-costs/providers/generated-providers.json
@@ -52,119 +52,171 @@
         "model": "claude-3-haiku",
         "cost": {
             "prompt_token": 2.5e-7,
-            "completion_token": 0.00000125
+            "completion_token": 0.00000125,
+            "cache_read_token": 3e-8,
+            "cache_write_token": 3e-7
         }
     },
     {
         "model": "claude-3-haiku:beta",
         "cost": {
             "prompt_token": 2.5e-7,
-            "completion_token": 0.00000125
+            "completion_token": 0.00000125,
+            "cache_read_token": 3e-8,
+            "cache_write_token": 3e-7
         }
     },
     {
         "model": "claude-3-opus",
         "cost": {
             "prompt_token": 0.000015,
-            "completion_token": 0.000075
+            "completion_token": 0.000075,
+            "cache_read_token": 0.0000015,
+            "cache_write_token": 0.00001875
         }
     },
     {
         "model": "claude-3-opus:beta",
         "cost": {
             "prompt_token": 0.000015,
-            "completion_token": 0.000075
+            "completion_token": 0.000075,
+            "cache_read_token": 0.0000015,
+            "cache_write_token": 0.00001875
         }
     },
     {
         "model": "claude-3-sonnet",
         "cost": {
             "prompt_token": 0.000003,
-            "completion_token": 0.000015
+            "completion_token": 0.000015,
+            "cache_read_token": 3e-7,
+            "cache_write_token": 0.00000375
         }
     },
     {
         "model": "claude-3-sonnet:beta",
         "cost": {
             "prompt_token": 0.000003,
-            "completion_token": 0.000015
+            "completion_token": 0.000015,
+            "cache_read_token": 3e-7,
+            "cache_write_token": 0.00000375
         }
     },
     {
         "model": "claude-3.5-haiku",
         "cost": {
             "prompt_token": 8e-7,
-            "completion_token": 0.000004
+            "completion_token": 0.000004,
+            "cache_read_token": 8e-8,
+            "cache_write_token": 0.000001
         }
     },
     {
         "model": "claude-3.5-haiku-20241022",
         "cost": {
             "prompt_token": 8e-7,
-            "completion_token": 0.000004
+            "completion_token": 0.000004,
+            "cache_read_token": 8e-8,
+            "cache_write_token": 0.000001
         }
     },
     {
         "model": "claude-3.5-haiku-20241022:beta",
         "cost": {
             "prompt_token": 8e-7,
-            "completion_token": 0.000004
+            "completion_token": 0.000004,
+            "cache_read_token": 8e-8,
+            "cache_write_token": 0.000001
         }
     },
     {
         "model": "claude-3.5-haiku:beta",
         "cost": {
             "prompt_token": 8e-7,
-            "completion_token": 0.000004
+            "completion_token": 0.000004,
+            "cache_read_token": 8e-8,
+            "cache_write_token": 0.000001
         }
     },
     {
         "model": "claude-3.5-sonnet",
         "cost": {
             "prompt_token": 0.000003,
-            "completion_token": 0.000015
+            "completion_token": 0.000015,
+            "cache_read_token": 3e-7,
+            "cache_write_token": 0.00000375
         }
     },
     {
         "model": "claude-3.5-sonnet-20240620",
         "cost": {
             "prompt_token": 0.000003,
-            "completion_token": 0.000015
+            "completion_token": 0.000015,
+            "cache_read_token": 3e-7,
+            "cache_write_token": 0.00000375
         }
     },
     {
         "model": "claude-3.5-sonnet-20240620:beta",
         "cost": {
             "prompt_token": 0.000003,
-            "completion_token": 0.000015
+            "completion_token": 0.000015,
+            "cache_read_token": 3e-7,
+            "cache_write_token": 0.00000375
         }
     },
     {
         "model": "claude-3.5-sonnet:beta",
         "cost": {
             "prompt_token": 0.000003,
-            "completion_token": 0.000015
+            "completion_token": 0.000015,
+            "cache_read_token": 3e-7,
+            "cache_write_token": 0.00000375
         }
     },
     {
         "model": "claude-3.7-sonnet",
         "cost": {
             "prompt_token": 0.000003,
-            "completion_token": 0.000015
+            "completion_token": 0.000015,
+            "cache_read_token": 3e-7,
+            "cache_write_token": 0.00000375
         }
     },
     {
         "model": "claude-3.7-sonnet:beta",
         "cost": {
             "prompt_token": 0.000003,
-            "completion_token": 0.000015
+            "completion_token": 0.000015,
+            "cache_read_token": 3e-7,
+            "cache_write_token": 0.00000375
         }
     },
     {
         "model": "claude-3.7-sonnet:thinking",
         "cost": {
             "prompt_token": 0.000003,
-            "completion_token": 0.000015
+            "completion_token": 0.000015,
+            "cache_read_token": 3e-7,
+            "cache_write_token": 0.00000375
+        }
+    },
+    {
+        "model": "claude-opus-4",
+        "cost": {
+            "prompt_token": 0.000015,
+            "completion_token": 0.000075,
+            "cache_read_token": 0.0000015,
+            "cache_write_token": 0.00001875
+        }
+    },
+    {
+        "model": "claude-sonnet-4",
+        "cost": {
+            "prompt_token": 0.000003,
+            "completion_token": 0.000015,
+            "cache_read_token": 3e-7,
+            "cache_write_token": 0.00000375
         }
     },
     {
@@ -185,7 +237,8 @@
         "model": "codex-mini",
         "cost": {
             "prompt_token": 0.0000015,
-            "completion_token": 0.000006
+            "completion_token": 0.000006,
+            "cache_read_token": 3.75e-7
         }
     },
     {
@@ -385,10 +438,26 @@
         }
     },
     {
+        "model": "devstral-small",
+        "cost": {
+            "prompt_token": 7e-8,
+            "completion_token": 1e-7
+        }
+    },
+    {
+        "model": "devstral-small:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
         "model": "gemini-2.0-flash-001",
         "cost": {
             "prompt_token": 1e-7,
-            "completion_token": 4e-7
+            "completion_token": 4e-7,
+            "cache_read_token": 2.5e-8,
+            "cache_write_token": 1.833e-7
         }
     },
     {
@@ -409,28 +478,36 @@
         "model": "gemini-2.5-flash-preview",
         "cost": {
             "prompt_token": 1.5e-7,
-            "completion_token": 6e-7
+            "completion_token": 6e-7,
+            "cache_read_token": 3.75e-8,
+            "cache_write_token": 2.333e-7
         }
     },
     {
         "model": "gemini-2.5-flash-preview-05-20",
         "cost": {
             "prompt_token": 1.5e-7,
-            "completion_token": 6e-7
+            "completion_token": 6e-7,
+            "cache_read_token": 3.75e-8,
+            "cache_write_token": 2.333e-7
         }
     },
     {
         "model": "gemini-2.5-flash-preview-05-20:thinking",
         "cost": {
             "prompt_token": 1.5e-7,
-            "completion_token": 0.0000035
+            "completion_token": 0.0000035,
+            "cache_read_token": 3.75e-8,
+            "cache_write_token": 2.333e-7
         }
     },
     {
         "model": "gemini-2.5-flash-preview:thinking",
         "cost": {
             "prompt_token": 1.5e-7,
-            "completion_token": 0.0000035
+            "completion_token": 0.0000035,
+            "cache_read_token": 3.75e-8,
+            "cache_write_token": 2.333e-7
         }
     },
     {
@@ -444,21 +521,27 @@
         "model": "gemini-2.5-pro-preview",
         "cost": {
             "prompt_token": 0.00000125,
-            "completion_token": 0.00001
+            "completion_token": 0.00001,
+            "cache_read_token": 3.1e-7,
+            "cache_write_token": 0.000001625
         }
     },
     {
         "model": "gemini-flash-1.5",
         "cost": {
             "prompt_token": 7.5e-8,
-            "completion_token": 3e-7
+            "completion_token": 3e-7,
+            "cache_read_token": 1.875e-8,
+            "cache_write_token": 1.583e-7
         }
     },
     {
         "model": "gemini-flash-1.5-8b",
         "cost": {
             "prompt_token": 3.75e-8,
-            "completion_token": 1.5e-7
+            "completion_token": 1.5e-7,
+            "cache_read_token": 1e-8,
+            "cache_write_token": 5.83e-8
         }
     },
     {
@@ -533,6 +616,13 @@
     },
     {
         "model": "gemma-3-4b-it:free",
+        "cost": {
+            "prompt_token": 0,
+            "completion_token": 0
+        }
+    },
+    {
+        "model": "gemma-3n-e4b-it:free",
         "cost": {
             "prompt_token": 0,
             "completion_token": 0
@@ -633,35 +723,40 @@
         "model": "gpt-4.1",
         "cost": {
             "prompt_token": 0.000002,
-            "completion_token": 0.000008
+            "completion_token": 0.000008,
+            "cache_read_token": 5e-7
         }
     },
     {
         "model": "gpt-4.1-mini",
         "cost": {
             "prompt_token": 4e-7,
-            "completion_token": 0.0000016
+            "completion_token": 0.0000016,
+            "cache_read_token": 1e-7
         }
     },
     {
         "model": "gpt-4.1-nano",
         "cost": {
             "prompt_token": 1e-7,
-            "completion_token": 4e-7
+            "completion_token": 4e-7,
+            "cache_read_token": 2.5e-8
         }
     },
     {
         "model": "gpt-4.5-preview",
         "cost": {
             "prompt_token": 0.000075,
-            "completion_token": 0.00015
+            "completion_token": 0.00015,
+            "cache_read_token": 0.0000375
         }
     },
     {
         "model": "gpt-4o",
         "cost": {
             "prompt_token": 0.0000025,
-            "completion_token": 0.00001
+            "completion_token": 0.00001,
+            "cache_read_token": 0.00000125
         }
     },
     {
@@ -675,28 +770,32 @@
         "model": "gpt-4o-2024-08-06",
         "cost": {
             "prompt_token": 0.0000025,
-            "completion_token": 0.00001
+            "completion_token": 0.00001,
+            "cache_read_token": 0.00000125
         }
     },
     {
         "model": "gpt-4o-2024-11-20",
         "cost": {
             "prompt_token": 0.0000025,
-            "completion_token": 0.00001
+            "completion_token": 0.00001,
+            "cache_read_token": 0.00000125
         }
     },
     {
         "model": "gpt-4o-mini",
         "cost": {
             "prompt_token": 1.5e-7,
-            "completion_token": 6e-7
+            "completion_token": 6e-7,
+            "cache_read_token": 7.5e-8
         }
     },
     {
         "model": "gpt-4o-mini-2024-07-18",
         "cost": {
             "prompt_token": 1.5e-7,
-            "completion_token": 6e-7
+            "completion_token": 6e-7,
+            "cache_read_token": 7.5e-8
         }
     },
     {
@@ -1081,35 +1180,40 @@
         "model": "o1",
         "cost": {
             "prompt_token": 0.000015,
-            "completion_token": 0.00006
+            "completion_token": 0.00006,
+            "cache_read_token": 0.0000075
         }
     },
     {
         "model": "o1-mini",
         "cost": {
             "prompt_token": 0.0000011,
-            "completion_token": 0.0000044
+            "completion_token": 0.0000044,
+            "cache_read_token": 5.5e-7
         }
     },
     {
         "model": "o1-mini-2024-09-12",
         "cost": {
             "prompt_token": 0.0000011,
-            "completion_token": 0.0000044
+            "completion_token": 0.0000044,
+            "cache_read_token": 5.5e-7
         }
     },
     {
         "model": "o1-preview",
         "cost": {
             "prompt_token": 0.000015,
-            "completion_token": 0.00006
+            "completion_token": 0.00006,
+            "cache_read_token": 0.0000075
         }
     },
     {
         "model": "o1-preview-2024-09-12",
         "cost": {
             "prompt_token": 0.000015,
-            "completion_token": 0.00006
+            "completion_token": 0.00006,
+            "cache_read_token": 0.0000075
         }
     },
     {
@@ -1123,35 +1227,40 @@
         "model": "o3",
         "cost": {
             "prompt_token": 0.00001,
-            "completion_token": 0.00004
+            "completion_token": 0.00004,
+            "cache_read_token": 0.0000025
         }
     },
     {
         "model": "o3-mini",
         "cost": {
             "prompt_token": 0.0000011,
-            "completion_token": 0.0000044
+            "completion_token": 0.0000044,
+            "cache_read_token": 5.5e-7
         }
     },
     {
         "model": "o3-mini-high",
         "cost": {
             "prompt_token": 0.0000011,
-            "completion_token": 0.0000044
+            "completion_token": 0.0000044,
+            "cache_read_token": 5.5e-7
         }
     },
     {
         "model": "o4-mini",
         "cost": {
             "prompt_token": 0.0000011,
-            "completion_token": 0.0000044
+            "completion_token": 0.0000044,
+            "cache_read_token": 2.75e-7
         }
     },
     {
         "model": "o4-mini-high",
         "cost": {
             "prompt_token": 0.0000011,
-            "completion_token": 0.0000044
+            "completion_token": 0.0000044,
+            "cache_read_token": 2.75e-7
         }
     },
     {

--- a/plugin-server/src/ingestion/ai-costs/providers/types.ts
+++ b/plugin-server/src/ingestion/ai-costs/providers/types.ts
@@ -3,5 +3,7 @@ export interface ModelRow {
     cost: {
         prompt_token: number
         completion_token: number
+        cache_read_token?: number
+        cache_write_token?: number
     }
 }

--- a/plugin-server/src/ingestion/ai-costs/scripts/update-ai-costs.ts
+++ b/plugin-server/src/ingestion/ai-costs/scripts/update-ai-costs.ts
@@ -7,6 +7,8 @@ interface ModelRow {
     cost: {
         prompt_token: number
         completion_token: number
+        cache_read_token?: number
+        cache_write_token?: number
     }
 }
 
@@ -62,11 +64,25 @@ const main = async () => {
         const promptPrice = new bigDecimal(model.pricing.prompt).getValue()
         const completionPrice = new bigDecimal(model.pricing.completion).getValue()
 
+        // Extract cache costs if available
+        let cacheReadCost: number | undefined
+        let cacheWriteCost: number | undefined
+
+        if (model.pricing.input_cache_read && parseFloat(model.pricing.input_cache_read) > 0) {
+            cacheReadCost = parseFloat(model.pricing.input_cache_read)
+        }
+
+        if (model.pricing.input_cache_write && parseFloat(model.pricing.input_cache_write) > 0) {
+            cacheWriteCost = parseFloat(model.pricing.input_cache_write)
+        }
+
         const modelRow: ModelRow = {
             model: modelParts.join('/'), // Only include the part after the provider
             cost: {
                 prompt_token: parseFloat(promptPrice),
                 completion_token: parseFloat(completionPrice),
+                ...(cacheReadCost !== undefined && { cache_read_token: cacheReadCost }),
+                ...(cacheWriteCost !== undefined && { cache_write_token: cacheWriteCost }),
             },
         }
 


### PR DESCRIPTION
## Problem

Posthog LLM O price matching was using a fixed 0.5 multipler for cache calculations. This is no longer accurate 
fixes: https://github.com/PostHog/posthog/issues/32050

## Changes

support cache read and write with real values