### PR TITLE
feat: add more dimensions to stats table

### DIFF
--- a/posthog/hogql/database/schema/web_analytics_preaggregated.py
+++ b/posthog/hogql/database/schema/web_analytics_preaggregated.py
@@ -41,16 +41,22 @@ class WebStatsDailyTable(Table):
     fields: dict[str, FieldOrTable] = {
         **web_preaggregated_base_fields,
         **web_preaggregated_base_aggregation_fields,
+        "entry_pathname": StringDatabaseField(name="entry_pathname", nullable=True),
+        "pathname": StringDatabaseField(name="pathname", nullable=True),
+        "end_pathname": StringDatabaseField(name="end_pathname", nullable=True),
         "browser": StringDatabaseField(name="browser", nullable=True),
         "os": StringDatabaseField(name="os", nullable=True),
-        "referring_domain": StringDatabaseField(name="referring_domain", nullable=True),
         "viewport": StringDatabaseField(name="viewport", nullable=True),
+        "referring_domain": StringDatabaseField(name="referring_domain", nullable=True),
         "utm_source": StringDatabaseField(name="utm_source", nullable=True),
         "utm_medium": StringDatabaseField(name="utm_medium", nullable=True),
         "utm_campaign": StringDatabaseField(name="utm_campaign", nullable=True),
         "utm_term": StringDatabaseField(name="utm_term", nullable=True),
         "utm_content": StringDatabaseField(name="utm_content", nullable=True),
-        "country": StringDatabaseField(name="country", nullable=True),
+        "country_code": StringDatabaseField(name="country_code", nullable=True),
+        "country_name": StringDatabaseField(name="country_name", nullable=True),
+        "city_name": StringDatabaseField(name="city_name", nullable=True),
+        "region_code": StringDatabaseField(name="region_code", nullable=True),
     }
 
     def to_printed_clickhouse(self, context):
@@ -64,7 +70,7 @@ class WebBouncesDailyTable(Table):
     fields: dict[str, FieldOrTable] = {
         **web_preaggregated_base_fields,
         **web_preaggregated_base_aggregation_fields,
-        "entry_path": StringDatabaseField(name="entry_path", nullable=True),
+        "entry_pathname": StringDatabaseField(name="entry_pathname", nullable=True),
         "bounces_count_state": DatabaseField(name="bounces_count_state"),
     }
 

--- a/posthog/hogql_queries/web_analytics/stats_table_pre_aggregated.py
+++ b/posthog/hogql_queries/web_analytics/stats_table_pre_aggregated.py
@@ -40,6 +40,7 @@ class StatsTablePreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder)
         WebStatsBreakdown.COUNTRY,
         WebStatsBreakdown.INITIAL_PAGE,
         WebStatsBreakdown.PAGE,
+        WebStatsBreakdown.EXIT_PAGE,
     ]
 
     def __init__(self, runner: "WebStatsTableQueryRunner") -> None:
@@ -57,7 +58,7 @@ class StatsTablePreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder)
 
         query_str = f"""
         SELECT
-            entry_path as `context.columns.breakdown_value`,
+            entry_pathname as `context.columns.breakdown_value`,
             tuple(
                 uniqMergeIf(persons_uniq_state, {current_period_filter}),
                 uniqMergeIf(persons_uniq_state, {previous_period_filter})
@@ -90,9 +91,9 @@ class StatsTablePreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder)
                 sumMergeIf(p.pageviews_count_state, {current_period_filter}),
                 sumMergeIf(p.pageviews_count_state, {previous_period_filter})
             ) as `context.columns.views`,
-            any(bounces.`context.columns.bounce_rate`) as `context.columns.bounce_rate`,
+            any(bounces.`context.columns.bounce_rate`) as `context.columns.bounce_rate`
         FROM
-            web_paths_daily p
+            web_stats_daily p
         LEFT JOIN ({self._bounce_rate_query()}) bounces
             ON p.pathname = bounces.`context.columns.breakdown_value`
         GROUP BY `context.columns.breakdown_value`
@@ -180,6 +181,10 @@ class StatsTablePreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder)
             case WebStatsBreakdown.INITIAL_UTM_CONTENT:
                 return "utm_content"
             case WebStatsBreakdown.COUNTRY:
-                return "country"
-            case WebStatsBreakdown.INITIAL_PAGE:
-                return "entry_path"
+                return "country_name"
+            case WebStatsBreakdown.CITY:
+                return "city_name"
+            case WebStatsBreakdown.REGION:
+                return "region_code"
+            case WebStatsBreakdown.EXIT_PAGE:
+                return "end_pathname"

--- a/posthog/models/web_preaggregated/sql.py
+++ b/posthog/models/web_preaggregated/sql.py
@@ -328,7 +328,6 @@ def WEB_STATS_INSERT_SQL(
                 argMinMerge(raw_sessions.initial_geoip_country_code) AS country_code,
                 argMinMerge(raw_sessions.initial_geoip_subdivision_1_code) AS region_code,
                 argMinMerge(raw_sessions.initial_geoip_subdivision_city_name) AS city_name,
-                argMinMerge(raw_sessions.initial_geoip_time_zone) AS timezone,
                 raw_sessions.session_id_v7 AS session_id_v7
             FROM raw_sessions
             WHERE {team_filter}

--- a/posthog/models/web_preaggregated/sql.py
+++ b/posthog/models/web_preaggregated/sql.py
@@ -44,8 +44,12 @@ WEB_OVERVIEW_METRICS_COLUMNS = """
     total_session_duration_state AggregateFunction(sum, Int64),
     total_bounces_state AggregateFunction(sum, UInt64)
 """
+WEB_OVERVIEW_ORDER_BY = "(team_id, day_bucket, host, device_type)"
 
 WEB_STATS_COLUMNS = """
+    entry_pathname String,
+    pathname String,
+    end_pathname String,
     browser String,
     os String,
     viewport String,
@@ -55,24 +59,45 @@ WEB_STATS_COLUMNS = """
     utm_campaign String,
     utm_term String,
     utm_content String,
-    country String,
+    country_code String,
+    country_name String,
+    city_name String,
+    region_code String,
     persons_uniq_state AggregateFunction(uniq, UUID),
     sessions_uniq_state AggregateFunction(uniq, String),
     pageviews_count_state AggregateFunction(sum, UInt64),
 """
-
-WEB_OVERVIEW_ORDER_BY = "(team_id, day_bucket, host, device_type)"
-WEB_STATS_ORDER_BY = "(team_id, day_bucket, host, device_type, os, browser, viewport, referring_domain, utm_source, utm_campaign, utm_medium, country)"
+WEB_STATS_ORDER_BY = """(
+    team_id,
+    day_bucket,
+    host,
+    device_type,
+    os,
+    browser,
+    viewport,
+    entry_pathname,
+    pathname,
+    end_pathname,
+    utm_source,
+    utm_medium,
+    utm_campaign,
+    utm_term,
+    utm_content,
+    country_code,
+    country_name,
+    region_code,
+    city_name
+)"""
 
 WEB_BOUNCES_COLUMNS = """
-    entry_path String,
+    entry_pathname String,
     persons_uniq_state AggregateFunction(uniq, UUID),
     sessions_uniq_state AggregateFunction(uniq, String),
     pageviews_count_state AggregateFunction(sum, UInt64),
     bounces_count_state AggregateFunction(sum, UInt64)
 """
 
-WEB_BOUNCES_ORDER_BY = "(team_id, day_bucket, host, device_type, entry_path)"
+WEB_BOUNCES_ORDER_BY = "(team_id, day_bucket, host, device_type, entry_pathname)"
 
 WEB_PATHS_COLUMNS = """
     pathname String,
@@ -232,6 +257,8 @@ def WEB_STATS_INSERT_SQL(
     person_team_filter = filters["person_distinct_id_overrides"]
     events_team_filter = filters["events"]
 
+    # Intentionally skipping $geoip_subdivision_1_name AS region_name since it is not materialized yet
+
     return f"""
     INSERT INTO {table_name}
     SELECT
@@ -239,6 +266,9 @@ def WEB_STATS_INSERT_SQL(
         team_id,
         host,
         device_type,
+        entry_pathname,
+        pathname,
+        end_pathname,
         browser,
         os,
         viewport,
@@ -248,7 +278,10 @@ def WEB_STATS_INSERT_SQL(
         utm_campaign,
         utm_term,
         utm_content,
-        country,
+        country_code,
+        country_name,
+        city_name,
+        region_code,
         uniqState(assumeNotNull(session_person_id)) AS persons_uniq_state,
         uniqState(assumeNotNull(session_id)) AS sessions_uniq_state,
         sumState(pageview_count) AS pageviews_count_state
@@ -262,13 +295,19 @@ def WEB_STATS_INSERT_SQL(
             e.mat_$browser AS browser,
             e.mat_$os AS os,
             concat(toString(e.mat_$viewport_width), 'x', toString(e.mat_$viewport_height)) AS viewport,
-            e.mat_$referring_domain AS referring_domain,
+            e.mat_$geoip_country_code AS country_code,
+            e.mat_$geoip_country_name AS country_name,
+            e.mat_$geoip_city_name AS city_name,
+            e.mat_$geoip_subdivision_1_code AS region_code,
+            e.mat_$pathname AS pathname,
             events__session.entry_utm_source AS utm_source,
             events__session.entry_utm_medium AS utm_medium,
             events__session.entry_utm_campaign AS utm_campaign,
             events__session.entry_utm_term AS utm_term,
             events__session.entry_utm_content AS utm_content,
-            e.mat_$geoip_country_name AS country,
+            events__session.entry_pathname AS entry_pathname,
+            events__session.end_pathname AS end_pathname,
+            events__session.referring_domain AS referring_domain,
             countIf(e.event IN ('$pageview', '$screen')) AS pageview_count,
             e.team_id AS team_id,
             min(events__session.start_timestamp) AS start_timestamp
@@ -278,11 +317,18 @@ def WEB_STATS_INSERT_SQL(
             SELECT
                 toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                 min(toTimeZone(raw_sessions.min_timestamp, '{timezone}')) AS start_timestamp,
+                path(coalesce(argMinMerge(raw_sessions.entry_url), '')) AS entry_pathname,
+                path(coalesce(argMaxMerge(raw_sessions.end_url), '')) AS end_pathname,
+                argMinMerge(raw_sessions.initial_referring_domain) AS referring_domain,
                 argMinMerge(raw_sessions.initial_utm_source) AS entry_utm_source,
                 argMinMerge(raw_sessions.initial_utm_medium) AS entry_utm_medium,
                 argMinMerge(raw_sessions.initial_utm_campaign) AS entry_utm_campaign,
                 argMinMerge(raw_sessions.initial_utm_term) AS entry_utm_term,
                 argMinMerge(raw_sessions.initial_utm_content) AS entry_utm_content,
+                argMinMerge(raw_sessions.initial_geoip_country_code) AS country_code,
+                argMinMerge(raw_sessions.initial_geoip_subdivision_1_code) AS region_code,
+                argMinMerge(raw_sessions.initial_geoip_subdivision_city_name) AS city_name,
+                argMinMerge(raw_sessions.initial_geoip_time_zone) AS timezone,
                 raw_sessions.session_id_v7 AS session_id_v7
             FROM raw_sessions
             WHERE {team_filter}
@@ -322,7 +368,13 @@ def WEB_STATS_INSERT_SQL(
             utm_campaign,
             utm_term,
             utm_content,
-            country
+            pathname,
+            entry_pathname,
+            end_pathname,
+            country_code,
+            country_name,
+            city_name,
+            region_code
         SETTINGS {settings}
     )
     GROUP BY
@@ -339,7 +391,13 @@ def WEB_STATS_INSERT_SQL(
         utm_campaign,
         utm_term,
         utm_content,
-        country
+        pathname,
+        entry_pathname,
+        end_pathname,
+        country_code,
+        country_name,
+        city_name,
+        region_code
     SETTINGS {settings}
     """
 
@@ -359,7 +417,7 @@ def WEB_BOUNCES_INSERT_SQL(
         team_id,
         host,
         device_type,
-        entry_path,
+        entry_pathname,
         uniqState(assumeNotNull(person_id)) AS persons_uniq_state,
         uniqState(assumeNotNull(session_id)) AS sessions_uniq_state,
         sumState(pageview_count) AS pageviews_count_state,
@@ -369,7 +427,7 @@ def WEB_BOUNCES_INSERT_SQL(
         SELECT
             any(if(NOT empty(events__override.distinct_id), events__override.person_id, events.person_id)) AS person_id,
             countIf(e.event IN ('$pageview', '$screen')) AS pageview_count,
-            events__session.entry_path AS entry_path,
+            events__session.entry_pathname AS entry_pathname,
             events__session.session_id AS session_id,
             any(events__session.is_bounce) AS is_bounce,
             e.mat_$host AS host,
@@ -380,7 +438,7 @@ def WEB_BOUNCES_INSERT_SQL(
         LEFT JOIN
         (
             SELECT
-                path(coalesce(argMinMerge(raw_sessions.entry_url), '')) AS entry_path,
+                path(coalesce(argMinMerge(raw_sessions.entry_url), '')) AS entry_pathname,
                 toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
                 if(ifNull(equals(uniqUpToMerge(1)(raw_sessions.page_screen_autocapture_uniq_up_to), 0), 0), NULL,
                     NOT(or(
@@ -415,7 +473,7 @@ def WEB_BOUNCES_INSERT_SQL(
             AND toTimeZone(e.timestamp, '{timezone}') < toDateTime('{date_end}', '{timezone}')
         GROUP BY
             session_id,
-            entry_path,
+            entry_pathname,
             team_id,
             host,
             device_type
@@ -423,7 +481,7 @@ def WEB_BOUNCES_INSERT_SQL(
     GROUP BY
         day_bucket,
         team_id,
-        entry_path,
+        entry_pathname,
         host,
         device_type
     SETTINGS {settings}


### PR DESCRIPTION
## Problem

We were missing some dimensions on the stats_table that were intentionally left as a future improvement so we could test the integration, this PR adds them.

This also enables the `End path` breakdown as it is on the `Paths` section but since it does not include bounces, the group by works.

## Changes

- Add new breakdowns and dimensions to the `web_stats_table`.

## Did you write or update any docs for this change?

- [x] No docs needed for this change

## How did you test this code?

Locally