### PR TITLE
fix: simplify meta patching detection

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.performance.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.performance.test.ts
@@ -144,7 +144,7 @@ describe('sessionRecordingDataLogic performance', () => {
             // eslint-disable-next-line no-console
             console.log(`Standard deviation: ${stdDev}ms`)
 
-            expect(averageDuration).toBeLessThan(800)
+            expect(averageDuration).toBeLessThan(1000)
             expect(stdDev).toBeLessThan(1000)
         })
     })

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -224,7 +224,10 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
                         throw e
                     })
 
-                    const parsedSnapshots = await parseEncodedSnapshots(response, props.sessionRecordingId)
+                    // sorting is very cheap for already sorted lists
+                    const parsedSnapshots = (await parseEncodedSnapshots(response, props.sessionRecordingId)).sort(
+                        (a, b) => a.timestamp - b.timestamp
+                    )
                     return { snapshots: parsedSnapshots, source }
                 },
             },

--- a/frontend/src/scenes/session-recordings/player/snapshot-processing/process-all-snapshots.ts
+++ b/frontend/src/scenes/session-recordings/player/snapshot-processing/process-all-snapshots.ts
@@ -39,16 +39,16 @@ export function processAllSnapshots(
     const result: RecordingSnapshot[] = []
     const matchedExtensions = new Set<string>()
 
+    let metaCount = 0
+    let fullSnapshotCount = 0
+
     // we loop over this data as little as possible,
     // since it could be large and processed more than once,
     // so we need to do as little as possible, as fast as possible
-    let needToPatchMeta = false
-
     for (const source of sources) {
         const sourceKey = keyForSource(source)
         const sourceSnapshots = snapshotsBySource?.[sourceKey]?.snapshots || []
 
-        let sawMeta = false
         for (const snapshot of sourceSnapshots) {
             const { delay: _delay, ...delayFreeSnapshot } = snapshot
 
@@ -60,21 +60,14 @@ export function processAllSnapshots(
             }
             seenHashes.add(key)
 
-            // we need to know if it is worth patching any meta-events into the data
-            if (sawMeta) {
-                if (snapshot.type === EventType.FullSnapshot) {
-                    // meta / full pair found 👍
-                    sawMeta = false
-                } else {
-                    // we had a meta-event not followed by a full snapshot
-                    needToPatchMeta = true
-                }
-            } else if (snapshot.type === EventType.Meta) {
-                sawMeta = true
+            if (snapshot.type === EventType.Meta) {
+                metaCount += 1
             }
 
             // Process chrome extension data
             if (snapshot.type === EventType.FullSnapshot) {
+                fullSnapshotCount += 1
+
                 const fullSnapshot = snapshot as RecordingSnapshot & fullSnapshotEvent & eventWithTime
 
                 if (
@@ -106,7 +99,8 @@ export function processAllSnapshots(
     // Sort by timestamp
     result.sort((a, b) => a.timestamp - b.timestamp)
 
-    // Second pass: patch meta-events on the sorted array
+    // Optional second pass: patch meta-events on the sorted array
+    const needToPatchMeta = fullSnapshotCount > 0 && fullSnapshotCount > metaCount
     return needToPatchMeta ? patchMetaEventIntoWebData(result, viewportForTimestamp, sessionRecordingId) : result
 }
 

--- a/frontend/src/scenes/session-recordings/player/snapshot-processing/process-all-snapshots.ts
+++ b/frontend/src/scenes/session-recordings/player/snapshot-processing/process-all-snapshots.ts
@@ -47,7 +47,10 @@ export function processAllSnapshots(
     // so we need to do as little as possible, as fast as possible
     for (const source of sources) {
         const sourceKey = keyForSource(source)
-        const sourceSnapshots = snapshotsBySource?.[sourceKey]?.snapshots || []
+        // sorting is very cheap for already sorted lists
+        const sourceSnapshots = (snapshotsBySource?.[sourceKey]?.snapshots || []).sort(
+            (a, b) => a.timestamp - b.timestamp
+        )
 
         for (const snapshot of sourceSnapshots) {
             const { delay: _delay, ...delayFreeSnapshot } = snapshot
@@ -96,7 +99,7 @@ export function processAllSnapshots(
         }
     }
 
-    // Sort by timestamp
+    // sorting is very cheap for already sorted lists
     result.sort((a, b) => a.timestamp - b.timestamp)
 
     // Optional second pass: patch meta-events on the sorted array


### PR DESCRIPTION
nothing like merging a PR to immediately see an easier way to track something
i was tracking flags to see if we need to patch a meta event into the web data
but we can simply count meta and fullsnapshots and check if we have the same amount

we also really need the data to be sorted by timestamp, and it's cheap to sort an already sorted list so we can be a bit over the top to make sure it is sorted