### PR TITLE
fix: exclude programmatic access from app limits

### DIFF
--- a/posthog/clickhouse/client/limit.py
+++ b/posthog/clickhouse/client/limit.py
@@ -206,6 +206,7 @@ def get_app_org_rate_limiter():
     if __APP_CONCURRENT_QUERY_PER_ORG is None:
         __APP_CONCURRENT_QUERY_PER_ORG = RateLimit(
             max_concurrency=10,
+            applicable=lambda *args, **kwargs: not TEST and kwargs.get("org_id") and not kwargs.get("personal_api_key"),
             limit_name="app_per_org",
             get_task_name=lambda *args, **kwargs: f"app:query:per-org:{kwargs.get('org_id')}",
             get_task_id=lambda *args, **kwargs: kwargs.get("task_id") or generate_short_id(),

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -879,7 +879,10 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                 tag_queries(chargeable=1)
 
             with get_app_org_rate_limiter().run(
-                org_id=self.team.organization_id, task_id=self.query_id, team_id=self.team.id
+                org_id=self.team.organization_id,
+                task_id=self.query_id,
+                team_id=self.team.id,
+                personal_api_key=get_query_tag_value("access_method") == "personal_api_key",
             ):
                 fresh_response_dict = {
                     **self.calculate().model_dump(),


### PR DESCRIPTION
## Problem

App rate limit influences API programatic access

## Changes

Exclude programatic access from rate limiter.

## Did you write or update any docs for this change?

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [X] No docs needed for this change

## How did you test this code?

run locally