### PR TITLE
fix(batch-exports): Fix invalid JSON errors in Postgres exports

### DIFF
--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -60,6 +60,15 @@ from posthog.temporal.common.logger import bind_temporal_worker_logger
 PostgreSQLField = tuple[str, typing.LiteralString]
 Fields = collections.abc.Iterable[PostgreSQLField]
 
+# Compiled regex patterns for PostgreSQL data cleaning
+NULL_UNICODE_PATTERN = re.compile(rb"(?<!\\)\\u0000")
+UNPAIRED_SURROGATE_PATTERN = re.compile(
+    rb"(\\u[dD][89A-Fa-f][0-9A-Fa-f]{2}\\u[dD][c-fC-F][0-9A-Fa-f]{2})|(\\u[dD][89A-Fa-f][0-9A-Fa-f]{2})"
+)
+UNPAIRED_SURROGATE_PATTERN_2 = re.compile(
+    rb"(\\u[dD][89A-Fa-f][0-9A-Fa-f]{2}\\u[dD][c-fC-F][0-9A-Fa-f]{2})|(\\u[dD][c-fC-F][0-9A-Fa-f]{2})"
+)
+
 
 class PostgreSQLConnectionError(Exception):
     pass
@@ -419,25 +428,21 @@ class PostgreSQLClient:
                     )
                 ) as copy:
                     while data := await asyncio.to_thread(tsv_file.read):
-                        # \u0000 cannot be present in PostgreSQL's jsonb type, and will cause an error.
-                        # See: https://www.postgresql.org/docs/17/datatype-json.html
-                        # We use a regex to avoid replacing escaped \u0000 (for example, \\u0000, which we have seen in
-                        # some actual data)
-                        data = re.sub(rb"(?<!\\)\\u0000", b"", data)
-
-                        # Remove unpaired unicode surrogates
-                        data = re.sub(
-                            rb"(\\u[dD][89A-Fa-f][0-9A-Fa-f]{2}\\u[dD][c-fC-F][0-9A-Fa-f]{2})|(\\u[dD][89A-Fa-f][0-9A-Fa-f]{2})",
-                            rb"\1",
-                            data,
-                        )
-                        data = re.sub(
-                            rb"(\\u[dD][89A-Fa-f][0-9A-Fa-f]{2}\\u[dD][c-fC-F][0-9A-Fa-f]{2})|(\\u[dD][c-fC-F][0-9A-Fa-f]{2})",
-                            rb"\1",
-                            data,
-                        )
-
+                        data = remove_invalid_json(data)
                         await copy.write(data)
+
+
+def remove_invalid_json(data: bytes) -> bytes:
+    """Remove invalid JSON from a byte string."""
+    # \u0000 cannot be present in PostgreSQL's jsonb type, and will cause an error.
+    # See: https://www.postgresql.org/docs/17/datatype-json.html
+    # We use a regex to avoid replacing escaped \u0000 (for example, \\u0000, which we have seen in
+    # some actual data)
+    data = NULL_UNICODE_PATTERN.sub(b"", data)
+    # Remove unpaired unicode surrogates
+    data = UNPAIRED_SURROGATE_PATTERN.sub(rb"\1", data)
+    data = UNPAIRED_SURROGATE_PATTERN_2.sub(rb"\1", data)
+    return data
 
 
 def postgres_default_fields() -> list[BatchExportField]:

--- a/posthog/temporal/tests/batch_exports/test_postgres_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_postgres_batch_export_workflow.py
@@ -1447,7 +1447,8 @@ async def test_insert_into_postgres_activity_completes_range_when_there_is_a_fai
             b"\uD83C\uDF89 Party \uD800 \uD83D\uDE0A mixed",
             b"\uD83C\uDF89 Party  \uD83D\uDE0A mixed",
         ),  # Mix of valid pairs and unpaired
-        (b"Hello \\u0000 World", b"Hello  World"),  # \u0000 is not a valid JSON character in PostgreSQL
+        (b"Hello \u0000 World", b"Hello  World"),  # \u0000 is not a valid JSON character in PostgreSQL
+        (b"Hello \\u0000 World", b"Hello  World"),  # this is the same as the above
         (b"Hello \\\\u0000 World", b"Hello \\\\u0000 World"),  # \\u0000 is escaped
     ],
 )


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We currently have a couple of different issues with parsing invalid JSON in our Postgres exports (these are both raised by Postgres during the `COPY INTO` operation

1. `Unicode low surrogate must follow a high surrogate` [Temporal workflow](https://cloud.temporal.io/namespaces/posthog-prod-us.usz2o/workflows/01970158-7e10-0001-d21a-ef89a011f5f3-2025-01-06T12%3A00%3A00Z/0197019c-fe1e-777a-a774-17e3d2a0172f/history)
2. `invalid input syntax for type json DETAIL:  Escape sequence \"\\'\" is invalid.` [Temporal workflow](https://cloud.temporal.io/namespaces/posthog-prod-us.usz2o/workflows/01970158-7e10-0001-d21a-ef89a011f5f3-2025-05-12T04%3A00%3A00Z/019701fe-4cad-7c4c-b858-0f2aab6da2bc/history)

## Changes

Handle invalid JSON better:
1. Implement checks for invalid unicode surrogate pairs (similar to [how we do in BigQuery](https://github.com/PostHog/posthog/pull/27466))
2. I think this case was occurring due to how we replace the unicode null character (`\u0000`), which is invalid in Postgres JSONB. In the example I looked at, we had a string `\\u0000'` which after replacement was `\'`, which is an invalid control sequence. This string should be left as is since it's not actually unicode due to the initial escaped `\`. Therefore, I have updated the replacement for this to use a regex.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

I added some additional test cases.

I also inspected the data locally. Here's an example:

Data in ClickHouse column:
```
{"$browser": "Chrome", "$os": "Mac OS X", "emoji": "\ud83e\udd23", "newline": "\n", "unicode_null": "\u0000", "invalid_unicode": "\\u0000'", "emoji_with_high_surrogate": "\ud83e\udd23\ud83e", "emoji_with_low_surrogate": "\ud83e\udd23\udd23", "emoji_with_high_surrogate_and_newline": "\ud83e\udd23\ud83e\n", "emoji_with_low_surrogate_and_newline": "\ud83e\udd23\udd23\n"}
```

Data exported to Postgres:
```
{"$os": "Mac OS X", "emoji": "🤣", "newline": "\n", "$browser": "Chrome", "unicode_null": "", "invalid_unicode": "\\u0000'", "emoji_with_low_surrogate": "🤣", "emoji_with_high_surrogate": "🤣", "emoji_with_low_surrogate_and_newline": "🤣\n", "emoji_with_high_surrogate_and_newline": "🤣\n"}
```
