### PR TITLE
feat: Add run status sensor for reporting status changes of Dagster jobs as Prometheus metrics

### DIFF
--- a/dags/common.py
+++ b/dags/common.py
@@ -71,7 +71,7 @@ def report_job_status_metric(context: dagster.RunStatusSensorContext) -> None:
     JOB_STATUS_COUNTER.labels(
         job_name=context.dagster_run.job_name,
         status=context.dagster_run.status.name,
-    )
+    ).inc()
 
 
 job_status_metrics_sensors = [

--- a/dags/definitions.py
+++ b/dags/definitions.py
@@ -5,7 +5,7 @@ from dagster_aws.s3.io_manager import s3_pickle_io_manager
 from dagster_aws.s3.resources import S3Resource
 from django.conf import settings
 
-from dags.common import ClickhouseClusterResource
+from dags.common import ClickhouseClusterResource, job_status_metrics_sensors
 from dags import (
     backups,
     ch_examples,
@@ -86,6 +86,7 @@ defs = dagster.Definitions(
     sensors=[
         deletes.run_deletes_after_squash,
         slack_alerts.notify_slack_on_failure,
+        *job_status_metrics_sensors,
     ],
     resources=resources,
 )


### PR DESCRIPTION
## Problem

We don't have a good way to set up alerts so that we can be sure important jobs are actually running and succeeding.

## Changes

Adds sensor for various job statuses that reports to Prometheus so that we can set up alerts using our existing alerting tools as needed.

## Did you write or update any docs for this change?

n/a

## How did you test this code?

Ran job locally, ensured sensor was enabled and fired as expected