### PR TITLE
feat: duplicate shared metric from the experiment page.

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/MetricHeader.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/MetricHeader.tsx
@@ -1,7 +1,6 @@
 import { IconCopy, IconPencil } from '@posthog/icons'
+import { LemonButton, LemonDialog, LemonTag } from '@posthog/lemon-ui'
 import { useActions } from 'kea'
-import { LemonButton } from 'lib/lemon-ui/LemonButton'
-import { LemonTag } from 'lib/lemon-ui/LemonTag'
 import { urls } from 'scenes/urls'
 
 import type { ExperimentMetric } from '~/queries/schema/schema-general'
@@ -72,15 +71,44 @@ export const MetricHeader = ({
                             size="xsmall"
                             icon={<IconCopy fontSize="12" />}
                             tooltip="Duplicate"
-                            to={
-                                metric.isSharedMetric
-                                    ? urls.experimentsSharedMetric(metric.sharedMetricId, 'duplicate')
-                                    : undefined
-                            }
                             onClick={() => {
+                                /**
+                                 * For shared metrics we open the duplicate form
+                                 * after a confirmation.
+                                 */
                                 if (metric.isSharedMetric) {
+                                    LemonDialog.open({
+                                        title: 'Duplicate this shared metric?',
+                                        content: (
+                                            <div className="text-sm text-secondary max-w-lg">
+                                                <p>
+                                                    You're about to duplicate a shared metric. You'll be taken to the
+                                                    shared metric form, where you can customize and save it. Once saved,
+                                                    the new metric will appear among your shared metrics.
+                                                </p>
+                                                <p>
+                                                    When you're done, head back to your experiment and add it to your
+                                                    list of tracked metrics.
+                                                </p>
+                                            </div>
+                                        ),
+                                        primaryButton: {
+                                            children: 'Duplicate metric',
+                                            to: urls.experimentsSharedMetric(metric.sharedMetricId, 'duplicate'),
+                                            type: 'primary',
+                                            size: 'small',
+                                        },
+                                        secondaryButton: {
+                                            children: 'Cancel',
+                                            type: 'tertiary',
+                                            size: 'small',
+                                        },
+                                    })
+
                                     return
                                 }
+
+                                // regular metrics just get duplicated
                                 onDuplicateMetricClick(metric)
                             }}
                         />

--- a/frontend/src/scenes/experiments/MetricsView/MetricHeader.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/MetricHeader.tsx
@@ -2,6 +2,7 @@ import { IconCopy, IconPencil } from '@posthog/icons'
 import { useActions } from 'kea'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { urls } from 'scenes/urls'
 
 import type { ExperimentMetric } from '~/queries/schema/schema-general'
 
@@ -71,6 +72,11 @@ export const MetricHeader = ({
                             size="xsmall"
                             icon={<IconCopy fontSize="12" />}
                             tooltip="Duplicate"
+                            to={
+                                metric.isSharedMetric
+                                    ? urls.experimentsSharedMetric(metric.sharedMetricId, 'duplicate')
+                                    : undefined
+                            }
                             onClick={() => {
                                 if (metric.isSharedMetric) {
                                     return

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1251,8 +1251,6 @@ export const experimentLogic = kea<experimentLogicType>([
                         ...sharedMetrics.map((m) => ({ name: m.name, ...m.query })),
                     ].reverse()
 
-                    // debugger
-
                     for (const query of metrics) {
                         const insightQuery = toInsightVizNode(query)
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a 
smoother review._

> [!NOTE]
> Close #31862

## Problem

To keep feature compatibility with the rest of the UI, we need to provide the user with an option to duplicate shared metrics. On #32595, we approached the problem with a "one-click" mindset, but the UI wasn't right. Here, we take a simpler approach by redirecting users to the `/duplicate` path of the shared metric.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We are adding a `to` url to the duplicate button, that overrides de onClick for shared metrics.

https://github.com/user-attachments/assets/2809f94a-5584-4594-9eaf-ed67f3c8f240

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/53015a64-31cf-495f-b5d2-7b79bfaddf74)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
