### PR TITLE
chore(nav): remove b2b analytics flag

### DIFF
--- a/frontend/src/layout/navigation-3000/navigationLogic.tsx
+++ b/frontend/src/layout/navigation-3000/navigationLogic.tsx
@@ -5,7 +5,6 @@ import {
     IconDashboard,
     IconDatabase,
     IconGraph,
-    IconGroups,
     IconHome,
     IconLive,
     IconLogomark,
@@ -29,10 +28,9 @@ import { actions, connect, events, kea, listeners, path, props, reducers, select
 import { router } from 'kea-router'
 import { subscriptions } from 'kea-subscriptions'
 import { FEATURE_FLAGS } from 'lib/constants'
-import { GroupsAccessStatus } from 'lib/introductions/groupsAccessLogic'
 import { LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { capitalizeFirstLetter, isNotNil } from 'lib/utils'
+import { isNotNil } from 'lib/utils'
 import { getAppContext } from 'lib/utils/getAppContext'
 import posthog from 'posthog-js'
 import React from 'react'
@@ -359,8 +357,6 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
                 s.hasOnboardedAnyProduct,
                 s.playlists,
                 s.playlistsLoading,
-                s.groupTypes,
-                s.groupsAccessStatus,
             ],
             (
                 featureFlags,
@@ -368,17 +364,9 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
                 pinnedDashboards,
                 hasOnboardedAnyProduct,
                 playlists,
-                playlistsLoading,
-                groupTypes,
-                groupsAccessStatus
+                playlistsLoading
             ): NavbarItem[][] => {
                 const isUsingSidebar = featureFlags[FEATURE_FLAGS.POSTHOG_3000_NAV]
-
-                const showGroupsIntroductionPage = [
-                    GroupsAccessStatus.HasAccess,
-                    GroupsAccessStatus.HasGroupTypes,
-                    GroupsAccessStatus.NoAccess,
-                ].includes(groupsAccessStatus)
 
                 const sectionOne: NavbarItem[] = hasOnboardedAnyProduct
                     ? [
@@ -440,7 +428,7 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
                           },
                           {
                               identifier: Scene.PersonsManagement,
-                              label: featureFlags[FEATURE_FLAGS.B2B_ANALYTICS] ? 'People' : 'People and groups',
+                              label: 'People and groups',
                               icon: <IconPeople />,
                               logic: isUsingSidebar ? personsAndGroupsSidebarLogic : undefined,
                               to: isUsingSidebar ? undefined : urls.persons(),
@@ -491,35 +479,6 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
                             to: isUsingSidebar ? undefined : urls.webAnalytics(),
                             tooltipDocLink: 'https://posthog.com/docs/web-analytics/getting-started',
                         },
-                        featureFlags[FEATURE_FLAGS.B2B_ANALYTICS]
-                            ? {
-                                  identifier: Scene.Groups,
-                                  label: 'B2B analytics',
-                                  icon: <IconGroups />,
-                                  to: urls.groups(0),
-                                  tag: 'alpha' as const,
-                                  tooltipDocLink: 'https://posthog.com/docs/product-analytics/group-analytics',
-                                  sideAction:
-                                      groupTypes.size > 1 && !showGroupsIntroductionPage
-                                          ? {
-                                                identifier: 'groups-dropdown',
-                                                dropdown: {
-                                                    overlay: (
-                                                        <LemonMenuOverlay
-                                                            items={Array.from(groupTypes.values()).map((groupType) => ({
-                                                                label: capitalizeFirstLetter(
-                                                                    groupType.name_plural || groupType.group_type
-                                                                ),
-                                                                to: urls.groups(groupType.group_type_index),
-                                                            }))}
-                                                        />
-                                                    ),
-                                                    placement: 'bottom-end',
-                                                },
-                                            }
-                                          : undefined,
-                              }
-                            : null,
 
                         featureFlags[FEATURE_FLAGS.REVENUE_ANALYTICS]
                             ? {

--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -293,21 +293,13 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
             : []),
         {
             identifier: 'PersonsManagement',
-            id: featureFlags[FEATURE_FLAGS.TREE_VIEW_PRODUCTS]
-                ? 'Persons'
-                : featureFlags[FEATURE_FLAGS.B2B_ANALYTICS]
-                ? 'Persons and cohorts'
-                : 'Persons and groups',
+            id: featureFlags[FEATURE_FLAGS.TREE_VIEW_PRODUCTS] ? 'Persons' : 'Persons and groups',
             icon: <IconPeople />,
             to: urls.persons(),
             onClick: () => {
                 handleStaticNavbarItemClick(urls.persons(), true)
             },
-            tooltip: featureFlags[FEATURE_FLAGS.TREE_VIEW_PRODUCTS]
-                ? 'Persons'
-                : featureFlags[FEATURE_FLAGS.B2B_ANALYTICS]
-                ? 'Persons and cohorts'
-                : 'Persons and groups',
+            tooltip: featureFlags[FEATURE_FLAGS.TREE_VIEW_PRODUCTS] ? 'Persons' : 'Persons and groups',
             tooltipDocLink: 'https://posthog.com/docs/data/persons',
         },
         {

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -246,7 +246,6 @@ export const FEATURE_FLAGS = {
     RECORDINGS_BLOBBY_V2_REPLAY: 'recordings-blobby-v2-replay', // owner: @pl #team-cdp
     SETTINGS_SESSIONS_V2_JOIN: 'settings-sessions-v2-join', // owner: @robbie-c #team-web-analytics
     SAVE_INSIGHT_TASK: 'save-insight-task', // owner: @joshsny #team-growth
-    B2B_ANALYTICS: 'b2b-analytics-alpha', // owner: @danielbachhuber #team-crm
     DASHBOARD_COLORS: 'dashboard-colors', // owner: @thmsobrmlr #team-product-analytics
     ERROR_TRACKING_INTEGRATIONS: 'error-tracking-integrations', // owner: @david #team-error-tracking
     ERROR_TRACKING_ALERT_ROUTING: 'error-tracking-alert-routing', // owner: #team-error-tracking

--- a/frontend/src/scenes/groups/groupLogic.ts
+++ b/frontend/src/scenes/groups/groupLogic.ts
@@ -2,7 +2,6 @@ import { actions, afterMount, connect, kea, key, listeners, path, props, reducer
 import { loaders } from 'kea-loaders'
 import { urlToAction } from 'kea-router'
 import api from 'lib/api'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { toParams } from 'lib/utils'
@@ -185,13 +184,11 @@ export const groupLogic = kea<groupLogicType>([
             (s, p) => [s.featureFlags, s.groupTypeName, p.groupTypeIndex, p.groupKey, s.groupData],
             (featureFlags, groupTypeName, groupTypeIndex, groupKey, groupData): Breadcrumb[] => {
                 const breadcrumbs: Breadcrumb[] = []
-                if (!featureFlags[FEATURE_FLAGS.B2B_ANALYTICS]) {
-                    breadcrumbs.push({
-                        key: Scene.DataManagement,
-                        name: 'People',
-                        path: urls.persons(),
-                    })
-                }
+                breadcrumbs.push({
+                    key: Scene.DataManagement,
+                    name: 'People',
+                    path: urls.persons(),
+                })
                 breadcrumbs.push({
                     key: groupTypeIndex,
                     name: capitalizeFirstLetter(groupTypeName),

--- a/frontend/src/scenes/groups/groupLogic.ts
+++ b/frontend/src/scenes/groups/groupLogic.ts
@@ -3,7 +3,6 @@ import { loaders } from 'kea-loaders'
 import { urlToAction } from 'kea-router'
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { toParams } from 'lib/utils'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
@@ -51,14 +50,7 @@ export const groupLogic = kea<groupLogicType>([
     path((key) => ['scenes', 'groups', 'groupLogic', key]),
     connect(() => ({
         actions: [groupsModel, ['createDetailDashboard']],
-        values: [
-            teamLogic,
-            ['currentTeamId'],
-            groupsModel,
-            ['groupTypes', 'aggregationLabel'],
-            featureFlagLogic,
-            ['featureFlags'],
-        ],
+        values: [teamLogic, ['currentTeamId'], groupsModel, ['groupTypes', 'aggregationLabel']],
     })),
     actions(() => ({
         setGroupData: (group: Group) => ({ group }),
@@ -181,8 +173,8 @@ export const groupLogic = kea<groupLogicType>([
             (groupTypes, index): number | null => groupTypes.get(index as GroupTypeIndex)?.detail_dashboard ?? null,
         ],
         breadcrumbs: [
-            (s, p) => [s.featureFlags, s.groupTypeName, p.groupTypeIndex, p.groupKey, s.groupData],
-            (featureFlags, groupTypeName, groupTypeIndex, groupKey, groupData): Breadcrumb[] => {
+            (s, p) => [s.groupTypeName, p.groupTypeIndex, p.groupKey, s.groupData],
+            (groupTypeName, groupTypeIndex, groupKey, groupData): Breadcrumb[] => {
                 const breadcrumbs: Breadcrumb[] = []
                 breadcrumbs.push({
                     key: Scene.DataManagement,

--- a/frontend/src/scenes/groups/groupsSceneLogic.ts
+++ b/frontend/src/scenes/groups/groupsSceneLogic.ts
@@ -1,9 +1,5 @@
 import { actions, connect, kea, path, reducers, selectors } from 'kea'
-import { urlToAction } from 'kea-router'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { GroupsAccessStatus } from 'lib/introductions/groupsAccessLogic'
-import { LemonTab } from 'lib/lemon-ui/LemonTabs'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
@@ -21,17 +17,10 @@ export type GroupsTab = {
     buttons?: any
 }
 
-export type GroupsTabs = Record<string, { url: string; label: LemonTab<any>['label']; content: any; buttons?: any }>
-
 export const groupsSceneLogic = kea<groupsSceneLogicType>([
     path(['scenes', 'groups', 'groupsSceneLogic']),
     connect(() => ({
-        values: [
-            groupsModel,
-            ['aggregationLabel', 'groupTypes', 'groupTypesLoading', 'groupsAccessStatus'],
-            featureFlagLogic,
-            ['featureFlags'],
-        ],
+        values: [groupsModel, ['aggregationLabel', 'groupTypes', 'groupTypesLoading', 'groupsAccessStatus']],
     })),
     actions({
         setGroupTypeIndex: (groupTypeIndex: number) => ({ groupTypeIndex }),
@@ -98,14 +87,5 @@ export const groupsSceneLogic = kea<groupsSceneLogicType>([
                 ].includes(groupsAccessStatus)
             },
         ],
-    }),
-    urlToAction(({ actions, values }) => {
-        const urlToAction = {} as Record<string, (...args: any[]) => void>
-        if (values.featureFlags[FEATURE_FLAGS.B2B_ANALYTICS]) {
-            urlToAction[urls.groups(':key')] = ({ key }: { key: string }) => {
-                actions.setGroupTypeIndex(parseInt(key))
-            }
-        }
-        return urlToAction
     }),
 ])

--- a/frontend/src/scenes/persons-management/PersonsManagementScene.tsx
+++ b/frontend/src/scenes/persons-management/PersonsManagementScene.tsx
@@ -1,8 +1,6 @@
 import { useActions, useValues } from 'kea'
 import { PageHeader } from 'lib/components/PageHeader'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonTab, LemonTabs } from 'lib/lemon-ui/LemonTabs'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 
 import { groupsModel } from '~/models/groupsModel'
@@ -13,7 +11,6 @@ export function PersonsManagementScene(): JSX.Element {
     const { tabs, activeTab, tabKey } = useValues(personsManagementSceneLogic)
     const { setTabKey } = useActions(personsManagementSceneLogic)
     const { showGroupsOptions } = useValues(groupsModel)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     const lemonTabs: LemonTab<string>[] = tabs.map((tab) => ({
         key: tab.key,
@@ -26,7 +23,7 @@ export function PersonsManagementScene(): JSX.Element {
         <>
             <PageHeader
                 caption={
-                    showGroupsOptions && !featureFlags[FEATURE_FLAGS.B2B_ANALYTICS]
+                    showGroupsOptions
                         ? 'A catalog of identified persons, groups, and your created cohorts.'
                         : 'A catalog of identified persons and your created cohorts.'
                 }

--- a/frontend/src/scenes/persons-management/personsManagementSceneLogic.tsx
+++ b/frontend/src/scenes/persons-management/personsManagementSceneLogic.tsx
@@ -1,10 +1,8 @@
-import { LemonButton, LemonTag } from '@posthog/lemon-ui'
+import { LemonButton } from '@posthog/lemon-ui'
 import { actions, connect, kea, path, reducers, selectors } from 'kea'
 import { actionToUrl, router, urlToAction } from 'kea-router'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { GroupsAccessStatus } from 'lib/introductions/groupsAccessLogic'
 import { LemonTab } from 'lib/lemon-ui/LemonTabs'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { Cohorts } from 'scenes/cohorts/Cohorts'
 import { Groups } from 'scenes/groups/Groups'
@@ -36,12 +34,7 @@ export const personsManagementSceneLogic = kea<personsManagementSceneLogicType>(
     path(['scenes', 'persons-management', 'personsManagementSceneLogic']),
     connect(() => ({
         actions: [groupsSceneLogic, ['setGroupTypeIndex']],
-        values: [
-            groupsModel,
-            ['aggregationLabel', 'groupTypes', 'groupTypesLoading', 'groupsAccessStatus'],
-            featureFlagLogic,
-            ['featureFlags'],
-        ],
+        values: [groupsModel, ['aggregationLabel', 'groupTypes', 'groupTypesLoading', 'groupsAccessStatus']],
     })),
     actions({
         setTabKey: (tabKey: string) => ({ tabKey }),
@@ -56,8 +49,8 @@ export const personsManagementSceneLogic = kea<personsManagementSceneLogicType>(
     }),
     selectors({
         tabs: [
-            (s) => [s.groupTabs, s.featureFlags],
-            (groupTabs, featureFlags): PersonsManagementTab[] => {
+            (s) => [s.groupTabs],
+            (groupTabs): PersonsManagementTab[] => {
                 return [
                     {
                         key: 'persons',
@@ -82,23 +75,7 @@ export const personsManagementSceneLogic = kea<personsManagementSceneLogicType>(
                         ),
                         tooltipDocLink: 'https://posthog.com/docs/data/cohorts',
                     },
-                    ...(featureFlags[FEATURE_FLAGS.B2B_ANALYTICS]
-                        ? [
-                              {
-                                  key: 'groups',
-                                  label: (
-                                      <div className="flex items-center gap-1">
-                                          <span>Groups → B2B analytics</span>
-                                          <LemonTag type="completion" size="small">
-                                              alpha
-                                          </LemonTag>
-                                      </div>
-                                  ),
-                                  url: urls.groups(0),
-                                  content: null,
-                              },
-                          ]
-                        : groupTabs),
+                    ...groupTabs,
                 ]
             },
         ],
@@ -178,7 +155,7 @@ export const personsManagementSceneLogic = kea<personsManagementSceneLogicType>(
             return [tabUrl, router.values.searchParams, router.values.hashParams, { replace: true }]
         },
     })),
-    urlToAction(({ actions, values }) => {
+    urlToAction(({ actions }) => {
         const urlToAction = {
             [urls.persons()]: () => {
                 actions.setTabKey('persons')
@@ -187,11 +164,9 @@ export const personsManagementSceneLogic = kea<personsManagementSceneLogicType>(
                 actions.setTabKey('cohorts')
             },
         } as Record<string, (...args: any[]) => void>
-        if (!values.featureFlags[FEATURE_FLAGS.B2B_ANALYTICS]) {
-            urlToAction[urls.groups(':key')] = ({ key }: { key: string }) => {
-                actions.setTabKey(`groups-${key}`)
-                actions.setGroupTypeIndex(parseInt(key))
-            }
+        urlToAction[urls.groups(':key')] = ({ key }: { key: string }) => {
+            actions.setTabKey(`groups-${key}`)
+            actions.setGroupTypeIndex(parseInt(key))
         }
         return urlToAction
     }),

--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -2,8 +2,7 @@ import { actions, BuiltLogic, connect, kea, listeners, path, props, reducers, se
 import { router, urlToAction } from 'kea-router'
 import { commandBarLogic } from 'lib/components/CommandBar/commandBarLogic'
 import { BarStatus } from 'lib/components/CommandBar/types'
-import { FEATURE_FLAGS, TeamMembershipLevel } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { TeamMembershipLevel } from 'lib/constants'
 import { getRelativeNextPath } from 'lib/utils'
 import { addProjectIdIfMissing, removeProjectIdIfPresent } from 'lib/utils/router-utils'
 import posthog from 'posthog-js'
@@ -76,14 +75,7 @@ export const sceneLogic = kea<sceneLogicType>([
             sourceWizardLogic,
             ['selectConnector', 'handleRedirect', 'setStep'],
         ],
-        values: [
-            featureFlagLogic,
-            ['featureFlags'],
-            billingLogic,
-            ['billing'],
-            organizationLogic,
-            ['organizationBeingDeleted'],
-        ],
+        values: [billingLogic, ['billing'], organizationLogic, ['organizationBeingDeleted']],
     })),
     actions({
         /* 1. Prepares to open the scene, as the listener may override and do something
@@ -474,7 +466,7 @@ export const sceneLogic = kea<sceneLogicType>([
             }
         },
     })),
-    urlToAction(({ actions, values }) => {
+    urlToAction(({ actions }) => {
         const mapping: Record<
             string,
             (
@@ -496,17 +488,8 @@ export const sceneLogic = kea<sceneLogicType>([
             }
         }
         for (const [path, [scene, sceneKey]] of Object.entries(routes)) {
-            if (
-                values.featureFlags[FEATURE_FLAGS.B2B_ANALYTICS] &&
-                scene === Scene.PersonsManagement &&
-                path === urls.groups(':groupTypeIndex')
-            ) {
-                mapping[path] = (params, searchParams, hashParams, { method }) =>
-                    actions.openScene(Scene.Groups, 'groups', { params, searchParams, hashParams }, method)
-            } else {
-                mapping[path] = (params, searchParams, hashParams, { method }) =>
-                    actions.openScene(scene, sceneKey, { params, searchParams, hashParams }, method)
-            }
+            mapping[path] = (params, searchParams, hashParams, { method }) =>
+                actions.openScene(scene, sceneKey, { params, searchParams, hashParams }, method)
         }
 
         mapping['/*'] = (_, __, { method }) => {


### PR DESCRIPTION
## Problem

We have this `B2B_ANALYTICS` flag, developed by someone who has since left the company. This flag is unlikely to be released, and just moves some pages around in the navbar, nothing else.

## Changes

Remove the flag to make the project tree work easier to manage.

## How did you test this code?

Group pages loaded locally.