### PR TITLE
fix: team id querying silliness

### DIFF
--- a/posthog/session_recordings/session_recording_v2_service.py
+++ b/posthog/session_recordings/session_recording_v2_service.py
@@ -24,7 +24,9 @@ ONE_DAY_IN_SECONDS = 24 * 60 * 60
 
 def listing_cache_key(recording: SessionRecording) -> str | None:
     try:
-        return f"@posthog/v2-blob-snapshots/recording_block_listing_{recording.team.id}_{recording.session_id}"
+        # NB this has to be `team_id` and not `team.id` as it's called in an async context
+        # and `team.id` can trigger a database query, and the Django ORM is synchronous
+        return f"@posthog/v2-blob-snapshots/recording_block_listing_{recording.team_id}_{recording.session_id}"
     except Exception as e:
         posthoganalytics.capture_exception(
             e,


### PR DESCRIPTION
we're reading `recording.team.id` which if in Django ORM context can trigger a query

we're sometimes doing that in an async context

which the Django ORM doesn't like, so for some recordings this caching is throwing

the fix is to `_` not `.` between team and id - since the django orm always makes that available and it's all we need 🤯