### PR TITLE
fix(capture-rs): adds metric and warn on force overflow

### DIFF
--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -15,7 +15,7 @@ use rdkafka::util::Timeout;
 use rdkafka::ClientConfig;
 use std::time::Duration;
 use tokio::task::JoinSet;
-use tracing::log::{debug, error, info, warn};
+use tracing::log::{debug, error, info};
 use tracing::{info_span, instrument, Instrument};
 
 struct KafkaContext {

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -243,6 +243,8 @@ impl KafkaSink {
                     // we configure to retain partition key or not.
                     // if is_limited is true, the OverflowLimiter is
                     // configured and is safe to unwrap here.
+                    counter!("capture_events_rerouted_overflow", &[("reason", "event_key")]).increment(1);
+                    warn!("event sent to overflow topic, event_key: {}", event_key);
                     if self.partition.as_ref().unwrap().should_preserve_locality() {
                         (&self.overflow_topic, Some(event_key.as_str()))
                     } else {

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -248,7 +248,6 @@ impl KafkaSink {
                         &[("reason", "event_key")]
                     )
                     .increment(1);
-                    warn!("event sent to overflow topic, event_key: {}", event_key);
                     if self.partition.as_ref().unwrap().should_preserve_locality() {
                         (&self.overflow_topic, Some(event_key.as_str()))
                     } else {

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -15,7 +15,7 @@ use rdkafka::util::Timeout;
 use rdkafka::ClientConfig;
 use std::time::Duration;
 use tokio::task::JoinSet;
-use tracing::log::{debug, error, info};
+use tracing::log::{debug, error, info, warn};
 use tracing::{info_span, instrument, Instrument};
 
 struct KafkaContext {
@@ -243,7 +243,11 @@ impl KafkaSink {
                     // we configure to retain partition key or not.
                     // if is_limited is true, the OverflowLimiter is
                     // configured and is safe to unwrap here.
-                    counter!("capture_events_rerouted_overflow", &[("reason", "event_key")]).increment(1);
+                    counter!(
+                        "capture_events_rerouted_overflow",
+                        &[("reason", "event_key")]
+                    )
+                    .increment(1);
                     warn!("event sent to overflow topic, event_key: {}", event_key);
                     if self.partition.as_ref().unwrap().should_preserve_locality() {
                         (&self.overflow_topic, Some(event_key.as_str()))


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

Would like to be able to track how many events we are forcing ot overflow from capture via a metric. Would also like to understand what event keys we are doing this for.

## Changes

Adds a metric and a warn log when forcing events to overflow from capture due to rate limiting.

## Did you write or update any docs for this change?

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Tested locally
