### PR TITLE
chore: remove dev endpoints from the website

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -996,7 +996,8 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, U
             raise exceptions.ValidationError(f"Invalid version: {version}")
 
     @extend_schema(
-        description="Generate regex patterns using AI. This is in development and likely to change, you should not depend on this API."
+        exclude=True,
+        description="Generate regex patterns using AI. This is in development and likely to change, you should not depend on this API.",
     )
     @action(methods=["POST"], detail=False, url_path="ai/regex")
     def ai_regex(self, request: Request, *args: Any, **kwargs: Any) -> Response:
@@ -1036,6 +1037,10 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, U
 
         return Response(response_data)
 
+    @extend_schema(
+        exclude=True,
+        description="Find recordings with similar event sequences to the given recording. This is in development and likely to change, you should not depend on this API.",
+    )
     @action(methods=["GET"], detail=True, url_path="analyze/similar")
     def similar_recordings(self, request: request.Request, **kwargs) -> Response:
         """Find recordings with similar event sequences to the given recording."""


### PR DESCRIPTION
2 endpoints:

POST /api/projects/:project_id/session_recordings/ai/regex/
GET  /api/projects/:project_id/session_recordings/:id/analyze/similar/

should not be in official docs for now as they are for us

