### PR TITLE
fix(project-tree): pinned folder nits 2

### DIFF
--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -445,7 +445,10 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
 
                                 {featureFlags[FEATURE_FLAGS.TREE_VIEW_PRODUCTS] ? (
                                     <div
-                                        className={!isLayoutNavCollapsed ? 'pt-1' : 'flex flex-col gap-px items-center'}
+                                        className={cn(
+                                            'flex flex-col gap-px h-full',
+                                            !isLayoutNavCollapsed ? 'pt-1' : 'items-center'
+                                        )}
                                     >
                                         <PinnedFolder />
                                     </div>

--- a/frontend/src/layout/panel-layout/PinnedFolder/PinnedFolder.tsx
+++ b/frontend/src/layout/panel-layout/PinnedFolder/PinnedFolder.tsx
@@ -32,7 +32,7 @@ export function PinnedFolder(): JSX.Element {
                     </ButtonPrimitive>
                 </div>
             )}
-            <div className="mt-[-0.25rem] h-full">
+            <div className="flex flex-col mt-[-0.25rem] h-full">
                 <ProjectTree root={pinnedFolder} onlyTree />
             </div>
             {modalVisible ? (

--- a/frontend/src/layout/panel-layout/PinnedFolder/PinnedFolder.tsx
+++ b/frontend/src/layout/panel-layout/PinnedFolder/PinnedFolder.tsx
@@ -33,7 +33,7 @@ export function PinnedFolder(): JSX.Element {
                 </div>
             )}
             <div className="flex flex-col mt-[-0.25rem] h-full">
-                <ProjectTree root={pinnedFolder} onlyTree />
+                <ProjectTree root={pinnedFolder} onlyTree treeSize={isLayoutNavCollapsed ? 'narrow' : 'default'} />
             </div>
             {modalVisible ? (
                 <LemonModal

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -5,7 +5,7 @@ import { moveToLogic } from 'lib/components/MoveTo/moveToLogic'
 import { ResizableElement } from 'lib/components/ResizeElement/ResizeElement'
 import { dayjs } from 'lib/dayjs'
 import { LemonTag } from 'lib/lemon-ui/LemonTag'
-import { LemonTree, LemonTreeRef, TreeDataItem } from 'lib/lemon-ui/LemonTree/LemonTree'
+import { LemonTree, LemonTreeRef, LemonTreeSize, TreeDataItem } from 'lib/lemon-ui/LemonTree/LemonTree'
 import { TreeNodeDisplayIcon } from 'lib/lemon-ui/LemonTree/LemonTreeUtils'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture/ProfilePicture'
 import { Tooltip } from 'lib/lemon-ui/Tooltip/Tooltip'
@@ -44,6 +44,7 @@ export interface ProjectTreeProps {
     root?: string
     onlyTree?: boolean
     searchPlaceholder?: string
+    treeSize?: LemonTreeSize
 }
 
 export const PROJECT_TREE_KEY = 'project-tree'
@@ -55,6 +56,7 @@ export function ProjectTree({
     root,
     onlyTree = false,
     searchPlaceholder,
+    treeSize = 'default',
 }: ProjectTreeProps): JSX.Element {
     const [uniqueKey] = useState(() => `project-tree-${counter++}`)
     const { treeItemsNew, viableItems } = useValues(projectTreeDataLogic)
@@ -411,6 +413,7 @@ export function ProjectTree({
                 }
                 return window.location.href.endsWith(item.record?.href)
             }}
+            size={treeSize}
             onItemChecked={onItemChecked}
             checkedItemCount={checkedItemCountNumeric}
             disableScroll={onlyTree ? true : false}

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -625,10 +625,25 @@ export function ProjectTree({
             }}
             renderItemTooltip={(item) => {
                 const user = item.record?.user as UserBasicType | undefined
-
+                const nameNode: JSX.Element = <span className="font-semibold">{item.displayName}</span>
+                if (root === 'games://') {
+                    return <>Play {nameNode}</>
+                }
+                if (root === 'products://') {
+                    return <>View {nameNode}</>
+                }
+                if (root === 'data-management://') {
+                    return <>View {nameNode}</>
+                }
+                if (root === 'new://') {
+                    if (item.children) {
+                        return <>View all</>
+                    }
+                    return <>Create a new {nameNode}</>
+                }
                 return projectTreeMode === 'tree' ? (
                     <>
-                        Name: <span className="font-semibold">{item.displayName}</span> <br />
+                        Name: {nameNode} <br />
                         Created by:{' '}
                         <ProfilePicture
                             user={user || { first_name: 'PostHog' }}

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -139,7 +139,7 @@ export function ProjectTree({
 
         return (
             <>
-                {item.record?.path && !item.disableSelect ? (
+                {item.record?.path && !item.disableSelect && !onlyTree ? (
                     <>
                         <MenuItem
                             asChild
@@ -214,7 +214,7 @@ export function ProjectTree({
                             <MenuSubTrigger asChild>
                                 <ButtonPrimitive menuItem>
                                     New...
-                                    <IconChevronRight className="ml-auto h-4 w-4" />
+                                    <IconChevronRight className="ml-auto size-3" />
                                 </ButtonPrimitive>
                             </MenuSubTrigger>
                             <MenuSubContent>
@@ -240,7 +240,7 @@ export function ProjectTree({
                                                         {treeItem.name ||
                                                             treeItem.id.charAt(0).toUpperCase() + treeItem.id.slice(1)}
                                                         ...
-                                                        <IconChevronRight className="ml-auto h-4 w-4" />
+                                                        <IconChevronRight className="ml-auto size-3" />
                                                     </ButtonPrimitive>
                                                 </MenuSubTrigger>
                                                 <MenuSubContent>

--- a/frontend/src/lib/components/ScrollableShadows/ScrollableShadows.tsx
+++ b/frontend/src/lib/components/ScrollableShadows/ScrollableShadows.tsx
@@ -18,10 +18,24 @@ export type ScrollableShadowsProps = {
     onBlur?: () => void
     styledScrollbars?: boolean
     style?: CSSProperties
+    /** Whether to disable scrolling. */
+    disableScroll?: boolean
+    /** Whether to hide the scrollable shadows. */
+    hideShadows?: boolean
 }
 
 export const ScrollableShadows = React.forwardRef<HTMLDivElement, ScrollableShadowsProps>(function ScrollableShadows(
-    { children, direction, className, innerClassName, scrollRef, styledScrollbars = false, ...props },
+    {
+        children,
+        direction,
+        className,
+        innerClassName,
+        scrollRef,
+        styledScrollbars = false,
+        disableScroll = false,
+        hideShadows = false,
+        ...props
+    },
     ref
 ) {
     const {
@@ -37,11 +51,10 @@ export const ScrollableShadows = React.forwardRef<HTMLDivElement, ScrollableShad
             className={clsx(
                 'ScrollableShadows',
                 `ScrollableShadows--${direction}`,
-
-                direction === 'horizontal' && isScrollableLeft && 'ScrollableShadows--left',
-                direction === 'horizontal' && isScrollableRight && 'ScrollableShadows--right',
-                direction === 'vertical' && isScrollableTop && 'ScrollableShadows--top',
-                direction === 'vertical' && isScrollableBottom && 'ScrollableShadows--bottom',
+                !hideShadows && direction === 'horizontal' && isScrollableLeft && 'ScrollableShadows--left',
+                !hideShadows && direction === 'horizontal' && isScrollableRight && 'ScrollableShadows--right',
+                !hideShadows && direction === 'vertical' && isScrollableTop && 'ScrollableShadows--top',
+                !hideShadows && direction === 'vertical' && isScrollableBottom && 'ScrollableShadows--bottom',
                 className
             )}
             ref={ref}
@@ -51,7 +64,8 @@ export const ScrollableShadows = React.forwardRef<HTMLDivElement, ScrollableShad
                 className={clsx(
                     'ScrollableShadows__inner',
                     styledScrollbars && 'show-scrollbar-on-hover',
-                    innerClassName
+                    innerClassName,
+                    disableScroll && 'overflow-hidden'
                 )}
                 ref={(refValue) => {
                     scrollRefScrollable.current = refValue

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -372,7 +372,6 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                             aria-disabled={!!item.disabledReason}
                             aria-haspopup={!!itemContextMenu?.(item)}
                             aria-roledescription="tree item"
-                            aria-rolemap={`item-${item.id}`}
                             aria-label={ariaLabel}
                             tooltip={
                                 isDragging || isEmptyFolder || mode === 'table' ? undefined : renderItemTooltip?.(item)

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -30,6 +30,7 @@ import {
 } from './LemonTreeUtils'
 
 export type LemonTreeSelectMode = 'default' | 'multi' | 'folder-only'
+export type LemonTreeSize = 'default' | 'narrow'
 
 export type TreeDataItem = {
     /** The ID of the item. */
@@ -165,7 +166,7 @@ type LemonTreeBaseProps = Omit<HTMLAttributes<HTMLDivElement>, 'onDragEnd'> & {
      *
      * narrow: icon, no text, side action hidden
      */
-    size?: 'default' | 'narrow'
+    size?: LemonTreeSize
 }
 
 export type LemonTreeProps = LemonTreeBaseProps & {

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -105,7 +105,7 @@ type LemonTreeBaseProps = Omit<HTMLAttributes<HTMLDivElement>, 'onDragEnd'> & {
     showFolderActiveState?: boolean
     /** Whether to enable drag and drop of items. */
     enableDragAndDrop?: boolean
-    /** The mode of the tree. */
+    /** The select mode of the tree. */
     selectMode?: LemonTreeSelectMode
     /** Whether the item is active, useful for highlighting the current item against a URL path,
      * this takes precedence over showFolderActiveState, and selectedId state */

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -1292,9 +1292,9 @@ const LemonTree = forwardRef<LemonTreeRef, LemonTreeProps>(
                     aria-label="Tree navigation"
                     onKeyDown={handleKeyDown}
                     className="flex-1"
-                    innerClassName={cn('relative overflow-x-auto', {
-                        'overflow-hidden': disableScroll,
-                    })}
+                    innerClassName="relative overflow-x-auto"
+                    disableScroll={disableScroll}
+                    hideShadows={disableScroll}
                     styledScrollbars
                     style={
                         {

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -472,7 +472,7 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                                         }}
                                     >
                                         {/* Folder lines */}
-                                        {depth !== 0 && (
+                                        {depth !== 0 && size !== 'narrow' && (
                                             <div
                                                 className="folder-line absolute border-r border-primary h-[calc(100%+2px)] -top-px pointer-events-none z-0"
                                                 // eslint-disable-next-line react/forbid-dom-props


### PR DESCRIPTION
## Problem
* You were able to enter "Select" mode via dropdown/context menus and there was no functionality to support it.
* Pinned tree didn't take up full height leading to some gnarly floating shadows.
* Tree menu item chevrons were a bit too big.
* Pinned tree collapsed wasn't working 
* Tooltips for some trees didn't make sense (example: created by for Products etc) 

## Changes
* Hide "Select" from menus if `onlyTree` is true
* Reworked the DOM to make sure the pinned tree was taking full height
* Updated size of menu chevrons
* Pinned tree gets `size=narrow` so a collapsed navbar has a working tree 
* Custom per-root tooltips added

![2025-05-22 19 34 15](https://github.com/user-attachments/assets/dcac6f66-4e8c-48cb-b7ee-c200f9820dbd)
<img width="304" alt="image" src="https://github.com/user-attachments/assets/8e57ec15-43a8-460e-802d-a0202447a3fa" />


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
