### PR TITLE
fix(project-tree): added tags (alpha/beta) to product tree

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -690,10 +690,26 @@ export function ProjectTree({
                         >
                             {item.displayName}
                         </span>
+
                         {sortMethod === 'recent' && projectTreeMode === 'tree' && item.type !== 'loading-indicator' && (
                             <span className="text-tertiary text-xxs pt-[3px] ml-1">
                                 {dayjs(item.record?.created_at).fromNow()}
                             </span>
+                        )}
+
+                        {root === 'products://' && item.tags?.length && (
+                            <>
+                                {item.tags?.map((tag) => (
+                                    <LemonTag
+                                        key={tag}
+                                        type={tag === 'alpha' ? 'completion' : tag === 'beta' ? 'warning' : 'success'}
+                                        size="small"
+                                        className="ml-2 relative top-[-1px]"
+                                    >
+                                        {tag.toUpperCase()}
+                                    </LemonTag>
+                                ))}
+                            </>
                         )}
                     </span>
                 )

--- a/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
@@ -237,6 +237,7 @@ export const getDefaultTreeProducts = (): FileSystemImport[] =>
             href: urls.heatmaps(),
             flag: FEATURE_FLAGS.HEATMAPS_UI,
             visualOrder: PRODUCT_VISUAL_ORDER.heatmaps,
+            tags: ['alpha'],
         } as FileSystemImport,
     ].sort((a, b) => {
         if (a.visualOrder === -1) {

--- a/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/utils.tsx
@@ -108,6 +108,7 @@ export function convertFileSystemEntryToTreeDataItem({
             icon: item._loading ? <Spinner /> : item.shortcut || allShortcuts ? wrapWithShortcutIcon(icon) : icon,
             record: { ...item, user },
             checked: checkedItems[nodeId],
+            tags: item.tags,
         }
         if (item && disabledReason?.(item)) {
             node.disabledReason = disabledReason(item)

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -68,6 +68,9 @@ export type TreeDataItem = {
      * @param open - boolean to indicate if it's a folder and it's open state
      */
     onClick?: (open?: boolean) => void
+
+    /** Tags for the item */
+    tags?: string[]
 }
 export type TreeMode = 'tree' | 'table'
 

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -8,6 +8,7 @@ import {
     IconDashboard,
     IconExternal,
     IconGraph,
+    IconMegaphone,
     IconMessage,
     IconNotebook,
     IconPeople,
@@ -18,7 +19,7 @@ import {
 } from '@posthog/icons'
 import { combineUrl } from 'kea-router'
 import type { AlertType } from 'lib/components/Alerts/types'
-import { FEATURE_FLAGS, PRODUCT_VISUAL_ORDER } from 'lib/constants'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { toParams } from 'lib/utils'
 import type { Params } from 'scenes/sceneTypes'
 import type { SurveysTabs } from 'scenes/surveys/surveysLogic'
@@ -44,6 +45,7 @@ import {
     RecordingUniversalFilters,
     ReplayTabs,
 } from './types'
+import { PRODUCT_VISUAL_ORDER } from './lib/constants'
 
 /** This const is auto-generated, as is the whole file */
 export const productScenes: Record<string, () => Promise<any>> = {
@@ -427,12 +429,14 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         href: urls.messagingBroadcasts(),
         type: 'hog_function/broadcast',
         visualOrder: PRODUCT_VISUAL_ORDER.messaging,
+        tags: ['alpha'],
     },
     {
         path: 'Campaigns',
         href: urls.messagingCampaigns(),
         type: 'hog_function/campaign',
         visualOrder: PRODUCT_VISUAL_ORDER.messaging,
+        tags: ['alpha'],
     },
     { path: 'Dashboards', type: 'dashboard', href: urls.dashboards() },
     { path: 'Early access features', type: 'early_access_feature', href: urls.earlyAccessFeatures() },
@@ -455,6 +459,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         href: urls.llmObservabilityDashboard(),
         flag: FEATURE_FLAGS.LLM_OBSERVABILITY,
         visualOrder: PRODUCT_VISUAL_ORDER.llmObservability,
+        tags: ['beta'],
     },
     {
         path: 'Links',
@@ -462,6 +467,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         href: urls.links(),
         flag: FEATURE_FLAGS.LINKS,
         visualOrder: PRODUCT_VISUAL_ORDER.links,
+        tags: ['alpha'],
     },
     {
         path: 'Logs',
@@ -469,6 +475,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         href: urls.logs(),
         flag: FEATURE_FLAGS.LOGS,
         visualOrder: PRODUCT_VISUAL_ORDER.logs,
+        tags: ['alpha'],
     },
     { path: 'Persons', iconType: 'cohort', href: urls.persons(), visualOrder: PRODUCT_VISUAL_ORDER.persons },
     {
@@ -482,6 +489,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         iconType: 'piggyBank',
         href: urls.revenueAnalytics(),
         visualOrder: PRODUCT_VISUAL_ORDER.revenueAnalytics,
+        tags: ['beta'],
     },
     {
         path: 'Session replay',

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -8,7 +8,6 @@ import {
     IconDashboard,
     IconExternal,
     IconGraph,
-    IconMegaphone,
     IconMessage,
     IconNotebook,
     IconPeople,
@@ -35,6 +34,7 @@ import {
     NodeKind,
 } from '~/queries/schema/schema-general'
 
+import { PRODUCT_VISUAL_ORDER } from './lib/constants'
 import { isDataTableNode, isDataVisualizationNode, isHogQLQuery } from './queries/utils'
 import {
     ActionType,
@@ -45,7 +45,6 @@ import {
     RecordingUniversalFilters,
     ReplayTabs,
 } from './types'
-import { PRODUCT_VISUAL_ORDER } from './lib/constants'
 
 /** This const is auto-generated, as is the whole file */
 export const productScenes: Record<string, () => Promise<any>> = {
@@ -335,7 +334,7 @@ export const fileSystemTypes = {
     early_access_feature: {
         icon: <IconRocket />,
         href: (ref: string) => urls.earlyAccessFeature(ref),
-        iconColor: ['var(--product-early-access-features-light)'],
+        iconColor: ['var(--product-early-access-features-light)', 'var(--product-early-access-features-dark)'],
     },
     experiment: {
         icon: <IconTestTube />,

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -9528,6 +9528,14 @@
                     "description": "Whether this is a shortcut or the actual item",
                     "type": "boolean"
                 },
+                "tags": {
+                    "description": "Tag for the product 'beta' / 'alpha'",
+                    "items": {
+                        "enum": ["alpha", "beta"],
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
                 "type": {
                     "description": "Type of object, used for icon, e.g. feature_flag, insight, etc",
                     "type": "string"
@@ -9575,6 +9583,14 @@
                 "shortcut": {
                     "description": "Whether this is a shortcut or the actual item",
                     "type": "boolean"
+                },
+                "tags": {
+                    "description": "Tag for the product 'beta' / 'alpha'",
+                    "items": {
+                        "enum": ["alpha", "beta"],
+                        "type": "string"
+                    },
+                    "type": "array"
                 },
                 "type": {
                     "description": "Type of object, used for icon, e.g. feature_flag, insight, etc",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2040,6 +2040,8 @@ export interface FileSystemEntry {
     shortcut?: boolean
     /** Used to indicate pending actions, frontend only */
     _loading?: boolean
+    /** Tag for the product 'beta' / 'alpha' */
+    tags?: ('alpha' | 'beta')[]
 }
 
 export interface FileSystemImport extends Omit<FileSystemEntry, 'id'> {
@@ -2048,6 +2050,8 @@ export interface FileSystemImport extends Omit<FileSystemEntry, 'id'> {
     flag?: string
     /** Order of object in tree */
     visualOrder?: number
+    /** Tag for the product 'beta' / 'alpha' */
+    tags?: ('alpha' | 'beta')[]
 }
 
 export interface PersistedFolder {

--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -345,7 +345,8 @@
     --product-user-interviews-light: rgb(0 140 255);
     --product-notebooks-light: rgb(255 7 243);
     --product-dashboards-light: rgb(255 139 7);
-    --product-early-access-features-light: rgb(53 213 189);
+    --product-early-access-features-light: rgb(39 171 151);
+    --product-early-access-features-dark: rgb(53 213 189);
 
     // Generic brand color assignments
     // Change these to change the brand colors

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1689,8 +1689,6 @@ importers:
         specifier: '*'
         version: 18.2.0
 
-  products/editor: {}
-
   products/experiments:
     dependencies:
       '@posthog/icons':
@@ -16257,8 +16255,8 @@ packages:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
 
-  unlayer-types@1.266.0:
-    resolution: {integrity: sha512-0o5P60todvhXUM2ubPxnH9GN3gCWYVC4Bkq9U7CxcgK6EE9ggm2OBXYeBrcUltCkfyJjsoqeJ0Tk8TLG2FcHhg==}
+  unlayer-types@1.268.0:
+    resolution: {integrity: sha512-zCb4tLjcZ96jiWKv6PPxS1LoIw+rHCqMgV9pJjcPzNkN4fc1FDvyeYdzfoTThS89pJdYl4Yb36kuEI5aC7MDTA==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -33084,7 +33082,7 @@ snapshots:
   react-email-editor@1.7.11(react@18.2.0):
     dependencies:
       react: 18.2.0
-      unlayer-types: 1.266.0
+      unlayer-types: 1.268.0
 
   react-error-overlay@6.0.9: {}
 
@@ -35239,7 +35237,7 @@ snapshots:
 
   universalify@2.0.0: {}
 
-  unlayer-types@1.266.0: {}
+  unlayer-types@1.268.0: {}
 
   unpipe@1.0.0: {}
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1075,6 +1075,11 @@ class FileSystemCount(BaseModel):
     count: float
 
 
+class Tag(StrEnum):
+    ALPHA = "alpha"
+    BETA = "beta"
+
+
 class FileSystemEntry(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -1091,6 +1096,7 @@ class FileSystemEntry(BaseModel):
     path: str = Field(..., description="Object's name and folder")
     ref: Optional[str] = Field(default=None, description="Object's ID or other unique reference")
     shortcut: Optional[bool] = Field(default=None, description="Whether this is a shortcut or the actual item")
+    tags: Optional[list[Tag]] = Field(default=None, description="Tag for the product 'beta' / 'alpha'")
     type: Optional[str] = Field(
         default=None, description="Type of object, used for icon, e.g. feature_flag, insight, etc"
     )
@@ -1114,6 +1120,7 @@ class FileSystemImport(BaseModel):
     path: str = Field(..., description="Object's name and folder")
     ref: Optional[str] = Field(default=None, description="Object's ID or other unique reference")
     shortcut: Optional[bool] = Field(default=None, description="Whether this is a shortcut or the actual item")
+    tags: Optional[list[Tag]] = Field(default=None, description="Tag for the product 'beta' / 'alpha'")
     type: Optional[str] = Field(
         default=None, description="Type of object, used for icon, e.g. feature_flag, insight, etc"
     )

--- a/products/early_access_features/manifest.tsx
+++ b/products/early_access_features/manifest.tsx
@@ -36,7 +36,7 @@ export const manifest: ProductManifest = {
         early_access_feature: {
             icon: <IconRocket />,
             href: (ref: string) => urls.earlyAccessFeature(ref),
-            iconColor: ['var(--product-early-access-features-light)'],
+            iconColor: ['var(--product-early-access-features-light)', 'var(--product-early-access-features-dark)'],
         },
     },
     treeItemsNew: [

--- a/products/links/manifest.tsx
+++ b/products/links/manifest.tsx
@@ -55,6 +55,7 @@ export const manifest: ProductManifest = {
             href: urls.links(),
             flag: FEATURE_FLAGS.LINKS,
             visualOrder: PRODUCT_VISUAL_ORDER.links,
+            tags: ['alpha'],
         },
     ],
     fileSystemFilterTypes: {

--- a/products/llm_observability/manifest.tsx
+++ b/products/llm_observability/manifest.tsx
@@ -77,6 +77,7 @@ export const manifest: ProductManifest = {
             href: urls.llmObservabilityDashboard(),
             flag: FEATURE_FLAGS.LLM_OBSERVABILITY,
             visualOrder: PRODUCT_VISUAL_ORDER.llmObservability,
+            tags: ['beta'],
         },
     ],
 }

--- a/products/logs/manifest.tsx
+++ b/products/logs/manifest.tsx
@@ -29,6 +29,7 @@ export const manifest: ProductManifest = {
             href: urls.logs(),
             flag: FEATURE_FLAGS.LOGS,
             visualOrder: PRODUCT_VISUAL_ORDER.logs,
+            tags: ['alpha'],
         },
     ],
 }

--- a/products/messaging/manifest.tsx
+++ b/products/messaging/manifest.tsx
@@ -93,12 +93,14 @@ export const manifest: ProductManifest = {
             href: urls.messagingBroadcasts(),
             type: 'hog_function/broadcast',
             visualOrder: PRODUCT_VISUAL_ORDER.messaging,
+            tags: ['alpha'],
         },
         {
             path: 'Campaigns',
             href: urls.messagingCampaigns(),
             type: 'hog_function/campaign',
             visualOrder: PRODUCT_VISUAL_ORDER.messaging,
+            tags: ['alpha'],
         },
     ],
     fileSystemFilterTypes: {

--- a/products/revenue_analytics/manifest.tsx
+++ b/products/revenue_analytics/manifest.tsx
@@ -26,6 +26,7 @@ export const manifest: ProductManifest = {
             iconType: 'piggyBank',
             href: urls.revenueAnalytics(),
             visualOrder: PRODUCT_VISUAL_ORDER.revenueAnalytics,
+            tags: ['beta'],
         },
     ],
     treeItemsDataManagement: [


### PR DESCRIPTION

## Problem
Products are either live, alpha or beta, in the new UI we didn't have the indicators.
Early access features icon was hard to see in light mode.
<img width="315" alt="image" src="https://github.com/user-attachments/assets/f255fbf6-a12b-4cc9-a787-a6b44ea8892c" />

## Changes
* Added `tags?: ('alpha' | 'beta')[]` in `FileSystemImport`, supporting multiple if needed later
* Fixed `Early access features` icon color was too bright in `light mode`, so made a bit darker.
<img width="502" alt="image" src="https://github.com/user-attachments/assets/91ff69ad-bb07-4ccc-a6b3-87ac2547eced" />

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
