### PR TITLE
fix(data-warehouse): Support numeric characters in Zendesk subdomain

### DIFF
--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -939,7 +939,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             api_key = request.data.get("api_key", "")
             email_address = request.data.get("email_address", "")
 
-            subdomain_regex = re.compile("^[a-zA-Z-]+$")
+            subdomain_regex = re.compile("^[a-zA-Z0-9-]+$")
             if not subdomain_regex.match(subdomain):
                 return Response(
                     status=status.HTTP_400_BAD_REQUEST,


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We don't support numeric characters in Zendesk subdomains, even though [these are valid](https://support.zendesk.com/hc/en-us/articles/4408845973914-Renaming-your-subdomain#ariaid-title7)

## Changes

Update subdomain regex

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

I didn't
