### PR TITLE
fix(cdp): Wrap offsetStore errors

### DIFF
--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -272,7 +272,11 @@ export class KafkaConsumer {
             } catch (e) {
                 // NOTE: We don't throw here - this can happen if we were re-assigned partitions
                 // and the offsets are no longer valid whilst processing a batch
-                logger.error('📝', 'Failed to store offsets', { error: e })
+                logger.error('📝', 'Failed to store offsets', {
+                    error: String(e),
+                    assignedPartitions: this.assignments(),
+                    topicPartitionOffsets,
+                })
                 captureException(e)
             }
         }

--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -267,7 +267,14 @@ export class KafkaConsumer {
 
         if (topicPartitionOffsets.length > 0) {
             logger.debug('📝', 'Storing offsets', { topicPartitionOffsets })
-            this.rdKafkaConsumer.offsetsStore(topicPartitionOffsets)
+            try {
+                this.rdKafkaConsumer.offsetsStore(topicPartitionOffsets)
+            } catch (e) {
+                // NOTE: We don't throw here - this can happen if we were re-assigned partitions
+                // and the offsets are no longer valid whilst processing a batch
+                logger.error('📝', 'Failed to store offsets', { error: e })
+                captureException(e)
+            }
         }
     }
 

--- a/plugin-server/src/server.ts
+++ b/plugin-server/src/server.ts
@@ -305,8 +305,8 @@ export class PluginServer {
             })
         }
 
-        process.on('unhandledRejection', (error: Error | any, promise: Promise<any>) => {
-            logger.error('🤮', `Unhandled Promise Rejection`, { error: String(error), promise })
+        process.on('unhandledRejection', (error: Error | any) => {
+            logger.error('🤮', `Unhandled Promise Rejection`, { error: String(error) })
 
             captureException(error, {
                 extra: { detected_at: `pluginServer.ts on unhandledRejection` },


### PR DESCRIPTION
## Problem

The offsetStore can error when a rebalance happens as we try to store offsets for an unassigned partition.

## Changes

* For now, wrapping the call with a catch to validate this is really the case and logging extra context

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
