### PR TITLE
fix: add exceptions and mobile replay to has_non_zero_usage

### DIFF
--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -1062,13 +1062,12 @@ def has_non_zero_usage(report: FullUsageReport) -> bool:
         report.event_count_in_period > 0
         or report.enhanced_persons_event_count_in_period > 0
         or report.recording_count_in_period > 0
-        # explicitly not including mobile_recording_count_in_period for now
+        or report.mobile_recording_count_in_period > 0
         or report.decide_requests_count_in_period > 0
         or report.local_evaluation_requests_count_in_period > 0
         or report.survey_responses_count_in_period > 0
         or report.rows_synced_in_period > 0
-        # explicitly not including issues_created or exceptions_captured
-        # for now given we do not charge for error tracking yet
+        or report.exceptions_captured_in_period > 0
     )
 
 


### PR DESCRIPTION
## Problem

`has_non_zero_usage` in `usage_report` didn't consider usage from mobile replays and error tracking, which meant that if a customer has only had usage from either of these products (and none from other products considered in `has_non_zero_usage`), we wouldn't create a usage report for that customer for that day.

This was initially intended, when we were not charging for these products, but should be fixed now that both are being charged for.

## Changes

Adds checks for `mobile_recording_count_in_period` and `exceptions_captured_in_period` in `has_non_zero_usage`

## Did you write or update any docs for this change?

- [x] No docs needed for this change

## How did you test this code?

n/a
