### PR TITLE
feat: support addons in usage and spend dashboards

### DIFF
--- a/frontend/src/scenes/billing/BillingEarlyAccessBanner.tsx
+++ b/frontend/src/scenes/billing/BillingEarlyAccessBanner.tsx
@@ -36,9 +36,9 @@ export function BillingEarlyAccessBanner(): JSX.Element {
                     <ul className="list-disc list-inside pl-2">
                         <li>Usage data updates daily (UTC) - so today's numbers show up tomorrow</li>
                         <li>
-                            Some product add-ons (like group analytics and data pipelines) and deleted projects aren't
-                            in here <span className="italic">yet</span>
+                            Deleted projects aren't in here <span className="italic">yet</span>
                         </li>
+                        <li>Historical spend is calculated using the current subscription plan</li>
                     </ul>
                 </div>
             </div>

--- a/frontend/src/scenes/billing/constants.ts
+++ b/frontend/src/scenes/billing/constants.ts
@@ -7,6 +7,8 @@ export const USAGE_TYPES = [
     { label: 'Rows Synced', value: 'rows_synced_in_period' },
     { label: 'Persons', value: 'enhanced_persons_event_count_in_period' },
     { label: 'Survey Responses', value: 'survey_responses_count_in_period' },
+    { label: 'Data Pipelines', value: 'data_pipelines' },
+    { label: 'Group Analytics', value: 'group_analytics' },
 ] as const
 
 export type UsageTypeOption = (typeof USAGE_TYPES)[number]


### PR DESCRIPTION
This PR should be merged after corresponding billing changes are live: https://github.com/PostHog/billing/pull/1291

## Changes

Adds group analytics and data pipelines addons to usage and spend dashboards

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [x] I've added or updated the docs (see https://github.com/PostHog/billing/pull/1291)

## How did you test this code?

- Updated tests, wrote tests, manually (see https://github.com/PostHog/billing/pull/1291)
