### PR TITLE
fix: dont skip first rating data

### DIFF
--- a/frontend/src/scenes/surveys/components/question-visualizations/RatingQuestionViz.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/RatingQuestionViz.tsx
@@ -378,10 +378,6 @@ export function RatingQuestionViz({ question, questionIndex, processedData }: Pr
     const barColor = CHART_INSIGHTS_COLORS[0]
 
     const { data } = processedData
-
-    // if scale is not 10, we need to skip the 0
-    const normalizeScaleData = question.scale !== 10 ? data.slice(1) : data
-
     const npsBreakdown = calculateNpsBreakdownFromProcessedData(processedData)
 
     return (
@@ -409,7 +405,7 @@ export function RatingQuestionViz({ question, questionIndex, processedData }: Pr
                                         label: 'Number of responses',
                                         barPercentage: 0.8,
                                         minBarLength: 2,
-                                        data: normalizeScaleData.map((d) => d.value),
+                                        data: data.map((d) => d.value),
                                         backgroundColor: barColor,
                                         borderColor: barColor,
                                         hoverBackgroundColor: barColor,


### PR DESCRIPTION
only the scale should change (including 0 depending if scale is 10 or not). but all data should be read instead of slicing the first one for scale ≠ 10.

[will fix this internal ticket](https://posthoghelp.zendesk.com/agent/tickets/31825)