### PR TITLE
feat: Route Rev Analytics errors to proper channel

### DIFF
--- a/dags/common.py
+++ b/dags/common.py
@@ -12,6 +12,7 @@ from posthog.clickhouse.cluster import (
 
 class JobOwners(str, Enum):
     TEAM_CLICKHOUSE = "team-clickhouse"
+    TEAM_REVENUE_ANALYTICS = "team-revenue-analytics"
     TEAM_WEB_ANALYTICS = "team-web-analytics"
 
 

--- a/dags/exchange_rate.py
+++ b/dags/exchange_rate.py
@@ -295,13 +295,13 @@ def hourly_exchange_rates_in_clickhouse(
 daily_exchange_rates_job = dagster.define_asset_job(
     name="daily_exchange_rates_job",
     selection=[daily_exchange_rates.key, daily_exchange_rates_in_clickhouse.key],
-    tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
+    tags={"owner": JobOwners.TEAM_REVENUE_ANALYTICS.value},
 )
 
 hourly_exchange_rates_job = dagster.define_asset_job(
     name="hourly_exchange_rates_job",
     selection=[hourly_exchange_rates.key, hourly_exchange_rates_in_clickhouse.key],
-    tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
+    tags={"owner": JobOwners.TEAM_REVENUE_ANALYTICS.value},
 )
 
 

--- a/dags/slack_alerts.py
+++ b/dags/slack_alerts.py
@@ -8,6 +8,7 @@ from dags.common import JobOwners
 notification_channel_per_team = {
     JobOwners.TEAM_CLICKHOUSE.value: "#alerts-clickhouse",
     JobOwners.TEAM_WEB_ANALYTICS.value: "#alerts-web-analytics",
+    JobOwners.TEAM_REVENUE_ANALYTICS.value: "#alerts-revenue-analytics",
 }
 
 


### PR DESCRIPTION
Now that we're a standalone team, we should send these to a proper channel rather than flood the Web Analytics one
