### PR TITLE
fix: survey actions

### DIFF
--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -16,7 +16,7 @@ import {
     Link,
     Popover,
 } from '@posthog/lemon-ui'
-import { BindLogic, useActions, useValues } from 'kea'
+import { BindLogic, useActions, useMountedLogic, useValues } from 'kea'
 import { EventSelect } from 'lib/components/EventSelect/EventSelect'
 import { FlagSelector } from 'lib/components/FlagSelector'
 import { PropertyValue } from 'lib/components/PropertyFilters/components/PropertyValue'
@@ -36,6 +36,7 @@ import { SurveyRepeatSchedule } from 'scenes/surveys/SurveyRepeatSchedule'
 import { SurveyResponsesCollection } from 'scenes/surveys/SurveyResponsesCollection'
 import { SurveyWidgetCustomization } from 'scenes/surveys/SurveyWidgetCustomization'
 
+import { actionsModel } from '~/models/actionsModel'
 import { getPropertyKey } from '~/taxonomy/helpers'
 import {
     ActionType,
@@ -249,6 +250,7 @@ export default function SurveyEdit(): JSX.Element {
     const { featureFlags } = useValues(enabledFeaturesLogic)
     const sortedItemIds = survey.questions.map((_, idx) => idx.toString())
     const { thankYouMessageDescriptionContentType = null } = survey.appearance ?? {}
+    useMountedLogic(actionsModel)
 
     function onSortEnd({ oldIndex, newIndex }: { oldIndex: number; newIndex: number }): void {
         function move(arr: SurveyQuestion[], from: number, to: number): SurveyQuestion[] {


### PR DESCRIPTION
## Problem

survey triggered by actions are currently disabled because they break the `surveyForm` logic.

The reason this is happening is because it relies on an logic that is not necessarily mounted within the Surveys logic.

## Changes

Make sure to initialize the `actionsModel` logic, by using `useMountedLogic`. This will allow us to re-enabled action triggers on surveys, which was also recently requested in a support ticket.

Otherwise, when someone tries to add an action to a survey, it causes the form to crash