### PR TITLE
feat: use http for enabled teams

### DIFF
--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -131,10 +131,10 @@ _clickhouse_http_pool_mgr = httputil.get_pool_manager(
 @contextmanager
 def get_http_client(**overrides):
     kwargs = {
-        "host": settings.QUERYSERVICE_HOST,
+        "host": settings.CLICKHOUSE_HOST,
         "database": settings.CLICKHOUSE_DATABASE,
-        "secure": settings.QUERYSERVICE_SECURE,
-        "username": settings.CLICKHOUSE_USER,
+        "secure": settings.CLICKHOUSE_SECURE,
+        "user": settings.CLICKHOUSE_USER,  # kwargs have user not username
         "password": settings.CLICKHOUSE_PASSWORD,
         "settings": {"mutations_sync": "1"} if settings.TEST else {},
         # Without this, OPTIMIZE table and other queries will regularly run into timeouts
@@ -181,8 +181,8 @@ def get_kwargs_for_client(
     # Note that `readonly` does nothing if the relevant vars are not set!
     if readonly and settings.READONLY_CLICKHOUSE_USER is not None and settings.READONLY_CLICKHOUSE_PASSWORD:
         return {
-            user: settings.READONLY_CLICKHOUSE_USER,
-            password: settings.READONLY_CLICKHOUSE_PASSWORD,
+            "user": settings.READONLY_CLICKHOUSE_USER,
+            "password": settings.READONLY_CLICKHOUSE_PASSWORD,
         }
 
     if (

--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -1,9 +1,9 @@
 import logging
 import os
-from collections.abc import Mapping
 from contextlib import contextmanager
 from enum import Enum
 from functools import cache
+from collections.abc import Mapping
 
 from clickhouse_connect import get_client
 from clickhouse_connect.driver import Client as HttpClient, httputil
@@ -83,15 +83,15 @@ class ProxyClient:
         self._client = client
 
     def execute(
-        self,
-        query,
-        params=None,
-        with_column_types=False,
-        external_tables=None,
-        query_id=None,
-        settings=None,
-        types_check=False,
-        columnar=False,
+            self,
+            query,
+            params=None,
+            with_column_types=False,
+            external_tables=None,
+            query_id=None,
+            settings=None,
+            types_check=False,
+            columnar=False,
     ):
         if query_id:
             settings["query_id"] = query_id
@@ -142,89 +142,76 @@ def get_http_client(**overrides):
     yield ProxyClient(get_client(**kwargs))
 
 
+def get_kwargs_for_client(
+        workload: Workload = Workload.DEFAULT,
+        team_id=None,
+        readonly=False,
+        ch_user: ClickHouseUser = ClickHouseUser.DEFAULT,
+):
+    if workload == Workload.LOGS:
+        return {
+            "host": settings.CLICKHOUSE_LOGS_CLUSTER_HOST,
+            "database": settings.CLICKHOUSE_LOGS_CLUSTER_DATABASE,
+            "user": settings.CLICKHOUSE_LOGS_CLUSTER_USER,
+            "password": settings.CLICKHOUSE_LOGS_CLUSTER_PASSWORD,
+            "secure": settings.CLICKHOUSE_LOGS_CLUSTER_SECURE,
+        }
+
+    (user, password) = get_clickhouse_creds(ch_user)
+    base_kwargs = {"user": user, "password": password}
+
+    if team_id is not None and str(team_id) in settings.CLICKHOUSE_PER_TEAM_SETTINGS:
+        user_settings = settings.CLICKHOUSE_PER_TEAM_SETTINGS[str(team_id)]
+        return {**base_kwargs, **user_settings}
+
+    # Note that `readonly` does nothing if the relevant vars are not set!
+    if readonly and settings.READONLY_CLICKHOUSE_USER is not None and settings.READONLY_CLICKHOUSE_PASSWORD:
+        return {
+            user: settings.READONLY_CLICKHOUSE_USER,
+            password: settings.READONLY_CLICKHOUSE_PASSWORD,
+        }
+
+    if (
+            workload == Workload.OFFLINE or workload == Workload.DEFAULT and _default_workload == Workload.OFFLINE
+    ) and settings.CLICKHOUSE_OFFLINE_CLUSTER_HOST is not None:
+        return {**base_kwargs, "host": settings.CLICKHOUSE_OFFLINE_CLUSTER_HOST, "verify": False}
+
+    return base_kwargs
+
+
 @patchable
 def get_client_from_pool(
-    workload: Workload = Workload.DEFAULT,
-    team_id=None,
-    readonly=False,
-    ch_user: ClickHouseUser = ClickHouseUser.DEFAULT,
+        workload: Workload = Workload.DEFAULT,
+        team_id=None,
+        readonly=False,
+        ch_user: ClickHouseUser = ClickHouseUser.DEFAULT,
 ):
     """
     Returns the client for a given workload.
 
     The connection pool for HTTP is managed by a library.
     """
+
     if settings.CLICKHOUSE_USE_HTTP:
-        if team_id is not None and str(team_id) in settings.CLICKHOUSE_PER_TEAM_SETTINGS:
-            return get_http_client(**settings.CLICKHOUSE_PER_TEAM_SETTINGS[str(team_id)])
-
-        # Note that `readonly` does nothing if the relevant vars are not set!
-        if readonly and settings.READONLY_CLICKHOUSE_USER is not None and settings.READONLY_CLICKHOUSE_PASSWORD:
-            return get_http_client(
-                username=settings.READONLY_CLICKHOUSE_USER,
-                password=settings.READONLY_CLICKHOUSE_PASSWORD,
-            )
-
-        if (
-            workload == Workload.OFFLINE or workload == Workload.DEFAULT and _default_workload == Workload.OFFLINE
-        ) and settings.CLICKHOUSE_OFFLINE_CLUSTER_HOST is not None:
-            return get_http_client(host=settings.CLICKHOUSE_OFFLINE_CLUSTER_HOST, verify=False)
-
-        if workload == Workload.LOGS:
-            return get_http_client(
-                host=settings.CLICKHOUSE_LOGS_CLUSTER_HOST,
-                database=settings.CLICKHOUSE_LOGS_CLUSTER_DATABASE,
-                user=settings.CLICKHOUSE_LOGS_CLUSTER_USER,
-                password=settings.CLICKHOUSE_LOGS_CLUSTER_PASSWORD,
-                secure=settings.CLICKHOUSE_LOGS_CLUSTER_SECURE,
-            )
-
-        return get_http_client()
+        kwargs = get_kwargs_for_client(workload=workload, team_id=team_id, readonly=readonly, ch_user=ch_user)
+        return get_http_client(**kwargs)
 
     return get_pool(workload=workload, team_id=team_id, readonly=readonly, ch_user=ch_user).get_client()
 
 
 def get_pool(
-    workload: Workload = Workload.DEFAULT,
-    team_id=None,
-    readonly=False,
-    ch_user: ClickHouseUser = ClickHouseUser.DEFAULT,
+        workload: Workload = Workload.DEFAULT,
+        team_id=None,
+        readonly=False,
+        ch_user: ClickHouseUser = ClickHouseUser.DEFAULT,
 ):
     """
     Returns the right connection pool given a workload.
 
     Note that the same pool should be returned every call.
     """
-    (user, password) = get_clickhouse_creds(ch_user)
-
-    if team_id is not None and str(team_id) in settings.CLICKHOUSE_PER_TEAM_SETTINGS:
-        user_settings = settings.CLICKHOUSE_PER_TEAM_SETTINGS[str(team_id)]
-        if "user" not in user_settings:
-            user_settings = {**user_settings, "user": user, "password": password}
-        return make_ch_pool(**user_settings)
-
-    # Note that `readonly` does nothing if the relevant vars are not set!
-    if readonly and settings.READONLY_CLICKHOUSE_USER is not None and settings.READONLY_CLICKHOUSE_PASSWORD:
-        return make_ch_pool(
-            user=settings.READONLY_CLICKHOUSE_USER,
-            password=settings.READONLY_CLICKHOUSE_PASSWORD,
-        )
-
-    if (
-        workload == Workload.OFFLINE or workload == Workload.DEFAULT and _default_workload == Workload.OFFLINE
-    ) and settings.CLICKHOUSE_OFFLINE_CLUSTER_HOST is not None:
-        return make_ch_pool(host=settings.CLICKHOUSE_OFFLINE_CLUSTER_HOST, verify=False, user=user, password=password)
-
-    if workload == Workload.LOGS:
-        return make_ch_pool(
-            host=settings.CLICKHOUSE_LOGS_CLUSTER_HOST,
-            database=settings.CLICKHOUSE_LOGS_CLUSTER_DATABASE,
-            user=settings.CLICKHOUSE_LOGS_CLUSTER_USER,
-            password=settings.CLICKHOUSE_LOGS_CLUSTER_PASSWORD,
-            secure=settings.CLICKHOUSE_LOGS_CLUSTER_SECURE,
-        )
-
-    return make_ch_pool(user=user, password=password)
+    kwargs = get_kwargs_for_client(workload=workload, team_id=team_id, readonly=readonly, ch_user=ch_user)
+    return make_ch_pool(**kwargs)
 
 
 def default_client(host=settings.CLICKHOUSE_HOST):

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -183,6 +183,11 @@ CLICKHOUSE_FALLBACK_CANCEL_QUERY_ON_CLUSTER = get_from_env(
 )
 
 CLICKHOUSE_USE_HTTP: str = get_from_env("CLICKHOUSE_USE_HTTP", False, type_cast=str_to_bool)
+CLICKHOUSE_USE_HTTP_PER_TEAM = set[int]([])
+with suppress(Exception):
+    as_json = json.loads(os.getenv("CLICKHOUSE_USE_HTTP_PER_TEAM", "[]"))
+    CLICKHOUSE_USE_HTTP_PER_TEAM = {int(v) for v in as_json}
+
 QUERYSERVICE_HOST: str = get_from_env("QUERYSERVICE_HOST", CLICKHOUSE_HOST)
 QUERYSERVICE_SECURE: bool = get_from_env("QUERYSERVICE_SECURE", CLICKHOUSE_SECURE, type_cast=str_to_bool)
 QUERYSERVICE_VERIFY: bool = get_from_env("QUERYSERVICE_VERIFY", CLICKHOUSE_VERIFY, type_cast=str_to_bool)
@@ -224,6 +229,10 @@ with suppress(Exception):
     as_json = json.loads(os.getenv("API_QUERIES_PER_TEAM", "{}"))
     API_QUERIES_PER_TEAM = {int(k): int(v) for k, v in as_json.items()}
 
+API_QUERIES_ON_ONLINE_CLUSTER = set[int]([])
+with suppress(Exception):
+    as_json = json.loads(os.getenv("API_QUERIES_ON_ONLINE_CLUSTER", "[]"))
+    API_QUERIES_ON_ONLINE_CLUSTER = {int(v) for v in as_json}
 
 _clickhouse_http_protocol = "http://"
 _clickhouse_http_port = "8123"


### PR DESCRIPTION
## Problem

We need to better loadbalance the CH traffic and introduce traffic shedding. For this, lets move to ClickHouse HTTP interface for queries

## Changes

Allow to test HTTP interface in production.

## Did you write or update any docs for this change?

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [X] No docs needed for this change

## How did you test this code?

Test locally.
