### PR TITLE
chore: add csp logs to debug report-to issue

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -437,6 +437,19 @@ def get_csp_event(request):
     if request.method == "OPTIONS":
         return cors_response(request, JsonResponse({"status": 1}))
 
+    debug_enabled = request.GET.get("debug", "").lower() == "true"
+    if debug_enabled:
+        logger.exception(
+            "CSP debug request",
+            method=request.method,
+            url=request.build_absolute_uri(),
+            content_type=request.content_type,
+            headers=dict(request.headers),
+            query_params=dict(request.GET),
+            body_size=len(request.body) if request.body else 0,
+            body=request.body.decode("utf-8", errors="ignore") if request.body else None,
+        )
+
     csp_report, error_response = process_csp_report(request)
 
     if error_response:

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -441,6 +441,7 @@ def get_csp_event(request):
     if debug_enabled:
         logger.exception(
             "CSP debug request",
+            error=ValueError("CSP debug request"),
             method=request.method,
             url=request.build_absolute_uri(),
             content_type=request.content_type,

--- a/posthog/api/csp.py
+++ b/posthog/api/csp.py
@@ -142,11 +142,10 @@ def process_csp_report(request):
         # If by any chance we got this far and this is not looking like a CSP report, keep the ingestion pipeline working as it was
         # we don't want to return an error here to avoid breaking the ingestion pipeline
         if request.content_type != "application/csp-report" and request.content_type != "application/reports+json":
-            logger.exception(
+            logger.warning(
                 "CSP report skipped - invalid content type",
                 content_type=request.content_type,
                 expected_types=["application/csp-report", "application/reports+json"],
-                error=ValueError("CSP report skipped - invalid content type"),
             )
             return None, None
 
@@ -167,11 +166,10 @@ def process_csp_report(request):
             properties = parse_report_uri(csp_data)
 
             if not sample_csp_report(properties, sample_rate, add_metadata=True):
-                logger.exception(
+                logger.warning(
                     "CSP report sampled out - report-uri format",
                     document_url=properties.get("document_url"),
                     sample_rate=sample_rate,
-                    error=ValueError("CSP report sampled out - report-uri format"),
                 )
                 return None, None
 
@@ -197,11 +195,10 @@ def process_csp_report(request):
                     sampled_violations.append(prop)
 
             if not sampled_violations:
-                logger.exception(
+                logger.warning(
                     "CSP report sampled out - report-to format",
                     total_violations=len(violations_props),
                     sample_rate=sample_rate,
-                    error=ValueError("CSP report sampled out - report-to format"),
                 )
                 return None, None
 

--- a/posthog/api/csp.py
+++ b/posthog/api/csp.py
@@ -146,6 +146,7 @@ def process_csp_report(request):
                 "CSP report skipped - invalid content type",
                 content_type=request.content_type,
                 expected_types=["application/csp-report", "application/reports+json"],
+                error=ValueError("CSP report skipped - invalid content type"),
             )
             return None, None
 
@@ -170,6 +171,7 @@ def process_csp_report(request):
                     "CSP report sampled out - report-uri format",
                     document_url=properties.get("document_url"),
                     sample_rate=sample_rate,
+                    error=ValueError("CSP report sampled out - report-uri format"),
                 )
                 return None, None
 
@@ -199,6 +201,7 @@ def process_csp_report(request):
                     "CSP report sampled out - report-to format",
                     total_violations=len(violations_props),
                     sample_rate=sample_rate,
+                    error=ValueError("CSP report sampled out - report-to format"),
                 )
                 return None, None
 
@@ -210,13 +213,13 @@ def process_csp_report(request):
             raise ValueError("Invalid CSP report")
 
     except json.JSONDecodeError as e:
-        logger.exception("Invalid CSP report JSON format", error=str(e))
+        logger.exception("Invalid CSP report JSON format", error=e)
         return None, cors_response(
             request,
             generate_exception_response("capture", "Invalid CSP report format", code="invalid_csp_payload"),
         )
     except ValueError as e:
-        logger.exception("Invalid CSP report properties", error=str(e))
+        logger.exception("Invalid CSP report properties", error=e)
         return None, cors_response(
             request,
             generate_exception_response(

--- a/posthog/api/csp.py
+++ b/posthog/api/csp.py
@@ -142,6 +142,11 @@ def process_csp_report(request):
         # If by any chance we got this far and this is not looking like a CSP report, keep the ingestion pipeline working as it was
         # we don't want to return an error here to avoid breaking the ingestion pipeline
         if request.content_type != "application/csp-report" and request.content_type != "application/reports+json":
+            logger.exception(
+                "CSP report skipped - invalid content type",
+                content_type=request.content_type,
+                expected_types=["application/csp-report", "application/reports+json"],
+            )
             return None, None
 
         csp_data = json.loads(request.body)
@@ -161,6 +166,11 @@ def process_csp_report(request):
             properties = parse_report_uri(csp_data)
 
             if not sample_csp_report(properties, sample_rate, add_metadata=True):
+                logger.exception(
+                    "CSP report sampled out - report-uri format",
+                    document_url=properties.get("document_url"),
+                    sample_rate=sample_rate,
+                )
                 return None, None
 
             return (
@@ -185,6 +195,11 @@ def process_csp_report(request):
                     sampled_violations.append(prop)
 
             if not sampled_violations:
+                logger.exception(
+                    "CSP report sampled out - report-to format",
+                    total_violations=len(violations_props),
+                    sample_rate=sample_rate,
+                )
                 return None, None
 
             return [
@@ -194,13 +209,14 @@ def process_csp_report(request):
         else:
             raise ValueError("Invalid CSP report")
 
-    except json.JSONDecodeError:
+    except json.JSONDecodeError as e:
+        logger.exception("Invalid CSP report JSON format", error=str(e))
         return None, cors_response(
             request,
             generate_exception_response("capture", "Invalid CSP report format", code="invalid_csp_payload"),
         )
     except ValueError as e:
-        logger.exception("Invalid CSP report properties are being parsed", error=e)
+        logger.exception("Invalid CSP report properties", error=str(e))
         return None, cors_response(
             request,
             generate_exception_response(
@@ -208,5 +224,5 @@ def process_csp_report(request):
             ),
         )
     except Exception as e:
-        logger.exception("Error processing CSP report", error=e)
+        logger.exception("CSP report processing failed with exception", error=e)
         return None, None

--- a/posthog/api/test/test_csp.py
+++ b/posthog/api/test/test_csp.py
@@ -454,7 +454,6 @@ class TestCSPModule(TestCase):
                 assert result1 == sample_on_property(case["document_url"], rate)
 
     def test_process_csp_report_with_sampling_out(self):
-        # Create a test properties dictionary that will be sampled out
         properties = {
             "document_url": "https://example.com/foo/bar",
             "effective_directive": "script-src",
@@ -462,9 +461,7 @@ class TestCSPModule(TestCase):
 
         # Test with 0% sampling rate (should be sampled out)
         result = sample_csp_report(properties, 0.0, True)
-        assert result is False
-        assert properties["csp_sampled"] is False
-        assert properties["csp_sample_threshold"] == 0.0
+        assert not result
 
     @patch("posthog.api.csp.logger")
     def test_process_csp_report_logs_invalid_content_type(self, mock_logger):

--- a/posthog/api/test/test_csp.py
+++ b/posthog/api/test/test_csp.py
@@ -3,6 +3,7 @@ import json
 
 from django.test import TestCase
 from django.test.client import RequestFactory
+from unittest.mock import patch
 
 from posthog.api.csp import (
     process_csp_report,
@@ -451,3 +452,129 @@ class TestCSPModule(TestCase):
             else:
                 # Non-empty document_url should use it for sampling
                 assert result1 == sample_on_property(case["document_url"], rate)
+
+    def test_process_csp_report_with_sampling_out(self):
+        # Create a test properties dictionary that will be sampled out
+        properties = {
+            "document_url": "https://example.com/foo/bar",
+            "effective_directive": "script-src",
+        }
+
+        # Test with 0% sampling rate (should be sampled out)
+        result = sample_csp_report(properties, 0.0, True)
+        assert result is False
+        assert properties["csp_sampled"] is False
+        assert properties["csp_sample_threshold"] == 0.0
+
+    @patch("posthog.api.csp.logger")
+    def test_process_csp_report_logs_invalid_content_type(self, mock_logger):
+        """Test that invalid content type is logged"""
+        request = self.factory.post(
+            "/report/",
+            data='{"test": "data"}',
+            content_type="application/json",  # Invalid content type
+        )
+
+        result, error = process_csp_report(request)
+
+        assert result is None
+        assert error is None
+        mock_logger.exception.assert_called_once_with(
+            "CSP report skipped - invalid content type",
+            content_type="application/json",
+            expected_types=["application/csp-report", "application/reports+json"],
+        )
+
+    @patch("posthog.api.csp.logger")
+    def test_process_csp_report_logs_sampling_out_report_uri(self, mock_logger):
+        """Test that sampling out is logged for report-uri format"""
+        csp_data = {
+            "csp-report": {
+                "document-uri": "https://example.com/foo/bar",
+                "violated-directive": "default-src self",
+            }
+        }
+
+        request = self.factory.post(
+            "/report/?sample_rate=0.0",  # 0% sampling rate
+            data=json.dumps(csp_data),
+            content_type="application/csp-report",
+        )
+
+        result, error = process_csp_report(request)
+
+        assert result is None
+        assert error is None
+        mock_logger.exception.assert_called_with(
+            "CSP report sampled out - report-uri format",
+            document_url="https://example.com/foo/bar",
+            sample_rate=0.0,
+        )
+
+    @patch("posthog.api.csp.logger")
+    def test_process_csp_report_logs_sampling_out_report_to(self, mock_logger):
+        """Test that sampling out is logged for report-to format"""
+        report_to_data = [
+            {
+                "type": "csp-violation",
+                "body": {
+                    "documentURL": "https://example.com/foo/bar",
+                    "effectiveDirective": "script-src",
+                },
+            }
+        ]
+
+        request = self.factory.post(
+            "/report/?sample_rate=0.0",  # 0% sampling rate
+            data=json.dumps(report_to_data),
+            content_type="application/reports+json",
+        )
+
+        result, error = process_csp_report(request)
+
+        assert result is None
+        assert error is None
+        mock_logger.exception.assert_called_with(
+            "CSP report sampled out - report-to format",
+            total_violations=1,
+            sample_rate=0.0,
+        )
+
+    @patch("posthog.api.csp.logger")
+    def test_process_csp_report_logs_json_decode_error(self, mock_logger):
+        """Test that JSON decode errors are logged as exceptions"""
+        request = self.factory.post(
+            "/report/",
+            data="invalid json",
+            content_type="application/csp-report",
+        )
+
+        result, error = process_csp_report(request)
+
+        assert result is None
+        assert error is not None  # Should return error response
+        mock_logger.exception.assert_called_once()
+        call_args = mock_logger.exception.call_args
+        assert call_args[0][0] == "Invalid CSP report JSON format"
+        assert "error" in call_args[1]
+
+    @patch("posthog.api.csp.logger")
+    def test_process_csp_report_logs_value_error(self, mock_logger):
+        """Test that value errors are logged as exceptions"""
+        # Create invalid CSP data that will trigger ValueError
+        invalid_data = {"invalid": "data"}
+
+        request = self.factory.post(
+            "/report/",
+            data=json.dumps(invalid_data),
+            content_type="application/csp-report",
+        )
+
+        result, error = process_csp_report(request)
+
+        assert result is None
+        assert error is not None  # Should return error response
+        mock_logger.exception.assert_called_once()
+        call_args = mock_logger.exception.call_args
+        assert call_args[0][0] == "Invalid CSP report properties"
+        assert "error" in call_args[1]

--- a/posthog/api/test/test_csp.py
+++ b/posthog/api/test/test_csp.py
@@ -476,7 +476,7 @@ class TestCSPModule(TestCase):
 
         assert result is None
         assert error is None
-        mock_logger.exception.assert_called_once_with(
+        mock_logger.warning.assert_called_once_with(
             "CSP report skipped - invalid content type",
             content_type="application/json",
             expected_types=["application/csp-report", "application/reports+json"],
@@ -502,7 +502,7 @@ class TestCSPModule(TestCase):
 
         assert result is None
         assert error is None
-        mock_logger.exception.assert_called_with(
+        mock_logger.warning.assert_called_with(
             "CSP report sampled out - report-uri format",
             document_url="https://example.com/foo/bar",
             sample_rate=0.0,
@@ -531,7 +531,7 @@ class TestCSPModule(TestCase):
 
         assert result is None
         assert error is None
-        mock_logger.exception.assert_called_with(
+        mock_logger.warning.assert_called_with(
             "CSP report sampled out - report-to format",
             total_violations=1,
             sample_rate=0.0,


### PR DESCRIPTION
## Problem

More details: https://posthog.slack.com/archives/C08S18PDPUN/p1748471480157489

I have been investigating a [Community Question](https://posthog.com/questions/no-csp-violation-reports-dashboard). After changing the headers to use only `report-uri`, it seems everything was working, so we're now facing the question of whether this is a configuration error or our careful ingestion is filtering out different `report-to` formats.

This PR adds some verbose logs so we can investigate the cases we're not ingesting to make sure we can reproduce them on tests.

## Changes

- Added a bunch of logs and some tests to check the logs.

## Did you write or update any docs for this change?

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Manually, locally.