### PR TITLE
fix: dagster scheduler root config for pre-agg

### DIFF
--- a/dags/web_preaggregated_internal.py
+++ b/dags/web_preaggregated_internal.py
@@ -190,8 +190,15 @@ def recreate_web_analytics_preaggregated_internal_data_daily(context: dagster.Sc
     while we test the integration. The usage of pre-aggregated tables is controlled
     by a query modifier AND is behind a feature flag.
     """
+    team_ids = [2]
+
     return dagster.RunRequest(
         run_config={
-            "team_ids": [2]  # We only care about the scheduler in prod so we're good with magic team
+            "ops": {
+                "web_analytics_overview_daily": {"config": {"team_ids": team_ids}},
+                "web_analytics_bounces_daily": {"config": {"team_ids": team_ids}},
+                "web_analytics_stats_table_daily": {"config": {"team_ids": team_ids}},
+                "web_analytics_paths_daily": {"config": {"team_ids": team_ids}},
+            }
         },
     )


### PR DESCRIPTION
## Problem

The scheduler config was outdated and failing, now it is fixed :) 

https://dagster.prod-us.posthog.dev/locations/posthog/schedules/recreate_web_analytics_preaggregated_internal_data_daily

## Changes

- Replaced root config for per-asset config

## Did you write or update any docs for this change?

- [x] No docs needed for this change

## How did you test this code?

Manually at local env.