### PR TITLE
feat(data-warehouse): Add `hs_buying_role` property to Hubspot contact

### DIFF
--- a/posthog/temporal/data_imports/pipelines/hubspot/settings.py
+++ b/posthog/temporal/data_imports/pipelines/hubspot/settings.py
@@ -86,6 +86,7 @@ DEFAULT_CONTACT_PROPS = [
     "hs_lead_status",
     "lastmodifieddate",
     "lastname",
+    "hs_buying_role",
 ]
 
 DEFAULT_TICKET_PROPS = [


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We're not returning the `hs_buying_role` property from the Hubspot contact object.

## Changes

Add `hs_buying_role` property

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

I haven't
