### PR TITLE
fix: fix odd behaviour with hour intervals

### DIFF
--- a/posthog/hogql_queries/utils/query_date_range.py
+++ b/posthog/hogql_queries/utils/query_date_range.py
@@ -61,6 +61,15 @@ class QueryDateRange:
         self._now_without_timezone = now
         self._earliest_timestamp_fallback = earliest_timestamp_fallback
 
+        # Hour intervals have strange behaviour in clickhouse:
+        # From the docs:
+        # (*) hour intervals are special: the calculation is always performed relative to 00:00:00 (midnight) of the current day
+        # Keep 1 hour intervals the same just in case there's subtle changes (there shouldn't be)
+        # but for other counts switch to 60x minute intervals
+        if self._interval == IntervalType.HOUR and self._interval_count > 1:
+            self._interval = IntervalType.MINUTE
+            self._interval_count *= 60
+
         if not isinstance(self._interval, IntervalType):
             raise ValueError(f"Value {repr(interval)} is not an instance of IntervalType")
         if self._interval == IntervalType.WEEK and self._interval_count > 1:


### PR DESCRIPTION
## Problem

hour intervals are special in clickhouse:

(*) hour intervals are special: the calculation is always performed relative to 00:00:00 (midnight) of the current day

this means if we used a query date range with e.g. 5 hour intervals, it would actually split into 5, 5, 5, 5, 4 hourly buckets as it always snaps back relative to midnight, which is probably not what we want (intervals should all be equal)

if using multiple hour intervals switch them to 60x minute intervals instead, which gets more normal behaviour

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
