### PR TITLE
fix(experiments): move winsorization above preview

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
@@ -61,12 +61,7 @@ export function ExperimentMetricForm({
     }
 
     const handleMetricTypeChange = (newMetricType: ExperimentMetricType): void => {
-        const newMetric = getDefaultExperimentMetric(newMetricType)
-        // Preserve the existing name when changing metric type
-        handleSetMetric({
-            ...newMetric,
-            name: metric.name,
-        })
+        handleSetMetric(getDefaultExperimentMetric(newMetricType))
     }
 
     const radioOptions = [

--- a/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
@@ -1,7 +1,6 @@
 import { DataWarehousePopoverField } from 'lib/components/TaxonomicFilter/types'
 import { LemonLabel } from 'lib/lemon-ui/LemonLabel'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
-import { useMemo } from 'react'
 import { ActionFilter } from 'scenes/insights/filters/ActionFilter/ActionFilter'
 
 import { Query } from '~/queries/Query/Query'
@@ -81,18 +80,15 @@ export function ExperimentMetricForm({
     ]
 
     const metricFilter = metricToFilter(metric)
-    const previewQuery = useMemo(() => metricToQuery(metric, filterTestAccounts), [metric, filterTestAccounts])
+    const previewQuery = metricToQuery(metric, filterTestAccounts)
 
-    const queryConfig = useMemo(
-        () => ({
-            kind: NodeKind.InsightVizNode,
-            source: previewQuery,
-            showTable: false,
-            showLastComputation: true,
-            showLastComputationRefresh: false,
-        }),
-        [previewQuery]
-    )
+    const queryConfig = {
+        kind: NodeKind.InsightVizNode,
+        source: previewQuery,
+        showTable: false,
+        showLastComputation: true,
+        showLastComputationRefresh: false,
+    }
 
     const hideDeleteBtn = (_: any, index: number): boolean => index === 0
 

--- a/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
@@ -1,7 +1,7 @@
 import { DataWarehousePopoverField } from 'lib/components/TaxonomicFilter/types'
 import { LemonLabel } from 'lib/lemon-ui/LemonLabel'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
-import { useCallback, useMemo } from 'react'
+import { useMemo } from 'react'
 import { ActionFilter } from 'scenes/insights/filters/ActionFilter/ActionFilter'
 
 import { Query } from '~/queries/Query/Query'
@@ -48,48 +48,39 @@ export function ExperimentMetricForm({
     handleSetMetric: (newMetric: ExperimentMetric) => void
     filterTestAccounts: boolean
 }): JSX.Element {
-    const mathAvailability = useMemo(() => getMathAvailability(metric.metric_type), [metric.metric_type])
-    const allowedMathTypes = useMemo(() => getAllowedMathTypes(metric.metric_type), [metric.metric_type])
+    const mathAvailability = getMathAvailability(metric.metric_type)
+    const allowedMathTypes = getAllowedMathTypes(metric.metric_type)
 
-    const handleSetFilters = useCallback(
-        ({ actions, events, data_warehouse }: Partial<FilterType>): void => {
-            const metricConfig = filterToMetricConfig(metric.metric_type, actions, events, data_warehouse)
-            if (metricConfig) {
-                handleSetMetric({
-                    ...metric,
-                    ...metricConfig,
-                })
-            }
+    const handleSetFilters = ({ actions, events, data_warehouse }: Partial<FilterType>): void => {
+        const metricConfig = filterToMetricConfig(metric.metric_type, actions, events, data_warehouse)
+        if (metricConfig) {
+            handleSetMetric({
+                ...metric,
+                ...metricConfig,
+            })
+        }
+    }
+
+    const handleMetricTypeChange = (newMetricType: ExperimentMetricType): void => {
+        handleSetMetric(getDefaultExperimentMetric(newMetricType))
+    }
+
+    const radioOptions = [
+        {
+            value: ExperimentMetricType.FUNNEL,
+            label: 'Funnel',
+            description:
+                'Calculates the percentage of users for whom the metric occurred at least once, useful for measuring conversion rates.',
         },
-        [metric, handleSetMetric]
-    )
-
-    const handleMetricTypeChange = useCallback(
-        (newMetricType: ExperimentMetricType) => {
-            handleSetMetric(getDefaultExperimentMetric(newMetricType))
+        {
+            value: ExperimentMetricType.MEAN,
+            label: 'Mean',
+            description:
+                'Tracks the value of the metric per user, useful for measuring count of clicks, revenue, or other numeric metrics such as session length.',
         },
-        [handleSetMetric]
-    )
+    ]
 
-    const radioOptions = useMemo(
-        () => [
-            {
-                value: ExperimentMetricType.FUNNEL,
-                label: 'Funnel',
-                description:
-                    'Calculates the percentage of users for whom the metric occurred at least once, useful for measuring conversion rates.',
-            },
-            {
-                value: ExperimentMetricType.MEAN,
-                label: 'Mean',
-                description:
-                    'Tracks the value of the metric per user, useful for measuring count of clicks, revenue, or other numeric metrics such as session length.',
-            },
-        ],
-        []
-    )
-
-    const metricFilter = useMemo(() => metricToFilter(metric), [metric])
+    const metricFilter = metricToFilter(metric)
     const previewQuery = useMemo(() => metricToQuery(metric, filterTestAccounts), [metric, filterTestAccounts])
 
     const queryConfig = useMemo(
@@ -103,7 +94,7 @@ export function ExperimentMetricForm({
         [previewQuery]
     )
 
-    const hideDeleteBtn = useCallback((_: any, index: number) => index === 0, [])
+    const hideDeleteBtn = (_: any, index: number): boolean => index === 0
 
     return (
         <div className="deprecated-space-y-4">

--- a/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
@@ -61,7 +61,12 @@ export function ExperimentMetricForm({
     }
 
     const handleMetricTypeChange = (newMetricType: ExperimentMetricType): void => {
-        handleSetMetric(getDefaultExperimentMetric(newMetricType))
+        const newMetric = getDefaultExperimentMetric(newMetricType)
+        // Preserve the existing name when changing metric type
+        handleSetMetric({
+            ...newMetric,
+            name: metric.name,
+        })
     }
 
     const radioOptions = [

--- a/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
@@ -148,6 +148,10 @@ export function ExperimentMetricForm({
                     />
                 )}
             </div>
+            <ExperimentMetricConversionWindowFilter metric={metric} handleSetMetric={handleSetMetric} />
+            {metric.metric_type === ExperimentMetricType.MEAN && (
+                <ExperimentMetricOutlierHandling metric={metric} handleSetMetric={handleSetMetric} />
+            )}
             <div>
                 <LemonLabel
                     className="mb-1"
@@ -168,10 +172,6 @@ export function ExperimentMetricForm({
             {metric.metric_type === ExperimentMetricType.MEAN &&
                 metric.source.kind !== NodeKind.ExperimentDataWarehouseNode && <Query query={queryConfig} readOnly />}
             {metric.metric_type === ExperimentMetricType.FUNNEL && <Query query={queryConfig} readOnly />}
-            <ExperimentMetricConversionWindowFilter metric={metric} handleSetMetric={handleSetMetric} />
-            {metric.metric_type === ExperimentMetricType.MEAN && (
-                <ExperimentMetricOutlierHandling metric={metric} handleSetMetric={handleSetMetric} />
-            )}
         </div>
     )
 }


### PR DESCRIPTION
## Problem

Winsorization is currently hidden below preview, unless you have a very big screen.

~~The whole page is re-rendered when editing a metric. This is very annoying and resource intensive on slower computers. Inputting a metric title is lagging. This has been reported in a support ticket already.~~

https://github.com/user-attachments/assets/0e56f107-c154-4401-b6ec-5ddc9cf5c34e

## Changes

EDIT: goes against our conventions to have local state like this. But I was not able to move this to Kea without adding too much code, so skipping the optimization for now.

So the only change here then is:
- Move the hidden conversion window and winsorization features above the preview
- Refactor to remove some code repetition

Only update a local metric state in the form, and then update the experiment when the form is saved. This avoids re-rendering of the whole page on every keystroke.

https://github.com/user-attachments/assets/2d6c1502-4e80-48ba-9c43-1a4e63c410e5

## How did you test this code?
- 👀 
