### PR TITLE
fix: use different method for forcing re-materialization in dag

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(ruff check:*)"
-    ],
-    "deny": []
-  }
-}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ruff check:*)"
+    ],
+    "deny": []
+  }
+}

--- a/dags/deletes.py
+++ b/dags/deletes.py
@@ -584,8 +584,8 @@ def delete_events(
     )
 
     delete_mutation_runner = LightweightDeleteMutationRunner(
-        EVENTS_DATA_TABLE(),
-        """or(
+        table=EVENTS_DATA_TABLE(),
+        predicate="""or(
             (dictHas(%(pending_deletes_dictionary)s, (team_id, %(person_deletion_type)s, person_id)) AND timestamp <= dictGet(%(pending_deletes_dictionary)s, 'created_at', (team_id, %(person_deletion_type)s, person_id))),
             (dictHas(%(pending_deletes_dictionary)s, (team_id, %(team_deletion_type)s, team_id))),
             (dictHas(%(adhoc_event_deletes_dictionary)s, (team_id, uuid)))
@@ -646,8 +646,8 @@ def delete_team_data(
     )
 
     delete_mutation_runner = LightweightDeleteMutationRunner(
-        table_name,
-        "dictHas(%(dictionary)s, (team_id, %(team_deletion_type)s, team_id))",
+        table=table_name,
+        predicate="dictHas(%(dictionary)s, (team_id, %(team_deletion_type)s, team_id))",
         parameters={
             "dictionary": load_and_verify_deletes_dictionary.qualified_name,
             "team_deletion_type": DeletionType.Team,

--- a/dags/materialized_columns.py
+++ b/dags/materialized_columns.py
@@ -1,7 +1,7 @@
 import datetime
 import itertools
 from collections import defaultdict
-from collections.abc import Iterator, Mapping, Set
+from collections.abc import Iterator, Mapping
 from typing import ClassVar, TypeVar, cast
 
 import dagster
@@ -35,14 +35,6 @@ def join_mappings(mappings: Mapping[K1, Mapping[K2, V]]) -> Mapping[K2, Mapping[
 
 
 PartitionId = str
-
-
-class ForceMaterializationRunner(AlterTableMutationRunner):
-    """A mutation runner that always creates new mutations, bypassing the check for existing ones."""
-
-    def find_existing_mutations(self, client: Client, commands: Set[str] | None = None) -> Mapping[str, str]:
-        """Always return empty to force new mutations to be created."""
-        return {}
 
 
 class PartitionRange(dagster.Config):
@@ -153,8 +145,9 @@ class MaterializationConfig(dagster.Config):
                 commands.add(f"MATERIALIZE INDEX {index} IN PARTITION %(partition)s")
 
             if commands:
-                Runner = ForceMaterializationRunner if self.force else AlterTableMutationRunner
-                mutations[partition] = Runner(self.table, commands, parameters={"partition": partition})
+                mutations[partition] = AlterTableMutationRunner(
+                    self.table, commands, parameters={"partition": partition}
+                )
 
         return mutations
 

--- a/dags/materialized_columns.py
+++ b/dags/materialized_columns.py
@@ -146,7 +146,7 @@ class MaterializationConfig(dagster.Config):
 
             if commands:
                 mutations[partition] = AlterTableMutationRunner(
-                    self.table, commands, parameters={"partition": partition}, force=self.force
+                    table=self.table, commands=commands, parameters={"partition": partition}, force=self.force
                 )
 
         return mutations

--- a/dags/materialized_columns.py
+++ b/dags/materialized_columns.py
@@ -146,7 +146,7 @@ class MaterializationConfig(dagster.Config):
 
             if commands:
                 mutations[partition] = AlterTableMutationRunner(
-                    self.table, commands, parameters={"partition": partition}
+                    self.table, commands, parameters={"partition": partition}, force=self.force
                 )
 
         return mutations

--- a/dags/person_overrides.py
+++ b/dags/person_overrides.py
@@ -173,8 +173,8 @@ class PersonOverridesSnapshotDictionary:
     @property
     def person_id_update_mutation_runner(self) -> AlterTableMutationRunner:
         return AlterTableMutationRunner(
-            EVENTS_DATA_TABLE(),
-            {
+            table=EVENTS_DATA_TABLE(),
+            commands={
                 "UPDATE person_id = dictGet(%(name)s, 'person_id', (team_id, distinct_id)) WHERE dictHas(%(name)s, (team_id, distinct_id))"
             },
             parameters={"name": self.qualified_name},
@@ -183,8 +183,8 @@ class PersonOverridesSnapshotDictionary:
     @property
     def overrides_delete_mutation_runner(self) -> LightweightDeleteMutationRunner:
         return LightweightDeleteMutationRunner(
-            PERSON_DISTINCT_ID_OVERRIDES_TABLE,
-            "isNotNull(dictGetOrNull(%(name)s, 'version', (team_id, distinct_id)) as snapshot_version) AND snapshot_version >= version",
+            table=PERSON_DISTINCT_ID_OVERRIDES_TABLE,
+            predicate="isNotNull(dictGetOrNull(%(name)s, 'version', (team_id, distinct_id)) as snapshot_version) AND snapshot_version >= version",
             parameters={"name": self.qualified_name},
         )
 

--- a/dags/tests/test_materialized_columns.py
+++ b/dags/tests/test_materialized_columns.py
@@ -15,7 +15,6 @@ from dags.materialized_columns import (
     materialize_column,
     run_materialize_mutations,
     join_mappings,
-    ForceMaterializationRunner,
 )
 from posthog.clickhouse.cluster import ClickhouseCluster, Query
 from posthog.test.base import materialized
@@ -55,16 +54,6 @@ def test_materialization_config_force_default():
         partitions=PartitionRange(lower="202401", upper="202403"),
     )
     assert config.force is False
-
-
-def test_force_materialization_runner():
-    # Test that ForceMaterializationRunner always returns empty mutations
-    runner = ForceMaterializationRunner(
-        table="test_table", commands={"MATERIALIZE COLUMN test_col IN PARTITION 202401"}
-    )
-    # Mock client - we don't actually need it since we're overriding find_existing_mutations
-    assert runner.find_existing_mutations(None) == {}
-    assert runner.find_existing_mutations(None, commands={"any", "commands"}) == {}
 
 
 @contextlib.contextmanager
@@ -191,5 +180,3 @@ def test_sharded_table_job(cluster: ClickhouseCluster):
                 for mutation in shard_mutations.values():
                     # mutations should only be for the column
                     assert all("MATERIALIZE COLUMN" in command for command in mutation.commands)
-                    # Verify that force=True uses ForceMaterializationRunner
-                    assert isinstance(mutation, ForceMaterializationRunner)

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -514,7 +514,7 @@ class MutationRunner(abc.ABC):
     table: str
     parameters: Mapping[str, Any] = field(default_factory=dict, kw_only=True)
     settings: Mapping[str, Any] = field(default_factory=dict, kw_only=True)
-    force: bool = False  # whether to force the mutation to run even if it already exists
+    force: bool = field(default=False, kw_only=True)  # whether to force the mutation to run even if it already exists
 
     @abc.abstractmethod
     def get_all_commands(self) -> Set[str]:
@@ -651,7 +651,9 @@ class MutationRunner(abc.ABC):
 
 @dataclass
 class AlterTableMutationRunner(MutationRunner):
-    commands: Set[str] = field(kw_only=True)  # the part after ALTER TABLE prefix, i.e. UPDATE, DELETE, MATERIALIZE, etc.
+    commands: Set[str] = field(
+        kw_only=True
+    )  # the part after ALTER TABLE prefix, i.e. UPDATE, DELETE, MATERIALIZE, etc.
 
     def get_all_commands(self) -> Set[str]:
         return self.commands

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -541,7 +541,7 @@ class MutationRunner(abc.ABC):
                 "Forcing mutation for %r, even if it already exists. This may cause issues if the mutation is already running.",
                 expected_commands,
             )
-            mutations_running = {}
+            mutations_running: Mapping[str, str] = {}
         else:
             logger.info("Ensuring mutation for %r is running or has completed.", expected_commands)
             mutations_running = self.find_existing_mutations(client, expected_commands)

--- a/posthog/clickhouse/test/test_cluster.py
+++ b/posthog/clickhouse/test/test_cluster.py
@@ -357,7 +357,7 @@ def test_alter_mutation_force_parameter(cluster: ClickhouseCluster) -> None:
     # Count mutations before force
     get_mutations_count = Query(
         "SELECT count() FROM system.mutations WHERE database = currentDatabase() AND table = %(table)s",
-        {"table": table}
+        {"table": table},
     )
     mutations_count_before = cluster.map_all_hosts(get_mutations_count).result()
 

--- a/posthog/clickhouse/test/test_cluster.py
+++ b/posthog/clickhouse/test/test_cluster.py
@@ -32,7 +32,7 @@ def cluster(django_db_setup) -> Iterator[ClickhouseCluster]:
 
 def test_mutation_runner_rejects_invalid_parameters() -> None:
     with pytest.raises(ValueError):
-        AlterTableMutationRunner("table", {"command"}, parameters={"__invalid_key": True})
+        AlterTableMutationRunner(table="table", commands={"command"}, parameters={"__invalid_key": True})
 
 
 def test_exception_summary(snapshot, cluster: ClickhouseCluster) -> None:
@@ -141,8 +141,8 @@ def test_alter_mutation_single_command(cluster: ClickhouseCluster) -> None:
     # construct the runner
     sentinel_uuid = uuid.uuid1()  # unique to this test run to ensure we have a clean slate
     runner = AlterTableMutationRunner(
-        table,
-        {
+        table=table,
+        commands={
             """
             UPDATE person_id = %(uuid)s, properties = %(properties)s
             -- this is a comment that will not appear in system.mutations
@@ -196,8 +196,8 @@ def test_alter_mutation_multiple_commands(cluster: ClickhouseCluster) -> None:
         materialized("events", f"{sentinel_uuid}_c") as column_c,
     ):
         runner = AlterTableMutationRunner(
-            table,
-            {f"MATERIALIZE COLUMN {column_a.name}", f"MATERIALIZE COLUMN {column_b.name}"},
+            table=table,
+            commands={f"MATERIALIZE COLUMN {column_a.name}", f"MATERIALIZE COLUMN {column_b.name}"},
         )
 
         # nothing should be running yet
@@ -215,8 +215,8 @@ def test_alter_mutation_multiple_commands(cluster: ClickhouseCluster) -> None:
         # if we run the same mutation with a subset of commands, nothing new should be scheduled (this ensures after a
         # code change that removes a command from the mutation, we won't error when we mutations from previous versions)
         runner_with_single_command = AlterTableMutationRunner(
-            table,
-            {f"MATERIALIZE COLUMN {column_a.name}"},
+            table=table,
+            commands={f"MATERIALIZE COLUMN {column_a.name}"},
         )
 
         # "start" all mutations (in actuality, this is a noop)
@@ -234,8 +234,8 @@ def test_alter_mutation_multiple_commands(cluster: ClickhouseCluster) -> None:
         # if we run the same mutation with additional commands, only the new command should be executed
         new_command = f"MATERIALIZE COLUMN {column_c.name}"
         runner_with_extra_command = AlterTableMutationRunner(
-            table,
-            {*runner.commands, new_command},
+            table=table,
+            commands={*runner.commands, new_command},
         )
 
         # the new command should not yet be findable
@@ -315,8 +315,8 @@ def test_lightweight_delete(cluster: ClickhouseCluster) -> None:
 
     # construct the runner with a DELETE command
     runner = LightweightDeleteMutationRunner(
-        table,
-        f"uuid = %(uuid)s",
+        table=table,
+        predicate=f"uuid = %(uuid)s",
         parameters={"uuid": eid},
     )
 
@@ -331,3 +331,50 @@ def test_lightweight_delete(cluster: ClickhouseCluster) -> None:
             host_info.shard_num, Query(f"SELECT count(1) FROM {table}")
         ).result()
         assert all(result[0][0] < count for result in query_results.values())
+
+
+def test_alter_mutation_force_parameter(cluster: ClickhouseCluster) -> None:
+    """Test that force=True skips checking for existing mutations"""
+    table = EVENTS_DATA_TABLE()
+    count = 100
+    
+    # Insert test data
+    cluster.map_one_host_per_shard(Query(f"INSERT INTO {table} SELECT * FROM generateRandom() LIMIT {count}")).result()
+    
+    sentinel_uuid = uuid.uuid1()
+    
+    # First run a mutation normally
+    runner = AlterTableMutationRunner(
+        table=table,
+        commands={"UPDATE person_id = %(uuid)s WHERE 1 = 1"},
+        parameters={"uuid": sentinel_uuid},
+    )
+    
+    # Run the mutation and wait for completion
+    shard_mutations = cluster.map_one_host_per_shard(runner).result()
+    wait_and_check_mutations_on_shards(cluster, shard_mutations)
+    
+    # Count mutations before force
+    get_mutations_count = Query(
+        "SELECT count() FROM system.mutations WHERE database = currentDatabase() AND table = %(table)s",
+        {"table": table}
+    )
+    mutations_count_before = cluster.map_all_hosts(get_mutations_count).result()
+    
+    # Now run the same mutation with force=True
+    runner_force = AlterTableMutationRunner(
+        table=table,
+        commands={"UPDATE person_id = %(uuid)s WHERE 1 = 1"},
+        parameters={"uuid": sentinel_uuid},
+        force=True,
+    )
+    
+    # This should create a new mutation even though one already exists
+    force_mutations = cluster.map_one_host_per_shard(runner_force).result()
+    
+    # Count mutations after force
+    mutations_count_after = cluster.map_all_hosts(get_mutations_count).result()
+    
+    # Should have more mutations after using force=True
+    for host in mutations_count_before:
+        assert mutations_count_after[host][0][0] > mutations_count_before[host][0][0]


### PR DESCRIPTION
Originally forgot about how we wait for mutations to finish using the `find_existing_mutations` function - this attempt does not overload that and just uses a force param
