### PR TITLE
feat(project-tree): second flag for org release

### DIFF
--- a/frontend/src/layout/navigation-3000/Navigation.tsx
+++ b/frontend/src/layout/navigation-3000/Navigation.tsx
@@ -55,7 +55,14 @@ export function Navigation({
                 Skip to content
             </a>
 
-            <FlaggedFeature flag={FEATURE_FLAGS.TREE_VIEW} fallback={<Navbar />}>
+            <FlaggedFeature
+                flag={FEATURE_FLAGS.TREE_VIEW}
+                fallback={
+                    <FlaggedFeature flag={FEATURE_FLAGS.TREE_VIEW_RELEASE} fallback={<Navbar />}>
+                        <PanelLayout mainRef={mainRef} />
+                    </FlaggedFeature>
+                }
+            >
                 <PanelLayout mainRef={mainRef} />
             </FlaggedFeature>
             <FlaggedFeature flag={FEATURE_FLAGS.POSTHOG_3000_NAV}>

--- a/frontend/src/layout/navigation-3000/components/TopBar.tsx
+++ b/frontend/src/layout/navigation-3000/components/TopBar.tsx
@@ -87,7 +87,9 @@ export function TopBar(): JSX.Element | null {
         return () => main.removeEventListener('scroll', handleScroll)
     }, [hasRenameState])
 
-    return breadcrumbs.length || (featureFlags[FEATURE_FLAGS.TREE_VIEW] && projectTreeRefEntry) ? (
+    return breadcrumbs.length ||
+        ((featureFlags[FEATURE_FLAGS.TREE_VIEW] || featureFlags[FEATURE_FLAGS.TREE_VIEW_RELEASE]) &&
+            projectTreeRefEntry) ? (
         <div
             className={clsx(
                 'TopBar3000',
@@ -102,12 +104,24 @@ export function TopBar(): JSX.Element | null {
                     <FlaggedFeature
                         flag={FEATURE_FLAGS.TREE_VIEW}
                         fallback={
-                            <LemonButton
-                                size="small"
-                                onClick={() => showNavOnMobile()}
-                                icon={<IconMenu />}
-                                className="TopBar3000__hamburger"
-                            />
+                            <FlaggedFeature
+                                flag={FEATURE_FLAGS.TREE_VIEW_RELEASE}
+                                fallback={
+                                    <LemonButton
+                                        size="small"
+                                        onClick={() => showNavOnMobile()}
+                                        icon={<IconMenu />}
+                                        className="TopBar3000__hamburger"
+                                    />
+                                }
+                            >
+                                <LemonButton
+                                    size="small"
+                                    onClick={() => showLayoutNavBar(!isLayoutNavbarVisibleForMobile)}
+                                    icon={isLayoutNavbarVisibleForMobile ? <IconX /> : <IconMenu />}
+                                    className="TopBar3000__hamburger"
+                                />
+                            </FlaggedFeature>
                         }
                     >
                         <LemonButton
@@ -129,38 +143,39 @@ export function TopBar(): JSX.Element | null {
                                     </div>
                                 </React.Fragment>
                             ))}
-                            {featureFlags[FEATURE_FLAGS.TREE_VIEW] && projectTreeRefEntry && (
-                                <>
-                                    <LemonButton
-                                        size="xsmall"
-                                        onClick={() => {
-                                            assureVisibility({ type: 'folder', ref: projectTreeRefEntry.path })
-                                            showLayoutPanel(true)
-                                            setActivePanelIdentifier('Project')
-                                        }}
-                                        icon={<IconFolderOpen />}
-                                        data-attr="top-bar-open-in-project-tree-button"
-                                        tooltip="Open in project tree"
-                                        disabledReason={renameState ? "Can't view in tree while renaming" : ''}
-                                    />
-                                    <LemonButton
-                                        size="xsmall"
-                                        onClick={() => openMoveToModal([projectTreeRefEntry])}
-                                        icon={<IconFolderMove />}
-                                        data-attr="top-bar-move-button"
-                                        tooltip="Move to another folder"
-                                        disabledReason={renameState ? "Can't move while renaming" : ''}
-                                    />
-                                    <LemonButton
-                                        size="xsmall"
-                                        onClick={() => addShortcutItem(projectTreeRefEntry)}
-                                        icon={<IconShortcut />}
-                                        data-attr="top-bar-add-to-shortcuts-button"
-                                        tooltip="Add to shortcuts panel"
-                                        disabledReason={renameState ? "Can't add to shortcuts while renaming" : ''}
-                                    />
-                                </>
-                            )}
+                            {(featureFlags[FEATURE_FLAGS.TREE_VIEW] || featureFlags[FEATURE_FLAGS.TREE_VIEW_RELEASE]) &&
+                                projectTreeRefEntry && (
+                                    <>
+                                        <LemonButton
+                                            size="xsmall"
+                                            onClick={() => {
+                                                assureVisibility({ type: 'folder', ref: projectTreeRefEntry.path })
+                                                showLayoutPanel(true)
+                                                setActivePanelIdentifier('Project')
+                                            }}
+                                            icon={<IconFolderOpen />}
+                                            data-attr="top-bar-open-in-project-tree-button"
+                                            tooltip="Open in project tree"
+                                            disabledReason={renameState ? "Can't view in tree while renaming" : ''}
+                                        />
+                                        <LemonButton
+                                            size="xsmall"
+                                            onClick={() => openMoveToModal([projectTreeRefEntry])}
+                                            icon={<IconFolderMove />}
+                                            data-attr="top-bar-move-button"
+                                            tooltip="Move to another folder"
+                                            disabledReason={renameState ? "Can't move while renaming" : ''}
+                                        />
+                                        <LemonButton
+                                            size="xsmall"
+                                            onClick={() => addShortcutItem(projectTreeRefEntry)}
+                                            icon={<IconShortcut />}
+                                            data-attr="top-bar-add-to-shortcuts-button"
+                                            tooltip="Add to shortcuts panel"
+                                            disabledReason={renameState ? "Can't add to shortcuts while renaming" : ''}
+                                        />
+                                    </>
+                                )}
                             <Breadcrumb
                                 breadcrumb={breadcrumbs[breadcrumbs.length - 1]}
                                 here

--- a/frontend/src/lib/components/SaveTo/saveToLogic.tsx
+++ b/frontend/src/lib/components/SaveTo/saveToLogic.tsx
@@ -59,7 +59,11 @@ export const saveToLogic = kea<saveToLogicType>([
         ],
     }),
     selectors({
-        isFeatureEnabled: [(s) => [s.featureFlags], (featureFlags) => featureFlags[FEATURE_FLAGS.TREE_VIEW] ?? false],
+        isFeatureEnabled: [
+            (s) => [s.featureFlags],
+            (featureFlags) =>
+                featureFlags[FEATURE_FLAGS.TREE_VIEW] || featureFlags[FEATURE_FLAGS.TREE_VIEW_RELEASE] || false,
+        ],
     }),
     listeners(({ actions, values }) => ({
         setLastNewFolder: ({ folder }) => {

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -228,6 +228,7 @@ export const FEATURE_FLAGS = {
     RECORDINGS_AI_FILTER: 'recordings-ai-filter', // owner: @veryayskiy #team-replay
     PATHS_V2: 'paths-v2', // owner: @thmsobrmlr #team-product-analytics
     TREE_VIEW: 'tree-view', // owner: @mariusandra #team-devex
+    TREE_VIEW_RELEASE: 'tree-view-release', // owner: @mariusandra #team-devex
     EXPERIMENTS_NEW_QUERY_RUNNER: 'experiments-new-query-runner', // owner: #team-experiments
     RECORDINGS_AI_REGEX: 'recordings-ai-regex', // owner: @veryayskiy #team-replay
     EXPERIMENTS_NEW_QUERY_RUNNER_AA_TEST: 'experiments-new-query-runner-aa-test', // #team-experiments


### PR DESCRIPTION
## Problem

We want to start rolling out the tree view flag, but we can't release it to a % of orgs because the early access feature locks us to per-user releases.

## Changes

Add a second flag which can be rolled out as we see fit.

## How did you test this code?

![2025-06-02 16 23 42](https://github.com/user-attachments/assets/48eb30fe-9c7a-41fc-9e0c-8539ae350ede)
