### PR TITLE
fix(cdp): return javascript code in destination templates

### DIFF
--- a/posthog/models/hog_function_template.py
+++ b/posthog/models/hog_function_template.py
@@ -173,7 +173,7 @@ class HogFunctionTemplate(UUIDModel):
             for mapping_template_dict in self.mapping_templates:
                 mapping_templates_list.append(HogFunctionMappingTemplate(**mapping_template_dict))
 
-        # hog is only set if language is hog, otherwise None
+        # hog is only set if language is hog or javascript, otherwise None
         hog_value = self.code if self.code_language in ("hog", "javascript") else ""
 
         # Create the dataclass

--- a/posthog/models/hog_function_template.py
+++ b/posthog/models/hog_function_template.py
@@ -174,7 +174,7 @@ class HogFunctionTemplate(UUIDModel):
                 mapping_templates_list.append(HogFunctionMappingTemplate(**mapping_template_dict))
 
         # hog is only set if language is hog, otherwise None
-        hog_value = self.code if self.code_language == "hog" else ""
+        hog_value = self.code if self.code_language in ("hog", "javascript") else ""
 
         # Create the dataclass
         return HogFunctionTemplateDTO(


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

The code for `site_destinations` wasn't being returned by the backend

## Changes

- return source code of javascript destinations as well

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
