### PR TITLE
chore: mark components that used pre-aggregated tables

### DIFF
--- a/frontend/src/queries/nodes/DataTable/DataTable.tsx
+++ b/frontend/src/queries/nodes/DataTable/DataTable.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx'
 import { BindLogic, useValues } from 'kea'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TaxonomicPopover } from 'lib/components/TaxonomicPopover/TaxonomicPopover'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { LemonTable, LemonTableColumn } from 'lib/lemon-ui/LemonTable'
@@ -135,6 +136,10 @@ export function DataTable({
         highlightedRows,
         backToSourceQuery,
     } = useValues(builtDataNodeLogic)
+
+    const canUseWebAnalyticsPreAggregatedTables = useFeatureFlag('SETTINGS_WEB_ANALYTICS_PRE_AGGREGATED_TABLES')
+    const usedWebAnalyticsPreAggregatedTables =
+        canUseWebAnalyticsPreAggregatedTables && response?.usedPreAggregatedTables && response?.hogql
 
     const dataTableLogicProps: DataTableLogicProps = {
         query,
@@ -522,7 +527,6 @@ export function DataTable({
             secondRowRight.push(editorButton)
         }
     }
-
     return (
         <BindLogic logic={dataTableLogic} props={dataTableLogicProps}>
             <BindLogic logic={dataNodeLogic} props={dataNodeLogicProps}>
@@ -550,7 +554,9 @@ export function DataTable({
                     {showResultsTable && (
                         <LemonTable
                             data-attr={dataAttr}
-                            className="DataTable"
+                            className={clsx('DataTable', {
+                                'border border-dotted border-success': usedWebAnalyticsPreAggregatedTables,
+                            })}
                             loading={responseLoading && !nextDataLoading && !newDataLoading}
                             columns={lemonColumns}
                             embedded={embedded}

--- a/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
+++ b/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
@@ -62,10 +62,7 @@ export function WebOverview(props: {
     return (
         <>
             <EvenlyDistributedRows
-                className={clsx('flex justify-center items-center flex-wrap w-full gap-2', {
-                    'border border-dashed border-success':
-                        canUseWebAnalyticsPreAggregatedTables && response?.usedPreAggregatedTables && response?.hogql,
-                })}
+                className="flex justify-center items-center flex-wrap w-full gap-2"
                 minWidthRems={OVERVIEW_ITEM_CELL_MIN_WIDTH_REMS + 2}
             >
                 {responseLoading

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -19277,6 +19277,9 @@
                 "previous": {
                     "type": "number"
                 },
+                "usedPreAggregatedTables": {
+                    "type": "boolean"
+                },
                 "value": {
                     "type": "number"
                 }

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1671,6 +1671,7 @@ export interface WebOverviewItem {
     kind: WebOverviewItemKind
     changeFromPreviousPct?: number
     isIncreaseBad?: boolean
+    usedPreAggregatedTables?: boolean
 }
 
 export interface SamplingRate {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -3650,6 +3650,7 @@ class WebOverviewItem(BaseModel):
     key: str
     kind: WebOverviewItemKind
     previous: Optional[float] = None
+    usedPreAggregatedTables: Optional[bool] = None
     value: Optional[float] = None
 
 


### PR DESCRIPTION
## Problem

Clearly not the best `aesthetic`, but it saves a ton of debugging over the Network tab. 

Suggestions accepted :) 

Reminder: this is still behind a FF/modifier, so intended for internal debugging only.

<img width="1625" alt="Screenshot 2025-05-22 at 17 41 06" src="https://github.com/user-attachments/assets/ca26870f-3291-4d56-8357-13a19dec52d1" />
<img width="1618" alt="Screenshot 2025-05-22 at 17 41 16" src="https://github.com/user-attachments/assets/36cea13b-f445-4282-be2f-6a71d4cc13f0" />



## Changes

- Added a green dotted border to highlight the components that utilized the pre-aggregated tables.

## Did you write or update any docs for this change?

- [x] No docs needed for this change

## How did you test this code?

Maually toggling the "Use Pre-aggregated tables" button on the context menu
