### PR TITLE
fix: skeletons and spacing for new surveys' question viz

### DIFF
--- a/frontend/src/scenes/surveys/SurveyStatsSummary.tsx
+++ b/frontend/src/scenes/surveys/SurveyStatsSummary.tsx
@@ -3,7 +3,7 @@ import { useActions, useValues } from 'kea'
 import { TZLabel } from 'lib/components/TZLabel'
 import { humanFriendlyNumber, percentage, pluralize } from 'lib/utils'
 import { memo } from 'react'
-import { StackedBar, StackedBarSegment } from 'scenes/surveys/components/StackedBar'
+import { StackedBar, StackedBarSegment, StackedBarSkeleton } from 'scenes/surveys/components/StackedBar'
 
 import { SurveyEventName, SurveyRates, SurveyStats } from '~/types'
 
@@ -22,7 +22,7 @@ function StatCard({ title, value, description, isLoading }: StatCardProps): JSX.
             <div className="text-xs font-semibold uppercase text-text-secondary">{title}</div>
             {isLoading ? (
                 <>
-                    <LemonSkeleton className="h-8 w-16" />
+                    <LemonSkeleton className="h-9 w-16" />
                     <LemonSkeleton className="h-4 w-32" />
                 </>
             ) : (
@@ -40,7 +40,7 @@ function UsersCount({ stats, rates }: { stats: SurveyStats; rates: SurveyRates }
     const uniqueUsersSent = stats[SurveyEventName.SENT].unique_persons
     const { answerFilterHogQLExpression } = useValues(surveyLogic)
     return (
-        <div className="flex flex-wrap gap-4 mb-4">
+        <div className="flex flex-wrap gap-4">
             <StatCard
                 title="Total Impressions by Unique Users"
                 value={humanFriendlyNumber(uniqueUsersShown)}
@@ -70,7 +70,7 @@ function ResponsesCount({ stats, rates }: { stats: SurveyStats; rates: SurveyRat
     const { answerFilterHogQLExpression } = useValues(surveyLogic)
 
     return (
-        <div className="flex flex-wrap gap-4 mb-4">
+        <div className="flex flex-wrap gap-4">
             <StatCard
                 title="Total Impressions"
                 value={humanFriendlyNumber(impressions)}
@@ -199,7 +199,7 @@ function SurveyStatsContainer({ children }: { children: React.ReactNode }): JSX.
                     </div>
                 </div>
             )}
-            {children}
+            <div className="flex flex-col gap-4">{children}</div>
         </div>
     )
 }
@@ -207,7 +207,7 @@ function SurveyStatsContainer({ children }: { children: React.ReactNode }): JSX.
 function SurveyStatsSummarySkeleton(): JSX.Element {
     return (
         <SurveyStatsContainer>
-            <div className="flex flex-wrap gap-4 mb-4">
+            <div className="flex flex-wrap gap-4">
                 <StatCard
                     title="Total Impressions by Unique Users"
                     value={0}
@@ -227,8 +227,7 @@ function SurveyStatsSummarySkeleton(): JSX.Element {
                     isLoading={true}
                 />
             </div>
-
-            <LemonSkeleton className="h-10 w-full" />
+            <StackedBarSkeleton />
         </SurveyStatsContainer>
     )
 }

--- a/frontend/src/scenes/surveys/components/StackedBar.tsx
+++ b/frontend/src/scenes/surveys/components/StackedBar.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx'
+import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { humanFriendlyNumber } from 'lib/utils'
 
@@ -19,6 +20,24 @@ export interface StackedBarSegment {
     tooltip?: string
 }
 
+export function StackedBarSkeleton(): JSX.Element {
+    return (
+        <div className="flex flex-col gap-4">
+            <div className="relative w-full mx-auto h-10">
+                <LemonSkeleton className="w-full h-10" />
+            </div>
+            <div className="flex items-center gap-4 justify-center">
+                {Array.from({ length: 3 }).map((_, index) => (
+                    <div key={index} className="flex items-center gap-2">
+                        <LemonSkeleton className="size-3 rounded-full" />
+                        <LemonSkeleton className="h-3 w-24" />
+                    </div>
+                ))}
+            </div>
+        </div>
+    )
+}
+
 export function StackedBar({ segments }: { segments: StackedBarSegment[] }): JSX.Element | null {
     const total = segments.reduce((sum, segment) => sum + segment.count, 0)
     let accumulatedPercentage = 0
@@ -28,8 +47,8 @@ export function StackedBar({ segments }: { segments: StackedBarSegment[] }): JSX
     }
 
     return (
-        <div>
-            <div className="relative w-full mx-auto h-10 mb-4">
+        <div className="flex flex-col gap-4">
+            <div className="relative w-full mx-auto h-10">
                 {segments.map(({ count, label, colorClass, tooltip }, index) => {
                     const percentage = (count / total) * 100
                     const left = accumulatedPercentage
@@ -68,12 +87,12 @@ export function StackedBar({ segments }: { segments: StackedBarSegment[] }): JSX
                 })}
             </div>
             <div className="w-full flex justify-center">
-                <div className="flex items-center">
+                <div className="flex items-center gap-8">
                     {segments.map(
                         ({ count, label, colorClass }) =>
                             count > 0 && (
-                                <div key={`stacked-bar-legend-${label}`} className="flex items-center mr-6">
-                                    <div className={clsx('w-3 h-3 rounded-full mr-2', colorClass)} />
+                                <div key={`stacked-bar-legend-${label}`} className="flex items-center gap-2">
+                                    <div className={clsx('size-3 rounded-full', colorClass)} />
                                     <span className="font-semibold text-secondary">{`${label} (${(
                                         (count / total) *
                                         100

--- a/frontend/src/scenes/surveys/components/StackedBar.tsx
+++ b/frontend/src/scenes/surveys/components/StackedBar.tsx
@@ -20,9 +20,9 @@ export interface StackedBarSegment {
     tooltip?: string
 }
 
-export function StackedBarSkeleton(): JSX.Element {
+export function StackedBarSkeleton({ className }: { className?: string }): JSX.Element {
     return (
-        <div className="flex flex-col gap-4">
+        <div className={clsx('flex flex-col gap-2', className)}>
             <div className="relative w-full mx-auto h-10">
                 <LemonSkeleton className="w-full h-10" />
             </div>
@@ -30,7 +30,7 @@ export function StackedBarSkeleton(): JSX.Element {
                 {Array.from({ length: 3 }).map((_, index) => (
                     <div key={index} className="flex items-center gap-2">
                         <LemonSkeleton className="size-3 rounded-full" />
-                        <LemonSkeleton className="h-3 w-24" />
+                        <LemonSkeleton className="h-6 w-24" />
                     </div>
                 ))}
             </div>
@@ -38,7 +38,13 @@ export function StackedBarSkeleton(): JSX.Element {
     )
 }
 
-export function StackedBar({ segments }: { segments: StackedBarSegment[] }): JSX.Element | null {
+export function StackedBar({
+    segments,
+    className,
+}: {
+    segments: StackedBarSegment[]
+    className?: string
+}): JSX.Element | null {
     const total = segments.reduce((sum, segment) => sum + segment.count, 0)
     let accumulatedPercentage = 0
 
@@ -47,7 +53,7 @@ export function StackedBar({ segments }: { segments: StackedBarSegment[] }): JSX
     }
 
     return (
-        <div className="flex flex-col gap-4">
+        <div className={clsx('flex flex-col gap-2', className)}>
             <div className="relative w-full mx-auto h-10">
                 {segments.map(({ count, label, colorClass, tooltip }, index) => {
                     const percentage = (count / total) * 100

--- a/frontend/src/scenes/surveys/components/question-visualizations/RatingQuestionViz.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/RatingQuestionViz.tsx
@@ -1,5 +1,5 @@
 import { IconInfo } from '@posthog/icons'
-import { LemonCollapse, Tooltip } from '@posthog/lemon-ui'
+import { LemonCollapse, LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
 import { BindLogic, useActions, useValues } from 'kea'
 import { CompareFilter } from 'lib/components/CompareFilter/CompareFilter'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
@@ -8,6 +8,7 @@ import { dayjs } from 'lib/dayjs'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { LineGraph } from 'scenes/insights/views/LineGraph/LineGraph'
 import { CHART_INSIGHTS_COLORS } from 'scenes/surveys/components/question-visualizations/util'
+import { StackedBarSkeleton } from 'scenes/surveys/components/StackedBar'
 import {
     NPS_DETRACTOR_LABEL,
     NPS_DETRACTOR_VALUES,
@@ -100,13 +101,11 @@ const CHART_LABELS: Record<number, string[]> = {
     3: ['1', '2', '3'],
 }
 
-function NPSBreakdownViz({ npsBreakdown }: { npsBreakdown: NPSBreakdown }): JSX.Element {
+export function NPSBreakdownSkeleton(): JSX.Element {
     return (
-        <div>
-            <div className="flex gap-2 items-center">
-                <div className="text-4xl font-bold">{npsBreakdown.score}</div>
-            </div>
-            <div className="mb-2 font-semibold text-secondary">
+        <div className="flex flex-col gap-2">
+            <div className="font-semibold text-secondary">
+                <LemonSkeleton className="h-4 w-20" />
                 <Tooltip
                     placement="bottom"
                     title="NPS Score is calculated by subtracting the percentage of detractors (0-6) from the percentage of promoters (9-10). Passives (7-8) are not included in the calculation. It can go from -100 to 100."
@@ -115,11 +114,25 @@ function NPSBreakdownViz({ npsBreakdown }: { npsBreakdown: NPSBreakdown }): JSX.
                     Latest NPS Score
                 </Tooltip>
             </div>
-            {npsBreakdown && (
-                <div className="mt-2 mb-4 deprecated-space-y-2">
-                    <NPSStackedBar npsBreakdown={npsBreakdown} />
-                </div>
-            )}
+            <StackedBarSkeleton />
+        </div>
+    )
+}
+
+function NPSBreakdownViz({ npsBreakdown }: { npsBreakdown: NPSBreakdown }): JSX.Element {
+    return (
+        <div className="flex flex-col gap-2">
+            <div className="font-semibold text-secondary">
+                <div className="text-4xl font-bold">{npsBreakdown.score}</div>
+                <Tooltip
+                    placement="bottom"
+                    title="NPS Score is calculated by subtracting the percentage of detractors (0-6) from the percentage of promoters (9-10). Passives (7-8) are not included in the calculation. It can go from -100 to 100."
+                >
+                    <IconInfo className="text-muted mr-1" />
+                    Latest NPS Score
+                </Tooltip>
+            </div>
+            {npsBreakdown && <NPSStackedBar npsBreakdown={npsBreakdown} />}
         </div>
     )
 }
@@ -372,43 +385,45 @@ export function RatingQuestionViz({ question, questionIndex, processedData }: Pr
     const npsBreakdown = calculateNpsBreakdownFromProcessedData(processedData)
 
     return (
-        <div className="flex flex-col gap-2">
-            <div className="h-50 border rounded pt-8">
-                <div className="relative h-full w-full">
-                    <BindLogic logic={insightLogic} props={insightProps}>
-                        <LineGraph
-                            inSurveyView={true}
-                            hideYAxis={true}
-                            showValuesOnSeries={true}
-                            labelGroupType={1}
-                            data-attr="survey-rating"
-                            type={GraphType.Bar}
-                            hideAnnotations={true}
-                            formula="-"
-                            tooltip={{
-                                showHeader: false,
-                                hideColorCol: true,
-                            }}
-                            datasets={[
-                                {
-                                    id: 1,
-                                    label: 'Number of responses',
-                                    barPercentage: 0.8,
-                                    minBarLength: 2,
-                                    data: normalizeScaleData.map((d) => d.value),
-                                    backgroundColor: barColor,
-                                    borderColor: barColor,
-                                    hoverBackgroundColor: barColor,
-                                },
-                            ]}
-                            labels={CHART_LABELS?.[question.scale] || ['1', '2', '3']}
-                        />
-                    </BindLogic>
+        <>
+            <div className="flex flex-col gap-1">
+                <div className="h-50 border rounded pt-8">
+                    <div className="relative h-full w-full">
+                        <BindLogic logic={insightLogic} props={insightProps}>
+                            <LineGraph
+                                inSurveyView={true}
+                                hideYAxis={true}
+                                showValuesOnSeries={true}
+                                labelGroupType={1}
+                                data-attr="survey-rating"
+                                type={GraphType.Bar}
+                                hideAnnotations={true}
+                                formula="-"
+                                tooltip={{
+                                    showHeader: false,
+                                    hideColorCol: true,
+                                }}
+                                datasets={[
+                                    {
+                                        id: 1,
+                                        label: 'Number of responses',
+                                        barPercentage: 0.8,
+                                        minBarLength: 2,
+                                        data: normalizeScaleData.map((d) => d.value),
+                                        backgroundColor: barColor,
+                                        borderColor: barColor,
+                                        hoverBackgroundColor: barColor,
+                                    },
+                                ]}
+                                labels={CHART_LABELS?.[question.scale] || ['1', '2', '3']}
+                            />
+                        </BindLogic>
+                    </div>
                 </div>
-            </div>
-            <div className="flex flex-row justify-between mt-1">
-                <div className="text-secondary pl-10">{question.lowerBoundLabel}</div>
-                <div className="text-secondary pr-10">{question.upperBoundLabel}</div>
+                <div className="flex flex-row justify-between">
+                    <div className="text-secondary pl-10">{question.lowerBoundLabel}</div>
+                    <div className="text-secondary pr-10">{question.upperBoundLabel}</div>
+                </div>
             </div>
             {npsBreakdown && <NPSBreakdownViz npsBreakdown={npsBreakdown} />}
             {question.scale === 10 && (
@@ -421,6 +436,6 @@ export function RatingQuestionViz({ question, questionIndex, processedData }: Pr
                     scale={question.scale as 3 | 5 | 7}
                 />
             )}
-        </div>
+        </>
     )
 }

--- a/frontend/src/scenes/surveys/components/question-visualizations/SurveyQuestionVisualization.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/SurveyQuestionVisualization.tsx
@@ -12,7 +12,7 @@ import { SurveyNoResponsesBanner } from 'scenes/surveys/SurveyNoResponsesBanner'
 import { ErrorBoundary } from '~/layout/ErrorBoundary'
 import { SurveyQuestion, SurveyQuestionType } from '~/types'
 
-import { RatingQuestionViz } from './RatingQuestionViz'
+import { NPSBreakdownSkeleton, RatingQuestionViz } from './RatingQuestionViz'
 import { SingleChoiceQuestionViz } from './SingleChoiceQuestionViz'
 
 interface Props {
@@ -72,25 +72,29 @@ function QuestionLoadingSkeleton({ question }: { question: SurveyQuestion }): JS
         case SurveyQuestionType.Rating:
             return (
                 <>
-                    <div className="h-50 border rounded p-4 flex flex-col gap-2">
-                        <div className="flex justify-between items-end h-full">
-                            {Array.from({ length: question.scale || 5 }).map((_, i) => {
-                                // Use predefined height classes for variety
-                                const heights = ['h-4', 'h-8', 'h-12', 'h-16', 'h-20', 'h-24', 'h-28', 'h-32']
-                                const randomHeight = heights[Math.floor(Math.random() * heights.length)]
-                                return (
-                                    <div key={i} className="flex flex-col items-center gap-1 flex-1">
-                                        <LemonSkeleton className={`w-8 sm:w-12 ${randomHeight}`} />
-                                        <span className="text-sm text-secondary font-semibold">{i + 1}</span>
-                                    </div>
-                                )
-                            })}
+                    <div className="flex flex-col gap-1">
+                        <div className="h-50 border rounded p-4 flex flex-col gap-2">
+                            <div className="flex justify-between items-end h-full">
+                                {Array.from({ length: question.scale || 5 }).map((_, i) => {
+                                    // Use predefined height classes for variety
+                                    const heights = ['h-4', 'h-8', 'h-12', 'h-16', 'h-20', 'h-24', 'h-28', 'h-32']
+                                    const randomHeight = heights[Math.floor(Math.random() * heights.length)]
+                                    return (
+                                        <div key={i} className="flex flex-col items-center gap-1 flex-1">
+                                            <LemonSkeleton className={`w-8 sm:w-12 ${randomHeight}`} />
+                                            <span className="text-sm text-secondary font-semibold">{i + 1}</span>
+                                        </div>
+                                    )
+                                })}
+                            </div>
+                        </div>
+                        <div className="flex flex-row justify-between">
+                            <div className="text-secondary pl-10">{question.lowerBoundLabel}</div>
+                            <div className="text-secondary pr-10">{question.upperBoundLabel}</div>
                         </div>
                     </div>
-                    <div className="flex flex-row justify-between mt-1">
-                        <div className="text-secondary pl-10">{question.lowerBoundLabel}</div>
-                        <div className="text-secondary pr-10">{question.upperBoundLabel}</div>
-                    </div>
+                    {question.scale === 10 && <NPSBreakdownSkeleton />}
+                    <LemonSkeleton className="h-9 w-full" />
                 </>
             )
         case SurveyQuestionType.SingleChoice:
@@ -176,7 +180,9 @@ export function SurveyQuestionVisualization({ question, questionIndex }: Props):
         return (
             <div className="flex flex-col gap-2">
                 <QuestionTitle question={question} questionIndex={questionIndex} />
-                <QuestionLoadingSkeleton question={question} />
+                <div className="flex flex-col gap-4">
+                    <QuestionLoadingSkeleton question={question} />
+                </div>
             </div>
         )
     }
@@ -197,26 +203,29 @@ export function SurveyQuestionVisualization({ question, questionIndex }: Props):
                 questionIndex={questionIndex}
                 totalResponses={processedData.totalResponses}
             />
-            <ErrorBoundary className="m-0">
-                {question.type === SurveyQuestionType.Rating && processedData.type === SurveyQuestionType.Rating && (
-                    <RatingQuestionViz
-                        question={question}
-                        questionIndex={questionIndex}
-                        processedData={processedData}
-                    />
-                )}
-                {question.type === SurveyQuestionType.SingleChoice &&
-                    processedData.type === SurveyQuestionType.SingleChoice && (
-                        <SingleChoiceQuestionViz question={question} processedData={processedData} />
+            <div className="flex flex-col gap-4">
+                <ErrorBoundary className="m-0">
+                    {question.type === SurveyQuestionType.Rating &&
+                        processedData.type === SurveyQuestionType.Rating && (
+                            <RatingQuestionViz
+                                question={question}
+                                questionIndex={questionIndex}
+                                processedData={processedData}
+                            />
+                        )}
+                    {question.type === SurveyQuestionType.SingleChoice &&
+                        processedData.type === SurveyQuestionType.SingleChoice && (
+                            <SingleChoiceQuestionViz question={question} processedData={processedData} />
+                        )}
+                    {question.type === SurveyQuestionType.MultipleChoice &&
+                        processedData.type === SurveyQuestionType.MultipleChoice && (
+                            <MultipleChoiceQuestionViz responseData={processedData.data} />
+                        )}
+                    {question.type === SurveyQuestionType.Open && processedData.type === SurveyQuestionType.Open && (
+                        <OpenQuestionViz question={question} responseData={processedData.data} />
                     )}
-                {question.type === SurveyQuestionType.MultipleChoice &&
-                    processedData.type === SurveyQuestionType.MultipleChoice && (
-                        <MultipleChoiceQuestionViz responseData={processedData.data} />
-                    )}
-                {question.type === SurveyQuestionType.Open && processedData.type === SurveyQuestionType.Open && (
-                    <OpenQuestionViz question={question} responseData={processedData.data} />
-                )}
-            </ErrorBoundary>
+                </ErrorBoundary>
+            </div>
         </div>
     )
 }

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -997,10 +997,6 @@ export const surveyLogic = kea<surveyLogicType>([
         },
         consolidatedSurveyResults: {
             loadConsolidatedSurveyResults: async (): Promise<ConsolidatedSurveyResults> => {
-                if (!values.isNewQuestionVizEnabled) {
-                    return { responsesByQuestion: {} }
-                }
-
                 if (props.id === NEW_SURVEY.id || !values.survey?.start_date) {
                     return { responsesByQuestion: {} }
                 }


### PR DESCRIPTION
improves spacing and skeletons for rating question visualizations, which doesn't only have the chart, but also has:

- NPS Breakdown when scale is 10
- Rating Over Time collapsible

these changes are all behind a feature flag so easily reversible if something goes wrong. for this PR though, they are mostly UI fixes