### PR TITLE
fix: add S25 YC batch

### DIFF
--- a/frontend/src/scenes/startups/startupProgramLogic.ts
+++ b/frontend/src/scenes/startups/startupProgramLogic.ts
@@ -41,6 +41,7 @@ export const RAISED_OPTIONS = [
 
 export const YC_BATCH_OPTIONS = [
     { label: 'Select your batch', value: '' },
+    { label: 'Summer 2025', value: 'Summer 2025' },
     { label: 'Spring 2025', value: 'Spring 2025' },
     { label: 'Winter 2025', value: 'Winter 2025' },
     { label: 'Fall 2024', value: 'Fall 2024' },


### PR DESCRIPTION
## Problem

- `Summer 2025` (which kicks off in July) is not listed on YC startups directory and it is therefore also not available in the API that we use, yet there are companies from `Summer 2025` already getting Bookface access
- This resulted in a problem being reported with our YC deal on Bookface

## Changes

- Adds `Summer 2025` to YC batch options
- `billing` changes: https://github.com/PostHog/billing/pull/1283

For more context see : https://posthog.slack.com/archives/C088RSQKH2T/p1748249226668359

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

n/a