### PR TITLE
fix: incorrect object to get settings from

### DIFF
--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -23,7 +23,7 @@ from posthog.clickhouse.query_tagging import tag_queries, get_query_tag_value, g
 from posthog.cloud_utils import is_cloud
 from posthog.errors import wrap_query_error, ch_error_type
 from posthog.exceptions import ClickhouseAtCapacity
-from posthog.settings import CLICKHOUSE_PER_TEAM_QUERY_SETTINGS, TEST
+from posthog.settings import CLICKHOUSE_PER_TEAM_QUERY_SETTINGS, TEST, API_QUERIES_ON_ONLINE_CLUSTER
 from posthog.utils import generate_short_id, patchable
 
 QUERY_STARTED_COUNTER = Counter(
@@ -141,7 +141,7 @@ def sync_execute(
         and workload == Workload.OFFLINE
         and chargeable
         and is_cloud()
-        and team_id in settings.API_QUERIES_ON_ONLINE_CLUSTER
+        and team_id in API_QUERIES_ON_ONLINE_CLUSTER
     ):
         workload = Workload.ONLINE
 


### PR DESCRIPTION
## Problem

some queries are crashing

## Changes

fix it

## Did you write or update any docs for this change?



- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [X] No docs needed for this change

