### PR TITLE
fix(zendesk): Add prefix to configuration values update

### DIFF
--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -307,6 +307,12 @@ class ExternalDataSourceSerializers(serializers.ModelSerializer):
         if instance.source_type == ExternalDataSource.Type.SNOWFLAKE:
             new_job_inputs = parse_snowflake_job_inputs(new_job_inputs)
 
+        elif instance.source_type == ExternalDataSource.Type.ZENDESK:
+            # Zendesk source requires a `zendesk_*` prefix, but our frontend displays
+            # values without a prefix.
+            # TODO: Integrate configuration class here.
+            new_job_inputs = {f"zendesk_{k}": v for k, v in new_job_inputs.items()}
+
         if existing_job_inputs:
             validated_data["job_inputs"] = {**existing_job_inputs, **new_job_inputs}
 


### PR DESCRIPTION
# Problem

Zendesk source requires a `zendesk_*` prefix on all configuration
values. For some reason, our frontend is sending values without this
prefix, and on `update` we do not add the prefix like we do in
`create`.

# Changes

This solves the problem in a bit of a rushed way by appending the prefix
to each value provided on update.

Ideally we should refactor the API to use a proper configuration class,
but I am leaving that for later.