### PR TITLE
chore: preserve query params in time sensitive auth checks

### DIFF
--- a/frontend/src/lib/components/TimeSensitiveAuthentication/TimeSensitiveAuthentication.tsx
+++ b/frontend/src/lib/components/TimeSensitiveAuthentication/TimeSensitiveAuthentication.tsx
@@ -22,7 +22,7 @@ export function TimeSensitiveAuthenticationModal(): JSX.Element {
     const showPassword = !ssoEnforcement && user?.has_password
 
     const extraQueryParams = {
-        next: window.location.pathname,
+        next: encodeURI(location.href.replace(location.origin, '')),
     }
 
     return (


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

We currently just redirected to the pathname - this is annoying as the query params are important and redirecting to the pathname takes you away from the current state.

## Changes

Include the full relative url in the `next` param

## How did you test this code?

I couldn't test it properly locally due to the lack of social auths and time checks  - will test in prod and revert if it's problematic