### PR TITLE
fix: Fix using person channel type in insights

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -328,7 +328,7 @@ def _use_person_id_from_person_overrides(database: Database) -> None:
     database.events.fields["event_person_id"] = StringDatabaseField(name="person_id")
     database.events.fields["override"] = LazyJoin(
         from_field=["distinct_id"],
-        join_table=PersonDistinctIdOverridesTable(),
+        join_table=database.person_distinct_id_overrides,
         join_function=join_with_person_distinct_id_overrides_table,
     )
     database.events.fields["person_id"] = ExpressionField(
@@ -416,7 +416,7 @@ def create_hogql_database(
             _use_person_id_from_person_overrides(database)
             database.events.fields["person"] = LazyJoin(
                 from_field=["person_id"],
-                join_table=PersonsTable(),
+                join_table=database.persons,
                 join_function=join_with_persons_table,
             )
 

--- a/posthog/hogql/database/schema/channel_type.py
+++ b/posthog/hogql/database/schema/channel_type.py
@@ -62,6 +62,7 @@ def create_initial_domain_type(name: str, timings: Optional[HogQLTimings] = None
                 )
             },
         ),
+        isolate_scope=True,
     )
 
 
@@ -110,6 +111,7 @@ def create_initial_channel_type(
             custom_rules=custom_rules,
             timings=timings,
         ),
+        isolate_scope=True,
     )
 
 

--- a/posthog/hogql/database/schema/test/test_persons.py
+++ b/posthog/hogql/database/schema/test/test_persons.py
@@ -1,3 +1,6 @@
+import unittest
+
+from posthog.hogql import ast
 from posthog.hogql.parser import parse_select
 from posthog.schema import (
     PersonsOnEventsMode,
@@ -16,6 +19,7 @@ from posthog.test.base import (
     _create_person,
     _create_event,
     snapshot_clickhouse_queries,
+    flush_persons_and_events,
 )
 from posthog.models.person.util import create_person
 from datetime import datetime
@@ -140,3 +144,62 @@ class TestPersonOptimization(ClickhouseTestMixin, APIBaseTest):
         assert response.clickhouse
         self.assertIn("where_optimization", response.clickhouse)
         self.assertNotIn("in(tuple(person.id, person.version)", response.clickhouse)
+
+
+class TestPersons(ClickhouseTestMixin, APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        person_properties = {"$initial_referring_domain": "https://google.com", "utm_source": "google"}
+        self.google_person = _create_person(
+            team_id=self.team.pk,
+            distinct_ids=["1"],
+            properties=person_properties,
+            created_at=datetime(2025, 5, 28, 12),
+        )
+        _create_event(
+            distinct_id="1",
+            event="$pageview",
+            person_properties=person_properties,
+            timestamp=datetime(2025, 5, 28, 12),
+            team=self.team,
+        )
+        flush_persons_and_events()
+
+    def test_virtual_person_properties(self):
+        response = execute_hogql_query(
+            parse_select("select $virt_initial_channel_type from persons where id = {person_id}"),
+            self.team,
+            placeholders={"person_id": ast.Constant(value=self.google_person.uuid)},
+        )
+        assert len(response.results) == 1
+        assert response.results[0][0] == "Organic Search"
+
+    def test_virtual_event_person_properties(self):
+        response = execute_hogql_query(
+            parse_select("select person.$virt_initial_channel_type from events where person.id = {person_id}"),
+            self.team,
+            placeholders={"person_id": ast.Constant(value=self.google_person.uuid)},
+        )
+        assert len(response.results) == 1
+        assert response.results[0][0] == "Organic Search"
+
+    @unittest.expectedFailure
+    def test_virtual_event_poe_properties(self):
+        response = execute_hogql_query(
+            parse_select("select events.poe.$virt_initial_channel_type from events where person.id = {person_id}"),
+            self.team,
+            placeholders={"person_id": ast.Constant(value=self.google_person.uuid)},
+        )
+        assert len(response.results) == 1
+        assert response.results[0][0] == "Organic Search"
+
+    def test_virtual_event_pdi_properties(self):
+        response = execute_hogql_query(
+            parse_select(
+                "select events.pdi.person.$virt_initial_channel_type from events where person.id = {person_id}"
+            ),
+            self.team,
+            placeholders={"person_id": ast.Constant(value=self.google_person.uuid)},
+        )
+        assert len(response.results) == 1
+        assert response.results[0][0] == "Organic Search"

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -216,7 +216,9 @@
                       "team_id",
                       "properties",
                       "is_identified",
-                      "pdi"
+                      "pdi",
+                      "$virt_initial_referring_domain_type",
+                      "$virt_initial_channel_type"
                   ],
                   "hogql_value": "person",
                   "id": "person",


### PR DESCRIPTION
## Problem

We couldn't use the virtual columns like channel types in some insights. This is because we were keeping multiple copies of the PersonsTable around, but only modifying one of them.


## Changes
Instead of creating a new copy of the PersonsTable, refer to the existing one.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've added or updated the docs
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Added some new tests. I haven't fixed `events.poe`, so that test is marked `xfail`, but will be fixed in a follow-up
