### PR TITLE
feat: wait till the query concurrency slot is free, only for 30s

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -6,7 +6,7 @@ export DEBUG=${DEBUG:-1}
 export SKIP_SERVICE_VERSION_REQUIREMENTS=${SKIP_SERVICE_VERSION_REQUIREMENTS:-1}
 export BILLING_SERVICE_URL=${BILLING_SERVICE_URL:-https://billing.dev.posthog.dev}
 export HOG_HOOK_URL=${HOG_HOOK_URL:-http://localhost:3300/hoghook}
-export API_QUERIES_PER_TEAM='{"1": 1}'
+export API_QUERIES_PER_TEAM='{"1": 100}'
 
 if [ -f .env ]; then
     set -o allexport

--- a/bin/start
+++ b/bin/start
@@ -6,6 +6,7 @@ export DEBUG=${DEBUG:-1}
 export SKIP_SERVICE_VERSION_REQUIREMENTS=${SKIP_SERVICE_VERSION_REQUIREMENTS:-1}
 export BILLING_SERVICE_URL=${BILLING_SERVICE_URL:-https://billing.dev.posthog.dev}
 export HOG_HOOK_URL=${HOG_HOOK_URL:-http://localhost:3300/hoghook}
+export API_QUERIES_PER_TEAM='{"1": 1}'
 
 if [ -f .env ]; then
     set -o allexport

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -155,7 +155,7 @@ services:
             CLICKHOUSE_API_PASSWORD: 'apipass'
             CLICKHOUSE_APP_USER: 'app'
             CLICKHOUSE_APP_PASSWORD: 'apppass'
-            API_QUERIES_PER_TEAM: '{"1": 7}'
+            API_QUERIES_PER_TEAM: '{"1": 100}'
             KAFKA_HOSTS: 'kafka'
             REDIS_URL: 'redis://redis:6379/'
             PGHOST: db

--- a/posthog/clickhouse/client/limit.py
+++ b/posthog/clickhouse/client/limit.py
@@ -170,7 +170,11 @@ def get_api_personal_rate_limiter():
             ),
             ttl=600,
             bypass_all=(not settings.API_QUERIES_ENABLED),
+            # the p25 duration for a query is 167ms, p50 is 458ms, there's a 25% chance that after 167ms the slot is free.
             retry=0.1314,
+            # The default timeout for a query on ClickHouse is 60s. p99 duration is 19s, 30 seconds should be enough
+            # for some other query to finish. If the query cannot get a slot in this period, the user should contact us
+            # about increasing the quota.
             retry_timeout=datetime.timedelta(seconds=30),
         )
     return __API_CONCURRENT_QUERY_PER_TEAM

--- a/posthog/clickhouse/client/limit.py
+++ b/posthog/clickhouse/client/limit.py
@@ -90,7 +90,7 @@ class RateLimit:
         """
         Acquire the resource before execution or throw exception.
         """
-        t0 = datetime.datetime.now()
+        wait_deadline = datetime.datetime.now() + self.retry_timeout
         task_name = self.get_task_name(*args, **kwargs)
         running_tasks_key = self.get_task_key(*args, **kwargs) if self.get_task_key else task_name
         task_id = self.get_task_id(*args, **kwargs)
@@ -127,8 +127,7 @@ class RateLimit:
             # team in beta cannot skip limits
             if bypass or (not in_beta and self.bypass_all):
                 return None, None
-            still_have_time = (datetime.datetime.now() - t0) < self.retry_timeout
-            if self.retry and still_have_time:
+            if self.retry and datetime.datetime.now() < wait_deadline:
                 sleep(backoff(count))
                 count += 1
                 continue

--- a/posthog/clickhouse/client/limit.py
+++ b/posthog/clickhouse/client/limit.py
@@ -170,8 +170,9 @@ def get_api_personal_rate_limiter():
             ),
             ttl=600,
             bypass_all=(not settings.API_QUERIES_ENABLED),
-            # the p25 duration for a query is 167ms, p50 is 458ms, there's a 25% chance that after 167ms the slot is free.
-            retry=0.1314,
+            # p20 duration for a query is 133ms, p25 is 164ms, p50 is 458ms, there's a 20% chance that after 134ms
+            # the slot is free.
+            retry=0.134,
             # The default timeout for a query on ClickHouse is 60s. p99 duration is 19s, 30 seconds should be enough
             # for some other query to finish. If the query cannot get a slot in this period, the user should contact us
             # about increasing the quota.

--- a/posthog/clickhouse/client/limit.py
+++ b/posthog/clickhouse/client/limit.py
@@ -104,6 +104,7 @@ class RateLimit:
         elif "limit" in kwargs:
             max_concurrency = kwargs.get("limit") or max_concurrency
 
+        # p80 is below 1.714ms, therefore max retry is 1.714s
         backoff = ExponentialBackoff(self.retry or 0.15, max_delay=1.714, exp=1.5)
         count = 1
         # Atomically check, remove expired if limit hit, and add the new task

--- a/posthog/clickhouse/client/limit.py
+++ b/posthog/clickhouse/client/limit.py
@@ -69,7 +69,7 @@ class RateLimit:
     ttl: int = 60
     bypass_all: bool = False
     redis_client = redis.get_client()
-    retry: Optional[float] = False
+    retry: Optional[float] = None
     retry_timeout: datetime.timedelta = datetime.timedelta(milliseconds=10000)
 
     @contextmanager

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -15,7 +15,7 @@ from concurrent.futures import (
 )
 from copy import copy
 from dataclasses import dataclass, field
-from typing import Any, Generic, Literal, NamedTuple, TypeVar
+from typing import Any, Generic, Literal, NamedTuple, TypeVar, Optional
 from collections.abc import Iterable
 
 import dagster
@@ -417,9 +417,12 @@ class Query:
 @dataclass
 class ExponentialBackoff:
     delay: float
+    max_delay: Optional[float] = None
+    exp: float = 2.0
 
     def __call__(self, attempt: int) -> float:
-        return self.delay * (attempt**2)
+        delay = self.delay * (attempt**self.exp)
+        return min(delay, self.max_delay) if self.max_delay is not None else delay
 
 
 @dataclass

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -222,6 +222,7 @@ try:
 except Exception:
     CLICKHOUSE_PER_TEAM_QUERY_SETTINGS = {}
 
+# Per-team API /query concurrent limits, e.g. {"2": 7}
 API_QUERIES_PER_TEAM: dict[int, int] = {}
 with suppress(Exception):
     as_json = json.loads(os.getenv("API_QUERIES_PER_TEAM", "{}"))


### PR DESCRIPTION
## Problem

Queries have limited concurrency, they fail if no concurrency is available.

## Changes

Allows us to queue instead of failing. Keep the connection opened.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [X] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
