### PR TITLE
refactor: extracting functions from MDE kea logic.

### DIFF
--- a/frontend/src/scenes/experiments/RunningTimeCalculator/experimentStatisticsUtils.ts
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/experimentStatisticsUtils.ts
@@ -1,0 +1,151 @@
+import type { ExperimentMetric } from '~/queries/schema/schema-general'
+import { ExperimentMetricType } from '~/queries/schema/schema-general'
+import { ExperimentMetricMathType } from '~/types'
+
+import { ConversionRateInputType } from './runningTimeCalculatorLogic'
+
+export const VARIANCE_SCALING_FACTOR_TOTAL_COUNT = 2
+export const VARIANCE_SCALING_FACTOR_SUM = 0.25
+
+/**
+ * Calculate the variance of the metric.
+ */
+export const calculateVariance = (
+    metric: ExperimentMetric,
+    averageEventsPerUser: number,
+    averagePropertyValuePerUser: number
+): number | null => {
+    if (!metric) {
+        return null
+    }
+
+    if (
+        metric.metric_type === ExperimentMetricType.MEAN &&
+        metric.source.math === ExperimentMetricMathType.TotalCount
+    ) {
+        return VARIANCE_SCALING_FACTOR_TOTAL_COUNT * averageEventsPerUser
+    }
+
+    if (metric.metric_type === ExperimentMetricType.MEAN && metric.source.math === ExperimentMetricMathType.Sum) {
+        return VARIANCE_SCALING_FACTOR_SUM * averagePropertyValuePerUser ** 2
+    }
+
+    return null
+}
+
+export const calculateRecommendedSampleSize = (
+    metric: ExperimentMetric,
+    minimumDetectableEffect: number,
+    variance: number,
+    averageEventsPerUser: number,
+    averagePropertyValuePerUser: number,
+    automaticConversionRateDecimal: number,
+    manualConversionRate: number,
+    conversionRateInputType: ConversionRateInputType,
+    numberOfVariants: number
+): number | null => {
+    if (!metric) {
+        return null
+    }
+
+    const minimumDetectableEffectDecimal = minimumDetectableEffect / 100
+
+    let d // Represents the absolute effect size (difference we want to detect)
+    let sampleSizeFormula // The correct sample size formula for each metric type
+
+    if (
+        metric.metric_type === ExperimentMetricType.MEAN &&
+        metric.source.math === ExperimentMetricMathType.TotalCount
+    ) {
+        /**
+         * Count Per User Metric:
+         * - "mean" is the average number of events per user (e.g., clicks per user).
+         * - MDE is applied as a percentage of this mean to compute `d`.
+         *
+         * Formula:
+         * d = MDE * averageEventsPerUser
+         */
+        d = minimumDetectableEffectDecimal * averageEventsPerUser
+
+        /**
+         * Sample size formula:
+         *
+         * N = (16 * variance) / d^2
+         *
+         * Where:
+         * - `16` comes from statistical power analysis:
+         *    - Based on a 95% confidence level (Z_alpha/2 = 1.96) and 80% power (Z_beta = 0.84),
+         *      the combined squared Z-scores yield approximately 16.
+         * - `variance` is the estimated variance of the event count per user.
+         * - `d` is the absolute effect size (MDE * mean).
+         */
+        sampleSizeFormula = (16 * variance) / d ** 2
+    } else if (
+        metric.metric_type === ExperimentMetricType.MEAN &&
+        metric.source.math === ExperimentMetricMathType.Sum
+    ) {
+        /**
+         * Continuous property metric:
+         *
+         * - "mean" is the average value of the measured property per user (e.g., revenue per user).
+         * - MDE is applied as a percentage of this mean to compute `d`.
+         *
+         * Formula:
+         *
+         * d = MDE * averagePropertyValuePerUser
+         */
+        d = minimumDetectableEffectDecimal * averagePropertyValuePerUser
+
+        /**
+         * Sample Size Formula for Continuous metrics:
+         *
+         * N = (16 * variance) / d^2
+         *
+         * Where:
+         * - `variance` is the estimated variance of the continuous property.
+         * - The formula is identical to the Count metric case.
+         */
+        sampleSizeFormula = (16 * variance) / d ** 2
+    } else if (metric.metric_type === ExperimentMetricType.FUNNEL) {
+        const manualConversionRateDecimal = manualConversionRate / 100
+        const conversionRate =
+            conversionRateInputType === ConversionRateInputType.MANUAL
+                ? manualConversionRateDecimal
+                : automaticConversionRateDecimal
+
+        /**
+         * Binomial metric (conversion rate):
+         *
+         * - Here, "mean" does not exist in the same way as for count/continuous metrics.
+         * - Instead, we use `p`, the baseline conversion rate (historical probability of success).
+         * - MDE is applied as an absolute percentage change to `p`.
+         *
+         * Formula:
+         *
+         * d = MDE * conversionRate
+         */
+        d = minimumDetectableEffectDecimal * conversionRate
+
+        /**
+         * Sample size formula:
+         *
+         * N = (16 * p * (1 - p)) / d^2
+         *
+         * Where:
+         * - `p` is the historical conversion rate (baseline success probability).
+         * - `d` is the absolute MDE (e.g., detecting a 5% increase means `d = 0.05`).
+         * - The variance is inherent in `p(1 - p)`, which represents binomial variance.
+         */
+        if (conversionRate !== null) {
+            sampleSizeFormula = (16 * conversionRate * (1 - conversionRate)) / d ** 2
+        } else {
+            return null
+        }
+    }
+
+    if (!d || !sampleSizeFormula) {
+        return null
+    }
+
+    return sampleSizeFormula * numberOfVariants
+}

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/metricQueryUtils.test.ts
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/metricQueryUtils.test.ts
@@ -1,0 +1,254 @@
+import { dayjs } from 'lib/dayjs'
+
+import { NodeKind } from '~/queries/schema/schema-general'
+import { BaseMathType, CountPerActorMathType } from '~/types'
+
+import { getFunnelQuery, getSumQuery, getTotalCountQuery } from './metricQueryUtils'
+
+const mockMetric = {
+    id: 'metric1',
+    name: 'Test Metric',
+    metric_type: 'mean',
+    source: {
+        kind: NodeKind.EventsNode,
+        event: 'test_event',
+        math: CountPerActorMathType.Average,
+    },
+} as any
+
+const mockExperiment = {
+    exposure_criteria: { filterTestAccounts: true },
+    id: 'test-experiment',
+    name: 'Test Experiment',
+    description: '',
+    start_date: null,
+    end_date: null,
+    feature_flag_key: 'test-flag',
+    parameters: {},
+    filters: {},
+    archived: false,
+    created_at: '2023-01-01T00:00:00Z',
+    created_by: null,
+    updated_at: '2023-01-01T00:00:00Z',
+    metrics: [],
+    saved_metrics: [],
+} as any
+
+const mockEventConfig = {
+    event: 'custom_event',
+    properties: [{ key: 'foo', value: 'bar' }],
+} as any
+
+describe('getTotalCountQuery', () => {
+    it('returns correct query with eventConfig and filterTestAccounts true', () => {
+        const result = getTotalCountQuery(mockMetric, mockExperiment, mockEventConfig)
+        expect(result.kind).toBe(NodeKind.TrendsQuery)
+        expect(result.series[0]).toMatchObject({
+            kind: NodeKind.EventsNode,
+            event: 'custom_event',
+            properties: [{ key: 'foo', value: 'bar' }],
+            math: BaseMathType.UniqueUsers,
+        })
+        expect(result.series[1].math).toBe(CountPerActorMathType.Average)
+        expect(result.filterTestAccounts).toBe(true)
+        expect(result.dateRange!.date_from).toContain(dayjs().subtract(14, 'day').format('YYYY-MM-DD')) // 14 is the default
+        expect(result.dateRange!.date_to).toContain(dayjs().format('YYYY-MM-DD'))
+        expect(result.dateRange!.explicitDate).toBe(true)
+    })
+
+    it('defaults event and properties if eventConfig is null', () => {
+        const result = getTotalCountQuery(mockMetric, mockExperiment, null)
+        if ('event' in result.series[0]) {
+            expect(result.series[0].event).toBe('$pageview')
+            expect(result.series[0].properties).toEqual([])
+        } else {
+            throw new Error('series[0] is not an EventsNode')
+        }
+    })
+
+    it('sets filterTestAccounts to false if not set', () => {
+        const experiment = { exposure_criteria: {} } as any
+        const result = getTotalCountQuery(mockMetric, experiment, null)
+        expect(result.filterTestAccounts).toBe(false)
+    })
+
+    it('handles missing exposure_criteria gracefully', () => {
+        const experiment = {} as any
+        const result = getTotalCountQuery(mockMetric, experiment, null)
+        expect(result.filterTestAccounts).toBe(false)
+    })
+})
+
+describe('getSumQuery', () => {
+    it('returns correct query with eventConfig and filterTestAccounts true (MEAN metric)', () => {
+        const metric = {
+            ...mockMetric,
+            metric_type: 'mean',
+            source: {
+                kind: NodeKind.EventsNode,
+                event: 'test_event',
+                math: CountPerActorMathType.Average,
+                math_property: 'some_property',
+            },
+        }
+        const result = getSumQuery(metric, mockExperiment, mockEventConfig)
+        expect(result.kind).toBe(NodeKind.TrendsQuery)
+        if ('event' in result.series[0]) {
+            expect(result.series[0].event).toBe('custom_event')
+            expect(result.series[0].properties).toEqual([{ key: 'foo', value: 'bar' }])
+            expect(result.series[0].math).toBe(BaseMathType.UniqueUsers)
+        } else {
+            throw new Error('series[0] is not an EventsNode')
+        }
+        expect(result.series[1].math).toBe('sum')
+        expect(result.series[1].math_property).toBe('some_property')
+        expect(result.series[1].math_property_type).toBe('numerical_event_properties')
+        expect(result.filterTestAccounts).toBe(true)
+        expect(result.dateRange!.date_from).toContain(dayjs().subtract(14, 'day').format('YYYY-MM-DD'))
+        expect(result.dateRange!.date_to).toContain(dayjs().format('YYYY-MM-DD'))
+        expect(result.dateRange!.explicitDate).toBe(true)
+    })
+
+    it('defaults event and properties if eventConfig is null', () => {
+        const metric = {
+            ...mockMetric,
+            metric_type: 'mean',
+            source: {
+                kind: NodeKind.EventsNode,
+                event: 'test_event',
+                math: CountPerActorMathType.Average,
+                math_property: 'some_property',
+            },
+        }
+        const result = getSumQuery(metric, mockExperiment, null)
+        if ('event' in result.series[0]) {
+            expect(result.series[0].event).toBe('$pageview')
+            expect(result.series[0].properties).toEqual([])
+        } else {
+            throw new Error('series[0] is not an EventsNode')
+        }
+    })
+
+    it('sets filterTestAccounts to false if not set', () => {
+        const experiment = { exposure_criteria: {} } as any
+        const metric = {
+            ...mockMetric,
+            metric_type: 'mean',
+            source: {
+                kind: NodeKind.EventsNode,
+                event: 'test_event',
+                math: CountPerActorMathType.Average,
+                math_property: 'some_property',
+            },
+        }
+        const result = getSumQuery(metric, experiment, null)
+        expect(result.filterTestAccounts).toBe(false)
+    })
+
+    it('handles missing exposure_criteria gracefully', () => {
+        const experiment = {} as any
+        const metric = {
+            ...mockMetric,
+            metric_type: 'mean',
+            source: {
+                kind: NodeKind.EventsNode,
+                event: 'test_event',
+                math: CountPerActorMathType.Average,
+                math_property: 'some_property',
+            },
+        }
+        const result = getSumQuery(metric, experiment, null)
+        expect(result.filterTestAccounts).toBe(false)
+    })
+
+    it('throws for unsupported metric_type', () => {
+        const metric = {
+            ...mockMetric,
+            metric_type: 'count',
+            source: {
+                kind: NodeKind.EventsNode,
+                event: 'test_event',
+                math: CountPerActorMathType.Average,
+            },
+        }
+        expect(() => getSumQuery(metric, mockExperiment, mockEventConfig)).toThrow('Unsupported metric type: count')
+    })
+})
+
+describe('getFunnelQuery', () => {
+    it('returns correct query with eventConfig and filterTestAccounts true', () => {
+        const metric = {
+            ...mockMetric,
+            metric_type: 'mean',
+            source: {
+                kind: NodeKind.EventsNode,
+                event: 'test_event',
+                math: CountPerActorMathType.Average,
+            },
+        }
+        const result = getFunnelQuery(metric, mockEventConfig, mockExperiment)
+        expect(result.kind).toBe(NodeKind.FunnelsQuery)
+        if ('event' in result.series[0]) {
+            expect(result.series[0].event).toBe('custom_event')
+            expect(result.series[0].properties).toEqual([{ key: 'foo', value: 'bar' }])
+        } else {
+            throw new Error('series[0] is not an EventsNode')
+        }
+        expect(result.series[1].kind).toBe(NodeKind.EventsNode)
+        expect(result.filterTestAccounts).toBe(true)
+        expect(result.dateRange!.date_from).toContain(dayjs().subtract(14, 'day').format('YYYY-MM-DD'))
+        expect(result.dateRange!.date_to).toContain(dayjs().format('YYYY-MM-DD'))
+        expect(result.dateRange!.explicitDate).toBe(true)
+        expect(result.interval).toBe('day')
+        expect(result.funnelsFilter!.funnelVizType).toBe('steps')
+    })
+
+    it('defaults event and properties if eventConfig is null', () => {
+        const metric = {
+            ...mockMetric,
+            metric_type: 'mean',
+            source: {
+                kind: NodeKind.EventsNode,
+                event: 'test_event',
+                math: CountPerActorMathType.Average,
+            },
+        }
+        const result = getFunnelQuery(metric, null, mockExperiment)
+        if ('event' in result.series[0]) {
+            expect(result.series[0].event).toBe('$pageview')
+            expect(result.series[0].properties).toEqual([])
+        } else {
+            throw new Error('series[0] is not an EventsNode')
+        }
+    })
+
+    it('sets filterTestAccounts to false if not set', () => {
+        const experiment = { exposure_criteria: {} } as any
+        const metric = {
+            ...mockMetric,
+            metric_type: 'mean',
+            source: {
+                kind: NodeKind.EventsNode,
+                event: 'test_event',
+                math: CountPerActorMathType.Average,
+            },
+        }
+        const result = getFunnelQuery(metric, null, experiment)
+        expect(result.filterTestAccounts).toBe(false)
+    })
+
+    it('handles missing exposure_criteria gracefully', () => {
+        const experiment = {} as any
+        const metric = {
+            ...mockMetric,
+            metric_type: 'mean',
+            source: {
+                kind: NodeKind.EventsNode,
+                event: 'test_event',
+                math: CountPerActorMathType.Average,
+            },
+        }
+        const result = getFunnelQuery(metric, null, experiment)
+        expect(result.filterTestAccounts).toBe(false)
+    })
+})

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/metricQueryUtils.test.ts
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/metricQueryUtils.test.ts
@@ -1,5 +1,3 @@
-import { dayjs } from 'lib/dayjs'
-
 import { NodeKind } from '~/queries/schema/schema-general'
 import { BaseMathType, CountPerActorMathType } from '~/types'
 
@@ -39,6 +37,16 @@ const mockEventConfig = {
     properties: [{ key: 'foo', value: 'bar' }],
 } as any
 
+jest.mock('lib/dayjs', () => {
+    const actual = jest.requireActual('dayjs')
+    // Always return 2023-01-01T00:00:00Z for dayjs()
+    const fixed = actual('2023-01-01T00:00:00Z')
+    return {
+        ...actual,
+        dayjs: jest.fn((...args) => (args.length === 0 ? fixed : actual(...args))),
+    }
+})
+
 describe('getTotalCountQuery', () => {
     it('returns correct query with eventConfig and filterTestAccounts true', () => {
         const result = getTotalCountQuery(mockMetric, mockExperiment, mockEventConfig)
@@ -51,8 +59,8 @@ describe('getTotalCountQuery', () => {
         })
         expect(result.series[1].math).toBe(CountPerActorMathType.Average)
         expect(result.filterTestAccounts).toBe(true)
-        expect(result.dateRange!.date_from).toContain(dayjs().subtract(14, 'day').format('YYYY-MM-DD')) // 14 is the default
-        expect(result.dateRange!.date_to).toContain(dayjs().format('YYYY-MM-DD'))
+        expect(result.dateRange!.date_from).toContain('2022-12-18') // 14 days before 2023-01-01
+        expect(result.dateRange!.date_to).toContain('2023-01-01')
         expect(result.dateRange!.explicitDate).toBe(true)
     })
 
@@ -104,8 +112,8 @@ describe('getSumQuery', () => {
         expect(result.series[1].math_property).toBe('some_property')
         expect(result.series[1].math_property_type).toBe('numerical_event_properties')
         expect(result.filterTestAccounts).toBe(true)
-        expect(result.dateRange!.date_from).toContain(dayjs().subtract(14, 'day').format('YYYY-MM-DD'))
-        expect(result.dateRange!.date_to).toContain(dayjs().format('YYYY-MM-DD'))
+        expect(result.dateRange!.date_from).toContain('2022-12-18')
+        expect(result.dateRange!.date_to).toContain('2023-01-01')
         expect(result.dateRange!.explicitDate).toBe(true)
     })
 
@@ -196,8 +204,8 @@ describe('getFunnelQuery', () => {
         }
         expect(result.series[1].kind).toBe(NodeKind.EventsNode)
         expect(result.filterTestAccounts).toBe(true)
-        expect(result.dateRange!.date_from).toContain(dayjs().subtract(14, 'day').format('YYYY-MM-DD'))
-        expect(result.dateRange!.date_to).toContain(dayjs().format('YYYY-MM-DD'))
+        expect(result.dateRange!.date_from).toContain('2022-12-18')
+        expect(result.dateRange!.date_to).toContain('2023-01-01')
         expect(result.dateRange!.explicitDate).toBe(true)
         expect(result.interval).toBe('day')
         expect(result.funnelsFilter!.funnelVizType).toBe('steps')

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/metricQueryUtils.test.ts
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/metricQueryUtils.test.ts
@@ -194,7 +194,7 @@ describe('getFunnelQuery', () => {
                 math: CountPerActorMathType.Average,
             },
         }
-        const result = getFunnelQuery(metric, mockEventConfig, mockExperiment)
+        const result = getFunnelQuery(metric, mockExperiment, mockEventConfig)
         expect(result.kind).toBe(NodeKind.FunnelsQuery)
         if ('event' in result.series[0]) {
             expect(result.series[0].event).toBe('custom_event')

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/metricQueryUtils.test.ts
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/metricQueryUtils.test.ts
@@ -221,7 +221,7 @@ describe('getFunnelQuery', () => {
                 math: CountPerActorMathType.Average,
             },
         }
-        const result = getFunnelQuery(metric, null, mockExperiment)
+        const result = getFunnelQuery(metric, mockExperiment, null)
         if ('event' in result.series[0]) {
             expect(result.series[0].event).toBe('$pageview')
             expect(result.series[0].properties).toEqual([])
@@ -241,7 +241,7 @@ describe('getFunnelQuery', () => {
                 math: CountPerActorMathType.Average,
             },
         }
-        const result = getFunnelQuery(metric, null, experiment)
+        const result = getFunnelQuery(metric, experiment, null)
         expect(result.filterTestAccounts).toBe(false)
     })
 
@@ -256,7 +256,7 @@ describe('getFunnelQuery', () => {
                 math: CountPerActorMathType.Average,
             },
         }
-        const result = getFunnelQuery(metric, null, experiment)
+        const result = getFunnelQuery(metric, experiment, null)
         expect(result.filterTestAccounts).toBe(false)
     })
 })

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/metricQueryUtils.ts
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/metricQueryUtils.ts
@@ -1,0 +1,168 @@
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { EXPERIMENT_DEFAULT_DURATION } from 'lib/constants'
+import { dayjs } from 'lib/dayjs'
+
+import type { ExperimentMetric, FunnelsQuery, TrendsQuery } from '~/queries/schema/schema-general'
+import {
+    ExperimentMetricType,
+    isExperimentFunnelMetric,
+    isExperimentMeanMetric,
+    NodeKind,
+} from '~/queries/schema/schema-general'
+import type { Experiment } from '~/types'
+import { BaseMathType, CountPerActorMathType, FunnelVizType, PropertyMathType } from '~/types'
+
+import type { EventConfig } from './runningTimeCalculatorLogic'
+
+// Creates the correct identifier properties for a series item based on metric type
+const getSeriesItemProps = (metric: ExperimentMetric): { kind: NodeKind } & Record<string, any> => {
+    if (isExperimentMeanMetric(metric)) {
+        const { source } = metric
+
+        if (source.kind === NodeKind.EventsNode) {
+            return {
+                kind: NodeKind.EventsNode,
+                event: source.event,
+            }
+        }
+
+        if (source.kind === NodeKind.ActionsNode) {
+            return {
+                kind: NodeKind.ActionsNode,
+                id: source.id,
+            }
+        }
+
+        if (source.kind === NodeKind.ExperimentDataWarehouseNode) {
+            return {
+                kind: NodeKind.ExperimentDataWarehouseNode,
+                table_name: source.table_name,
+            }
+        }
+    }
+
+    if (isExperimentFunnelMetric(metric)) {
+        /**
+         * For multivariate funnels, we select the last step
+         * Although we know that the last step is always an EventsNode, TS infers that the last step might be undefined
+         * so we use the non-null assertion operator (!) to tell TS that we know the last step is always an EventsNode
+         */
+        const step = metric.series.at(-1)!
+
+        if (step.kind === NodeKind.EventsNode) {
+            return {
+                kind: NodeKind.EventsNode,
+                event: step.event,
+            }
+        }
+
+        if (step.kind === NodeKind.ActionsNode) {
+            return {
+                kind: NodeKind.ActionsNode,
+                id: step.id,
+            }
+        }
+    }
+
+    throw new Error(`Unsupported metric type: ${metric.metric_type || 'unknown'}`)
+}
+
+export const getTotalCountQuery = (
+    metric: ExperimentMetric,
+    experiment: Experiment,
+    eventConfig: EventConfig | null
+): TrendsQuery => {
+    const baseProps = getSeriesItemProps(metric)
+
+    return {
+        kind: NodeKind.TrendsQuery,
+        series: [
+            {
+                kind: NodeKind.EventsNode,
+                event: eventConfig?.event ?? '$pageview',
+                properties: eventConfig?.properties ?? [],
+                math: BaseMathType.UniqueUsers,
+            },
+            {
+                ...baseProps,
+                math: CountPerActorMathType.Average,
+            },
+        ],
+        trendsFilter: {},
+        filterTestAccounts: experiment.exposure_criteria?.filterTestAccounts === true,
+        dateRange: {
+            date_from: dayjs().subtract(EXPERIMENT_DEFAULT_DURATION, 'day').format('YYYY-MM-DDTHH:mm'),
+            date_to: dayjs().endOf('d').format('YYYY-MM-DDTHH:mm'),
+            explicitDate: true,
+        },
+    } as TrendsQuery
+}
+
+export const getSumQuery = (
+    metric: ExperimentMetric,
+    experiment: Experiment,
+    eventConfig: EventConfig | null
+): TrendsQuery => {
+    const baseProps = getSeriesItemProps(metric)
+    const mathProperty =
+        metric.metric_type === ExperimentMetricType.MEAN
+            ? {
+                  math_property: metric.source.math_property,
+                  math_property_type: TaxonomicFilterGroupType.NumericalEventProperties,
+              }
+            : {}
+
+    return {
+        kind: NodeKind.TrendsQuery,
+        series: [
+            {
+                kind: NodeKind.EventsNode,
+                event: eventConfig?.event ?? '$pageview',
+                properties: eventConfig?.properties ?? [],
+                math: BaseMathType.UniqueUsers,
+            },
+            {
+                ...baseProps,
+                math: PropertyMathType.Sum,
+                ...mathProperty,
+            },
+        ],
+        trendsFilter: {},
+        filterTestAccounts: experiment.exposure_criteria?.filterTestAccounts === true,
+        dateRange: {
+            date_from: dayjs().subtract(EXPERIMENT_DEFAULT_DURATION, 'day').format('YYYY-MM-DDTHH:mm'),
+            date_to: dayjs().endOf('d').format('YYYY-MM-DDTHH:mm'),
+            explicitDate: true,
+        },
+    } as TrendsQuery
+}
+
+export const getFunnelQuery = (
+    metric: ExperimentMetric,
+    eventConfig: EventConfig | null,
+    experiment: Experiment
+): FunnelsQuery => {
+    const baseProps = getSeriesItemProps(metric)
+
+    return {
+        kind: NodeKind.FunnelsQuery,
+        series: [
+            {
+                kind: NodeKind.EventsNode,
+                event: eventConfig?.event ?? '$pageview',
+                properties: eventConfig?.properties ?? [],
+            },
+            baseProps,
+        ],
+        funnelsFilter: {
+            funnelVizType: FunnelVizType.Steps,
+        },
+        filterTestAccounts: experiment.exposure_criteria?.filterTestAccounts === true,
+        dateRange: {
+            date_from: dayjs().subtract(EXPERIMENT_DEFAULT_DURATION, 'day').format('YYYY-MM-DDTHH:mm'),
+            date_to: dayjs().endOf('d').format('YYYY-MM-DDTHH:mm'),
+            explicitDate: true,
+        },
+        interval: 'day',
+    } as FunnelsQuery
+}

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/metricQueryUtils.ts
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/metricQueryUtils.ts
@@ -141,8 +141,8 @@ export const getSumQuery = (
 
 export const getFunnelQuery = (
     metric: ExperimentMetric,
-    eventConfig: EventConfig | null,
-    experiment: Experiment
+    experiment: Experiment,
+    eventConfig: EventConfig | null
 ): FunnelsQuery => {
     const baseProps = getSeriesItemProps(metric)
 

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/metricQueryUtils.ts
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/metricQueryUtils.ts
@@ -67,6 +67,16 @@ const getSeriesItemProps = (metric: ExperimentMetric): { kind: NodeKind } & Reco
     throw new Error(`Unsupported metric type: ${metric.metric_type || 'unknown'}`)
 }
 
+const getQueryDateRange = (): {
+    date_from: string
+    date_to: string
+    explicitDate: boolean
+} => ({
+    date_from: dayjs().subtract(EXPERIMENT_DEFAULT_DURATION, 'day').format('YYYY-MM-DDTHH:mm'),
+    date_to: dayjs().endOf('d').format('YYYY-MM-DDTHH:mm'),
+    explicitDate: true,
+})
+
 export const getTotalCountQuery = (
     metric: ExperimentMetric,
     experiment: Experiment,
@@ -90,11 +100,7 @@ export const getTotalCountQuery = (
         ],
         trendsFilter: {},
         filterTestAccounts: experiment.exposure_criteria?.filterTestAccounts === true,
-        dateRange: {
-            date_from: dayjs().subtract(EXPERIMENT_DEFAULT_DURATION, 'day').format('YYYY-MM-DDTHH:mm'),
-            date_to: dayjs().endOf('d').format('YYYY-MM-DDTHH:mm'),
-            explicitDate: true,
-        },
+        dateRange: getQueryDateRange(),
     } as TrendsQuery
 }
 
@@ -129,11 +135,7 @@ export const getSumQuery = (
         ],
         trendsFilter: {},
         filterTestAccounts: experiment.exposure_criteria?.filterTestAccounts === true,
-        dateRange: {
-            date_from: dayjs().subtract(EXPERIMENT_DEFAULT_DURATION, 'day').format('YYYY-MM-DDTHH:mm'),
-            date_to: dayjs().endOf('d').format('YYYY-MM-DDTHH:mm'),
-            explicitDate: true,
-        },
+        dateRange: getQueryDateRange(),
     } as TrendsQuery
 }
 
@@ -158,11 +160,7 @@ export const getFunnelQuery = (
             funnelVizType: FunnelVizType.Steps,
         },
         filterTestAccounts: experiment.exposure_criteria?.filterTestAccounts === true,
-        dateRange: {
-            date_from: dayjs().subtract(EXPERIMENT_DEFAULT_DURATION, 'day').format('YYYY-MM-DDTHH:mm'),
-            date_to: dayjs().endOf('d').format('YYYY-MM-DDTHH:mm'),
-            explicitDate: true,
-        },
+        dateRange: getQueryDateRange(),
         interval: 'day',
     } as FunnelsQuery
 }

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeCalculatorLogic.tsx
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeCalculatorLogic.tsx
@@ -336,7 +336,15 @@ export const runningTimeCalculatorLogic = kea<runningTimeCalculatorLogicType>([
             (metricResult: { automaticConversionRateDecimal: number }) =>
                 metricResult?.automaticConversionRateDecimal ?? null,
         ],
-        variance: [(s) => [s.metric, s.averageEventsPerUser, s.averagePropertyValuePerUser], calculateVariance],
+        variance: [
+            (s) => [s.metric, s.averageEventsPerUser, s.averagePropertyValuePerUser],
+            (metric: ExperimentMetric, averageEventsPerUser: number, averagePropertyValuePerUser: number) =>
+                /**
+                 * we need this to satify kea's typegen.
+                 * Do not dispair, this will be removed.
+                 */
+                calculateVariance(metric, averageEventsPerUser, averagePropertyValuePerUser),
+        ],
         standardDeviation: [(s) => [s.variance], (variance: number) => (variance ? Math.sqrt(variance) : null)],
         numberOfVariants: [
             (s) => [s.experiment],
@@ -354,7 +362,32 @@ export const runningTimeCalculatorLogic = kea<runningTimeCalculatorLogicType>([
                 s.conversionRateInputType,
                 s.numberOfVariants,
             ],
-            calculateRecommendedSampleSize,
+            (
+                metric: ExperimentMetric,
+                minimumDetectableEffect: number,
+                variance: number,
+                averageEventsPerUser: number,
+                averagePropertyValuePerUser: number,
+                automaticConversionRateDecimal: number,
+                manualConversionRate: number,
+                conversionRateInputType: string,
+                numberOfVariants: number
+            ): number | null =>
+                /**
+                 * we need this to satify kea's typegen.
+                 * Do not dispair, this will be removed.
+                 */
+                calculateRecommendedSampleSize(
+                    metric,
+                    minimumDetectableEffect,
+                    variance,
+                    averageEventsPerUser,
+                    averagePropertyValuePerUser,
+                    automaticConversionRateDecimal,
+                    manualConversionRate,
+                    conversionRateInputType as ConversionRateInputType,
+                    numberOfVariants
+                ),
         ],
         recommendedRunningTime: [
             (s) => [s.recommendedSampleSize, s.uniqueUsers],

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeCalculatorLogic.tsx
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeCalculatorLogic.tsx
@@ -14,6 +14,7 @@ import {
 } from '~/queries/schema/schema-general'
 import { AnyPropertyFilter, Experiment, ExperimentMetricMathType } from '~/types'
 
+import { calculateRecommendedSampleSize, calculateVariance } from './experimentStatisticsUtils'
 import { getFunnelQuery, getSumQuery, getTotalCountQuery } from './metricQueryUtils'
 import type { runningTimeCalculatorLogicType } from './runningTimeCalculatorLogicType'
 
@@ -335,27 +336,7 @@ export const runningTimeCalculatorLogic = kea<runningTimeCalculatorLogicType>([
             (metricResult: { automaticConversionRateDecimal: number }) =>
                 metricResult?.automaticConversionRateDecimal ?? null,
         ],
-        variance: [
-            (s) => [s.metric, s.averageEventsPerUser, s.averagePropertyValuePerUser],
-            (metric: ExperimentMetric, averageEventsPerUser: number, averagePropertyValuePerUser: number) => {
-                if (!metric) {
-                    return null
-                }
-
-                if (
-                    metric.metric_type === ExperimentMetricType.MEAN &&
-                    metric.source.math === ExperimentMetricMathType.TotalCount
-                ) {
-                    return VARIANCE_SCALING_FACTOR_TOTAL_COUNT * averageEventsPerUser
-                } else if (
-                    metric.metric_type === ExperimentMetricType.MEAN &&
-                    metric.source.math === ExperimentMetricMathType.Sum
-                ) {
-                    return VARIANCE_SCALING_FACTOR_SUM * averagePropertyValuePerUser ** 2
-                }
-                return null
-            },
-        ],
+        variance: [(s) => [s.metric, s.averageEventsPerUser, s.averagePropertyValuePerUser], calculateVariance],
         standardDeviation: [(s) => [s.variance], (variance: number) => (variance ? Math.sqrt(variance) : null)],
         numberOfVariants: [
             (s) => [s.experiment],
@@ -373,118 +354,7 @@ export const runningTimeCalculatorLogic = kea<runningTimeCalculatorLogicType>([
                 s.conversionRateInputType,
                 s.numberOfVariants,
             ],
-            (
-                metric: ExperimentMetric,
-                minimumDetectableEffect: number,
-                variance: number,
-                averageEventsPerUser: number,
-                averagePropertyValuePerUser: number,
-                automaticConversionRateDecimal: number,
-                manualConversionRate: number,
-                conversionRateInputType: string,
-                numberOfVariants: number
-            ): number | null => {
-                if (!metric) {
-                    return null
-                }
-
-                const minimumDetectableEffectDecimal = minimumDetectableEffect / 100
-
-                let d // Represents the absolute effect size (difference we want to detect)
-                let sampleSizeFormula // The correct sample size formula for each metric type
-
-                if (
-                    metric.metric_type === ExperimentMetricType.MEAN &&
-                    metric.source.math === ExperimentMetricMathType.TotalCount
-                ) {
-                    /*
-                        Count Per User Metric:
-                        - "mean" is the average number of events per user (e.g., clicks per user).
-                        - MDE is applied as a percentage of this mean to compute `d`.
-
-                        Formula:
-                        d = MDE * averageEventsPerUser
-                    */
-                    d = minimumDetectableEffectDecimal * averageEventsPerUser
-
-                    /*
-                        Sample size formula:
-
-                        N = (16 * variance) / d^2
-
-                        Where:
-                        - `16` comes from statistical power analysis:
-                            - Based on a 95% confidence level (Z_alpha/2 = 1.96) and 80% power (Z_beta = 0.84),
-                              the combined squared Z-scores yield approximately 16.
-                        - `variance` is the estimated variance of the event count per user.
-                        - `d` is the absolute effect size (MDE * mean).
-                    */
-                    sampleSizeFormula = (16 * variance) / d ** 2
-                } else if (
-                    metric.metric_type === ExperimentMetricType.MEAN &&
-                    metric.source.math === ExperimentMetricMathType.Sum
-                ) {
-                    /*
-                        Continuous property metric:
-                        - "mean" is the average value of the measured property per user (e.g., revenue per user).
-                        - MDE is applied as a percentage of this mean to compute `d`.
-
-                        Formula:
-                        d = MDE * averagePropertyValuePerUser
-                    */
-                    d = minimumDetectableEffectDecimal * averagePropertyValuePerUser
-
-                    /*
-                        Sample Size Formula for Continuous metrics:
-
-                        N = (16 * variance) / d^2
-
-                        Where:
-                        - `variance` is the estimated variance of the continuous property.
-                        - The formula is identical to the Count metric case.
-                    */
-                    sampleSizeFormula = (16 * variance) / d ** 2
-                } else if (metric.metric_type === ExperimentMetricType.FUNNEL) {
-                    const manualConversionRateDecimal = manualConversionRate / 100
-                    const conversionRate =
-                        conversionRateInputType === ConversionRateInputType.MANUAL
-                            ? manualConversionRateDecimal
-                            : automaticConversionRateDecimal
-
-                    /*
-                        Binomial metric (conversion rate):
-                        - Here, "mean" does not exist in the same way as for count/continuous metrics.
-                        - Instead, we use `p`, the baseline conversion rate (historical probability of success).
-                        - MDE is applied as an absolute percentage change to `p`.
-
-                        Formula:
-                        d = MDE * conversionRate
-                    */
-                    d = minimumDetectableEffectDecimal * conversionRate
-
-                    /*
-                        Sample size formula:
-
-                        N = (16 * p * (1 - p)) / d^2
-
-                        Where:
-                        - `p` is the historical conversion rate (baseline success probability).
-                        - `d` is the absolute MDE (e.g., detecting a 5% increase means `d = 0.05`).
-                        - The variance is inherent in `p(1 - p)`, which represents binomial variance.
-                    */
-                    if (conversionRate !== null) {
-                        sampleSizeFormula = (16 * conversionRate * (1 - conversionRate)) / d ** 2
-                    } else {
-                        return null
-                    }
-                }
-
-                if (!d || !sampleSizeFormula) {
-                    return null
-                }
-
-                return sampleSizeFormula * numberOfVariants
-            },
+            calculateRecommendedSampleSize,
         ],
         recommendedRunningTime: [
             (s) => [s.recommendedSampleSize, s.uniqueUsers],

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeCalculatorLogic.tsx
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeCalculatorLogic.tsx
@@ -124,7 +124,7 @@ export const runningTimeCalculatorLogic = kea<runningTimeCalculatorLogicType>([
                         : metric.metric_type === ExperimentMetricType.MEAN &&
                           metric.source.math === ExperimentMetricMathType.Sum
                         ? getSumQuery(metric, values.experiment, values.exposureEstimateConfig?.eventFilter ?? null)
-                        : getFunnelQuery(metric, values.exposureEstimateConfig?.eventFilter ?? null, values.experiment)
+                        : getFunnelQuery(metric, values.experiment, values.exposureEstimateConfig?.eventFilter ?? null)
 
                 const result = (await performQuery(query, undefined, 'force_blocking')) as Partial<TrendsQueryResponse>
 

--- a/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeCalculatorLogic.tsx
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeCalculatorLogic.tsx
@@ -341,7 +341,7 @@ export const runningTimeCalculatorLogic = kea<runningTimeCalculatorLogicType>([
             (metric: ExperimentMetric, averageEventsPerUser: number, averagePropertyValuePerUser: number) =>
                 /**
                  * we need this to satify kea's typegen.
-                 * Do not dispair, this will be removed.
+                 * Do not despair, this will be removed.
                  */
                 calculateVariance(metric, averageEventsPerUser, averagePropertyValuePerUser),
         ],
@@ -375,7 +375,7 @@ export const runningTimeCalculatorLogic = kea<runningTimeCalculatorLogicType>([
             ): number | null =>
                 /**
                  * we need this to satify kea's typegen.
-                 * Do not dispair, this will be removed.
+                 * Do not despair, this will be removed.
                  */
                 calculateRecommendedSampleSize(
                     metric,


### PR DESCRIPTION
Part of #31920, full refactor on #32480

> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

To improve DX and make fixing some bugs easier, we are trimming down some Kea code to make it more manageable and easier to understand. This is the first of five PRs with small refactors on the Running Time Calculator, a modal that has numerous interactions, and it has been counterintuitive to manage.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We extracted all the utility functions and larger calculations from the `runningTimeCalculatorModal` into two separate files, `metricsQueryUtils` and `experimentStatisticsUtils`, and referenced those functions within the logic. The unit tests are the only new code, so there's no change in functionality.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

Added some unit tests...

```bash
pnpm --filter=@posthog/frontend jest src/scenes/experiments/RunningTimeCalculator/metricQueryUtils.test.ts
```

but the rest is...

![cat-type-small](https://github.com/user-attachments/assets/3be88903-3c48-424c-8a56-703ad0356cee)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
