### PR TITLE
fix(data-warehouse): Fix updating BigQuery source config

### DIFF
--- a/posthog/temporal/tests/batch_exports/test_monitoring.py
+++ b/posthog/temporal/tests/batch_exports/test_monitoring.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 import pytest_asyncio
+from freezegun import freeze_time
 from temporalio.common import RetryPolicy
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
@@ -28,9 +29,8 @@ from posthog.temporal.tests.utils.models import (
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
 
-GENERATE_TEST_DATA_END = dt.datetime.now(tz=dt.UTC).replace(
-    minute=0, second=0, microsecond=0, tzinfo=dt.UTC
-) - dt.timedelta(hours=1)
+NOW = dt.datetime.now(tz=dt.UTC)
+GENERATE_TEST_DATA_END = NOW.replace(minute=0, second=0, microsecond=0, tzinfo=dt.UTC) - dt.timedelta(hours=1)
 GENERATE_TEST_DATA_START = GENERATE_TEST_DATA_END - dt.timedelta(hours=1)
 
 
@@ -157,6 +157,7 @@ async def test_monitoring_workflow_when_no_event_data(batch_export):
     "simulate_missing_batch_export_runs",
     [True, False],
 )
+@freeze_time(NOW)
 async def test_monitoring_workflow(
     simulate_missing_batch_export_runs,
     batch_export,

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -234,6 +234,7 @@ class ExternalDataSourceSerializers(serializers.ModelSerializer):
             "project_id",
             "client_email",
             "token_uri",
+            "temporary-dataset",
         }
         job_inputs = representation.get("job_inputs", {})
         if isinstance(job_inputs, dict):
@@ -252,6 +253,13 @@ class ExternalDataSourceSerializers(serializers.ModelSerializer):
                     },
                 }
                 job_inputs["ssh-tunnel"] = ssh_tunnel
+
+            # Reconstruct BigQuery structure for UI handling
+            if job_inputs.get("using_temporary_dataset") == "True":  # encyrpted as string
+                job_inputs["temporary-dataset"] = {
+                    "enabled": True,
+                    "temporary_dataset_id": job_inputs.pop("temporary_dataset_id", None),
+                }
 
             # Remove sensitive fields
             for key in list(job_inputs.keys()):  # Use list() to avoid modifying dict during iteration
@@ -312,6 +320,9 @@ class ExternalDataSourceSerializers(serializers.ModelSerializer):
             # values without a prefix.
             # TODO: Integrate configuration class here.
             new_job_inputs = {f"zendesk_{k}": v for k, v in new_job_inputs.items()}
+
+        elif instance.source_type == ExternalDataSource.Type.BIGQUERY:
+            new_job_inputs = parse_bigquery_job_inputs(new_job_inputs)
 
         if existing_job_inputs:
             validated_data["job_inputs"] = {**existing_job_inputs, **new_job_inputs}
@@ -781,34 +792,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         prefix = request.data.get("prefix", None)
         source_type = request.data["source_type"]
 
-        key_file = payload.get("key_file", {})
-        project_id = key_file.get("project_id")
-
-        dataset_id = payload.get("dataset_id")
-        # Very common to include the project_id as a prefix of the dataset_id.
-        # We remove it if it's there.
-        if dataset_id:
-            dataset_id = dataset_id.removeprefix(f"{project_id}.")
-
-        private_key = key_file.get("private_key")
-        private_key_id = key_file.get("private_key_id")
-        client_email = key_file.get("client_email")
-        token_uri = key_file.get("token_uri")
-
-        temporary_dataset = request.data.get("temporary-dataset", {})
-        using_temporary_dataset = temporary_dataset.get("enabled", False)
-        temporary_dataset_id = temporary_dataset.get("temporary_dataset_id", None)
-
-        job_inputs = {
-            "dataset_id": dataset_id,
-            "project_id": project_id,
-            "private_key": private_key,
-            "private_key_id": private_key_id,
-            "client_email": client_email,
-            "token_uri": token_uri,
-            "using_temporary_dataset": using_temporary_dataset,
-            "temporary_dataset_id": temporary_dataset_id,
-        }
+        job_inputs = parse_bigquery_job_inputs(payload)
 
         required_inputs = {"private_key", "private_key_id", "client_email", "dataset_id", "project_id", "token_uri"}
         have_all_required = all(job_inputs.get(input_name, None) is not None for input_name in required_inputs)
@@ -1437,4 +1421,35 @@ def parse_snowflake_job_inputs(payload: dict[str, Any]) -> dict[str, Any]:
         "password": auth_type_password,
         "passphrase": auth_type_passphrase,
         "private_key": auth_type_private_key,
+    }
+
+
+def parse_bigquery_job_inputs(payload: dict[str, Any]) -> dict[str, Any]:
+    key_file = payload.get("key_file", {})
+    project_id = key_file.get("project_id")
+
+    dataset_id = payload.get("dataset_id")
+    # Very common to include the project_id as a prefix of the dataset_id.
+    # We remove it if it's there.
+    if dataset_id:
+        dataset_id = dataset_id.removeprefix(f"{project_id}.")
+
+    private_key = key_file.get("private_key")
+    private_key_id = key_file.get("private_key_id")
+    client_email = key_file.get("client_email")
+    token_uri = key_file.get("token_uri")
+
+    temporary_dataset = payload.get("temporary-dataset", {})
+    using_temporary_dataset = temporary_dataset.get("enabled", False)
+    temporary_dataset_id = temporary_dataset.get("temporary_dataset_id", None)
+
+    return {
+        "dataset_id": dataset_id,
+        "project_id": project_id,
+        "private_key": private_key,
+        "private_key_id": private_key_id,
+        "client_email": client_email,
+        "token_uri": token_uri,
+        "using_temporary_dataset": using_temporary_dataset,
+        "temporary_dataset_id": temporary_dataset_id,
     }

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -255,7 +255,7 @@ class ExternalDataSourceSerializers(serializers.ModelSerializer):
                 job_inputs["ssh-tunnel"] = ssh_tunnel
 
             # Reconstruct BigQuery structure for UI handling
-            if job_inputs.get("using_temporary_dataset") == "True":  # encyrpted as string
+            if job_inputs.get("using_temporary_dataset") == "True":  # encrypted as string
                 job_inputs["temporary-dataset"] = {
                     "enabled": True,
                     "temporary_dataset_id": job_inputs.pop("temporary_dataset_id", None),


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

At the moment there are numerous issues with updating the config for a BigQuery source:
- updating the `temporary-dataset` doesn't work
- updating the service account doesn't work
- the frontend form doesn't reflect the `temporary-dataset` settings

## Changes

Update the source config handling for BigQuery:
- support file uploads in the update form in the frontend
- map the `temporary-dataset` fields correctly

## Did you write or update any docs for this change?

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Tested locally. Also added unit test to cover API.
