### PR TITLE
fix(experiments): preserve variant order in exposures

### DIFF
--- a/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_exposures_query_runner.py
@@ -239,8 +239,20 @@ class ExperimentExposuresQueryRunner(QueryRunner):
                 variant=variant, days=sorted_days, exposure_counts=cumulative_counts
             )
 
+        # Sort timeseries by original variant order, with MULTIPLE_VARIANT_KEY last
+        ordered_timeseries = []
+
+        # Add variants in original order
+        for variant in self.variants:
+            if variant in variant_series:
+                ordered_timeseries.append(variant_series[variant])
+
+        # Add MULTIPLE_VARIANT_KEY last if present
+        if MULTIPLE_VARIANT_KEY in variant_series:
+            ordered_timeseries.append(variant_series[MULTIPLE_VARIANT_KEY])
+
         return ExperimentExposureQueryResponse(
-            timeseries=list(variant_series.values()),
+            timeseries=ordered_timeseries,
             total_exposures={variant: int(series.exposure_counts[-1]) for variant, series in variant_series.items()},
             date_range=self.date_range,
         )


### PR DESCRIPTION
## Problem
The order of variants in the exposures table appears random, based on how the exposure query returns them. This is confusing, as the list is neither sorted by count nor follows the original variant order:
<img width="275" alt="image" src="https://github.com/user-attachments/assets/ccfb133c-1768-4707-9516-a58544cfa8af" />

## Changes
Preserve the original variant order, with `$multiple` always being last:
<img width="258" alt="image" src="https://github.com/user-attachments/assets/a9302dc9-7bc2-4e75-8330-23860f09fa34" />

## How did you test this code?
👀 