### PR TITLE
feat: test explore not activity label

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -272,6 +272,7 @@ export const FEATURE_FLAGS = {
     USAGE_SPEND_DASHBOARDS: 'usage-spend-dashboards', // owner: @pawel-cebula #team-billing
     SIMPLE_INFINITE_LIST_NUMERICAL_FILTER: 'simple-infinite-list-numerical-filter', // owner: @rafaeelaudibert #team-revenue-analytics
     REPLAY_SCREENSHOT: 'replay-screenshot', // owner: @veryayskiy #team-replay
+    ACTIVITY_OR_EXPLORE: 'activity-or-explore', // owner: @pauldambra #team-replay
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/scenes/session-recordings/player/player-meta/PlayerInspectorButton.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/PlayerInspectorButton.tsx
@@ -1,7 +1,6 @@
-/**
- * @fileoverview PlayerInspector component is a button that opens the inspector sidebar
- */
+import { IconSearch } from '@posthog/icons'
 import { useActions, useValues } from 'kea'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { IconUnverifiedEvent } from 'lib/lemon-ui/icons'
 import { SettingsToggle } from 'scenes/session-recordings/components/PanelSettings'
 
@@ -15,18 +14,20 @@ export function PlayerInspectorButton(): JSX.Element {
     const { setSidebarOpen } = useActions(playerSettingsLogic)
     const { sidebarOpen } = useValues(playerSettingsLogic)
 
+    const usesExploreText = useFeatureFlag('ACTIVITY_OR_EXPLORE', 'explore')
+    const label = usesExploreText ? 'Explore' : 'Activity'
+    const icon = usesExploreText ? <IconSearch /> : <IconUnverifiedEvent />
     return (
         <SettingsToggle
             title="View all activities from this session, including events, console logs, network requests, and an overview. Explore what happened in detail."
-            label="Activity"
-            icon={<IconUnverifiedEvent />}
+            label={label}
+            icon={icon}
             active={sidebarOpen}
             onClick={(): void => {
                 setSidebarOpen(!sidebarOpen)
                 setTab(SessionRecordingSidebarTab.INSPECTOR)
             }}
-        >
-            Activity
-        </SettingsToggle>
+            data-attr="open-player-inspector-button"
+        />
     )
 }

--- a/frontend/src/scenes/session-recordings/player/player-meta/PlayerInspectorButton.tsx
+++ b/frontend/src/scenes/session-recordings/player/player-meta/PlayerInspectorButton.tsx
@@ -2,6 +2,7 @@ import { IconSearch } from '@posthog/icons'
 import { useActions, useValues } from 'kea'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { IconUnverifiedEvent } from 'lib/lemon-ui/icons'
+import posthog from 'posthog-js'
 import { SettingsToggle } from 'scenes/session-recordings/components/PanelSettings'
 
 import { SessionRecordingSidebarTab } from '~/types'
@@ -26,7 +27,9 @@ export function PlayerInspectorButton(): JSX.Element {
             onClick={(): void => {
                 setSidebarOpen(!sidebarOpen)
                 setTab(SessionRecordingSidebarTab.INSPECTOR)
+                posthog.capture(!sidebarOpen ? 'opening player inspector' : 'closing player inspector', {})
             }}
+            data-ph-capture-attribute-opening={!sidebarOpen}
             data-attr="open-player-inspector-button"
         />
     )


### PR DESCRIPTION
|control/existing|test|
|- | - | 
|<img width="433" alt="Screenshot 2025-05-27 at 08 14 10" src="https://github.com/user-attachments/assets/af70c061-2a47-4bd7-afeb-c05383f1d3d9" />|<img width="588" alt="Screenshot 2025-05-27 at 08 13 51" src="https://github.com/user-attachments/assets/3cad513d-912c-4270-87a2-f70c85075fba" />|

i'm always surprised how few people click to open the inspector https://us.posthog.com/project/2/insights/K69dJsmv
let's run an experiment and see if something as simple as changing the label can help
