### PR TITLE
fix: translation error crashing the entire app

### DIFF
--- a/frontend/src/layout/navigation-3000/components/TopBar.tsx
+++ b/frontend/src/layout/navigation-3000/components/TopBar.tsx
@@ -16,6 +16,7 @@ import { Popover } from 'lib/lemon-ui/Popover/Popover'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import React, { useLayoutEffect, useState } from 'react'
 
+import { ErrorBoundary } from '~/layout/ErrorBoundary'
 import { breadcrumbsLogic } from '~/layout/navigation/Breadcrumbs/breadcrumbsLogic'
 import { navigationLogic } from '~/layout/navigation/navigationLogic'
 import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
@@ -228,7 +229,7 @@ function Breadcrumb({ breadcrumb, here, isOnboarding }: BreadcrumbProps): JSX.El
     } else {
         nameElement = (
             <span className="flex items-center gap-1.5">
-                {breadcrumbName || <i>Unnamed</i>}
+                {breadcrumbName === '' ? <em>Unnamed</em> : breadcrumbName}
                 {'tag' in breadcrumb && breadcrumb.tag && <LemonTag size="small">{breadcrumb.tag}</LemonTag>}
             </span>
         )
@@ -284,7 +285,7 @@ function Breadcrumb({ breadcrumb, here, isOnboarding }: BreadcrumbProps): JSX.El
         )
     }
 
-    return breadcrumbContent
+    return <ErrorBoundary>{breadcrumbContent}</ErrorBoundary>
 }
 
 interface HereProps {


### PR DESCRIPTION
when chrome is translating automatically our website, it can change our DOM structure.

because of that, sometimes it fails React lifecycle to render components because the DOM nodes itself can change.

this one specifically is causing the entire app to crash when it happens. As the TopBar component is loading in the beginning of the tree.

so this will both:

- fix the issue so it does't happen again
- wrap it into an error boundary so if it crashes it won't kipp the entire thing

[discovered via this ticket](https://posthoghelp.zendesk.com/agent/tickets/31192)