### PR TITLE
fix(web-analytics): hourly data recreating tables

### DIFF
--- a/dags/definitions.py
+++ b/dags/definitions.py
@@ -74,7 +74,7 @@ defs = dagster.Definitions(
         backups.sharded_backup,
         backups.non_sharded_backup,
         web_preaggregated_internal.recreate_web_pre_aggregated_data_job,
-        web_preaggregated_hourly.recreate_web_pre_aggregated_hourly_data_job,
+        web_preaggregated_hourly.web_pre_aggregate_current_day_hourly_job,
     ],
     schedules=[
         exchange_rate.daily_exchange_rates_schedule,
@@ -87,7 +87,7 @@ defs = dagster.Definitions(
         backups.full_non_sharded_backup_schedule,
         backups.incremental_non_sharded_backup_schedule,
         web_preaggregated_internal.recreate_web_analytics_preaggregated_internal_data_daily,
-        web_preaggregated_hourly.recreate_web_analytics_preaggregated_hourly_data,
+        web_preaggregated_hourly.web_pre_aggregate_current_day_hourly_schedule,
     ],
     sensors=[
         deletes.run_deletes_after_squash,

--- a/dags/web_preaggregated_hourly.py
+++ b/dags/web_preaggregated_hourly.py
@@ -55,7 +55,7 @@ def pre_aggregate_web_analytics_hourly_data(
     # so this is just to make sure we get complete hours
     now = datetime.now(UTC)
     current_hour = now.replace(minute=0, second=0, microsecond=0)
-    date_end = current_hour.strftime("%Y-%m-%d %H:%M:%S")
+    date_end = (current_hour + timedelta(hours=1)).strftime("%Y-%m-%d %H:%M:%S")
     date_start = (current_hour - timedelta(hours=hours_back)).strftime("%Y-%m-%d %H:%M:%S")
 
     insert_query = sql_generator(
@@ -153,7 +153,7 @@ web_pre_aggregate_current_day_hourly_job = dagster.define_asset_job(
     execution_timezone="UTC",
     tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
 )
-def recreate_web_analytics_preaggregated_hourly_data(context: dagster.ScheduleEvaluationContext):
+def web_pre_aggregate_current_day_hourly_schedule(context: dagster.ScheduleEvaluationContext):
     """
     Creates real-time web analytics pre-aggregated data with 24h TTL for real-time analytics.
     Runs every 5 minutes and processes the last hour to handle late-arriving data.

--- a/dags/web_preaggregated_hourly.py
+++ b/dags/web_preaggregated_hourly.py
@@ -137,16 +137,19 @@ def web_stats_hourly(context: dagster.AssetExecutionContext) -> None:
     )
 
 
-recreate_web_pre_aggregated_hourly_data_job = dagster.define_asset_job(
-    name="recreate_web_pre_aggregated_hourly_data",
-    selection=dagster.AssetSelection.groups("web_analytics_hourly"),
+web_pre_aggregate_current_day_hourly_job = dagster.define_asset_job(
+    name="web_pre_aggregate_current_day_hourly_job",
+    selection=dagster.AssetSelection.assets(
+        "web_analytics_bounces_hourly",
+        "web_analytics_stats_table_hourly",
+    ),
     tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
 )
 
 
 @dagster.schedule(
-    cron_schedule="*/5 * * * *",  # Run every 5 minutes
-    job=recreate_web_pre_aggregated_hourly_data_job,
+    cron_schedule="*/10 * * * *",
+    job=web_pre_aggregate_current_day_hourly_job,
     execution_timezone="UTC",
     tags={"owner": JobOwners.TEAM_WEB_ANALYTICS.value},
 )


### PR DESCRIPTION
## Problem

Copy-pastad too much. 

https://github.com/PostHog/posthog/pull/33018 introduced hourly pre-aggregated tables, which, unlike their daily counterparts, should not be replaced on every run.

## Changes

- Selected the appropriate assets instead of recreating the whole group.

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Manually
