### PR TITLE
fix: clean recording metric path for person or persons

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -425,7 +425,8 @@ def clean_referer_url(current_url: str | None) -> str:
 
         path = re.sub(r"^/?project/\d+", "", path)
 
-        path = re.sub(r"^/?person/.*$", "person-page", path)
+        # matches person or persons
+        path = re.sub(r"^/?persons?/.*$", "person-page", path)
 
         path = re.sub(r"^/?insights/[^/]+/edit$", "insight-edit", path)
 


### PR DESCRIPTION
either this was never right or we changed paths recently

it looks like we lost all of our person-page traffic, but we're newly reporting lots of `persons` traffic

this merges them into one result