### PR TITLE
chore: filter tiles that support pre-aggregated

### DIFF
--- a/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
@@ -68,6 +68,7 @@ export const WebAnalyticsFilters = (): JSX.Element => {
 const FoldableFilters = (): JSX.Element => {
     const {
         dateFilter: { dateTo, dateFrom },
+        preAggregatedEnabled,
     } = useValues(webAnalyticsLogic)
     const { setDates } = useActions(webAnalyticsLogic)
 
@@ -76,13 +77,13 @@ const FoldableFilters = (): JSX.Element => {
             <DateFilter allowTimePrecision dateFrom={dateFrom} dateTo={dateTo} onChange={setDates} />
             <WebAnalyticsCompareFilter />
 
-            <WebConversionGoal />
+            {!preAggregatedEnabled && <WebConversionGoal />}
             <TableSortingIndicator />
 
             <WebVitalsPercentileToggle />
-            <PathCleaningToggle />
+            {!preAggregatedEnabled && <PathCleaningToggle />}
 
-            <WebPropertyFilters />
+            {!preAggregatedEnabled && <WebPropertyFilters />}
         </div>
     )
 }

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -183,7 +183,7 @@ export const TILES_ALLOWED_ON_PRE_AGGREGATED = [
     TileId.SOURCES,
     TileId.DEVICES,
 
-    // Not 100% supported yet but we fast enough that we can show them
+    // Not 100% supported yet but they are fast enough that we can show them
     TileId.GRAPHS,
     TileId.GEOGRAPHY,
 ]

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -175,7 +175,7 @@ const loadPriorityMap: Record<TileId, number> = {
 // To enable a tile here, you must update the QueryRunner to support it
 // or make sure it can load in a decent time (which event-only tiles usually do).
 // We filter them here to enable a faster experience for the user as the
-// the tiles that don't support pre-aggregated tables take a longer time to load
+// tiles that don't support pre-aggregated tables take a longer time to load
 // and will effectively block other queries to load because of the concurrencyController
 export const TILES_ALLOWED_ON_PRE_AGGREGATED = [
     TileId.OVERVIEW,

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -183,7 +183,7 @@ export const TILES_ALLOWED_ON_PRE_AGGREGATED = [
     TileId.SOURCES,
     TileId.DEVICES,
 
-    // Not 100% supported yet but we fast enought that we can show them
+    // Not 100% supported yet but we fast enough that we can show them
     TileId.GRAPHS,
     TileId.GEOGRAPHY,
 ]


### PR DESCRIPTION
## Problem

This changes the allowed tiles and filters on `WebAnalyticsDashboard` to only enable those supported by pre-aggregated tables when the modifier is enabled.

The reasoning here is to allow us to focus on what does work for that scenario and build upon that on future PRs (e.g: allow property filters on the dimensions we support).

I think most of our tiles can be supported with this new modifier, but because of the `concurrencyController`, any slow query will effectively slow down the complete load, and this is more usable for our intended use cases.

Aiming for that snappy page load 🤞 

## Changes

- Filter out tiles and components when `preAggregated` modifier is enabled

## Did you write or update any docs for this change?

- [x] No docs needed for this change

## How did you test this code?

Manually.