### PR TITLE
fix: more validation on snapshots API

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -621,6 +621,10 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, U
             raise exceptions.NotFound("Recording not found")
 
         source = request.GET.get("source")
+
+        if source not in ["realtime", "blob", "blob_v2", None]:
+            raise exceptions.ValidationError("Invalid source must be one of [realtime, blob, blob_v2, None]")
+
         is_v2_enabled = request.GET.get("blob_v2", "false") == "true"
 
         if source:

--- a/posthog/session_recordings/test/test_session_recordings.py
+++ b/posthog/session_recordings/test/test_session_recordings.py
@@ -1377,12 +1377,13 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
     @parameterized.expand(
         [
             ("blob", True, status.HTTP_200_OK),
-            ("blob_v2", True, status.HTTP_200_OK),
+            # not a 400, 404 because we didn't mock the right things for a 200
+            ("blob_v2", True, status.HTTP_404_NOT_FOUND),
             ("realtime", True, status.HTTP_200_OK),
             (None, True, status.HTTP_200_OK),  # No source parameter
             ("invalid_source", False, status.HTTP_400_BAD_REQUEST),
             ("", False, status.HTTP_400_BAD_REQUEST),
-            ("BLOB", False, status.HTTP_400_BAD_REQUEST),  # Case sensitive
+            ("BLOB", False, status.HTTP_400_BAD_REQUEST),  # Case-sensitive
             ("real-time", False, status.HTTP_400_BAD_REQUEST),
         ]
     )
@@ -1421,7 +1422,9 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
 
         response = self.client.get(url)
 
-        assert response.status_code == expected_status
+        assert (
+            response.status_code == expected_status
+        ), f"Expected status {expected_status}, got {response.status_code} for source '{source_value}'"
 
         if not is_valid:
             # For invalid sources, we expect a validation error


### PR DESCRIPTION
now this isn't an internal only API we can see it being called with invalid values
let's bail early to save hitting databases and datastores with nonsense
<img width="103" alt="Screenshot 2025-05-24 at 19 19 50" src="https://github.com/user-attachments/assets/1d62d242-0772-4b84-8567-e4391b826cdd" />
