### PR TITLE
fix: active screens query is too slow

### DIFF
--- a/frontend/src/scenes/session-recordings/components/ReplayActiveScreensTable.tsx
+++ b/frontend/src/scenes/session-recordings/components/ReplayActiveScreensTable.tsx
@@ -1,6 +1,8 @@
+import { IconInfo } from '@posthog/icons'
 import { useValues } from 'kea'
 import { router } from 'kea-router'
 import { LemonTable } from 'lib/lemon-ui/LemonTable'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { replayActiveScreensTableLogic } from 'scenes/session-recordings/components/replayActiveScreensTableLogic'
 import { urls } from 'scenes/urls'
 
@@ -15,7 +17,15 @@ export const ReplayActiveScreensTable = (): JSX.Element => {
                 embedded={true}
                 columns={[
                     {
-                        title: 'Your most active pages',
+                        title: (
+                            <>
+                                <Tooltip title="Click a row to see the latest results">
+                                    <div className="flex flex-row gap-2 items-center cursor-pointer">
+                                        <IconInfo className="text-xl" /> Your most active pages
+                                    </div>
+                                </Tooltip>
+                            </>
+                        ),
                         dataIndex: 'screen',
                         align: 'left',
                         width: '90%',

--- a/frontend/src/scenes/session-recordings/components/ReplayActiveUsersTable.tsx
+++ b/frontend/src/scenes/session-recordings/components/ReplayActiveUsersTable.tsx
@@ -1,6 +1,8 @@
+import { IconInfo } from '@posthog/icons'
 import { useValues } from 'kea'
 import { router } from 'kea-router'
 import { LemonTable } from 'lib/lemon-ui/LemonTable'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 import { urls } from 'scenes/urls'
 
@@ -17,7 +19,15 @@ export const ReplayActiveUsersTable = (): JSX.Element => {
                 embedded={true}
                 columns={[
                     {
-                        title: 'Your most active users',
+                        title: (
+                            <>
+                                <Tooltip title="Click a row to see the latest results">
+                                    <div className="flex flex-row gap-2 items-center cursor-pointer">
+                                        <IconInfo className="text-xl" /> Your most active users
+                                    </div>
+                                </Tooltip>
+                            </>
+                        ),
                         dataIndex: 'person',
                         align: 'left',
                         render: (p) => <PersonDisplay person={p as PersonType} withIcon={true} noLink={true} />,

--- a/frontend/src/scenes/session-recordings/components/replayActiveScreensTableLogic.ts
+++ b/frontend/src/scenes/session-recordings/components/replayActiveScreensTableLogic.ts
@@ -21,43 +21,14 @@ export const replayActiveScreensTableLogic = kea<replayActiveScreensTableLogicTy
     lazyLoaders(() => ({
         countedScreens: {
             loadCountedScreens: async (_, breakpoint): Promise<{ screen: string; count: number }[]> => {
-                // we can't use the all_urls column yet :/
-                // const q = hogql`
-                //     select cutQueryString(cutFragment(url)) as u, count(distinct session_id) as c
-                //     from (select session_id, arrayJoin(all_urls) as url
-                //           from raw_session_replay_events
-                //           where min_first_timestamp >= now() - toIntervalDay(7)
-                //             and min_first_timestamp <= now())
-                //     group by u
-                //     order by c desc limit 10
-                // `
                 const q = hogql`
-                    select cutQueryString(cutFragment(the_url)) as cut_url, count(distinct session_id) as c
-                    from (with (select \`$session_id\` as session_id, properties.$current_url as url
-                                from events
-                                where timestamp >= now() - toIntervalDay(7)
-                                  and timestamp <= now()
-                                  and properties.$current_url is not null
-                                  and properties.$current_url != '') as event_urls
-                          select raw_session_replay_events.session_id, arrayJoin(groupArray(event_urls.url)) as the_url
+                    select cutQueryString(cutFragment(url)) as u, count(distinct session_id) as c
+                    from (select session_id, arrayJoin(all_urls) as url
                           from raw_session_replay_events
-                              left join event_urls
-                          on raw_session_replay_events.session_id = event_urls.session_id
                           where min_first_timestamp >= now() - toIntervalDay(7)
-                            and min_first_timestamp <= now()
-                            and raw_session_replay_events.session_id in (
-                              select \`$session_id\`
-                              from events
-                              where timestamp >= now() - toIntervalDay(7)
-                            and timestamp <= now()
-                            and properties.$current_url is not null
-                            and properties.$current_url != ''
-                              )
-                          group by raw_session_replay_events.session_id
-                          having date_diff('second', min (min_first_timestamp), max (max_last_timestamp)) > 5000)
-                    group by cut_url
-                    order by c desc
-                    limit 5
+                            and min_first_timestamp <= now())
+                    group by u
+                    order by c desc limit 10
                 `
 
                 const qResponse = await api.query<HogQLQuery>({


### PR DESCRIPTION
let's switch to the replay events table URLs query - the events based one is way too slow