### PR TITLE
feat: hourly pre-aggregated tables for current day's data

### DIFF
--- a/dags/definitions.py
+++ b/dags/definitions.py
@@ -18,6 +18,7 @@ from dags import (
     property_definitions,
     slack_alerts,
     web_preaggregated_internal,
+    web_preaggregated_hourly,
 )
 
 # Define resources for different environments
@@ -57,6 +58,9 @@ defs = dagster.Definitions(
         web_preaggregated_internal.web_analytics_preaggregated_tables,
         web_preaggregated_internal.web_stats_daily,
         web_preaggregated_internal.web_bounces_daily,
+        web_preaggregated_hourly.web_analytics_preaggregated_hourly_tables,
+        web_preaggregated_hourly.web_stats_hourly,
+        web_preaggregated_hourly.web_bounces_hourly,
     ],
     jobs=[
         deletes.deletes_job,
@@ -70,6 +74,7 @@ defs = dagster.Definitions(
         backups.sharded_backup,
         backups.non_sharded_backup,
         web_preaggregated_internal.recreate_web_pre_aggregated_data_job,
+        web_preaggregated_hourly.recreate_web_pre_aggregated_hourly_data_job,
     ],
     schedules=[
         exchange_rate.daily_exchange_rates_schedule,
@@ -82,6 +87,7 @@ defs = dagster.Definitions(
         backups.full_non_sharded_backup_schedule,
         backups.incremental_non_sharded_backup_schedule,
         web_preaggregated_internal.recreate_web_analytics_preaggregated_internal_data_daily,
+        web_preaggregated_hourly.recreate_web_analytics_preaggregated_hourly_data,
     ],
     sensors=[
         deletes.run_deletes_after_squash,

--- a/dags/web_preaggregated_hourly.py
+++ b/dags/web_preaggregated_hourly.py
@@ -1,0 +1,164 @@
+from datetime import datetime, UTC, timedelta
+from collections.abc import Callable
+
+import dagster
+from dagster import Field, Array
+from clickhouse_driver import Client
+from dags.common import JobOwners
+from posthog.clickhouse.client import sync_execute
+
+from posthog.models.web_preaggregated.sql import (
+    DISTRIBUTED_WEB_BOUNCES_HOURLY_SQL,
+    WEB_BOUNCES_HOURLY_SQL,
+    WEB_BOUNCES_INSERT_SQL,
+    WEB_STATS_HOURLY_SQL,
+    DISTRIBUTED_WEB_STATS_HOURLY_SQL,
+    WEB_STATS_INSERT_SQL,
+)
+from posthog.clickhouse.cluster import ClickhouseCluster
+
+
+WEB_ANALYTICS_HOURLY_CONFIG_SCHEMA = {
+    "team_ids": Field(
+        Array(int),
+        default_value=[],
+        description="List of team IDs to process - if empty we will process for teams [1,2] only",
+    ),
+    "clickhouse_settings": Field(
+        str,
+        default_value="max_execution_time=300,max_bytes_before_external_group_by=21474836480,distributed_aggregation_memory_efficient=1",
+        description="ClickHouse execution settings",
+    ),
+    "hours_back": Field(
+        float,
+        default_value=1.0,
+        description="Number of hours back to process data for",
+    ),
+}
+
+
+def pre_aggregate_web_analytics_hourly_data(
+    context: dagster.AssetExecutionContext,
+    table_name: str,
+    sql_generator: Callable,
+) -> None:
+    config = context.op_config
+    team_ids = config.get("team_ids", [1, 2])
+    clickhouse_settings = config["clickhouse_settings"]
+    hours_back = config["hours_back"]
+
+    # Process the last N hours to handle any late-arriving data
+    # Align with hour boundaries to match toStartOfHour() used in SQL, we convert this to UTC
+    # on the SQL side so this is just to make sure we get complete hours
+    now = datetime.now(UTC)
+    current_hour = now.replace(minute=0, second=0, microsecond=0)
+    date_end = current_hour.strftime("%Y-%m-%d %H:%M:%S")
+    date_start = (current_hour - timedelta(hours=hours_back)).strftime("%Y-%m-%d %H:%M:%S")
+
+    insert_query = sql_generator(
+        date_start=date_start,
+        date_end=date_end,
+        team_ids=team_ids,
+        settings=clickhouse_settings,
+        table_name=table_name,
+        granularity="hourly",
+    )
+
+    # We intentionally log the query to make it easier to debug using the UI
+    context.log.info(f"Processing hourly data from {date_start} to {date_end}")
+    context.log.info(insert_query)
+
+    sync_execute(insert_query)
+
+
+@dagster.asset(
+    name="web_analytics_preaggregated_hourly_tables",
+    group_name="web_analytics_hourly",
+    description="Creates the hourly tables needed for web analytics preaggregated data with 24h TTL for real-time analytics.",
+    tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
+)
+def web_analytics_preaggregated_hourly_tables(
+    cluster: dagster.ResourceParam[ClickhouseCluster],
+) -> bool:
+    def drop_tables(client: Client):
+        client.execute("DROP TABLE IF EXISTS web_stats_hourly SYNC")
+        client.execute("DROP TABLE IF EXISTS web_bounces_hourly SYNC")
+
+    def create_tables(client: Client):
+        client.execute(WEB_STATS_HOURLY_SQL())
+        client.execute(WEB_BOUNCES_HOURLY_SQL())
+
+        client.execute(DISTRIBUTED_WEB_STATS_HOURLY_SQL())
+        client.execute(DISTRIBUTED_WEB_BOUNCES_HOURLY_SQL())
+
+    cluster.map_all_hosts(drop_tables).result()
+    cluster.map_all_hosts(create_tables).result()
+    return True
+
+
+@dagster.asset(
+    name="web_analytics_bounces_hourly",
+    group_name="web_analytics_hourly",
+    config_schema=WEB_ANALYTICS_HOURLY_CONFIG_SCHEMA,
+    deps=["web_analytics_preaggregated_hourly_tables"],
+    metadata={"table": "web_bounces_hourly"},
+    tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
+)
+def web_bounces_hourly(
+    context: dagster.AssetExecutionContext,
+) -> None:
+    """
+    Real-time hourly bounce rate data for web analytics with 24h TTL. Updates every 5 minutes.
+    """
+    return pre_aggregate_web_analytics_hourly_data(
+        context=context, table_name="web_bounces_hourly", sql_generator=WEB_BOUNCES_INSERT_SQL
+    )
+
+
+@dagster.asset(
+    name="web_analytics_stats_table_hourly",
+    group_name="web_analytics_hourly",
+    config_schema=WEB_ANALYTICS_HOURLY_CONFIG_SCHEMA,
+    deps=["web_analytics_preaggregated_hourly_tables"],
+    metadata={"table": "web_stats_hourly"},
+    tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
+)
+def web_stats_hourly(context: dagster.AssetExecutionContext) -> None:
+    """
+    Real-time hourly aggregated dimensional data with pageviews and unique user counts with 24h TTL. Updates every 5 minutes.
+    """
+    return pre_aggregate_web_analytics_hourly_data(
+        context=context,
+        table_name="web_stats_hourly",
+        sql_generator=WEB_STATS_INSERT_SQL,
+    )
+
+
+recreate_web_pre_aggregated_hourly_data_job = dagster.define_asset_job(
+    name="recreate_web_pre_aggregated_hourly_data",
+    selection=dagster.AssetSelection.groups("web_analytics_hourly"),
+    tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
+)
+
+
+@dagster.schedule(
+    cron_schedule="*/5 * * * *",  # Run every 5 minutes
+    job=recreate_web_pre_aggregated_hourly_data_job,
+    execution_timezone="UTC",
+    tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
+)
+def recreate_web_analytics_preaggregated_hourly_data(context: dagster.ScheduleEvaluationContext):
+    """
+    Creates real-time web analytics pre-aggregated data with 24h TTL for real-time analytics.
+    Runs every 5 minutes and processes the last hour to handle late-arriving data.
+    """
+    team_ids = [2, 55348, 47074]
+
+    return dagster.RunRequest(
+        run_config={
+            "ops": {
+                "web_analytics_bounces_hourly": {"config": {"team_ids": team_ids}},
+                "web_analytics_stats_table_hourly": {"config": {"team_ids": team_ids}},
+            }
+        },
+    )

--- a/dags/web_preaggregated_hourly.py
+++ b/dags/web_preaggregated_hourly.py
@@ -22,7 +22,7 @@ WEB_ANALYTICS_HOURLY_CONFIG_SCHEMA = {
     "team_ids": Field(
         Array(int),
         default_value=[],
-        description="List of team IDs to process - if empty we will process for teams [1,2] only",
+        description="List of team IDs to process - if empty we will process for default teams only",
     ),
     "clickhouse_settings": Field(
         str,

--- a/dags/web_preaggregated_internal.py
+++ b/dags/web_preaggregated_internal.py
@@ -48,6 +48,7 @@ def pre_aggregate_web_analytics_data(
         team_ids=team_ids,
         settings=clickhouse_settings,
         table_name=table_name,
+        granularity="daily",
     )
 
     # We intentionally log the query to make it easier to debug using the UI

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -95,7 +95,9 @@ from posthog.hogql.database.schema.sessions_v2 import (
 from posthog.hogql.database.schema.static_cohort_people import StaticCohortPeople
 from posthog.hogql.database.schema.web_analytics_preaggregated import (
     WebBouncesDailyTable,
+    WebBouncesHourlyTable,
     WebStatsDailyTable,
+    WebStatsHourlyTable,
 )
 from posthog.hogql.errors import QueryError, ResolutionError
 from posthog.hogql.parser import parse_expr
@@ -156,6 +158,8 @@ class Database(BaseModel):
     # Web analytics pre-aggregated tables (internal use only)
     web_stats_daily: WebStatsDailyTable = WebStatsDailyTable()
     web_bounces_daily: WebBouncesDailyTable = WebBouncesDailyTable()
+    web_stats_hourly: WebStatsHourlyTable = WebStatsHourlyTable()
+    web_bounces_hourly: WebBouncesHourlyTable = WebBouncesHourlyTable()
 
     raw_session_replay_events: RawSessionReplayEventsTable = RawSessionReplayEventsTable()
     raw_person_distinct_ids: RawPersonDistinctIdsTable = RawPersonDistinctIdsTable()

--- a/posthog/hogql/database/schema/test/test_web_analytics_preaggregated.py
+++ b/posthog/hogql/database/schema/test/test_web_analytics_preaggregated.py
@@ -7,8 +7,8 @@ from posthog.hogql.database.schema.web_analytics_preaggregated import (
     UTM_FIELDS,
     ATTRIBUTION_TRACKING_FIELDS,
     PATH_FIELDS,
-    WEB_STATS_DAILY_SPECIFIC_FIELDS,
-    WEB_BOUNCES_DAILY_SPECIFIC_FIELDS,
+    WEB_STATS_SPECIFIC_FIELDS,
+    WEB_BOUNCES_SPECIFIC_FIELDS,
 )
 
 
@@ -26,13 +26,13 @@ class TestWebAnalyticsPreAggregatedSchema:
         bounces_table = WebBouncesDailyTable()
 
         # Stats table specific fields
-        for field_name in WEB_STATS_DAILY_SPECIFIC_FIELDS.keys():
+        for field_name in WEB_STATS_SPECIFIC_FIELDS.keys():
             assert (
                 field_name in stats_table.fields
             ), f"Stats-specific field '{field_name}' missing from WebStatsDailyTable"
 
         # Bounces table specific fields
-        for field_name in WEB_BOUNCES_DAILY_SPECIFIC_FIELDS.keys():
+        for field_name in WEB_BOUNCES_SPECIFIC_FIELDS.keys():
             assert (
                 field_name in bounces_table.fields
             ), f"Bounces-specific field '{field_name}' missing from WebBouncesDailyTable"

--- a/posthog/hogql/database/schema/web_analytics_preaggregated.py
+++ b/posthog/hogql/database/schema/web_analytics_preaggregated.py
@@ -3,7 +3,6 @@ from posthog.hogql.database.models import (
     DatabaseField,
     IntegerDatabaseField,
     StringDatabaseField,
-    DateDatabaseField,
     DateTimeDatabaseField,
     Table,
     FieldOrTable,
@@ -71,12 +70,12 @@ SHARED_SCHEMA_FIELDS = {
 }
 
 # Web stats daily specific fields
-WEB_STATS_DAILY_SPECIFIC_FIELDS = {
+WEB_STATS_SPECIFIC_FIELDS = {
     "pathname": StringDatabaseField(name="pathname", nullable=True),
 }
 
 # Web bounces daily specific fields (session calculations: bounce and duration)
-WEB_BOUNCES_DAILY_SPECIFIC_FIELDS = {
+WEB_BOUNCES_SPECIFIC_FIELDS = {
     "bounces_count_state": DatabaseField(name="bounces_count_state"),
     "total_session_duration_state": DatabaseField(name="total_session_duration_state"),
 }
@@ -87,7 +86,7 @@ def web_preaggregated_base_fields(granularity: Literal["daily", "hourly"]):
 
     return {
         "team_id": IntegerDatabaseField(name="team_id"),
-        bucket_name: DateDatabaseField(name=bucket_name),
+        bucket_name: DateTimeDatabaseField(name=bucket_name),
         "host": StringDatabaseField(name="host", nullable=True),
         "device_type": StringDatabaseField(name="device_type", nullable=True),
         "updated_at": DateTimeDatabaseField(name="updated_at"),
@@ -106,7 +105,7 @@ class WebStatsDailyTable(Table):
         **web_preaggregated_base_fields("daily"),
         **web_preaggregated_base_aggregation_fields,
         **SHARED_SCHEMA_FIELDS,
-        **WEB_STATS_DAILY_SPECIFIC_FIELDS,
+        **WEB_STATS_SPECIFIC_FIELDS,
     }
 
     def to_printed_clickhouse(self, context):
@@ -121,7 +120,7 @@ class WebBouncesDailyTable(Table):
         **web_preaggregated_base_fields("daily"),
         **web_preaggregated_base_aggregation_fields,
         **SHARED_SCHEMA_FIELDS,
-        **WEB_BOUNCES_DAILY_SPECIFIC_FIELDS,
+        **WEB_BOUNCES_SPECIFIC_FIELDS,
     }
 
     def to_printed_clickhouse(self, context):
@@ -136,6 +135,7 @@ class WebStatsHourlyTable(Table):
         **web_preaggregated_base_fields("hourly"),
         **web_preaggregated_base_aggregation_fields,
         **SHARED_SCHEMA_FIELDS,
+        **WEB_STATS_SPECIFIC_FIELDS,
     }
 
     def to_printed_clickhouse(self, context):
@@ -150,6 +150,7 @@ class WebBouncesHourlyTable(Table):
         **web_preaggregated_base_fields("hourly"),
         **web_preaggregated_base_aggregation_fields,
         **SHARED_SCHEMA_FIELDS,
+        **WEB_BOUNCES_SPECIFIC_FIELDS,
     }
 
     def to_printed_clickhouse(self, context):

--- a/posthog/models/web_preaggregated/sql.py
+++ b/posthog/models/web_preaggregated/sql.py
@@ -29,7 +29,6 @@ def HOURLY_TABLE_TEMPLATE(table_name, columns, order_by, on_cluster=True, ttl=No
     engine = ReplacingMergeTree(table_name, replication_scheme=ReplicationScheme.REPLICATED, ver="updated_at")
     on_cluster_clause = f"ON CLUSTER '{CLICKHOUSE_CLUSTER}'" if on_cluster else ""
 
-    # Add TTL clause if specified
     ttl_clause = f"TTL hour_bucket + INTERVAL {ttl} DELETE" if ttl else ""
 
     return f"""
@@ -42,7 +41,6 @@ def HOURLY_TABLE_TEMPLATE(table_name, columns, order_by, on_cluster=True, ttl=No
         updated_at DateTime64(6, 'UTC') DEFAULT now(),
         {columns}
     ) ENGINE = {engine}
-    PARTITION BY toYYYYMM(hour_bucket)
     ORDER BY {order_by}
     {ttl_clause}
     """

--- a/posthog/models/web_preaggregated/sql.py
+++ b/posthog/models/web_preaggregated/sql.py
@@ -9,6 +9,7 @@ CLICKHOUSE_DATABASE = settings.CLICKHOUSE_DATABASE
 def TABLE_TEMPLATE(table_name, columns, order_by, on_cluster=True):
     engine = ReplacingMergeTree(table_name, replication_scheme=ReplicationScheme.REPLICATED, ver="updated_at")
     on_cluster_clause = f"ON CLUSTER '{CLICKHOUSE_CLUSTER}'" if on_cluster else ""
+
     return f"""
     CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
     (
@@ -24,11 +25,36 @@ def TABLE_TEMPLATE(table_name, columns, order_by, on_cluster=True):
     """
 
 
-def DISTRIBUTED_TABLE_TEMPLATE(dist_table_name, base_table_name, columns):
+def HOURLY_TABLE_TEMPLATE(table_name, columns, order_by, on_cluster=True, ttl=None):
+    engine = ReplacingMergeTree(table_name, replication_scheme=ReplicationScheme.REPLICATED, ver="updated_at")
+    on_cluster_clause = f"ON CLUSTER '{CLICKHOUSE_CLUSTER}'" if on_cluster else ""
+
+    # Add TTL clause if specified
+    ttl_clause = f"TTL hour_bucket + INTERVAL {ttl} DELETE" if ttl else ""
+
+    return f"""
+    CREATE TABLE IF NOT EXISTS {table_name} {on_cluster_clause}
+    (
+        hour_bucket DateTime,
+        team_id UInt64,
+        host String,
+        device_type String,
+        updated_at DateTime64(6, 'UTC') DEFAULT now(),
+        {columns}
+    ) ENGINE = {engine}
+    PARTITION BY toYYYYMM(hour_bucket)
+    ORDER BY {order_by}
+    {ttl_clause}
+    """
+
+
+def DISTRIBUTED_TABLE_TEMPLATE(dist_table_name, base_table_name, columns, granularity="daily"):
+    bucket_name = "day_bucket" if granularity == "daily" else "hour_bucket"
+
     return f"""
     CREATE TABLE IF NOT EXISTS {dist_table_name} ON CLUSTER '{CLICKHOUSE_CLUSTER}'
     (
-        day_bucket DateTime,
+        {bucket_name} DateTime,
         team_id UInt64,
         host String,
         device_type String,
@@ -73,18 +99,60 @@ WEB_STATS_COLUMNS = """
     mc_cid String,
     igshid String,
     ttclid String,
-    epik String,
-    qclid String,
-    sccid String,
     _kx String,
     irclid String,
     persons_uniq_state AggregateFunction(uniq, UUID),
     sessions_uniq_state AggregateFunction(uniq, String),
     pageviews_count_state AggregateFunction(sum, UInt64),
 """
-WEB_STATS_ORDER_BY = """(
+
+WEB_BOUNCES_COLUMNS = """
+    entry_pathname String,
+    end_pathname String,
+    browser String,
+    browser_version String,
+    os String,
+    os_version String,
+    viewport_width Int64,
+    viewport_height Int64,
+    referring_domain String,
+    utm_source String,
+    utm_medium String,
+    utm_campaign String,
+    utm_term String,
+    utm_content String,
+    country_code String,
+    city_name String,
+    region_code String,
+    region_name String,
+    time_zone String,
+    gclid String,
+    gad_source String,
+    gclsrc String,
+    dclid String,
+    gbraid String,
+    wbraid String,
+    fbclid String,
+    msclkid String,
+    twclid String,
+    li_fat_id String,
+    mc_cid String,
+    igshid String,
+    ttclid String,
+    _kx String,
+    irclid String,
+    persons_uniq_state AggregateFunction(uniq, UUID),
+    sessions_uniq_state AggregateFunction(uniq, String),
+    pageviews_count_state AggregateFunction(sum, UInt64),
+    bounces_count_state AggregateFunction(sum, UInt64),
+    total_session_duration_state AggregateFunction(sum, Int64)
+"""
+
+
+def WEB_STATS_ORDER_BY_FUNC(bucket_column="day_bucket"):
+    return f"""(
     team_id,
-    day_bucket,
+    {bucket_column},
     host,
     device_type,
     os,
@@ -120,61 +188,15 @@ WEB_STATS_ORDER_BY = """(
     mc_cid,
     igshid,
     ttclid,
-    epik,
-    qclid,
-    sccid,
     _kx,
     irclid
 )"""
 
-WEB_BOUNCES_COLUMNS = """
-    entry_pathname String,
-    end_pathname String,
-    browser String,
-    browser_version String,
-    os String,
-    os_version String,
-    viewport_width Int64,
-    viewport_height Int64,
-    referring_domain String,
-    utm_source String,
-    utm_medium String,
-    utm_campaign String,
-    utm_term String,
-    utm_content String,
-    country_code String,
-    city_name String,
-    region_code String,
-    region_name String,
-    time_zone String,
-    gclid String,
-    gad_source String,
-    gclsrc String,
-    dclid String,
-    gbraid String,
-    wbraid String,
-    fbclid String,
-    msclkid String,
-    twclid String,
-    li_fat_id String,
-    mc_cid String,
-    igshid String,
-    ttclid String,
-    epik String,
-    qclid String,
-    sccid String,
-    _kx String,
-    irclid String,
-    persons_uniq_state AggregateFunction(uniq, UUID),
-    sessions_uniq_state AggregateFunction(uniq, String),
-    pageviews_count_state AggregateFunction(sum, UInt64),
-    bounces_count_state AggregateFunction(sum, UInt64),
-    total_session_duration_state AggregateFunction(sum, Int64)
-"""
 
-WEB_BOUNCES_ORDER_BY = """(
+def WEB_BOUNCES_ORDER_BY_FUNC(bucket_column="day_bucket"):
+    return f"""(
     team_id,
-    day_bucket,
+    {bucket_column},
     host,
     device_type,
     entry_pathname,
@@ -209,9 +231,6 @@ WEB_BOUNCES_ORDER_BY = """(
     mc_cid,
     igshid,
     ttclid,
-    epik,
-    qclid,
-    sccid,
     _kx,
     irclid
 )"""
@@ -220,24 +239,54 @@ WEB_BOUNCES_ORDER_BY = """(
 def create_table_pair(base_table_name, columns, order_by, on_cluster=True):
     """Create both a local and distributed table with the same schema"""
     base_sql = TABLE_TEMPLATE(base_table_name, columns, order_by, on_cluster)
-    dist_sql = DISTRIBUTED_TABLE_TEMPLATE(f"{base_table_name}_distributed", base_table_name, columns)
+    dist_sql = DISTRIBUTED_TABLE_TEMPLATE(
+        f"{base_table_name}_distributed", base_table_name, columns, granularity="daily"
+    )
     return base_sql, dist_sql
 
 
 def WEB_STATS_DAILY_SQL(table_name="web_stats_daily", on_cluster=True):
-    return TABLE_TEMPLATE(table_name, WEB_STATS_COLUMNS, WEB_STATS_ORDER_BY, on_cluster)
+    return TABLE_TEMPLATE(table_name, WEB_STATS_COLUMNS, WEB_STATS_ORDER_BY_FUNC("day_bucket"), on_cluster)
 
 
 def DISTRIBUTED_WEB_STATS_DAILY_SQL():
-    return DISTRIBUTED_TABLE_TEMPLATE("web_stats_daily_distributed", "web_stats_daily", WEB_STATS_COLUMNS)
+    return DISTRIBUTED_TABLE_TEMPLATE(
+        "web_stats_daily_distributed", "web_stats_daily", WEB_STATS_COLUMNS, granularity="daily"
+    )
 
 
 def WEB_BOUNCES_DAILY_SQL(table_name="web_bounces_daily", on_cluster=True):
-    return TABLE_TEMPLATE(table_name, WEB_BOUNCES_COLUMNS, WEB_BOUNCES_ORDER_BY, on_cluster)
+    return TABLE_TEMPLATE(table_name, WEB_BOUNCES_COLUMNS, WEB_BOUNCES_ORDER_BY_FUNC("day_bucket"), on_cluster)
 
 
 def DISTRIBUTED_WEB_BOUNCES_DAILY_SQL():
-    return DISTRIBUTED_TABLE_TEMPLATE("web_bounces_daily_distributed", "web_bounces_daily", WEB_BOUNCES_COLUMNS)
+    return DISTRIBUTED_TABLE_TEMPLATE(
+        "web_bounces_daily_distributed", "web_bounces_daily", WEB_BOUNCES_COLUMNS, granularity="daily"
+    )
+
+
+def WEB_STATS_HOURLY_SQL(on_cluster=True):
+    return HOURLY_TABLE_TEMPLATE(
+        "web_stats_hourly", WEB_STATS_COLUMNS, WEB_STATS_ORDER_BY_FUNC("hour_bucket"), on_cluster, ttl="24 HOUR"
+    )
+
+
+def DISTRIBUTED_WEB_STATS_HOURLY_SQL():
+    return DISTRIBUTED_TABLE_TEMPLATE(
+        "web_stats_hourly_distributed", "web_stats_hourly", WEB_STATS_COLUMNS, granularity="hourly"
+    )
+
+
+def WEB_BOUNCES_HOURLY_SQL(on_cluster=True):
+    return HOURLY_TABLE_TEMPLATE(
+        "web_bounces_hourly", WEB_BOUNCES_COLUMNS, WEB_BOUNCES_ORDER_BY_FUNC("hour_bucket"), on_cluster, ttl="24 HOUR"
+    )
+
+
+def DISTRIBUTED_WEB_BOUNCES_HOURLY_SQL():
+    return DISTRIBUTED_TABLE_TEMPLATE(
+        "web_bounces_hourly_distributed", "web_bounces_hourly", WEB_BOUNCES_COLUMNS, granularity="hourly"
+    )
 
 
 def format_team_ids(team_ids):
@@ -248,25 +297,46 @@ def get_team_filters(team_ids):
     team_ids_str = format_team_ids(team_ids) if team_ids else None
     return {
         "raw_sessions": f"raw_sessions.team_id IN({team_ids_str})" if team_ids else "1=1",
-        "person_distinct_id_overrides": f"person_distinct_id_overrides.team_id IN({team_ids_str})"
-        if team_ids
-        else "1=1",
+        "person_distinct_id_overrides": (
+            f"person_distinct_id_overrides.team_id IN({team_ids_str})" if team_ids else "1=1"
+        ),
         "events": f"e.team_id IN({team_ids_str})" if team_ids else "1=1",
     }
 
 
-def WEB_STATS_INSERT_SQL(
-    date_start, date_end, team_ids=None, timezone="UTC", settings="", table_name="web_stats_daily"
-):
+def get_insert_params(team_ids, granularity="daily"):
     filters = get_team_filters(team_ids)
-    team_filter = filters["raw_sessions"]
-    person_team_filter = filters["person_distinct_id_overrides"]
-    events_team_filter = filters["events"]
+
+    if granularity == "hourly":
+        time_bucket_func = "toStartOfHour"
+        bucket_column = "hour_bucket"
+    else:
+        time_bucket_func = "toStartOfDay"
+        bucket_column = "day_bucket"
+
+    return {
+        "team_filter": filters["raw_sessions"],
+        "person_team_filter": filters["person_distinct_id_overrides"],
+        "events_team_filter": filters["events"],
+        "time_bucket_func": time_bucket_func,
+        "bucket_column": bucket_column,
+    }
+
+
+def WEB_STATS_INSERT_SQL(
+    date_start, date_end, team_ids=None, timezone="UTC", settings="", table_name="web_stats_daily", granularity="daily"
+):
+    params = get_insert_params(team_ids, granularity)
+    team_filter = params["team_filter"]
+    person_team_filter = params["person_team_filter"]
+    events_team_filter = params["events_team_filter"]
+    time_bucket_func = params["time_bucket_func"]
+    bucket_column = params["bucket_column"]
 
     return f"""
     INSERT INTO {table_name}
     SELECT
-        toStartOfDay(start_timestamp) AS day_bucket,
+        {time_bucket_func}(start_timestamp) AS {bucket_column},
         team_id,
         host,
         device_type,
@@ -305,9 +375,6 @@ def WEB_STATS_INSERT_SQL(
         mc_cid,
         igshid,
         ttclid,
-        epik,
-        qclid,
-        sccid,
         _kx,
         irclid,
         uniqState(assumeNotNull(session_person_id)) AS persons_uniq_state,
@@ -354,9 +421,6 @@ def WEB_STATS_INSERT_SQL(
             events__session.mc_cid AS mc_cid,
             events__session.igshid AS igshid,
             events__session.ttclid AS ttclid,
-            events__session.epik AS epik,
-            events__session.qclid AS qclid,
-            events__session.sccid AS sccid,
             events__session._kx AS _kx,
             events__session.irclid AS irclid,
             countIf(e.event IN ('$pageview', '$screen')) AS pageview_count,
@@ -394,9 +458,6 @@ def WEB_STATS_INSERT_SQL(
                 argMinMerge(raw_sessions.initial_mc_cid) AS mc_cid,
                 argMinMerge(raw_sessions.initial_igshid) AS igshid,
                 argMinMerge(raw_sessions.initial_ttclid) AS ttclid,
-                argMinMerge(raw_sessions.initial_epik) AS epik,
-                argMinMerge(raw_sessions.initial_qclid) AS qclid,
-                argMinMerge(raw_sessions.initial_sccid) AS sccid,
                 argMinMerge(raw_sessions.initial__kx) AS _kx,
                 argMinMerge(raw_sessions.initial_irclid) AS irclid,
                 raw_sessions.session_id_v7 AS session_id_v7
@@ -463,15 +524,12 @@ def WEB_STATS_INSERT_SQL(
             mc_cid,
             igshid,
             ttclid,
-            epik,
-            qclid,
-            sccid,
             _kx,
             irclid
         SETTINGS {settings}
     )
     GROUP BY
-        day_bucket,
+        {bucket_column},
         team_id,
         host,
         device_type,
@@ -509,9 +567,6 @@ def WEB_STATS_INSERT_SQL(
         mc_cid,
         igshid,
         ttclid,
-        epik,
-        qclid,
-        sccid,
         _kx,
         irclid
     SETTINGS {settings}
@@ -519,17 +574,25 @@ def WEB_STATS_INSERT_SQL(
 
 
 def WEB_BOUNCES_INSERT_SQL(
-    date_start, date_end, team_ids=None, timezone="UTC", settings="", table_name="web_bounces_daily"
+    date_start,
+    date_end,
+    team_ids=None,
+    timezone="UTC",
+    settings="",
+    table_name="web_bounces_daily",
+    granularity="daily",
 ):
-    filters = get_team_filters(team_ids)
-    team_filter = filters["raw_sessions"]
-    person_team_filter = filters["person_distinct_id_overrides"]
-    events_team_filter = filters["events"]
+    params = get_insert_params(team_ids, granularity)
+    team_filter = params["team_filter"]
+    person_team_filter = params["person_team_filter"]
+    events_team_filter = params["events_team_filter"]
+    time_bucket_func = params["time_bucket_func"]
+    bucket_column = params["bucket_column"]
 
     return f"""
     INSERT INTO {table_name}
     SELECT
-        toStartOfDay(start_timestamp) AS day_bucket,
+        {time_bucket_func}(start_timestamp) AS {bucket_column},
         team_id,
         host,
         device_type,
@@ -566,9 +629,6 @@ def WEB_BOUNCES_INSERT_SQL(
         mc_cid,
         igshid,
         ttclid,
-        epik,
-        qclid,
-        sccid,
         _kx,
         irclid,
         uniqState(assumeNotNull(person_id)) AS persons_uniq_state,
@@ -607,9 +667,6 @@ def WEB_BOUNCES_INSERT_SQL(
             events__session.mc_cid AS mc_cid,
             events__session.igshid AS igshid,
             events__session.ttclid AS ttclid,
-            events__session.epik AS epik,
-            events__session.qclid AS qclid,
-            events__session.sccid AS sccid,
             events__session._kx AS _kx,
             events__session.irclid AS irclid,
             e.mat_$host AS host,
@@ -655,9 +712,6 @@ def WEB_BOUNCES_INSERT_SQL(
                 argMinMerge(raw_sessions.initial_mc_cid) AS mc_cid,
                 argMinMerge(raw_sessions.initial_igshid) AS igshid,
                 argMinMerge(raw_sessions.initial_ttclid) AS ttclid,
-                argMinMerge(raw_sessions.initial_epik) AS epik,
-                argMinMerge(raw_sessions.initial_qclid) AS qclid,
-                argMinMerge(raw_sessions.initial_sccid) AS sccid,
                 argMinMerge(raw_sessions.initial__kx) AS _kx,
                 argMinMerge(raw_sessions.initial_irclid) AS irclid,
                 toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
@@ -721,9 +775,6 @@ def WEB_BOUNCES_INSERT_SQL(
             mc_cid,
             igshid,
             ttclid,
-            epik,
-            qclid,
-            sccid,
             _kx,
             irclid,
             team_id,
@@ -737,7 +788,7 @@ def WEB_BOUNCES_INSERT_SQL(
             viewport_height
     )
     GROUP BY
-        day_bucket,
+        {bucket_column},
         team_id,
         entry_pathname,
         end_pathname,
@@ -765,9 +816,6 @@ def WEB_BOUNCES_INSERT_SQL(
         mc_cid,
         igshid,
         ttclid,
-        epik,
-        qclid,
-        sccid,
         _kx,
         irclid,
         host,


### PR DESCRIPTION
## Problem

So far we have been dealing with daily pre-aggregated data only, but after talking with @joshsny about [his RRC](https://github.com/PostHog/product-internal/pull/779), we think that having a hourly table will help us achieve our goals in a simpler way.

In order to minimize the resources used we're limiting the teams so we can test our solutions with the ones in beta. 

This also provides us with an alternative approach to https://github.com/PostHog/posthog/pull/32985, which combines current-day data for relative date periods in web analytics.

You can ask in Slack for more details on the resources comparison. 

## Changes

This is not the most DRY solution, but it gives us the foundation to make the POC work, it also minimizes the conflicts with the other branch I was working on for the [daily backfill](https://github.com/PostHog/posthog/compare/master...feat/generate-pre-agg-by-day)... So I promise I will refactor this afterwards :)

- Fixed a problem with missing attribution columns
- Added a new DAG definition for the hourly tables
- Created new hourly tables relying on Clickhouse TTL + ReplacingMergeTree, so this will only have a rolling 24h dataset, and we can replace the current-hour data on every 5min run.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
