### PR TITLE
feat(logs): fix comparisons with numeric types

### DIFF
--- a/posthog/clickhouse/property_groups.py
+++ b/posthog/clickhouse/property_groups.py
@@ -210,12 +210,24 @@ property_groups = PropertyGroupManager(
         },
         "logs": {
             "attributes": {
-                "custom": PropertyGroupDefinition(
-                    "true",
-                    lambda key: True,
+                "str": PropertyGroupDefinition(
+                    "key like '%__str'",
+                    lambda key: key.endswith("__str"),
                     column_type_name="map",
                     is_materialized=False,
-                )
+                ),
+                "float": PropertyGroupDefinition(
+                    "key like '%__float'",
+                    lambda key: key.endswith("__float"),
+                    column_type_name="map",
+                    is_materialized=False,
+                ),
+                "datetime": PropertyGroupDefinition(
+                    "key like '%__datetime'",
+                    lambda key: key.endswith("__datetime"),
+                    column_type_name="map",
+                    is_materialized=False,
+                ),
             }
         },
     }

--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -35,6 +35,34 @@ class LogsQueryRunner(QueryRunner):
             offset=self.query.offset,
         )
 
+        def get_property_type(value):
+            try:
+                value = float(value)
+                return "float"
+            except ValueError:
+                pass
+            # todo: datetime?
+            return "str"
+
+        if len(self.query.filterGroup.values) > 0:
+            # dynamically detect type of the given property values
+            # if they all convert cleanly to float, use the __float property mapping instead
+            # we keep multiple attribute maps for different types:
+            # attribute_map_str
+            # attribute_map_float
+            # attribute_map_datetime
+            #
+            # for now we'll just check str and float as we need a decent UI for datetime filtering.
+            for property_filter in self.query.filterGroup.values[0].values:
+                property_type = "str"
+                if property_filter.value:
+                    property_types = {get_property_type(v) for v in property_filter.value}
+                    # only use the detected type if all given values have the same type
+                    # e.g. if values are '1', '2', we can use float, if values are '1', 'a', stick to str
+                    if len(property_types) == 1:
+                        property_type = property_types.pop()
+                property_filter.key += f"__{property_type}"
+
     def calculate(self) -> LogsQueryResponse:
         self.modifiers.convertToProjectTimezone = False
         self.modifiers.propertyGroupsMode = PropertyGroupsMode.OPTIMIZED


### PR DESCRIPTION
## Problem
previously if you filtered on e.g. > 1000 it would return results including things like '239.3' because '239.3' > '1000' when comparing strings.

in clickhouse i've added separate attribute maps for different types, but adding suffixes to attribute names we can use property groups to dynamically choose which map to use

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
