### PR TITLE
fix: removing nav3k check for experiments

### DIFF
--- a/frontend/src/layout/navigation-3000/navigationLogic.tsx
+++ b/frontend/src/layout/navigation-3000/navigationLogic.tsx
@@ -525,7 +525,7 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
                             identifier: Scene.Experiments,
                             label: 'Experiments',
                             icon: <IconTestTube />,
-                            to: isUsingSidebar ? undefined : urls.experiments(),
+                            to: urls.experiments(),
                             tooltipDocLink: 'https://posthog.com/docs/experiments/creating-an-experiment',
                         },
                         {


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

> [!NOTE]
> Follow up on #32908, fix for #32768 

## Problem

~~The experiment item is broken for users with the `POSTHOG_3000_NAV` feature flag on.~~

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Using `to` with an url as the only option for the experiments item, regardless of feature flag status.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

![cat-type-small](https://github.com/user-attachments/assets/1ff08710-242b-4f1b-b16b-7d851789c2b6)


<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
