### PR TITLE
fix: add custom series name for stickiness

### DIFF
--- a/posthog/hogql_queries/insights/stickiness_query_runner.py
+++ b/posthog/hogql_queries/insights/stickiness_query_runner.py
@@ -318,6 +318,7 @@ class StickinessQueryRunner(QueryRunner):
                     "type": "events",
                     "name": series_label or "All events",
                     "id": series_label,
+                    "custom_name": series_with_extra.series.custom_name,
                 }
 
                 # Modifications for when comparing to previous period


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Custom series names were not being added to stickiness graphs, this fixes it uses the same convention used for other graphs.

## Changes

Added `"custom_name": series_with_extra.series.custom_name` to `series_object["action"]` in `posthog/hogql_queries/insights/stickiness_query_runner.py`

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [x] No docs needed for this change

## How did you test this code?

Tested locally
