### PR TITLE
fix(project-tree): rename "data" to "metadata"

### DIFF
--- a/common/esbuilder/utils.mjs
+++ b/common/esbuilder/utils.mjs
@@ -564,7 +564,7 @@ export function gatherProductManifests(__dirname) {
     const fileSystemTypes = []
     const treeItemsNew = {}
     const treeItemsGames = {}
-    const treeItemsDataManagement = {}
+    const treeItemsMetadata = {}
     const treeItemsProducts = {}
 
     const sourceFiles = []
@@ -676,7 +676,7 @@ export function gatherProductManifests(__dirname) {
             } else if (
                 ts.isPropertyAssignment(node) &&
                 ts.isArrayLiteralExpression(node.initializer) &&
-                (node.name.text === 'treeItemsProducts' || node.name.text === 'treeItemsDataManagement' || node.name.text === 'treeItemsGames')
+                (node.name.text === 'treeItemsProducts' || node.name.text === 'treeItemsMetadata' || node.name.text === 'treeItemsGames')
             ) {
                 for (const element of node.initializer.elements) {
                     if (ts.isObjectLiteralExpression(element)) {
@@ -685,8 +685,8 @@ export function gatherProductManifests(__dirname) {
                         if (path) {
                             if (node.name.text === 'treeItemsProducts') {
                                 treeItemsProducts[path] = cloneNode(element)
-                            } else if (node.name.text === 'treeItemsDataManagement') {
-                                treeItemsDataManagement[path] = cloneNode(element)
+                            } else if (node.name.text === 'treeItemsMetadata') {
+                                treeItemsMetadata[path] = cloneNode(element)
                             } else {
                                 treeItemsGames[path] = cloneNode(element)
                             }
@@ -765,12 +765,12 @@ export function gatherProductManifests(__dirname) {
         ),
         sourceFile
     )
-    const manifestTreeItemsDataManagement = printer.printNode(
+    const manifestTreeItemsMetadata = printer.printNode(
         ts.EmitHint.Unspecified,
         ts.factory.createArrayLiteralExpression(
-            Object.keys(treeItemsDataManagement)
+            Object.keys(treeItemsMetadata)
                 .sort()
-                .map((key) => treeItemsDataManagement[key])
+                .map((key) => treeItemsMetadata[key])
         ),
         sourceFile
     )
@@ -815,7 +815,7 @@ export function gatherProductManifests(__dirname) {
         ${autogenComment}
         export const getTreeItemsGames = (): FileSystemImport[] => ${manifestTreeItemsGames}\n
         ${autogenComment}
-        export const getTreeItemsDataManagement = (): FileSystemImport[] => ${manifestTreeItemsDataManagement}\n
+        export const getTreeItemsMetadata = (): FileSystemImport[] => ${manifestTreeItemsMetadata}\n
     `
 
     // safe temporary path in /tmp

--- a/frontend/src/layout/panel-layout/PanelLayout.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayout.tsx
@@ -162,8 +162,8 @@ export function PanelLayout({ mainRef }: { mainRef: React.RefObject<HTMLElement>
                     {activePanelIdentifier === 'Shortcuts' && (
                         <ProjectTree root="shortcuts://" searchPlaceholder="Search your shortcuts" />
                     )}
-                    {activePanelIdentifier === 'Data' && (
-                        <ProjectTree root="data-management://" searchPlaceholder="Search data" />
+                    {activePanelIdentifier === 'Metadata' && (
+                        <ProjectTree root="metadata://" searchPlaceholder="Search metadata" />
                     )}
                     {activePanelIdentifier === 'People' && (
                         <ProjectTree root="persons://" searchPlaceholder="Search persons" />

--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -196,16 +196,15 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
             },
         },
         {
-            identifier: 'Data',
-            id: 'Data',
+            identifier: 'Metadata',
+            id: 'Metadata',
             icon: <IconDatabase />,
             onClick: (e?: React.KeyboardEvent) => {
                 if (!e || e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowRight') {
-                    handlePanelTriggerClick('Data')
+                    handlePanelTriggerClick('Metadata')
                 }
             },
             showChevron: true,
-            tooltip: isLayoutPanelVisible && activePanelIdentifier === 'Data' ? 'Close data' : 'Open data',
         },
         {
             identifier: 'People',
@@ -217,7 +216,6 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
                 }
             },
             showChevron: true,
-            tooltip: isLayoutPanelVisible && activePanelIdentifier === 'People' ? 'Close people' : 'Open people',
             tooltipDocLink: 'https://posthog.com/docs/data/persons',
         },
         {
@@ -230,7 +228,6 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
                 }
             },
             showChevron: true,
-            tooltip: isLayoutPanelVisible && activePanelIdentifier === 'Products' ? 'Close products' : 'Open products',
         },
         {
             identifier: 'Activity',
@@ -253,8 +250,6 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
                 }
             },
             showChevron: true,
-            tooltip:
-                isLayoutPanelVisible && activePanelIdentifier === 'Shortcuts' ? 'Close shortcuts' : 'Open shortcuts',
         },
     ]
 

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -617,7 +617,7 @@ export function ProjectTree({
             renderItemTooltip={(item) => {
                 const user = item.record?.user as UserBasicType | undefined
                 const nameNode: JSX.Element = <span className="font-semibold">{item.displayName}</span>
-                if (root === 'products://' || root === 'data-management://' || root === 'persons://') {
+                if (root === 'products://' || root === 'metadata://' || root === 'persons://') {
                     return <>View {nameNode}</>
                 }
                 if (root === 'new://') {

--- a/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
@@ -27,8 +27,8 @@ import { urls } from 'scenes/urls'
 
 import {
     fileSystemTypes,
-    getTreeItemsDataManagement,
     getTreeItemsGames,
+    getTreeItemsMetadata,
     getTreeItemsNew,
     getTreeItemsProducts,
 } from '~/products'
@@ -204,8 +204,8 @@ export const getDefaultTreeNew = (): FileSystemImport[] =>
         },
     ].sort((a, b) => a.path.localeCompare(b.path, undefined, { sensitivity: 'accent' }))
 
-export const getDefaultTreeDataManagement = (): FileSystemImport[] => [
-    ...getTreeItemsDataManagement(),
+export const getDefaultTreeMetadata = (): FileSystemImport[] => [
+    ...getTreeItemsMetadata(),
     {
         path: 'Event definitions',
         iconType: 'definitions',

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
@@ -10,7 +10,7 @@ import { urls } from 'scenes/urls'
 
 import { breadcrumbsLogic } from '~/layout/navigation/Breadcrumbs/breadcrumbsLogic'
 import {
-    getDefaultTreeDataManagement,
+    getDefaultTreeMetadata,
     getDefaultTreeNew,
     getDefaultTreePersons,
     getDefaultTreeProducts,
@@ -592,7 +592,7 @@ export const projectTreeDataLogic = kea<projectTreeDataLogicType>([
                 return function getStaticItems(searchTerm: string, onlyFolders: boolean): TreeDataItem[] {
                     const data: [string, FileSystemImport[]][] = [
                         ['products://', getDefaultTreeProducts()],
-                        ['data-management://', getDefaultTreeDataManagement()],
+                        ['metadata://', getDefaultTreeMetadata()],
                         ['persons://', [...getDefaultTreePersons(), ...groupItems]],
                         ['new://', getDefaultTreeNew()],
                         ['shortcuts://', shortcutData],

--- a/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
+++ b/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
@@ -4,7 +4,7 @@ import { LemonTreeRef } from 'lib/lemon-ui/LemonTree/LemonTree'
 import { navigation3000Logic } from '../navigation-3000/navigationLogic'
 import type { panelLayoutLogicType } from './panelLayoutLogicType'
 
-export type PanelLayoutNavIdentifier = 'Project' | 'Products' | 'People' | 'Games' | 'Shortcuts' | 'Data'
+export type PanelLayoutNavIdentifier = 'Project' | 'Products' | 'People' | 'Games' | 'Shortcuts' | 'Metadata'
 export type PanelLayoutTreeRef = React.RefObject<LemonTreeRef> | null
 export type PanelLayoutMainContentRef = React.RefObject<HTMLElement> | null
 export const PANEL_LAYOUT_DEFAULT_WIDTH: number = 320

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -586,7 +586,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
 export const getTreeItemsGames = (): FileSystemImport[] => [{ path: '368 Hedgehogs', href: urls.game368hedgehogs() }]
 
 /** This const is auto-generated, as is the whole file */
-export const getTreeItemsDataManagement = (): FileSystemImport[] => [
+export const getTreeItemsMetadata = (): FileSystemImport[] => [
     { path: 'Actions', iconType: 'rocket', href: urls.actions() },
     { path: 'Revenue settings', iconType: 'handMoney', href: urls.revenueSettings() },
 ]

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5446,7 +5446,7 @@ export interface ProductManifest {
     treeItemsNew?: FileSystemImport[]
     treeItemsProducts?: FileSystemImport[]
     treeItemsGames?: FileSystemImport[]
-    treeItemsDataManagement?: FileSystemImport[]
+    treeItemsMetadata?: FileSystemImport[]
 }
 
 export interface ProjectTreeRef {

--- a/products/actions/manifest.tsx
+++ b/products/actions/manifest.tsx
@@ -29,7 +29,7 @@ export const manifest: ProductManifest = {
             href: urls.createAction(),
         },
     ],
-    treeItemsDataManagement: [
+    treeItemsMetadata: [
         {
             path: 'Actions',
             iconType: 'rocket',

--- a/products/cohorts/manifest.tsx
+++ b/products/cohorts/manifest.tsx
@@ -25,5 +25,5 @@ export const manifest: ProductManifest = {
         },
     ],
     treeItemsProducts: [],
-    treeItemsDataManagement: [],
+    treeItemsMetadata: [],
 }

--- a/products/revenue_analytics/manifest.tsx
+++ b/products/revenue_analytics/manifest.tsx
@@ -29,7 +29,7 @@ export const manifest: ProductManifest = {
             tags: ['beta'],
         },
     ],
-    treeItemsDataManagement: [
+    treeItemsMetadata: [
         {
             path: 'Revenue settings',
             iconType: 'handMoney',


### PR DESCRIPTION
## Problem

The tab "Data" is unintuitive, as it doesn't actually contain data from your database, but the data that describes your data. In the industry we call this kind of data... "Metadata"

## Changes

Rename the panel to say "Metadata"

![image](https://github.com/user-attachments/assets/e74f3903-5c1f-4842-b78b-e09585f75ae4)

## How did you test this code?

👀 