### PR TITLE
fix(devex): resizer z-index

### DIFF
--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -620,13 +620,13 @@
     --z-annotation-popover: 100;
     --z-drawer: 900;
     --z-notifications-popover: 800; // below the TZ aware popover but over the main-nav
-    --z-resizer: 761;
     --z-layout-panel: 760;
     --z-layout-panel-under: 759;
     --z-layout-navbar-over: 757;
     --z-layout-navbar: 756;
     --z-layout-navbar-under: 755;
     --z-main-nav: 750;
+    --z-resizer: 701;
     --z-lemon-sidebar: 700;
     --z-lemon-activation-sidebar: 650;
     --z-mobile-nav-overlay: 600;


### PR DESCRIPTION
## Problem
Resizer z-index was above new layout...

![image](https://github.com/user-attachments/assets/1eddc933-6ef5-4249-a068-5fa98d3e5e71)

## Changes
Drop resizer CSS var z-index value to below new layout

Fix:
![2025-05-29 15 26 04](https://github.com/user-attachments/assets/4e374d39-9bba-462f-bcdd-9ad0050574d2)



## How did you test this code?
Manually