### PR TITLE
feat(project-tree): hide panel when dragging below threshold

### DIFF
--- a/frontend/src/layout/panel-layout/PanelLayoutPanel.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutPanel.tsx
@@ -57,6 +57,10 @@ const panelLayoutPanelVariants = cva({
             true: 'absolute top-0 left-[var(--panel-layout-mobile-offset)] bottom-0 z-[var(--z-layout-panel)]',
             false: '',
         },
+        panelWillHide: {
+            true: 'opacity-50',
+            false: '',
+        },
     },
     compoundVariants: [
         {
@@ -176,13 +180,8 @@ export function PanelLayoutPanel({
     children,
     showFilterDropdown = false,
 }: PanelLayoutPanelProps): JSX.Element {
-    const { toggleLayoutPanelPinned, setPanelWidth } = useActions(panelLayoutLogic)
-    const {
-        isLayoutPanelPinned,
-        panelTreeRef,
-        isLayoutNavCollapsed,
-        panelWidth: computedPanelWidth,
-    } = useValues(panelLayoutLogic)
+    const { toggleLayoutPanelPinned, setPanelWidth, setPanelIsResizing, showLayoutPanel} = useActions(panelLayoutLogic)
+    const { isLayoutPanelPinned, isLayoutNavCollapsed, panelWidth: computedPanelWidth, panelWillHide } = useValues(panelLayoutLogic)
     const containerRef = useRef<HTMLDivElement | null>(null)
     const { mobileLayout: isMobileLayout } = useValues(navigation3000Logic)
     const { projectTreeMode } = useValues(projectTreeLogic({ key: PROJECT_TREE_KEY }))
@@ -194,6 +193,7 @@ export function PanelLayoutPanel({
                     projectTreeMode: projectTreeMode,
                     isLayoutNavCollapsed,
                     isMobileLayout,
+                    panelWillHide,
                 })
             )}
             ref={containerRef}
@@ -292,6 +292,8 @@ export function PanelLayoutPanel({
             aria-label="Resize handle for panel layout panel"
             borderPosition="right"
             innerClassName="z-[var(--z-layout-panel)]"
+            onResizeStart={() => setPanelIsResizing(true)}
+            onResizeEnd={() => setPanelIsResizing(false)}
         >
             {panelContents}
         </ResizableElement>

--- a/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
+++ b/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
@@ -1,4 +1,4 @@
-import { actions, connect, kea, path, reducers, selectors, listeners } from 'kea'
+import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { LemonTreeRef } from 'lib/lemon-ui/LemonTree/LemonTree'
 
 import { navigation3000Logic } from '../navigation-3000/navigationLogic'
@@ -132,26 +132,14 @@ export const panelLayoutLogic = kea<panelLayoutLogicType>([
         panelWillHide: [
             false,
             {
-                setPanelWillHide: (_, { willHide }) => willHide,
+                showLayoutPanel: (state, { visible }) => (visible ? false : state),
+                setPanelWidth: (_, { width }) => width <= PANEL_LAYOUT_MIN_WIDTH - 1,
             },
         ],
     }),
     listeners(({ actions, values }) => ({
-        showLayoutPanel: ({ visible }) => {
-            if (visible) {
-                actions.setPanelWillHide(false)
-            }
-        },
-        // We add a visual cue to the panel when it's at or below the minimum width
-        setPanelWidth: ({ width }) => {
-            if (width <= PANEL_LAYOUT_MIN_WIDTH - 1) {
-                actions.setPanelWillHide(true)
-            } else {
-                actions.setPanelWillHide(false)
-            }
-        },
-        // If we're not resizing and the panel is at or below the minimum width, hide it
         setPanelIsResizing: ({ isResizing }) => {
+            // If we're not resizing and the panel is at or below the minimum width, hide it
             if (!isResizing && values.panelWidth <= PANEL_LAYOUT_MIN_WIDTH - 1) {
                 actions.showLayoutPanel(false)
                 actions.clearActivePanelIdentifier()

--- a/frontend/src/lib/components/ResizeElement/ResizeElement.tsx
+++ b/frontend/src/lib/components/ResizeElement/ResizeElement.tsx
@@ -50,15 +50,18 @@ export function ResizableElement({
         currentWidthRef.current = newWidth
     }, [])
 
-    const handleMouseDown = useCallback((e: React.MouseEvent | React.TouchEvent) => {
-        document.body.classList.add('is-resizing')
-        const clientX = 'touches' in e ? e.touches[0].clientX : e.clientX
-        startXRef.current = clientX
-        startWidthRef.current = currentWidthRef.current
-        isResizing.current = true
-        e.preventDefault()
-        onResizeStart?.()
-    }, [onResizeStart])
+    const handleMouseDown = useCallback(
+        (e: React.MouseEvent | React.TouchEvent) => {
+            document.body.classList.add('is-resizing')
+            const clientX = 'touches' in e ? e.touches[0].clientX : e.clientX
+            startXRef.current = clientX
+            startWidthRef.current = currentWidthRef.current
+            isResizing.current = true
+            e.preventDefault()
+            onResizeStart?.()
+        },
+        [onResizeStart]
+    )
 
     const handleMove = useCallback(
         (clientX: number) => {

--- a/frontend/src/lib/components/ResizeElement/ResizeElement.tsx
+++ b/frontend/src/lib/components/ResizeElement/ResizeElement.tsx
@@ -11,6 +11,8 @@ type ResizableElementProps = {
     innerClassName?: string
     style?: React.CSSProperties
     borderPosition?: 'center' | 'left' | 'right'
+    onResizeStart?: () => void
+    onResizeEnd?: () => void
 }
 
 export function ResizableElement({
@@ -23,6 +25,8 @@ export function ResizableElement({
     innerClassName,
     style,
     borderPosition = 'center',
+    onResizeStart,
+    onResizeEnd,
     ...props
 }: ResizableElementProps): JSX.Element {
     const [width, setWidth] = useState(defaultWidth)
@@ -53,7 +57,8 @@ export function ResizableElement({
         startWidthRef.current = currentWidthRef.current
         isResizing.current = true
         e.preventDefault()
-    }, [])
+        onResizeStart?.()
+    }, [onResizeStart])
 
     const handleMove = useCallback(
         (clientX: number) => {
@@ -112,8 +117,9 @@ export function ResizableElement({
                 rafRef.current = null
             }
             document.body.classList.remove('is-resizing')
+            onResizeEnd?.()
         }
-    }, [])
+    }, [onResizeEnd])
 
     // Use effect for adding/removing global event listeners
     useEffect(() => {

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -495,8 +495,7 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                                                     }}
                                                     className={cn('absolute z-2', {
                                                         // Hide checkboxwhen select mode is default/folder only
-                                                        hidden:
-                                                            selectMode === 'default' || selectMode === 'folder-only',
+                                                        hidden: selectMode === 'default',
                                                     })}
                                                     style={{
                                                         left: `${firstColumnOffset - 20}px`,

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -495,7 +495,8 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                                                     }}
                                                     className={cn('absolute z-2', {
                                                         // Hide checkboxwhen select mode is default/folder only
-                                                        hidden: selectMode === 'default',
+                                                        hidden:
+                                                            selectMode === 'default' || selectMode === 'folder-only',
                                                     })}
                                                     style={{
                                                         left: `${firstColumnOffset - 20}px`,


### PR DESCRIPTION
## Problem
People wanted to man-handle the panel and force it closed
![2025-05-27 11 39 55](https://github.com/user-attachments/assets/4342b466-2fb1-4dfb-82b2-98e1d6ed46fc)

## Changes
Add logic to watch for width/resizing and if below a certain width, hide panel
+ Bonus, visual cue that the panel will hide (opacity 50%)

Note: I purposefully didn't implement double click because: a) it's really difficult to do... and b) it's really hard to do. So maybe later.

## How did you test this code?
Manually