### PR TITLE
fix: Dont set theme=dark during the storybook-test-runner for unauth pages

### DIFF
--- a/frontend/src/layout/navigation-3000/themeLogic.ts
+++ b/frontend/src/layout/navigation-3000/themeLogic.ts
@@ -72,10 +72,13 @@ export const themeLogic = kea<themeLogicType>([
         isDarkModeOn: [
             (s) => [s.themeMode, s.darkModeSystemPreference, sceneLogic.selectors.sceneConfig, s.theme],
             (themeMode, darkModeSystemPreference, sceneConfig, theme) => {
+                const isUnauthenticatedScene = sceneConfig?.allowUnauthenticated || sceneConfig?.onlyUnauthenticated
+
                 if (
                     typeof window !== 'undefined' &&
                     window.document &&
                     document.body.classList.contains('storybook-test-runner') &&
+                    !isUnauthenticatedScene &&
                     document.body.getAttribute('theme') == 'dark'
                 ) {
                     return true
@@ -84,7 +87,7 @@ export const themeLogic = kea<themeLogicType>([
                     return !!theme?.dark
                 }
                 // NOTE: Unauthenticated users always get the light mode until we have full support for dark mode there
-                if (sceneConfig?.allowUnauthenticated || sceneConfig?.onlyUnauthenticated) {
+                if (isUnauthenticatedScene) {
                     return false
                 }
 


### PR DESCRIPTION
## Problem

Closes #32663

## Changes

- Change themeLogic so that it doesn't set theme=dark during the storybook-test-runner for unauth pages. This avoid the unrealistic scenario where `theme=dark` on the `body` of the document for unauthorized pages, where there is no UI to set darkmode explicitly yet.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

- Manually
