### PR TITLE
feat: Max UI revenue context

### DIFF
--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -29,6 +29,7 @@ class MessageSerializer(serializers.Serializer):
     conversation = serializers.UUIDField(required=False)
     contextual_tools = serializers.DictField(required=False, child=serializers.JSONField())
     trace_id = serializers.UUIDField(required=True)
+    ui_context = serializers.JSONField(required=False)
 
     def validate(self, data):
         try:
@@ -96,6 +97,7 @@ class ConversationViewSet(TeamAndOrgViewSetMixin, ListModelMixin, RetrieveModelM
             new_message=serializer.validated_data["message"],
             user=cast(User, request.user),
             contextual_tools=serializer.validated_data.get("contextual_tools"),
+            ui_context=serializer.validated_data.get("ui_context"),
             is_new_conversation=not conversation_id,
             trace_id=serializer.validated_data["trace_id"],
             mode=AssistantMode.ASSISTANT,

--- a/ee/hogai/assistant.py
+++ b/ee/hogai/assistant.py
@@ -120,11 +120,13 @@ class Assistant:
         is_new_conversation: bool = False,
         trace_id: Optional[str | UUID] = None,
         tool_call_partial_state: Optional[AssistantState] = None,
+        ui_context: Optional[dict[str, Any]] = None,
     ):
         self._team = team
         self._contextual_tools = contextual_tools or {}
         self._user = user
         self._conversation = conversation
+        self._ui_context = ui_context
         if not new_message and not tool_call_partial_state:
             raise ValueError("Either new_message or tool_call_partial_state must be provided")
         self._latest_message = new_message.model_copy(deep=True, update={"id": str(uuid4())}) if new_message else None
@@ -254,6 +256,7 @@ class Assistant:
                 "distinct_id": self._user.distinct_id if self._user else None,
                 "contextual_tools": self._contextual_tools,
                 "team_id": self._team.id,
+                "ui_context": self._ui_context,
             },
         }
         return config

--- a/ee/hogai/graph/query_executor/nodes.py
+++ b/ee/hogai/graph/query_executor/nodes.py
@@ -1,20 +1,9 @@
-import json
-from time import sleep
-from typing import Any
 from uuid import uuid4
 
-from django.conf import settings
-from django.core.serializers.json import DjangoJSONEncoder
 from langchain_core.runnables import RunnableConfig
-from rest_framework.exceptions import APIException
 
 from ee.hogai.utils.types import AssistantNodeName, AssistantState, PartialAssistantState
-from posthog.api.services.query import process_query_dict
-from posthog.clickhouse.client.execute_async import get_query_status
-from posthog.errors import ExposedCHQueryError
 from posthog.exceptions_capture import capture_exception
-from posthog.hogql.errors import ExposedHogQLError
-from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.schema import (
     AssistantFunnelsQuery,
     AssistantHogQLQuery,
@@ -27,12 +16,7 @@ from posthog.schema import (
 )
 
 from ..base import AssistantNode
-from .format import (
-    FunnelResultsFormatter,
-    RetentionResultsFormatter,
-    SQLResultsFormatter,
-    TrendsResultsFormatter,
-)
+from .format import QueryRunner
 from .prompts import (
     FALLBACK_EXAMPLE_PROMPT,
     FUNNEL_STEPS_EXAMPLE_PROMPT,
@@ -60,67 +44,15 @@ class QueryExecutorNode(AssistantNode):
         if not tool_call_id:
             return None
 
+        query_runner = QueryRunner(self._team, self._utc_now_datetime)
         try:
-            results_response = process_query_dict(  # type: ignore
-                self._team,  # TODO: Add user
-                viz_message.answer.model_dump(mode="json"),
-                # Celery doesn't run in tests, so there we use force_blocking instead
-                # This does mean that the waiting logic is not tested
-                execution_mode=(
-                    ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE
-                    if not settings.TEST
-                    else ExecutionMode.CALCULATE_BLOCKING_ALWAYS
-                ),
-            ).model_dump(mode="json")
-            # If response has an async query_status, that's always the thing to use
-            if query_status := results_response.get("query_status"):
-                if not query_status["complete"]:
-                    # If it's an in-progress (likely just kicked off) status, let's poll until complete
-                    for wait_ms in range(100, 12000, 100):  # 726 s in total, if my math is correct
-                        sleep(wait_ms / 1000)
-                        query_status = get_query_status(team_id=self._team.pk, query_id=query_status["id"]).model_dump(
-                            mode="json"
-                        )
-                        if query_status["complete"]:
-                            break
-                    else:
-                        raise APIException(
-                            "Query hasn't completed in time. It's worth trying again, maybe with a shorter time range."
-                        )
-                # With results ready, let's first check for errors - then actually use the results
-                if query_status.get("error"):
-                    if error_message := query_status.get("error_message"):
-                        raise APIException(error_message)
-                    raise Exception("Query failed")
-                results_response = query_status["results"]
-        except (APIException, ExposedHogQLError, ExposedCHQueryError) as err:
-            err_message = str(err)
-            if isinstance(err, APIException):
-                if isinstance(err.detail, dict):
-                    err_message = ", ".join(f"{key}: {value}" for key, value in err.detail.items())
-                elif isinstance(err.detail, list):
-                    err_message = ", ".join(map(str, err.detail))
-            return PartialAssistantState(
-                messages=[
-                    FailureMessage(content=f"There was an error running this query: {err_message}", id=str(uuid4()))
-                ]
-            )
-        except Exception as err:
-            capture_exception(err)
-            return PartialAssistantState(
-                messages=[FailureMessage(content="There was an unknown error running this query.", id=str(uuid4()))]
-            )
-
-        try:
-            results = self._compress_results(viz_message, results_response)
-            example_prompt = self._get_example_prompt(viz_message)
+            results, used_fallback = query_runner.run_and_format_query_with_fallback_info(viz_message.answer)
+            example_prompt = FALLBACK_EXAMPLE_PROMPT if used_fallback else self._get_example_prompt(viz_message)
         except Exception as err:
             if isinstance(err, NotImplementedError):
                 raise
             capture_exception(err)
-            # In case something is wrong with the compression, we fall back to the plain JSON.
-            results = json.dumps(results_response["results"], cls=DjangoJSONEncoder, separators=(",", ":"))
-            example_prompt = FALLBACK_EXAMPLE_PROMPT
+            return PartialAssistantState(messages=[FailureMessage(content=str(err), id=str(uuid4()))])
 
         query_result = QUERY_RESULTS_PROMPT.format(
             query_kind=viz_message.answer.kind,
@@ -143,19 +75,6 @@ class QueryExecutorNode(AssistantNode):
             root_tool_insight_plan="",
             root_tool_insight_type="",
         )
-
-    def _compress_results(self, viz_message: VisualizationMessage, response: dict[str, Any]) -> str:
-        if isinstance(viz_message.answer, AssistantTrendsQuery):
-            return TrendsResultsFormatter(viz_message.answer, response["results"]).format()
-        elif isinstance(viz_message.answer, AssistantFunnelsQuery):
-            return FunnelResultsFormatter(
-                viz_message.answer, response["results"], self._team, self._utc_now_datetime
-            ).format()
-        elif isinstance(viz_message.answer, AssistantRetentionQuery):
-            return RetentionResultsFormatter(viz_message.answer, response["results"]).format()
-        elif isinstance(viz_message.answer, AssistantHogQLQuery):
-            return SQLResultsFormatter(viz_message.answer, response["results"], response["columns"]).format()
-        raise NotImplementedError(f"Unsupported query type: {type(viz_message.answer)}")
 
     def _get_example_prompt(self, viz_message: VisualizationMessage) -> str:
         if isinstance(viz_message.answer, AssistantTrendsQuery):

--- a/ee/hogai/graph/root/nodes.py
+++ b/ee/hogai/graph/root/nodes.py
@@ -31,6 +31,9 @@ from posthog.schema import (
     AssistantToolCallMessage,
     FailureMessage,
     HumanMessage,
+    RevenueAnalyticsGrowthRateQuery,
+    RevenueAnalyticsOverviewQuery,
+    RevenueAnalyticsTopCustomersQuery,
     # Import full UI query types
     TrendsQuery,
     FunnelsQuery,
@@ -316,6 +319,9 @@ class RootNode(AssistantNode):
             "FunnelsQuery": FunnelsQuery,
             "RetentionQuery": RetentionQuery,
             "HogQLQuery": HogQLQuery,
+            "RevenueAnalyticsOverviewQuery": RevenueAnalyticsOverviewQuery,
+            "RevenueAnalyticsGrowthRateQuery": RevenueAnalyticsGrowthRateQuery,
+            "RevenueAnalyticsTopCustomersQuery": RevenueAnalyticsTopCustomersQuery,
         }
 
         for _, insight in ui_context.active_insights.items():

--- a/ee/hogai/graph/root/prompts.py
+++ b/ee/hogai/graph/root/prompts.py
@@ -48,6 +48,16 @@ Do not generate any code like Python scripts. Users do not know how to read or r
 You have access to the core memory about the user's company and product in the <core_memory> tag. Use this memory in your responses. New memories will automatically be added to the core memory as the conversation progresses. If users ask to save, update, or delete the core memory, say you have done it.
 </basic_functionality>
 
+<ui_context>
+You have access to contextual information about what the user is currently viewing and working with in PostHog:
+
+{{{ui_context_dashboard}}}
+{{{ui_context_insights}}}
+{{{ui_context_navigation}}}
+
+Use this context to provide more relevant and specific assistance.
+</ui_context>
+
 <format_instructions>
 You can use light Markdown formatting for readability.
 </format_instructions>

--- a/ee/hogai/utils/ui_context_types.py
+++ b/ee/hogai/utils/ui_context_types.py
@@ -1,0 +1,47 @@
+from typing import Any, Optional, Union
+from pydantic import BaseModel, RootModel
+
+
+class InsightContextForMax(BaseModel):
+    """Context for a single insight, to be used by Max"""
+
+    id: Union[str, int]
+    name: Optional[str] = None
+    description: Optional[str] = None
+    query: dict[str, Any]  # The actual query node, e.g., TrendsQuery, HogQLQuery
+    insight_type: Optional[str] = None  # Type of insight, e.g., NodeKind.TrendsQuery
+
+
+class DashboardDisplayContext(BaseModel):
+    """Context for a dashboard being viewed"""
+
+    id: Union[str, int]
+    name: Optional[str] = None
+    description: Optional[str] = None
+
+
+class MultiInsightContainer(RootModel[dict[str, InsightContextForMax]]):
+    """Container for multiple active insights, typically on a dashboard"""
+
+    pass
+
+
+class MaxNavigationContext(BaseModel):
+    """Navigation context for Max"""
+
+    path: str
+    page_title: Optional[str] = None
+
+
+class GlobalInfo(BaseModel):
+    """General information that's always good to have, if available"""
+
+    navigation: Optional[MaxNavigationContext] = None
+
+
+class MaxContextShape(BaseModel):
+    """The main shape for the UI context sent to the backend"""
+
+    active_dashboard: Optional[DashboardDisplayContext] = None
+    active_insights: Optional[dict[str, InsightContextForMax]] = None
+    global_info: Optional[GlobalInfo] = None

--- a/frontend/src/lib/ai/maxContextLogic.ts
+++ b/frontend/src/lib/ai/maxContextLogic.ts
@@ -1,0 +1,148 @@
+import { kea } from 'kea'
+import { router } from 'kea-router'
+
+import { breadcrumbsLogic } from '~/layout/navigation/Breadcrumbs/breadcrumbsLogic'
+import { sceneLogic } from '~/scenes/sceneLogic'
+
+import type { maxContextLogicType } from './maxContextLogicType'
+import {
+    DashboardDisplayContext,
+    InsightContextForMax,
+    MaxContextShape,
+    MaxNavigationContext,
+    MultiInsightContainer,
+} from './maxTypes'
+
+export const maxContextLogic = kea<maxContextLogicType>({
+    path: ['lib', 'ai', 'maxContextLogic'],
+    connect: () => ({
+        values: [breadcrumbsLogic({ hashParams: {} }), ['documentTitle']],
+        actions: [],
+    }),
+    actions: {
+        addOrUpdateActiveInsight: (key: string, data: InsightContextForMax) => ({ key, data }),
+        removeActiveInsight: (key: string) => ({ key }),
+        clearAllActiveInsights: true,
+        setNavigationContext: (path: string, pageTitle?: string) => ({ path, pageTitle }),
+        clearNavigationContext: true,
+        setDashboardContext: (dashboardContext: DashboardDisplayContext) => ({ dashboardContext }),
+        clearDashboardContext: true,
+    },
+    reducers: {
+        activeInsights: [
+            {} as MultiInsightContainer,
+            {
+                addOrUpdateActiveInsight: (
+                    state: MultiInsightContainer,
+                    { key, data }: { key: string; data: InsightContextForMax }
+                ) => ({ ...state, [key]: data }),
+                removeActiveInsight: (state: MultiInsightContainer, { key }: { key: string }) => {
+                    const { [key]: _removed, ...rest } = state
+                    return rest
+                },
+                clearAllActiveInsights: () => ({}),
+            },
+        ],
+        navigation: [
+            null as MaxNavigationContext | null,
+            {
+                setNavigationContext: (_: any, { path, pageTitle }: { path: string; pageTitle?: string }) => ({
+                    path,
+                    page_title: pageTitle,
+                }),
+                clearNavigationContext: () => null,
+            },
+        ],
+        dashboardContext: [
+            null as DashboardDisplayContext | null,
+            {
+                setDashboardContext: (_: any, { dashboardContext }: { dashboardContext: DashboardDisplayContext }) =>
+                    dashboardContext,
+                clearDashboardContext: () => null,
+            },
+        ],
+    },
+    listeners: ({ actions, values }) => ({
+        [router.actionTypes.locationChanged]: () => {
+            actions.clearAllActiveInsights()
+            actions.clearDashboardContext()
+        },
+        [sceneLogic.actionTypes.setScene]: () => {
+            // Scene has been set, now update navigation with proper title
+            setTimeout(() => {
+                actions.setNavigationContext(router.values.location.pathname, values.documentTitle)
+            }, 100)
+        },
+    }),
+    events: ({ actions, values }) => ({
+        afterMount: () => {
+            actions.setNavigationContext(router.values.location.pathname, values.documentTitle)
+        },
+    }),
+    selectors: {
+        compiledContext: [
+            (s: any) => [s.activeInsights, s.navigation, s.dashboardContext],
+            (
+                activeInsights: MultiInsightContainer | null,
+                navigation: MaxNavigationContext | null,
+                dashboardContext: DashboardDisplayContext | null
+            ): MaxContextShape | null => {
+                const context: MaxContextShape = {}
+                let hasData = false
+
+                // Set dashboard as primary focus if available
+                if (dashboardContext) {
+                    context.active_dashboard = dashboardContext
+                    hasData = true
+                }
+
+                if (activeInsights && Object.keys(activeInsights).length > 0) {
+                    context.active_insights = activeInsights
+                    hasData = true
+                }
+
+                if (navigation) {
+                    context.global_info = { ...(context.global_info || {}), navigation }
+                    hasData = true
+                }
+                return hasData ? context : null
+            },
+        ],
+        contextSummary: [
+            (s: any) => [s.activeInsights, s.dashboardContext, s.revenueAnalyticsQueries],
+            (
+                activeInsights: MultiInsightContainer | null,
+                dashboardContext: DashboardDisplayContext | null
+            ): { items: Array<{ icon: 'dashboard' | 'insights'; text: string }> } | null => {
+                const contextItems: Array<{ icon: 'dashboard' | 'insights'; text: string }> = []
+
+                if (dashboardContext) {
+                    contextItems.push({
+                        icon: 'dashboard',
+                        text: `Dashboard: ${dashboardContext.name || 'Current dashboard'}`,
+                    })
+                }
+
+                let totalInsights = 0
+                if (activeInsights && Object.keys(activeInsights).length > 0) {
+                    totalInsights += Object.keys(activeInsights).length
+                }
+
+                if (totalInsights > 0) {
+                    contextItems.push({
+                        icon: 'insights',
+                        text: `${totalInsights} insight${totalInsights > 1 ? 's' : ''} from this page`,
+                    })
+                }
+
+                if (contextItems.length === 0) {
+                    return null
+                }
+
+                return {
+                    items: contextItems,
+                }
+            },
+        ],
+    },
+})

--- a/frontend/src/lib/ai/maxTypes.ts
+++ b/frontend/src/lib/ai/maxTypes.ts
@@ -1,0 +1,43 @@
+import { Node } from '~/queries/schema/schema-general'
+
+// Context for a single insight, to be used by Max
+export interface InsightContextForMax {
+    id: string | number
+    name?: string
+    description?: string
+
+    query: Node // The actual query node, e.g., TrendsQuery, HogQLQuery
+
+    insight_type?: string
+}
+
+// Context for a dashboard being viewed
+export interface DashboardDisplayContext {
+    id: string | number
+    name?: string
+    description?: string
+}
+
+// Container for multiple active insights, typically on a dashboard
+// Keyed by a unique identifier for the insight on the dashboard (e.g., dashboard_item_id)
+export interface MultiInsightContainer {
+    [insightKey: string]: InsightContextForMax
+}
+
+export interface MaxNavigationContext {
+    path: string
+    page_title?: string
+}
+
+// The main shape for the UI context sent to the backend
+export interface MaxContextShape {
+    active_dashboard?: DashboardDisplayContext | null
+
+    // Context for multiple insights, especially when a dashboard is in primaryFocus
+    active_insights?: MultiInsightContainer | null
+
+    // General information that's always good to have, if available
+    global_info?: {
+        navigation?: MaxNavigationContext
+    }
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -142,6 +142,7 @@ import {
     UserType,
 } from '~/types'
 
+import { MaxContextShape } from './ai/maxTypes'
 import { AlertType, AlertTypeWrite } from './components/Alerts/types'
 import {
     ErrorTrackingStackFrame,
@@ -3391,6 +3392,7 @@ const api = {
             data: {
                 content: string
                 contextual_tools?: Record<string, any>
+                ui_context?: MaxContextShape
                 conversation?: string | null
                 trace_id: string
             },

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -35,6 +35,7 @@ import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
 import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigation-3000/sidepanel/types'
+import { maxContextLogic } from '~/lib/ai/maxContextLogic'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { insightsModel } from '~/models/insightsModel'
 import { variableDataLogic } from '~/queries/nodes/DataVisualization/Components/Variables/variableDataLogic'
@@ -206,7 +207,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
             dataThemeLogic,
             ['getTheme'],
         ],
-        logic: [dashboardsModel, insightsModel, eventUsageLogic, variableDataLogic],
+        logic: [dashboardsModel, insightsModel, eventUsageLogic, variableDataLogic, maxContextLogic],
     })),
 
     props({} as DashboardLogicProps),
@@ -1278,6 +1279,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 window.clearInterval(cache.autoRefreshInterval)
                 cache.autoRefreshInterval = null
             }
+            // Clear dashboard context when unmounting
+            maxContextLogic.actions.clearDashboardContext()
         },
     })),
     sharedListeners(({ values, props }) => ({
@@ -1692,6 +1695,15 @@ export const dashboardLogic = kea<dashboardLogicType>([
 
             if (!values.dashboard) {
                 return // We hit a 404
+            }
+
+            // Set dashboard context for Max AI
+            if (values.dashboard.name || values.dashboard.description) {
+                maxContextLogic.actions.setDashboardContext({
+                    id: values.dashboard.id,
+                    name: values.dashboard.name,
+                    description: values.dashboard.description,
+                })
             }
 
             const { action, dashboardQueryId } = values.dashboardLoadTimerData

--- a/frontend/src/scenes/insights/insightDataLogic.tsx
+++ b/frontend/src/scenes/insights/insightDataLogic.tsx
@@ -190,7 +190,7 @@ export const insightDataLogic = kea<insightDataLogicType>([
         ],
     }),
 
-    listeners(({ actions, values }) => ({
+    listeners(({ actions, values, props }) => ({
         setInsight: ({ insight: { query, result }, options: { overrideQuery } }) => {
             // we don't want to override the query for example when updating the insight's name
             if (!overrideQuery) {
@@ -212,6 +212,12 @@ export const insightDataLogic = kea<insightDataLogicType>([
             actions.setInsightData({ ...values.insightData, result: savedResult ? savedResult : null })
         },
         setQuery: ({ query }) => {
+            // Update MaxAI context when query changes
+            const mountedInsightLogic = insightLogic.findMounted(props)
+            if (mountedInsightLogic) {
+                mountedInsightLogic.actions.setMaxContext()
+            }
+
             // if the query is not changed, don't save it
             if (!query || !values.queryChanged) {
                 return

--- a/frontend/src/scenes/max/Intro.tsx
+++ b/frontend/src/scenes/max/Intro.tsx
@@ -1,17 +1,32 @@
 import { offset } from '@floating-ui/react'
+import { IconDashboard, IconGraph, IconInfo } from '@posthog/icons'
+import { Tooltip } from '@posthog/lemon-ui'
 import { useValues } from 'kea'
 import { HedgehogBuddy } from 'lib/components/HedgehogBuddy/HedgehogBuddy'
 import { hedgehogBuddyLogic } from 'lib/components/HedgehogBuddy/hedgehogBuddyLogic'
 import { useState } from 'react'
 import { AIConsentPopoverWrapper } from 'scenes/settings/organization/AIConsentPopoverWrapper'
 
+import { maxContextLogic } from '~/lib/ai/maxContextLogic'
+
 import { maxLogic } from './maxLogic'
 
 export function Intro(): JSX.Element {
     const { hedgehogConfig } = useValues(hedgehogBuddyLogic)
     const { headline, description } = useValues(maxLogic)
+    const { contextSummary } = useValues(maxContextLogic)
 
     const [hedgehogDirection, setHedgehogDirection] = useState<'left' | 'right'>('right')
+
+    const getIconForType = (iconType: 'dashboard' | 'insights'): JSX.Element | null => {
+        switch (iconType) {
+            case 'dashboard':
+                return <IconDashboard className="w-4 h-4" />
+            case 'insights':
+                return <IconGraph className="w-4 h-4" />
+        }
+        return null
+    }
 
     return (
         <>
@@ -49,7 +64,31 @@ export function Intro(): JSX.Element {
             </div>
             <div className="text-center mb-1">
                 <h2 className="text-xl @md/max-welcome:text-2xl font-bold mb-2 text-balance">{headline}</h2>
-                <div className="text-sm text-secondary text-pretty">{description}</div>
+                <div className="text-sm text-secondary text-pretty">
+                    {description}
+                    {contextSummary && (
+                        <Tooltip
+                            title={
+                                <div className="space-y-2">
+                                    <div className="font-medium">Max has context about:</div>
+                                    <ul className="space-y-1">
+                                        {contextSummary.items.map((item, index) => (
+                                            <li key={index} className="text-sm flex items-center gap-2">
+                                                {getIconForType(item.icon)}
+                                                {item.text}
+                                            </li>
+                                        ))}
+                                    </ul>
+                                    <div className="text-xs text-muted-foreground mt-2 pt-2 border-t">
+                                        Max can answer questions about this data.
+                                    </div>
+                                </div>
+                            }
+                        >
+                            <IconInfo className="ml-1 w-4 h-4 inline text-muted-foreground" />
+                        </Tooltip>
+                    )}
+                </div>
             </div>
         </>
     )

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -14,6 +14,7 @@ import {
     reducers,
     selectors,
 } from 'kea'
+import { maxContextLogic } from 'lib/ai/maxContextLogic'
 import api, { ApiError } from 'lib/api'
 import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
@@ -96,6 +97,8 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             ['dataProcessingAccepted', 'toolMap', 'tools'],
             maxLogic,
             ['question', 'threadKeys', 'autoRun', 'conversationId as selectedConversationId', 'activeStreamingThreads'],
+            maxContextLogic,
+            ['compiledContext'],
         ],
         actions: [
             maxLogic,
@@ -218,6 +221,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                     {
                         content: prompt,
                         contextual_tools: Object.fromEntries(values.tools.map((tool) => [tool.name, tool.context])),
+                        ui_context: values.compiledContext || undefined,
                         conversation: values.conversation?.id,
                         trace_id: traceId,
                     },

--- a/products/revenue_analytics/frontend/revenueAnalyticsLogic.ts
+++ b/products/revenue_analytics/frontend/revenueAnalyticsLogic.ts
@@ -7,6 +7,7 @@ import { databaseTableListLogic } from 'scenes/data-management/database/database
 import { dataWarehouseSettingsLogic } from 'scenes/data-warehouse/settings/dataWarehouseSettingsLogic'
 import { urls } from 'scenes/urls'
 
+import { maxContextLogic } from '~/lib/ai/maxContextLogic'
 import {
     DatabaseSchemaManagedViewTable,
     DatabaseSchemaManagedViewTableKind,
@@ -81,7 +82,12 @@ export const revenueAnalyticsLogic = kea<revenueAnalyticsLogicType>([
             revenueAnalyticsSettingsLogic,
             ['baseCurrency', 'events', 'dataWarehouseSources', 'goals as revenueGoals'],
         ],
-        actions: [dataWarehouseSettingsLogic, ['loadSourcesSuccess']],
+        actions: [
+            dataWarehouseSettingsLogic,
+            ['loadSourcesSuccess'],
+            maxContextLogic,
+            ['addRevenueAnalyticsQueries', 'clearRevenueAnalyticsQueries'],
+        ],
     })),
     actions({
         setDates: (dateFrom: string | null, dateTo: string | null) => ({ dateFrom, dateTo }),
@@ -344,6 +350,12 @@ export const revenueAnalyticsLogic = kea<revenueAnalyticsLogicType>([
                 dataWarehouseSources: dataWarehouseSources.results.filter((source) => source.revenue_analytics_enabled),
             })
         },
+        setDates: () => {
+            actions.addRevenueAnalyticsQueries(values.queries)
+        },
+        setRevenueSources: () => {
+            actions.addRevenueAnalyticsQueries(values.queries)
+        },
     })),
     afterMount(({ actions, values }) => {
         if (values.events !== null && values.dataWarehouseSources !== null) {
@@ -353,6 +365,11 @@ export const revenueAnalyticsLogic = kea<revenueAnalyticsLogicType>([
                     (source) => source.revenue_analytics_enabled
                 ),
             })
+        }
+
+        // Add queries to max context on mount
+        if (values.queries) {
+            actions.addRevenueAnalyticsQueries(values.queries)
         }
     }),
 ])


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
🔴 Requires [this PR](https://github.com/PostHog/posthog/pull/32740) to be merged first

We started working on exposing revenue analytics data to Max, for example [in this PR](https://github.com/PostHog/posthog/pull/32620), which tries to expose data warehouse tables connected to revenue, to Max.

This PR builds on a new approach, where we inject context into Max directly from the frontend, in this case, revenue analytics context. This will allow Max to respond to revenue-based questions, when viewing the Revenue Analytics page.

Max can now read custom `RevenueAnalyticsOverviewQuery`, `RevenueAnalyticsGrowthRateQuery` and `RevenueAnalyticsTopCustomersQuery`.

Next steps will be to give Max the ability to trigger these queries regardless of which page the user is looking at.

## Changes
- Add Revenue Analytics queries to the new maxContextLogic
- Support Revenue Analytics queries in the query executor/formatter

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?
Draft PR
