### PR TITLE
test(max): Make evals reflect user flow by using root node

### DIFF
--- a/.github/workflows/ci-ai.yml
+++ b/.github/workflows/ci-ai.yml
@@ -63,6 +63,8 @@ jobs:
                   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
                   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
                   GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+                  AZURE_INFERENCE_CREDENTIAL: ${{ secrets.AZURE_INFERENCE_CREDENTIAL }}
+                  AZURE_INFERENCE_ENDPOINT: ${{ secrets.AZURE_INFERENCE_ENDPOINT }}
 
             - name: Post eval summary to PR
               if: github.event_name == 'pull_request'

--- a/ee/hogai/eval/eval_root.py
+++ b/ee/hogai/eval/eval_root.py
@@ -13,7 +13,7 @@ from .scorers import ToolRelevance
 
 
 @pytest.fixture
-def call_node(demo_org_team_user):
+def call_root(demo_org_team_user):
     graph = (
         AssistantGraph(demo_org_team_user[1])
         .add_edge(AssistantNodeName.START, AssistantNodeName.ROOT)
@@ -42,10 +42,10 @@ def call_node(demo_org_team_user):
 
 
 @pytest.mark.django_db
-def eval_root(call_node):
+def eval_root(call_root):
     MaxEval(
         experiment_name="root",
-        task=call_node,
+        task=call_root,
         scores=[ToolRelevance(semantic_similarity_args={"query_description"})],
         data=[
             EvalCase(

--- a/ee/hogai/eval/eval_sql.py
+++ b/ee/hogai/eval/eval_sql.py
@@ -1,6 +1,4 @@
-from ee.hogai.graph import InsightsAssistantGraph
 from ee.hogai.graph.sql.toolkit import SQL_SCHEMA
-from ee.models.assistant import Conversation
 from posthog.errors import InternalCHQueryError
 from posthog.hogql.errors import BaseHogQLError
 from posthog.hogql_queries.hogql_query_runner import HogQLQueryRunner
@@ -11,9 +9,8 @@ from braintrust import EvalCase, Score
 from braintrust_core.score import Scorer
 from asgiref.sync import sync_to_async
 
-from ee.hogai.utils.types import AssistantNodeName, AssistantState
-from posthog.schema import AssistantHogQLQuery, HumanMessage, NodeKind, VisualizationMessage
-from .scorers import PlanCorrectness, QueryAndPlanAlignment, TimeRangeRelevancy, PlanAndQueryOutput
+from posthog.schema import AssistantHogQLQuery, NodeKind
+from .scorers import QueryKindSelection, PlanCorrectness, QueryAndPlanAlignment, TimeRangeRelevancy, PlanAndQueryOutput
 
 
 class SQLSyntaxCorrectness(Scorer):
@@ -57,54 +54,13 @@ class SQLSyntaxCorrectness(Scorer):
             return Score(name=self._name(), score=1.0)
 
 
-@pytest.fixture
-def call_node(demo_org_team_user):
-    # This graph structure will first get a plan, then generate the SQL query.
-    graph = (
-        InsightsAssistantGraph(demo_org_team_user[1])
-        .add_edge(AssistantNodeName.START, AssistantNodeName.SQL_PLANNER)
-        .add_sql_planner(next_node=AssistantNodeName.SQL_GENERATOR)  # Planner output goes to generator
-        .add_sql_generator(AssistantNodeName.END)  # Generator output is the final output
-        .compile()
-    )
-
-    def callable(query: str) -> PlanAndQueryOutput:
-        conversation = Conversation.objects.create(team=demo_org_team_user[1], user=demo_org_team_user[2])
-        # Initial state for the graph
-        initial_state = AssistantState(
-            messages=[HumanMessage(content=f"Answer this question: {query}")],
-            root_tool_insight_plan=query,  # User query is the initial plan for the planner
-            root_tool_call_id="eval_test_sql",
-            root_tool_insight_type="sql",
-        )
-
-        # Invoke the graph. The state will be updated through planner and then generator.
-        final_state_raw = graph.invoke(
-            initial_state,
-            {"configurable": {"thread_id": conversation.id}},
-        )
-        final_state = AssistantState.model_validate(final_state_raw)
-
-        if not final_state.messages or not isinstance(final_state.messages[-1], VisualizationMessage):
-            return {"plan": None, "query": None}
-
-        # Ensure the answer is of the expected type for SQL eval
-        answer = final_state.messages[-1].answer
-        if not isinstance(answer, AssistantHogQLQuery):
-            # This case should ideally not happen if the graph is configured correctly for SQL
-            return {"plan": final_state.messages[-1].plan, "query": None}
-
-        return {"plan": final_state.messages[-1].plan, "query": answer}
-
-    return callable
-
-
 @pytest.mark.django_db
-def eval_sql(call_node):
+def eval_sql(call_root_for_insight_generation):
     MaxEval(
         experiment_name="sql",
-        task=call_node,
+        task=call_root_for_insight_generation,
         scores=[
+            QueryKindSelection(expected=NodeKind.HOG_QL_QUERY),
             PlanCorrectness(
                 query_kind=NodeKind.HOG_QL_QUERY,
                 evaluation_criteria="""
@@ -305,5 +261,23 @@ WHERE event_count = 3
                     ),
                 ),
             ),
-        ],
+            EvalCase(
+                input="The number of distinct values of property $browser seen in each of the last 14 days",
+                expected=PlanAndQueryOutput(
+                    plan="""
+Query:
+- Count distinct values of property $browser seen in each of the last 14 days
+""",
+                    query=AssistantHogQLQuery(
+                        query="""
+SELECT date_trunc('day', timestamp) as day, count(distinct properties.$browser) as distinct_browser_count
+FROM events
+WHERE event = '$pageview'
+GROUP BY day
+ORDER BY day
+"""
+                    ),
+                ),
+            ),
+        ][-1:],
     )

--- a/ee/hogai/eval/eval_sql.py
+++ b/ee/hogai/eval/eval_sql.py
@@ -93,7 +93,7 @@ Important points:
         ],
         data=[
             EvalCase(
-                input="Count pageviews by browser",
+                input="Count pageviews by browser, using SQL",
                 expected=PlanAndQueryOutput(
                     plan="""
 Query to count pageviews grouped by browser:
@@ -116,7 +116,7 @@ LIMIT 100
                 ),
             ),
             EvalCase(
-                input="What are the top 10 countries by number of users in the last 7 days?",
+                input="What are the top 10 countries by number of users in the last 7 days? Use SQL",
                 expected=PlanAndQueryOutput(
                     plan="""
 Query to find the top 10 countries by number of users in the last 7 days:
@@ -140,7 +140,7 @@ LIMIT 10
                 ),
             ),
             EvalCase(
-                input="Show me the average session duration by day of week",
+                input="Show me the average session duration by day of week, using SQL",
                 expected=PlanAndQueryOutput(
                     plan="""
 Query to calculate average session duration by day of week:
@@ -161,7 +161,7 @@ ORDER BY day_of_week
                 ),
             ),
             EvalCase(
-                input="What percentage of users who visited the pricing page made a purchase in this month?",
+                input="What percentage of users who visited the pricing page made a purchase in this month? Use SQL",
                 expected=PlanAndQueryOutput(
                     plan="""
 Query to calculate the percentage of users who visited the pricing page and also made a purchase this month:
@@ -195,7 +195,7 @@ LEFT JOIN purchasers p ON pv.person_id = p.person_id
                 ),
             ),
             EvalCase(
-                input="How many users completed the onboarding flow (viewed welcome page, created profile, and completed tutorial) in sequence?",
+                input="How many users completed the onboarding flow (viewed welcome page, created profile, and completed tutorial) in sequence? Use SQL",
                 expected=PlanAndQueryOutput(
                     plan="""
 Query to count users who completed the full onboarding sequence:
@@ -233,7 +233,7 @@ WHERE welcome_time < profile_time AND profile_time < tutorial_time
                 ),
             ),
             EvalCase(
-                input="How many users completed the onboarding flow (viewed welcome page, created profile, and completed tutorial) regardless of sequence?",
+                input="How many users completed the onboarding flow (viewed welcome page, created profile, and completed tutorial) regardless of sequence? Use SQL",
                 expected=PlanAndQueryOutput(
                     plan="""
 Query to count users who completed the full onboarding sequence:
@@ -262,6 +262,7 @@ WHERE event_count = 3
                 ),
             ),
             EvalCase(
+                # As of May 2025, trends insights don't support "number of distinct values of property" math, so we MUST use SQL here
                 input="The number of distinct values of property $browser seen in each of the last 14 days",
                 expected=PlanAndQueryOutput(
                     plan="""

--- a/ee/hogai/eval/eval_trends.py
+++ b/ee/hogai/eval/eval_trends.py
@@ -1,12 +1,9 @@
-from ee.hogai.graph import InsightsAssistantGraph
 from ee.hogai.graph.trends.toolkit import TRENDS_SCHEMA
-from ee.models.assistant import Conversation
 from .conftest import MaxEval
 import pytest
 from braintrust import EvalCase
 from datetime import datetime
 
-from ee.hogai.utils.types import AssistantNodeName, AssistantState
 from posthog.schema import (
     AssistantTrendsQuery,
     AssistantTrendsEventsNode,
@@ -14,61 +11,18 @@ from posthog.schema import (
     AssistantTrendsBreakdownFilter,
     AssistantGenericMultipleBreakdownFilter,
     AssistantEventMultipleBreakdownFilterType,
-    HumanMessage,
     NodeKind,
-    VisualizationMessage,
 )
-from .scorers import PlanCorrectness, QueryAndPlanAlignment, TimeRangeRelevancy, PlanAndQueryOutput
-
-
-@pytest.fixture
-def call_node(demo_org_team_user):
-    # This graph structure will first get a plan, then generate the trends query.
-    graph = (
-        InsightsAssistantGraph(demo_org_team_user[1])
-        .add_edge(AssistantNodeName.START, AssistantNodeName.TRENDS_PLANNER)
-        .add_trends_planner(next_node=AssistantNodeName.TRENDS_GENERATOR)  # Planner output goes to generator
-        .add_trends_generator(AssistantNodeName.END)  # Generator output is the final output
-        .compile()
-    )
-
-    def callable(query: str) -> PlanAndQueryOutput:
-        conversation = Conversation.objects.create(team=demo_org_team_user[1], user=demo_org_team_user[2])
-        # Initial state for the graph
-        initial_state = AssistantState(
-            messages=[HumanMessage(content=f"Answer this question: {query}")],
-            root_tool_insight_plan=query,  # User query is the initial plan for the planner
-            root_tool_call_id="eval_test_trends",
-            root_tool_insight_type="trends",
-        )
-
-        # Invoke the graph. The state will be updated through planner and then generator.
-        final_state_raw = graph.invoke(
-            initial_state,
-            {"configurable": {"thread_id": conversation.id}},
-        )
-        final_state = AssistantState.model_validate(final_state_raw)
-
-        if not final_state.messages or not isinstance(final_state.messages[-1], VisualizationMessage):
-            return {"plan": None, "query": None}
-
-        # Ensure the answer is of the expected type for Trends eval
-        answer = final_state.messages[-1].answer
-        if not isinstance(answer, AssistantTrendsQuery):
-            # This case should ideally not happen if the graph is configured correctly for Trends
-            return {"plan": final_state.messages[-1].plan, "query": None}
-
-        return {"plan": final_state.messages[-1].plan, "query": answer}
-
-    return callable
+from .scorers import PlanCorrectness, QueryAndPlanAlignment, QueryKindSelection, TimeRangeRelevancy, PlanAndQueryOutput
 
 
 @pytest.mark.django_db
-def eval_trends(call_node):
+def eval_trends(call_root_for_insight_generation):
     MaxEval(
         experiment_name="trends",
-        task=call_node,
+        task=call_root_for_insight_generation,
         scores=[
+            QueryKindSelection(expected=NodeKind.TRENDS_QUERY),
             PlanCorrectness(
                 query_kind=NodeKind.TRENDS_QUERY,
                 evaluation_criteria="""
@@ -143,7 +97,7 @@ Events:
                 ),
             ),
             EvalCase(
-                input="What is the MAU?",
+                input="What is our MAU?",
                 expected=PlanAndQueryOutput(
                     plan="""
 Events:
@@ -261,7 +215,7 @@ Formula:
                 ),
             ),
             EvalCase(
-                input="what is the average session duration?",
+                input="what is our average session duration?",
                 expected=PlanAndQueryOutput(
                     plan="""
 Events:

--- a/ee/hogai/eval/scorers.py
+++ b/ee/hogai/eval/scorers.py
@@ -1,9 +1,9 @@
-import json
 from typing import TypedDict
 from autoevals.partial import ScorerWithPartial
 from autoevals.ragas import AnswerSimilarity
-from langchain_core.messages import AIMessage as LangchainAIMessage
 from autoevals.llm import LLMClassifier
+import json
+from langchain_core.messages import AIMessage as LangchainAIMessage
 
 from braintrust import Score
 from posthog.schema import (
@@ -58,6 +58,26 @@ class ToolRelevance(ScorerWithPartial):
 class PlanAndQueryOutput(TypedDict):
     plan: str | None
     query: AssistantTrendsQuery | AssistantFunnelsQuery | AssistantRetentionQuery | AssistantHogQLQuery | None
+
+
+class QueryKindSelection(ScorerWithPartial):
+    """Evaluate if the generated plan is of the correct type."""
+
+    _expected: NodeKind
+
+    def __init__(self, expected: NodeKind, **kwargs):
+        super().__init__(**kwargs)
+        self._expected = expected
+
+    def _run_eval_sync(self, output: PlanAndQueryOutput, expected=None, **kwargs):
+        if not output.get("query"):
+            return Score(name=self._name(), score=0.0, metadata={"reason": "No query present"})
+        score = 1 if output["query"].kind == self._expected else 0
+        return Score(
+            name=self._name(),
+            score=score,
+            metadata={"reason": f"Expected {self._expected}, got {output['query'].kind}"} if not score else {},
+        )
 
 
 class PlanCorrectness(LLMClassifier):

--- a/ee/hogai/eval/scorers.py
+++ b/ee/hogai/eval/scorers.py
@@ -71,7 +71,7 @@ class QueryKindSelection(ScorerWithPartial):
 
     def _run_eval_sync(self, output: PlanAndQueryOutput, expected=None, **kwargs):
         if not output.get("query"):
-            return Score(name=self._name(), score=0.0, metadata={"reason": "No query present"})
+            return Score(name=self._name(), score=None, metadata={"reason": "No query present"})
         score = 1 if output["query"].kind == self._expected else 0
         return Score(
             name=self._name(),

--- a/ee/hogai/graph/graph.py
+++ b/ee/hogai/graph/graph.py
@@ -287,20 +287,22 @@ class InsightsAssistantGraph(BaseAssistantGraph):
         builder.add_edge(AssistantNodeName.QUERY_EXECUTOR, next_node)
         return self
 
-    def compile_full_graph(self):
+    def add_query_creation_flow(self, next_node: AssistantNodeName = AssistantNodeName.QUERY_EXECUTOR):
+        """Add all nodes and edges EXCEPT query execution."""
         return (
             self.add_rag_context()
             .add_trends_planner()
-            .add_trends_generator()
+            .add_trends_generator(next_node=next_node)
             .add_funnel_planner()
-            .add_funnel_generator()
+            .add_funnel_generator(next_node=next_node)
             .add_retention_planner()
-            .add_retention_generator()
+            .add_retention_generator(next_node=next_node)
             .add_sql_planner()
-            .add_sql_generator()
-            .add_query_executor()
-            .compile()
+            .add_sql_generator(next_node=next_node)
         )
+
+    def compile_full_graph(self):
+        return self.add_query_creation_flow().add_query_executor().compile()
 
 
 class AssistantGraph(BaseAssistantGraph):


### PR DESCRIPTION
## Problem

We have dozens of AI evaluation cases, but they don't test insight type selection right now, as they all feed questions into an already-selected insight type flow.

## Changes

Let's make insight creation evals evaluate reality, by going through the root node. This will allow us to actually see the failure modes around wrong insight types being chosen. Insight-kind specific `call_node`s fixtures are replaced by a common `call_root_for_insight_generation`.

We now also have a simple eval scorer for query kind selection, called… `QueryKindSelection`.

## How did you test this code?

These are the tests.