### PR TITLE
feat(experiments): new engine for users on free plan

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -269,7 +269,8 @@ export const FEATURE_FLAGS = {
     USAGE_SPEND_DASHBOARDS: 'usage-spend-dashboards', // owner: @pawel-cebula #team-billing
     SIMPLE_INFINITE_LIST_NUMERICAL_FILTER: 'simple-infinite-list-numerical-filter', // owner: @rafaeelaudibert #team-revenue-analytics
     REPLAY_SCREENSHOT: 'replay-screenshot', // owner: @veryayskiy #team-replay
-    ACTIVITY_OR_EXPLORE: 'activity-or-explore', // owner: @pauldambra #team-replay
+    ACTIVITY_OR_EXPLORE: 'activity-or-explore', // owner: @pauldambra #team-replay,
+    EXPERIMENTS_NEW_QUERY_RUNNER_FOR_NON_PAYING_USERS: 'experiments-new-query-runner-for-non-paying-users', // owner: #team-experiments
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -270,7 +270,7 @@ export const FEATURE_FLAGS = {
     SIMPLE_INFINITE_LIST_NUMERICAL_FILTER: 'simple-infinite-list-numerical-filter', // owner: @rafaeelaudibert #team-revenue-analytics
     REPLAY_SCREENSHOT: 'replay-screenshot', // owner: @veryayskiy #team-replay
     ACTIVITY_OR_EXPLORE: 'activity-or-explore', // owner: @pauldambra #team-replay,
-    EXPERIMENTS_NEW_QUERY_RUNNER_FOR_NON_PAYING_USERS: 'experiments-new-query-runner-for-non-paying-users', // owner: #team-experiments
+    EXPERIMENTS_NEW_QUERY_RUNNER_FOR_USERS_ON_FREE_PLAN: 'experiments-new-query-runner-for-users-on-free-plan', // owner: #team-experiments
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
@@ -3,13 +3,13 @@ import { actions, connect, kea, key, listeners, path, props, reducers, selectors
 import { loaders } from 'kea-loaders'
 import { router, urlToAction } from 'kea-router'
 import api from 'lib/api'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic, FeatureFlagsSet } from 'lib/logic/featureFlagLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { billingLogic } from 'scenes/billing/billingLogic'
 
-import { UserBasicType } from '~/types'
+import { BillingType, UserBasicType } from '~/types'
 
-import { getDefaultFunnelMetric, getDefaultTrendsMetric } from '../utils'
+import { getDefaultFunnelMetric, getDefaultTrendsMetric, shouldUseNewQueryRunnerForNewObjects } from '../utils'
 import type { sharedMetricLogicType } from './sharedMetricLogicType'
 import { sharedMetricsLogic } from './sharedMetricsLogic'
 
@@ -43,7 +43,7 @@ export const sharedMetricLogic = kea<sharedMetricLogicType>([
 
     connect(() => ({
         actions: [sharedMetricsLogic, ['loadSharedMetrics'], eventUsageLogic, ['reportExperimentSharedMetricCreated']],
-        values: [featureFlagLogic, ['featureFlags']],
+        values: [featureFlagLogic, ['featureFlags'], billingLogic, ['billing']],
     })),
 
     actions({
@@ -132,10 +132,10 @@ export const sharedMetricLogic = kea<sharedMetricLogicType>([
         ],
         action: [() => [(_, props) => props.action], (action: 'create' | 'update' | 'duplicate') => action],
         newSharedMetric: [
-            (s) => [s.featureFlags],
-            (featureFlags: FeatureFlagsSet) => ({
+            (s) => [s.featureFlags, s.billing],
+            (featureFlags: FeatureFlagsSet, billing: BillingType) => ({
                 ...NEW_SHARED_METRIC,
-                query: featureFlags[FEATURE_FLAGS.EXPERIMENTS_NEW_QUERY_RUNNER]
+                query: shouldUseNewQueryRunnerForNewObjects(featureFlags, billing)
                     ? getDefaultFunnelMetric()
                     : getDefaultTrendsMetric(),
             }),

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -4,14 +4,14 @@ import { loaders } from 'kea-loaders'
 import { router, urlToAction } from 'kea-router'
 import api from 'lib/api'
 import { openSaveToModal } from 'lib/components/SaveTo/saveToLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { featureFlagLogic, FeatureFlagsSet } from 'lib/logic/featureFlagLogic'
 import { hasFormErrors, toParams } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { ProductIntentContext } from 'lib/utils/product-intents'
 import { addProjectIdIfMissing } from 'lib/utils/router-utils'
+import { billingLogic } from 'scenes/billing/billingLogic'
 import {
     featureFlagLogic as sceneFeatureFlagLogic,
     indexToVariantKeyFeatureFlagPayloads,
@@ -47,6 +47,7 @@ import {
     NodeKind,
 } from '~/queries/schema/schema-general'
 import {
+    BillingType,
     Breadcrumb,
     BreakdownAttributionType,
     BreakdownType,
@@ -81,6 +82,7 @@ import {
     featureFlagEligibleForExperiment,
     isLegacyExperiment,
     percentageDistribution,
+    shouldUseNewQueryRunnerForNewObjects,
     toInsightVizNode,
     transformFiltersForWinningVariant,
 } from './utils'
@@ -211,6 +213,8 @@ export const experimentLogic = kea<experimentLogicType>([
             ['featureFlags'],
             holdoutsLogic,
             ['holdouts'],
+            billingLogic,
+            ['billing'],
             // Hook the insight state to get the results for the sample size estimation
             funnelDataLogic({ dashboardItemId: MetricInsightId.Funnels }),
             ['results as funnelResults', 'conversionMetrics'],
@@ -249,6 +253,8 @@ export const experimentLogic = kea<experimentLogicType>([
             ['addProductIntent'],
             featureFlagsLogic,
             ['updateFlag'],
+            billingLogic,
+            ['loadBillingSuccess'],
         ],
     })),
     actions({
@@ -1519,6 +1525,12 @@ export const experimentLogic = kea<experimentLogicType>([
                 )
             },
         ],
+        isOnPaidPlan: [
+            (s) => [s.billing],
+            (billing: BillingType | null): boolean => {
+                return !!billing?.has_active_subscription
+            },
+        ],
         breadcrumbs: [
             (s) => [s.experiment, s.experimentId],
             (experiment, experimentId): Breadcrumb[] => [
@@ -1866,8 +1878,8 @@ export const experimentLogic = kea<experimentLogicType>([
             },
         ],
         usesNewQueryRunner: [
-            (s) => [s.experiment, s.featureFlags],
-            (experiment: Experiment, featureFlags: Record<string, boolean>): boolean => {
+            (s) => [s.experiment, s.featureFlags, s.billing],
+            (experiment: Experiment, featureFlags: FeatureFlagsSet, billing: BillingType): boolean => {
                 const hasLegacyMetrics = isLegacyExperiment(experiment)
 
                 const allMetrics = [...experiment.metrics, ...experiment.metrics_secondary, ...experiment.saved_metrics]
@@ -1881,7 +1893,8 @@ export const experimentLogic = kea<experimentLogicType>([
                     return false
                 }
 
-                return featureFlags[FEATURE_FLAGS.EXPERIMENTS_NEW_QUERY_RUNNER]
+                // If the experiment has no experiment metrics, we use the new query runner if the feature is enabled
+                return shouldUseNewQueryRunnerForNewObjects(featureFlags, billing)
             },
         ],
         hasMinimumExposureForResults: [

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1523,12 +1523,6 @@ export const experimentLogic = kea<experimentLogicType>([
                 )
             },
         ],
-        isOnPaidPlan: [
-            (s) => [s.billing],
-            (billing: BillingType | null): boolean => {
-                return !!billing?.has_active_subscription
-            },
-        ],
         breadcrumbs: [
             (s) => [s.experiment, s.experimentId],
             (experiment, experimentId): Breadcrumb[] => [

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -253,8 +253,6 @@ export const experimentLogic = kea<experimentLogicType>([
             ['addProductIntent'],
             featureFlagsLogic,
             ['updateFlag'],
-            billingLogic,
-            ['loadBillingSuccess'],
         ],
     })),
     actions({

--- a/frontend/src/scenes/experiments/experimentsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.ts
@@ -7,14 +7,15 @@ import api from 'lib/api'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { featureFlagLogic, FeatureFlagsSet } from 'lib/logic/featureFlagLogic'
+import { billingLogic } from 'scenes/billing/billingLogic'
 import { featureFlagsLogic, type FeatureFlagsResult } from 'scenes/feature-flags/featureFlagsLogic'
 import { projectLogic } from 'scenes/projectLogic'
 import { userLogic } from 'scenes/userLogic'
 
-import { Experiment, ExperimentsTabs, ProgressStatus } from '~/types'
+import { BillingType, Experiment, ExperimentsTabs, ProgressStatus } from '~/types'
 
 import type { experimentsLogicType } from './experimentsLogicType'
-import { isLegacyExperiment } from './utils'
+import { isLegacyExperiment, shouldUseNewQueryRunnerForNewObjects } from './utils'
 
 export function getExperimentStatus(experiment: Experiment): ProgressStatus {
     if (!experiment.start_date) {
@@ -50,6 +51,8 @@ export const experimentsLogic = kea<experimentsLogicType>([
             ['featureFlags'],
             router,
             ['location'],
+            billingLogic,
+            ['billing'],
         ],
     })),
     actions({
@@ -171,8 +174,8 @@ export const experimentsLogic = kea<experimentsLogicType>([
             },
         ],
         showLegacyBadge: [
-            (s) => [featureFlagsLogic.selectors.featureFlags, s.experiments],
-            (featureFlags: FeatureFlagsSet, experiments: Experiment[]): boolean => {
+            (s) => [featureFlagsLogic.selectors.featureFlags, s.experiments, s.billing],
+            (featureFlags: FeatureFlagsSet, experiments: Experiment[], billing: BillingType): boolean => {
                 /**
                  * If the new query runner is enabled, we want to always show the legacy badge,
                  * even if all existing experiments are legacy experiments.
@@ -180,7 +183,7 @@ export const experimentsLogic = kea<experimentsLogicType>([
                  * Not ideal to use feature flags at this level, but this is how things are and
                  * it'll take a while to change.
                  */
-                if (featureFlags[FEATURE_FLAGS.EXPERIMENTS_NEW_QUERY_RUNNER]) {
+                if (shouldUseNewQueryRunnerForNewObjects(featureFlags, billing)) {
                     return true
                 }
 

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -768,7 +768,7 @@ export const isLegacySharedMetric = ({ query }: SharedMetric): boolean => isLega
 export const shouldUseNewQueryRunnerForNewObjects = (featureFlags: FeatureFlagsSet, billing: BillingType): boolean => {
     // For non-paying users, we use dedicated flag to control the rollout of the new query runner
     const isOnFreePlan = billing?.subscription_level === 'free'
-    if (isOnFreePlan && !!featureFlags[FEATURE_FLAGS.EXPERIMENTS_NEW_QUERY_RUNNER_FOR_NON_PAYING_USERS]) {
+    if (isOnFreePlan && !!featureFlags[FEATURE_FLAGS.EXPERIMENTS_NEW_QUERY_RUNNER_FOR_USERS_ON_FREE_PLAN]) {
         return true
     }
 

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -1,6 +1,7 @@
 import { getSeriesColor } from 'lib/colors'
-import { EXPERIMENT_DEFAULT_DURATION, FunnelLayout } from 'lib/constants'
+import { EXPERIMENT_DEFAULT_DURATION, FEATURE_FLAGS, FunnelLayout } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
+import { FeatureFlagsSet } from 'lib/logic/featureFlagLogic'
 import merge from 'lodash.merge'
 import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
 
@@ -30,6 +31,7 @@ import {
 import { isFunnelsQuery, isNodeWithSource, isTrendsQuery, isValidQueryForExperiment } from '~/queries/utils'
 import {
     ActionFilter,
+    BillingType,
     ChartDisplayType,
     Experiment,
     ExperimentMetricMathType,
@@ -762,3 +764,15 @@ export const isLegacyExperiment = ({ metrics, metrics_secondary, saved_metrics }
 }
 
 export const isLegacySharedMetric = ({ query }: SharedMetric): boolean => isLegacyExperimentQuery(query)
+
+export const shouldUseNewQueryRunnerForNewObjects = (featureFlags: FeatureFlagsSet, billing: BillingType): boolean => {
+    // For non-paying users, we use dedicated flag to control the rollout of the new query runner
+    const isOnFreePlan = billing?.subscription_level === 'free'
+    if (isOnFreePlan && !!featureFlags[FEATURE_FLAGS.EXPERIMENTS_NEW_QUERY_RUNNER_FOR_NON_PAYING_USERS]) {
+        return true
+    }
+
+    // If the users org. is on a paid plan, or the feature flag above is disabled, we use the default
+    // feature flag to control the rollout of the new query runner
+    return !!featureFlags[FEATURE_FLAGS.EXPERIMENTS_NEW_QUERY_RUNNER]
+}


### PR DESCRIPTION
## Problem
We would like to roll out the new engine to customers on the free plan.

## Changes
Add a new feature flag that we can turn on to enable the new engine for customers on the free plan. We can't target free plan customers with a feature flag rollout condition unfortunately, so for now we have to rely on the `billingLogic`, and use the `billing.subscription_level` to determine this. All functions relying on this is refactored to use the centralized function to control this. So the feature flag `EXPERIMENTS_NEW_QUERY_RUNNER` is only used in that function now.

## How did you test this code?
- manually tested