### PR TITLE
fix: query more than the first 100 responses on surveys

### DIFF
--- a/frontend/src/scenes/surveys/components/question-visualizations/SurveyQuestionVisualization.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/SurveyQuestionVisualization.tsx
@@ -167,7 +167,8 @@ function QuestionLoadingSkeleton({ question }: { question: SurveyQuestion }): JS
 }
 
 export function SurveyQuestionVisualization({ question, questionIndex }: Props): JSX.Element | null {
-    const { consolidatedSurveyResults, consolidatedSurveyResultsLoading } = useValues(surveyLogic)
+    const { consolidatedSurveyResults, consolidatedSurveyResultsLoading, surveyBaseStatsLoading } =
+        useValues(surveyLogic)
 
     if (!question.id || question.type === SurveyQuestionType.Link) {
         return null
@@ -176,7 +177,7 @@ export function SurveyQuestionVisualization({ question, questionIndex }: Props):
     const processedData: QuestionProcessedResponses | undefined =
         consolidatedSurveyResults?.responsesByQuestion[question.id]
 
-    if (consolidatedSurveyResultsLoading || !processedData) {
+    if (consolidatedSurveyResultsLoading || surveyBaseStatsLoading || !processedData) {
         return (
             <div className="flex flex-col gap-2">
                 <QuestionTitle question={question} questionIndex={questionIndex} />

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -16,6 +16,7 @@ import { urls } from 'scenes/urls'
 
 import { activationLogic, ActivationTask } from '~/layout/navigation-3000/sidepanel/panels/activation/activationLogic'
 import { refreshTreeItem } from '~/layout/panel-layout/ProjectTree/projectTreeLogic'
+import { MAX_SELECT_RETURNED_ROWS } from '~/queries/nodes/DataTable/DataTableExport'
 import { CompareFilter, DataTableNode, HogQLQuery, InsightVizNode, NodeKind } from '~/queries/schema/schema-general'
 import {
     AnyPropertyFilter,
@@ -415,9 +416,6 @@ function processResultsForSurveyQuestions(
 
     return responsesByQuestion
 }
-
-// Sync with posthog/hogql/constants.py
-export const MAX_SELECT_RETURNED_ROWS = 50000
 
 export const surveyLogic = kea<surveyLogicType>([
     props({} as SurveyLogicProps),

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -416,8 +416,8 @@ function processResultsForSurveyQuestions(
     return responsesByQuestion
 }
 
-// Limit for one query is 10000, source: https://posthog.com/questions/how-do-i-get-the-next-page-of-results-in-a-hog-ql-result-set-from-the-api
-const QUERY_RESPONSES_LIMIT = 10000
+// Sync with posthog/hogql/constants.py
+export const MAX_SELECT_RETURNED_ROWS = 50000
 
 export const surveyLogic = kea<surveyLogicType>([
     props({} as SurveyLogicProps),
@@ -1004,7 +1004,7 @@ export const surveyLogic = kea<surveyLogicType>([
         },
         consolidatedSurveyResults: {
             loadConsolidatedSurveyResults: async (
-                limit = QUERY_RESPONSES_LIMIT
+                limit = MAX_SELECT_RETURNED_ROWS
             ): Promise<ConsolidatedSurveyResults> => {
                 if (props.id === NEW_SURVEY.id || !values.survey?.start_date) {
                     return { responsesByQuestion: {} }

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -1009,8 +1009,7 @@ export const surveyLogic = kea<surveyLogicType>([
                 // Also get distinct_id and person properties for open text questions
                 const query: HogQLQuery = {
                     kind: NodeKind.HogQLQuery,
-                    query: `
-                        -- QUERYING ALL SURVEY RESPONSES IN ONE GO
+                    query: `-- QUERYING ALL SURVEY RESPONSES IN ONE GO
                         SELECT
                             ${questionFields.join(',\n')},
                             person.properties,
@@ -1022,6 +1021,7 @@ export const surveyLogic = kea<surveyLogicType>([
                             ${values.answerFilterHogQLExpression}
                             ${values.partialResponsesFilter}
                             AND {filters}
+                        LIMIT 10000
                     `,
                     filters: {
                         properties: values.propertyFilters,

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -416,6 +416,9 @@ function processResultsForSurveyQuestions(
     return responsesByQuestion
 }
 
+// Limit for one query is 10000, source: https://posthog.com/questions/how-do-i-get-the-next-page-of-results-in-a-hog-ql-result-set-from-the-api
+const QUERY_RESPONSES_LIMIT = 10000
+
 export const surveyLogic = kea<surveyLogicType>([
     props({} as SurveyLogicProps),
     key(({ id }) => id),
@@ -1000,7 +1003,9 @@ export const surveyLogic = kea<surveyLogicType>([
             },
         },
         consolidatedSurveyResults: {
-            loadConsolidatedSurveyResults: async (limit = 1000): Promise<ConsolidatedSurveyResults> => {
+            loadConsolidatedSurveyResults: async (
+                limit = QUERY_RESPONSES_LIMIT
+            ): Promise<ConsolidatedSurveyResults> => {
                 if (props.id === NEW_SURVEY.id || !values.survey?.start_date) {
                     return { responsesByQuestion: {} }
                 }

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -1030,6 +1030,7 @@ export const surveyLogic = kea<surveyLogicType>([
                             ${values.answerFilterHogQLExpression}
                             ${values.partialResponsesFilter}
                             AND {filters}
+                        ORDER BY events.timestamp DESC
                         LIMIT ${limit}
                     `,
                     filters: {


### PR DESCRIPTION
right now, our question viz tools are limited to 100 responses due to not setting an explicit limit. changing it so instead it uses the number of `survey sent` events.

[should fix the issue described here too](https://posthog.slack.com/archives/C08NXBEL4LA/p1748890225201449)