### PR TITLE
fix: logging of failed timings gen

### DIFF
--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -561,7 +561,7 @@ class ServerTimingsGathered:
                 """
                 capture_exception(
                     Exception(f"Server timing header exceeded 10k limit with {len(timings)} timings"),
-                    properties={"timings": timings},
+                    properties={"timings": ", ".join(result)},
                 )
                 break
 

--- a/posthog/api/utils.py
+++ b/posthog/api/utils.py
@@ -561,7 +561,7 @@ class ServerTimingsGathered:
                 """
                 capture_exception(
                     Exception(f"Server timing header exceeded 10k limit with {len(timings)} timings"),
-                    properties={"timings": ", ".join(result)},
+                    properties={"generated_so_far": ", ".join(result), "length_of_timings": len(timings)},
                 )
                 break
 

--- a/posthog/session_recordings/queries/test/listing_recordings/__snapshots__/test_session_recordings_list_by_group_properties.ambr
+++ b/posthog/session_recordings/queries/test/listing_recordings/__snapshots__/test_session_recordings_list_by_group_properties.ambr
@@ -44,7 +44,8 @@
                     max_bytes_before_external_group_by=0,
                     allow_experimental_analyzer=0,
                     transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1
   '''
 # ---
 # name: TestSessionRecordingsListByGroupProperties.test_filter_with_group_properties.1
@@ -92,7 +93,8 @@
                     max_bytes_before_external_group_by=0,
                     allow_experimental_analyzer=0,
                     transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1
   '''
 # ---
 # name: TestSessionRecordingsListByGroupProperties.test_filter_with_group_properties.2
@@ -140,7 +142,8 @@
                     max_bytes_before_external_group_by=0,
                     allow_experimental_analyzer=0,
                     transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1
   '''
 # ---
 # name: TestSessionRecordingsListByGroupProperties.test_filter_with_group_properties.3
@@ -188,7 +191,8 @@
                     max_bytes_before_external_group_by=0,
                     allow_experimental_analyzer=0,
                     transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1
   '''
 # ---
 # name: TestSessionRecordingsListByGroupProperties.test_filter_with_group_properties.4
@@ -236,7 +240,8 @@
                     max_bytes_before_external_group_by=0,
                     allow_experimental_analyzer=0,
                     transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1
   '''
 # ---
 # name: TestSessionRecordingsListByGroupProperties.test_filter_with_group_properties.5
@@ -284,7 +289,8 @@
                     max_bytes_before_external_group_by=0,
                     allow_experimental_analyzer=0,
                     transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1
   '''
 # ---
 # name: TestSessionRecordingsListByGroupProperties.test_filter_with_group_prpoerties


### PR DESCRIPTION
we get some reports of this in error tracking https://us.posthog.com/project/2/error_tracking/0196f1e3-a3fc-70e3-9f8a-30ec39fd2502

but the timings are not included... let's try something else