### PR TITLE
fix: HogFunction context for displaying filters correctly

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivitySubscriptions.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivitySubscriptions.tsx
@@ -6,7 +6,6 @@ export function SidePanelActivitySubscriptions(): JSX.Element {
             <p>Get notified of your team's activity</p>
 
             <LinkedHogFunctions
-                logicKey="activity-log"
                 type="internal_destination"
                 subTemplateIds={['activity-log']}
                 filters={{

--- a/frontend/src/lib/components/Alerts/views/AlertDestinationSelector.tsx
+++ b/frontend/src/lib/components/Alerts/views/AlertDestinationSelector.tsx
@@ -18,18 +18,18 @@ export function AlertDestinationSelector({ alertId }: AlertDestinationSelectorPr
             subTemplateIds={[INSIGHT_ALERT_FIRING_SUB_TEMPLATE_ID]}
             hideFeedback={true}
             filters={{
+                properties: [
+                    {
+                        key: 'alert_id',
+                        value: alertId,
+                        operator: PropertyOperator.Exact,
+                        type: PropertyFilterType.Event,
+                    },
+                ],
                 events: [
                     {
                         id: INSIGHT_ALERT_FIRING_EVENT_ID,
                         type: 'events',
-                        properties: [
-                            {
-                                key: 'alert_id',
-                                value: alertId,
-                                operator: PropertyOperator.Exact,
-                                type: PropertyFilterType.Event,
-                            },
-                        ],
                     },
                 ],
             }}

--- a/frontend/src/lib/components/Alerts/views/AlertDestinationSelector.tsx
+++ b/frontend/src/lib/components/Alerts/views/AlertDestinationSelector.tsx
@@ -13,7 +13,6 @@ export const INSIGHT_ALERT_FIRING_EVENT_ID = '$insight_alert_firing'
 export function AlertDestinationSelector({ alertId }: AlertDestinationSelectorProps): JSX.Element {
     return (
         <LinkedHogFunctions
-            logicKey={INSIGHT_ALERT_DESTINATION_LOGIC_KEY}
             type="internal_destination"
             subTemplateIds={[INSIGHT_ALERT_FIRING_SUB_TEMPLATE_ID]}
             hideFeedback={true}

--- a/frontend/src/scenes/actions/ActionHogFunctions.tsx
+++ b/frontend/src/scenes/actions/ActionHogFunctions.tsx
@@ -35,7 +35,6 @@ export function ActionHogFunctions(): JSX.Element | null {
             ) : null}
 
             <LinkedHogFunctions
-                logicKey="actions"
                 type="destination"
                 filters={filters}
                 newDisabledReason={

--- a/frontend/src/scenes/data-management/definition/DefinitionView.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionView.tsx
@@ -281,7 +281,6 @@ export function DefinitionView(props: DefinitionLogicProps = {}): JSX.Element {
                     <p>Get notified via Slack, webhooks or more whenever this event is captured.</p>
 
                     <LinkedHogFunctions
-                        logicKey="event-definitions"
                         type="destination"
                         filters={{
                             events: [

--- a/frontend/src/scenes/error-tracking/configuration/alerting/ErrorTrackingAlerting.tsx
+++ b/frontend/src/scenes/error-tracking/configuration/alerting/ErrorTrackingAlerting.tsx
@@ -1,10 +1,11 @@
+import { ERROR_TRACKING_LOGIC_KEY } from 'scenes/error-tracking/utils'
 import { LinkedHogFunctions } from 'scenes/hog-functions/list/LinkedHogFunctions'
 import { HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES } from 'scenes/hog-functions/sub-templates/sub-templates'
 
 export function ErrorTrackingAlerting(): JSX.Element {
     return (
         <LinkedHogFunctions
-            logicKey="error-tracking"
+            logicKey={ERROR_TRACKING_LOGIC_KEY}
             type="internal_destination"
             subTemplateIds={['error-tracking-issue-created', 'error-tracking-issue-reopened']}
             filters={HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['error-tracking-issue-created']?.filters ?? {}}

--- a/frontend/src/scenes/error-tracking/configuration/alerting/ErrorTrackingAlerting.tsx
+++ b/frontend/src/scenes/error-tracking/configuration/alerting/ErrorTrackingAlerting.tsx
@@ -1,11 +1,9 @@
-import { ERROR_TRACKING_LOGIC_KEY } from 'scenes/error-tracking/utils'
 import { LinkedHogFunctions } from 'scenes/hog-functions/list/LinkedHogFunctions'
 import { HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES } from 'scenes/hog-functions/sub-templates/sub-templates'
 
 export function ErrorTrackingAlerting(): JSX.Element {
     return (
         <LinkedHogFunctions
-            logicKey={ERROR_TRACKING_LOGIC_KEY}
             type="internal_destination"
             subTemplateIds={['error-tracking-issue-created', 'error-tracking-issue-reopened']}
             filters={HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['error-tracking-issue-created']?.filters ?? {}}

--- a/frontend/src/scenes/error-tracking/configuration/alerting/ErrorTrackingAlerting.tsx
+++ b/frontend/src/scenes/error-tracking/configuration/alerting/ErrorTrackingAlerting.tsx
@@ -4,7 +4,6 @@ import { HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES } from 'scenes/hog-function
 export function ErrorTrackingAlerting(): JSX.Element {
     return (
         <LinkedHogFunctions
-            logicKey="error-tracking"
             type="internal_destination"
             subTemplateIds={['error-tracking-issue-created', 'error-tracking-issue-reopened']}
             filters={HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['error-tracking-issue-created']?.filters ?? {}}

--- a/frontend/src/scenes/error-tracking/configuration/alerting/ErrorTrackingAlerting.tsx
+++ b/frontend/src/scenes/error-tracking/configuration/alerting/ErrorTrackingAlerting.tsx
@@ -4,6 +4,7 @@ import { HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES } from 'scenes/hog-function
 export function ErrorTrackingAlerting(): JSX.Element {
     return (
         <LinkedHogFunctions
+            logicKey="error-tracking"
             type="internal_destination"
             subTemplateIds={['error-tracking-issue-created', 'error-tracking-issue-reopened']}
             filters={HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES['error-tracking-issue-created']?.filters ?? {}}

--- a/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
+++ b/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
@@ -167,7 +167,7 @@ export const scene: SceneExport = {
     paramsToProps: ({ params: { id, templateId }, hashParams }): (typeof hogFunctionSceneLogic)['props'] => ({
         id,
         templateId,
-        logicKey: hashParams.configuration.logicKey,
+        logicKey: hashParams?.configuration?.logicKey,
     }),
 }
 

--- a/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
+++ b/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
@@ -164,14 +164,18 @@ export const hogFunctionSceneLogic = kea<hogFunctionSceneLogicType>([
 export const scene: SceneExport = {
     component: HogFunctionScene,
     logic: hogFunctionSceneLogic,
-    paramsToProps: ({ params: { id, templateId } }): (typeof hogFunctionSceneLogic)['props'] => ({ id, templateId }),
+    paramsToProps: ({ params: { id, templateId }, hashParams }): (typeof hogFunctionSceneLogic)['props'] => ({
+        id,
+        templateId,
+        logicKey: hashParams.configuration.logicKey,
+    }),
 }
 
 export function HogFunctionScene(): JSX.Element {
     const { currentTab, loading, loaded, logicProps } = useValues(hogFunctionSceneLogic)
     const { setCurrentTab } = useActions(hogFunctionSceneLogic)
 
-    const { id, templateId } = logicProps
+    const { id, templateId, logicKey } = logicProps
 
     if (loading && !loaded) {
         return (
@@ -187,7 +191,7 @@ export function HogFunctionScene(): JSX.Element {
     }
 
     if (templateId) {
-        return <HogFunctionConfiguration templateId={templateId} />
+        return <HogFunctionConfiguration templateId={templateId} logicKey={logicKey} />
     }
 
     if (!id) {
@@ -201,6 +205,7 @@ export function HogFunctionScene(): JSX.Element {
             content: (
                 <HogFunctionConfiguration
                     id={id}
+                    logicKey={logicKey}
                     // displayOptions={{ hideTestingConfiguration: false }}
                 />
             ),

--- a/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
+++ b/frontend/src/scenes/hog-functions/HogFunctionScene.tsx
@@ -164,18 +164,14 @@ export const hogFunctionSceneLogic = kea<hogFunctionSceneLogicType>([
 export const scene: SceneExport = {
     component: HogFunctionScene,
     logic: hogFunctionSceneLogic,
-    paramsToProps: ({ params: { id, templateId }, hashParams }): (typeof hogFunctionSceneLogic)['props'] => ({
-        id,
-        templateId,
-        logicKey: hashParams?.configuration?.logicKey,
-    }),
+    paramsToProps: ({ params: { id, templateId } }): (typeof hogFunctionSceneLogic)['props'] => ({ id, templateId }),
 }
 
 export function HogFunctionScene(): JSX.Element {
     const { currentTab, loading, loaded, logicProps } = useValues(hogFunctionSceneLogic)
     const { setCurrentTab } = useActions(hogFunctionSceneLogic)
 
-    const { id, templateId, logicKey } = logicProps
+    const { id, templateId } = logicProps
 
     if (loading && !loaded) {
         return (
@@ -191,7 +187,7 @@ export function HogFunctionScene(): JSX.Element {
     }
 
     if (templateId) {
-        return <HogFunctionConfiguration templateId={templateId} logicKey={logicKey} />
+        return <HogFunctionConfiguration templateId={templateId} />
     }
 
     if (!id) {
@@ -202,13 +198,7 @@ export function HogFunctionScene(): JSX.Element {
         {
             label: 'Configuration',
             key: 'configuration',
-            content: (
-                <HogFunctionConfiguration
-                    id={id}
-                    logicKey={logicKey}
-                    // displayOptions={{ hideTestingConfiguration: false }}
-                />
-            ),
+            content: <HogFunctionConfiguration id={id} />,
         },
         {
             label: 'Metrics',

--- a/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/hog-functions/configuration/hogFunctionConfigurationLogic.tsx
@@ -14,7 +14,6 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { uuid } from 'lib/utils'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import posthog from 'posthog-js'
-import { ERROR_TRACKING_LOGIC_KEY } from 'scenes/error-tracking/utils'
 import { asDisplay } from 'scenes/persons/person-utils'
 import { pipelineNodeLogic } from 'scenes/pipeline/pipelineNodeLogic'
 import { projectLogic } from 'scenes/projectLogic'
@@ -43,6 +42,7 @@ import {
     ChartDisplayType,
     EventType,
     FilterLogicalOperator,
+    HogFunctionConfigurationContextId,
     HogFunctionConfigurationType,
     HogFunctionInputSchemaType,
     HogFunctionInputType,
@@ -60,6 +60,7 @@ import {
 } from '~/types'
 
 import { EmailTemplate } from '../email-templater/emailTemplaterLogic'
+import { eventToHogFunctionContextId } from '../sub-templates/sub-templates'
 import type { hogFunctionConfigurationLogicType } from './hogFunctionConfigurationLogicType'
 
 export interface HogFunctionConfigurationLogicProps {
@@ -681,6 +682,14 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
             (hogFunctionLoading, templateLoading) => hogFunctionLoading || templateLoading,
         ],
         loaded: [(s) => [s.hogFunction, s.template], (hogFunction, template) => !!hogFunction || !!template],
+
+        contextId: [
+            (s) => [s.configuration],
+            (configuration): HogFunctionConfigurationContextId => {
+                return eventToHogFunctionContextId(configuration.filters?.events?.[0]?.id)
+            },
+        ],
+
         inputFormErrors: [
             (s) => [s.configuration],
             (configuration) => {
@@ -744,8 +753,8 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
             },
         ],
         exampleInvocationGlobals: [
-            (s) => [s.configuration, s.currentProject, s.groupTypes, s.logicProps],
-            (configuration, currentProject, groupTypes, logicProps): HogFunctionInvocationGlobals => {
+            (s) => [s.configuration, s.currentProject, s.groupTypes, s.contextId],
+            (configuration, currentProject, groupTypes, contextId): HogFunctionInvocationGlobals => {
                 const currentUrl = window.location.href.split('#')[0]
                 const eventId = uuid()
                 const personId = uuid()
@@ -755,12 +764,21 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                     timestamp: dayjs().toISOString(),
                     elements_chain: '',
                     url: `${window.location.origin}/project/${currentProject?.id}/events/`,
-                    ...(logicProps.logicKey === ERROR_TRACKING_LOGIC_KEY
+                    ...(contextId === 'error-tracking'
                         ? {
                               event: configuration?.filters?.events?.[0].id || '$error_tracking_issue_created',
                               properties: {
                                   name: 'Test issue',
                                   description: 'This is the issue description',
+                              },
+                          }
+                        : contextId === 'activity-log'
+                        ? {
+                              event: '$activity_log_entry_created',
+                              properties: {
+                                  activity: 'created',
+                                  scope: 'Insight',
+                                  item_id: 'abcdef',
                               },
                           }
                         : {
@@ -775,7 +793,7 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                 const globals: HogFunctionInvocationGlobals = {
                     event,
                     person:
-                        logicProps.logicKey != ERROR_TRACKING_LOGIC_KEY
+                        contextId !== 'error-tracking'
                             ? {
                                   id: personId,
                                   properties: {
@@ -796,19 +814,21 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                         url: currentUrl,
                     },
                 }
-                groupTypes.forEach((groupType) => {
-                    if (logicProps.logicKey === ERROR_TRACKING_LOGIC_KEY) {
-                        return
-                    }
-                    const id = uuid()
-                    globals.groups![groupType.group_type] = {
-                        id: id,
-                        type: groupType.group_type,
-                        index: groupType.group_type_index,
-                        url: `${window.location.origin}/groups/${groupType.group_type_index}/${encodeURIComponent(id)}`,
-                        properties: {},
-                    }
-                })
+
+                if (contextId !== 'error-tracking') {
+                    groupTypes.forEach((groupType) => {
+                        const id = uuid()
+                        globals.groups![groupType.group_type] = {
+                            id: id,
+                            type: groupType.group_type,
+                            index: groupType.group_type_index,
+                            url: `${window.location.origin}/groups/${groupType.group_type_index}/${encodeURIComponent(
+                                id
+                            )}`,
+                            properties: {},
+                        }
+                    })
+                }
 
                 return globals
             },
@@ -1272,8 +1292,7 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
 
         if (props.templateId) {
             cache.configFromUrl = router.values.hashParams.configuration
-            cache.subTemplateId = router.values.hashParams.sub_template_id
-            actions.loadTemplate() // comes with plugin info
+            actions.loadTemplate()
         } else if (props.id && props.id !== 'new') {
             actions.loadHogFunction()
         }

--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
@@ -80,7 +80,7 @@ export function HogFunctionFiltersInternal(): JSX.Element {
         } else if (contextId === 'insight-alerts') {
             return [TaxonomicFilterGroupType.Events]
         }
-        return [TaxonomicFilterGroupType.EventProperties]
+        return []
     }, [contextId, hasAlertRouting])
 
     return (

--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
@@ -1,8 +1,8 @@
 import { LemonSelect } from '@posthog/lemon-ui'
 import { useValues } from 'kea'
+import { FlaggedFeature } from 'lib/components/FlaggedFeature'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { useMemo } from 'react'
 
@@ -67,13 +67,11 @@ const setSimpleFilterValue = (options: FilterOption[], value: string): HogFuncti
 }
 
 export function HogFunctionFiltersInternal(): JSX.Element {
-    const hasAlertRouting = useFeatureFlag('ERROR_TRACKING_ALERT_ROUTING')
     const {
         logicProps: { id },
         contextId,
     } = useValues(hogFunctionConfigurationLogic)
 
-    const taxonomicGroupTypes = useMemo(() => getTaxonomicGroupTypes(contextId), [contextId])
     const options = useMemo(() => getFilterOptions(contextId), [contextId])
 
     return (
@@ -88,10 +86,10 @@ export function HogFunctionFiltersInternal(): JSX.Element {
                             onChange={(value) => onChange(setSimpleFilterValue(options, value))}
                             placeholder="Select a filter"
                         />
-                        {hasAlertRouting && taxonomicGroupTypes.length > 0 ? (
+                        <FlaggedFeature flag="error-tracking-alert-routing">
                             <PropertyFilters
                                 propertyFilters={value?.properties ?? []}
-                                taxonomicGroupTypes={taxonomicGroupTypes}
+                                taxonomicGroupTypes={[TaxonomicFilterGroupType.ErrorTrackingIssues]}
                                 onChange={(properties: AnyPropertyFilter[]) => {
                                     onChange({
                                         ...value,
@@ -102,7 +100,8 @@ export function HogFunctionFiltersInternal(): JSX.Element {
                                 buttonSize="small"
                                 disablePopover
                             />
-                        ) : null}
+                        </FlaggedFeature>
+
                         {contextId === 'insight-alerts' ? (
                             <PropertyFilters
                                 propertyFilters={value?.events?.[0]?.properties ?? []}

--- a/frontend/src/scenes/hog-functions/list/LinkedHogFunctions.tsx
+++ b/frontend/src/scenes/hog-functions/list/LinkedHogFunctions.tsx
@@ -32,6 +32,7 @@ export function LinkedHogFunctions({
 
     return showNewDestination ? (
         <HogFunctionTemplateList
+            logicKey={logicKey}
             defaultFilters={{}}
             type={templateType}
             subTemplateIds={subTemplateIds}

--- a/frontend/src/scenes/hog-functions/list/LinkedHogFunctions.tsx
+++ b/frontend/src/scenes/hog-functions/list/LinkedHogFunctions.tsx
@@ -7,7 +7,6 @@ import { HogFunctionList } from './HogFunctionsList'
 import { HogFunctionTemplateList } from './HogFunctionTemplateList'
 
 export type LinkedHogFunctionsProps = {
-    logicKey?: string
     type: HogFunctionTypeType
     filters: HogFunctionFiltersType
     subTemplateIds?: HogFunctionSubTemplateIdType[]
@@ -16,7 +15,6 @@ export type LinkedHogFunctionsProps = {
 }
 
 export function LinkedHogFunctions({
-    logicKey,
     type,
     filters,
     subTemplateIds,
@@ -32,7 +30,6 @@ export function LinkedHogFunctions({
 
     return showNewDestination ? (
         <HogFunctionTemplateList
-            logicKey={logicKey}
             defaultFilters={{}}
             type={templateType}
             subTemplateIds={subTemplateIds}
@@ -47,7 +44,6 @@ export function LinkedHogFunctions({
         />
     ) : (
         <HogFunctionList
-            logicKey={logicKey}
             forceFilters={{ filters }}
             type={type}
             hideFeedback={hideFeedback}

--- a/frontend/src/scenes/hog-functions/list/hogFunctionTemplateListLogic.tsx
+++ b/frontend/src/scenes/hog-functions/list/hogFunctionTemplateListLogic.tsx
@@ -30,6 +30,7 @@ export type HogFunctionTemplateListFilters = {
 }
 
 export type HogFunctionTemplateListLogicProps = {
+    logicKey?: string
     type: HogFunctionTypeType
     additionalTypes?: HogFunctionTypeType[]
     subTemplateIds?: HogFunctionSubTemplateIdType[]
@@ -170,7 +171,7 @@ export const hogFunctionTemplateListLogic = kea<hogFunctionTemplateListLogicType
 
         urlForTemplate: [
             () => [(_, props) => props],
-            ({ forceFilters }): ((template: HogFunctionTemplateWithSubTemplateType) => string) => {
+            ({ forceFilters, logicKey }): ((template: HogFunctionTemplateWithSubTemplateType) => string) => {
                 return (template: HogFunctionTemplateWithSubTemplateType) => {
                     const subTemplate = template.sub_template_id
                         ? getSubTemplate(template, template.sub_template_id)
@@ -178,6 +179,7 @@ export const hogFunctionTemplateListLogic = kea<hogFunctionTemplateListLogicType
 
                     const configuration: Record<string, any> = {
                         ...(subTemplate ?? {}),
+                        logicKey,
                     }
                     if (forceFilters?.filters) {
                         // Always use the forced filters if given

--- a/frontend/src/scenes/hog-functions/list/hogFunctionTemplateListLogic.tsx
+++ b/frontend/src/scenes/hog-functions/list/hogFunctionTemplateListLogic.tsx
@@ -30,7 +30,6 @@ export type HogFunctionTemplateListFilters = {
 }
 
 export type HogFunctionTemplateListLogicProps = {
-    logicKey?: string
     type: HogFunctionTypeType
     additionalTypes?: HogFunctionTypeType[]
     subTemplateIds?: HogFunctionSubTemplateIdType[]
@@ -171,7 +170,7 @@ export const hogFunctionTemplateListLogic = kea<hogFunctionTemplateListLogicType
 
         urlForTemplate: [
             () => [(_, props) => props],
-            ({ forceFilters, logicKey }): ((template: HogFunctionTemplateWithSubTemplateType) => string) => {
+            ({ forceFilters }): ((template: HogFunctionTemplateWithSubTemplateType) => string) => {
                 return (template: HogFunctionTemplateWithSubTemplateType) => {
                     const subTemplate = template.sub_template_id
                         ? getSubTemplate(template, template.sub_template_id)
@@ -179,7 +178,6 @@ export const hogFunctionTemplateListLogic = kea<hogFunctionTemplateListLogicType
 
                     const configuration: Record<string, any> = {
                         ...(subTemplate ?? {}),
-                        logicKey,
                     }
                     if (forceFilters?.filters) {
                         // Always use the forced filters if given

--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -1,4 +1,5 @@
 import {
+    HogFunctionConfigurationContextId,
     HogFunctionSubTemplateIdType,
     HogFunctionSubTemplateType,
     HogFunctionTemplateType,
@@ -10,11 +11,12 @@ import {
 
 export const HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES: Record<
     HogFunctionSubTemplateIdType,
-    Pick<HogFunctionSubTemplateType, 'sub_template_id' | 'type'> &
-        Omit<Partial<HogFunctionSubTemplateType>, 'sub_template_id' | 'type'>
+    Pick<HogFunctionSubTemplateType, 'sub_template_id' | 'type' | 'context_id'> &
+        Omit<Partial<HogFunctionSubTemplateType>, 'sub_template_id' | 'type' | 'context_id'>
 > = {
     'survey-response': {
         sub_template_id: 'survey-response',
+        context_id: 'standard',
         type: 'destination',
         filters: {
             events: [
@@ -36,26 +38,31 @@ export const HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES: Record<
     'early-access-feature-enrollment': {
         sub_template_id: 'early-access-feature-enrollment',
         type: 'destination',
+        context_id: 'standard',
         filters: { events: [{ id: '$feature_enrollment_update', type: 'events' }] },
     },
     'activity-log': {
         sub_template_id: 'activity-log',
         type: 'internal_destination',
+        context_id: 'activity-log',
         filters: { events: [{ id: '$activity_log_entry_created', type: 'events' }] },
     },
     'error-tracking-issue-created': {
         sub_template_id: 'error-tracking-issue-created',
         type: 'internal_destination',
+        context_id: 'error-tracking',
         filters: { events: [{ id: '$error_tracking_issue_created', type: 'events' }] },
     },
     'error-tracking-issue-reopened': {
         sub_template_id: 'error-tracking-issue-reopened',
         type: 'internal_destination',
+        context_id: 'error-tracking',
         filters: { events: [{ id: '$error_tracking_issue_reopened', type: 'events' }] },
     },
     'insight-alert-firing': {
         sub_template_id: 'insight-alert-firing',
         type: 'internal_destination',
+        context_id: 'insight-alerts',
         filters: { events: [{ id: '$insight_alert_firing', type: 'events' }] },
     },
 }
@@ -439,4 +446,18 @@ export const getSubTemplate = (
     subTemplateId: HogFunctionSubTemplateIdType
 ): HogFunctionSubTemplateType | null => {
     return HOG_FUNCTION_SUB_TEMPLATES[subTemplateId].find((x) => x.template_id === template.id) || null
+}
+
+export const eventToHogFunctionContextId = (event: string | undefined): HogFunctionConfigurationContextId => {
+    switch (event) {
+        case '$error_tracking_issue_created':
+        case '$error_tracking_issue_reopened':
+            return 'error-tracking'
+        case '$insight_alert_firing':
+            return 'insight-alerts'
+        case '$activity_log_entry_created':
+            return 'activity-log'
+        default:
+            return 'standard'
+    }
 }

--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -306,7 +306,6 @@ export function SurveyView({ id }: { id: string }): JSX.Element {
                                     <div>
                                         <p>Get notified whenever a survey result is submitted</p>
                                         <LinkedHogFunctions
-                                            logicKey="survey"
                                             type="destination"
                                             subTemplateIds={['survey-response']}
                                             filters={{

--- a/frontend/src/scenes/surveys/Surveys.tsx
+++ b/frontend/src/scenes/surveys/Surveys.tsx
@@ -126,7 +126,6 @@ export function Surveys(): JSX.Element {
                 <>
                     <p>Get notified whenever a survey result is submitted</p>
                     <LinkedHogFunctions
-                        logicKey="surveys"
                         type="destination"
                         subTemplateIds={['survey-response']}
                         filters={{

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5170,6 +5170,10 @@ export type HogFunctionType = {
 }
 
 export type HogFunctionTemplateStatus = 'stable' | 'alpha' | 'beta' | 'deprecated' | 'coming_soon'
+
+// Contexts change the way the UI is rendered allowing different teams to customize the UI for their use case
+export type HogFunctionConfigurationContextId = 'standard' | 'error-tracking' | 'activity-log' | 'insight-alerts'
+
 export type HogFunctionSubTemplateIdType =
     | 'early-access-feature-enrollment'
     | 'survey-response'
@@ -5191,6 +5195,7 @@ export type HogFunctionSubTemplateType = Pick<
     'filters' | 'inputs' | 'masking' | 'mappings' | 'type'
 > & {
     template_id: HogFunctionTemplateType['id']
+    context_id: HogFunctionConfigurationContextId
     sub_template_id: HogFunctionSubTemplateIdType
     name?: string
     description?: string

--- a/products/early_access_features/frontend/EarlyAccessFeature.tsx
+++ b/products/early_access_features/frontend/EarlyAccessFeature.tsx
@@ -401,7 +401,6 @@ export function EarlyAccessFeature({ id }: { id?: string } = {}): JSX.Element {
                         <h3>Notifications</h3>
                         <p>Get notified when people opt in or out of your feature.</p>
                         <LinkedHogFunctions
-                            logicKey="early-access-feature"
                             type="destination"
                             filters={destinationFilters}
                             subTemplateIds={['early-access-feature-enrollment']}


### PR DESCRIPTION
## Problem

Fixes https://posthog.com/questions/post-to-slack-on-issue-reopened-trigger-automatically-set-to-error-tracking-issue-created-instead-of-error-tracking-issue-reopened

Think this has been broken since https://github.com/PostHog/posthog/pull/32080/files

## Changes


~We rely on the logicKey to do a bunch of conditional check in `hogFunctionConfigurationLogic` and `HogFunctionFiltersInternal`. There has got to be a better way but I'll leave that up to @benjackwhite who has a much clearer picture of where this UI is going and how we can target error tracking alerts specifically~

- [x] Changed to have a more reliable selector. We should really never rely on logicKeys - its soooo fragile
- [ ] Need to fix up insight alerts still

|Before|After|
|----|----|
| <img width="408" alt="Screenshot 2025-06-02 at 17 56 52" src="https://github.com/user-attachments/assets/f1ba6d60-4fa0-4610-8e85-5e449a4235fa" /> | <img width="434" alt="Screenshot 2025-06-02 at 17 50 39" src="https://github.com/user-attachments/assets/ef91032a-162d-4584-932b-34a53e9f013f" /> |