### PR TITLE
feat: enable path cleaning on pre-aggregated tables 

### DIFF
--- a/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsFilters.tsx
@@ -81,7 +81,7 @@ const FoldableFilters = (): JSX.Element => {
             <TableSortingIndicator />
 
             <WebVitalsPercentileToggle />
-            {!preAggregatedEnabled && <PathCleaningToggle />}
+            <PathCleaningToggle />
 
             <WebPropertyFilters />
         </div>

--- a/posthog/hogql_queries/web_analytics/stats_table_pre_aggregated.py
+++ b/posthog/hogql_queries/web_analytics/stats_table_pre_aggregated.py
@@ -61,8 +61,10 @@ class StatsTablePreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder)
         # Like in the original stats_table, we will need this method to build the "Paths" tile so it is a special breakdown
         previous_period_filter, current_period_filter = self.get_date_ranges()
 
-        query = parse_select(
-            """
+        query = cast(
+            ast.SelectQuery,
+            parse_select(
+                """
             SELECT
                 {breakdown_value} as `context.columns.breakdown_value`,
                 {visitors_tuple} AS `context.columns.visitors`,
@@ -71,26 +73,30 @@ class StatsTablePreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder)
             FROM web_bounces_daily
             GROUP BY `context.columns.breakdown_value`
             """,
-            placeholders={
-                "breakdown_value": self._apply_path_cleaning(ast.Field(chain=["entry_pathname"])),
-                "visitors_tuple": self._period_comparison_tuple(
-                    "persons_uniq_state", "uniqMergeIf", current_period_filter, previous_period_filter
-                ),
-                "views_tuple": self._period_comparison_tuple(
-                    "pageviews_count_state", "sumMergeIf", current_period_filter, previous_period_filter
-                ),
-                "bounce_rate_tuple": self._bounce_rate_calculation_tuple(current_period_filter, previous_period_filter),
-            },
+                placeholders={
+                    "breakdown_value": self._apply_path_cleaning(ast.Field(chain=["entry_pathname"])),
+                    "visitors_tuple": self._period_comparison_tuple(
+                        "persons_uniq_state", "uniqMergeIf", current_period_filter, previous_period_filter
+                    ),
+                    "views_tuple": self._period_comparison_tuple(
+                        "pageviews_count_state", "sumMergeIf", current_period_filter, previous_period_filter
+                    ),
+                    "bounce_rate_tuple": self._bounce_rate_calculation_tuple(
+                        current_period_filter, previous_period_filter
+                    ),
+                },
+            ),
         )
 
-        assert isinstance(query, ast.SelectQuery)
         return query
 
     def _path_query(self) -> ast.SelectQuery:
         previous_period_filter, current_period_filter = self.get_date_ranges(table_name="web_stats_daily")
 
-        query = parse_select(
-            """
+        query = cast(
+            ast.SelectQuery,
+            parse_select(
+                """
             SELECT
                 {breakdown_value} as `context.columns.breakdown_value`,
                 {visitors_tuple} AS `context.columns.visitors`,
@@ -102,32 +108,32 @@ class StatsTablePreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder)
                 ON {join_condition}
             GROUP BY `context.columns.breakdown_value`
             """,
-            placeholders={
-                "breakdown_value": self._apply_path_cleaning(ast.Field(chain=["pathname"])),
-                "visitors_tuple": self._period_comparison_tuple(
-                    "persons_uniq_state",
-                    "uniqMergeIf",
-                    current_period_filter,
-                    previous_period_filter,
-                    table_prefix="web_stats_daily",
-                ),
-                "views_tuple": self._period_comparison_tuple(
-                    "pageviews_count_state",
-                    "sumMergeIf",
-                    current_period_filter,
-                    previous_period_filter,
-                    table_prefix="web_stats_daily",
-                ),
-                "bounce_subquery": self._bounce_rate_query(),
-                "join_condition": ast.CompareOperation(
-                    op=ast.CompareOperationOp.Eq,
-                    left=self._apply_path_cleaning(ast.Field(chain=["web_stats_daily", "pathname"])),
-                    right=ast.Field(chain=["bounces", "context.columns.breakdown_value"]),
-                ),
-            },
+                placeholders={
+                    "breakdown_value": self._apply_path_cleaning(ast.Field(chain=["pathname"])),
+                    "visitors_tuple": self._period_comparison_tuple(
+                        "persons_uniq_state",
+                        "uniqMergeIf",
+                        current_period_filter,
+                        previous_period_filter,
+                        table_prefix="web_stats_daily",
+                    ),
+                    "views_tuple": self._period_comparison_tuple(
+                        "pageviews_count_state",
+                        "sumMergeIf",
+                        current_period_filter,
+                        previous_period_filter,
+                        table_prefix="web_stats_daily",
+                    ),
+                    "bounce_subquery": self._bounce_rate_query(),
+                    "join_condition": ast.CompareOperation(
+                        op=ast.CompareOperationOp.Eq,
+                        left=self._apply_path_cleaning(ast.Field(chain=["web_stats_daily", "pathname"])),
+                        right=ast.Field(chain=["bounces", "context.columns.breakdown_value"]),
+                    ),
+                },
+            ),
         )
 
-        assert isinstance(query, ast.SelectQuery)
         return query
 
     def get_query(self) -> ast.SelectQuery:
@@ -140,8 +146,10 @@ class StatsTablePreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder)
         else:
             previous_period_filter, current_period_filter = self.get_date_ranges()
 
-            query = parse_select(
-                """
+            query = cast(
+                ast.SelectQuery,
+                parse_select(
+                    """
                 SELECT
                     {breakdown_field} as `context.columns.breakdown_value`,
                     {visitors_tuple} AS `context.columns.visitors`,
@@ -149,19 +157,18 @@ class StatsTablePreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder)
                 FROM web_stats_daily
                 GROUP BY `context.columns.breakdown_value`
                 """,
-                placeholders={
-                    "breakdown_field": self._get_breakdown_field(),
-                    "visitors_tuple": self._period_comparison_tuple(
-                        "persons_uniq_state", "uniqMergeIf", current_period_filter, previous_period_filter
-                    ),
-                    "views_tuple": self._period_comparison_tuple(
-                        "pageviews_count_state", "sumMergeIf", current_period_filter, previous_period_filter
-                    ),
-                },
+                    placeholders={
+                        "breakdown_field": self._get_breakdown_field(),
+                        "visitors_tuple": self._period_comparison_tuple(
+                            "persons_uniq_state", "uniqMergeIf", current_period_filter, previous_period_filter
+                        ),
+                        "views_tuple": self._period_comparison_tuple(
+                            "pageviews_count_state", "sumMergeIf", current_period_filter, previous_period_filter
+                        ),
+                    },
+                ),
             )
             table_name = "web_stats_daily"
-
-        assert isinstance(query, ast.SelectQuery)
 
         filters = self._get_filters(table_name=table_name)
         if filters:
@@ -239,7 +246,7 @@ class StatsTablePreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder)
         previous_period_filter: ast.Expr,
         table_prefix: str | None = None,
     ) -> ast.Tuple:
-        field_chain = [table_prefix, state_field] if table_prefix else [state_field]
+        field_chain: list[str | int] = [table_prefix, state_field] if table_prefix else [state_field]
 
         return ast.Tuple(
             exprs=[

--- a/posthog/hogql_queries/web_analytics/stats_table_pre_aggregated.py
+++ b/posthog/hogql_queries/web_analytics/stats_table_pre_aggregated.py
@@ -57,84 +57,111 @@ class StatsTablePreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder)
 
         return self.runner.query.breakdownBy in self.SUPPORTED_BREAKDOWNS
 
-    def _bounce_rate_query(self, include_filters: bool = False) -> str:
+    def _bounce_rate_query(self) -> ast.SelectQuery:
         # Like in the original stats_table, we will need this method to build the "Paths" tile so it is a special breakdown
         previous_period_filter, current_period_filter = self.get_date_ranges()
 
-        query_str = f"""
-        SELECT
-            entry_pathname as `context.columns.breakdown_value`,
-            tuple(
-                uniqMergeIf(persons_uniq_state, {current_period_filter}),
-                uniqMergeIf(persons_uniq_state, {previous_period_filter})
-            ) AS `context.columns.visitors`,
-            tuple(
-                sumMergeIf(pageviews_count_state, {current_period_filter}),
-                sumMergeIf(pageviews_count_state, {previous_period_filter})
-            ) as `context.columns.views`,
-            tuple(
-                (sumMergeIf(bounces_count_state, {current_period_filter}) / nullif(uniqMergeIf(sessions_uniq_state, {current_period_filter}), 0)),
-                (sumMergeIf(bounces_count_state, {previous_period_filter}) / nullif(uniqMergeIf(sessions_uniq_state, {previous_period_filter}), 0))
-            ) as `context.columns.bounce_rate`
-        FROM web_bounces_daily
-        GROUP BY `context.columns.breakdown_value`
-        """
+        query = parse_select(
+            """
+            SELECT
+                {breakdown_value} as `context.columns.breakdown_value`,
+                {visitors_tuple} AS `context.columns.visitors`,
+                {views_tuple} as `context.columns.views`,
+                {bounce_rate_tuple} as `context.columns.bounce_rate`
+            FROM web_bounces_daily
+            GROUP BY `context.columns.breakdown_value`
+            """,
+            placeholders={
+                "breakdown_value": self._apply_path_cleaning(ast.Field(chain=["entry_pathname"])),
+                "visitors_tuple": self._period_comparison_tuple(
+                    "persons_uniq_state", "uniqMergeIf", current_period_filter, previous_period_filter
+                ),
+                "views_tuple": self._period_comparison_tuple(
+                    "pageviews_count_state", "sumMergeIf", current_period_filter, previous_period_filter
+                ),
+                "bounce_rate_tuple": self._bounce_rate_calculation_tuple(current_period_filter, previous_period_filter),
+            },
+        )
 
-        return query_str
+        assert isinstance(query, ast.SelectQuery)
+        return query
 
-    def _path_query(self) -> str:
-        previous_period_filter, current_period_filter = self.get_date_ranges(table_name="p")
+    def _path_query(self) -> ast.SelectQuery:
+        previous_period_filter, current_period_filter = self.get_date_ranges(table_name="web_stats_daily")
 
-        query_str = f"""
-        SELECT
-            pathname as `context.columns.breakdown_value`,
-            tuple(
-                uniqMergeIf(p.persons_uniq_state, {current_period_filter}),
-                uniqMergeIf(p.persons_uniq_state, {previous_period_filter})
-            ) AS `context.columns.visitors`,
-            tuple(
-                sumMergeIf(p.pageviews_count_state, {current_period_filter}),
-                sumMergeIf(p.pageviews_count_state, {previous_period_filter})
-            ) as `context.columns.views`,
-            any(bounces.`context.columns.bounce_rate`) as `context.columns.bounce_rate`
-        FROM
-            web_stats_daily p
-        LEFT JOIN ({self._bounce_rate_query()}) bounces
-            ON p.pathname = bounces.`context.columns.breakdown_value`
-        GROUP BY `context.columns.breakdown_value`
-        """
+        query = parse_select(
+            """
+            SELECT
+                {breakdown_value} as `context.columns.breakdown_value`,
+                {visitors_tuple} AS `context.columns.visitors`,
+                {views_tuple} as `context.columns.views`,
+                any(bounces.`context.columns.bounce_rate`) as `context.columns.bounce_rate`
+            FROM
+                web_stats_daily
+            LEFT JOIN ({bounce_subquery}) bounces
+                ON {join_condition}
+            GROUP BY `context.columns.breakdown_value`
+            """,
+            placeholders={
+                "breakdown_value": self._apply_path_cleaning(ast.Field(chain=["pathname"])),
+                "visitors_tuple": self._period_comparison_tuple(
+                    "persons_uniq_state",
+                    "uniqMergeIf",
+                    current_period_filter,
+                    previous_period_filter,
+                    table_prefix="web_stats_daily",
+                ),
+                "views_tuple": self._period_comparison_tuple(
+                    "pageviews_count_state",
+                    "sumMergeIf",
+                    current_period_filter,
+                    previous_period_filter,
+                    table_prefix="web_stats_daily",
+                ),
+                "bounce_subquery": self._bounce_rate_query(),
+                "join_condition": ast.CompareOperation(
+                    op=ast.CompareOperationOp.Eq,
+                    left=self._apply_path_cleaning(ast.Field(chain=["web_stats_daily", "pathname"])),
+                    right=ast.Field(chain=["bounces", "context.columns.breakdown_value"]),
+                ),
+            },
+        )
 
-        return query_str
+        assert isinstance(query, ast.SelectQuery)
+        return query
 
     def get_query(self) -> ast.SelectQuery:
-        previous_period_filter, current_period_filter = self.get_date_ranges()
-
-        query_str = ""
-        table_name = "web_stats_daily"
         if self.runner.query.breakdownBy == WebStatsBreakdown.INITIAL_PAGE:
-            query_str = self._bounce_rate_query()
+            query = self._bounce_rate_query()
             table_name = "web_bounces_daily"
         elif self.runner.query.breakdownBy == WebStatsBreakdown.PAGE:
-            query_str = self._path_query()
-            table_name = "p"
+            query = self._path_query()
+            table_name = "web_stats_daily"
         else:
-            breakdown_field = self._get_breakdown_field()
-            query_str = f"""
-            SELECT
-                {breakdown_field} as `context.columns.breakdown_value`,
-                tuple(
-                    uniqMergeIf(persons_uniq_state, {current_period_filter}),
-                    uniqMergeIf(persons_uniq_state, {previous_period_filter})
-                ) AS `context.columns.visitors`,
-                tuple(
-                    sumMergeIf(pageviews_count_state, {current_period_filter}),
-                    sumMergeIf(pageviews_count_state, {previous_period_filter})
-                ) as `context.columns.views`
-            FROM web_stats_daily
-            GROUP BY `context.columns.breakdown_value`
-            """
+            previous_period_filter, current_period_filter = self.get_date_ranges()
 
-        query = cast(ast.SelectQuery, parse_select(query_str))
+            query = parse_select(
+                """
+                SELECT
+                    {breakdown_field} as `context.columns.breakdown_value`,
+                    {visitors_tuple} AS `context.columns.visitors`,
+                    {views_tuple} as `context.columns.views`
+                FROM web_stats_daily
+                GROUP BY `context.columns.breakdown_value`
+                """,
+                placeholders={
+                    "breakdown_field": self._get_breakdown_field(),
+                    "visitors_tuple": self._period_comparison_tuple(
+                        "persons_uniq_state", "uniqMergeIf", current_period_filter, previous_period_filter
+                    ),
+                    "views_tuple": self._period_comparison_tuple(
+                        "pageviews_count_state", "sumMergeIf", current_period_filter, previous_period_filter
+                    ),
+                },
+            )
+            table_name = "web_stats_daily"
+
+        assert isinstance(query, ast.SelectQuery)
 
         filters = self._get_filters(table_name=table_name)
         if filters:
@@ -169,30 +196,103 @@ class StatsTablePreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder)
     def _get_breakdown_field(self):
         match self.runner.query.breakdownBy:
             case WebStatsBreakdown.DEVICE_TYPE:
-                return "device_type"
+                return ast.Field(chain=["device_type"])
             case WebStatsBreakdown.BROWSER:
-                return "browser"
+                return ast.Field(chain=["browser"])
             case WebStatsBreakdown.OS:
-                return "os"
+                return ast.Field(chain=["os"])
             case WebStatsBreakdown.VIEWPORT:
-                return "viewport"
+                return ast.Field(chain=["viewport"])
             case WebStatsBreakdown.INITIAL_REFERRING_DOMAIN:
-                return "referring_domain"
+                return ast.Field(chain=["referring_domain"])
             case WebStatsBreakdown.INITIAL_UTM_SOURCE:
-                return "utm_source"
+                return ast.Field(chain=["utm_source"])
             case WebStatsBreakdown.INITIAL_UTM_MEDIUM:
-                return "utm_medium"
+                return ast.Field(chain=["utm_medium"])
             case WebStatsBreakdown.INITIAL_UTM_CAMPAIGN:
-                return "utm_campaign"
+                return ast.Field(chain=["utm_campaign"])
             case WebStatsBreakdown.INITIAL_UTM_TERM:
-                return "utm_term"
+                return ast.Field(chain=["utm_term"])
             case WebStatsBreakdown.INITIAL_UTM_CONTENT:
-                return "utm_content"
+                return ast.Field(chain=["utm_content"])
             case WebStatsBreakdown.COUNTRY:
-                return "country_name"
+                return ast.Field(chain=["country_name"])
             case WebStatsBreakdown.CITY:
-                return "city_name"
+                return ast.Field(chain=["city_name"])
             case WebStatsBreakdown.REGION:
-                return "region_code"
+                return ast.Field(chain=["region_code"])
             case WebStatsBreakdown.EXIT_PAGE:
-                return "end_pathname"
+                return self._apply_path_cleaning(ast.Field(chain=["end_pathname"]))
+
+    def _apply_path_cleaning(self, path_expr: ast.Expr) -> ast.Expr:
+        """Apply path cleaning to path expressions, similar to the non-pre-aggregated version"""
+        if not self.runner.query.doPathCleaning:
+            return path_expr
+
+        return self.runner._apply_path_cleaning(path_expr)
+
+    def _period_comparison_tuple(
+        self,
+        state_field: str,
+        function_name: str,
+        current_period_filter: ast.Expr,
+        previous_period_filter: ast.Expr,
+        table_prefix: str | None = None,
+    ) -> ast.Tuple:
+        field_chain = [table_prefix, state_field] if table_prefix else [state_field]
+
+        return ast.Tuple(
+            exprs=[
+                ast.Call(
+                    name=function_name,
+                    args=[
+                        ast.Field(chain=field_chain),
+                        current_period_filter,
+                    ],
+                ),
+                ast.Call(
+                    name=function_name,
+                    args=[
+                        ast.Field(chain=field_chain),
+                        previous_period_filter,
+                    ],
+                ),
+            ]
+        )
+
+    def _bounce_rate_calculation_tuple(
+        self, current_period_filter: ast.Expr, previous_period_filter: ast.Expr
+    ) -> ast.Tuple:
+        def safe_bounce_rate(period_filter: ast.Expr) -> ast.Call:
+            return ast.Call(
+                name="divide",
+                args=[
+                    ast.Call(
+                        name="sumMergeIf",
+                        args=[
+                            ast.Field(chain=["bounces_count_state"]),
+                            period_filter,
+                        ],
+                    ),
+                    ast.Call(
+                        name="nullif",
+                        args=[
+                            ast.Call(
+                                name="uniqMergeIf",
+                                args=[
+                                    ast.Field(chain=["sessions_uniq_state"]),
+                                    period_filter,
+                                ],
+                            ),
+                            ast.Constant(value=0),
+                        ],
+                    ),
+                ],
+            )
+
+        return ast.Tuple(
+            exprs=[
+                safe_bounce_rate(current_period_filter),
+                safe_bounce_rate(previous_period_filter),
+            ]
+        )

--- a/posthog/hogql_queries/web_analytics/web_overview_pre_aggregated.py
+++ b/posthog/hogql_queries/web_analytics/web_overview_pre_aggregated.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_select
@@ -20,41 +20,94 @@ class WebOverviewPreAggregatedQueryBuilder(WebAnalyticsPreAggregatedQueryBuilder
     def get_query(self) -> ast.SelectQuery:
         previous_period_filter, current_period_filter = self.get_date_ranges()
 
-        def safe_avg_sessions(metric, period_filter):
-            sessions = f"uniqMergeIf(sessions_uniq_state, {period_filter})"
-            return f"""
-            if(
-                {sessions} > 0,
-                sumMergeIf({metric}_state, {period_filter}) / {sessions},
-                0
-            )"""
+        query = parse_select(
+            """
+            SELECT
+                {unique_persons_current} AS unique_persons,
+                {unique_persons_previous} AS previous_unique_persons,
 
-        query_str = f"""
-        SELECT
-            uniqMergeIf(persons_uniq_state, {current_period_filter}) AS unique_persons,
-            uniqMergeIf(persons_uniq_state, {previous_period_filter}) AS previous_unique_persons,
+                {pageviews_current} AS pageviews,
+                {pageviews_previous} AS previous_pageviews,
 
-            sumMergeIf(pageviews_count_state, {current_period_filter}) AS pageviews,
-            sumMergeIf(pageviews_count_state, {previous_period_filter}) AS previous_pageviews,
+                {unique_sessions_current} AS unique_sessions,
+                {unique_sessions_previous} AS previous_unique_sessions,
 
-            uniqMergeIf(sessions_uniq_state, {current_period_filter}) AS unique_sessions,
-            uniqMergeIf(sessions_uniq_state, {previous_period_filter}) AS previous_unique_sessions,
+                {avg_session_duration_current} AS avg_session_duration,
+                {avg_session_duration_previous} AS previous_avg_session_duration,
 
-            {safe_avg_sessions("total_session_duration", current_period_filter)} AS avg_session_duration,
-            {safe_avg_sessions("total_session_duration", previous_period_filter)} AS previous_avg_session_duration,
+                {bounce_rate_current} AS bounce_rate,
+                {bounce_rate_previous} AS previous_bounce_rate,
 
-            {safe_avg_sessions("total_bounces", current_period_filter)} AS bounce_rate,
-            {safe_avg_sessions("total_bounces", previous_period_filter)} AS previous_bounce_rate,
+                NULL AS revenue,
+                NULL AS previous_revenue
+            FROM web_overview_daily
+            """,
+            placeholders={
+                "unique_persons_current": self._uniq_merge_if("persons_uniq_state", current_period_filter),
+                "unique_persons_previous": self._uniq_merge_if("persons_uniq_state", previous_period_filter),
+                "pageviews_current": self._sum_merge_if("pageviews_count_state", current_period_filter),
+                "pageviews_previous": self._sum_merge_if("pageviews_count_state", previous_period_filter),
+                "unique_sessions_current": self._uniq_merge_if("sessions_uniq_state", current_period_filter),
+                "unique_sessions_previous": self._uniq_merge_if("sessions_uniq_state", previous_period_filter),
+                "avg_session_duration_current": self._safe_avg_sessions(
+                    "total_session_duration_state", current_period_filter
+                ),
+                "avg_session_duration_previous": self._safe_avg_sessions(
+                    "total_session_duration_state", previous_period_filter
+                ),
+                "bounce_rate_current": self._safe_avg_sessions("total_bounces_state", current_period_filter),
+                "bounce_rate_previous": self._safe_avg_sessions("total_bounces_state", previous_period_filter),
+            },
+        )
 
-            NULL AS revenue,
-            NULL AS previous_revenue
-        FROM web_overview_daily
-        """
-
-        query = cast(ast.SelectQuery, parse_select(query_str))
+        assert isinstance(query, ast.SelectQuery)
 
         filters = self._get_filters(table_name="web_overview_daily")
         if filters:
             query.where = filters
 
         return query
+
+    def _uniq_merge_if(self, state_field: str, period_filter: ast.Expr) -> ast.Call:
+        """Utility method to create uniqMergeIf expressions"""
+        return ast.Call(
+            name="uniqMergeIf",
+            args=[
+                ast.Field(chain=[state_field]),
+                period_filter,
+            ],
+        )
+
+    def _sum_merge_if(self, state_field: str, period_filter: ast.Expr) -> ast.Call:
+        """Utility method to create sumMergeIf expressions"""
+        return ast.Call(
+            name="sumMergeIf",
+            args=[
+                ast.Field(chain=[state_field]),
+                period_filter,
+            ],
+        )
+
+    def _safe_avg_sessions(self, metric_state: str, period_filter: ast.Expr) -> ast.Call:
+        """
+        Utility method to safely calculate averages per session, avoiding division by zero.
+        Returns: if(sessions > 0, metric / sessions, 0)
+        """
+        sessions_count = self._uniq_merge_if("sessions_uniq_state", period_filter)
+        metric_sum = self._sum_merge_if(metric_state, period_filter)
+
+        return ast.Call(
+            name="if",
+            args=[
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Gt,
+                    left=sessions_count,
+                    right=ast.Constant(value=0),
+                ),
+                ast.Call(
+                    name="divide",
+                    args=[metric_sum, sessions_count],
+                ),
+                ast.Constant(value=0),
+            ],
+        )


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Path cleaning was not working, now it is :)

I've also added some refactors to rely more on AST instead of just SQL strings. I did not go the whole way also to include helpers, as I think it will make more sense to do that while combining the non-pre-aggregated data together, so we can have helpers that work for pre-aggregated and non-pre-aggregated functions.

This will be more helpful for upcoming PRs, as it allows combining non-pre-aggregated queries with pre-aggregated ones.

## Changes

- Enabled path cleaning transformations
- Refactored to use AST placeholders instead of string concats

## Did you write or update any docs for this change?

- [x] No docs needed for this change

## How did you test this code?

Manually