### PR TITLE
chore: dont use loading toast for new question viz

### DIFF
--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -465,7 +465,7 @@ export function SurveyResult({ disableEventsTable }: { disableEventsTable?: bool
 
     const atLeastOneResponse = !!processedSurveyStats?.[SurveyEventName.SENT].total_count
 
-    if (isAnyResultsLoading) {
+    if (isAnyResultsLoading && !isNewQuestionVizEnabled) {
         lemonToast.info('Loading survey results...', {
             toastId: LOADING_SURVEY_RESULTS_TOAST_ID,
             hideProgressBar: true,


### PR DESCRIPTION
new question viz has dedicated loading skeletons for all charts, so no need for this. it was a quick workaround for the older question visualizations which had a poor loading UX.