### PR TITLE
feat: enable filters on pre-aggregated tables

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -554,11 +554,21 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         name: 'Session properties',
                         searchPlaceholder: 'sessions',
                         type: TaxonomicFilterGroupType.SessionProperties,
-                        options: undefined,
+                        ...(propertyAllowList
+                            ? {
+                                  options: propertyAllowList[TaxonomicFilterGroupType.SessionProperties]?.map(
+                                      (property) => ({
+                                          name: property,
+                                          value: property,
+                                      })
+                                  ),
+                              }
+                            : {
+                                  endpoint: `api/environments/${teamId}/sessions/property_definitions`,
+                              }),
                         getName: (option: any) => option.name,
                         getValue: (option) => option.name,
                         getPopoverHeader: () => 'Session',
-                        endpoint: `api/environments/${teamId}/sessions/property_definitions`,
                         getIcon: getPropertyDefinitionIcon,
                     },
                     {

--- a/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
@@ -83,7 +83,7 @@ const FoldableFilters = (): JSX.Element => {
             <WebVitalsPercentileToggle />
             {!preAggregatedEnabled && <PathCleaningToggle />}
 
-            {!preAggregatedEnabled && <WebPropertyFilters />}
+            <WebPropertyFilters />
         </div>
     )
 }

--- a/frontend/src/scenes/web-analytics/WebPropertyFilters.tsx
+++ b/frontend/src/scenes/web-analytics/WebPropertyFilters.tsx
@@ -11,10 +11,42 @@ import { useState } from 'react'
 import { webAnalyticsLogic } from './webAnalyticsLogic'
 
 export const WebPropertyFilters = (): JSX.Element => {
-    const { rawWebAnalyticsFilters } = useValues(webAnalyticsLogic)
+    const { rawWebAnalyticsFilters, preAggregatedEnabled } = useValues(webAnalyticsLogic)
     const { setWebAnalyticsFilters } = useActions(webAnalyticsLogic)
 
     const [displayFilters, setDisplayFilters] = useState(false)
+
+    const taxonomicGroupTypes = [
+        TaxonomicFilterGroupType.EventProperties,
+        TaxonomicFilterGroupType.SessionProperties,
+        ...(!preAggregatedEnabled ? [TaxonomicFilterGroupType.PersonProperties] : []),
+    ]
+
+    const webAnalyticsPropertyAllowList = preAggregatedEnabled
+        ? {
+              [TaxonomicFilterGroupType.EventProperties]: [
+                  '$host',
+                  '$device_type',
+                  '$browser',
+                  '$os',
+                  '$referring_domain',
+                  '$geoip_country_name',
+                  '$geoip_country_code',
+                  '$geoip_city_name',
+                  '$geoip_subdivision_1_code',
+                  '$pathname',
+              ],
+              [TaxonomicFilterGroupType.SessionProperties]: [
+                  '$entry_pathname',
+                  '$end_pathname',
+                  '$entry_utm_source',
+                  '$entry_utm_medium',
+                  '$entry_utm_campaign',
+                  '$entry_utm_term',
+                  '$entry_utm_content',
+              ],
+          }
+        : undefined
 
     return (
         <Popover
@@ -26,11 +58,8 @@ export const WebPropertyFilters = (): JSX.Element => {
                 <div className="p-2">
                     <PropertyFilters
                         disablePopover
-                        taxonomicGroupTypes={[
-                            TaxonomicFilterGroupType.EventProperties,
-                            TaxonomicFilterGroupType.PersonProperties,
-                            TaxonomicFilterGroupType.SessionProperties,
-                        ]}
+                        propertyAllowList={webAnalyticsPropertyAllowList}
+                        taxonomicGroupTypes={taxonomicGroupTypes}
                         onChange={(filters) =>
                             setWebAnalyticsFilters(filters.filter(isEventPersonOrSessionPropertyFilter))
                         }

--- a/frontend/src/scenes/web-analytics/WebPropertyFilters.tsx
+++ b/frontend/src/scenes/web-analytics/WebPropertyFilters.tsx
@@ -22,6 +22,7 @@ export const WebPropertyFilters = (): JSX.Element => {
         ...(!preAggregatedEnabled ? [TaxonomicFilterGroupType.PersonProperties] : []),
     ]
 
+    // Keep in sync with posthog/hogql_queries/web_analytics/stats_table_pre_aggregated.py
     const webAnalyticsPropertyAllowList = preAggregatedEnabled
         ? {
               [TaxonomicFilterGroupType.EventProperties]: [

--- a/posthog/hogql_queries/web_analytics/pre_aggregated/property_transformer.py
+++ b/posthog/hogql_queries/web_analytics/pre_aggregated/property_transformer.py
@@ -3,7 +3,7 @@ from posthog.hogql.visitor import CloningVisitor
 
 
 class PreAggregatedPropertyTransformer(CloningVisitor):
-    """Transforms property field chains to match pre-aggregated table column names"""
+    """Transforms field chains to reference pre-aggregated table columns."""
 
     def __init__(self, table_name: str, supported_props_filters: dict):
         super().__init__()
@@ -11,25 +11,15 @@ class PreAggregatedPropertyTransformer(CloningVisitor):
         self.supported_props_filters = supported_props_filters
 
     def visit_field(self, node: ast.Field) -> ast.Field:
-        if len(node.chain) >= 2:
-            if node.chain[:2] == ["events", "properties"] and len(node.chain) == 3:
-                prop_key = node.chain[2]
-                if prop_key in self.supported_props_filters:
-                    return ast.Field(chain=[self.table_name, self.supported_props_filters[prop_key]])
+        chain = node.chain
 
-            elif node.chain[:2] == ["person", "properties"] and len(node.chain) == 3:
-                prop_key = node.chain[2]
-                if prop_key in self.supported_props_filters:
-                    return ast.Field(chain=[self.table_name, self.supported_props_filters[prop_key]])
+        prop_key = None
+        if chain[:2] == ["events", "properties"] and len(chain) == 3:
+            prop_key = chain[2]
+        elif (chain[:1] == ["session"] or chain[:1] == ["properties"]) and len(chain) == 2:
+            prop_key = chain[1]
 
-            elif node.chain[0] == "session" and len(node.chain) == 2:
-                prop_key = node.chain[1]
-                if prop_key in self.supported_props_filters:
-                    return ast.Field(chain=[self.table_name, self.supported_props_filters[prop_key]])
-
-            elif node.chain[0] == "properties" and len(node.chain) == 2:
-                prop_key = node.chain[1]
-                if prop_key in self.supported_props_filters:
-                    return ast.Field(chain=[self.table_name, self.supported_props_filters[prop_key]])
+        if prop_key and prop_key in self.supported_props_filters:
+            return ast.Field(chain=[self.table_name, self.supported_props_filters[prop_key]])
 
         return super().visit_field(node)

--- a/posthog/hogql_queries/web_analytics/pre_aggregated/property_transformer.py
+++ b/posthog/hogql_queries/web_analytics/pre_aggregated/property_transformer.py
@@ -1,0 +1,35 @@
+from posthog.hogql import ast
+from posthog.hogql.visitor import CloningVisitor
+
+
+class PreAggregatedPropertyTransformer(CloningVisitor):
+    """Transforms property field chains to match pre-aggregated table column names"""
+
+    def __init__(self, table_name: str, supported_props_filters: dict):
+        super().__init__()
+        self.table_name = table_name
+        self.supported_props_filters = supported_props_filters
+
+    def visit_field(self, node: ast.Field) -> ast.Field:
+        if len(node.chain) >= 2:
+            if node.chain[:2] == ["events", "properties"] and len(node.chain) == 3:
+                prop_key = node.chain[2]
+                if prop_key in self.supported_props_filters:
+                    return ast.Field(chain=[self.table_name, self.supported_props_filters[prop_key]])
+
+            elif node.chain[:2] == ["person", "properties"] and len(node.chain) == 3:
+                prop_key = node.chain[2]
+                if prop_key in self.supported_props_filters:
+                    return ast.Field(chain=[self.table_name, self.supported_props_filters[prop_key]])
+
+            elif node.chain[0] == "session" and len(node.chain) == 2:
+                prop_key = node.chain[1]
+                if prop_key in self.supported_props_filters:
+                    return ast.Field(chain=[self.table_name, self.supported_props_filters[prop_key]])
+
+            elif node.chain[0] == "properties" and len(node.chain) == 2:
+                prop_key = node.chain[1]
+                if prop_key in self.supported_props_filters:
+                    return ast.Field(chain=[self.table_name, self.supported_props_filters[prop_key]])
+
+        return super().visit_field(node)

--- a/posthog/hogql_queries/web_analytics/pre_aggregated/query_builder.py
+++ b/posthog/hogql_queries/web_analytics/pre_aggregated/query_builder.py
@@ -29,28 +29,24 @@ class WebAnalyticsPreAggregatedQueryBuilder:
         return True
 
     def _get_filters(self, table_name: str):
-        current_date_expr = ast.And(
-            exprs=[
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.GtEq,
-                    left=ast.Field(chain=[table_name, "day_bucket"]),
-                    right=ast.Constant(
-                        value=(
-                            self.runner.query_compare_to_date_range.date_from()
-                            if self.runner.query_compare_to_date_range
-                            else self.runner.query_date_range.date_from()
-                        )
-                    ),
+        filter_exprs: list[ast.Expr] = [
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.GtEq,
+                left=ast.Field(chain=[table_name, "day_bucket"]),
+                right=ast.Constant(
+                    value=(
+                        self.runner.query_compare_to_date_range.date_from()
+                        if self.runner.query_compare_to_date_range
+                        else self.runner.query_date_range.date_from()
+                    )
                 ),
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.LtEq,
-                    left=ast.Field(chain=[table_name, "day_bucket"]),
-                    right=ast.Constant(value=self.runner.query_date_range.date_to()),
-                ),
-            ]
-        )
-
-        filter_exprs = [current_date_expr]
+            ),
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.LtEq,
+                left=ast.Field(chain=[table_name, "day_bucket"]),
+                right=ast.Constant(value=self.runner.query_date_range.date_to()),
+            ),
+        ]
 
         if self.runner.query.properties:
             supported_properties = [

--- a/posthog/hogql_queries/web_analytics/pre_aggregated/query_builder.py
+++ b/posthog/hogql_queries/web_analytics/pre_aggregated/query_builder.py
@@ -1,7 +1,9 @@
-from typing import Optional, cast, Union
+from typing import Optional
 from datetime import datetime, UTC
 
 from posthog.hogql import ast
+from posthog.hogql.property import property_to_expr
+from posthog.hogql_queries.web_analytics.pre_aggregated.property_transformer import PreAggregatedPropertyTransformer
 
 
 class WebAnalyticsPreAggregatedQueryBuilder:
@@ -26,21 +28,13 @@ class WebAnalyticsPreAggregatedQueryBuilder:
 
         return True
 
-    # We can probably use the hogql general filters somehow but it was not working by default and it was a lot of moving parts to debug at once so
-    # TODO: come back to this later to make sure we're not overcomplicating things
     def _get_filters(self, table_name: str):
         current_date_expr = ast.And(
             exprs=[
                 ast.CompareOperation(
                     op=ast.CompareOperationOp.GtEq,
                     left=ast.Field(chain=[table_name, "day_bucket"]),
-                    right=ast.Constant(
-                        value=(
-                            self.runner.query_compare_to_date_range.date_from()
-                            if self.runner.query_compare_to_date_range
-                            else self.runner.query_date_range.date_from()
-                        )
-                    ),
+                    right=ast.Constant(value=self.runner.query_date_range.date_from()),
                 ),
                 ast.CompareOperation(
                     op=ast.CompareOperationOp.LtEq,
@@ -50,41 +44,24 @@ class WebAnalyticsPreAggregatedQueryBuilder:
             ]
         )
 
-        filter_parts: list[Union[ast.And, ast.CompareOperation]] = [current_date_expr]
+        filter_exprs = [current_date_expr]
 
-        for posthog_field, table_field in self.supported_props_filters.items():
-            for prop in self.runner.query.properties:
-                if hasattr(prop, "key") and prop.key == posthog_field and hasattr(prop, "value"):
-                    value = prop.value
+        if self.runner.query.properties:
+            supported_properties = [
+                prop
+                for prop in self.runner.query.properties
+                if hasattr(prop, "key") and prop.key in self.supported_props_filters
+            ]
 
-                    if value is not None and hasattr(value, "id"):
-                        value = value.id
+            if supported_properties:
+                property_expr = property_to_expr(supported_properties, self.runner.team)
 
-                    # The device_type input differs between "Desktop" | ["Mobile", "Tablet"]
-                    if isinstance(value, list):
-                        values = [v.id if v is not None and hasattr(v, "id") else v for v in value]
-                        filter_expr = ast.CompareOperation(
-                            op=ast.CompareOperationOp.In,
-                            left=ast.Field(chain=[table_name, table_field]),
-                            right=ast.Tuple(exprs=[ast.Constant(value=v) for v in values]),
-                        )
+                transformer = PreAggregatedPropertyTransformer(table_name, self.supported_props_filters)
+                transformed_expr = transformer.visit(property_expr)
 
-                        filter_parts.append(filter_expr)
-                    else:
-                        filter_expr = ast.CompareOperation(
-                            op=ast.CompareOperationOp.Eq,
-                            left=ast.Field(chain=[table_name, table_field]),
-                            right=ast.Constant(value=value),
-                        )
+                filter_exprs.append(transformed_expr)
 
-                        filter_parts.append(filter_expr)
-
-        if len(filter_parts) > 1:
-            return ast.Call(name="and", args=cast(list[ast.Expr], filter_parts))
-        elif len(filter_parts) == 1:
-            return filter_parts[0]
-
-        return None
+        return ast.And(exprs=filter_exprs) if len(filter_exprs) > 1 else filter_exprs[0]
 
     def get_date_ranges(self, table_name: Optional[str] = None) -> tuple[str, str]:
         current_date_from = self.runner.query_date_range.date_from_str

--- a/posthog/hogql_queries/web_analytics/pre_aggregated/query_builder.py
+++ b/posthog/hogql_queries/web_analytics/pre_aggregated/query_builder.py
@@ -34,7 +34,13 @@ class WebAnalyticsPreAggregatedQueryBuilder:
                 ast.CompareOperation(
                     op=ast.CompareOperationOp.GtEq,
                     left=ast.Field(chain=[table_name, "day_bucket"]),
-                    right=ast.Constant(value=self.runner.query_date_range.date_from()),
+                    right=ast.Constant(
+                        value=(
+                            self.runner.query_compare_to_date_range.date_from()
+                            if self.runner.query_compare_to_date_range
+                            else self.runner.query_date_range.date_from()
+                        )
+                    ),
                 ),
                 ast.CompareOperation(
                     op=ast.CompareOperationOp.LtEq,

--- a/posthog/hogql_queries/web_analytics/stats_table_pre_aggregated.py
+++ b/posthog/hogql_queries/web_analytics/stats_table_pre_aggregated.py
@@ -8,7 +8,7 @@ from posthog.schema import WebAnalyticsOrderByDirection, WebAnalyticsOrderByFiel
 if TYPE_CHECKING:
     from posthog.hogql_queries.web_analytics.stats_table import WebStatsTableQueryRunner
 
-# While we don't offer a property endpoint or definition, keep those in sync with frontend/src/scenes/web-analytics/WebPropertyFilters.tsx
+# Keep those in sync with frontend/src/scenes/web-analytics/WebPropertyFilters.tsx
 STATS_TABLE_SUPPORTED_FILTERS = {
     "$entry_pathname": "entry_pathname",
     "$pathname": "pathname",

--- a/posthog/hogql_queries/web_analytics/stats_table_pre_aggregated.py
+++ b/posthog/hogql_queries/web_analytics/stats_table_pre_aggregated.py
@@ -8,20 +8,25 @@ from posthog.schema import WebAnalyticsOrderByDirection, WebAnalyticsOrderByFiel
 if TYPE_CHECKING:
     from posthog.hogql_queries.web_analytics.stats_table import WebStatsTableQueryRunner
 
-# We can enable more filters here, but keeping the same as web_overview while we test in
+# While we don't offer a property endpoint or definition, keep those in sync with frontend/src/scenes/web-analytics/WebPropertyFilters.tsx
 STATS_TABLE_SUPPORTED_FILTERS = {
+    "$entry_pathname": "entry_pathname",
+    "$pathname": "pathname",
+    "$end_pathname": "end_pathname",
     "$host": "host",
     "$device_type": "device_type",
-    # "$browser": "browser",
-    # "$os": "os",
-    # "$viewport": "viewport",
-    # "$referring_domain": "referring_domain",
-    # "$utm_source": "utm_source",
-    # "$utm_medium": "utm_medium",
-    # "$utm_campaign": "utm_campaign",
-    # "$utm_term": "utm_term",
-    # "$utm_content": "utm_content",
-    # "$country": "country",
+    "$browser": "browser",
+    "$os": "os",
+    "$referring_domain": "referring_domain",
+    "$entry_utm_source": "utm_source",
+    "$entry_utm_medium": "utm_medium",
+    "$entry_utm_campaign": "utm_campaign",
+    "$entry_utm_term": "utm_term",
+    "$entry_utm_content": "utm_content",
+    "$geoip_country_name": "country_name",
+    "$geoip_country_code": "country_code",
+    "$geoip_city_name": "city_name",
+    "$geoip_subdivision_1_code": "region_code",
 }
 
 

--- a/posthog/hogql_queries/web_analytics/stats_table_pre_aggregated.py
+++ b/posthog/hogql_queries/web_analytics/stats_table_pre_aggregated.py
@@ -155,7 +155,10 @@ class StatsTablePreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder)
                 column = "context.columns.visitors"
             elif field == WebAnalyticsOrderByFields.VIEWS:
                 column = "context.columns.views"
-            elif field == WebAnalyticsOrderByFields.BOUNCE_RATE:
+            elif field == WebAnalyticsOrderByFields.BOUNCE_RATE and self.runner.query.breakdownBy in [
+                WebStatsBreakdown.INITIAL_PAGE,
+                WebStatsBreakdown.PAGE,
+            ]:
                 column = "context.columns.bounce_rate"
 
             if column:


### PR DESCRIPTION
## Problem

We can only support a limited amount of filters on those pre-aggregated tables as each dimension is a new data folding/group by clause. This PR adds support to our current `stats_table` dimensions. 

This does not enable filter support on the WebOverview as we need to be more careful on session-specific filters so this is coming on the next PRs.

<img width="999" alt="image" src="https://github.com/user-attachments/assets/6df343ae-6cff-41a3-be46-65076bdc30e9" />


## Changes

- Re-enable the filter component on the frontend
- Changed Sessions Taxonomy to support the `allowedPropertyList` as the endpoint did not support filtering like the event counterpart.
- Created a hogql transformer to rely on our existing property filters implementation instead of my previous ad-hoc one so we can use all operators and the frontend UI will work as usual.

## Did you write or update any docs for this change?

- [x] No docs needed for this change

## How did you test this code?

Manually