### PR TITLE
feat: Make backup workload configurable, default to offline

### DIFF
--- a/dags/backups.py
+++ b/dags/backups.py
@@ -251,6 +251,7 @@ def get_latest_backup(
 @dagster.op
 def check_latest_backup_status(
     context: dagster.OpExecutionContext,
+    config: BackupConfig,
     latest_backup: Optional[Backup],
     cluster: dagster.ResourceParam[ClickhouseCluster],
 ) -> Optional[Backup]:
@@ -333,6 +334,7 @@ def run_backup(
 @dagster.op
 def wait_for_backup(
     context: dagster.OpExecutionContext,
+    config: BackupConfig,
     backup: Optional[Backup],
     cluster: dagster.ResourceParam[ClickhouseCluster],
 ):
@@ -416,8 +418,8 @@ def run_backup_request(table: str, incremental: bool) -> dagster.RunRequest:
         run_key=f"{timestamp}-{table}",
         run_config={
             "ops": {
-                "get_latest_backup": {"config": config.model_dump()},
-                "run_backup": {"config": config.model_dump()},
+                op.name: {"config": config.model_dump()}
+                for op in [get_latest_backup, run_backup, check_latest_backup_status, wait_for_backup]
             }
         },
         tags={

--- a/dags/backups.py
+++ b/dags/backups.py
@@ -423,7 +423,6 @@ def run_backup_request(table: str, incremental: bool) -> dagster.RunRequest:
         date=timestamp,
         table=table,
         incremental=incremental,
-        workload=Workload.ONLINE,
     )
     return dagster.RunRequest(
         run_key=f"{timestamp}-{table}",

--- a/dags/backups.py
+++ b/dags/backups.py
@@ -200,7 +200,7 @@ class BackupConfig(dagster.Config):
         pattern=r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$",
         validate_default=True,
     )
-    workload: Workload = Workload.ONLINE
+    workload: Workload = Workload.OFFLINE
 
 
 def get_most_recent_status(statuses: list[BackupStatus]) -> Optional[BackupStatus]:


### PR DESCRIPTION
## Problem

Backups cause high iowait on the nodes they are run on. When run on online nodes, this causes noticeable impact on user-facing workloads (slower performance, more errors, general instability and increased variance.)

## Changes

Run backups on offline instead by default.

Kinda sorta reverts #30386, at least in spirit. This keeps the workload configurable so that the existing tests can still be run on the CI cluster which only has a single online node.

We'll likely need to provision more resources here (especially in EU) to manage impact on the offline pool.

## Did you write or update any docs for this change?

No docs needed for this change

## How did you test this code?

Updated them