### PR TITLE
feat: use web_bounces_daily on pre_aggregated stats_table

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -93,7 +93,11 @@ from posthog.hogql.database.schema.sessions_v2 import (
     join_events_table_to_sessions_table_v2,
 )
 from posthog.hogql.database.schema.static_cohort_people import StaticCohortPeople
-from posthog.hogql.database.schema.web_analytics_preaggregated import WebOverviewDailyTable, WebStatsDailyTable
+from posthog.hogql.database.schema.web_analytics_preaggregated import (
+    WebBouncesDailyTable,
+    WebOverviewDailyTable,
+    WebStatsDailyTable,
+)
 from posthog.hogql.errors import QueryError, ResolutionError
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.timings import HogQLTimings
@@ -157,6 +161,7 @@ class Database(BaseModel):
     # Web analytics pre-aggregated tables (internal use only)
     web_overview_daily: WebOverviewDailyTable = WebOverviewDailyTable()
     web_stats_daily: WebStatsDailyTable = WebStatsDailyTable()
+    web_bounces_daily: WebBouncesDailyTable = WebBouncesDailyTable()
 
     raw_session_replay_events: RawSessionReplayEventsTable = RawSessionReplayEventsTable()
     raw_person_distinct_ids: RawPersonDistinctIdsTable = RawPersonDistinctIdsTable()

--- a/posthog/hogql/database/schema/web_analytics_preaggregated.py
+++ b/posthog/hogql/database/schema/web_analytics_preaggregated.py
@@ -8,15 +8,24 @@ from posthog.hogql.database.models import (
 )
 
 
+web_preaggregated_base_fields = {
+    "team_id": IntegerDatabaseField(name="team_id"),
+    "day_bucket": DateDatabaseField(name="day_bucket"),
+    "host": StringDatabaseField(name="host", nullable=True),
+    "device_type": StringDatabaseField(name="device_type", nullable=True),
+}
+
+web_preaggregated_base_aggregation_fields = {
+    "persons_uniq_state": DatabaseField(name="persons_uniq_state"),
+    "pageviews_count_state": DatabaseField(name="pageviews_count_state"),
+    "sessions_uniq_state": DatabaseField(name="sessions_uniq_state"),
+}
+
+
 class WebOverviewDailyTable(Table):
     fields: dict[str, FieldOrTable] = {
-        "team_id": IntegerDatabaseField(name="team_id"),
-        "day_bucket": DateDatabaseField(name="day_bucket"),
-        "host": StringDatabaseField(name="host", nullable=True),
-        "device_type": StringDatabaseField(name="device_type", nullable=True),
-        "persons_uniq_state": DatabaseField(name="persons_uniq_state"),
-        "pageviews_count_state": DatabaseField(name="pageviews_count_state"),
-        "sessions_uniq_state": DatabaseField(name="sessions_uniq_state"),
+        **web_preaggregated_base_fields,
+        **web_preaggregated_base_aggregation_fields,
         "total_session_duration_state": DatabaseField(name="total_session_duration_state"),
         "total_bounces_state": DatabaseField(name="total_bounces_state"),
     }
@@ -30,10 +39,8 @@ class WebOverviewDailyTable(Table):
 
 class WebStatsDailyTable(Table):
     fields: dict[str, FieldOrTable] = {
-        "team_id": IntegerDatabaseField(name="team_id"),
-        "day_bucket": DateDatabaseField(name="day_bucket"),
-        "host": StringDatabaseField(name="host", nullable=True),
-        "device_type": StringDatabaseField(name="device_type", nullable=True),
+        **web_preaggregated_base_fields,
+        **web_preaggregated_base_aggregation_fields,
         "browser": StringDatabaseField(name="browser", nullable=True),
         "os": StringDatabaseField(name="os", nullable=True),
         "referring_domain": StringDatabaseField(name="referring_domain", nullable=True),
@@ -44,9 +51,6 @@ class WebStatsDailyTable(Table):
         "utm_term": StringDatabaseField(name="utm_term", nullable=True),
         "utm_content": StringDatabaseField(name="utm_content", nullable=True),
         "country": StringDatabaseField(name="country", nullable=True),
-        "persons_uniq_state": DatabaseField(name="persons_uniq_state"),
-        "sessions_uniq_state": DatabaseField(name="sessions_uniq_state"),
-        "pageviews_count_state": DatabaseField(name="pageviews_count_state"),
     }
 
     def to_printed_clickhouse(self, context):
@@ -54,3 +58,18 @@ class WebStatsDailyTable(Table):
 
     def to_printed_hogql(self):
         return "web_stats_daily"
+
+
+class WebBouncesDailyTable(Table):
+    fields: dict[str, FieldOrTable] = {
+        **web_preaggregated_base_fields,
+        **web_preaggregated_base_aggregation_fields,
+        "entry_path": StringDatabaseField(name="entry_path", nullable=True),
+        "bounces_count_state": DatabaseField(name="bounces_count_state"),
+    }
+
+    def to_printed_clickhouse(self, context):
+        return "web_bounces_daily"
+
+    def to_printed_hogql(self):
+        return "web_bounces_daily"

--- a/posthog/hogql_queries/web_analytics/pre_aggregated/query_builder.py
+++ b/posthog/hogql_queries/web_analytics/pre_aggregated/query_builder.py
@@ -1,14 +1,13 @@
-from typing import cast
+from typing import cast, Union
 from datetime import datetime, UTC
 
 from posthog.hogql import ast
 
 
 class WebAnalyticsPreAggregatedQueryBuilder:
-    def __init__(self, runner, supported_props_filters, table_name) -> None:
+    def __init__(self, runner, supported_props_filters) -> None:
         self.runner = runner
         self.supported_props_filters = supported_props_filters
-        self.table_name = table_name
 
     def can_use_preaggregated_tables(self) -> bool:
         query = self.runner.query
@@ -29,12 +28,12 @@ class WebAnalyticsPreAggregatedQueryBuilder:
 
     # We can probably use the hogql general filters somehow but it was not working by default and it was a lot of moving parts to debug at once so
     # TODO: come back to this later to make sure we're not overcomplicating things
-    def _get_filters(self):
+    def _get_filters(self, table_name: str):
         current_date_expr = ast.And(
             exprs=[
                 ast.CompareOperation(
                     op=ast.CompareOperationOp.GtEq,
-                    left=ast.Field(chain=[self.table_name, "day_bucket"]),
+                    left=ast.Field(chain=[table_name, "day_bucket"]),
                     right=ast.Constant(
                         value=(
                             self.runner.query_compare_to_date_range.date_from()
@@ -45,13 +44,13 @@ class WebAnalyticsPreAggregatedQueryBuilder:
                 ),
                 ast.CompareOperation(
                     op=ast.CompareOperationOp.LtEq,
-                    left=ast.Field(chain=[self.table_name, "day_bucket"]),
+                    left=ast.Field(chain=[table_name, "day_bucket"]),
                     right=ast.Constant(value=self.runner.query_date_range.date_to()),
                 ),
             ]
         )
 
-        filter_parts = [current_date_expr]
+        filter_parts: list[Union[ast.And, ast.CompareOperation]] = [current_date_expr]
 
         for posthog_field, table_field in self.supported_props_filters.items():
             for prop in self.runner.query.properties:
@@ -66,7 +65,7 @@ class WebAnalyticsPreAggregatedQueryBuilder:
                         values = [v.id if v is not None and hasattr(v, "id") else v for v in value]
                         filter_expr = ast.CompareOperation(
                             op=ast.CompareOperationOp.In,
-                            left=ast.Field(chain=[self.table_name, table_field]),
+                            left=ast.Field(chain=[table_name, table_field]),
                             right=ast.Tuple(exprs=[ast.Constant(value=v) for v in values]),
                         )
 
@@ -74,7 +73,7 @@ class WebAnalyticsPreAggregatedQueryBuilder:
                     else:
                         filter_expr = ast.CompareOperation(
                             op=ast.CompareOperationOp.Eq,
-                            left=ast.Field(chain=[self.table_name, table_field]),
+                            left=ast.Field(chain=[table_name, table_field]),
                             right=ast.Constant(value=value),
                         )
 

--- a/posthog/hogql_queries/web_analytics/stats_table_pre_aggregated.py
+++ b/posthog/hogql_queries/web_analytics/stats_table_pre_aggregated.py
@@ -42,12 +42,7 @@ class StatsTablePreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder)
     ]
 
     def __init__(self, runner: "WebStatsTableQueryRunner") -> None:
-        _table_name = "web_stats_daily"
-
-        if runner.query.breakdownBy == WebStatsBreakdown.INITIAL_PAGE:
-            _table_name = "web_bounces_daily"
-
-        super().__init__(runner=runner, supported_props_filters=STATS_TABLE_SUPPORTED_FILTERS, table_name=_table_name)
+        super().__init__(runner=runner, supported_props_filters=STATS_TABLE_SUPPORTED_FILTERS)
 
     def can_use_preaggregated_tables(self) -> bool:
         if not super().can_use_preaggregated_tables():
@@ -74,7 +69,7 @@ class StatsTablePreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder)
                 (sumMergeIf(bounces_count_state, {current_period_filter}) / nullif(uniqMergeIf(sessions_uniq_state, {current_period_filter}), 0)),
                 (sumMergeIf(bounces_count_state, {previous_period_filter}) / nullif(uniqMergeIf(sessions_uniq_state, {previous_period_filter}), 0))
             ) as `context.columns.bounce_rate`
-        FROM {self.table_name}
+        FROM web_bounces_daily
         GROUP BY `context.columns.breakdown_value`
         """
 
@@ -99,13 +94,13 @@ class StatsTablePreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder)
                     sumMergeIf(pageviews_count_state, {current_period_filter}),
                     sumMergeIf(pageviews_count_state, {previous_period_filter})
                 ) as `context.columns.views`
-            FROM {self.table_name}
+            FROM web_stats_daily
             GROUP BY `context.columns.breakdown_value`
             """
 
         query = cast(ast.SelectQuery, parse_select(query_str))
 
-        filters = self._get_filters()
+        filters = self._get_filters(table_name="web_stats_daily")
         if filters:
             query.where = filters
 

--- a/posthog/hogql_queries/web_analytics/web_overview_pre_aggregated.py
+++ b/posthog/hogql_queries/web_analytics/web_overview_pre_aggregated.py
@@ -15,7 +15,7 @@ SUPPORTED_PROPERTIES = {
 
 class WebOverviewPreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder):
     def __init__(self, runner: "WebOverviewQueryRunner") -> None:
-        super().__init__(runner, supported_props_filters=SUPPORTED_PROPERTIES, table_name="web_overview_daily")
+        super().__init__(runner, supported_props_filters=SUPPORTED_PROPERTIES)
 
     def get_query(self) -> ast.SelectQuery:
         previous_period_filter, current_period_filter = self.get_date_ranges()
@@ -53,7 +53,7 @@ class WebOverviewPreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder
 
         query = cast(ast.SelectQuery, parse_select(query_str))
 
-        filters = self._get_filters()
+        filters = self._get_filters(table_name="web_overview_daily")
         if filters:
             query.where = filters
 

--- a/posthog/models/web_preaggregated/sql.py
+++ b/posthog/models/web_preaggregated/sql.py
@@ -112,15 +112,26 @@ def format_team_ids(team_ids):
     return ", ".join(str(team_id) for team_id in team_ids)
 
 
+def get_team_filters(team_ids):
+    team_ids_str = format_team_ids(team_ids) if team_ids else None
+    return {
+        "raw_sessions": f"raw_sessions.team_id IN({team_ids_str})" if team_ids else "1=1",
+        "person_distinct_id_overrides": f"person_distinct_id_overrides.team_id IN({team_ids_str})"
+        if team_ids
+        else "1=1",
+        "events": f"e.team_id IN({team_ids_str})" if team_ids else "1=1",
+    }
+
+
 # This should be similar and kept in sync with what the web_overview query runner needs at posthog/hogql_queries/web_analytics/web_overview.py
 # It is ok if we have some difference in order to make the aggregations work.
 def WEB_OVERVIEW_INSERT_SQL(
     date_start, date_end, team_ids=None, timezone="UTC", settings="", table_name="web_overview_daily"
 ):
-    team_ids_str = format_team_ids(team_ids)
-    team_filter = f"raw_sessions.team_id IN({team_ids_str})" if team_ids else "1=1"
-    person_team_filter = f"person_distinct_id_overrides.team_id IN({team_ids_str})" if team_ids else "1=1"
-    events_team_filter = f"e.team_id IN({team_ids_str})" if team_ids else "1=1"
+    filters = get_team_filters(team_ids)
+    team_filter = filters["raw_sessions"]
+    person_team_filter = filters["person_distinct_id_overrides"]
+    events_team_filter = filters["events"]
 
     return f"""
     INSERT INTO {table_name}
@@ -199,10 +210,10 @@ def WEB_OVERVIEW_INSERT_SQL(
 def WEB_STATS_INSERT_SQL(
     date_start, date_end, team_ids=None, timezone="UTC", settings="", table_name="web_stats_daily"
 ):
-    team_ids_str = format_team_ids(team_ids)
-    team_filter = f"raw_sessions.team_id IN({team_ids_str})" if team_ids else "1=1"
-    person_team_filter = f"person_distinct_id_overrides.team_id IN({team_ids_str})" if team_ids else "1=1"
-    events_team_filter = f"e.team_id IN({team_ids_str})" if team_ids else "1=1"
+    filters = get_team_filters(team_ids)
+    team_filter = filters["raw_sessions"]
+    person_team_filter = filters["person_distinct_id_overrides"]
+    events_team_filter = filters["events"]
 
     return f"""
     INSERT INTO {table_name}
@@ -319,10 +330,10 @@ def WEB_STATS_INSERT_SQL(
 def WEB_BOUNCES_INSERT_SQL(
     date_start, date_end, team_ids=None, timezone="UTC", settings="", table_name="web_bounces_daily"
 ):
-    team_ids_str = format_team_ids(team_ids)
-    team_filter = f"raw_sessions.team_id IN({team_ids_str})" if team_ids else "1=1"
-    person_team_filter = f"person_distinct_id_overrides.team_id IN({team_ids_str})" if team_ids else "1=1"
-    events_team_filter = f"e.team_id IN({team_ids_str})" if team_ids else "1=1"
+    filters = get_team_filters(team_ids)
+    team_filter = filters["raw_sessions"]
+    person_team_filter = filters["person_distinct_id_overrides"]
+    events_team_filter = filters["events"]
 
     return f"""
     INSERT INTO {table_name}


### PR DESCRIPTION
## Problem

Uses the `web_bounces_daily` table materialized on https://github.com/PostHog/posthog/pull/32497 for the "Initial Path" tile breakdown. 

I put it in its own method because we will need it for the "Paths" tile as well and it could be useful for other queries as that is the slowest one we have right now. Even optimized it takes 0.4s-1.2s for a month's data of some million rows (but that's better than timing out I guess)

## Changes

- The usual changes for the pre-aggregated query
- Added a default filter for the time period on the main `WHERE` clause; we were only fetching filtering inside the tuples for the calculations `if`s, so this guarantees it will fetch less data on the query plan.

## Did you write or update any docs for this change?

- [x] No docs needed for this change

## How did you test this code?

- Materialize the tables on Dagster 
	- `DEBUG=1 dagster dev -m dags.definitions`
	- `http://localhost:3000/locations/dags.definitions/asset-groups/web_analytics` -> Materialize All
- Enable the pre-aggregated query modifier on the context top-right context menu.
- Refresh the page or change the breakdown option