### PR TITLE
fix(config): Convert port to int in MySQL and MSSQL

### DIFF
--- a/posthog/temporal/data_imports/pipelines/mssql/mssql.py
+++ b/posthog/temporal/data_imports/pipelines/mssql/mssql.py
@@ -38,11 +38,11 @@ if typing.TYPE_CHECKING:
 @config.config
 class MSSQLSourceConfig(config.Config):
     host: str
-    port: int
     user: str
     password: str
     database: str
     schema: str
+    port: int = config.value(converter=int)
     ssh_tunnel: SSHTunnelConfig | None = None
 
 

--- a/posthog/temporal/data_imports/pipelines/mysql/mysql.py
+++ b/posthog/temporal/data_imports/pipelines/mysql/mysql.py
@@ -42,8 +42,8 @@ class MySQLSourceConfig(config.Config):
     password: str
     database: str
     schema: str
-    using_ssl: bool = True
     port: int = config.value(converter=int)
+    using_ssl: bool = True
     ssh_tunnel: SSHTunnelConfig | None = None
 
 

--- a/posthog/temporal/data_imports/pipelines/mysql/mysql.py
+++ b/posthog/temporal/data_imports/pipelines/mysql/mysql.py
@@ -38,12 +38,12 @@ from posthog.warehouse.types import IncrementalFieldType, PartitionSettings
 @config.config
 class MySQLSourceConfig(config.Config):
     host: str
-    port: int
     user: str
     password: str
     database: str
     schema: str
     using_ssl: bool = True
+    port: int = config.value(converter=int)
     ssh_tunnel: SSHTunnelConfig | None = None
 
 

--- a/posthog/temporal/tests/data_imports/test_postgres_source.py
+++ b/posthog/temporal/tests/data_imports/test_postgres_source.py
@@ -186,7 +186,7 @@ async def test_postgres_source_full_refresh(
     assert res.results == TEST_DATA
 
 
-def test_postgresql_sql_source_config_loads():
+def test_postgresql__source_config_loads():
     job_inputs = {
         "host": "host.com",
         "port": "5432",
@@ -205,7 +205,7 @@ def test_postgresql_sql_source_config_loads():
     assert config.ssh_tunnel is None
 
 
-def test_postgresql_sql_source_config_loads_int_port():
+def test_postgresql_source_config_loads_int_port():
     job_inputs = {
         "host": "host.com",
         "port": 5432,
@@ -224,7 +224,7 @@ def test_postgresql_sql_source_config_loads_int_port():
     assert config.ssh_tunnel is None
 
 
-def test_postgresql_sql_source_config_loads_with_ssh_tunnel():
+def test_postgresql_source_config_loads_with_ssh_tunnel():
     job_inputs = {
         "host": "host.com",
         "port": "5432",
@@ -255,7 +255,7 @@ def test_postgresql_sql_source_config_loads_with_ssh_tunnel():
     assert config.ssh_tunnel.host == "other-host.com"
 
 
-def test_postgresql_sql_source_config_loads_with_nested_dict_enabled_tunnel():
+def test_postgresql_source_config_loads_with_nested_dict_enabled_tunnel():
     job_inputs = {
         "host": "host.com",
         "port": 5432,
@@ -291,7 +291,7 @@ def test_postgresql_sql_source_config_loads_with_nested_dict_enabled_tunnel():
     assert config.ssh_tunnel.auth.password == "password"
 
 
-def test_postgresql_sql_source_config_loads_with_nested_dict_disabled_tunnel():
+def test_postgresql_source_config_loads_with_nested_dict_disabled_tunnel():
     job_inputs = {
         "host": "host.com",
         "port": 5432,


### PR DESCRIPTION
## Problem

Port number is expected to be an int, but can be passed as a string when configuring a source.

## Changes

This adds a converter to cast the value to an int in the configuration for MySQL and MSSQL sources.

Finally, I also did a small name change in some test names (`postgresql_sql` to just `postgresql`).

## Testing

I've added some unit tests covering configuration parsing. Similar to tests covering `PostgreSQLSourceConfig`.