### PR TITLE
fix: register early access task + add debugging

### DIFF
--- a/posthog/tasks/__init__.py
+++ b/posthog/tasks/__init__.py
@@ -21,6 +21,7 @@ from . import (
     user_identify,
     verify_persons_data_in_sync,
     warehouse,
+    early_access_feature,
 )
 
 __all__ = [
@@ -44,4 +45,5 @@ __all__ = [
     "user_identify",
     "verify_persons_data_in_sync",
     "warehouse",
+    "early_access_feature",
 ]

--- a/posthog/tasks/early_access_feature.py
+++ b/posthog/tasks/early_access_feature.py
@@ -1,16 +1,33 @@
 from celery import shared_task
 import structlog
+from posthog.cloud_utils import is_cloud
 from posthog.models import EarlyAccessFeature
 from posthog.models.person.person import Person
 import posthoganalytics
+from django.conf import settings
 
 logger = structlog.get_logger(__name__)
+
+POSTHOG_TEAM_ID = 2
 
 
 # Note: If the task fails and is retried, events may be sent multiple times. This is handled by Customer.io when consuming the events.
 @shared_task(ignore_result=True, max_retries=1)
 def send_events_for_early_access_feature_stage_change(feature_id: str, from_stage: str, to_stage: str) -> None:
+    print(
+        f"[CELERY][EARLY ACCESS FEATURE] Sending events for early access feature stage change for feature {feature_id} from {from_stage} to {to_stage}"
+    )  # noqa: T201
     instance = EarlyAccessFeature.objects.get(id=feature_id)
+
+    team_id = instance.team.id
+
+    send_events_for_change = (team_id is POSTHOG_TEAM_ID and is_cloud()) or settings.DEBUG
+
+    if not send_events_for_change:
+        print(  # noqa: T201
+            f"[CELERY][EARLY ACCESS FEATURE] Skipping sending events for early access feature stage change for feature because it's not the PostHog team"
+        )
+        return
 
     feature_flag = instance.feature_flag
 
@@ -32,10 +49,7 @@ def send_events_for_early_access_feature_stage_change(feature_id: str, from_stag
         **{f"properties__$feature_enrollment/{feature_flag.key}": True, "team_id": instance.team_id}
     )
 
-    logger.info(
-        f"[CELERY][EARLY ACCESS FEATURE] Found {len(enrolled_persons)} persons enrolled in feature",
-        feature_id=feature_id,
-    )
+    print(f"[CELERY][EARLY ACCESS FEATURE] Found {len(enrolled_persons)} persons enrolled in feature {feature_id}")  # noqa: T201
 
     for person in enrolled_persons:
         if len(person.distinct_ids) == 0:
@@ -48,12 +62,7 @@ def send_events_for_early_access_feature_stage_change(feature_id: str, from_stag
         distinct_id = person.distinct_ids[0]
         email = person.properties.get("email", "")
 
-        logger.info(
-            f"[CELERY][EARLY ACCESS FEATURE] Sending event for person",
-            person_id=person.id,
-            distinct_id=distinct_id,
-            email=email,
-        )
+        print(f"[CELERY][EARLY ACCESS FEATURE] Sending event for person {person.id} with distinct_id {distinct_id}")  # noqa: T201
 
         posthoganalytics.capture(
             distinct_id,
@@ -68,9 +77,4 @@ def send_events_for_early_access_feature_stage_change(feature_id: str, from_stag
             },
         )
 
-        logger.info(
-            f"[CELERY][EARLY ACCESS FEATURE] Sent event for person",
-            person_id=person.id,
-            distinct_id=distinct_id,
-            email=email,
-        )
+        print(f"[CELERY][EARLY ACCESS FEATURE] Sent event for person {person.id} with distinct_id {distinct_id}")  # noqa: T201

--- a/posthog/tasks/early_access_feature.py
+++ b/posthog/tasks/early_access_feature.py
@@ -21,7 +21,7 @@ def send_events_for_early_access_feature_stage_change(feature_id: str, from_stag
 
     team_id = instance.team.id
 
-    send_events_for_change = (team_id is POSTHOG_TEAM_ID and is_cloud()) or settings.DEBUG
+    send_events_for_change = (team_id == POSTHOG_TEAM_ID and is_cloud()) or settings.DEBUG
 
     if not send_events_for_change:
         print(  # noqa: T201

--- a/posthog/tasks/early_access_feature.py
+++ b/posthog/tasks/early_access_feature.py
@@ -14,9 +14,9 @@ POSTHOG_TEAM_ID = 2
 # Note: If the task fails and is retried, events may be sent multiple times. This is handled by Customer.io when consuming the events.
 @shared_task(ignore_result=True, max_retries=1)
 def send_events_for_early_access_feature_stage_change(feature_id: str, from_stage: str, to_stage: str) -> None:
-    print(
+    print(  # noqa: T201
         f"[CELERY][EARLY ACCESS FEATURE] Sending events for early access feature stage change for feature {feature_id} from {from_stage} to {to_stage}"
-    )  # noqa: T201
+    )
     instance = EarlyAccessFeature.objects.get(id=feature_id)
 
     team_id = instance.team.id

--- a/posthog/tasks/early_access_feature.py
+++ b/posthog/tasks/early_access_feature.py
@@ -1,6 +1,6 @@
 from celery import shared_task
 import structlog
-from posthog.cloud_utils import is_cloud
+from posthog.cloud_utils import is_ci, is_cloud
 from posthog.models import EarlyAccessFeature
 from posthog.models.person.person import Person
 import posthoganalytics
@@ -21,7 +21,7 @@ def send_events_for_early_access_feature_stage_change(feature_id: str, from_stag
 
     team_id = instance.team.id
 
-    send_events_for_change = (team_id == POSTHOG_TEAM_ID and is_cloud()) or settings.DEBUG
+    send_events_for_change = (team_id == POSTHOG_TEAM_ID and is_cloud()) or settings.DEBUG or is_ci()
 
     if not send_events_for_change:
         print(  # noqa: T201


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Task wasn't being picked up by the auto registration correctly - also celery isn't working with our logger.

## Changes

Use print for debugging, add task to `__init__.py` for registration
