### PR TITLE
fix(cdp): allow custom code for transformations without pipelines add on

### DIFF
--- a/frontend/src/scenes/hog-functions/configuration/HogFunctionConfiguration.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/HogFunctionConfiguration.tsx
@@ -476,7 +476,8 @@ export function HogFunctionConfiguration({
                                                     }, 100)
                                                 }}
                                                 disabledReason={
-                                                    !hasAddon
+                                                    // We allow editing the source code for transformations without the Data Pipelines addon
+                                                    !hasAddon && type !== 'transformation'
                                                         ? 'Editing the source code requires the Data Pipelines addon'
                                                         : undefined
                                                 }


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

<img width="579" alt="Screenshot 2025-05-29 at 09 19 39" src="https://github.com/user-attachments/assets/0c59304e-2d7c-4679-8d4b-d3fac3648fa3" />

Folks can't write custom transformations because we prohibit editing of the source code when folks do not have the data pipelines add on. We do not want that for transformations as they are free of charge.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- make transformations code editable in any instance

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->


## How did you test this code?

- local dev

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
