### PR TITLE
fix: remove capture error for RequestParsingError in decide

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -248,7 +248,8 @@ def get_decide(request: HttpRequest) -> HttpResponse:
             generate_exception_response("decide", f"Malformed request data: {error}", code="malformed_data"),
         )
     except RequestParsingError as error:
-        capture_exception(error)  # We still capture this on Sentry to identify actual potential bugs
+        # do not capture for now to allow error tracking to catch up
+        # capture_exception(error)  # We still capture this on Sentry to identify actual potential bugs
         return cors_response(
             request,
             generate_exception_response("decide", f"Malformed request data: {error}", code="malformed_data"),

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -5750,4 +5750,5 @@ class TestDecideExceptions(TestCase):
         response = get_decide(request)
 
         self.assertEqual(response.status_code, 400)
-        mock_capture_exception.assert_called_once()
+        # also comment out for now to allow error tracking to catch up
+        # mock_capture_exception.assert_called_once()


### PR DESCRIPTION
removing a posthog error tracking on this exception so we can allow the error tracking consumer to catch up for all other customers