### PR TITLE
feat: duplicate shared metrics on the experiment

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -542,7 +542,7 @@ class EnterpriseExperimentsViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
                 ).exists():
                     return Response({"detail": "Shared metric is not part of this experiment"}, status=400)
 
-                # Create a new saved metric based on he existing one
+                # Create a new saved metric based on the existing one
                 new_shared_metric = ExperimentSavedMetric.objects.create(
                     name=f"{shared_metric.name} (copy)",
                     description=shared_metric.description,

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -425,6 +425,19 @@ const duplicateMetric =
         }
     }
 
+type SharedMetric = ExperimentMetric & {
+    isSharedMetric: true
+    sharedMetricId: number
+}
+
+const isSharedMetric = (metric: ExperimentMetric): metric is SharedMetric => {
+    /**
+     * the === true is to please the type checker. isSharedMetric is a boolean,
+     * but the type checker doesn't know that so it treat is as unknown.
+     */
+    return 'isSharedMetric' in metric && metric.isSharedMetric === true
+}
+
 // Main DeltaChart component
 export function DeltaChart({
     isSecondary,
@@ -464,7 +477,8 @@ export function DeltaChart({
         hasMinimumExposureForResults,
     } = useValues(experimentLogic)
 
-    const { openVariantDeltaTimeseriesModal, setExperiment, updateExperimentMetrics } = useActions(experimentLogic)
+    const { openVariantDeltaTimeseriesModal, setExperiment, updateExperimentMetrics, duplicateSharedMetric } =
+        useActions(experimentLogic)
 
     // Loading state
     const resultsLoading = isSecondary ? secondaryMetricResultsLoading : metricResultsLoading
@@ -501,6 +515,11 @@ export function DeltaChart({
             metricType={metricType}
             isPrimaryMetric={!isSecondary}
             onDuplicateMetricClick={(metric) => {
+                if (isSharedMetric(metric)) {
+                    duplicateSharedMetric(metric.sharedMetricId, { type: !isSecondary ? 'primary' : 'secondary' })
+                    return
+                }
+
                 setExperiment(onDuplicateMetric(metric))
                 updateExperimentMetrics()
             }}

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -433,7 +433,7 @@ type SharedMetric = ExperimentMetric & {
 const isSharedMetric = (metric: ExperimentMetric): metric is SharedMetric => {
     /**
      * the === true is to please the type checker. isSharedMetric is a boolean,
-     * but the type checker doesn't know that so it treat is as unknown.
+     * but the type checker doesn't know that so it treats it as unknown.
      */
     return 'isSharedMetric' in metric && metric.isSharedMetric === true
 }

--- a/frontend/src/scenes/experiments/MetricsView/MetricHeader.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/MetricHeader.tsx
@@ -72,9 +72,6 @@ export const MetricHeader = ({
                             icon={<IconCopy fontSize="12" />}
                             tooltip="Duplicate"
                             onClick={() => {
-                                if (metric.isSharedMetric) {
-                                    return
-                                }
                                 onDuplicateMetricClick(metric)
                             }}
                         />

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1385,7 +1385,13 @@ export const experimentLogic = kea<experimentLogicType>([
                 }
             }
         },
-        duplicateSharedMetric: async ({ sharedMetricId, metadata }: { sharedMetricId: number }) => {
+        duplicateSharedMetric: async ({
+            sharedMetricId,
+            metadata,
+        }: {
+            sharedMetricId: number
+            metadata: { type: 'primary' | 'secondary' }
+        }) => {
             await api.create(`api/projects/@current/experiments/${values.experimentId}/duplicate_shared_metric/`, {
                 shared_metric_id: sharedMetricId,
                 metadata,

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -414,6 +414,10 @@ export const experimentLogic = kea<experimentLogicType>([
         validateFeatureFlag: (featureFlagKey: string) => ({ featureFlagKey }),
         openCalculateRunningTimeModal: true,
         closeCalculateRunningTimeModal: true,
+        duplicateSharedMetric: (sharedMetricId: number, metadata: { ['type']: 'primary' | 'secondary' }) => ({
+            sharedMetricId,
+            metadata,
+        }),
     }),
     reducers({
         experiment: [
@@ -1380,6 +1384,14 @@ export const experimentLogic = kea<experimentLogicType>([
                     logic.actions.loadFeatureFlag() // Access the loader through actions
                 }
             }
+        },
+        duplicateSharedMetric: async ({ sharedMetricId, metadata }: { sharedMetricId: number }) => {
+            await api.create(`api/projects/@current/experiments/${values.experimentId}/duplicate_shared_metric/`, {
+                shared_metric_id: sharedMetricId,
+                metadata,
+            })
+
+            actions.loadExperiment()
         },
     })),
     loaders(({ actions, props, values }) => ({


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

Close #31862 

## Problem

The final chapter allows users to duplicate metrics, this time, the dreaded _shared metric_ (_saved_ metric for the backend).

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

_Shared Metrics_ (again... _saved_ for python) are stored independently of experiments, and have a one-to-many relationship with them. Doing this in the frontend required juggling multiple state managers, so to make things simpler, we've added a new action to the Experiments REST API, and we make all the updates on the server.
We are not optimistically updating the client, but rather refreshing the experiment.

### Before

https://github.com/user-attachments/assets/f7793149-10c8-42c1-abc9-3a323c6763f9

### After

https://github.com/user-attachments/assets/17dae7d0-db18-413e-aa72-84f61fcf7a2b

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

There's a related Documentation PR with a callout to this: https://github.com/PostHog/posthog.com/pull/11557

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
