### PR TITLE
chore: Use offline nodes for backups

### DIFF
--- a/dags/backups.py
+++ b/dags/backups.py
@@ -318,13 +318,13 @@ def run_backup(
         cluster.map_any_host_in_shards_by_role(
             {backup.shard: backup.create},
             node_role=NodeRole.DATA,
-            workload=Workload.ONLINE,
+            workload=Workload.OFFLINE,
         ).result()
     else:
         cluster.any_host_by_role(
             backup.create,
             node_role=NodeRole.DATA,
-            workload=Workload.ONLINE,
+            workload=Workload.OFFLINE,
         ).result()
 
     return backup
@@ -343,9 +343,9 @@ def wait_for_backup(
     def map_hosts(func: Callable[[Client], Any]):
         if backup.shard:
             return cluster.map_hosts_in_shard_by_role(
-                fn=func, shard_num=backup.shard, node_role=NodeRole.DATA, workload=Workload.ONLINE
+                fn=func, shard_num=backup.shard, node_role=NodeRole.DATA, workload=Workload.OFFLINE
             )
-        return cluster.map_hosts_by_role(fn=func, node_role=NodeRole.DATA, workload=Workload.ONLINE)
+        return cluster.map_hosts_by_role(fn=func, node_role=NodeRole.DATA, workload=Workload.OFFLINE)
 
     if backup:
         map_hosts(backup.wait).result().values()


### PR DESCRIPTION
## Problem

These cause high iowait on the online nodes and causes impact on user-facing workloads, so run them on offline instead. 

## Changes

Kinda sorta reverts #30386.

We'll likely need to provision more resources here (especially in EU) to manage impact on the offline pool.

## Did you write or update any docs for this change?

No docs needed for this change

## How did you test this code?

🙈 