### PR TITLE
feat: materialize and use web_paths_daily for paths breakdowns 

### DIFF
--- a/dags/definitions.py
+++ b/dags/definitions.py
@@ -58,6 +58,7 @@ defs = dagster.Definitions(
         web_preaggregated_internal.web_overview_daily,
         web_preaggregated_internal.web_stats_daily,
         web_preaggregated_internal.web_bounces_daily,
+        web_preaggregated_internal.web_paths_daily,
     ],
     jobs=[
         deletes.deletes_job,

--- a/dags/web_preaggregated_internal.py
+++ b/dags/web_preaggregated_internal.py
@@ -162,7 +162,7 @@ def web_stats_daily(context: dagster.AssetExecutionContext) -> None:
 )
 def web_paths_daily(context: dagster.AssetExecutionContext) -> None:
     """
-    Simple daily pathnames data with pageviews and unique visitors per path. Intented to use with web_bounces_daily for path-specific analysis.
+    Simple daily pathnames data with pageviews and unique visitors per path. Intended to use with web_bounces_daily for path-specific analysis.
     """
     return pre_aggregate_web_analytics_data(
         context=context,

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -93,7 +93,11 @@ from posthog.hogql.database.schema.sessions_v2 import (
     join_events_table_to_sessions_table_v2,
 )
 from posthog.hogql.database.schema.static_cohort_people import StaticCohortPeople
-from posthog.hogql.database.schema.web_analytics_preaggregated import WebOverviewDailyTable, WebStatsDailyTable
+from posthog.hogql.database.schema.web_analytics_preaggregated import (
+    WebBouncesDailyTable,
+    WebOverviewDailyTable,
+    WebStatsDailyTable,
+)
 from posthog.hogql.errors import QueryError, ResolutionError
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.timings import HogQLTimings
@@ -157,6 +161,7 @@ class Database(BaseModel):
     # Web analytics pre-aggregated tables (internal use only)
     web_overview_daily: WebOverviewDailyTable = WebOverviewDailyTable()
     web_stats_daily: WebStatsDailyTable = WebStatsDailyTable()
+    web_bounces_daily: WebBouncesDailyTable = WebBouncesDailyTable()
 
     raw_session_replay_events: RawSessionReplayEventsTable = RawSessionReplayEventsTable()
     raw_person_distinct_ids: RawPersonDistinctIdsTable = RawPersonDistinctIdsTable()

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -96,6 +96,7 @@ from posthog.hogql.database.schema.static_cohort_people import StaticCohortPeopl
 from posthog.hogql.database.schema.web_analytics_preaggregated import (
     WebBouncesDailyTable,
     WebOverviewDailyTable,
+    WebPathsDailyTable,
     WebStatsDailyTable,
 )
 from posthog.hogql.errors import QueryError, ResolutionError
@@ -162,6 +163,7 @@ class Database(BaseModel):
     web_overview_daily: WebOverviewDailyTable = WebOverviewDailyTable()
     web_stats_daily: WebStatsDailyTable = WebStatsDailyTable()
     web_bounces_daily: WebBouncesDailyTable = WebBouncesDailyTable()
+    web_paths_daily: WebPathsDailyTable = WebPathsDailyTable()
 
     raw_session_replay_events: RawSessionReplayEventsTable = RawSessionReplayEventsTable()
     raw_person_distinct_ids: RawPersonDistinctIdsTable = RawPersonDistinctIdsTable()

--- a/posthog/hogql/database/schema/web_analytics_preaggregated.py
+++ b/posthog/hogql/database/schema/web_analytics_preaggregated.py
@@ -8,15 +8,24 @@ from posthog.hogql.database.models import (
 )
 
 
+web_preaggregated_base_fields = {
+    "team_id": IntegerDatabaseField(name="team_id"),
+    "day_bucket": DateDatabaseField(name="day_bucket"),
+    "host": StringDatabaseField(name="host", nullable=True),
+    "device_type": StringDatabaseField(name="device_type", nullable=True),
+}
+
+web_preaggregated_base_aggregation_fields = {
+    "persons_uniq_state": DatabaseField(name="persons_uniq_state"),
+    "pageviews_count_state": DatabaseField(name="pageviews_count_state"),
+    "sessions_uniq_state": DatabaseField(name="sessions_uniq_state"),
+}
+
+
 class WebOverviewDailyTable(Table):
     fields: dict[str, FieldOrTable] = {
-        "team_id": IntegerDatabaseField(name="team_id"),
-        "day_bucket": DateDatabaseField(name="day_bucket"),
-        "host": StringDatabaseField(name="host", nullable=True),
-        "device_type": StringDatabaseField(name="device_type", nullable=True),
-        "persons_uniq_state": DatabaseField(name="persons_uniq_state"),
-        "pageviews_count_state": DatabaseField(name="pageviews_count_state"),
-        "sessions_uniq_state": DatabaseField(name="sessions_uniq_state"),
+        **web_preaggregated_base_fields,
+        **web_preaggregated_base_aggregation_fields,
         "total_session_duration_state": DatabaseField(name="total_session_duration_state"),
         "total_bounces_state": DatabaseField(name="total_bounces_state"),
     }
@@ -30,10 +39,8 @@ class WebOverviewDailyTable(Table):
 
 class WebStatsDailyTable(Table):
     fields: dict[str, FieldOrTable] = {
-        "team_id": IntegerDatabaseField(name="team_id"),
-        "day_bucket": DateDatabaseField(name="day_bucket"),
-        "host": StringDatabaseField(name="host", nullable=True),
-        "device_type": StringDatabaseField(name="device_type", nullable=True),
+        **web_preaggregated_base_fields,
+        **web_preaggregated_base_aggregation_fields,
         "browser": StringDatabaseField(name="browser", nullable=True),
         "os": StringDatabaseField(name="os", nullable=True),
         "referring_domain": StringDatabaseField(name="referring_domain", nullable=True),
@@ -44,9 +51,6 @@ class WebStatsDailyTable(Table):
         "utm_term": StringDatabaseField(name="utm_term", nullable=True),
         "utm_content": StringDatabaseField(name="utm_content", nullable=True),
         "country": StringDatabaseField(name="country", nullable=True),
-        "persons_uniq_state": DatabaseField(name="persons_uniq_state"),
-        "sessions_uniq_state": DatabaseField(name="sessions_uniq_state"),
-        "pageviews_count_state": DatabaseField(name="pageviews_count_state"),
     }
 
     def to_printed_clickhouse(self, context):
@@ -54,3 +58,18 @@ class WebStatsDailyTable(Table):
 
     def to_printed_hogql(self):
         return "web_stats_daily"
+
+
+class WebBouncesDailyTable(Table):
+    fields: dict[str, FieldOrTable] = {
+        **web_preaggregated_base_fields,
+        **web_preaggregated_base_aggregation_fields,
+        "entry_path": StringDatabaseField(name="entry_path", nullable=True),
+        "bounces_count_state": DatabaseField(name="bounces_count_state"),
+    }
+
+    def to_printed_clickhouse(self, context):
+        return "web_bounces_daily"
+
+    def to_printed_hogql(self):
+        return "web_bounces_daily"

--- a/posthog/hogql/database/schema/web_analytics_preaggregated.py
+++ b/posthog/hogql/database/schema/web_analytics_preaggregated.py
@@ -73,3 +73,17 @@ class WebBouncesDailyTable(Table):
 
     def to_printed_hogql(self):
         return "web_bounces_daily"
+
+
+class WebPathsDailyTable(Table):
+    fields: dict[str, FieldOrTable] = {
+        **web_preaggregated_base_fields,
+        **web_preaggregated_base_aggregation_fields,
+        "pathname": StringDatabaseField(name="pathname", nullable=True),
+    }
+
+    def to_printed_clickhouse(self, context):
+        return "web_paths_daily"
+
+    def to_printed_hogql(self):
+        return "web_paths_daily"

--- a/posthog/hogql_queries/web_analytics/pre_aggregated/query_builder.py
+++ b/posthog/hogql_queries/web_analytics/pre_aggregated/query_builder.py
@@ -1,4 +1,4 @@
-from typing import cast, Union
+from typing import Optional, cast, Union
 from datetime import datetime, UTC
 
 from posthog.hogql import ast
@@ -86,7 +86,7 @@ class WebAnalyticsPreAggregatedQueryBuilder:
 
         return None
 
-    def get_date_ranges(self) -> tuple[str, str]:
+    def get_date_ranges(self, table_name: Optional[str] = None) -> tuple[str, str]:
         current_date_from = self.runner.query_date_range.date_from_str
         current_date_to = self.runner.query_date_range.date_to_str
 
@@ -100,7 +100,9 @@ class WebAnalyticsPreAggregatedQueryBuilder:
             previous_date_from = current_date_from
             previous_date_to = current_date_to
 
-        current_period_filter = f"day_bucket >= '{current_date_from}' AND day_bucket <= '{current_date_to}'"
-        previous_period_filter = f"day_bucket >= '{previous_date_from}' AND day_bucket <= '{previous_date_to}'"
+        field_name = f"{table_name}.day_bucket" if table_name else "day_bucket"
+
+        current_period_filter = f"{field_name} >= '{current_date_from}' AND {field_name} <= '{current_date_to}'"
+        previous_period_filter = f"{field_name} >= '{previous_date_from}' AND {field_name} <= '{previous_date_to}'"
 
         return (previous_period_filter, current_period_filter)

--- a/posthog/hogql_queries/web_analytics/pre_aggregated/query_builder.py
+++ b/posthog/hogql_queries/web_analytics/pre_aggregated/query_builder.py
@@ -5,10 +5,9 @@ from posthog.hogql import ast
 
 
 class WebAnalyticsPreAggregatedQueryBuilder:
-    def __init__(self, runner, supported_props_filters, table_name) -> None:
+    def __init__(self, runner, supported_props_filters) -> None:
         self.runner = runner
         self.supported_props_filters = supported_props_filters
-        self.table_name = table_name
 
     def can_use_preaggregated_tables(self) -> bool:
         query = self.runner.query
@@ -29,12 +28,12 @@ class WebAnalyticsPreAggregatedQueryBuilder:
 
     # We can probably use the hogql general filters somehow but it was not working by default and it was a lot of moving parts to debug at once so
     # TODO: come back to this later to make sure we're not overcomplicating things
-    def _get_filters(self):
+    def _get_filters(self, table_name: str):
         current_date_expr = ast.And(
             exprs=[
                 ast.CompareOperation(
                     op=ast.CompareOperationOp.GtEq,
-                    left=ast.Field(chain=[self.table_name, "day_bucket"]),
+                    left=ast.Field(chain=[table_name, "day_bucket"]),
                     right=ast.Constant(
                         value=(
                             self.runner.query_compare_to_date_range.date_from()
@@ -45,7 +44,7 @@ class WebAnalyticsPreAggregatedQueryBuilder:
                 ),
                 ast.CompareOperation(
                     op=ast.CompareOperationOp.LtEq,
-                    left=ast.Field(chain=[self.table_name, "day_bucket"]),
+                    left=ast.Field(chain=[table_name, "day_bucket"]),
                     right=ast.Constant(value=self.runner.query_date_range.date_to()),
                 ),
             ]
@@ -66,7 +65,7 @@ class WebAnalyticsPreAggregatedQueryBuilder:
                         values = [v.id if v is not None and hasattr(v, "id") else v for v in value]
                         filter_expr = ast.CompareOperation(
                             op=ast.CompareOperationOp.In,
-                            left=ast.Field(chain=[self.table_name, table_field]),
+                            left=ast.Field(chain=[table_name, table_field]),
                             right=ast.Tuple(exprs=[ast.Constant(value=v) for v in values]),
                         )
 
@@ -74,7 +73,7 @@ class WebAnalyticsPreAggregatedQueryBuilder:
                     else:
                         filter_expr = ast.CompareOperation(
                             op=ast.CompareOperationOp.Eq,
-                            left=ast.Field(chain=[self.table_name, table_field]),
+                            left=ast.Field(chain=[table_name, table_field]),
                             right=ast.Constant(value=value),
                         )
 

--- a/posthog/hogql_queries/web_analytics/stats_table_pre_aggregated.py
+++ b/posthog/hogql_queries/web_analytics/stats_table_pre_aggregated.py
@@ -51,7 +51,7 @@ class StatsTablePreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder)
 
         return self.runner.query.breakdownBy in self.SUPPORTED_BREAKDOWNS
 
-    def _bounce_rate_query(self) -> str:
+    def _bounce_rate_query(self, include_filters: bool = False) -> str:
         # Like in the original stats_table, we will need this method to build the "Paths" tile so it is a special breakdown
         previous_period_filter, current_period_filter = self.get_date_ranges()
 
@@ -90,7 +90,7 @@ class StatsTablePreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder)
                 sumMergeIf(p.pageviews_count_state, {current_period_filter}),
                 sumMergeIf(p.pageviews_count_state, {previous_period_filter})
             ) as `context.columns.views`,
-            avg(bounces.`context.columns.bounce_rate`) as `context.columns.bounce_rate`
+            any(bounces.`context.columns.bounce_rate`) as `context.columns.bounce_rate`,
         FROM
             web_paths_daily p
         LEFT JOIN ({self._bounce_rate_query()}) bounces

--- a/posthog/hogql_queries/web_analytics/stats_table_pre_aggregated.py
+++ b/posthog/hogql_queries/web_analytics/stats_table_pre_aggregated.py
@@ -90,7 +90,7 @@ class StatsTablePreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder)
                 sumMergeIf(p.pageviews_count_state, {current_period_filter}),
                 sumMergeIf(p.pageviews_count_state, {previous_period_filter})
             ) as `context.columns.views`,
-            any(bounces.`context.columns.bounce_rate`) as `context.columns.bounce_rate`
+            avg(bounces.`context.columns.bounce_rate`) as `context.columns.bounce_rate`
         FROM
             web_paths_daily p
         LEFT JOIN ({self._bounce_rate_query()}) bounces

--- a/posthog/models/web_preaggregated/sql.py
+++ b/posthog/models/web_preaggregated/sql.py
@@ -112,15 +112,26 @@ def format_team_ids(team_ids):
     return ", ".join(str(team_id) for team_id in team_ids)
 
 
+def get_team_filters(team_ids):
+    team_ids_str = format_team_ids(team_ids) if team_ids else None
+    return {
+        "raw_sessions": f"raw_sessions.team_id IN({team_ids_str})" if team_ids else "1=1",
+        "person_distinct_id_overrides": f"person_distinct_id_overrides.team_id IN({team_ids_str})"
+        if team_ids
+        else "1=1",
+        "events": f"e.team_id IN({team_ids_str})" if team_ids else "1=1",
+    }
+
+
 # This should be similar and kept in sync with what the web_overview query runner needs at posthog/hogql_queries/web_analytics/web_overview.py
 # It is ok if we have some difference in order to make the aggregations work.
 def WEB_OVERVIEW_INSERT_SQL(
     date_start, date_end, team_ids=None, timezone="UTC", settings="", table_name="web_overview_daily"
 ):
-    team_ids_str = format_team_ids(team_ids)
-    team_filter = f"raw_sessions.team_id IN({team_ids_str})" if team_ids else "1=1"
-    person_team_filter = f"person_distinct_id_overrides.team_id IN({team_ids_str})" if team_ids else "1=1"
-    events_team_filter = f"e.team_id IN({team_ids_str})" if team_ids else "1=1"
+    filters = get_team_filters(team_ids)
+    team_filter = filters["raw_sessions"]
+    person_team_filter = filters["person_distinct_id_overrides"]
+    events_team_filter = filters["events"]
 
     return f"""
     INSERT INTO {table_name}
@@ -199,10 +210,10 @@ def WEB_OVERVIEW_INSERT_SQL(
 def WEB_STATS_INSERT_SQL(
     date_start, date_end, team_ids=None, timezone="UTC", settings="", table_name="web_stats_daily"
 ):
-    team_ids_str = format_team_ids(team_ids)
-    team_filter = f"raw_sessions.team_id IN({team_ids_str})" if team_ids else "1=1"
-    person_team_filter = f"person_distinct_id_overrides.team_id IN({team_ids_str})" if team_ids else "1=1"
-    events_team_filter = f"e.team_id IN({team_ids_str})" if team_ids else "1=1"
+    filters = get_team_filters(team_ids)
+    team_filter = filters["raw_sessions"]
+    person_team_filter = filters["person_distinct_id_overrides"]
+    events_team_filter = filters["events"]
 
     return f"""
     INSERT INTO {table_name}
@@ -319,10 +330,10 @@ def WEB_STATS_INSERT_SQL(
 def WEB_BOUNCES_INSERT_SQL(
     date_start, date_end, team_ids=None, timezone="UTC", settings="", table_name="web_bounces_daily"
 ):
-    team_ids_str = format_team_ids(team_ids)
-    team_filter = f"raw_sessions.team_id IN({team_ids_str})" if team_ids else "1=1"
-    person_team_filter = f"person_distinct_id_overrides.team_id IN({team_ids_str})" if team_ids else "1=1"
-    events_team_filter = f"e.team_id IN({team_ids_str})" if team_ids else "1=1"
+    filters = get_team_filters(team_ids)
+    team_filter = filters["raw_sessions"]
+    person_team_filter = filters["person_distinct_id_overrides"]
+    events_team_filter = filters["events"]
 
     return f"""
     INSERT INTO {table_name}

--- a/posthog/models/web_preaggregated/sql.py
+++ b/posthog/models/web_preaggregated/sql.py
@@ -74,6 +74,15 @@ WEB_BOUNCES_COLUMNS = """
 
 WEB_BOUNCES_ORDER_BY = "(team_id, day_bucket, host, device_type, entry_path)"
 
+WEB_PATHS_COLUMNS = """
+    pathname String,
+    persons_uniq_state AggregateFunction(uniq, UUID),
+    sessions_uniq_state AggregateFunction(uniq, String),
+    pageviews_count_state AggregateFunction(sum, UInt64)
+"""
+
+WEB_PATHS_ORDER_BY = "(team_id, day_bucket, host, device_type, pathname)"
+
 
 def create_table_pair(base_table_name, columns, order_by, on_cluster=True):
     """Create both a local and distributed table with the same schema"""
@@ -106,6 +115,14 @@ def WEB_BOUNCES_DAILY_SQL(table_name="web_bounces_daily", on_cluster=True):
 
 def DISTRIBUTED_WEB_BOUNCES_DAILY_SQL():
     return DISTRIBUTED_TABLE_TEMPLATE("web_bounces_daily_distributed", "web_bounces_daily", WEB_BOUNCES_COLUMNS)
+
+
+def WEB_PATHS_DAILY_SQL(table_name="web_paths_daily", on_cluster=True):
+    return TABLE_TEMPLATE(table_name, WEB_PATHS_COLUMNS, WEB_PATHS_ORDER_BY, on_cluster)
+
+
+def DISTRIBUTED_WEB_PATHS_DAILY_SQL():
+    return DISTRIBUTED_TABLE_TEMPLATE("web_paths_daily_distributed", "web_paths_daily", WEB_PATHS_COLUMNS)
 
 
 def format_team_ids(team_ids):
@@ -409,5 +426,81 @@ def WEB_BOUNCES_INSERT_SQL(
         entry_path,
         host,
         device_type
+    SETTINGS {settings}
+    """
+
+
+def WEB_PATHS_INSERT_SQL(
+    date_start, date_end, team_ids=None, timezone="UTC", settings="", table_name="web_paths_daily"
+):
+    filters = get_team_filters(team_ids)
+    team_filter = filters["raw_sessions"]
+    person_team_filter = filters["person_distinct_id_overrides"]
+    events_team_filter = filters["events"]
+
+    return f"""
+    INSERT INTO {table_name}
+    SELECT
+        toStartOfDay(timestamp) AS day_bucket,
+        team_id,
+        host,
+        device_type,
+        pathname,
+        uniqState(assumeNotNull(person_id)) AS persons_uniq_state,
+        uniqState(assumeNotNull(session_id)) AS sessions_uniq_state,
+        sumState(toUInt64(1)) AS pageviews_count_state
+    FROM
+    (
+        SELECT
+            any(if(NOT empty(events__override.distinct_id), events__override.person_id, events.person_id)) AS person_id,
+            events__session.session_id AS session_id,
+            e.mat_$host AS host,
+            e.mat_$device_type AS device_type,
+            e.mat_$pathname AS pathname,
+            e.team_id AS team_id,
+            min(e.timestamp) AS timestamp
+        FROM events AS e
+        LEFT JOIN
+        (
+            SELECT
+                toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                raw_sessions.session_id_v7 AS session_id_v7
+            FROM raw_sessions
+            WHERE {team_filter}
+                AND toTimeZone(raw_sessions.min_timestamp, '{timezone}') >= toDateTime('{date_start}', '{timezone}')
+                AND toTimeZone(raw_sessions.min_timestamp, '{timezone}') < toDateTime('{date_end}', '{timezone}')
+            GROUP BY raw_sessions.session_id_v7
+            SETTINGS {settings}
+        ) AS events__session ON toUInt128(accurateCastOrNull(e.`$session_id`, 'UUID')) = events__session.session_id_v7
+        LEFT JOIN
+        (
+            SELECT
+                argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                person_distinct_id_overrides.distinct_id AS distinct_id
+            FROM person_distinct_id_overrides
+            WHERE {person_team_filter}
+            GROUP BY person_distinct_id_overrides.distinct_id
+            HAVING ifNull(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version) = 0, 0)
+            SETTINGS {settings}
+        ) AS events__override ON e.distinct_id = events__override.distinct_id
+        WHERE {events_team_filter}
+            AND ((e.event = '$pageview') OR (e.event = '$screen'))
+            AND (e.`$session_id` IS NOT NULL)
+            AND toTimeZone(e.timestamp, '{timezone}') >= toDateTime('{date_start}', '{timezone}')
+            AND toTimeZone(e.timestamp, '{timezone}') < toDateTime('{date_end}', '{timezone}')
+        GROUP BY
+            session_id,
+            team_id,
+            host,
+            device_type,
+            pathname
+        SETTINGS {settings}
+    )
+    GROUP BY
+        day_bucket,
+        team_id,
+        host,
+        device_type,
+        pathname
     SETTINGS {settings}
     """


### PR DESCRIPTION
## Problem

(This is our bread and butter, all the query work lead us here. (drumroll))

The path's breakdowns require an inner query with the bounce calculations for each entry path, and then join them by pathname.

Now this should be the biggest perf improvement as the WebOverview does not have a group by :) 

## Changes

- Added the asset materialization query
- Included the paths calculation as a inner query and the actual paths breakdown

## Did you write or update any docs for this change?

- [x] No docs needed for this change

## How did you test this code?

Manually 