### PR TITLE
feat(project-tree): sidebar nits and fixes

### DIFF
--- a/frontend/src/layout/navigation-3000/navigationLogic.tsx
+++ b/frontend/src/layout/navigation-3000/navigationLogic.tsx
@@ -353,8 +353,7 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
                 s.playlistsLoading,
             ],
             (featureFlags, dashboardsLoading, pinnedDashboards, playlists, playlistsLoading): NavbarItem[][] => {
-                // const isUsingSidebar = featureFlags[FEATURE_FLAGS.POSTHOG_3000_NAV]
-                const isUsingSidebar = true
+                const isUsingSidebar = featureFlags[FEATURE_FLAGS.POSTHOG_3000_NAV]
 
                 return [
                     [

--- a/frontend/src/layout/panel-layout/PanelLayout.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayout.tsx
@@ -170,10 +170,10 @@ export function PanelLayout({ mainRef }: { mainRef: React.RefObject<HTMLElement>
                     {activePanelIdentifier === 'Shortcuts' && (
                         <ProjectTree root="shortcuts://" searchPlaceholder="Search your shortcuts" />
                     )}
-                    {activePanelIdentifier === 'Data management' && (
+                    {activePanelIdentifier === 'Data' && (
                         <ProjectTree root="data-management://" searchPlaceholder="Search data management" />
                     )}
-                    {activePanelIdentifier === 'Persons' && (
+                    {activePanelIdentifier === 'People' && (
                         <ProjectTree root="persons://" searchPlaceholder="Search persons" />
                     )}
                 </PanelLayoutNavBar>

--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -143,7 +143,7 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
             onClick: () => {
                 handleStaticNavbarItemClick(urls.projectHomepage(), true)
             },
-            tooltip: 'Home',
+            tooltip: isLayoutNavCollapsed ? 'Home' : null,
         },
         {
             identifier: 'Project',
@@ -155,10 +155,11 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
                 }
             },
             showChevron: true,
-            tooltip:
-                isLayoutPanelVisible && activePanelIdentifier === 'Project'
+            tooltip: isLayoutNavCollapsed
+                ? isLayoutPanelVisible && activePanelIdentifier === 'Project'
                     ? 'Close project tree'
-                    : 'Open project tree',
+                    : 'Open project tree'
+                : null,
         },
         {
             identifier: 'Recent',
@@ -170,19 +171,11 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
                 }
             },
             showChevron: true,
-            tooltip: isLayoutPanelVisible && activePanelIdentifier === 'Recent' ? 'Close recent' : 'Open recent',
-        },
-        {
-            identifier: 'Products',
-            id: 'Products',
-            icon: <IconCdCase />,
-            onClick: (e?: React.KeyboardEvent) => {
-                if (!e || e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowRight') {
-                    handlePanelTriggerClick('Products')
-                }
-            },
-            showChevron: true,
-            tooltip: isLayoutPanelVisible && activePanelIdentifier === 'Products' ? 'Close products' : 'Open products',
+            tooltip: isLayoutNavCollapsed
+                ? isLayoutPanelVisible && activePanelIdentifier === 'Recent'
+                    ? 'Close recent'
+                    : 'Open recent'
+                : null,
         },
         {
             identifier: 'Shortcuts',
@@ -194,36 +187,60 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
                 }
             },
             showChevron: true,
-            tooltip:
-                isLayoutPanelVisible && activePanelIdentifier === 'Shortcuts' ? 'Close shortcuts' : 'Open shortcuts',
+            tooltip: isLayoutNavCollapsed
+                ? isLayoutPanelVisible && activePanelIdentifier === 'Shortcuts'
+                    ? 'Close shortcuts'
+                    : 'Open shortcuts'
+                : null,
         },
         {
-            identifier: 'Data management',
-            id: 'Data management',
+            identifier: 'Data',
+            id: 'Data',
             icon: <IconDatabase />,
             onClick: (e?: React.KeyboardEvent) => {
                 if (!e || e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowRight') {
-                    handlePanelTriggerClick('Data management')
+                    handlePanelTriggerClick('Data')
                 }
             },
             showChevron: true,
-            tooltip:
-                isLayoutPanelVisible && activePanelIdentifier === 'Data management'
+            tooltip: isLayoutNavCollapsed
+                ? isLayoutPanelVisible && activePanelIdentifier === 'Data'
                     ? 'Close data management'
-                    : 'Open data management',
+                    : 'Open data management'
+                : null,
         },
         {
-            identifier: 'Persons',
-            id: 'Persons',
+            identifier: 'People',
+            id: 'People',
             icon: <IconPeople />,
             onClick: (e?: React.KeyboardEvent) => {
                 if (!e || e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowRight') {
-                    handlePanelTriggerClick('Persons')
+                    handlePanelTriggerClick('People')
                 }
             },
             showChevron: true,
-            tooltip: isLayoutPanelVisible && activePanelIdentifier === 'Persons' ? 'Close persons' : 'Open persons',
+            tooltip: isLayoutNavCollapsed
+                ? isLayoutPanelVisible && activePanelIdentifier === 'People'
+                    ? 'Close persons'
+                    : 'Open persons'
+                : null,
             tooltipDocLink: 'https://posthog.com/docs/data/persons',
+        },
+        {
+            identifier: 'Products',
+            id: 'Products',
+            icon: <IconCdCase />,
+            onClick: (e?: React.KeyboardEvent) => {
+                if (!e || e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowRight') {
+                    handlePanelTriggerClick('Products')
+                }
+            },
+            showChevron: true,
+            tooltip: isLayoutNavCollapsed
+                ? isLayoutPanelVisible && activePanelIdentifier === 'Products'
+                    ? 'Close products'
+                    : 'Open products'
+                : null,
         },
         {
             identifier: 'Activity',
@@ -233,7 +250,7 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
             onClick: () => {
                 handleStaticNavbarItemClick(urls.activity(), true)
             },
-            tooltip: 'Activity',
+            tooltip: isLayoutNavCollapsed ? 'Activity' : null,
             tooltipDocLink: 'https://posthog.com/docs/data/events',
         },
     ]

--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -221,8 +221,8 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
             showChevron: true,
             tooltip: isLayoutNavCollapsed
                 ? isLayoutPanelVisible && activePanelIdentifier === 'People'
-                    ? 'Close persons'
-                    : 'Open persons'
+                    ? 'Close people'
+                    : 'Open people'
                 : null,
             tooltipDocLink: 'https://posthog.com/docs/data/persons',
         },

--- a/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
+++ b/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
@@ -4,14 +4,7 @@ import { LemonTreeRef } from 'lib/lemon-ui/LemonTree/LemonTree'
 import { navigation3000Logic } from '../navigation-3000/navigationLogic'
 import type { panelLayoutLogicType } from './panelLayoutLogicType'
 
-export type PanelLayoutNavIdentifier =
-    | 'Project'
-    | 'Recent'
-    | 'Products'
-    | 'Persons'
-    | 'Games'
-    | 'Shortcuts'
-    | 'Data management'
+export type PanelLayoutNavIdentifier = 'Project' | 'Recent' | 'Products' | 'People' | 'Games' | 'Shortcuts' | 'Data'
 export type PanelLayoutTreeRef = React.RefObject<LemonTreeRef> | null
 export type PanelLayoutMainContentRef = React.RefObject<HTMLElement> | null
 export const PANEL_LAYOUT_DEFAULT_WIDTH: number = 320


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C08499A7REU/p1748827730519399

## Changes

- Remove tooltips from the top of the navbar unless it's collapsed
- Rename "Persons" -> "People"
- Rename "Data management" -> "Data"

## How did you test this code?

WIP