### PR TITLE
fix(cdp): lower case mailchimp email before md5 hashing

### DIFF
--- a/posthog/cdp/templates/mailchimp/template_mailchimp.py
+++ b/posthog/cdp/templates/mailchimp/template_mailchimp.py
@@ -15,7 +15,11 @@ if (empty(inputs.email)) {
     return
 }
 
+let email := lower(inputs.email)
+let subscriberHash := md5Hex(email)
+
 let properties := {}
+
 
 for (let key, value in inputs.properties) {
     if (not empty(value)) {
@@ -31,7 +35,7 @@ if (inputs.include_all_properties) {
     }
 }
 
-let userStatus := fetch(f'https://{inputs.dataCenterId}.api.mailchimp.com/3.0/lists/{inputs.audienceId}/members/{md5Hex(inputs.email)}', {
+let userStatus := fetch(f'https://{inputs.dataCenterId}.api.mailchimp.com/3.0/lists/{inputs.audienceId}/members/{subscriberHash}', {
     'method': 'GET',
     'headers': {
         'Authorization': f'Bearer {inputs.apiKey}',
@@ -40,7 +44,7 @@ let userStatus := fetch(f'https://{inputs.dataCenterId}.api.mailchimp.com/3.0/li
 })
 
 if (userStatus.status == 404 or userStatus.status == 200) {
-    let res := fetch(f'https://{inputs.dataCenterId}.api.mailchimp.com/3.0/lists/{inputs.audienceId}/members/{md5Hex(inputs.email)}', {
+    let res := fetch(f'https://{inputs.dataCenterId}.api.mailchimp.com/3.0/lists/{inputs.audienceId}/members/{subscriberHash}', {
         'method': 'PUT',
         'headers': {
             'Authorization': f'Bearer {inputs.apiKey}',

--- a/posthog/cdp/templates/mailchimp/test_template_mailchimp.py
+++ b/posthog/cdp/templates/mailchimp/test_template_mailchimp.py
@@ -90,3 +90,19 @@ class TestTemplateMailchimp(BaseHogFunctionTemplateTest):
 
         assert not self.get_mock_fetch_calls()
         assert self.get_mock_print_calls() == snapshot([("No email set. Skipping...",)])
+
+    def test_email_case_normalization(self):
+        # Test with lowercase email
+        self.run_function(
+            inputs=create_inputs(email="max@posthog.com"),
+        )
+        lowercase_url = self.get_mock_fetch_calls()[0][0]
+
+        # Test with mixed case email
+        self.run_function(
+            inputs=create_inputs(email="Max@Posthog.com"),
+        )
+        mixed_case_url = self.get_mock_fetch_calls()[0][0]
+
+        # Verify both URLs are identical since email is normalized to lowercase
+        assert lowercase_url == mixed_case_url


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

mailchimp requires to lowercase the email address before md5-hashing it .. otherwise the hashes are different and this can lead to 404 errors of not finding the right email address

see docs https://mailchimp.com/developer/marketing/docs/methods-parameters/

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- added new test
- made the test fail 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
