### PR TITLE
fix: create experiment dashboard failing for ExperimentMetric.

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -44,8 +44,6 @@ import {
     ExperimentMetric,
     ExperimentMetricType,
     ExperimentTrendsQuery,
-    InsightQueryNode,
-    InsightVizNode,
     NodeKind,
 } from '~/queries/schema/schema-general'
 import {
@@ -83,6 +81,7 @@ import {
     featureFlagEligibleForExperiment,
     isLegacyExperiment,
     percentageDistribution,
+    toInsightVizNode,
     transformFiltersForWinningVariant,
 } from './utils'
 
@@ -1247,13 +1246,12 @@ export const experimentLogic = kea<experimentLogicType>([
                         ...singleMetrics,
                         ...sharedMetrics.map((m) => ({ name: m.name, ...m.query })),
                     ].reverse()
+
+                    // debugger
+
                     for (const query of metrics) {
-                        const insightQuery: InsightVizNode = {
-                            kind: NodeKind.InsightVizNode,
-                            source: (query.kind === NodeKind.ExperimentTrendsQuery
-                                ? query.count_query
-                                : query.funnels_query) as InsightQueryNode,
-                        }
+                        const insightQuery = toInsightVizNode(query)
+
                         await api.create(`api/projects/${projectLogic.values.currentProjectId}/insights`, {
                             name: query.name || undefined,
                             query: insightQuery,


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

> [!NOTE]
> Closes #32735
> ZenDesk Ticket: https://posthoghelp.zendesk.com/agent/tickets/31496 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/33231)

## Problem

The experiment's _Create dashboard_ feature is working only for _legacy_ metrics. Any new `ExperimentMetric` fails.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We've refactored the conversion functions between queries and insight sources to support the _legacy_ experiment metrics and the new ExperimentMetric.

### Before

https://github.com/user-attachments/assets/deedd7a4-4866-4be9-91c9-ad9a8bf1cd59

### After

https://github.com/user-attachments/assets/41468d92-ed16-4026-9fc5-88708b9251de




<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/2060a9bb-a3ef-491f-9bd3-f6a53af0237b)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
