### PR TITLE
fix: fix convert to project timezone modifier

### DIFF
--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -165,17 +165,13 @@ def prepare_ast_for_printing(
             resolve_lazy_tables(node, dialect, stack, context)
 
         with context.timings.measure("swap_properties"):
-            set_timezones = True
-            if context.modifiers.convertToProjectTimezone is not None:
-                set_timezones = context.modifiers.convertToProjectTimezone
-
             node = PropertySwapper(
                 timezone=context.property_swapper.timezone,
                 group_properties={},
                 person_properties=context.property_swapper.person_properties,
                 event_properties=context.property_swapper.event_properties,
                 context=context,
-                setTimeZones=set_timezones,
+                setTimeZones=context.modifiers.convertToProjectTimezone is not False,
             ).visit(node)
 
         # We support global query settings, and local subquery settings.
@@ -1772,6 +1768,8 @@ class _Printer(Visitor):
         )
 
     def _get_timezone(self) -> str:
+        if self.context.modifiers.convertToProjectTimezone is False:
+            return "UTC"
         return self.context.database.get_timezone() if self.context.database else "UTC"
 
     def _get_week_start_day(self) -> WeekStartDay:


### PR DESCRIPTION

> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
previously we just fixed the propertyswapper but we also need to replace the _get_timezone call with UTC as we inject automatically in toDateTime calls

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
