### PR TITLE
fix(project-tree): consistency across folder selects

### DIFF
--- a/frontend/src/layout/panel-layout/PinnedFolder/PinnedFolder.tsx
+++ b/frontend/src/layout/panel-layout/PinnedFolder/PinnedFolder.tsx
@@ -52,7 +52,12 @@ export function PinnedFolder(): JSX.Element {
                     }
                 >
                     <div className="w-192 max-w-full">
-                        <FolderSelect value={selectedFolder} onChange={setSelectedFolder} includeProtocol />
+                        <FolderSelect
+                            value={selectedFolder}
+                            onChange={setSelectedFolder}
+                            includeProtocol
+                            className="h-[60vh] min-h-[200px]"
+                        />
                     </div>
                 </LemonModal>
             ) : null}

--- a/frontend/src/lib/components/FolderSelect/FolderSelect.tsx
+++ b/frontend/src/lib/components/FolderSelect/FolderSelect.tsx
@@ -1,4 +1,3 @@
-import { IconCheckCircle } from '@posthog/icons'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
@@ -10,6 +9,8 @@ import { ReactNode, useEffect, useRef, useState } from 'react'
 
 import { projectTreeLogic, ProjectTreeLogicProps } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
 import { FileSystemEntry } from '~/queries/schema/schema-general'
+
+import { ScrollableShadows } from '../ScrollableShadows/ScrollableShadows'
 
 export interface FolderSelectProps {
     /** The folder to select */
@@ -53,7 +54,6 @@ export function FolderSelect({
         toggleFolderOpen,
     } = useActions(projectTreeLogic(props))
     const treeRef = useRef<LemonTreeRef>(null)
-    const [selectedFolder, setSelectedFolder] = useState<string | undefined>(value)
 
     useEffect(() => {
         if (includeProtocol) {
@@ -114,7 +114,7 @@ export function FolderSelect({
                 onChange={(search) => setSearchTerm(search)}
                 value={searchTerm}
             />
-            <div className={clsx('bg-surface-primary p-2 border rounded-[var(--radius)] overflow-y-scroll', className)}>
+            <ScrollableShadows direction="vertical" className={clsx('bg-surface-primary border rounded', className)}>
                 <LemonTree
                     ref={treeRef}
                     selectMode="folder-only"
@@ -141,29 +141,13 @@ export function FolderSelect({
                     onFolderClick={(folder, isExpanded) => {
                         if (folder) {
                             if (includeProtocol) {
-                                setSelectedFolder(folder.id)
                                 toggleFolderOpen(folder.id, isExpanded)
                                 onChange?.(folder.id)
                             } else {
-                                setSelectedFolder(folder.record?.path)
                                 toggleFolderOpen(folder.id || '', isExpanded)
                                 onChange?.(folder.record?.path ?? '')
                             }
                         }
-                    }}
-                    renderItem={(item) => {
-                        return (
-                            <span>
-                                {item.record?.path === selectedFolder ? (
-                                    <span className="flex items-center gap-1">
-                                        {item.displayName}
-                                        <IconCheckCircle className="size-4 text-success" />
-                                    </span>
-                                ) : (
-                                    item.displayName
-                                )}
-                            </span>
-                        )
                     }}
                     expandedItemIds={searchTerm ? expandedSearchFolders : expandedFolders}
                     onSetExpandedItemIds={searchTerm ? setExpandedSearchFolders : setExpandedFolders}
@@ -186,7 +170,7 @@ export function FolderSelect({
                         )
                     }}
                 />
-            </div>
+            </ScrollableShadows>
         </div>
     )
 }

--- a/frontend/src/lib/components/MoveTo/MoveTo.tsx
+++ b/frontend/src/lib/components/MoveTo/MoveTo.tsx
@@ -1,3 +1,4 @@
+import { LemonSnack } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { FolderSelect } from 'lib/components/FolderSelect/FolderSelect'
@@ -10,14 +11,19 @@ export function MoveToModal(): JSX.Element {
     const { isOpen, form, movingItems } = useValues(moveToLogic)
     const { closeMoveToModal, submitForm } = useActions(moveToLogic)
 
+    const destinationFolder = form.folder || 'Project root'
+
     return (
         <LemonModal
             onClose={closeMoveToModal}
             isOpen={isOpen}
             title="Select a folder to move to"
-            description={`You are moving ${movingItems.length} item${movingItems.length === 1 ? '' : 's'} to ${
-                form.folder || 'Project root'
-            }`}
+            description={
+                <>
+                    You are moving {movingItems.length} item{movingItems.length === 1 ? '' : 's'} to{' '}
+                    <LemonSnack>{destinationFolder}</LemonSnack>`
+                </>
+            }
             // This is a bit of a hack. Without it, the flow "insight" -> "add to dashboard button" ->
             // "new dashboard template picker modal" -> "save dashboard to modal" wouldn't work.
             // Since MoveToModal is added to the DOM earlier as part of global modals, it's below it in hierarchy.
@@ -26,7 +32,7 @@ export function MoveToModal(): JSX.Element {
                 <>
                     <div className="flex-1" />
                     <LemonButton type="primary" onClick={submitForm}>
-                        Move
+                        Move to {destinationFolder}
                     </LemonButton>
                 </>
             }


### PR DESCRIPTION
## Problem
Pinned folder and Move to used `<FolderSelect>`, and they both were a bit different.

## Changes
Set height and min-height `PinnedFolder`'s `<FolderSelect>` (to copy `MoveTo`)
Set the selected folder in `PinnedFolder` button (to copy `MoveTo`)
Removed iconCheckmark from `MoveTo`'s selected folder, we'll use the background image as denoting selection

## How did you test this code?
Manually