### PR TITLE
fix(project-tree): pre-launch nits 2

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -464,6 +464,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         type: 'hog_function/campaign',
         visualOrder: PRODUCT_VISUAL_ORDER.messaging,
         tags: ['alpha'],
+        flag: FEATURE_FLAGS.MESSAGING_AUTOMATION,
     },
     { path: 'Dashboards', type: 'dashboard', href: urls.dashboards(), visualOrder: PRODUCT_VISUAL_ORDER.dashboards },
     {

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -457,6 +457,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         type: 'hog_function/broadcast',
         visualOrder: PRODUCT_VISUAL_ORDER.messaging,
         tags: ['alpha'],
+        flag: FEATURE_FLAGS.MESSAGING,
     },
     {
         path: 'Campaigns',

--- a/products/messaging/manifest.tsx
+++ b/products/messaging/manifest.tsx
@@ -107,6 +107,7 @@ export const manifest: ProductManifest = {
             type: 'hog_function/campaign',
             visualOrder: PRODUCT_VISUAL_ORDER.messaging,
             tags: ['alpha'],
+            flag: FEATURE_FLAGS.MESSAGING_AUTOMATION,
         },
     ],
 }

--- a/products/messaging/manifest.tsx
+++ b/products/messaging/manifest.tsx
@@ -100,6 +100,7 @@ export const manifest: ProductManifest = {
             type: 'hog_function/broadcast',
             visualOrder: PRODUCT_VISUAL_ORDER.messaging,
             tags: ['alpha'],
+            flag: FEATURE_FLAGS.MESSAGING,
         },
         {
             path: 'Campaigns',


### PR DESCRIPTION

## Problem
Both messaging products (inside manifest) were missing their flags and therefor were showing up in /products list regardless of flag active or not.

## Changes
Add flags to the product field

## How did you test this code?
Manually