### PR TITLE
feat: add tuple support to state aggregation transformer

### DIFF
--- a/posthog/hogql/transforms/state_aggregations.py
+++ b/posthog/hogql/transforms/state_aggregations.py
@@ -2,6 +2,7 @@ from posthog.hogql import ast
 from posthog.hogql.functions.mapping import HOGQL_AGGREGATIONS
 from posthog.hogql.visitor import CloningVisitor
 from typing import Union, cast
+from posthog.hogql.parser import parse_select
 
 QueryType = Union[ast.SelectQuery, ast.SelectSetQuery]
 
@@ -272,3 +273,51 @@ def wrap_state_query_in_merge_query(
         outer_query.offset = state_query.offset
 
     return cast(QueryType, outer_query)
+
+
+def combine_queries_with_state_and_merge(*query_strings: str) -> QueryType:
+    """
+    Utility function to combine multiple queries using the state + UNION ALL + merge pattern.
+
+    This simulates the common pattern where you have:
+    1. Pre-aggregated data (e.g., from materialized views or pre-aggregated tables)
+    2. Real-time data that needs to be combined
+
+    This is especially useful for PostHog's web analytics where we combine:
+    - Historical data from materialized views (stats_table_preaggregated)
+    - Real-time data from events table
+
+    Args:
+        *query_strings: Variable number of HogQL query strings to combine
+
+    Returns:
+        A wrapped query that combines all input queries with state/merge functions
+
+    Example:
+        >>> historical_query = "SELECT uniq(distinct_id) FROM events WHERE date < '2023-01-01'"
+        >>> realtime_query = "SELECT uniq(distinct_id) FROM events WHERE date >= '2023-01-01'"
+        >>> combined = combine_queries_with_state_and_merge(historical_query, realtime_query)
+    """
+
+    if len(query_strings) == 0:
+        raise ValueError("At least one query string is required")
+
+    if len(query_strings) == 1:
+        query_ast = parse_select(query_strings[0])
+        state_query_ast = transform_query_to_state_aggregations(query_ast)
+        return wrap_state_query_in_merge_query(state_query_ast)
+
+    state_queries = []
+    for query_str in query_strings:
+        query_ast = parse_select(query_str)
+        state_query_ast = transform_query_to_state_aggregations(query_ast)
+        state_queries.append(state_query_ast)
+
+    select_set_query_ast = ast.SelectSetQuery(
+        initial_select_query=state_queries[0],
+        subsequent_select_queries=[
+            ast.SelectSetNode(select_query=state_query, set_operator="UNION ALL") for state_query in state_queries[1:]
+        ],
+    )
+
+    return wrap_state_query_in_merge_query(select_set_query_ast)

--- a/posthog/hogql/transforms/test/__snapshots__/test_state_aggregations.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_state_aggregations.ambr
@@ -60,6 +60,27 @@
   LIMIT 50000
   '''
 # ---
+# name: TestStateTransforms.test_combine_mixed_transformation_stages_with_tuples
+  '''
+  
+  SELECT tuple(uniqMerge(tupleElement(user_metrics, 1)), countMerge(tupleElement(user_metrics, 2))) AS user_metrics, tuple(sumMerge(tupleElement(activity_metrics, 1)), avgMerge(tupleElement(activity_metrics, 2))) AS activity_metrics, date AS date 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countState()) AS user_metrics, tuple(sumState(1), avgState(1)) AS activity_metrics, toDate(toTimeZone(events.timestamp, %(hogql_val_0)s)) AS date 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), less(toDate(toTimeZone(events.timestamp, %(hogql_val_1)s)), %(hogql_val_2)s)) 
+  GROUP BY date) 
+  GROUP BY date 
+  LIMIT 50000 UNION ALL 
+  SELECT tuple(uniqMerge(tupleElement(user_metrics, 1)), countMerge(tupleElement(user_metrics, 2))) AS user_metrics, tuple(sumMerge(tupleElement(activity_metrics, 1)), avgMerge(tupleElement(activity_metrics, 2))) AS activity_metrics, date AS date 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countState()) AS user_metrics, tuple(sumState(1), avgState(1)) AS activity_metrics, toDate(toTimeZone(events.timestamp, %(hogql_val_3)s)) AS date 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), greaterOrEquals(toTimeZone(events.timestamp, %(hogql_val_4)s), %(hogql_val_5)s)) 
+  GROUP BY date) 
+  GROUP BY date 
+  LIMIT 50000
+  '''
+# ---
 # name: TestStateTransforms.test_combine_multiple_time_periods_with_conditional_aggregations
   '''
   
@@ -74,6 +95,23 @@
   SELECT tuple(uniqStateIf(events.distinct_id, equals(events.event, %(hogql_val_6)s)), countStateIf(equals(events.event, %(hogql_val_7)s)), sumStateIf(1, 1)) AS metrics 
   FROM events 
   WHERE and(equals(events.team_id, 420), greaterOrEquals(toTimeZone(events.timestamp, %(hogql_val_8)s), %(hogql_val_9)s))) 
+  LIMIT 50000
+  '''
+# ---
+# name: TestStateTransforms.test_combine_regular_and_state_aggregations_mixed
+  '''
+  
+  SELECT tuple(uniqMerge(tupleElement(metrics, 1)), countMerge(tupleElement(metrics, 2)), sumMerge(tupleElement(metrics, 3))) AS metrics, %(hogql_val_4)s AS source_type 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countState(), sumStateIf(1, equals(events.event, %(hogql_val_0)s))) AS metrics, %(hogql_val_1)s AS source_type 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), greaterOrEquals(toTimeZone(events.timestamp, %(hogql_val_2)s), %(hogql_val_3)s))) 
+  LIMIT 50000 UNION ALL 
+  SELECT tuple(uniqMerge(tupleElement(metrics, 1)), countMerge(tupleElement(metrics, 2)), sumMerge(tupleElement(metrics, 3))) AS metrics, %(hogql_val_9)s AS source_type 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countState(), sumStateIf(1, equals(events.event, %(hogql_val_5)s))) AS metrics, %(hogql_val_6)s AS source_type 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), less(toTimeZone(events.timestamp, %(hogql_val_7)s), %(hogql_val_8)s))) 
   LIMIT 50000
   '''
 # ---
@@ -302,6 +340,29 @@
   SELECT uniqState(events.distinct_id) AS unique_users, NULL AS previous_unique_users, countState() AS total_events, 123 AS constant_value 
   FROM events 
   WHERE and(equals(events.team_id, 420), greaterOrEquals(toTimeZone(events.timestamp, %(hogql_val_0)s), %(hogql_val_1)s))) 
+  LIMIT 50000
+  '''
+# ---
+# name: TestStateTransforms.test_three_way_mixed_aggregation_stages
+  '''
+  
+  SELECT tuple(uniqMerge(tupleElement(pageview_metrics, 1)), countMerge(tupleElement(pageview_metrics, 2))) AS pageview_metrics 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countStateIf(equals(events.event, %(hogql_val_0)s))) AS pageview_metrics 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), less(toTimeZone(events.timestamp, %(hogql_val_1)s), %(hogql_val_2)s))) 
+  LIMIT 50000 UNION ALL 
+  SELECT tuple(uniqMerge(tupleElement(pageview_metrics, 1)), countMerge(tupleElement(pageview_metrics, 2))) AS pageview_metrics 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countStateIf(equals(events.event, %(hogql_val_3)s))) AS pageview_metrics 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), greaterOrEquals(toTimeZone(events.timestamp, %(hogql_val_4)s), %(hogql_val_5)s), less(toTimeZone(events.timestamp, %(hogql_val_6)s), %(hogql_val_7)s))) 
+  LIMIT 50000 UNION ALL 
+  SELECT tuple(uniqMerge(tupleElement(pageview_metrics, 1)), countMerge(tupleElement(pageview_metrics, 2))) AS pageview_metrics 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countStateIf(equals(events.event, %(hogql_val_8)s))) AS pageview_metrics 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), greaterOrEquals(toTimeZone(events.timestamp, %(hogql_val_9)s), %(hogql_val_10)s))) 
   LIMIT 50000
   '''
 # ---

--- a/posthog/hogql/transforms/test/__snapshots__/test_state_aggregations.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_state_aggregations.ambr
@@ -1,4 +1,111 @@
 # serializer version: 1
+# name: TestStateTransforms.test_combine_cohort_analysis_time_windows
+  '''
+  
+  SELECT tuple(uniqMerge(tupleElement(cohort_metrics, 1)), countMerge(tupleElement(cohort_metrics, 2)), sumMerge(tupleElement(cohort_metrics, 3))) AS cohort_metrics, %(hogql_val_7)s AS cohort_period 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countStateIf(equals(events.event, %(hogql_val_0)s)), sumStateIf(1, equals(events.event, %(hogql_val_1)s))) AS cohort_metrics, %(hogql_val_2)s AS cohort_period 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), greaterOrEquals(toTimeZone(events.timestamp, %(hogql_val_3)s), %(hogql_val_4)s), less(toTimeZone(events.timestamp, %(hogql_val_5)s), %(hogql_val_6)s))) 
+  LIMIT 50000 UNION ALL 
+  SELECT tuple(uniqMerge(tupleElement(cohort_metrics, 1)), countMerge(tupleElement(cohort_metrics, 2)), sumMerge(tupleElement(cohort_metrics, 3))) AS cohort_metrics, %(hogql_val_15)s AS cohort_period 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countStateIf(equals(events.event, %(hogql_val_8)s)), sumStateIf(1, equals(events.event, %(hogql_val_9)s))) AS cohort_metrics, %(hogql_val_10)s AS cohort_period 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), greaterOrEquals(toTimeZone(events.timestamp, %(hogql_val_11)s), %(hogql_val_12)s), less(toTimeZone(events.timestamp, %(hogql_val_13)s), %(hogql_val_14)s))) 
+  LIMIT 50000 UNION ALL 
+  SELECT tuple(uniqMerge(tupleElement(cohort_metrics, 1)), countMerge(tupleElement(cohort_metrics, 2)), sumMerge(tupleElement(cohort_metrics, 3))) AS cohort_metrics, %(hogql_val_23)s AS cohort_period 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countStateIf(equals(events.event, %(hogql_val_16)s)), sumStateIf(1, equals(events.event, %(hogql_val_17)s))) AS cohort_metrics, %(hogql_val_18)s AS cohort_period 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), greaterOrEquals(toTimeZone(events.timestamp, %(hogql_val_19)s), %(hogql_val_20)s), less(toTimeZone(events.timestamp, %(hogql_val_21)s), %(hogql_val_22)s))) 
+  LIMIT 50000
+  '''
+# ---
+# name: TestStateTransforms.test_combine_complex_nested_aggregation_patterns
+  '''
+  
+  SELECT tuple(uniqMerge(tupleElement(comprehensive_metrics, 1)), countMerge(tupleElement(comprehensive_metrics, 2)), sumMerge(tupleElement(comprehensive_metrics, 3)), avgMerge(tupleElement(comprehensive_metrics, 4))) AS comprehensive_metrics, source AS source 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countStateIf(equals(events.event, %(hogql_val_0)s)), sumStateIf(1, equals(events.event, %(hogql_val_1)s)), avgStateIf(1, equals(events.event, %(hogql_val_2)s))) AS comprehensive_metrics, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_3)s), ''), 'null'), '^"|"$', '') AS source 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_4)s), ''), 'null'), '^"|"$', ''), %(hogql_val_5)s), 0)) 
+  GROUP BY source) 
+  GROUP BY source 
+  LIMIT 50000 UNION ALL 
+  SELECT tuple(uniqMerge(tupleElement(comprehensive_metrics, 1)), countMerge(tupleElement(comprehensive_metrics, 2)), sumMerge(tupleElement(comprehensive_metrics, 3)), avgMerge(tupleElement(comprehensive_metrics, 4))) AS comprehensive_metrics, source AS source 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countStateIf(equals(events.event, %(hogql_val_6)s)), sumStateIf(1, equals(events.event, %(hogql_val_7)s)), avgStateIf(1, equals(events.event, %(hogql_val_8)s))) AS comprehensive_metrics, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_9)s), ''), 'null'), '^"|"$', '') AS source 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_10)s), ''), 'null'), '^"|"$', ''), %(hogql_val_11)s), 0)) 
+  GROUP BY source) 
+  GROUP BY source 
+  LIMIT 50000
+  '''
+# ---
+# name: TestStateTransforms.test_combine_funnel_analysis_segments
+  '''
+  
+  SELECT tuple(uniqMerge(tupleElement(funnel_metrics, 1)), countMerge(tupleElement(funnel_metrics, 2)), countMerge(tupleElement(funnel_metrics, 3))) AS funnel_metrics 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countStateIf(equals(events.event, %(hogql_val_0)s)), countStateIf(equals(events.event, %(hogql_val_1)s))) AS funnel_metrics 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_2)s), ''), 'null'), '^"|"$', ''), %(hogql_val_3)s), 0))) 
+  LIMIT 50000 UNION ALL 
+  SELECT tuple(uniqMerge(tupleElement(funnel_metrics, 1)), countMerge(tupleElement(funnel_metrics, 2)), countMerge(tupleElement(funnel_metrics, 3))) AS funnel_metrics 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countStateIf(equals(events.event, %(hogql_val_4)s)), countStateIf(equals(events.event, %(hogql_val_5)s))) AS funnel_metrics 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_6)s), ''), 'null'), '^"|"$', ''), %(hogql_val_7)s), 0))) 
+  LIMIT 50000
+  '''
+# ---
+# name: TestStateTransforms.test_combine_multiple_time_periods_with_conditional_aggregations
+  '''
+  
+  SELECT tuple(uniqMerge(tupleElement(metrics, 1)), countMerge(tupleElement(metrics, 2)), sumMerge(tupleElement(metrics, 3))) AS metrics 
+  FROM (
+  SELECT tuple(uniqStateIf(events.distinct_id, equals(events.event, %(hogql_val_0)s)), countStateIf(equals(events.event, %(hogql_val_1)s)), sumStateIf(1, 1)) AS metrics 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), greaterOrEquals(toTimeZone(events.timestamp, %(hogql_val_2)s), %(hogql_val_3)s), less(toTimeZone(events.timestamp, %(hogql_val_4)s), %(hogql_val_5)s))) 
+  LIMIT 50000 UNION ALL 
+  SELECT tuple(uniqMerge(tupleElement(metrics, 1)), countMerge(tupleElement(metrics, 2)), sumMerge(tupleElement(metrics, 3))) AS metrics 
+  FROM (
+  SELECT tuple(uniqStateIf(events.distinct_id, equals(events.event, %(hogql_val_6)s)), countStateIf(equals(events.event, %(hogql_val_7)s)), sumStateIf(1, 1)) AS metrics 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), greaterOrEquals(toTimeZone(events.timestamp, %(hogql_val_8)s), %(hogql_val_9)s))) 
+  LIMIT 50000
+  '''
+# ---
+# name: TestStateTransforms.test_combine_three_data_sources_with_mixed_tuples
+  '''
+  
+  SELECT tuple(uniqMerge(tupleElement(user_metrics, 1)), countMerge(tupleElement(user_metrics, 2))) AS user_metrics, tuple(sumMerge(tupleElement(value_metrics, 1)), avgMerge(tupleElement(value_metrics, 2))) AS value_metrics, host AS host 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countState()) AS user_metrics, tuple(sumState(1), avgState(1)) AS value_metrics, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', '') AS host 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), less(toTimeZone(events.timestamp, %(hogql_val_1)s), %(hogql_val_2)s)) 
+  GROUP BY host) 
+  GROUP BY host 
+  LIMIT 50000 UNION ALL 
+  SELECT tuple(uniqMerge(tupleElement(user_metrics, 1)), countMerge(tupleElement(user_metrics, 2))) AS user_metrics, tuple(sumMerge(tupleElement(value_metrics, 1)), avgMerge(tupleElement(value_metrics, 2))) AS value_metrics, host AS host 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countState()) AS user_metrics, tuple(sumState(1), avgState(1)) AS value_metrics, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_3)s), ''), 'null'), '^"|"$', '') AS host 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), greaterOrEquals(toTimeZone(events.timestamp, %(hogql_val_4)s), %(hogql_val_5)s), less(toTimeZone(events.timestamp, %(hogql_val_6)s), %(hogql_val_7)s)) 
+  GROUP BY host) 
+  GROUP BY host 
+  LIMIT 50000 UNION ALL 
+  SELECT tuple(uniqMerge(tupleElement(user_metrics, 1)), countMerge(tupleElement(user_metrics, 2))) AS user_metrics, tuple(sumMerge(tupleElement(value_metrics, 1)), avgMerge(tupleElement(value_metrics, 2))) AS value_metrics, host AS host 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countState()) AS user_metrics, tuple(sumState(1), avgState(1)) AS value_metrics, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_8)s), ''), 'null'), '^"|"$', '') AS host 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), greaterOrEquals(toTimeZone(events.timestamp, %(hogql_val_9)s), %(hogql_val_10)s)) 
+  GROUP BY host) 
+  GROUP BY host 
+  LIMIT 50000
+  '''
+# ---
 # name: TestStateTransforms.test_combine_two_different_state_queries_into_one_merge_query
   '''
   
@@ -13,6 +120,48 @@
   SELECT countState() AS total_pageviews 
   FROM events 
   WHERE and(equals(events.team_id, 420), greaterOrEquals(toTimeZone(events.timestamp, %(hogql_val_2)s), minus(now64(6, %(hogql_val_3)s), toIntervalDay(1))))) 
+  LIMIT 50000
+  '''
+# ---
+# name: TestStateTransforms.test_combine_web_analytics_historical_and_realtime_data
+  '''
+  
+  SELECT tuple(uniqMerge(tupleElement(daily_metrics, 1)), countMerge(tupleElement(daily_metrics, 2)), sumMerge(tupleElement(daily_metrics, 3))) AS daily_metrics, date AS date 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countState(), sumStateIf(1, equals(events.event, %(hogql_val_0)s))) AS daily_metrics, toDate(toTimeZone(events.timestamp, %(hogql_val_1)s)) AS date 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), less(toDate(toTimeZone(events.timestamp, %(hogql_val_2)s)), %(hogql_val_3)s)) 
+  GROUP BY date) 
+  GROUP BY date 
+  LIMIT 50000 UNION ALL 
+  SELECT tuple(uniqMerge(tupleElement(daily_metrics, 1)), countMerge(tupleElement(daily_metrics, 2)), sumMerge(tupleElement(daily_metrics, 3))) AS daily_metrics, date AS date 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countState(), sumStateIf(1, equals(events.event, %(hogql_val_4)s))) AS daily_metrics, toDate(toTimeZone(events.timestamp, %(hogql_val_5)s)) AS date 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), equals(toDate(toTimeZone(events.timestamp, %(hogql_val_6)s)), %(hogql_val_7)s)) 
+  GROUP BY date) 
+  GROUP BY date 
+  LIMIT 50000
+  '''
+# ---
+# name: TestStateTransforms.test_complex_tuple_union_all_with_grouping
+  '''
+  
+  SELECT tuple(uniqMerge(tupleElement(stats_tuple, 1)), countMerge(tupleElement(stats_tuple, 2)), sumMerge(tupleElement(stats_tuple, 3))) AS stats_tuple, date_key AS date_key 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countStateIf(1), sumState(1)) AS stats_tuple, toDate(toTimeZone(events.timestamp, %(hogql_val_0)s)) AS date_key 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), less(toDate(toTimeZone(events.timestamp, %(hogql_val_1)s)), %(hogql_val_2)s)) 
+  GROUP BY date_key) 
+  GROUP BY date_key 
+  LIMIT 50000 UNION ALL 
+  SELECT tuple(uniqMerge(tupleElement(stats_tuple, 1)), countMerge(tupleElement(stats_tuple, 2)), sumMerge(tupleElement(stats_tuple, 3))) AS stats_tuple, date_key AS date_key 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countStateIf(1), sumState(1)) AS stats_tuple, toDate(toTimeZone(events.timestamp, %(hogql_val_3)s)) AS date_key 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), greaterOrEquals(toDate(toTimeZone(events.timestamp, %(hogql_val_4)s)), %(hogql_val_5)s)) 
+  GROUP BY date_key) 
+  GROUP BY date_key 
   LIMIT 50000
   '''
 # ---
@@ -39,6 +188,23 @@
   LIMIT 10) 
   GROUP BY host ORDER BY total_events DESC 
   LIMIT 10
+  '''
+# ---
+# name: TestStateTransforms.test_multi_level_tuple_union_all_transformation
+  '''
+  
+  SELECT tuple(uniqMerge(tupleElement(user_metrics, 1)), countMerge(tupleElement(user_metrics, 2))) AS user_metrics, tuple(sumMerge(tupleElement(session_metrics, 1)), avgMerge(tupleElement(session_metrics, 2))) AS session_metrics 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countState()) AS user_metrics, tuple(sumState(1), avgState(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', ''), %(hogql_val_1)s))) AS session_metrics 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), less(toTimeZone(events.timestamp, %(hogql_val_2)s), %(hogql_val_3)s))) 
+  LIMIT 50000 UNION ALL 
+  SELECT tuple(uniqMerge(tupleElement(user_metrics, 1)), countMerge(tupleElement(user_metrics, 2))) AS user_metrics, tuple(sumMerge(tupleElement(session_metrics, 1)), avgMerge(tupleElement(session_metrics, 2))) AS session_metrics 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countState()) AS user_metrics, tuple(sumState(1), avgState(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_4)s), ''), 'null'), '^"|"$', ''), %(hogql_val_5)s))) AS session_metrics 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), greaterOrEquals(toTimeZone(events.timestamp, %(hogql_val_6)s), %(hogql_val_7)s))) 
+  LIMIT 50000
   '''
 # ---
 # name: TestStateTransforms.test_multiple_tuples_with_state_aggregations
@@ -76,6 +242,22 @@
   WHERE equals(events.team_id, 420) 
   GROUP BY host) 
   GROUP BY host 
+  LIMIT 50000
+  '''
+# ---
+# name: TestStateTransforms.test_nested_subquery_with_tuple_union_all
+  '''
+  
+  SELECT sumMerge(final_users) AS final_users, avgMerge(final_avg_duration) AS final_avg_duration 
+  FROM (
+  SELECT sumState(combined_stats.total_users) AS final_users, avgState(combined_stats.avg_duration) AS final_avg_duration 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), avgState(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', ''), %(hogql_val_1)s))) AS user_duration_tuple, tupleElement(user_duration_tuple, 1) AS total_users, tupleElement(user_duration_tuple, 2) AS avg_duration 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), equals(events.event, %(hogql_val_2)s), less(toTimeZone(events.timestamp, %(hogql_val_3)s), %(hogql_val_4)s)) UNION ALL 
+  SELECT tuple(uniqState(events.distinct_id), avgState(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_5)s), ''), 'null'), '^"|"$', ''), %(hogql_val_6)s))) AS user_duration_tuple, tupleElement(user_duration_tuple, 1) AS total_users, tupleElement(user_duration_tuple, 2) AS avg_duration 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), equals(events.event, %(hogql_val_7)s), greaterOrEquals(toTimeZone(events.timestamp, %(hogql_val_8)s), %(hogql_val_9)s))) AS combined_stats) 
   LIMIT 50000
   '''
 # ---
@@ -165,6 +347,23 @@
   LIMIT 50000
   '''
 # ---
+# name: TestStateTransforms.test_tuple_union_all_with_different_conditions
+  '''
+  
+  SELECT tuple(uniqMerge(tupleElement(pageview_stats, 1)), countMerge(tupleElement(pageview_stats, 2))) AS pageview_stats, tuple(uniqMerge(tupleElement(click_stats, 1)), countMerge(tupleElement(click_stats, 2))) AS click_stats 
+  FROM (
+  SELECT tuple(uniqStateIf(events.distinct_id, equals(events.event, %(hogql_val_0)s)), countStateIf(equals(events.event, %(hogql_val_1)s))) AS pageview_stats, tuple(uniqStateIf(events.distinct_id, equals(events.event, %(hogql_val_2)s)), countStateIf(equals(events.event, %(hogql_val_3)s))) AS click_stats 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), greaterOrEquals(toTimeZone(events.timestamp, %(hogql_val_4)s), %(hogql_val_5)s), lessOrEquals(toTimeZone(events.timestamp, %(hogql_val_6)s), %(hogql_val_7)s))) 
+  LIMIT 50000 UNION ALL 
+  SELECT tuple(uniqMerge(tupleElement(pageview_stats, 1)), countMerge(tupleElement(pageview_stats, 2))) AS pageview_stats, tuple(uniqMerge(tupleElement(click_stats, 1)), countMerge(tupleElement(click_stats, 2))) AS click_stats 
+  FROM (
+  SELECT tuple(uniqStateIf(events.distinct_id, equals(events.event, %(hogql_val_8)s)), countStateIf(equals(events.event, %(hogql_val_9)s))) AS pageview_stats, tuple(uniqStateIf(events.distinct_id, equals(events.event, %(hogql_val_10)s)), countStateIf(equals(events.event, %(hogql_val_11)s))) AS click_stats 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), greaterOrEquals(toTimeZone(events.timestamp, %(hogql_val_12)s), %(hogql_val_13)s), lessOrEquals(toTimeZone(events.timestamp, %(hogql_val_14)s), %(hogql_val_15)s))) 
+  LIMIT 50000
+  '''
+# ---
 # name: TestStateTransforms.test_tuple_with_conditional_aggregations
   '''
   
@@ -225,6 +424,23 @@
   SELECT countState() AS total_pageviews 
   FROM events 
   WHERE and(equals(events.team_id, 420), greaterOrEquals(toTimeZone(events.timestamp, %(hogql_val_2)s), minus(now64(6, %(hogql_val_3)s), toIntervalDay(1))))) 
+  LIMIT 50000
+  '''
+# ---
+# name: TestStateTransforms.test_union_all_tuples_with_state_aggregations
+  '''
+  
+  SELECT tuple(uniqMerge(tupleElement(user_stats, 1)), countMerge(tupleElement(user_stats, 2))) AS user_stats, tuple(sumMerge(tupleElement(metric_stats, 1)), avgMerge(tupleElement(metric_stats, 2))) AS metric_stats, %(hogql_val_3)s AS data_source 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countState()) AS user_stats, tuple(sumState(1), avgState(1)) AS metric_stats, %(hogql_val_0)s AS data_source 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), less(toTimeZone(events.timestamp, %(hogql_val_1)s), %(hogql_val_2)s))) 
+  LIMIT 50000 UNION ALL 
+  SELECT tuple(uniqMerge(tupleElement(user_stats, 1)), countMerge(tupleElement(user_stats, 2))) AS user_stats, tuple(sumMerge(tupleElement(metric_stats, 1)), avgMerge(tupleElement(metric_stats, 2))) AS metric_stats, %(hogql_val_7)s AS data_source 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countState()) AS user_stats, tuple(sumState(1), avgState(1)) AS metric_stats, %(hogql_val_4)s AS data_source 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), greaterOrEquals(toTimeZone(events.timestamp, %(hogql_val_5)s), %(hogql_val_6)s))) 
   LIMIT 50000
   '''
 # ---

--- a/posthog/hogql/transforms/test/__snapshots__/test_state_aggregations.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_state_aggregations.ambr
@@ -41,6 +41,17 @@
   LIMIT 10
   '''
 # ---
+# name: TestStateTransforms.test_multiple_tuples_with_state_aggregations
+  '''
+  
+  SELECT tuple(uniqMerge(tupleElement(user_stats, 1)), countMerge(tupleElement(user_stats, 2))) AS user_stats, tuple(sumMerge(tupleElement(metric_stats, 1)), avgMerge(tupleElement(metric_stats, 2))) AS metric_stats 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countState()) AS user_stats, tuple(sumState(1), avgState(1)) AS metric_stats 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), greaterOrEquals(toTimeZone(events.timestamp, %(hogql_val_0)s), %(hogql_val_1)s))) 
+  LIMIT 50000
+  '''
+# ---
 # name: TestStateTransforms.test_nested_aggregations_in_subquery
   '''
   
@@ -127,6 +138,76 @@
   SELECT uniqState(events.distinct_id) AS unique_users, countState() AS total_events 
   FROM events 
   WHERE and(equals(events.team_id, 420), greaterOrEquals(toTimeZone(events.timestamp, %(hogql_val_0)s), %(hogql_val_1)s)) 
+  LIMIT 50000
+  '''
+# ---
+# name: TestStateTransforms.test_transformation_from_regular_to_state_then_merge_with_tuples
+  '''
+  
+  SELECT tuple(uniqMerge(tupleElement(user_stats, 1)), countMerge(tupleElement(user_stats, 2))) AS user_stats, tuple(sumMerge(tupleElement(metric_stats, 1)), avgMerge(tupleElement(metric_stats, 2))) AS metric_stats 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countState()) AS user_stats, tuple(sumState(1), avgState(1)) AS metric_stats 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), greaterOrEquals(toTimeZone(events.timestamp, %(hogql_val_0)s), %(hogql_val_1)s))) 
+  LIMIT 50000
+  '''
+# ---
+# name: TestStateTransforms.test_tuple_in_subquery_remains_unchanged
+  '''
+  
+  SELECT sumMerge(aggregated_total) AS aggregated_total 
+  FROM (
+  SELECT sumState(filtered_metrics.total_count) AS aggregated_total 
+  FROM (
+  SELECT tuple(uniq(events.distinct_id), count()) AS user_metrics, sum(1) AS total_count 
+  FROM events 
+  WHERE equals(events.team_id, 420)) AS filtered_metrics) 
+  LIMIT 50000
+  '''
+# ---
+# name: TestStateTransforms.test_tuple_with_conditional_aggregations
+  '''
+  
+  SELECT tuple(uniqMerge(tupleElement(conditional_stats, 1)), countMerge(tupleElement(conditional_stats, 2)), sumMerge(tupleElement(conditional_stats, 3))) AS conditional_stats 
+  FROM (
+  SELECT tuple(uniqStateIf(events.distinct_id, 1), countStateIf(1), sumStateIf(1, 1)) AS conditional_stats 
+  FROM events 
+  WHERE equals(events.team_id, 420)) 
+  LIMIT 50000
+  '''
+# ---
+# name: TestStateTransforms.test_tuple_with_constants_and_state_aggregations
+  '''
+  
+  SELECT tuple(uniqMerge(tupleElement(mixed_tuple, 1)), tupleElement(mixed_tuple, 2), countMerge(tupleElement(mixed_tuple, 3)), tupleElement(mixed_tuple, 4), tupleElement(mixed_tuple, 5)) AS mixed_tuple 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), NULL, countState(), %(hogql_val_0)s, 42) AS mixed_tuple 
+  FROM events 
+  WHERE equals(events.team_id, 420)) 
+  LIMIT 50000
+  '''
+# ---
+# name: TestStateTransforms.test_tuple_with_mixed_aggregations_and_non_aggregations
+  '''
+  
+  SELECT tuple(uniqMerge(tupleElement(mixed_stats, 1)), tupleElement(mixed_stats, 2), countMerge(tupleElement(mixed_stats, 3))) AS mixed_stats, sumMerge(total_sum) AS total_sum 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), %(hogql_val_0)s, countState()) AS mixed_stats, sumState(1) AS total_sum 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), greaterOrEquals(toTimeZone(events.timestamp, %(hogql_val_1)s), %(hogql_val_2)s))) 
+  LIMIT 50000
+  '''
+# ---
+# name: TestStateTransforms.test_tuple_with_state_aggregations
+  '''
+  
+  SELECT tuple(uniqMerge(tupleElement(user_stats, 1)), countMerge(tupleElement(user_stats, 2))) AS user_stats, host AS host 
+  FROM (
+  SELECT tuple(uniqState(events.distinct_id), countState()) AS user_stats, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', '') AS host 
+  FROM events 
+  WHERE and(equals(events.team_id, 420), greaterOrEquals(toTimeZone(events.timestamp, %(hogql_val_1)s), %(hogql_val_2)s)) 
+  GROUP BY host) 
+  GROUP BY host 
   LIMIT 50000
   '''
 # ---


### PR DESCRIPTION
## Problem

The existing implementation did not support tuples; it was an oversight at the time, as I was only considering the `WebOverview` simplest scenario. This PR adds support to it as we rely heavily on returning tuples for the previous period comparisons on web analytics... as well as this would be useful in other cases.

Note: I added numerous tests to ensure this covers a broader range of scenarios, so the actual code change is quite small but the tests helped with asserting this.

## Changes

- Changed the `wrap_state_query_in_merge_query` to support tuples and correctly wrap the state functions with `Merge`.

## Did you write or update any docs for this change?

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Manually, executing the queries and with snapshots.