### PR TITLE
fix: removing redundant listener from the MDE calculator.

### DIFF
--- a/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeCalculatorLogic.tsx
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeCalculatorLogic.tsx
@@ -334,9 +334,6 @@ export const runningTimeCalculatorLogic = kea<runningTimeCalculatorLogicType>([
             }
             actions.loadMetricResult()
         },
-        setExposureEstimateConfig: () => {
-            actions.loadMetricResult()
-        },
         setManualConversionRate: () => {
             /**
              * We listen for changes in the manual conversion rate and update the exposure estimate config


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

> [!NOTE]
> Fixes #31920
> Related: https://posthoghelp.zendesk.com/agent/tickets/30660 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/33083)

## Problem

The MDE calculator triggers unnecessary events when the user changes the conversion rate type or the conversion rate. Those calculations are performed locally and only require filters and metrics. This behavior was turning the MDE calculator into something difficult to use.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We updated the MDE Calculator Logic by removing a redundant listener being called on every change of the exposure estimate, even when not necessary.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/bbf7cd30-3316-4f75-99b0-289c031618bd)


<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
