### PR TITLE
fix(exports): use separate user dir for webdriver instances

### DIFF
--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -1,5 +1,6 @@
 import json
 import os
+import tempfile
 import uuid
 from datetime import timedelta
 from typing import Literal, Optional
@@ -56,6 +57,10 @@ def get_driver() -> webdriver.Chrome:
     options.add_experimental_option(
         "excludeSwitches", ["enable-automation"]
     )  # Removes the "Chrome is being controlled by automated test software" bar
+
+    # add a unique user data dir to avoid shared profile conflicts
+    user_data_dir = tempfile.mkdtemp()
+    options.add_argument(f"--user-data-dir={user_data_dir}")
 
     if os.environ.get("CHROMEDRIVER_BIN"):
         service = webdriver.ChromeService(executable_path=os.environ["CHROMEDRIVER_BIN"])


### PR DESCRIPTION
## Problem

See https://posthog.slack.com/archives/C02E3BKC78F/p1748888413132369

## Changes

Tries using a separate directory for webdriver instances.

## How did you test this code?

Exports still work locally