### PR TITLE
chore: Also bump uv version in Flox manifest

### DIFF
--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -10,7 +10,7 @@ version = 1
 # the `[install]` section.
 [install]
 # Python - Python itself is installed on activation via `uv sync`
-uv = { pkg-path = "uv", pkg-group = "uv", version = "0.6.12" }
+uv = { pkg-path = "uv", pkg-group = "uv", version = "0.7.8" }
 xmlsec = { pkg-path = "xmlsec", version = "1.3.6" }
 freetds = { pkg-path = "freetds" } # For pymssql
 # Node


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/pull/32891 increased the version of `uv` required to run the app, but didn't update the Flox manifest.

## Changes

Updated the Flox manifest too.