### PR TITLE
fix: stop copying all the snapshotdata on every response

### DIFF
--- a/frontend/src/scenes/session-recordings/file-playback/sessionRecordingFilePlaybackSceneLogic.ts
+++ b/frontend/src/scenes/session-recordings/file-playback/sessionRecordingFilePlaybackSceneLogic.ts
@@ -29,7 +29,7 @@ export const parseExportedSessionRecording = (fileData: string): ExportedSession
         return {
             version: '2023-04-28',
             data: {
-                id: '', // This wasn't available in previous version
+                id: '', // This wasn't available in a previous version
                 person: data.data.person || undefined,
                 snapshots: Object.entries(data.data.snapshotsByWindowId)
                     .flatMap(([windowId, snapshots]) => {
@@ -51,7 +51,7 @@ export const parseExportedSessionRecording = (fileData: string): ExportedSession
  *
  * This method waits for the dataLogic to be mounted and returns it
  *
- * in practice, it will only wait for 1-2 retries
+ * in practice, it will only wait for 1-2 retries,
  * but a timeout is provided to avoid waiting forever when something breaks
  */
 const waitForDataLogic = async (playerKey: string): Promise<BuiltLogic<sessionRecordingDataLogicType>> => {
@@ -138,8 +138,13 @@ export const sessionRecordingFilePlaybackSceneLogic = kea<sessionRecordingFilePl
             const snapshots = values.sessionRecording.snapshots
 
             // Simulate a loaded source and sources so that nothing extra gets loaded
+            dataLogic.cache.snapshotsBySource = {
+                'file-file': {
+                    snapshots: snapshots,
+                    source: { source: 'file' },
+                },
+            }
             dataLogic.actions.loadSnapshotsForSourceSuccess({
-                snapshots: snapshots,
                 source: { source: 'file' },
             })
             dataLogic.actions.loadSnapshotSourcesSuccess([{ source: 'file' }])

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.test.ts
@@ -267,6 +267,7 @@ describe('sessionRecordingDataLogic', () => {
                 ])
                 .toDispatchActions([sessionRecordingEventUsageLogic.actionTypes.reportRecording])
         })
+
         it('sends `recording viewed` and `recording analyzed` event on first contentful paint', async () => {
             await expectLogic(logic, () => {
                 logic.actions.loadSnapshots()

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -784,7 +784,7 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
                 viewportForTimestamp,
                 sessionRecordingId,
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                _snapshotsBySourceSuccessCount
+                _snapshotsBySourceSuccessCocopyunt
             ): RecordingSnapshot[] => {
             if (!sources || !cache.snapshotsBySource) {
                 return []

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1068,6 +1068,7 @@ export type SessionRecordingSnapshotParams =
 
 export interface SessionRecordingSnapshotSourceResponse {
     source: Pick<SessionRecordingSnapshotSource, 'source' | 'blob_key'>
+    snapshots?: RecordingSnapshot[]
 }
 
 export interface SessionRecordingSnapshotResponse {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1068,7 +1068,6 @@ export type SessionRecordingSnapshotParams =
 
 export interface SessionRecordingSnapshotSourceResponse {
     source: Pick<SessionRecordingSnapshotSource, 'source' | 'blob_key'>
-    snapshots?: RecordingSnapshot[]
 }
 
 export interface SessionRecordingSnapshotResponse {


### PR DESCRIPTION
in the replay data logic we copy all of the snapshot sources because of kea's immutability
it's probably fine since we're copying the object
but it's making [the multi-block PR](https://github.com/PostHog/posthog/pull/32649) more confusing
so let's not do it