### PR TITLE
feat: support attaching images by pasting

### DIFF
--- a/frontend/src/lib/components/Support/SupportForm.tsx
+++ b/frontend/src/lib/components/Support/SupportForm.tsx
@@ -79,7 +79,7 @@ export function SupportForm(): JSX.Element | null {
             if (item.type.startsWith('image/')) {
                 const file = item.getAsFile()
                 if (file) {
-                    setFilesToUpload((prev) => [...prev, file])
+                    setFilesToUpload([...filesToUpload, file])
                 }
             }
         }

--- a/frontend/src/lib/components/Support/SupportForm.tsx
+++ b/frontend/src/lib/components/Support/SupportForm.tsx
@@ -79,7 +79,7 @@ export function SupportForm(): JSX.Element | null {
             if (item.type.startsWith('image/')) {
                 const file = item.getAsFile()
                 if (file) {
-                    setFilesToUpload([file])
+                    setFilesToUpload((prev) => [...prev, file])
                 }
             }
         }

--- a/frontend/src/lib/components/Support/SupportForm.tsx
+++ b/frontend/src/lib/components/Support/SupportForm.tsx
@@ -67,6 +67,24 @@ export function SupportForm(): JSX.Element | null {
     // Track which fields have been initialized (had cursor positioned at end)
     const initializedFields = useRef<Record<string, boolean>>({})
 
+    const handlePaste = (e: React.ClipboardEvent<HTMLDivElement>): void => {
+        const items = e.clipboardData?.items
+        if (!items) {
+            return
+        }
+
+        // Convert DataTransferItemList to array for iteration
+        const itemsArray = Array.from(items)
+        for (const item of itemsArray) {
+            if (item.type.startsWith('image/')) {
+                const file = item.getAsFile()
+                if (file) {
+                    setFilesToUpload([file])
+                }
+            }
+        }
+    }
+
     // Restore focus to the appropriate field after re-renders
     // Only position cursor at the end on first focus for each field
     useEffect(() => {
@@ -170,7 +188,7 @@ export function SupportForm(): JSX.Element | null {
                 label={sendSupportRequest.kind ? SUPPORT_TICKET_KIND_TO_PROMPT[sendSupportRequest.kind] : 'Content'}
             >
                 {(props) => (
-                    <div ref={dropRef} className="flex flex-col gap-2">
+                    <div ref={dropRef} className="flex flex-col gap-2" onPaste={handlePaste}>
                         <LemonTextArea
                             placeholder={SUPPORT_TICKET_TEMPLATES[sendSupportRequest.kind] ?? 'Type your message here'}
                             data-attr="support-form-content-input"

--- a/posthog/hogql_queries/insights/stickiness_query_runner.py
+++ b/posthog/hogql_queries/insights/stickiness_query_runner.py
@@ -318,6 +318,7 @@ class StickinessQueryRunner(QueryRunner):
                     "type": "events",
                     "name": series_label or "All events",
                     "id": series_label,
+                    "custom_name": series_with_extra.series.custom_name,
                 }
 
                 # Modifications for when comparing to previous period

--- a/posthog/hogql_queries/insights/stickiness_query_runner.py
+++ b/posthog/hogql_queries/insights/stickiness_query_runner.py
@@ -318,7 +318,6 @@ class StickinessQueryRunner(QueryRunner):
                     "type": "events",
                     "name": series_label or "All events",
                     "id": series_label,
-                    "custom_name": series_with_extra.series.custom_name,
                 }
 
                 # Modifications for when comparing to previous period


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

UX for contacting support would be better if users could attach images by pasting from their clipboard, this adds support for that.

## Changes

Here are the changes made to implement clipboard paste functionality in `SupportForm.tsx`:

1. Added `handlePaste` function
2. Added `onPaste` handler to the textarea container

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [x] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

Tested locally
