### PR TITLE
Revert "chore: preserve query params in time sensitive auth checks"

### DIFF
--- a/frontend/src/lib/components/TimeSensitiveAuthentication/TimeSensitiveAuthentication.tsx
+++ b/frontend/src/lib/components/TimeSensitiveAuthentication/TimeSensitiveAuthentication.tsx
@@ -22,7 +22,7 @@ export function TimeSensitiveAuthenticationModal(): JSX.Element {
     const showPassword = !ssoEnforcement && user?.has_password
 
     const extraQueryParams = {
-        next: encodeURI(location.href.replace(location.origin, '')),
+        next: window.location.pathname,
     }
 
     return (


### PR DESCRIPTION
Here in case the change doesn't work when testing.