### PR TITLE
feat(cli): simplify host configuration

### DIFF
--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -12,8 +12,8 @@ use crate::error::CapturedError;
 #[command(version, about, long_about = None)]
 pub struct Cli {
     /// The PostHog host to connect to
-    #[arg(long, default_value = "https://us.posthog.com")]
-    host: String,
+    #[arg(long)]
+    host: Option<String>,
 
     #[command(subcommand)]
     command: Commands,
@@ -83,14 +83,14 @@ impl Cli {
                     version,
                 } => {
                     sourcemap::upload::upload(
-                        &command.host,
+                        command.host,
                         directory,
                         project.clone(),
                         version.clone(),
                     )?;
                 }
             },
-            Commands::Query { cmd } => query::query_command(&command.host, cmd)?,
+            Commands::Query { cmd } => query::query_command(command.host, cmd)?,
         }
 
         Ok(())

--- a/cli/src/commands/query.rs
+++ b/cli/src/commands/query.rs
@@ -43,8 +43,9 @@ pub enum QueryCommand {
     },
 }
 
-pub fn query_command(host: &str, query: &QueryCommand) -> Result<(), Error> {
+pub fn query_command(host: Option<String>, query: &QueryCommand) -> Result<(), Error> {
     let creds = load_token()?;
+    let host = creds.get_host(host.as_deref());
 
     match query {
         QueryCommand::Editor {
@@ -54,7 +55,7 @@ pub fn query_command(host: &str, query: &QueryCommand) -> Result<(), Error> {
         } => {
             // Given this is an interactive command, we're happy enough to not join the capture handle
             let handle = capture_command_invoked("query_editor", Some(creds.env_id.clone()));
-            let res = start_query_editor(host, creds.clone(), *debug)?;
+            let res = start_query_editor(&host, creds.clone(), *debug)?;
             if !no_print {
                 println!("Final query: {}", res);
             }

--- a/cli/src/commands/sourcemap/upload.rs
+++ b/cli/src/commands/sourcemap/upload.rs
@@ -11,12 +11,13 @@ use crate::utils::release::{create_release, CreateReleaseResponse};
 use crate::utils::sourcemaps::{read_pairs, ChunkUpload, SourcePair};
 
 pub fn upload(
-    host: &str,
+    host: Option<String>,
     directory: &PathBuf,
     project: Option<String>,
     version: Option<String>,
 ) -> Result<()> {
     let token = load_token().context("While starting upload command")?;
+    let host = token.get_host(host.as_deref());
 
     let capture_handle = capture_command_invoked("sourcemap_upload", Some(&token.env_id));
 
@@ -36,7 +37,7 @@ pub fn upload(
     //        or we could even just allow adding new chunks to an existing release, but for now I'm
     //        leaving it like this... Reviewers, lets chat about the right approach here
     let release = create_release(
-        host,
+        &host,
         &token,
         Some(directory.clone()),
         Some(content_hash(&uploads)),

--- a/cli/src/utils/auth.rs
+++ b/cli/src/utils/auth.rs
@@ -1,14 +1,24 @@
 use super::homedir::{ensure_homedir_exists, posthog_home_dir};
 use anyhow::{Context, Error};
 use inquire::{validator::Validation, CustomUserError};
+use reqwest::Url;
 use tracing::info;
 
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Token {
+    pub host: Option<String>,
     pub token: String,
     pub env_id: String,
+}
+
+impl Token {
+    pub fn get_host(&self, host: Option<&str>) -> String {
+        self.host
+            .clone()
+            .unwrap_or_else(|| host.unwrap_or("https://us.posthog.com").to_string())
+    }
 }
 
 pub trait CredentialProvider {
@@ -56,9 +66,14 @@ pub struct EnvVarProvider;
 
 impl CredentialProvider for EnvVarProvider {
     fn get_credentials(&self) -> Result<Token, Error> {
+        let host = std::env::var("POSTHOG_CLI_HOST").ok();
         let token = std::env::var("POSTHOG_CLI_TOKEN").context("While trying to read env var")?;
         let env_id = std::env::var("POSTHOG_CLI_ENV_ID").context("While trying to read env var")?;
-        Ok(Token { token, env_id })
+        Ok(Token {
+            host,
+            token,
+            env_id,
+        })
     }
 
     fn store_credentials(&self, _token: Token) -> Result<(), Error> {
@@ -68,6 +83,14 @@ impl CredentialProvider for EnvVarProvider {
     fn report_location(&self) -> String {
         unimplemented!("We should never try to save a credential to the env");
     }
+}
+
+pub fn host_validator(host: &str) -> Result<Validation, CustomUserError> {
+    if host.is_empty() || Url::parse(host).is_err() {
+        return Ok(Validation::Invalid("Host must be a valid URL".into()));
+    }
+
+    Ok(Validation::Valid)
 }
 
 pub fn token_validator(token: &str) -> Result<Validation, CustomUserError> {


### PR DESCRIPTION
## Problem

When not using `us.posthog.com`, the host option needs to be given every time to the cli

## Changes

- Save host during login command
- Add `POSTHOG_CLI_HOST` env variable
- Allow overriding previous values with cli option --host (for backward compatibility)