### PR TITLE
fix(err): allow issue titles to be edited

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2392,7 +2392,7 @@ const api = {
 
         async updateIssue(
             id: ErrorTrackingIssue['id'],
-            data: Partial<Pick<ErrorTrackingIssue, 'status'>>
+            data: Partial<Pick<ErrorTrackingIssue, 'status' | 'name'>>
         ): Promise<ErrorTrackingRelationalIssue> {
             return await new ApiRequest().errorTrackingIssue(id).update({ data })
         },

--- a/frontend/src/scenes/error-tracking/errorTrackingIssueSceneLogic.ts
+++ b/frontend/src/scenes/error-tracking/errorTrackingIssueSceneLogic.ts
@@ -47,6 +47,7 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
         setIssue: (issue: ErrorTrackingRelationalIssue) => ({ issue }),
         updateStatus: (status: ErrorTrackingIssueStatus) => ({ status }),
         updateAssignee: (assignee: ErrorTrackingIssueAssignee | null) => ({ assignee }),
+        updateName: (name: string) => ({ name }),
         setLastSeen: (lastSeen: Dayjs) => ({ lastSeen }),
     }),
 
@@ -65,6 +66,9 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
             },
             updateStatus: (state, { status }) => {
                 return state ? { ...state, status } : null
+            },
+            updateName: (state, { name }) => {
+                return state ? { ...state, name } : null
             },
         },
         summary: {},
@@ -92,6 +96,11 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
                     {
                         key: [Scene.ErrorTrackingIssue, exceptionType],
                         name: exceptionType,
+                        onRename: issue
+                            ? async (name: string) => {
+                                  await errorTrackingIssueSceneLogic({ id: issue.id }).asyncActions.updateName(name)
+                              }
+                            : undefined,
                     },
                 ]
             },
@@ -198,6 +207,10 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
             updateAssignee: async ({ assignee }) => {
                 posthog.capture('error_tracking_issue_assigned', { issue_id: props.id })
                 await api.errorTracking.assignIssue(props.id, assignee)
+            },
+            updateName: async ({ name }) => {
+                posthog.capture('error_tracking_issue_name_updated', { name, issue_id: props.id })
+                await api.errorTracking.updateIssue(props.id, { name })
             },
         }
     }),

--- a/frontend/src/scenes/error-tracking/errorTrackingIssueSceneLogic.ts
+++ b/frontend/src/scenes/error-tracking/errorTrackingIssueSceneLogic.ts
@@ -82,7 +82,7 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
         },
     }),
 
-    selectors({
+    selectors(({ asyncActions }) => ({
         breadcrumbs: [
             (s) => [s.issue],
             (issue: ErrorTrackingRelationalIssue | null): Breadcrumb[] => {
@@ -96,14 +96,9 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
                     {
                         key: [Scene.ErrorTrackingIssue, exceptionType],
                         name: exceptionType,
-                        onRename: issue
-                            ? async (name: string) => {
-                                  const mounted = errorTrackingIssueSceneLogic.findMounted({ id: issue.id })
-                                  if (mounted) {
-                                      await mounted.asyncActions.updateName(name)
-                                  }
-                              }
-                            : undefined,
+                        onRename: async (name: string) => {
+                            return await asyncActions.updateName(name)
+                        },
                     },
                 ]
             },
@@ -137,7 +132,7 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
         ],
 
         aggregations: [(s) => [s.summary], (summary: ErrorTrackingIssueSummary | null) => summary?.aggregations],
-    }),
+    })),
 
     loaders(({ values, actions, props }) => ({
         issue: {

--- a/frontend/src/scenes/error-tracking/errorTrackingIssueSceneLogic.ts
+++ b/frontend/src/scenes/error-tracking/errorTrackingIssueSceneLogic.ts
@@ -98,7 +98,10 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
                         name: exceptionType,
                         onRename: issue
                             ? async (name: string) => {
-                                  await errorTrackingIssueSceneLogic({ id: issue.id }).asyncActions.updateName(name)
+                                  const mounted = errorTrackingIssueSceneLogic.findMounted({ id: issue.id })
+                                  if (mounted) {
+                                      await mounted.asyncActions.updateName(name)
+                                  }
                               }
                             : undefined,
                     },

--- a/posthog/api/error_tracking.py
+++ b/posthog/api/error_tracking.py
@@ -115,15 +115,7 @@ class ErrorTrackingIssueSerializer(serializers.ModelSerializer):
                 activity="updated",
                 detail=Detail(
                     name=instance.name,
-                    changes=[
-                        Change(
-                            type="ErrorTrackingIssue",
-                            field="status",
-                            before=status_before,
-                            after=status_after,
-                            action="changed",
-                        )
-                    ],
+                    changes=changes,
                 ),
             )
 

--- a/posthog/api/error_tracking.py
+++ b/posthog/api/error_tracking.py
@@ -82,9 +82,29 @@ class ErrorTrackingIssueSerializer(serializers.ModelSerializer):
         status_before = instance.status
         status_updated = "status" in validated_data and status_after != status_before
 
+        name_after = validated_data.get("name")
+        name_before = instance.name
+        name_updated = "name" in validated_data and name_after != name_before
+
         updated_instance = super().update(instance, validated_data)
 
+        changes = []
         if status_updated:
+            changes.append(
+                Change(
+                    type="ErrorTrackingIssue",
+                    field="status",
+                    before=status_before,
+                    after=status_after,
+                    action="changed",
+                )
+            )
+        if name_updated:
+            changes.append(
+                Change(type="ErrorTrackingIssue", field="name", before=name_before, after=name_after, action="changed")
+            )
+
+        if changes:
             log_activity(
                 organization_id=team.organization.id,
                 team_id=team.id,


### PR DESCRIPTION
Came up in support, sometimes people want issue titles to be something other than the type of the first exception in the chain. They can set custom hooks to achieve that, but it's a lot easier just to let them edit the title in the UI.