### PR TITLE
fix(data-warehouse): Use the correct primary keys for temporal workflows table

### DIFF
--- a/posthog/temporal/data_imports/pipelines/temporalio/source.py
+++ b/posthog/temporal/data_imports/pipelines/temporalio/source.py
@@ -187,7 +187,7 @@ def temporalio_source(
         return SourceResponse(
             name=resource.value,
             items=workflows,
-            primary_keys=["id"],
+            primary_keys=["id", "run_id"],
             partition_count=1,  # this enables partitioning
             partition_size=1,  # this enables partitioning
             partition_mode="datetime",


### PR DESCRIPTION
## Problem
- `id` is not a unique column in workflows, this was stopping syncs from working
- https://posthog.slack.com/archives/C019RAX2XBN/p1748867552418579
- https://delta-users.slack.com/archives/C013LCAEB98/p1748862167133999
