### PR TITLE
feat: Reverse order on Revenue Analytics

### DIFF
--- a/products/revenue_analytics/frontend/nodes/RevenueAnalyticsInsightsNode.tsx
+++ b/products/revenue_analytics/frontend/nodes/RevenueAnalyticsInsightsNode.tsx
@@ -72,6 +72,8 @@ export function RevenueAnalyticsInsightsNode(props: {
                             legend={{
                                 display: grossRevenueGroupBy === 'product' && datasets.length > 1,
                                 position: 'right',
+                                // By default chart.js renders first item at the bottom of stack, but legend goes at the top, let's reverse the legend instead
+                                reverse: true,
                             }}
                             trendsFilter={{
                                 aggregationAxisFormat: 'numeric',


### PR DESCRIPTION
Our bar charts put the first dataset at the bottom of the bar, but display it first in the legend which is misleading. I will not change this everywhere, but will change it for Revenue Analytics because it's what I care the most.