### PR TITLE
feat: enable screen recordings for the new experiment engine.

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/SummaryTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/SummaryTable.tsx
@@ -33,7 +33,7 @@ import {
     getHighestProbabilityVariant,
 } from '../experimentCalculations'
 import { experimentLogic } from '../experimentLogic'
-import { getViewRecordingFilters, getViewRecordingFiltersNew, isLegacyExperimentQuery } from '../utils'
+import { getViewRecordingFilters, getViewRecordingFiltersLegacy, isLegacyExperimentQuery } from '../utils'
 import { VariantTag } from './components'
 
 export function SummaryTable({
@@ -372,8 +372,8 @@ export function SummaryTable({
             const variantKey = item.key
 
             const filters = isLegacyExperimentQuery(metric)
-                ? getViewRecordingFilters(metric, experiment.feature_flag_key, variantKey)
-                : getViewRecordingFiltersNew(experiment, metric, variantKey)
+                ? getViewRecordingFiltersLegacy(metric, experiment.feature_flag_key, variantKey)
+                : getViewRecordingFilters(experiment, metric, variantKey)
 
             return (
                 <LemonButton
@@ -397,7 +397,7 @@ export function SummaryTable({
                             date_to: experiment?.end_date,
                             filter_test_accounts:
                                 metric.kind === NodeKind.ExperimentMetric
-                                    ? false
+                                    ? experiment.exposure_criteria?.filterTestAccounts ?? false
                                     : metric.kind === NodeKind.ExperimentTrendsQuery
                                     ? metric.count_query.filterTestAccounts
                                     : metric.funnels_query.filterTestAccounts,

--- a/frontend/src/scenes/experiments/ExperimentView/SummaryTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/SummaryTable.tsx
@@ -33,7 +33,7 @@ import {
     getHighestProbabilityVariant,
 } from '../experimentCalculations'
 import { experimentLogic } from '../experimentLogic'
-import { getViewRecordingFilters } from '../utils'
+import { getViewRecordingFilters, getViewRecordingFiltersNew, isLegacyExperimentQuery } from '../utils'
 import { VariantTag } from './components'
 
 export function SummaryTable({
@@ -371,7 +371,10 @@ export function SummaryTable({
         render: function Key(_, item): JSX.Element {
             const variantKey = item.key
 
-            const filters = getViewRecordingFilters(metric, experiment.feature_flag_key, variantKey)
+            const filters = isLegacyExperimentQuery(metric)
+                ? getViewRecordingFilters(metric, experiment.feature_flag_key, variantKey)
+                : getViewRecordingFiltersNew(experiment, metric, variantKey)
+
             return (
                 <LemonButton
                     size="xsmall"

--- a/frontend/src/scenes/experiments/utils.test.ts
+++ b/frontend/src/scenes/experiments/utils.test.ts
@@ -275,6 +275,12 @@ describe('getViewRecordingFilters', () => {
                     operator: PropertyOperator.IsNot,
                     type: PropertyFilterType.Event,
                 },
+                {
+                    key: '$feature/my-flag',
+                    type: PropertyFilterType.Event,
+                    value: ['variantA'],
+                    operator: PropertyOperator.Exact,
+                },
             ],
         })
     })
@@ -294,9 +300,15 @@ describe('getViewRecordingFilters', () => {
             type: 'events',
             properties: [
                 {
-                    key: '$feature/my-flag',
+                    key: '$feature_flag_response',
                     type: PropertyFilterType.Event,
                     value: ['variantA'],
+                    operator: PropertyOperator.Exact,
+                },
+                {
+                    key: '$feature_flag',
+                    type: PropertyFilterType.Event,
+                    value: 'my-flag',
                     operator: PropertyOperator.Exact,
                 },
             ],
@@ -324,9 +336,15 @@ describe('getViewRecordingFilters', () => {
             type: 'events',
             properties: [
                 {
-                    key: '$feature/my-flag',
+                    key: '$feature_flag_response',
                     type: PropertyFilterType.Event,
                     value: ['variantA'],
+                    operator: PropertyOperator.Exact,
+                },
+                {
+                    key: '$feature_flag',
+                    type: PropertyFilterType.Event,
+                    value: 'my-flag',
                     operator: PropertyOperator.Exact,
                 },
             ],
@@ -371,7 +389,12 @@ describe('getViewRecordingFilters', () => {
             name: 'event1',
             type: 'events',
             properties: [
-                { key: 'foo', value: 'bar', operator: PropertyOperator.Exact, type: PropertyFilterType.Event },
+                {
+                    key: 'foo',
+                    value: 'bar',
+                    operator: PropertyOperator.Exact,
+                    type: PropertyFilterType.Event,
+                },
             ],
         })
     })

--- a/frontend/src/scenes/experiments/utils.test.ts
+++ b/frontend/src/scenes/experiments/utils.test.ts
@@ -38,6 +38,7 @@ import {
     filterToMetricConfig,
     getFunnelPreviewSeries,
     getViewRecordingFilters,
+    getViewRecordingFiltersLegacy,
     isLegacyExperiment,
     isLegacyExperimentQuery,
     metricToFilter,
@@ -215,10 +216,171 @@ describe('getNiceTickValues', () => {
 })
 
 describe('getViewRecordingFilters', () => {
+    const experimentBase = {
+        id: 1,
+        name: 'test experiment',
+        feature_flag_key: 'my-flag',
+        exposure_criteria: undefined,
+        filters: {},
+        metrics: [],
+        metrics_secondary: [],
+        saved_metrics_ids: [],
+        saved_metrics: [],
+        parameters: {
+            feature_flag_variants: [
+                { key: 'control', rollout_percentage: 50 },
+                { key: 'test', rollout_percentage: 50 },
+            ],
+        },
+        secondary_metrics: [],
+        created_at: null,
+        created_by: null,
+        updated_at: null,
+    }
+
+    it('adds exposure criteria if present', () => {
+        const experiment = {
+            ...experimentBase,
+            exposure_criteria: {
+                exposure_config: {
+                    kind: NodeKind.ExperimentEventExposureConfig,
+                    event: 'exposure_event',
+                    properties: [
+                        {
+                            key: 'foo',
+                            value: 'bar',
+                            operator: PropertyOperator.IsNot,
+                            type: PropertyFilterType.Event,
+                        },
+                    ],
+                },
+            },
+        } satisfies Experiment
+
+        const metric = {
+            kind: NodeKind.ExperimentMetric,
+            metric_type: ExperimentMetricType.MEAN,
+            source: { kind: NodeKind.EventsNode, event: 'event1', name: 'event1' },
+        } satisfies ExperimentMetric
+
+        const filters = getViewRecordingFilters(experiment, metric, 'variantA')
+        expect(filters[0]).toEqual({
+            id: 'exposure_event',
+            name: 'exposure_event',
+            type: 'events',
+            properties: [
+                {
+                    key: 'foo',
+                    value: 'bar',
+                    operator: 'is_not',
+                    type: 'event',
+                },
+            ],
+        })
+    })
+
+    it('adds default exposure event if no exposure criteria', () => {
+        const experiment = { ...experimentBase }
+        const metric = {
+            kind: NodeKind.ExperimentMetric,
+            metric_type: ExperimentMetricType.MEAN,
+            source: { kind: NodeKind.EventsNode, event: 'event1', name: 'event1' },
+        } satisfies ExperimentMetric
+
+        const filters = getViewRecordingFilters(experiment, metric, 'variantA')
+        expect(filters[0]).toEqual({
+            id: '$feature_flag_called',
+            name: '$feature_flag_called',
+            type: 'events',
+            properties: [
+                {
+                    key: '$feature/my-flag',
+                    type: PropertyFilterType.Event,
+                    value: ['variantA'],
+                    operator: PropertyOperator.Exact,
+                },
+            ],
+        })
+    })
+
+    it('adds mean metric event filter', () => {
+        const experiment = { ...experimentBase }
+        const metric = {
+            kind: NodeKind.ExperimentMetric,
+            metric_type: ExperimentMetricType.MEAN,
+            source: { kind: NodeKind.EventsNode, event: 'event1', name: 'event1' },
+        } satisfies ExperimentMetric
+
+        const filters = getViewRecordingFilters(experiment, metric, 'variantA')
+        expect(filters[1]).toEqual({
+            id: 'event1',
+            name: 'event1',
+            type: 'events',
+            properties: [
+                {
+                    key: '$feature/my-flag',
+                    type: PropertyFilterType.Event,
+                    value: ['variantA'],
+                    operator: PropertyOperator.Exact,
+                },
+            ],
+        })
+    })
+
+    it('adds mean metric action filter', () => {
+        const experiment = { ...experimentBase }
+        const metric = {
+            kind: NodeKind.ExperimentMetric,
+            metric_type: ExperimentMetricType.MEAN,
+            source: { kind: NodeKind.ActionsNode, id: 123, name: 'action1' },
+        } satisfies ExperimentMetric
+
+        const filters = getViewRecordingFilters(experiment, metric, 'variantA')
+        expect(filters[1]).toEqual({
+            id: 123,
+            name: 'action1',
+            type: 'actions',
+        })
+    })
+
+    it('adds funnel metric filters for each series', () => {
+        const experiment = { ...experimentBase }
+        const metric = {
+            kind: NodeKind.ExperimentMetric,
+            metric_type: ExperimentMetricType.FUNNEL,
+            series: [
+                { kind: NodeKind.EventsNode, event: 'event1', name: 'event1' },
+                { kind: NodeKind.ActionsNode, id: 123, name: 'action1' },
+            ],
+        } satisfies ExperimentMetric
+
+        const filters = getViewRecordingFilters(experiment, metric, 'variantA')
+        expect(filters[1]).toEqual({
+            id: 'event1',
+            name: 'event1',
+            type: 'events',
+            properties: [
+                {
+                    key: '$feature/my-flag',
+                    type: PropertyFilterType.Event,
+                    value: ['variantA'],
+                    operator: PropertyOperator.Exact,
+                },
+            ],
+        })
+        expect(filters[2]).toEqual({
+            id: 123,
+            name: 'action1',
+            type: 'actions',
+        })
+    })
+})
+
+describe('getViewRecordingFiltersLegacy', () => {
     const featureFlagKey = 'jan-16-running'
 
     it('returns the correct filters for an experiment query', () => {
-        const filters = getViewRecordingFilters(
+        const filters = getViewRecordingFiltersLegacy(
             EXPERIMENT_V3_WITH_ONE_EXPERIMENT_QUERY.metrics[0] as ExperimentMetric,
             featureFlagKey,
             'control'
@@ -241,7 +403,7 @@ describe('getViewRecordingFilters', () => {
     })
 
     it('returns the correct filters for a funnel metric', () => {
-        const filters = getViewRecordingFilters(
+        const filters = getViewRecordingFiltersLegacy(
             metricFunnelEventsJson as ExperimentFunnelsQuery,
             featureFlagKey,
             'control'
@@ -276,7 +438,7 @@ describe('getViewRecordingFilters', () => {
         ])
     })
     it('returns the correct filters for a trend metric', () => {
-        const filters = getViewRecordingFilters(
+        const filters = getViewRecordingFiltersLegacy(
             metricTrendFeatureFlagCalledJson as ExperimentTrendsQuery,
             featureFlagKey,
             'test'
@@ -317,7 +479,7 @@ describe('getViewRecordingFilters', () => {
         ])
     })
     it('returns the correct filters for a trend metric with custom exposure', () => {
-        const filters = getViewRecordingFilters(
+        const filters = getViewRecordingFiltersLegacy(
             metricTrendCustomExposureJson as ExperimentTrendsQuery,
             featureFlagKey,
             'test'
@@ -352,7 +514,11 @@ describe('getViewRecordingFilters', () => {
         ])
     })
     it('returns the correct filters for a trend metric with an action', () => {
-        const filters = getViewRecordingFilters(metricTrendActionJson as ExperimentTrendsQuery, featureFlagKey, 'test')
+        const filters = getViewRecordingFiltersLegacy(
+            metricTrendActionJson as ExperimentTrendsQuery,
+            featureFlagKey,
+            'test'
+        )
         expect(filters).toEqual([
             {
                 id: '$feature_flag_called',

--- a/frontend/src/scenes/experiments/utils.test.ts
+++ b/frontend/src/scenes/experiments/utils.test.ts
@@ -303,6 +303,36 @@ describe('getViewRecordingFilters', () => {
         })
     })
 
+    it('falls back to default exposure event if exposure_criteria exists but exposure_config is undefined', () => {
+        const experiment = {
+            ...experimentBase,
+            exposure_criteria: {
+                exposure_config: undefined,
+            },
+        } satisfies Experiment
+
+        const metric = {
+            kind: NodeKind.ExperimentMetric,
+            metric_type: ExperimentMetricType.MEAN,
+            source: { kind: NodeKind.EventsNode, event: 'event1', name: 'event1' },
+        } satisfies ExperimentMetric
+
+        const filters = getViewRecordingFilters(experiment, metric, 'variantA')
+        expect(filters[0]).toEqual({
+            id: '$feature_flag_called',
+            name: '$feature_flag_called',
+            type: 'events',
+            properties: [
+                {
+                    key: '$feature/my-flag',
+                    type: PropertyFilterType.Event,
+                    value: ['variantA'],
+                    operator: PropertyOperator.Exact,
+                },
+            ],
+        })
+    })
+
     it('adds mean metric event filter', () => {
         const experiment = { ...experimentBase }
         const metric = {

--- a/frontend/src/scenes/experiments/utils.test.ts
+++ b/frontend/src/scenes/experiments/utils.test.ts
@@ -272,8 +272,8 @@ describe('getViewRecordingFilters', () => {
                 {
                     key: 'foo',
                     value: 'bar',
-                    operator: 'is_not',
-                    type: 'event',
+                    operator: PropertyOperator.IsNot,
+                    type: PropertyFilterType.Event,
                 },
             ],
         })
@@ -333,7 +333,7 @@ describe('getViewRecordingFilters', () => {
         })
     })
 
-    it('adds mean metric event filter', () => {
+    it('adds mean metric event filter (no extra properties)', () => {
         const experiment = { ...experimentBase }
         const metric = {
             kind: NodeKind.ExperimentMetric,
@@ -346,13 +346,32 @@ describe('getViewRecordingFilters', () => {
             id: 'event1',
             name: 'event1',
             type: 'events',
+            properties: [],
+        })
+    })
+
+    it('adds mean metric event filter (with properties)', () => {
+        const experiment = { ...experimentBase }
+        const metric = {
+            kind: NodeKind.ExperimentMetric,
+            metric_type: ExperimentMetricType.MEAN,
+            source: {
+                kind: NodeKind.EventsNode,
+                event: 'event1',
+                name: 'event1',
+                properties: [
+                    { key: 'foo', value: 'bar', operator: PropertyOperator.Exact, type: PropertyFilterType.Event },
+                ],
+            },
+        } satisfies ExperimentMetric
+
+        const filters = getViewRecordingFilters(experiment, metric, 'variantA')
+        expect(filters[1]).toEqual({
+            id: 'event1',
+            name: 'event1',
+            type: 'events',
             properties: [
-                {
-                    key: '$feature/my-flag',
-                    type: PropertyFilterType.Event,
-                    value: ['variantA'],
-                    operator: PropertyOperator.Exact,
-                },
+                { key: 'foo', value: 'bar', operator: PropertyOperator.Exact, type: PropertyFilterType.Event },
             ],
         })
     })
@@ -379,7 +398,14 @@ describe('getViewRecordingFilters', () => {
             kind: NodeKind.ExperimentMetric,
             metric_type: ExperimentMetricType.FUNNEL,
             series: [
-                { kind: NodeKind.EventsNode, event: 'event1', name: 'event1' },
+                {
+                    kind: NodeKind.EventsNode,
+                    event: 'event1',
+                    name: 'event1',
+                    properties: [
+                        { key: 'bar', value: 'baz', operator: PropertyOperator.Exact, type: PropertyFilterType.Event },
+                    ],
+                },
                 { kind: NodeKind.ActionsNode, id: 123, name: 'action1' },
             ],
         } satisfies ExperimentMetric
@@ -390,12 +416,7 @@ describe('getViewRecordingFilters', () => {
             name: 'event1',
             type: 'events',
             properties: [
-                {
-                    key: '$feature/my-flag',
-                    type: PropertyFilterType.Event,
-                    value: ['variantA'],
-                    operator: PropertyOperator.Exact,
-                },
+                { key: 'bar', value: 'baz', operator: PropertyOperator.Exact, type: PropertyFilterType.Event },
             ],
         })
         expect(filters[2]).toEqual({

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -119,6 +119,25 @@ function seriesToFilter(
     return null
 }
 
+/**
+ * Gets the Filters to ExperimentMetrics
+ */
+export const getViewRecordingFiltersNew = (
+    experiment: Experiment,
+    metric: ExperimentMetric,
+    variantKey: string
+): UniversalFiltersGroupValue[] => {
+    /**
+     * We need to check the exposure criteria as the first on the filter chain
+     */
+
+    // for mean metrics, we only need to add one other filtter, could be an aciton or an event
+
+    // for funnel metrics, we need to add one item for each of the series
+
+    return []
+}
+
 export function getViewRecordingFilters(
     metric: ExperimentMetric | ExperimentTrendsQuery | ExperimentFunnelsQuery,
     featureFlagKey: string,

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -156,12 +156,20 @@ export function getViewRecordingFilters(
      * exposure criteria can only be events, not actions
      */
     const exposureCriteria = experiment.exposure_criteria?.exposure_config
-    if (exposureCriteria) {
+    if (exposureCriteria && exposureCriteria.event !== '$feature_flag_called') {
         filters.push({
             id: exposureCriteria.event,
             name: exposureCriteria.event,
             type: 'events',
-            properties: exposureCriteria.properties,
+            properties: [
+                ...(exposureCriteria.properties || []),
+                {
+                    key: `$feature/${experiment.feature_flag_key}`,
+                    type: PropertyFilterType.Event,
+                    value: [variantKey],
+                    operator: PropertyOperator.Exact,
+                },
+            ],
         })
     } else {
         filters.push({
@@ -170,9 +178,15 @@ export function getViewRecordingFilters(
             type: 'events',
             properties: [
                 {
-                    key: `$feature/${experiment.feature_flag_key}`,
+                    key: '$feature_flag_response',
                     type: PropertyFilterType.Event,
                     value: [variantKey],
+                    operator: PropertyOperator.Exact,
+                },
+                {
+                    key: '$feature_flag',
+                    type: PropertyFilterType.Event,
+                    value: experiment.feature_flag_key,
                     operator: PropertyOperator.Exact,
                 },
             ],


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

> [!NOTE]
> Close #32779 

## Problem

The existing implementation of the results summary table does not support translating the new metric format into filters for the _screen recording_ page.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We are branching execution based on the metric type. If it's a _legacy_ metric, nothing changes. If it's a `ExperimentMetric`, we call a new function that will:

- Use the exposure criteria as the first filter. Either the default or a custom criteria should work.
- For _trend_ metrics, use the `metric.source` as the single, second filter.
- For _funnel_ metrics, create a filter for each element in the metric `series`.

Also, we are passing `filterTestAccounts`.

| Funnel Metric | Filter with Default Exposure Criteria |
| - | - |
|  <img width="1003" alt="image" src="https://github.com/user-attachments/assets/185a0d4d-71c9-47a1-b891-4574d799e7fc" /> | <img width="751" alt="image" src="https://github.com/user-attachments/assets/adeeff8a-3e6a-4ccb-8ff1-649317e87c87" /> |

| Trend Metric | Filter with Default Exposure Criteria |
| - | - |
| <img width="1000" alt="image" src="https://github.com/user-attachments/assets/bb517f98-4fd4-42cf-af6c-e7fcbdf606f0" /> | <img width="752" alt="image" src="https://github.com/user-attachments/assets/a357db98-4b3b-4aa7-b555-063a133dae1b" /> |

https://github.com/user-attachments/assets/33c5f156-4667-4d00-80ed-bae2cf4e859f


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Unit Tests for the new functions:

```bash
pnpm --filter=@posthog/frontend jest src/scenes/experiments/utils.test.ts
```

the rest...

![cat-type-small](https://github.com/user-attachments/assets/0a36989d-3396-4bde-a5c8-d30d0e2019e0)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
