### PR TITLE
fix(project-tree): pre-launch nits 4

### DIFF
--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -115,6 +115,9 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
         if (isKeyboardAction) {
             mainContentRef?.current?.focus()
         }
+        if (isMobileLayout && isLayoutNavbarVisible) {
+            showLayoutNavBar(false)
+        }
         if (to) {
             router.actions.push(to)
         }
@@ -554,7 +557,7 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
                             showLayoutNavBar(false)
                             clearActivePanelIdentifier()
                         }}
-                        className="z-[var(--z-layout-navbar-under)] fixed inset-0 w-screen h-screen bg-[var(--bg-fill-highlight-100)] lg:bg-transparent"
+                        className="z-[var(--z-layout-navbar-under)] fixed inset-0 w-screen h-screen bg-[var(--bg-fill-highlight-200)] lg:bg-transparent"
                     />
                 )}
 
@@ -564,7 +567,7 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
                             showLayoutPanel(false)
                             clearActivePanelIdentifier()
                         }}
-                        className="z-[var(--z-layout-navbar-over)] fixed inset-0 w-screen h-screen bg-[var(--bg-fill-highlight-100)] lg:bg-transparent"
+                        className="z-[var(--z-layout-navbar-over)] fixed inset-0 w-screen h-screen bg-[var(--bg-fill-highlight-200)] lg:bg-transparent"
                     />
                 )}
             </div>

--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -272,7 +272,7 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
 
                         {!isLayoutNavCollapsed && (
                             <div
-                                className={`flex gap-1 ${isLayoutNavCollapsed ? 'justify-center' : ''}`}
+                                className={`flex gap-px ${isLayoutNavCollapsed ? 'justify-center' : ''}`}
                                 aria-label="Add a new item menu actions"
                             >
                                 <ButtonPrimitive

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -29,6 +29,7 @@ import {
 import { cn } from 'lib/utils/css-classes'
 import { RefObject, useEffect, useRef, useState } from 'react'
 
+import { navigation3000Logic } from '~/layout/navigation-3000/navigationLogic'
 import { NewMenu } from '~/layout/panel-layout/menus/NewMenu'
 import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
 import { projectTreeDataLogic } from '~/layout/panel-layout/ProjectTree/projectTreeDataLogic'
@@ -110,9 +111,12 @@ export function ProjectTree({
         setSearchTerm,
     } = useActions(projectTreeLogic(projectTreeLogicProps))
     const { openMoveToModal } = useActions(moveToLogic)
+    const { mobileLayout: isMobileLayout } = useValues(navigation3000Logic)
 
-    const { showLayoutPanel, setPanelTreeRef, clearActivePanelIdentifier } = useActions(panelLayoutLogic)
-    const { mainContentRef, isLayoutPanelPinned } = useValues(panelLayoutLogic)
+    const { showLayoutPanel, setPanelTreeRef, clearActivePanelIdentifier, showLayoutNavBar } =
+        useActions(panelLayoutLogic)
+    const { mainContentRef, isLayoutPanelPinned, isLayoutPanelVisible, isLayoutNavbarVisible } =
+        useValues(panelLayoutLogic)
     const treeRef = useRef<LemonTreeRef>(null)
     const { projectTreeMode } = useValues(projectTreeLogic({ key: PROJECT_TREE_KEY }))
     const { setProjectTreeMode } = useActions(projectTreeLogic({ key: PROJECT_TREE_KEY }))
@@ -137,6 +141,14 @@ export function ProjectTree({
             clearScrollTarget()
         }
     }, [scrollTargetId, treeRef, clearScrollTarget, setLastViewedId])
+
+    function handleNodeClick(): void {
+        if (isMobileLayout && (isLayoutNavbarVisible || isLayoutPanelVisible)) {
+            showLayoutPanel(false)
+            showLayoutNavBar(false)
+            clearActivePanelIdentifier()
+        }
+    }
 
     // Merge duplicate menu code for both context and dropdown menus
     const renderMenuItems = (item: TreeDataItem, type: 'context' | 'dropdown'): JSX.Element => {
@@ -385,6 +397,7 @@ export function ProjectTree({
                     router.actions.push(
                         typeof item.record.href === 'function' ? item.record.href(item.record.ref) : item.record.href
                     )
+                    handleNodeClick()
                 }
                 if (!isLayoutPanelPinned || projectTreeMode === 'table') {
                     clearActivePanelIdentifier()

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -704,12 +704,7 @@ export function ProjectTree({
             }
             searchField={
                 <BindLogic logic={projectTreeLogic} props={projectTreeLogicProps}>
-                    <TreeSearchField
-                        root={root}
-                        placeholder={searchPlaceholder}
-                        logicKey={logicKey}
-                        uniqueKey={uniqueKey}
-                    />
+                    <TreeSearchField root={root} placeholder={searchPlaceholder} />
                 </BindLogic>
             }
             panelActions={

--- a/frontend/src/layout/panel-layout/ProjectTree/TreeSearchField.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/TreeSearchField.tsx
@@ -31,15 +31,13 @@ const productTypesMapped = [
 
 interface TreeSearchFieldProps {
     root?: string
-    logicKey?: string
-    uniqueKey: string
     placeholder?: string
 }
 
-export function TreeSearchField({ root, placeholder, logicKey, uniqueKey }: TreeSearchFieldProps): JSX.Element {
+export function TreeSearchField({ root, placeholder }: TreeSearchFieldProps): JSX.Element {
     const { panelTreeRef } = useValues(panelLayoutLogic)
-    const { searchTerm } = useValues(projectTreeLogic({ key: logicKey ?? uniqueKey, root: root }))
-    const { setSearchTerm, clearSearch } = useActions(projectTreeLogic({ key: logicKey ?? uniqueKey, root: root }))
+    const { searchTerm } = useValues(projectTreeLogic())
+    const { setSearchTerm, clearSearch } = useActions(projectTreeLogic())
     const { featureFlags } = useValues(featureFlagLogic)
 
     function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>): void {

--- a/frontend/src/layout/panel-layout/ProjectTree/TreeSearchField.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/TreeSearchField.tsx
@@ -36,8 +36,8 @@ interface TreeSearchFieldProps {
 
 export function TreeSearchField({ root, placeholder }: TreeSearchFieldProps): JSX.Element {
     const { panelTreeRef } = useValues(panelLayoutLogic)
-    const { searchTerm } = useValues(projectTreeLogic())
-    const { setSearchTerm, clearSearch } = useActions(projectTreeLogic())
+    const { searchTerm } = useValues(projectTreeLogic)
+    const { setSearchTerm, clearSearch } = useActions(projectTreeLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 
     function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>): void {

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -7,13 +7,13 @@ import {
     IconCursor,
     IconDashboard,
     IconExternal,
+    IconFlask,
     IconGraph,
     IconMessage,
     IconNotebook,
     IconPeople,
     IconRewindPlay,
     IconRocket,
-    IconTestTube,
     IconToggle,
 } from '@posthog/icons'
 import { combineUrl } from 'kea-router'
@@ -338,7 +338,7 @@ export const fileSystemTypes = {
     },
     experiment: {
         name: 'Experiment',
-        icon: <IconTestTube />,
+        icon: <IconFlask />,
         href: (ref: string) => urls.experiment(ref),
         iconColor: ['var(--product-experiments-light)'],
         filterKey: 'experiment',

--- a/products/experiments/manifest.tsx
+++ b/products/experiments/manifest.tsx
@@ -1,4 +1,4 @@
-import { IconTestTube } from '@posthog/icons'
+import { IconFlask } from '@posthog/icons'
 import { PRODUCT_VISUAL_ORDER } from 'lib/constants'
 import { toParams } from 'lib/utils'
 import { urls } from 'scenes/urls'
@@ -29,7 +29,7 @@ export const manifest: ProductManifest = {
     fileSystemTypes: {
         experiment: {
             name: 'Experiment',
-            icon: <IconTestTube />,
+            icon: <IconFlask />,
             href: (ref: string) => urls.experiment(ref),
             iconColor: ['var(--product-experiments-light)'],
             filterKey: 'experiment',


### PR DESCRIPTION

## Problem
* Mobile tree experience wasn't closing the menus when clicking an item
* Experiments was using wrong icon for product

## Changes
* IF mobile, Close navbar if mobile and clicking an a non-panel trigger
* IF mobile, Close navbar + panel if clicking an node in tree
*  Update experiments product to flask
* cleaned up logic props that weren't necessary

![2025-06-02 16 15 01](https://github.com/user-attachments/assets/af13403c-4f32-4b23-a2e1-f6e1086b0cb0)

## How did you test this code?
Manually