### PR TITLE
fix(project-tree): shortcuts with slashes

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
@@ -243,7 +243,7 @@ export const projectTreeDataLogic = kea<projectTreeDataLogicType>([
                 },
                 addShortcutItem: async ({ item }) => {
                     const response = await api.fileSystemShortcuts.create({
-                        path: splitPath(item.path).pop() ?? 'Unnamed',
+                        path: joinPath([splitPath(item.path).pop() ?? 'Unnamed']),
                         type: item.type,
                         ref: item.ref,
                         href: item.href,


### PR DESCRIPTION
## Problem

You couldn't add files with slashes as shortcuts

## Changes

Fixed:

<img width="585" alt="image" src="https://github.com/user-attachments/assets/d9f26664-300e-4431-ad48-d9ede74a47e1" />
