### PR TITLE
fix(project-tree): can't move to on a product

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -332,22 +332,25 @@ export function ProjectTree({
                     )
                 ) : null}
 
-                <MenuItem
-                    asChild
-                    onClick={(e: any) => {
-                        e.stopPropagation()
-                        if (
-                            checkedItemsArray.length > 0 &&
-                            checkedItemsArray.find(({ id }) => id === item.record?.id)
-                        ) {
-                            openMoveToModal(checkedItemsArray)
-                        } else {
-                            openMoveToModal([item.record as unknown as FileSystemEntry])
-                        }
-                    }}
-                >
-                    <ButtonPrimitive menuItem>Move to...</ButtonPrimitive>
-                </MenuItem>
+                {item.id.startsWith('project/') || item.id.startsWith('project://') ? (
+                    <MenuItem
+                        asChild
+                        onClick={(e: any) => {
+                            e.stopPropagation()
+                            if (
+                                checkedItemsArray.length > 0 &&
+                                checkedItemsArray.find(({ id }) => id === item.record?.id)
+                            ) {
+                                openMoveToModal(checkedItemsArray)
+                            } else {
+                                openMoveToModal([item.record as unknown as FileSystemEntry])
+                            }
+                        }}
+                    >
+                        <ButtonPrimitive menuItem>Move to...</ButtonPrimitive>
+                    </MenuItem>
+                ) : null}
+
                 {item.record?.path && item.record?.type === 'folder' ? (
                     <MenuItem
                         asChild

--- a/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
@@ -24,8 +24,9 @@ export interface ConvertProps {
     allShortcuts?: boolean
 }
 
-export function getItemId(item: FileSystemImport | FileSystemEntry): string {
-    return item.type === 'folder' ? `project://${item.path}` : `project/${item.id || item.path}`
+export function getItemId(item: FileSystemImport | FileSystemEntry, protocol = 'project://'): string {
+    const root = protocol.replace(/\/+/, '').replace(':', '')
+    return item.type === 'folder' ? `${root}://${item.path}` : `${root}/${item.id || item.path}`
 }
 
 export function protocolTitle(str: string): string {
@@ -85,7 +86,7 @@ export function convertFileSystemEntryToTreeDataItem({
     function itemToTreeDataItem(item: FileSystemImport | FileSystemEntry): TreeDataItem {
         const pathSplit = splitPath(item.path)
         const itemName = unescapePath(pathSplit.pop() ?? 'Unnamed')
-        const nodeId = getItemId(item)
+        const nodeId = getItemId(item, root)
         const displayName = <SearchHighlightMultiple string={itemName} substring={searchTerm ?? ''} />
         const user: UserBasicType | undefined = item.meta?.created_by ? users?.[item.meta.created_by] : undefined
 


### PR DESCRIPTION
## Problem

You were able to click "move to" on a product (e.g. "feature flags") and then get an error when actually trying to move it.

## Changes

Moving is now only for things in the project tree:

![2025-05-23 00 27 00](https://github.com/user-attachments/assets/af91d2bf-92d1-4d6f-a8e5-ea32f72eec2a)
