### PR TITLE
fix(cdp): Don't autocreate topics

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -48,6 +48,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         CONSUMER_BATCH_SIZE: 500,
         CONSUMER_MAX_HEARTBEAT_INTERVAL_MS: 30_000,
         CONSUMER_MAX_BACKGROUND_TASKS: 1,
+        CONSUMER_AUTO_CREATE_TOPICS: true,
         KAFKA_HOSTS: 'kafka:9092', // KEEP IN SYNC WITH posthog/settings/data_stores.py
         KAFKA_CLIENT_CERT_B64: undefined,
         KAFKA_CLIENT_CERT_KEY_B64: undefined,

--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -295,7 +295,10 @@ export class KafkaConsumer {
 
         this.heartbeat() // Setup the heartbeat so we are healthy since connection is established
 
-        await ensureTopicExists(this.consumerConfig, this.config.topic)
+        if (defaultConfig.CONSUMER_AUTO_CREATE_TOPICS) {
+            await ensureTopicExists(this.consumerConfig, this.config.topic)
+        }
+
 
         // The consumer has an internal pre-fetching queue that sequentially pools
         // each partition, with the consumerMaxWaitMs timeout. We want to read big

--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -296,6 +296,7 @@ export class KafkaConsumer {
         this.heartbeat() // Setup the heartbeat so we are healthy since connection is established
 
         if (defaultConfig.CONSUMER_AUTO_CREATE_TOPICS) {
+            // For hobby deploys we want to auto-create, but on cloud we don't
             await ensureTopicExists(this.consumerConfig, this.config.topic)
         }
 

--- a/plugin-server/src/kafka/consumer.ts
+++ b/plugin-server/src/kafka/consumer.ts
@@ -300,7 +300,6 @@ export class KafkaConsumer {
             await ensureTopicExists(this.consumerConfig, this.config.topic)
         }
 
-
         // The consumer has an internal pre-fetching queue that sequentially pools
         // each partition, with the consumerMaxWaitMs timeout. We want to read big
         // batches from this queue, but guarantee we are still running (with smaller

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -191,6 +191,7 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
     CONSUMER_BATCH_SIZE: number // Primarily for kafka consumers the batch size to use
     CONSUMER_MAX_HEARTBEAT_INTERVAL_MS: number // Primarily for kafka consumers the max heartbeat interval to use after which it will be considered unhealthy
     CONSUMER_MAX_BACKGROUND_TASKS: number
+    CONSUMER_AUTO_CREATE_TOPICS: boolean
 
     // Kafka params - identical for client and producer
     KAFKA_HOSTS: string // comma-delimited Kafka hosts


### PR DESCRIPTION
## Problem

For hobby deploys and local dev we want to create topics automatically. For cloud we dont

## Changes

* Adds an env var check

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
