### PR TITLE
feat(web-analytics): Hide $session_entry_X properties from appear in the taxonomy UI

### DIFF
--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -3677,6 +3677,11 @@
             "description": "Google Click Source Data from the first event in this session.",
             "label": "Entry gclsrc"
         },
+        "$entry_host": {
+            "description": "The hostname of the entry URL.",
+            "examples": ["example.com", "localhost:8000"],
+            "label": "Entry host"
+        },
         "$entry_igshid": {
             "description": "Instagram Share ID Data from the first event in this session.",
             "label": "Entry igshid"

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -1165,129 +1165,158 @@
         },
         "$session_entry__kx": {
             "description": "Klaviyo Tracking ID Captured at the start of the session and remains constant for the duration of the session.",
-            "label": "Session entry _kx"
+            "label": "Session entry _kx",
+            "ignored_in_assistant": true
         },
         "$session_entry_dclid": {
             "description": "DoubleClick ID Captured at the start of the session and remains constant for the duration of the session.",
-            "label": "Session entry dclid"
+            "label": "Session entry dclid",
+            "ignored_in_assistant": true
         },
         "$session_entry_epik": {
             "description": "Pinterest Click ID Captured at the start of the session and remains constant for the duration of the session.",
-            "label": "Session entry epik"
+            "label": "Session entry epik",
+            "ignored_in_assistant": true
         },
         "$session_entry_fbclid": {
             "description": "Facebook Click ID Captured at the start of the session and remains constant for the duration of the session.",
-            "label": "Session entry fbclid"
+            "label": "Session entry fbclid",
+            "ignored_in_assistant": true
         },
         "$session_entry_gad_source": {
             "description": "Google Ads Source Captured at the start of the session and remains constant for the duration of the session.",
-            "label": "Session entry gad_source"
+            "label": "Session entry gad_source",
+            "ignored_in_assistant": true
         },
         "$session_entry_gbraid": {
             "description": "Google Ads, web to app Captured at the start of the session and remains constant for the duration of the session.",
-            "label": "Session entry gbraid"
+            "label": "Session entry gbraid",
+            "ignored_in_assistant": true
         },
         "$session_entry_gclid": {
             "description": "Google Click ID Captured at the start of the session and remains constant for the duration of the session.",
-            "label": "Session entry gclid"
+            "label": "Session entry gclid",
+            "ignored_in_assistant": true
         },
         "$session_entry_gclsrc": {
             "description": "Google Click Source Captured at the start of the session and remains constant for the duration of the session.",
-            "label": "Session entry gclsrc"
+            "label": "Session entry gclsrc",
+            "ignored_in_assistant": true
         },
         "$session_entry_host": {
             "description": "The hostname of the Current URL. Captured at the start of the session and remains constant for the duration of the session.",
             "examples": ["example.com", "localhost:8000"],
-            "label": "Session entry Host"
+            "label": "Session entry Host",
+            "ignored_in_assistant": true
         },
         "$session_entry_igshid": {
             "description": "Instagram Share ID Captured at the start of the session and remains constant for the duration of the session.",
-            "label": "Session entry igshid"
+            "label": "Session entry igshid",
+            "ignored_in_assistant": true
         },
         "$session_entry_irclid": {
             "description": "Impact Click ID Captured at the start of the session and remains constant for the duration of the session.",
-            "label": "Session entry irclid"
+            "label": "Session entry irclid",
+            "ignored_in_assistant": true
         },
         "$session_entry_li_fat_id": {
             "description": "LinkedIn First-Party Ad Tracking ID Captured at the start of the session and remains constant for the duration of the session.",
-            "label": "Session entry li_fat_id"
+            "label": "Session entry li_fat_id",
+            "ignored_in_assistant": true
         },
         "$session_entry_mc_cid": {
             "description": "Mailchimp Campaign ID Captured at the start of the session and remains constant for the duration of the session.",
-            "label": "Session entry mc_cid"
+            "label": "Session entry mc_cid",
+            "ignored_in_assistant": true
         },
         "$session_entry_msclkid": {
             "description": "Microsoft Click ID Captured at the start of the session and remains constant for the duration of the session.",
-            "label": "Session entry msclkid"
+            "label": "Session entry msclkid",
+            "ignored_in_assistant": true
         },
         "$session_entry_pathname": {
             "description": "The path of the Current URL, which means everything in the url after the domain. Captured at the start of the session and remains constant for the duration of the session.",
             "examples": ["/pricing", "/about-us/team"],
-            "label": "Session entry Path name"
+            "label": "Session entry Path name",
+            "ignored_in_assistant": true
         },
         "$session_entry_qclid": {
             "description": "Quora Click ID Captured at the start of the session and remains constant for the duration of the session.",
-            "label": "Session entry qclid"
+            "label": "Session entry qclid",
+            "ignored_in_assistant": true
         },
         "$session_entry_rdt_cid": {
             "description": "Reddit Click ID Captured at the start of the session and remains constant for the duration of the session.",
-            "label": "Session entry rdt_cid"
+            "label": "Session entry rdt_cid",
+            "ignored_in_assistant": true
         },
         "$session_entry_referrer": {
             "description": "URL of where the user came from. Captured at the start of the session and remains constant for the duration of the session.",
             "examples": ["https://google.com/search?q=posthog&rlz=1C..."],
-            "label": "Session entry Referrer URL"
+            "label": "Session entry Referrer URL",
+            "ignored_in_assistant": true
         },
         "$session_entry_referring_domain": {
             "description": "Domain of where the user came from. Captured at the start of the session and remains constant for the duration of the session.",
             "examples": ["google.com", "facebook.com"],
-            "label": "Session entry Referring domain"
+            "label": "Session entry Referring domain",
+            "ignored_in_assistant": true
         },
         "$session_entry_sccid": {
             "description": "Snapchat Click ID Captured at the start of the session and remains constant for the duration of the session.",
-            "label": "Session entry sccid"
+            "label": "Session entry sccid",
+            "ignored_in_assistant": true
         },
         "$session_entry_ttclid": {
             "description": "TikTok Click ID Captured at the start of the session and remains constant for the duration of the session.",
-            "label": "Session entry ttclid"
+            "label": "Session entry ttclid",
+            "ignored_in_assistant": true
         },
         "$session_entry_twclid": {
             "description": "Twitter Click ID Captured at the start of the session and remains constant for the duration of the session.",
-            "label": "Session entry twclid"
+            "label": "Session entry twclid",
+            "ignored_in_assistant": true
         },
         "$session_entry_url": {
             "description": "The URL visited at the time of the event. Captured at the start of the session and remains constant for the duration of the session.",
             "examples": ["https://example.com/interesting-article?parameter=true"],
-            "label": "Session entry Current URL"
+            "label": "Session entry Current URL",
+            "ignored_in_assistant": true
         },
         "$session_entry_utm_campaign": {
             "description": "UTM campaign tag. Captured at the start of the session and remains constant for the duration of the session.",
             "examples": ["feature launch", "discount"],
-            "label": "Session entry UTM campaign"
+            "label": "Session entry UTM campaign",
+            "ignored_in_assistant": true
         },
         "$session_entry_utm_content": {
             "description": "UTM content tag. Captured at the start of the session and remains constant for the duration of the session.",
             "examples": ["bottom link", "second button"],
-            "label": "Session entry UTM content"
+            "label": "Session entry UTM content",
+            "ignored_in_assistant": true
         },
         "$session_entry_utm_medium": {
             "description": "UTM medium tag. Captured at the start of the session and remains constant for the duration of the session.",
             "examples": ["Social", "Organic", "Paid", "Email"],
-            "label": "Session entry UTM medium"
+            "label": "Session entry UTM medium",
+            "ignored_in_assistant": true
         },
         "$session_entry_utm_source": {
             "description": "UTM source tag. Captured at the start of the session and remains constant for the duration of the session.",
             "examples": ["Google", "Bing", "Twitter", "Facebook"],
-            "label": "Session entry UTM source"
+            "label": "Session entry UTM source",
+            "ignored_in_assistant": true
         },
         "$session_entry_utm_term": {
             "description": "UTM term tag. Captured at the start of the session and remains constant for the duration of the session.",
             "examples": ["free goodies"],
-            "label": "Session entry UTM term"
+            "label": "Session entry UTM term",
+            "ignored_in_assistant": true
         },
         "$session_entry_wbraid": {
             "description": "Google Ads, app to web Captured at the start of the session and remains constant for the duration of the session.",
-            "label": "Session entry wbraid"
+            "label": "Session entry wbraid",
+            "ignored_in_assistant": true
         },
         "$session_id": {
             "description": "Unique session ID for session recording disambiguation",

--- a/posthog/api/test/test_property_definition.py
+++ b/posthog/api/test/test_property_definition.py
@@ -48,6 +48,8 @@ class TestPropertyDefinitionAPI(APIBaseTest):
         PropertyDefinition.objects.create(
             team=self.team, name="$initial_referrer", property_type="String"
         )  # We want to hide this property on events, but not on persons
+        # We want to make sure that $session_entry_X properties are not returned
+        PropertyDefinition.objects.get_or_create(team=self.team, name="$session_entry_utm_source")
 
         EventProperty.objects.get_or_create(team=self.team, event="$pageview", property="$browser")
         EventProperty.objects.get_or_create(team=self.team, event="$pageview", property="first_visit")

--- a/posthog/taxonomy/property_definition_api.py
+++ b/posthog/taxonomy/property_definition_api.py
@@ -409,6 +409,13 @@ ALWAYS_EXCLUDED_EVENT_PROPERTIES = set(
         "$group_set",
     ]
     + [f"$group_{i}" for i in range(GROUP_TYPES_LIMIT)]
+    # The $session_entry_X event properties should never be used, the corresponding session property should be used instead.
+    # These were added as a workaround for the CDP not supporting true session properties yet.
+    + [
+        prop
+        for prop in CORE_FILTER_DEFINITIONS_BY_GROUP["event_properties"].keys()
+        if prop.startswith("$session_entry_")
+    ]
 )
 
 

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -401,128 +401,157 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         "$session_entry__kx": {
             "description": "Klaviyo Tracking ID Captured at the start of the session and remains constant for the duration of the session.",
             "label": "Session entry _kx",
+            "ignored_in_assistant": True,
         },
         "$session_entry_dclid": {
             "description": "DoubleClick ID Captured at the start of the session and remains constant for the duration of the session.",
             "label": "Session entry dclid",
+            "ignored_in_assistant": True,
         },
         "$session_entry_epik": {
             "description": "Pinterest Click ID Captured at the start of the session and remains constant for the duration of the session.",
             "label": "Session entry epik",
+            "ignored_in_assistant": True,
         },
         "$session_entry_fbclid": {
             "description": "Facebook Click ID Captured at the start of the session and remains constant for the duration of the session.",
             "label": "Session entry fbclid",
+            "ignored_in_assistant": True,
         },
         "$session_entry_gad_source": {
             "description": "Google Ads Source Captured at the start of the session and remains constant for the duration of the session.",
             "label": "Session entry gad_source",
+            "ignored_in_assistant": True,
         },
         "$session_entry_gbraid": {
             "description": "Google Ads, web to app Captured at the start of the session and remains constant for the duration of the session.",
             "label": "Session entry gbraid",
+            "ignored_in_assistant": True,
         },
         "$session_entry_gclid": {
             "description": "Google Click ID Captured at the start of the session and remains constant for the duration of the session.",
             "label": "Session entry gclid",
+            "ignored_in_assistant": True,
         },
         "$session_entry_gclsrc": {
             "description": "Google Click Source Captured at the start of the session and remains constant for the duration of the session.",
             "label": "Session entry gclsrc",
+            "ignored_in_assistant": True,
         },
         "$session_entry_host": {
             "description": "The hostname of the Current URL. Captured at the start of the session and remains constant for the duration of the session.",
             "examples": ["example.com", "localhost:8000"],
             "label": "Session entry Host",
+            "ignored_in_assistant": True,
         },
         "$session_entry_igshid": {
             "description": "Instagram Share ID Captured at the start of the session and remains constant for the duration of the session.",
             "label": "Session entry igshid",
+            "ignored_in_assistant": True,
         },
         "$session_entry_irclid": {
             "description": "Impact Click ID Captured at the start of the session and remains constant for the duration of the session.",
             "label": "Session entry irclid",
+            "ignored_in_assistant": True,
         },
         "$session_entry_li_fat_id": {
             "description": "LinkedIn First-Party Ad Tracking ID Captured at the start of the session and remains constant for the duration of the session.",
             "label": "Session entry li_fat_id",
+            "ignored_in_assistant": True,
         },
         "$session_entry_mc_cid": {
             "description": "Mailchimp Campaign ID Captured at the start of the session and remains constant for the duration of the session.",
             "label": "Session entry mc_cid",
+            "ignored_in_assistant": True,
         },
         "$session_entry_msclkid": {
             "description": "Microsoft Click ID Captured at the start of the session and remains constant for the duration of the session.",
             "label": "Session entry msclkid",
+            "ignored_in_assistant": True,
         },
         "$session_entry_pathname": {
             "description": "The path of the Current URL, which means everything in the url after the domain. Captured at the start of the session and remains constant for the duration of the session.",
             "examples": ["/pricing", "/about-us/team"],
             "label": "Session entry Path name",
+            "ignored_in_assistant": True,
         },
         "$session_entry_qclid": {
             "description": "Quora Click ID Captured at the start of the session and remains constant for the duration of the session.",
             "label": "Session entry qclid",
+            "ignored_in_assistant": True,
         },
         "$session_entry_rdt_cid": {
             "description": "Reddit Click ID Captured at the start of the session and remains constant for the duration of the session.",
             "label": "Session entry rdt_cid",
+            "ignored_in_assistant": True,
         },
         "$session_entry_referrer": {
             "description": "URL of where the user came from. Captured at the start of the session and remains constant for the duration of the session.",
             "examples": ["https://google.com/search?q=posthog&rlz=1C..."],
             "label": "Session entry Referrer URL",
+            "ignored_in_assistant": True,
         },
         "$session_entry_referring_domain": {
             "description": "Domain of where the user came from. Captured at the start of the session and remains constant for the duration of the session.",
             "examples": ["google.com", "facebook.com"],
             "label": "Session entry Referring domain",
+            "ignored_in_assistant": True,
         },
         "$session_entry_sccid": {
             "description": "Snapchat Click ID Captured at the start of the session and remains constant for the duration of the session.",
             "label": "Session entry sccid",
+            "ignored_in_assistant": True,
         },
         "$session_entry_ttclid": {
             "description": "TikTok Click ID Captured at the start of the session and remains constant for the duration of the session.",
             "label": "Session entry ttclid",
+            "ignored_in_assistant": True,
         },
         "$session_entry_twclid": {
             "description": "Twitter Click ID Captured at the start of the session and remains constant for the duration of the session.",
             "label": "Session entry twclid",
+            "ignored_in_assistant": True,
         },
         "$session_entry_url": {
             "description": "The URL visited at the time of the event. Captured at the start of the session and remains constant for the duration of the session.",
             "examples": ["https://example.com/interesting-article?parameter=true"],
             "label": "Session entry Current URL",
+            "ignored_in_assistant": True,
         },
         "$session_entry_utm_campaign": {
             "description": "UTM campaign tag. Captured at the start of the session and remains constant for the duration of the session.",
             "examples": ["feature launch", "discount"],
             "label": "Session entry UTM campaign",
+            "ignored_in_assistant": True,
         },
         "$session_entry_utm_content": {
             "description": "UTM content tag. Captured at the start of the session and remains constant for the duration of the session.",
             "examples": ["bottom link", "second button"],
             "label": "Session entry UTM content",
+            "ignored_in_assistant": True,
         },
         "$session_entry_utm_medium": {
             "description": "UTM medium tag. Captured at the start of the session and remains constant for the duration of the session.",
             "examples": ["Social", "Organic", "Paid", "Email"],
             "label": "Session entry UTM medium",
+            "ignored_in_assistant": True,
         },
         "$session_entry_utm_source": {
             "description": "UTM source tag. Captured at the start of the session and remains constant for the duration of the session.",
             "examples": ["Google", "Bing", "Twitter", "Facebook"],
             "label": "Session entry UTM source",
+            "ignored_in_assistant": True,
         },
         "$session_entry_utm_term": {
             "description": "UTM term tag. Captured at the start of the session and remains constant for the duration of the session.",
             "examples": ["free goodies"],
             "label": "Session entry UTM term",
+            "ignored_in_assistant": True,
         },
         "$session_entry_wbraid": {
             "description": "Google Ads, app to web Captured at the start of the session and remains constant for the duration of the session.",
             "label": "Session entry wbraid",
+            "ignored_in_assistant": True,
         },
         "$session_recording_recorder_version_server_side": {
             "label": "Session recording recorder version server-side",

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -104,7 +104,7 @@ SESSION_PROPERTIES_ALSO_INCLUDED_IN_EVENTS = {
     *SESSION_INITIAL_PROPERTIES_ADAPTED_FROM_EVENTS,
 }
 
-# synced with frontend/src/lib/taxonomy.tsx
+# synced with frontend/src/lib/taxonomy.tsx and core-filter-definitions-by-group.json
 CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
     "events": {
         # in front end this key is the empty string
@@ -397,6 +397,132 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "description": "If console log recording has been enabled server-side.",
             "system": True,
             "ignored_in_assistant": True,
+        },
+        "$session_entry__kx": {
+            "description": "Klaviyo Tracking ID Captured at the start of the session and remains constant for the duration of the session.",
+            "label": "Session entry _kx",
+        },
+        "$session_entry_dclid": {
+            "description": "DoubleClick ID Captured at the start of the session and remains constant for the duration of the session.",
+            "label": "Session entry dclid",
+        },
+        "$session_entry_epik": {
+            "description": "Pinterest Click ID Captured at the start of the session and remains constant for the duration of the session.",
+            "label": "Session entry epik",
+        },
+        "$session_entry_fbclid": {
+            "description": "Facebook Click ID Captured at the start of the session and remains constant for the duration of the session.",
+            "label": "Session entry fbclid",
+        },
+        "$session_entry_gad_source": {
+            "description": "Google Ads Source Captured at the start of the session and remains constant for the duration of the session.",
+            "label": "Session entry gad_source",
+        },
+        "$session_entry_gbraid": {
+            "description": "Google Ads, web to app Captured at the start of the session and remains constant for the duration of the session.",
+            "label": "Session entry gbraid",
+        },
+        "$session_entry_gclid": {
+            "description": "Google Click ID Captured at the start of the session and remains constant for the duration of the session.",
+            "label": "Session entry gclid",
+        },
+        "$session_entry_gclsrc": {
+            "description": "Google Click Source Captured at the start of the session and remains constant for the duration of the session.",
+            "label": "Session entry gclsrc",
+        },
+        "$session_entry_host": {
+            "description": "The hostname of the Current URL. Captured at the start of the session and remains constant for the duration of the session.",
+            "examples": ["example.com", "localhost:8000"],
+            "label": "Session entry Host",
+        },
+        "$session_entry_igshid": {
+            "description": "Instagram Share ID Captured at the start of the session and remains constant for the duration of the session.",
+            "label": "Session entry igshid",
+        },
+        "$session_entry_irclid": {
+            "description": "Impact Click ID Captured at the start of the session and remains constant for the duration of the session.",
+            "label": "Session entry irclid",
+        },
+        "$session_entry_li_fat_id": {
+            "description": "LinkedIn First-Party Ad Tracking ID Captured at the start of the session and remains constant for the duration of the session.",
+            "label": "Session entry li_fat_id",
+        },
+        "$session_entry_mc_cid": {
+            "description": "Mailchimp Campaign ID Captured at the start of the session and remains constant for the duration of the session.",
+            "label": "Session entry mc_cid",
+        },
+        "$session_entry_msclkid": {
+            "description": "Microsoft Click ID Captured at the start of the session and remains constant for the duration of the session.",
+            "label": "Session entry msclkid",
+        },
+        "$session_entry_pathname": {
+            "description": "The path of the Current URL, which means everything in the url after the domain. Captured at the start of the session and remains constant for the duration of the session.",
+            "examples": ["/pricing", "/about-us/team"],
+            "label": "Session entry Path name",
+        },
+        "$session_entry_qclid": {
+            "description": "Quora Click ID Captured at the start of the session and remains constant for the duration of the session.",
+            "label": "Session entry qclid",
+        },
+        "$session_entry_rdt_cid": {
+            "description": "Reddit Click ID Captured at the start of the session and remains constant for the duration of the session.",
+            "label": "Session entry rdt_cid",
+        },
+        "$session_entry_referrer": {
+            "description": "URL of where the user came from. Captured at the start of the session and remains constant for the duration of the session.",
+            "examples": ["https://google.com/search?q=posthog&rlz=1C..."],
+            "label": "Session entry Referrer URL",
+        },
+        "$session_entry_referring_domain": {
+            "description": "Domain of where the user came from. Captured at the start of the session and remains constant for the duration of the session.",
+            "examples": ["google.com", "facebook.com"],
+            "label": "Session entry Referring domain",
+        },
+        "$session_entry_sccid": {
+            "description": "Snapchat Click ID Captured at the start of the session and remains constant for the duration of the session.",
+            "label": "Session entry sccid",
+        },
+        "$session_entry_ttclid": {
+            "description": "TikTok Click ID Captured at the start of the session and remains constant for the duration of the session.",
+            "label": "Session entry ttclid",
+        },
+        "$session_entry_twclid": {
+            "description": "Twitter Click ID Captured at the start of the session and remains constant for the duration of the session.",
+            "label": "Session entry twclid",
+        },
+        "$session_entry_url": {
+            "description": "The URL visited at the time of the event. Captured at the start of the session and remains constant for the duration of the session.",
+            "examples": ["https://example.com/interesting-article?parameter=true"],
+            "label": "Session entry Current URL",
+        },
+        "$session_entry_utm_campaign": {
+            "description": "UTM campaign tag. Captured at the start of the session and remains constant for the duration of the session.",
+            "examples": ["feature launch", "discount"],
+            "label": "Session entry UTM campaign",
+        },
+        "$session_entry_utm_content": {
+            "description": "UTM content tag. Captured at the start of the session and remains constant for the duration of the session.",
+            "examples": ["bottom link", "second button"],
+            "label": "Session entry UTM content",
+        },
+        "$session_entry_utm_medium": {
+            "description": "UTM medium tag. Captured at the start of the session and remains constant for the duration of the session.",
+            "examples": ["Social", "Organic", "Paid", "Email"],
+            "label": "Session entry UTM medium",
+        },
+        "$session_entry_utm_source": {
+            "description": "UTM source tag. Captured at the start of the session and remains constant for the duration of the session.",
+            "examples": ["Google", "Bing", "Twitter", "Facebook"],
+            "label": "Session entry UTM source",
+        },
+        "$session_entry_utm_term": {
+            "description": "UTM term tag. Captured at the start of the session and remains constant for the duration of the session.",
+            "examples": ["free goodies"],
+            "label": "Session entry UTM term",
+        },
+        "$session_entry_wbraid": {
+            "description": "Google Ads, app to web Captured at the start of the session and remains constant for the duration of the session.",
+            "label": "Session entry wbraid",
         },
         "$session_recording_recorder_version_server_side": {
             "label": "Session recording recorder version server-side",


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We added these event properties as a workaround for the CDP not supporting true session properties.

Unfortunately they appear earlier in the search if the user enters "session entry utm source", so have been used instead of the correct ones (see https://posthoghelp.zendesk.com/agent/tickets/30010 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/33654))

## Changes

Hide these property from the property API

## Did you write or update any docs for this change?
n/a

## How did you test this code?

Added to the existing tests to ensure these are not returned. Also, tested manually, see here:

before
<img width="664" alt="Screenshot 2025-06-02 at 14 00 21" src="https://github.com/user-attachments/assets/b07324c2-2ca9-4b37-9bc7-3d28cadf5a41" />

after
<img width="664" alt="Screenshot 2025-06-02 at 14 00 55" src="https://github.com/user-attachments/assets/96233c0d-bcb1-4b7d-9e0f-b8a47c5755c9" />


