### PR TITLE
chore: disable cohortpeople data deletion for now

### DIFF
--- a/dags/deletes.py
+++ b/dags/deletes.py
@@ -784,8 +784,9 @@ def deletes_job():
     delete_mutations = delete_team_data_from(GROUPS_TABLE)(load_dict, waited_mutation)
     waited_mutation = wait_for_delete_mutations_in_all_hosts(delete_mutations)
 
-    delete_mutations = delete_team_data_from("cohortpeople")(load_dict, waited_mutation)
-    waited_mutation = wait_for_delete_mutations_in_all_hosts(delete_mutations)
+    # Disable cohortpeople data deletion for now, the mutations run here overload the cluster pretty badly
+    # delete_mutations = delete_team_data_from("cohortpeople")(load_dict, waited_mutation)
+    # waited_mutation = wait_for_delete_mutations_in_all_hosts(delete_mutations)
 
     delete_mutations = delete_team_data_from(PERSON_STATIC_COHORT_TABLE)(load_dict, waited_mutation)
     waited_mutation = wait_for_delete_mutations_in_all_hosts(delete_mutations)

--- a/dags/tests/test_deletes.py
+++ b/dags/tests/test_deletes.py
@@ -291,8 +291,8 @@ def test_full_job_team_deletes(cluster: ClickhouseCluster):
     final_groups = cluster.any_host(partial(get_by_team, "groups")).result()
     assert len(final_groups) == event_count - delete_count, f"expected groups data was not deleted"
 
-    final_cohortpeople = cluster.any_host(partial(get_by_team, "cohortpeople")).result()
-    assert len(final_cohortpeople) == event_count - delete_count, f"expected cohortpeople data was not deleted"
+    # final_cohortpeople = cluster.any_host(partial(get_by_team, "cohortpeople")).result()
+    # assert len(final_cohortpeople) == event_count - delete_count, f"expected cohortpeople data was not deleted"
 
     final_person_static_cohort = cluster.any_host(partial(get_by_team, "person_static_cohort")).result()
     assert (


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

When this mutation is run, the cluster is overloaded pretty badly.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Disable it for now.

