### PR TITLE
fix(nested-date-tokenization): Fix invalid array date parsing

### DIFF
--- a/posthog/hogql/transforms/test/test_state_aggregations.py
+++ b/posthog/hogql/transforms/test/test_state_aggregations.py
@@ -1022,7 +1022,7 @@ class TestStateTransformsIntegration(ClickhouseTestMixin, APIBaseTest):
             'recent' as data_source
         FROM events
         WHERE timestamp >= '2023-01-02'
-        ORDER BY data_source ASC
+        ORDER BY data_source DESC
         """
 
         original_query_ast = parse_select(original_query_str)

--- a/posthog/warehouse/models/test/test_table.py
+++ b/posthog/warehouse/models/test/test_table.py
@@ -209,6 +209,31 @@ class TestTable(BaseTest):
         assert list(table.hogql_definition().fields.keys()) == ["id", "timestamp-dash"]
         assert table.hogql_definition().structure == "`id` String, `timestamp-dash` DateTime64(3, 'UTC')"
 
+    def test_complex_type_with_array_nested_datetime_fields(self):
+        credential = DataWarehouseCredential.objects.create(access_key="test", access_secret="test", team=self.team)
+        table = DataWarehouseTable.objects.create(
+            name="bla",
+            url_pattern="https://databeach-hackathon.s3.amazonaws.com/peter_test/test_events6.pqt",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            team=self.team,
+            columns={
+                "id": {"clickhouse": "Nullable(String)", "hogql": "StringDatabaseField", "valid": True},
+                "nested": {
+                    "clickhouse": "Array(Tuple(url Nullable(String), date Tuple(member0 Nullable(DateTime64(6, 'UTC')), member1 Nullable(String)), text Nullable(String), type Nullable(String), email Nullable(String), field Tuple(id Nullable(String), _airbyte_additional_properties Map(String, Nullable(String))), choice Tuple(id Nullable(String), label Nullable(String), _airbyte_additional_properties Map(String, Nullable(String))), number Nullable(Float64), boolean Nullable(Bool), choices Tuple(ids Array(Nullable(String)), labels Array(Nullable(String)), _airbyte_additional_properties Map(String, Nullable(String))), payment Tuple(name Nullable(String), last4 Nullable(String), amount Nullable(String), success Nullable(Bool), _airbyte_additional_properties Map(String, Nullable(String))), file_url Nullable(String), phone_number Nullable(String), _airbyte_additional_properties Map(String, Nullable(String))))",
+                    "hogql": "StringArrayDatabaseField",
+                    "valid": True,
+                },
+            },
+            credential=credential,
+        )
+
+        definition = table.hogql_definition()
+        assert len(definition.fields) == 2
+        assert (
+            definition.structure
+            == "`id` Nullable(String), `nested` Array(Tuple( Nullable(String),  Tuple( Nullable(DateTime64(6, 'UTC')),  Nullable(String)),  Nullable(String),  Nullable(String),  Nullable(String),  Tuple( Nullable(String),  Map(String, Nullable(String))),  Tuple( Nullable(String),  Nullable(String),  Map(String, Nullable(String))),  Nullable(Float64),  Nullable(Bool),  Tuple( Array(Nullable(String)),  Array(Nullable(String)),  Map(String, Nullable(String))),  Tuple( Nullable(String),  Nullable(String),  Nullable(String),  Nullable(Bool),  Map(String, Nullable(String))),  Nullable(String),  Nullable(String),  Map(String, Nullable(String))))"
+        )
+
     def test_hogql_definition_tuple_patch(self):
         credential = DataWarehouseCredential.objects.create(access_key="test", access_secret="test", team=self.team)
         table = DataWarehouseTable.objects.create(


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem
When `DateTime64` and `DateTime32` type objects are nested inside of arrays, our translator from databases tables --> actual ClickHouse flavored SQL generates SQL that is not valid.

Before we would be generating SQL
```sql
SELECT
    id
FROM s3(
    'https://example-bucket.s3.amazonaws.com/path/to/files/*.parquet',
    'ACCESS_KEY_ID',
    'SECRET_ACCESS_KEY',
    'Parquet',
    '
        id Nullable(String),
        data Array(
            Tuple(
                Nullable(String),
                Tuple(
                    # invalid SQL we were trying to execute
                    Nullable(DateTime64(, \'\'))),
                    Nullable(String)
                )
            )
        )
    '
) AS response
LIMIT 100
SETTINGS
    allow_experimental_object_type = 1;
```

> Note: I'm relying on the tests here to make sure that this change is ok, it may need a rollback, but we are generating invalid SQL and trying to execute.

## Changes
- [x] Specific handling for these multi token expression in the tuple anonymizer function.
- [x] TDD test for this one.

## How did you test this code?
Test included
