### PR TITLE
chore(data-warehouse): Use finished_at timestamp for usage reports

### DIFF
--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -1450,22 +1450,20 @@ class TestExternalDataSyncUsageReport(ClickhouseDestroyTablesMixin, TestCase, Cl
             source_type=ExternalDataSource.Type.STRIPE,
         )
 
-        for i in range(5):
-            start_time = (now() - relativedelta(hours=i)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        for _ in range(5):
             ExternalDataJob.objects.create(
                 team_id=3,
-                created_at=start_time,
+                finished_at=now(),
                 rows_synced=10,
                 status=ExternalDataJob.Status.COMPLETED,
                 pipeline=source,
                 pipeline_version=ExternalDataJob.PipelineVersion.V1,
             )
 
-        for i in range(5):
-            start_time = (now() - relativedelta(hours=i)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        for _ in range(5):
             ExternalDataJob.objects.create(
                 team_id=4,
-                created_at=start_time,
+                finished_at=now(),
                 rows_synced=10,
                 status=ExternalDataJob.Status.COMPLETED,
                 pipeline=source,
@@ -1510,22 +1508,20 @@ class TestExternalDataSyncUsageReport(ClickhouseDestroyTablesMixin, TestCase, Cl
             source_type=ExternalDataSource.Type.STRIPE,
         )
 
-        for i in range(5):
-            start_time = (now() - relativedelta(hours=i)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        for _ in range(5):
             ExternalDataJob.objects.create(
                 team_id=3,
-                created_at=start_time,
+                finished_at=now(),
                 rows_synced=10,
                 status=ExternalDataJob.Status.COMPLETED,
                 pipeline=source,
                 pipeline_version=ExternalDataJob.PipelineVersion.V1,
             )
 
-        for i in range(5):
-            start_time = (now() - relativedelta(hours=i)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        for _ in range(5):
             ExternalDataJob.objects.create(
                 team_id=4,
-                created_at=start_time,
+                finished_at=now(),
                 rows_synced=10,
                 status=ExternalDataJob.Status.FAILED,
                 pipeline=source,
@@ -1570,22 +1566,20 @@ class TestExternalDataSyncUsageReport(ClickhouseDestroyTablesMixin, TestCase, Cl
             source_type=ExternalDataSource.Type.STRIPE,
         )
 
-        for i in range(5):
-            start_time = (now() - relativedelta(hours=i)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        for _ in range(5):
             ExternalDataJob.objects.create(
                 team_id=3,
-                created_at=start_time,
+                finished_at=now(),
                 rows_synced=10,
                 status=ExternalDataJob.Status.COMPLETED,
                 pipeline=source,
                 pipeline_version=ExternalDataJob.PipelineVersion.V1,
             )
 
-        for i in range(5):
-            start_time = (now() - relativedelta(hours=i)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        for _ in range(5):
             ExternalDataJob.objects.create(
                 team_id=4,
-                created_at=start_time,
+                finished_at=now(),
                 rows_synced=10,
                 status=ExternalDataJob.Status.COMPLETED,
                 pipeline=source,

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -850,7 +850,7 @@ def get_teams_with_ai_event_count_in_period(
 def get_teams_with_rows_synced_in_period(begin: datetime, end: datetime) -> list:
     return list(
         ExternalDataJob.objects.filter(
-            created_at__gte=begin, created_at__lte=end, billable=True, status=ExternalDataJob.Status.COMPLETED
+            finished_at__gte=begin, finished_at__lte=end, billable=True, status=ExternalDataJob.Status.COMPLETED
         )
         .values("team_id")
         .annotate(total=Sum("rows_synced"))


### PR DESCRIPTION
## Changes
- Part 2 of https://github.com/PostHog/posthog/pull/32539
- Use the new `finished_at` timestamp when querying jobs for usage reports
- Also turns out the unit tests for these were not really setup correctly, but have fixed that too 

## How did you test this code?
Updated unit tests
