### PR TITLE
fix: remove unexpected unhandled error from snapshots api

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -27,7 +27,7 @@ from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.utils.encoders import JSONEncoder
 from rest_framework.request import Request
-from rest_framework.exceptions import Throttled
+from rest_framework.exceptions import Throttled, NotFound
 
 from ee.api.conversation import ServerSentEventRenderer
 from posthog.errors import CHQueryErrorTooManySimultaneousQueries
@@ -751,6 +751,8 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, U
 
             response.headers["Server-Timing"] = timer.to_header_string()
             return response
+        except NotFound:
+            raise
         except Exception as e:
             posthoganalytics.capture_exception(
                 e,
@@ -760,6 +762,7 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, U
                     "session_id": str(recording.session_id) if recording else None,
                 },
             )
+            breakpoint()
             return Response(
                 {"error": "An unexpected error has occurred. Please try again later."},
                 status=500,

--- a/posthog/session_recordings/session_recording_v2_service.py
+++ b/posthog/session_recordings/session_recording_v2_service.py
@@ -1,5 +1,7 @@
 import dataclasses
 from datetime import datetime
+
+import posthoganalytics
 import structlog
 from django.core.cache import cache
 from posthog.session_recordings.models.metadata import RecordingBlockListing
@@ -20,8 +22,18 @@ FIVE_SECONDS = 5
 ONE_DAY_IN_SECONDS = 24 * 60 * 60
 
 
-def listing_cache_key(recording: SessionRecording) -> str:
-    return f"@posthog/v2-blob-snapshots/recording_block_listing_{recording.team.id}_{recording.session_id}"
+def listing_cache_key(recording: SessionRecording) -> str | None:
+    try:
+        return f"@posthog/v2-blob-snapshots/recording_block_listing_{recording.team.id}_{recording.session_id}"
+    except Exception as e:
+        posthoganalytics.capture_exception(
+            e,
+            properties={
+                "location": "session_recording_v2_service.listing_cache_key",
+                "recording": recording.__dict__ if recording else None,
+            },
+        )
+        return None
 
 
 def within_the_last_day(start_time: datetime | None) -> bool:
@@ -39,13 +51,14 @@ def load_blocks(recording: SessionRecording) -> RecordingBlockListing | None:
     then we don't hit ClickHouse too often.
     """
     cache_key = listing_cache_key(recording)
-    cached_block_listing = cache.get(cache_key)
-    if cached_block_listing is not None:
-        return cached_block_listing
+    if cache_key is not None:
+        cached_block_listing = cache.get(cache_key)
+        if cached_block_listing is not None:
+            return cached_block_listing
 
     listed_blocks = SessionReplayEvents().list_blocks(recording.session_id, recording.team)
 
-    if listed_blocks is not None and not listed_blocks.is_empty():
+    if listed_blocks is not None and not listed_blocks.is_empty() and cache_key is not None:
         # If a recording started more than 24 hours ago, then it is complete
         # we can cache it for a long time.
         # If not, we might still be receiving blocks, so we cache it for a short time.

--- a/posthog/session_recordings/test/test_session_recordings.py
+++ b/posthog/session_recordings/test/test_session_recordings.py
@@ -1306,7 +1306,7 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
         self.produce_replay_summary("user", session_id, now() - relativedelta(days=1))
 
         personal_api_key = generate_random_token_personal()
-        PersonalAPIKey.objects.create(
+        personal_api_key_object: PersonalAPIKey = PersonalAPIKey.objects.create(
             label="X",
             user=self.user,
             last_used_at="2021-08-25T21:09:14",
@@ -1322,7 +1322,7 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
         assert response.status_code == status.HTTP_200_OK, response.json()
 
         assert mock_capture.call_args_list[0] == call(
-            self.user.distinct_id,
+            personal_api_key_object.secure_value,
             "snapshots_api_called_with_personal_api_key",
             {
                 "key_label": "X",


### PR DESCRIPTION
when visiting a customer's recording i got an error
this is in caching code which we can skip rather than explode
let's try and catch better and not explode in front of the customer