### PR TITLE
feat(batch-exports): Configure virtual style addressing in S3

### DIFF
--- a/frontend/src/scenes/pipeline/batch-exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/pipeline/batch-exports/BatchExportEditForm.tsx
@@ -218,6 +218,24 @@ export function BatchExportsEditFields({
                         >
                             <LemonInput placeholder={isNew ? 'e.g. https://your-minio-host:9000' : 'Leave unchanged'} />
                         </LemonField>
+
+                        <LemonField
+                            name="use_virtual_style_addressing"
+                            label="Virtual style addressing"
+                            showOptional
+                            info={
+                                <>
+                                    Some non-AWS S3-compatible destinations may require this setting enabled. Check your
+                                    destination's documentation if "virtual hosted style" is required, otherwise leave
+                                    unchecked
+                                </>
+                            }
+                        >
+                            <LemonCheckbox
+                                bordered
+                                label={<span className="flex items-center gap-2">Use virtual style addressing</span>}
+                            />
+                        </LemonField>
                     </>
                 ) : batchExportConfigForm.destination === 'Snowflake' ? (
                     <>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4628,6 +4628,7 @@ export type BatchExportServiceS3 = {
         endpoint_url: string | null
         file_format: string
         max_file_size_mb: number | null
+        use_virtual_style_addressing: boolean
     }
 }
 

--- a/posthog/api/test/batch_exports/test_create.py
+++ b/posthog/api/test/batch_exports/test_create.py
@@ -39,6 +39,7 @@ def test_create_batch_export_with_interval_schedule(client: HttpClient, interval
             "prefix": "posthog-events/",
             "aws_access_key_id": "abc123",
             "aws_secret_access_key": "secret",
+            "use_virtual_style_addressing": True,
         },
     }
 
@@ -123,6 +124,7 @@ def test_create_batch_export_with_interval_schedule(client: HttpClient, interval
         assert args["prefix"] == "posthog-events/"
         assert args["aws_access_key_id"] == "abc123"
         assert args["aws_secret_access_key"] == "secret"
+        assert args["use_virtual_style_addressing"]
 
 
 @pytest.mark.parametrize(

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -155,6 +155,7 @@ class S3BatchExportInputs(BaseBatchExportInputs):
     endpoint_url: str | None = None
     file_format: str = "JSONLines"
     max_file_size_mb: int | None = None
+    use_virtual_style_addressing: bool = False
 
     def __post_init__(self):
         if self.max_file_size_mb:


### PR DESCRIPTION
## Problem

Some non-AWS but S3-compatible destinations require virtual style host
addressing. This is configured in the boto3 client, but we currently
have no way to set this configuration.

## Changes

This PR adds a new setting to both the UI and the backend to allow
configuring this specific setting to unblock users.

In the future, we could expand this to support the full breadth of
configuration options, but for the time being we only need this, so
I've kept the changes focused.