### PR TITLE
feat: allow not converting timezones in queries

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -10953,6 +10953,9 @@
                 },
                 "useWebAnalyticsPreAggregatedTables": {
                     "type": "boolean"
+                },
+                "convertToProjectTimezone": {
+                    "type": "boolean"
                 }
             },
             "type": "object"

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -10884,6 +10884,9 @@
                     "enum": ["count_pageviews", "uniq_urls", "uniq_page_screen_autocaptures"],
                     "type": "string"
                 },
+                "convertToProjectTimezone": {
+                    "type": "boolean"
+                },
                 "customChannelTypeRules": {
                     "items": {
                         "$ref": "#/definitions/CustomChannelRule"
@@ -10952,9 +10955,6 @@
                     "type": "boolean"
                 },
                 "useWebAnalyticsPreAggregatedTables": {
-                    "type": "boolean"
-                },
-                "convertToProjectTimezone": {
                     "type": "boolean"
                 }
             },

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -305,6 +305,7 @@ export interface HogQLQueryModifiers {
     usePresortedEventsTable?: boolean
     useWebAnalyticsPreAggregatedTables?: boolean
     formatCsvAllowDoubleQuotes?: boolean
+    convertToProjectTimezone?: boolean
 }
 
 export interface DataWarehouseEventsModifier {

--- a/posthog/hogql/modifiers.py
+++ b/posthog/hogql/modifiers.py
@@ -106,6 +106,9 @@ def set_default_modifier_values(modifiers: HogQLQueryModifiers, team: "Team"):
     if modifiers.propertyGroupsMode is None and is_cloud():
         modifiers.propertyGroupsMode = PropertyGroupsMode.OPTIMIZED
 
+    if modifiers.convertToProjectTimezone is None:
+        modifiers.convertToProjectTimezone = True
+
 
 def set_default_in_cohort_via(modifiers: HogQLQueryModifiers) -> HogQLQueryModifiers:
     if modifiers.inCohortVia is None or modifiers.inCohortVia == InCohortVia.AUTO:

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -165,13 +165,17 @@ def prepare_ast_for_printing(
             resolve_lazy_tables(node, dialect, stack, context)
 
         with context.timings.measure("swap_properties"):
+            set_timezones = True
+            if context.modifiers.convertToProjectTimezone is not None:
+                set_timezones = context.modifiers.convertToProjectTimezone
+
             node = PropertySwapper(
                 timezone=context.property_swapper.timezone,
                 group_properties={},
                 person_properties=context.property_swapper.person_properties,
                 event_properties=context.property_swapper.event_properties,
                 context=context,
-                setTimeZones=context.modifiers.convertToProjectTimezone,
+                setTimeZones=set_timezones,
             ).visit(node)
 
         # We support global query settings, and local subquery settings.

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -171,7 +171,7 @@ def prepare_ast_for_printing(
                 person_properties=context.property_swapper.person_properties,
                 event_properties=context.property_swapper.event_properties,
                 context=context,
-                setTimeZones=True,
+                setTimeZones=context.modifiers.convertToProjectTimezone,
             ).visit(node)
 
         # We support global query settings, and local subquery settings.

--- a/posthog/hogql/test/test_modifiers.py
+++ b/posthog/hogql/test/test_modifiers.py
@@ -307,6 +307,8 @@ class TestModifiers(BaseTest):
             team=self.team,
             modifiers=HogQLQueryModifiers(),
         )
+        assert response is not None
+        assert response.clickhouse is not None
         assert response.clickhouse.count("toTimeZone") == 1
 
         response = execute_hogql_query(
@@ -314,4 +316,6 @@ class TestModifiers(BaseTest):
             team=self.team,
             modifiers=HogQLQueryModifiers(convertToProjectTimezone=False),
         )
+        assert response is not None
+        assert response.clickhouse is not None
         assert response.clickhouse.count("toTimeZone") == 0

--- a/posthog/hogql/test/test_modifiers.py
+++ b/posthog/hogql/test/test_modifiers.py
@@ -299,3 +299,19 @@ class TestModifiers(BaseTest):
         assert response is not None
         assert response.clickhouse is not None
         assert response.clickhouse.count("ilike") == 2
+
+    def test_no_convert_timezone(self):
+        # default to convert to timezone
+        response = execute_hogql_query(
+            f"select timestamp from events limit 1",
+            team=self.team,
+            modifiers=HogQLQueryModifiers(),
+        )
+        assert response.clickhouse.count("toTimeZone") == 1
+
+        response = execute_hogql_query(
+            f"select timestamp from events limit 1",
+            team=self.team,
+            modifiers=HogQLQueryModifiers(convertToProjectTimezone=False),
+        )
+        assert response.clickhouse.count("toTimeZone") == 0

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -121,7 +121,7 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        assert cache_key == "cache_39826429ae3c6e686de1daf2028642af"
+        assert cache_key == "cache_81cddfbbf27c8656cc0c71e17917c8bd"
 
     def test_cache_key_runner_subclass(self):
         TestQueryRunner = self.setup_test_query_runner_class()

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -103,6 +103,7 @@ class TestQueryRunner(BaseTest):
                 "useMaterializedViews": True,
                 "sessionsV2JoinMode": "string",
                 "usePresortedEventsTable": False,
+                "convertToProjectTimezone": True,
             },
             "limit_context": "query",
             "query": {"kind": "TestQuery", "some_attr": "bla"},
@@ -134,7 +135,7 @@ class TestQueryRunner(BaseTest):
         runner = TestSubclassQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        assert cache_key == "cache_814a34da287ce2c35b1db608dde1ba42"
+        assert cache_key == "cache_ac85f6f0bfcc738665881287b9d86890"
 
     def test_cache_key_different_timezone(self):
         TestQueryRunner = self.setup_test_query_runner_class()
@@ -145,7 +146,7 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        assert cache_key == "cache_117db0ffec0eeed95e8086cd049f3d86"
+        assert cache_key == "cache_2c629e23e4015d311ade6565dcdf0387"
 
     @mock.patch("django.db.transaction.on_commit")
     def test_cache_response(self, mock_on_commit):

--- a/posthog/hogql_queries/utils/query_date_range.py
+++ b/posthog/hogql_queries/utils/query_date_range.py
@@ -53,7 +53,7 @@ class QueryDateRange:
         now: datetime,
         earliest_timestamp_fallback: Optional[datetime] = None,
         interval_count: Optional[int] = None,
-        timezone: Optional[ZoneInfo] = None,
+        timezone_info: Optional[ZoneInfo] = None,
     ) -> None:
         self._team = team
         self._date_range = date_range
@@ -61,7 +61,7 @@ class QueryDateRange:
         self._interval_count = interval_count or 1
         self._now_without_timezone = now
         self._earliest_timestamp_fallback = earliest_timestamp_fallback
-        self._timezone = timezone or self._team.timezone_info
+        self._timezone_info = timezone_info or self._team.timezone_info
 
         if not isinstance(self._interval, IntervalType):
             raise ValueError(f"Value {repr(interval)} is not an instance of IntervalType")
@@ -77,7 +77,7 @@ class QueryDateRange:
         if self._date_range and self._date_range.date_to:
             date_to, delta_mapping, _position = relative_date_parse_with_delta_mapping(
                 self._date_range.date_to,
-                self._timezone,
+                self._timezone_info,
                 always_truncate=False,
                 now=self.now_with_timezone,
             )
@@ -108,7 +108,7 @@ class QueryDateRange:
         elif self._date_range and isinstance(self._date_range.date_from, str):
             date_from = relative_date_parse(
                 self._date_range.date_from,
-                self._timezone,
+                self._timezone_info,
                 now=self.now_with_timezone,
                 # this makes sure we truncate date_from to the start of the day, when looking at last N days by hour
                 # when we look at graphs by minute (last hour or last three hours), don't truncate
@@ -127,7 +127,7 @@ class QueryDateRange:
 
     @cached_property
     def now_with_timezone(self) -> datetime:
-        return self._now_without_timezone.astimezone(self._timezone)
+        return self._now_without_timezone.astimezone(self._timezone_info)
 
     def format_date(self, datetime) -> str:
         return datetime.strftime("%Y-%m-%d %H:%M:%S")
@@ -265,7 +265,7 @@ class QueryDateRange:
 
         _date_from, delta_mapping, _position = relative_date_parse_with_delta_mapping(
             self._date_range.date_from,
-            self._timezone,
+            self._timezone_info,
             always_truncate=True,
             now=self.now_with_timezone,
         )

--- a/posthog/hogql_queries/utils/query_date_range.py
+++ b/posthog/hogql_queries/utils/query_date_range.py
@@ -53,6 +53,7 @@ class QueryDateRange:
         now: datetime,
         earliest_timestamp_fallback: Optional[datetime] = None,
         interval_count: Optional[int] = None,
+        timezone: Optional[ZoneInfo] = None,
     ) -> None:
         self._team = team
         self._date_range = date_range
@@ -60,6 +61,7 @@ class QueryDateRange:
         self._interval_count = interval_count or 1
         self._now_without_timezone = now
         self._earliest_timestamp_fallback = earliest_timestamp_fallback
+        self._timezone = timezone or self._team.timezone_info
 
         if not isinstance(self._interval, IntervalType):
             raise ValueError(f"Value {repr(interval)} is not an instance of IntervalType")
@@ -75,7 +77,7 @@ class QueryDateRange:
         if self._date_range and self._date_range.date_to:
             date_to, delta_mapping, _position = relative_date_parse_with_delta_mapping(
                 self._date_range.date_to,
-                self._team.timezone_info,
+                self._timezone,
                 always_truncate=False,
                 now=self.now_with_timezone,
             )
@@ -106,7 +108,7 @@ class QueryDateRange:
         elif self._date_range and isinstance(self._date_range.date_from, str):
             date_from = relative_date_parse(
                 self._date_range.date_from,
-                self._team.timezone_info,
+                self._timezone,
                 now=self.now_with_timezone,
                 # this makes sure we truncate date_from to the start of the day, when looking at last N days by hour
                 # when we look at graphs by minute (last hour or last three hours), don't truncate
@@ -125,7 +127,7 @@ class QueryDateRange:
 
     @cached_property
     def now_with_timezone(self) -> datetime:
-        return self._now_without_timezone.astimezone(ZoneInfo(self._team.timezone))
+        return self._now_without_timezone.astimezone(self._timezone)
 
     def format_date(self, datetime) -> str:
         return datetime.strftime("%Y-%m-%d %H:%M:%S")
@@ -263,7 +265,7 @@ class QueryDateRange:
 
         _date_from, delta_mapping, _position = relative_date_parse_with_delta_mapping(
             self._date_range.date_from,
-            self._team.timezone_info,
+            self._timezone,
             always_truncate=True,
             now=self.now_with_timezone,
         )

--- a/posthog/hogql_queries/utils/test/test_query_date_range.py
+++ b/posthog/hogql_queries/utils/test/test_query_date_range.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 from dateutil import parser
+from zoneinfo import ZoneInfo
 
 from posthog.hogql import ast
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange, QueryDateRangeWithIntervals
@@ -142,6 +143,28 @@ class TestQueryDateRange(APIBaseTest):
         self.assertEqual(query_date_range.all_values()[4], parser.isoparse("2021-08-24T23:34:00.000000Z"))
         self.assertEqual(query_date_range.all_values()[5], parser.isoparse("2021-08-24T23:44:00.000000Z"))
         self.assertEqual(query_date_range.all_values()[6], parser.isoparse("2021-08-24T23:54:00.000000Z"))
+
+    def test_explicit_timezone(self):
+        now = parser.isoparse("2021-08-25T00:00:00.000Z")
+        date_range = DateRange(date_from="-1d", date_to=None, explicitDate=False)
+        self.team.timezone = "Europe/Berlin"
+
+        query_date_range = QueryDateRange(
+            team=self.team, date_range=date_range, interval=IntervalType.MINUTE, interval_count=10, now=now
+        )
+        query_date_range_utc = QueryDateRange(
+            team=self.team,
+            date_range=date_range,
+            interval=IntervalType.MINUTE,
+            interval_count=10,
+            now=now,
+            timezone_info=ZoneInfo("UTC"),
+        )
+
+        # the tz shouldn't affect the actual time, should both be equal
+        self.assertEqual(query_date_range.date_to(), query_date_range_utc.date_to())
+        self.assertEqual(query_date_range.date_to().tzinfo.key, "Europe/Berlin")
+        self.assertEqual(query_date_range_utc.date_to().tzinfo.key, "UTC")
 
 
 class TestQueryDateRangeWithIntervals(APIBaseTest):

--- a/posthog/hogql_queries/utils/test/test_query_date_range.py
+++ b/posthog/hogql_queries/utils/test/test_query_date_range.py
@@ -162,9 +162,12 @@ class TestQueryDateRange(APIBaseTest):
         )
 
         # the tz shouldn't affect the actual time, should both be equal
-        self.assertEqual(query_date_range.date_to(), query_date_range_utc.date_to())
-        self.assertEqual(query_date_range.date_to().tzinfo.key, "Europe/Berlin")
-        self.assertEqual(query_date_range_utc.date_to().tzinfo.key, "UTC")
+        date_to = query_date_range.date_to()
+        date_to_utc = query_date_range_utc.date_to()
+        self.assertEqual(date_to, date_to_utc)
+        assert date_to.tzinfo != date_to_utc.tzinfo
+        self.assertEqual(date_to.tzinfo, ZoneInfo("Europe/Berlin"))
+        self.assertEqual(date_to_utc.tzinfo, ZoneInfo("UTC"))
 
 
 class TestQueryDateRangeWithIntervals(APIBaseTest):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -2846,6 +2846,7 @@ class HogQLQueryModifiers(BaseModel):
     )
     bounceRateDurationSeconds: Optional[float] = None
     bounceRatePageViewMode: Optional[BounceRatePageViewMode] = None
+    convertToProjectTimezone: Optional[bool] = None
     customChannelTypeRules: Optional[list[CustomChannelRule]] = None
     dataWarehouseEventsModifiers: Optional[list[DataWarehouseEventsModifier]] = None
     debug: Optional[bool] = None
@@ -2863,7 +2864,6 @@ class HogQLQueryModifiers(BaseModel):
     useMaterializedViews: Optional[bool] = None
     usePresortedEventsTable: Optional[bool] = None
     useWebAnalyticsPreAggregatedTables: Optional[bool] = None
-    convertToProjectTimezone: Optional[bool] = None
 
 
 class HogQuery(BaseModel):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -2863,6 +2863,7 @@ class HogQLQueryModifiers(BaseModel):
     useMaterializedViews: Optional[bool] = None
     usePresortedEventsTable: Optional[bool] = None
     useWebAnalyticsPreAggregatedTables: Optional[bool] = None
+    convertToProjectTimezone: Optional[bool] = None
 
 
 class HogQuery(BaseModel):


### PR DESCRIPTION
## Problem

some queries can have performance problems caused by toTimezone (it can break indexes on timestamps)

add a modifier to not convert timestamps in a query, and update QueryDateRange to take a timezone argument instead of using the team's timezone

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
added new unit tests for query_date_range and modifiers