### PR TITLE
feat: add loading skeleton to pay gate

### DIFF
--- a/frontend/src/lib/components/PayGateMini/PayGateMini.tsx
+++ b/frontend/src/lib/components/PayGateMini/PayGateMini.tsx
@@ -1,5 +1,5 @@
 import { IconInfo, IconOpenSidebar, IconUnlock } from '@posthog/icons'
-import { LemonButton, Link, Tooltip } from '@posthog/lemon-ui'
+import { LemonButton, LemonSkeleton, Link, Tooltip } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
@@ -25,6 +25,10 @@ export type PayGateMiniProps = PayGateMiniLogicProps & {
     background?: boolean
     isGrandfathered?: boolean
     docsLink?: string
+    /**
+     * Custom loading state to show while billing data is loading
+     */
+    loadingSkeleton?: JSX.Element
 }
 
 /** A sort of paywall for premium features.
@@ -41,6 +45,7 @@ export function PayGateMini({
     background = true,
     isGrandfathered,
     docsLink,
+    loadingSkeleton,
 }: PayGateMiniProps): JSX.Element | null {
     const { productWithFeature, featureInfo, gateVariant, bypassPaywall } = useValues(
         payGateMiniLogic({ feature, currentUsage })
@@ -71,7 +76,26 @@ export function PayGateMini({
     }
 
     if (billingLoading) {
-        return null
+        return (
+            loadingSkeleton || (
+                <div
+                    className={clsx(
+                        className,
+                        background && 'bg-primary border border-primary',
+                        'PayGateMini rounded flex flex-col items-center p-4 text-center'
+                    )}
+                >
+                    <LemonSkeleton className="w-20 h-10 mb-2" />
+                    <LemonSkeleton className="w-48 h-12 mb-2" />
+                    <LemonSkeleton className="w-1/2 h-6 mb-2" />
+                    <LemonSkeleton className="w-1/2 h-6 mb-2" />
+                    <div className="flex items-center justify-center gap-x-2 mt-3">
+                        <LemonSkeleton className="w-32 h-10" />
+                        <LemonSkeleton className="w-32 h-10" />
+                    </div>
+                </div>
+            )
+        )
     }
 
     if (gateVariant && preflight?.instance_preferences?.disable_paid_fs) {


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changes

Billing can take a while to load so this adds an animation instead of rendering nothing. In the future we can work on the performance of the billing endpoint so this isn't needed. There are some tricky dependencies.

![Screenshot 2025-05-28 at 4 21 34 PM](https://github.com/user-attachments/assets/174cb62f-57d9-436c-8304-213f323f35dc)

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
