### PR TITLE
chore(ci): pin dorny/paths-filter to v3.0.2

### DIFF
--- a/.github/workflows/container-images-ci.yml
+++ b/.github/workflows/container-images-ci.yml
@@ -17,7 +17,7 @@ jobs:
         outputs:
             docker_files: ${{ steps.filter.outputs.docker_files }}
         steps:
-            - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
+            - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
               id: filter
               with:
                   predicate-quantifier: 'every'


### PR DESCRIPTION
## Problem

- dorny/paths-filter v2 does not support `predicate-quantifier`

## Changes

- pin dorny/paths-filter to v3.0.2
