### PR TITLE
chore: add writing docs guide to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@
 
 <!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->
 
-- [ ] I've added or updated the docs
+- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
 - [ ] I've reached out for help from the docs team
 - [ ] No docs needed for this change
 


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We say "write docs" but don't provide guidance on how or where!

## Changes

Added newly written guide to writing docs for engineers to PR template

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change (meta)

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

Looked at it
