### PR TITLE
chore(capture-rs): publish metric when events without name are submitted

### DIFF
--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -197,7 +197,12 @@ async fn handle_legacy(
     let events = match request.events(path.as_str()) {
         Ok(events) => events,
         Err(e) => {
+            // at the moment, main way this can fail on RequestParsingError is
+            // when an unnamed event (no "event" attrib) is submitted to an
+            // endpoint other than /engage
             error!("event hydration from request failed: {}", e);
+            report_dropped_events("event_missing_name", 1);
+            report_internal_error_metrics(e.to_metric_tag(), "event_hydration");
             return Err(e);
         }
     };
@@ -347,7 +352,12 @@ async fn handle_common(
     let events = match request.events(path.as_str()) {
         Ok(events) => events,
         Err(e) => {
+            // at the moment, main way this can fail on RequestParsingError is
+            // when an unnamed event (no "event" attrib) is submitted to an
+            // endpoint other than /engage
             error!("event hydration from request failed: {}", e);
+            report_dropped_events("event_missing_name", 1);
+            report_internal_error_metrics(e.to_metric_tag(), "event_hydration");
             return Err(e);
         }
     };


### PR DESCRIPTION
## Problem
The `/engage` endpoint expects person-properties updating events but does not require SDKs to submit with an event name. This is shimmed in the `capture.py` implementation (and also in `capture-rs`'s new legacy endpoint support as of [this PR](https://github.com/PostHog/posthog/pull/32135)) but we should ensure we're statting and not just logging these submissions when customers send them to a non-`/engage` endpoint.
 
## Changes
Add instrumentation when `RawEngageEvent`s are submitted to the wrong endpoint so we stat as well as log them.

## Did you write or update any docs for this change?

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Locally, CI, and soon in mirror deploy test 
