### PR TITLE
ci(max): Only run AI evals on relevant master commits

### DIFF
--- a/.github/workflows/ci-ai.yml
+++ b/.github/workflows/ci-ai.yml
@@ -4,6 +4,9 @@ on:
     push:
         branches:
             - master
+        paths:
+            - 'ee/hogai/**'
+            - '.github/workflows/ci-ai.yml'
     pull_request:
         paths:
             - 'ee/hogai/**'


### PR DESCRIPTION
## Problem

We've been running AI evals on _all_ master commits, while most have nothing to do with AI features – expensive.

## Changes

Making things much more efficient: only running evals on relevant commits.