### PR TITLE
fix: remove top bar zindex covering nav

### DIFF
--- a/frontend/src/layout/navigation-3000/components/TopBar.scss
+++ b/frontend/src/layout/navigation-3000/components/TopBar.scss
@@ -4,7 +4,6 @@
     position: sticky;
     top: 0;
     z-index: var(--z-top-navigation);
-    z-index: 1000;
     display: flex;
     align-items: start;
     height: var(--breadcrumbs-height-full);


### PR DESCRIPTION
## Problem
A Survey preview PR introduced a `zindex: 1000` for the `topBar` which covers the new nav

https://github.com/PostHog/posthog/pull/32292#issuecomment-2889897109

![2025-06-02 23 52 37](https://github.com/user-attachments/assets/68ed1027-9784-472f-9262-299dd95ac112)

## Changes
Remove this 

## How did you test this code?
Manually — removing this z-index seems doesn't seem to affect survey previews
Checked in: notebooks (adding survey there)
Checked in: Surveys > settings > full screen preview
Checked in: Surveys > Edit id

Can't reproduce the issue where the `topbar` covers the survey preview...