### PR TITLE
chore(err): make inject command idempotent

### DIFF
--- a/cli/src/commands/sourcemap/inject.rs
+++ b/cli/src/commands/sourcemap/inject.rs
@@ -20,10 +20,22 @@ pub fn inject(directory: &Path) -> Result<()> {
         bail!("No source files found");
     }
     info!("Found {} pairs", pairs.len());
+    let mut skipped_pairs = 0;
     for pair in &mut pairs {
+        if pair.has_chunk_id() {
+            skipped_pairs += 1;
+            continue;
+        }
         let chunk_id = uuid::Uuid::now_v7().to_string();
         pair.set_chunk_id(chunk_id)?;
     }
+    if skipped_pairs > 0 {
+        info!(
+            "Skipped {} pairs because chunk IDs already exist",
+            skipped_pairs
+        );
+    }
+
     // Write the source and sourcemaps back to disk
     for pair in &pairs {
         pair.save()?;

--- a/cli/src/utils/sourcemaps.rs
+++ b/cli/src/utils/sourcemaps.rs
@@ -64,8 +64,12 @@ pub struct ChunkUpload {
 }
 
 impl SourcePair {
+    pub fn has_chunk_id(&self) -> bool {
+        self.chunk_id.is_some()
+    }
+
     pub fn set_chunk_id(&mut self, chunk_id: String) -> Result<()> {
-        if self.chunk_id.is_some() {
+        if self.has_chunk_id() {
             return Err(anyhow!("Chunk ID already set"));
         }
         let (new_source_content, source_adjustment) = {
@@ -156,8 +160,8 @@ pub fn read_pairs(directory: &PathBuf) -> Result<Vec<SourcePair>> {
     let mut pairs = Vec::new();
     for entry in WalkDir::new(directory).into_iter().filter_map(|e| e.ok()) {
         let entry_path = entry.path().canonicalize()?;
-        info!("Processing file: {}", entry_path.display());
         if is_javascript_file(&entry_path) {
+            info!("Processing file: {}", entry_path.display());
             let source = SourceFile::load(&entry_path)?;
             let sourcemap_path = guess_sourcemap_path(&source.path);
             if sourcemap_path.exists() {


### PR DESCRIPTION
## Problem

- When running inject commands multiple times on the same sources, command fails
- We need this command to be idempotent to add chunk ids during nextjs build process

## Changes

- Do not raise an error when chunk id already exist but log skipped files count