### PR TITLE
feat: Expose Rev Analytics views for Max SQL queries

### DIFF
--- a/ee/hogai/README.md
+++ b/ee/hogai/README.md
@@ -33,20 +33,20 @@ You'll need to set env vars OPENAI_API_KEY and ANTHROPIC_API_KEY in order to hac
         name: str = "your_tool_name"  # Must match a value in AssistantContextualTool enum
         description: str = "What this tool does"
         thinking_message: str = "What to show while tool is working"
-        root_system_prompt_template: str = "Context about the tool state: {context_var}" 
+        root_system_prompt_template: str = "Context about the tool state: {context_var}"
         args_schema: type[BaseModel] = YourToolArgs
 
         def _run_impl(self, parameter_name: str) -> tuple[str, Any]:
             # Implement tool logic here
             # Access context with self.context (must have context_var from template)
-            
+
             # Optional: Use LLM to process inputs or generate structured outputs
             model = (
                 ChatOpenAI(model="gpt-4o", temperature=0.2)
                 .with_structured_output(OutputType)
                 .with_retry()
             )
-            
+
             # Process and return results as (message, structured_data)
             return "Tool execution completed", result_data
     ```
@@ -65,7 +65,7 @@ import { MaxTool } from 'scenes/max/MaxTool'
 function YourComponent() {
     return (
         <MaxTool
-            name="your_tool_name"  // Must match backend tool name - enforced by the AssistantContextualTool enum
+            name="your_tool_name" // Must match backend tool name - enforced by the AssistantContextualTool enum
             displayName="Human-friendly name"
             context={{
                 // Context data passed to backend - can be empty if there truly is no context
@@ -73,7 +73,7 @@ function YourComponent() {
             }}
             callback={(toolOutput) => {
                 // Handle structured output from tool
-                updateUIWithToolResults(toolOutput);
+                updateUIWithToolResults(toolOutput)
             }}
             initialMaxPrompt="Optional initial prompt for Max"
             onMaxOpen={() => {
@@ -99,9 +99,9 @@ If you've got any requests for Max, including around tools, let us know at #team
 
 ## Best practices for LLM-based tools
 
-- Provide comprehensive context about current state from the frontend
-- Test with diverse inputs and edge cases
-- Keep prompts clear and structured with explicit rules
-- Allow users to both get things done from scratch, and refine what's already there
+-   Provide comprehensive context about current state from the frontend
+-   Test with diverse inputs and edge cases
+-   Keep prompts clear and structured with explicit rules
+-   Allow users to both get things done from scratch, and refine what's already there
 
 For a _lot_ of great detail on prompting, check out the [GPT-4.1 prompting guide](https://cookbook.openai.com/examples/gpt4-1_prompting_guide). While somewhat GPT-4.1 specific, those principles largely apply to LLMs overall.

--- a/ee/hogai/graph/root/prompts.py
+++ b/ee/hogai/graph/root/prompts.py
@@ -155,9 +155,13 @@ Examples of use cases include:
 The 'sql' insight type allows you to write arbitrary SQL queries to retrieve data.
 
 The SQL insights have the following features:
-- Filter data using arbitrary SQL.
+- Filter data using arbitrary SQL from any table in our ClickHouse database + custom tables/views created by customers via our Data Warehouse.
 - All ClickHouse SQL features.
 - You can nest subqueries as needed.
+
+Example of use cases include:
+- What the data in the connected database looks like.
+- What revenue data both from Stripe and from our own Revenue Analytics looks like. These tables/views will be appropriately prefixed indicating the source.
 """.strip()
 
 ROOT_HARD_LIMIT_REACHED_PROMPT = """

--- a/ee/hogai/graph/sql/prompts.py
+++ b/ee/hogai/graph/sql/prompts.py
@@ -1,3 +1,7 @@
+from typing import Optional
+from posthog.hogql.database.database import DatabaseSchemaTable
+from posthog.schema import DatabaseSchemaManagedViewTable, DatabaseSchemaManagedViewTableKind
+
 SQL_REACT_SYSTEM_PROMPT = """
 <agent_info>
 You are an expert product analyst agent specializing in SQL. Your primary task is to understand a user's data taxonomy and create a plan for writing an SQL query to answer the user's question.
@@ -38,3 +42,11 @@ Write the final plan as a logical description of the SQL query that will accurat
 Don't write the SQL itself, instead describe the logic behind the query, and the tables and columns that will be used.
 </planning>
 """.strip()
+
+
+def description_for_table(table: DatabaseSchemaTable) -> Optional[str]:
+    if isinstance(table, DatabaseSchemaManagedViewTable):
+        if table.kind == DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_CHARGE:
+            return "Useful for Revenue-related questions, contains charges for customers"
+        elif table.kind == DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_CUSTOMER:
+            return "Useful for Revenue-related questions, contains the customers that have been charged"

--- a/ee/hogai/graph/sql/test/test_nodes.py
+++ b/ee/hogai/graph/sql/test/test_nodes.py
@@ -8,9 +8,24 @@ from ee.hogai.utils.types import AssistantState, PartialAssistantState
 from posthog.schema import (
     AssistantHogQLQuery,
     HumanMessage,
+    DatabaseSchemaPostHogTable,
     VisualizationMessage,
+    DatabaseSerializedFieldType,
+    DatabaseSchemaField,
+    DatabaseSchemaManagedViewTable,
+    DatabaseSchemaManagedViewTableKind,
 )
 from posthog.test.base import BaseTest
+
+
+def deindent(text: str) -> str:
+    lines = text.strip("\n").split("\n")
+
+    # Count how many leading spaces are in the first line
+    leading_spaces = len(lines[0]) - len(lines[0].lstrip())
+
+    # Strip leading spaces from each line
+    return "\n".join(line[leading_spaces:] for line in lines).strip()
 
 
 class TestSQLPlannerNode(BaseTest):
@@ -55,3 +70,61 @@ class TestSQLGeneratorNode(BaseTest):
                 intermediate_steps=[],
                 plan="",
             )
+
+    def test_schema_description_for_table_basic(self):
+        node = SQLGeneratorNode(self.team)
+        table = DatabaseSchemaPostHogTable(
+            id="test_table",
+            name="test_table",
+            fields={
+                "id": DatabaseSchemaField(
+                    name="id", type=DatabaseSerializedFieldType.INTEGER, hogql_value="id", schema_valid=True
+                ),
+                "name": DatabaseSchemaField(
+                    name="name", type=DatabaseSerializedFieldType.STRING, hogql_value="name", schema_valid=True
+                ),
+            },
+        )
+
+        result = node._schema_description_for_table("test_table", table)
+
+        expected = """
+            Table `test_table`
+            Fields:
+            - id (integer)
+            - name (string)
+        """
+
+        self.assertEqual(result, deindent(expected))
+
+    def test_schema_description_for_table_with_description(self):
+        node = SQLGeneratorNode(self.team)
+        table = DatabaseSchemaManagedViewTable(
+            id="revenue_charges",
+            name="revenue_charges",
+            fields={
+                "customer_id": DatabaseSchemaField(
+                    name="customer_id",
+                    type=DatabaseSerializedFieldType.STRING,
+                    hogql_value="customer_id",
+                    schema_valid=True,
+                ),
+                "amount": DatabaseSchemaField(
+                    name="amount", type=DatabaseSerializedFieldType.DECIMAL, hogql_value="amount", schema_valid=True
+                ),
+            },
+            query={"query": "SELECT * FROM anything"},  # Not used for schema description
+            kind=DatabaseSchemaManagedViewTableKind.REVENUE_ANALYTICS_CHARGE,
+        )
+
+        result = node._schema_description_for_table("revenue_charges", table)
+
+        expected = """
+            Table `revenue_charges`
+            When to use this table: Useful for Revenue-related questions, contains charges for customers
+            Fields:
+            - customer_id (string)
+            - amount (decimal)
+        """
+
+        self.assertEqual(result, deindent(expected))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1689,8 +1689,6 @@ importers:
         specifier: '*'
         version: 18.2.0
 
-  products/editor: {}
-
   products/experiments:
     dependencies:
       '@posthog/icons':
@@ -16257,8 +16255,8 @@ packages:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
 
-  unlayer-types@1.266.0:
-    resolution: {integrity: sha512-0o5P60todvhXUM2ubPxnH9GN3gCWYVC4Bkq9U7CxcgK6EE9ggm2OBXYeBrcUltCkfyJjsoqeJ0Tk8TLG2FcHhg==}
+  unlayer-types@1.268.0:
+    resolution: {integrity: sha512-zCb4tLjcZ96jiWKv6PPxS1LoIw+rHCqMgV9pJjcPzNkN4fc1FDvyeYdzfoTThS89pJdYl4Yb36kuEI5aC7MDTA==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -33084,7 +33082,7 @@ snapshots:
   react-email-editor@1.7.11(react@18.2.0):
     dependencies:
       react: 18.2.0
-      unlayer-types: 1.266.0
+      unlayer-types: 1.268.0
 
   react-error-overlay@6.0.9: {}
 
@@ -35239,7 +35237,7 @@ snapshots:
 
   universalify@2.0.0: {}
 
-  unlayer-types@1.266.0: {}
+  unlayer-types@1.268.0: {}
 
   unpipe@1.0.0: {}
 


### PR DESCRIPTION
Max only knows about a handful of built-in SQL tables + the tables coming from the data warehouse. Let's make it aware of our revenue analytics views. We can always revert this if we see worse performance from Max.

Closes #32486