### PR TITLE
fix(dwh-googleads): Get resource name from schema not inputs

### DIFF
--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -709,12 +709,24 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
                 google_ads_source,
             )
 
-            config = GoogleAdsServiceAccountSourceConfig.from_dict(model.pipeline.job_inputs)
+            config = GoogleAdsServiceAccountSourceConfig.from_dict(
+                {**model.pipeline.job_inputs, **{"resource_name": schema.name}}
+            )
             source = google_ads_source(config)
+            return _run(
+                job_inputs=job_inputs,
+                source=source,
+                logger=logger,
+                inputs=inputs,
+                schema=schema,
+                reset_pipeline=reset_pipeline,
+                shutdown_monitor=shutdown_monitor,
+            )
+
         elif model.pipeline.source_type == ExternalDataSource.Type.TEMPORALIO:
             from posthog.temporal.data_imports.pipelines.temporalio.source import (
-                TemporalIOSourceConfig,
                 TemporalIOResource,
+                TemporalIOSourceConfig,
                 temporalio_source,
             )
 

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -863,7 +863,6 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         source_type = request.data["source_type"]
 
         customer_id = payload.get("customer_id", "")
-        resource_name = payload.get("resource_name", "")
 
         new_source_model = ExternalDataSource.objects.create(
             source_id=str(uuid.uuid4()),
@@ -873,11 +872,12 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             created_by=request.user if isinstance(request.user, User) else None,
             status="Running",
             source_type=source_type,
-            job_inputs={"customer_id": customer_id, "resource_name": resource_name},
+            job_inputs={"customer_id": customer_id},
             prefix=prefix,
         )
 
-        schemas = get_google_ads_schemas(GoogleAdsServiceAccountSourceConfig.from_dict(new_source_model.job_inputs))
+        config = GoogleAdsServiceAccountSourceConfig.from_dict({**new_source_model.job_inputs, **{"resource_name": ""}})
+        schemas = get_google_ads_schemas(config)
 
         return new_source_model, list(schemas.keys())
 


### PR DESCRIPTION
## Problem

We are getting the resource name from job inputs, but it should be coming from the schema.

## Changes

Get resource name from schema instead of job inputs.