### PR TITLE
feat: make project deletion async via celery

### DIFF
--- a/posthog/api/test/test_project.py
+++ b/posthog/api/test/test_project.py
@@ -38,7 +38,7 @@ class TestProjectAPI(team_api_test_factory()):  # type: ignore
             "Only the project belonging to the scoped organization should be listed, the other one should be excluded",
         )
 
-    @patch('posthog.tasks.delete_project.delete_project_async.delay')
+    @patch("posthog.tasks.delete_project.delete_project_async.delay")
     def test_delete_project_queues_async_task(self, mock_delete_task):
         """Test that deleting a project queues an async task instead of deleting synchronously."""
         # Set user as admin to have delete permissions
@@ -46,11 +46,7 @@ class TestProjectAPI(team_api_test_factory()):  # type: ignore
         self.organization_membership.save()
 
         # Create a second team for the project
-        second_team = Team.objects.create(
-            organization=self.organization,
-            project=self.project,
-            name="Second Team"
-        )
+        second_team = Team.objects.create(organization=self.organization, project=self.project, name="Second Team")
 
         # Store IDs before deletion
         project_id = self.project.id

--- a/posthog/api/test/test_project.py
+++ b/posthog/api/test/test_project.py
@@ -44,25 +44,25 @@ class TestProjectAPI(team_api_test_factory()):  # type: ignore
         # Set user as admin to have delete permissions
         self.organization_membership.level = OrganizationMembership.Level.ADMIN
         self.organization_membership.save()
-        
+
         # Create a second team for the project
         second_team = Team.objects.create(
             organization=self.organization,
             project=self.project,
             name="Second Team"
         )
-        
+
         # Store IDs before deletion
         project_id = self.project.id
         project_name = self.project.name
         organization_id = self.organization.id
-        
+
         # Delete the project
         response = self.client.delete(f"/api/projects/{self.project.id}/")
-        
+
         # Should return 204 No Content immediately
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-        
+
         # Verify the async task was queued with correct parameters
         mock_delete_task.assert_called_once_with(
             project_id=project_id,
@@ -71,7 +71,7 @@ class TestProjectAPI(team_api_test_factory()):  # type: ignore
             user_id=self.user.id,
             was_impersonated=False,
         )
-        
+
         # Verify project still exists (since task is mocked)
         self.assertTrue(Project.objects.filter(id=project_id).exists())
         self.assertTrue(Team.objects.filter(id=self.team.id).exists())

--- a/posthog/tasks/__init__.py
+++ b/posthog/tasks/__init__.py
@@ -3,6 +3,7 @@
 from . import (
     async_migrations,
     calculate_cohort,
+    delete_project,
     demo_create_data,
     demo_reset_master_team,
     email,
@@ -26,6 +27,7 @@ from . import (
 __all__ = [
     "async_migrations",
     "calculate_cohort",
+    "delete_project",
     "demo_create_data",
     "demo_reset_master_team",
     "email",

--- a/posthog/tasks/delete_project.py
+++ b/posthog/tasks/delete_project.py
@@ -1,0 +1,139 @@
+from typing import cast
+from uuid import UUID
+
+from celery import shared_task
+from structlog import get_logger
+
+from posthog.event_usage import report_user_action
+from posthog.models import Project, User
+from posthog.models.activity_logging.activity_log import Detail, log_activity
+from posthog.models.async_deletion import AsyncDeletion, DeletionType
+from posthog.models.signals import mute_selected_signals
+from posthog.models.team.util import delete_batch_exports, delete_bulky_postgres_data
+from posthog.models.utils import UUIDT
+from posthog.tasks.utils import CeleryQueue
+
+logger = get_logger(__name__)
+
+
+@shared_task(
+    ignore_result=True,
+    queue=CeleryQueue.DEFAULT.value,
+    max_retries=3,
+    autoretry_for=(Exception,),
+    retry_backoff=60,
+    retry_backoff_max=3600,
+)
+def delete_project_async(
+    project_id: int,
+    organization_id: UUID,
+    project_name: str,
+    user_id: int,
+    was_impersonated: bool = False,
+) -> None:
+    """
+    Asynchronously delete a project and all associated data.
+
+    This task handles the heavy lifting of project deletion, including:
+    - Deleting bulky PostgreSQL data
+    - Deleting batch exports
+    - Creating AsyncDeletion entries for ClickHouse data cleanup
+    - Logging activity for audit trail
+    """
+    try:
+        logger.info(
+            "Starting async project deletion",
+            project_id=project_id,
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+
+        # Get the user who initiated the deletion
+        try:
+            user = User.objects.get(pk=user_id)
+        except User.DoesNotExist:
+            logger.warning("User not found for project deletion", user_id=user_id, project_id=project_id)
+            user = None
+
+        # Get the project and its teams
+        try:
+            project = Project.objects.get(pk=project_id)
+            teams = list(project.teams.only("id", "uuid", "name", "organization_id").all())
+        except Project.DoesNotExist:
+            logger.warning("Project already deleted", project_id=project_id)
+            return
+
+        # Delete bulky PostgreSQL data and batch exports
+        team_ids = [team.id for team in teams]
+        delete_bulky_postgres_data(team_ids=team_ids)
+        delete_batch_exports(team_ids=team_ids)
+
+        # Delete the project with muted signals to avoid cascading effects
+        with mute_selected_signals():
+            project.delete()
+
+        # Create AsyncDeletion entries for ClickHouse data cleanup
+        if user:
+            AsyncDeletion.objects.bulk_create(
+                [
+                    AsyncDeletion(
+                        deletion_type=DeletionType.Team,
+                        team_id=team.id,
+                        key=str(team.id),
+                        created_by=user,
+                    )
+                    for team in teams
+                ],
+                ignore_conflicts=True,
+            )
+
+        # Log activity for each team deletion
+        for team in teams:
+            if user:
+                log_activity(
+                    organization_id=cast(UUIDT, organization_id),
+                    team_id=team.pk,
+                    user=user,
+                    was_impersonated=was_impersonated,
+                    scope="Team",
+                    item_id=team.pk,
+                    activity="deleted",
+                    detail=Detail(name=str(team.name)),
+                )
+                report_user_action(user, "team deleted", team=team)
+
+        # Log project deletion activity
+        if user:
+            log_activity(
+                organization_id=cast(UUIDT, organization_id),
+                team_id=project_id,
+                user=user,
+                was_impersonated=was_impersonated,
+                scope="Project",
+                item_id=project_id,
+                activity="deleted",
+                detail=Detail(name=str(project_name)),
+            )
+            report_user_action(
+                user,
+                "project deleted",
+                {"project_name": project_name},
+                team=teams[0] if teams else None,
+            )
+
+        logger.info(
+            "Successfully completed async project deletion",
+            project_id=project_id,
+            organization_id=organization_id,
+            teams_deleted=len(teams),
+        )
+
+    except Exception as e:
+        logger.error(
+            "Error during async project deletion",
+            project_id=project_id,
+            organization_id=organization_id,
+            error=str(e),
+            exc_info=True,
+        )
+        raise

--- a/posthog/tasks/test/test_delete_project.py
+++ b/posthog/tasks/test/test_delete_project.py
@@ -1,0 +1,122 @@
+from unittest.mock import patch, MagicMock
+from uuid import uuid4
+
+from django.test import TestCase
+from rest_framework import status
+
+from posthog.models import Project, User, Team, Organization, OrganizationMembership
+from posthog.models.async_deletion import AsyncDeletion, DeletionType
+from posthog.tasks.delete_project import delete_project_async
+
+
+class TestDeleteProjectTask(TestCase):
+    def setUp(self):
+        self.organization = Organization.objects.create(name="Test Org")
+        self.user = User.objects.create_user(email="test@example.com", password="testpass")
+        OrganizationMembership.objects.create(
+            user=self.user, 
+            organization=self.organization,
+            level=OrganizationMembership.Level.ADMIN
+        )
+        
+        # Create a project with teams
+        self.project = Project.objects.create(
+            name="Test Project",
+            organization=self.organization,
+        )
+        self.team1 = Team.objects.create(
+            name="Team 1",
+            organization=self.organization,
+            project=self.project,
+        )
+        self.team2 = Team.objects.create(
+            name="Team 2", 
+            organization=self.organization,
+            project=self.project,
+        )
+
+    @patch('posthog.tasks.delete_project.delete_bulky_postgres_data')
+    @patch('posthog.tasks.delete_project.delete_batch_exports')
+    @patch('posthog.tasks.delete_project.log_activity')
+    @patch('posthog.tasks.delete_project.report_user_action')
+    def test_delete_project_async_success(
+        self, 
+        mock_report_user_action,
+        mock_log_activity,
+        mock_delete_batch_exports,
+        mock_delete_bulky_postgres_data
+    ):
+        # Call the task
+        delete_project_async(
+            project_id=self.project.id,
+            organization_id=self.organization.id,
+            project_name=self.project.name,
+            user_id=self.user.id,
+            was_impersonated=False,
+        )
+        
+        # Verify project was deleted
+        self.assertFalse(Project.objects.filter(id=self.project.id).exists())
+        
+        # Verify teams were deleted  
+        self.assertFalse(Team.objects.filter(project=self.project).exists())
+        
+        # Verify bulk deletion functions were called
+        mock_delete_bulky_postgres_data.assert_called_once()
+        mock_delete_batch_exports.assert_called_once()
+        
+        # Verify AsyncDeletion entries were created
+        async_deletions = AsyncDeletion.objects.filter(
+            deletion_type=DeletionType.Team,
+            created_by=self.user
+        )
+        self.assertEqual(async_deletions.count(), 2)
+        
+        # Verify activity logging
+        self.assertEqual(mock_log_activity.call_count, 3)  # 2 teams + 1 project
+        self.assertEqual(mock_report_user_action.call_count, 3)  # 2 teams + 1 project
+
+    @patch('posthog.tasks.delete_project.logger')
+    def test_delete_project_async_already_deleted(self, mock_logger):
+        # Delete the project first
+        project_id = self.project.id
+        self.project.delete()
+        
+        # Call the task
+        delete_project_async(
+            project_id=project_id,
+            organization_id=self.organization.id,
+            project_name="Test Project",
+            user_id=self.user.id,
+            was_impersonated=False,
+        )
+        
+        # Verify warning was logged
+        mock_logger.warning.assert_called_once_with(
+            "Project already deleted", 
+            project_id=project_id
+        )
+
+    @patch('posthog.tasks.delete_project.logger')
+    def test_delete_project_async_user_not_found(self, mock_logger):
+        # Call the task with non-existent user
+        delete_project_async(
+            project_id=self.project.id,
+            organization_id=self.organization.id,
+            project_name=self.project.name,
+            user_id=99999,
+            was_impersonated=False,
+        )
+        
+        # Verify error was logged
+        mock_logger.error.assert_called_once_with(
+            "User not found for project deletion",
+            user_id=99999,
+            project_id=self.project.id
+        )
+        
+        # Verify project was still deleted
+        self.assertFalse(Project.objects.filter(id=self.project.id).exists())
+        
+        # Verify no AsyncDeletion entries were created (since user is None)
+        self.assertEqual(AsyncDeletion.objects.count(), 0)

--- a/posthog/tasks/test/test_delete_project.py
+++ b/posthog/tasks/test/test_delete_project.py
@@ -1,8 +1,6 @@
-from unittest.mock import patch, MagicMock
-from uuid import uuid4
+from unittest.mock import patch
 
 from django.test import TestCase
-from rest_framework import status
 
 from posthog.models import Project, User, Team, Organization, OrganizationMembership
 from posthog.models.async_deletion import AsyncDeletion, DeletionType
@@ -14,11 +12,11 @@ class TestDeleteProjectTask(TestCase):
         self.organization = Organization.objects.create(name="Test Org")
         self.user = User.objects.create_user(email="test@example.com", password="testpass")
         OrganizationMembership.objects.create(
-            user=self.user, 
+            user=self.user,
             organization=self.organization,
             level=OrganizationMembership.Level.ADMIN
         )
-        
+
         # Create a project with teams
         self.project = Project.objects.create(
             name="Test Project",
@@ -30,7 +28,7 @@ class TestDeleteProjectTask(TestCase):
             project=self.project,
         )
         self.team2 = Team.objects.create(
-            name="Team 2", 
+            name="Team 2",
             organization=self.organization,
             project=self.project,
         )
@@ -40,7 +38,7 @@ class TestDeleteProjectTask(TestCase):
     @patch('posthog.tasks.delete_project.log_activity')
     @patch('posthog.tasks.delete_project.report_user_action')
     def test_delete_project_async_success(
-        self, 
+        self,
         mock_report_user_action,
         mock_log_activity,
         mock_delete_batch_exports,
@@ -54,24 +52,24 @@ class TestDeleteProjectTask(TestCase):
             user_id=self.user.id,
             was_impersonated=False,
         )
-        
+
         # Verify project was deleted
         self.assertFalse(Project.objects.filter(id=self.project.id).exists())
-        
-        # Verify teams were deleted  
+
+        # Verify teams were deleted
         self.assertFalse(Team.objects.filter(project=self.project).exists())
-        
+
         # Verify bulk deletion functions were called
         mock_delete_bulky_postgres_data.assert_called_once()
         mock_delete_batch_exports.assert_called_once()
-        
+
         # Verify AsyncDeletion entries were created
         async_deletions = AsyncDeletion.objects.filter(
             deletion_type=DeletionType.Team,
             created_by=self.user
         )
         self.assertEqual(async_deletions.count(), 2)
-        
+
         # Verify activity logging
         self.assertEqual(mock_log_activity.call_count, 3)  # 2 teams + 1 project
         self.assertEqual(mock_report_user_action.call_count, 3)  # 2 teams + 1 project
@@ -81,7 +79,7 @@ class TestDeleteProjectTask(TestCase):
         # Delete the project first
         project_id = self.project.id
         self.project.delete()
-        
+
         # Call the task
         delete_project_async(
             project_id=project_id,
@@ -90,10 +88,10 @@ class TestDeleteProjectTask(TestCase):
             user_id=self.user.id,
             was_impersonated=False,
         )
-        
+
         # Verify warning was logged
         mock_logger.warning.assert_called_once_with(
-            "Project already deleted", 
+            "Project already deleted",
             project_id=project_id
         )
 
@@ -107,16 +105,16 @@ class TestDeleteProjectTask(TestCase):
             user_id=99999,
             was_impersonated=False,
         )
-        
+
         # Verify error was logged
         mock_logger.error.assert_called_once_with(
             "User not found for project deletion",
             user_id=99999,
             project_id=self.project.id
         )
-        
+
         # Verify project was still deleted
         self.assertFalse(Project.objects.filter(id=self.project.id).exists())
-        
+
         # Verify no AsyncDeletion entries were created (since user is None)
         self.assertEqual(AsyncDeletion.objects.count(), 0)


### PR DESCRIPTION
When projects get very large and users want to delete those projects you can basically time out just trying to delete stuff out of postgres and get a 504.

This kicks the deletion process into an async celery job that is kicked off now when you hit the endpoint.

Fix for this issue a customer had:
https://posthog.slack.com/archives/C01MM7VT7MG/p1748645626831339
