### PR TITLE
fix: Inline pymssql imports

### DIFF
--- a/posthog/temporal/data_imports/pipelines/mssql/mssql.py
+++ b/posthog/temporal/data_imports/pipelines/mssql/mssql.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 import collections
 import math
+import typing
 from collections.abc import Iterator
 from typing import Any
 
 import pyarrow as pa
-import pymssql
 from dlt.common.normalizers.naming.snake_case import NamingConvention
-from pymssql import Cursor
 
 from posthog.exceptions_capture import capture_exception
 from posthog.temporal.common.logger import FilteringBoundLogger
@@ -31,6 +30,9 @@ from posthog.temporal.data_imports.pipelines.sql_database.settings import (
 )
 from posthog.warehouse.models.ssh_tunnel import SSHTunnel, SSHTunnelConfig
 from posthog.warehouse.types import IncrementalFieldType, PartitionSettings
+
+if typing.TYPE_CHECKING:
+    from pymssql import Cursor
 
 
 @config.config
@@ -466,6 +468,8 @@ def mssql_source(
     incremental_field: str | None = None,
     incremental_field_type: IncrementalFieldType | None = None,
 ) -> SourceResponse:
+    import pymssql
+
     table_name = table_names[0]
     if not table_name:
         raise ValueError("Table name is missing")


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Pymssql is a pain to import.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Don't import it until necessary.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

Manually:
`DEBUG=1 python manage.py shell` breaks on `master` on certain development setups, runs on this branch.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
