### PR TITLE
feat: Add ForceMaterializationRunner to allow re-materialization of columns

### DIFF
--- a/dags/materialized_columns.py
+++ b/dags/materialized_columns.py
@@ -2,7 +2,6 @@ import datetime
 import itertools
 from collections import defaultdict
 from collections.abc import Iterator, Mapping, Set
-from dataclasses import dataclass
 from typing import ClassVar, TypeVar, cast
 
 import dagster
@@ -155,9 +154,7 @@ class MaterializationConfig(dagster.Config):
 
             if commands:
                 Runner = ForceMaterializationRunner if self.force else AlterTableMutationRunner
-                mutations[partition] = Runner(
-                    self.table, commands, parameters={"partition": partition}
-                )
+                mutations[partition] = Runner(self.table, commands, parameters={"partition": partition})
 
         return mutations
 

--- a/dags/materialized_columns.py
+++ b/dags/materialized_columns.py
@@ -1,7 +1,8 @@
 import datetime
 import itertools
 from collections import defaultdict
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterator, Mapping, Set
+from dataclasses import dataclass
 from typing import ClassVar, TypeVar, cast
 
 import dagster
@@ -35,6 +36,15 @@ def join_mappings(mappings: Mapping[K1, Mapping[K2, V]]) -> Mapping[K2, Mapping[
 
 
 PartitionId = str
+
+
+@dataclass
+class ForceMaterializationRunner(AlterTableMutationRunner):
+    """A mutation runner that always creates new mutations, bypassing the check for existing ones."""
+
+    def find_existing_mutations(self, client: Client, commands: Set[str] | None = None) -> Mapping[str, str]:
+        """Always return empty to force new mutations to be created."""
+        return {}
 
 
 class PartitionRange(dagster.Config):
@@ -145,9 +155,14 @@ class MaterializationConfig(dagster.Config):
                 commands.add(f"MATERIALIZE INDEX {index} IN PARTITION %(partition)s")
 
             if commands:
-                mutations[partition] = AlterTableMutationRunner(
-                    self.table, commands, parameters={"partition": partition}
-                )
+                if self.force:
+                    mutations[partition] = ForceMaterializationRunner(
+                        self.table, commands, parameters={"partition": partition}
+                    )
+                else:
+                    mutations[partition] = AlterTableMutationRunner(
+                        self.table, commands, parameters={"partition": partition}
+                    )
 
         return mutations
 

--- a/dags/materialized_columns.py
+++ b/dags/materialized_columns.py
@@ -154,14 +154,10 @@ class MaterializationConfig(dagster.Config):
                 commands.add(f"MATERIALIZE INDEX {index} IN PARTITION %(partition)s")
 
             if commands:
-                if self.force:
-                    mutations[partition] = ForceMaterializationRunner(
-                        self.table, commands, parameters={"partition": partition}
-                    )
-                else:
-                    mutations[partition] = AlterTableMutationRunner(
-                        self.table, commands, parameters={"partition": partition}
-                    )
+                Runner = ForceMaterializationRunner if self.force else AlterTableMutationRunner
+                mutations[partition] = Runner(
+                    self.table, commands, parameters={"partition": partition}
+                )
 
         return mutations
 

--- a/dags/materialized_columns.py
+++ b/dags/materialized_columns.py
@@ -38,7 +38,6 @@ def join_mappings(mappings: Mapping[K1, Mapping[K2, V]]) -> Mapping[K2, Mapping[
 PartitionId = str
 
 
-@dataclass
 class ForceMaterializationRunner(AlterTableMutationRunner):
     """A mutation runner that always creates new mutations, bypassing the check for existing ones."""
 

--- a/dags/tests/test_materialized_columns.py
+++ b/dags/tests/test_materialized_columns.py
@@ -15,6 +15,7 @@ from dags.materialized_columns import (
     materialize_column,
     run_materialize_mutations,
     join_mappings,
+    ForceMaterializationRunner,
 )
 from posthog.clickhouse.cluster import ClickhouseCluster, Query
 from posthog.test.base import materialized
@@ -54,6 +55,17 @@ def test_materialization_config_force_default():
         partitions=PartitionRange(lower="202401", upper="202403"),
     )
     assert config.force is False
+
+
+def test_force_materialization_runner():
+    # Test that ForceMaterializationRunner always returns empty mutations
+    runner = ForceMaterializationRunner(
+        table="test_table",
+        commands={"MATERIALIZE COLUMN test_col IN PARTITION 202401"}
+    )
+    # Mock client - we don't actually need it since we're overriding find_existing_mutations
+    assert runner.find_existing_mutations(None) == {}
+    assert runner.find_existing_mutations(None, commands={"any", "commands"}) == {}
 
 
 @contextlib.contextmanager
@@ -180,3 +192,5 @@ def test_sharded_table_job(cluster: ClickhouseCluster):
                 for mutation in shard_mutations.values():
                     # mutations should only be for the column
                     assert all("MATERIALIZE COLUMN" in command for command in mutation.commands)
+                    # Verify that force=True uses ForceMaterializationRunner
+                    assert isinstance(mutation, ForceMaterializationRunner)

--- a/dags/tests/test_materialized_columns.py
+++ b/dags/tests/test_materialized_columns.py
@@ -60,8 +60,7 @@ def test_materialization_config_force_default():
 def test_force_materialization_runner():
     # Test that ForceMaterializationRunner always returns empty mutations
     runner = ForceMaterializationRunner(
-        table="test_table",
-        commands={"MATERIALIZE COLUMN test_col IN PARTITION 202401"}
+        table="test_table", commands={"MATERIALIZE COLUMN test_col IN PARTITION 202401"}
     )
     # Mock client - we don't actually need it since we're overriding find_existing_mutations
     assert runner.find_existing_mutations(None) == {}


### PR DESCRIPTION
  1. Created ForceMaterializationRunner class

  - This custom mutation runner extends AlterTableMutationRunner
  - Overrides find_existing_mutations() to always return empty, forcing new mutations
  - This bypasses the default behavior that skips already-completed mutations

  2. Updated get_mutations_to_run logic

  - When force=False (default): Uses the standard AlterTableMutationRunner which checks for existing
   mutations
  - When force=True: Uses ForceMaterializationRunner which always creates new mutations

  3. Added comprehensive test coverage

  - Unit test for default force=False behavior
  - Unit test for ForceMaterializationRunner behavior
  - Integration test verifying the correct mutation runner is used when force=True

  How it works:

  The key here was that the MutationRunner base class checks the system.mutations table for
  existing mutations and skips creating new ones if they already exist (and are not killed). By
  creating a custom ForceMaterializationRunner that overrides find_existing_mutations() to always
  return an empty dict, we trick the system into thinking no mutations exist, forcing it to create
  new ones.

  This allows you to re-materialize columns even if they were already materialized before, which is
  useful for:
  - Fixing corrupted materializations
  - Re-materializing after schema changes
  - Force refreshing materialized data
