### PR TITLE
fix(err): no longer clear query on close

### DIFF
--- a/frontend/src/scenes/error-tracking/components/ErrorFilters/FilterGroup.tsx
+++ b/frontend/src/scenes/error-tracking/components/ErrorFilters/FilterGroup.tsx
@@ -48,10 +48,9 @@ const UniversalSearch = (): JSX.Element => {
     const searchInputRef = useRef<HTMLInputElement | null>(null)
     const floatingRef = useRef<HTMLDivElement | null>(null)
 
-    const onClose = (query: string): void => {
+    const onClose = (): void => {
         searchInputRef.current?.blur()
         setVisible(false)
-        setSearchQuery(query)
     }
 
     const taxonomicFilterLogicProps: TaxonomicFilterLogicProps = {
@@ -84,13 +83,13 @@ const UniversalSearch = (): JSX.Element => {
                 visible={visible}
                 closeOnClickInside={false}
                 floatingRef={floatingRef}
-                onClickOutside={() => onClose('')}
+                onClickOutside={() => onClose()}
             >
                 <TaxonomicFilterSearchInput
                     prefix={<RecordingsUniversalFilterGroup />}
                     onClick={() => setVisible(true)}
                     searchInputRef={searchInputRef}
-                    onClose={() => onClose('')}
+                    onClose={() => onClose()}
                     onChange={setSearchQuery}
                     size="small"
                     fullWidth


### PR DESCRIPTION
I _think_ this was a bug, or at least, it caused a bug for sure and this fixes that bug (clicking focus away from the search bar reloaded the query with no search text), but I'm somewhat less confident it's correct in the broader context (I think it is, but am not certain, so please review a little carefully)