### PR TITLE
fix(data-modeling): Invalidate s3fs cache

### DIFF
--- a/posthog/temporal/data_imports/util.py
+++ b/posthog/temporal/data_imports/util.py
@@ -16,6 +16,7 @@ def prepare_s3_files_for_querying(
     delete_existing: bool = True,
 ):
     s3 = get_s3_client()
+    s3.invalidate_cache()
 
     normalized_table_name = NamingConvention().normalize_identifier(table_name)
 


### PR DESCRIPTION
## Problem
- s3fs is caching a previous `ls` request to S3, but the underlying files are changing and so when doing a `cp` later on, we get a pre-mature `FileNotFound` error due to the new files not being in the s3fs cache
- https://posthog.slack.com/archives/C019RAX2XBN/p1748523460705919?thread_ts=1748431592.455829&cid=C019RAX2XBN

## Changes
- Clear the cache before we attempt to copy any files 