### PR TITLE
feat: measure heap usage of the app

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -280,6 +280,7 @@ export const FEATURE_FLAGS = {
     SCREENSHOT_EDITOR: 'screenshot-editor', // owner: @veryayskiy #team-replay
     ACTIVITY_OR_EXPLORE: 'activity-or-explore', // owner: @pauldambra #team-replay
     EXPERIMENTS_NEW_QUERY_RUNNER_FOR_USERS_ON_FREE_PLAN: 'experiments-new-query-runner-for-users-on-free-plan', // owner: #team-experiments
+    TRACK_MEMORY_USAGE: 'track-memory-usage', // owner: @pauldambra #team-replay
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -38,14 +38,16 @@ export function loadPostHogJS(): void {
                 } else {
                     loadedInstance.opt_in_capturing()
 
-                    setInterval(() => {
-                        const memory = (window.performance as any).memory
-                        if (memory) {
-                            loadedInstance.capture('memory_usage', {
-                                memory,
-                            })
-                        }
-                    }, 60000)
+                    if (loadedInstance.getFeatureFlag(FEATURE_FLAGS.TRACK_MEMORY_USAGE)) {
+                        setInterval(() => {
+                            const memory = (window.performance as any).memory
+                            if (memory) {
+                                loadedInstance.capture('memory_usage', {
+                                    memory,
+                                })
+                            }
+                        }, 60000)
+                    }
                 }
 
                 const Cypress = (window as WindowWithCypressCaptures).Cypress

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -39,14 +39,18 @@ export function loadPostHogJS(): void {
                     loadedInstance.opt_in_capturing()
 
                     if (loadedInstance.getFeatureFlag(FEATURE_FLAGS.TRACK_MEMORY_USAGE)) {
+                        const oneMinuteInMs = 60000
                         setInterval(() => {
+                            // this is deprecated, and not available in all browsers
+                            // but the supposed standard at https://developer.mozilla.org/en-US/docs/Web/API/Performance/measureUserAgentSpecificMemory
+                            // isn't available in Chrome even so 🤷
                             const memory = (window.performance as any).memory
-                            if (memory) {
+                            if (memory && memory.usedJSHeapSize) {
                                 loadedInstance.capture('memory_usage', {
                                     memory,
                                 })
                             }
-                        }, 60000)
+                        }, oneMinuteInMs)
                     }
                 }
 

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -39,15 +39,22 @@ export function loadPostHogJS(): void {
                     loadedInstance.opt_in_capturing()
 
                     if (loadedInstance.getFeatureFlag(FEATURE_FLAGS.TRACK_MEMORY_USAGE)) {
+                        // no point in tracking memory if it's not available
+                        const hasMemory = 'memory' in window.performance
+                        if (!hasMemory) {
+                            return
+                        }
+
                         const oneMinuteInMs = 60000
                         setInterval(() => {
-                            // this is deprecated, and not available in all browsers
+                            // this is deprecated and not available in all browsers,
                             // but the supposed standard at https://developer.mozilla.org/en-US/docs/Web/API/Performance/measureUserAgentSpecificMemory
                             // isn't available in Chrome even so 🤷
                             const memory = (window.performance as any).memory
                             if (memory && memory.usedJSHeapSize) {
                                 loadedInstance.capture('memory_usage', {
-                                    memory,
+                                    totalJSHeapSize: memory.totalJSHeapSize,
+                                    usedJSHeapSize: memory.usedJSHeapSize,
                                 })
                             }
                         }, oneMinuteInMs)

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -57,6 +57,15 @@ export function loadPostHogJS(): void {
                     loadedInstance.sessionManager?.resetSessionId()
                 }
 
+                setInterval(() => {
+                    const memory = (window.performance as any).memory
+                    if (memory) {
+                        loadedInstance.capture('memory_usage', {
+                            memory,
+                        })
+                    }
+                }, 60000)
+
                 // Make sure we have access to the object in window for debugging
                 window.posthog = loadedInstance
             },

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -37,6 +37,15 @@ export function loadPostHogJS(): void {
                     loadedInstance.opt_out_capturing()
                 } else {
                     loadedInstance.opt_in_capturing()
+
+                    setInterval(() => {
+                        const memory = (window.performance as any).memory
+                        if (memory) {
+                            loadedInstance.capture('memory_usage', {
+                                memory,
+                            })
+                        }
+                    }, 60000)
                 }
 
                 const Cypress = (window as WindowWithCypressCaptures).Cypress
@@ -56,15 +65,6 @@ export function loadPostHogJS(): void {
                 if (shouldResetSessionOnLoad) {
                     loadedInstance.sessionManager?.resetSessionId()
                 }
-
-                setInterval(() => {
-                    const memory = (window.performance as any).memory
-                    if (memory) {
-                        loadedInstance.capture('memory_usage', {
-                            memory,
-                        })
-                    }
-                }, 60000)
 
                 // Make sure we have access to the object in window for debugging
                 window.posthog = loadedInstance


### PR DESCRIPTION
not all browser provide this
and we don't want a tonne of data
but it's frustrating to keep asking users to tell me if we've fixed RAM issues

so, behind a flag, let's capture usage once a minute in browsers that support it

Related to #32479
