### PR TITLE
fix(data-warehouse): Increase the page size of the saved query list endpoint

### DIFF
--- a/posthog/warehouse/api/saved_query.py
+++ b/posthog/warehouse/api/saved_query.py
@@ -50,6 +50,7 @@ from posthog.warehouse.data_load.saved_query_service import (
     recreate_model_paths,
 )
 from rest_framework.response import Response
+from rest_framework.pagination import PageNumberPagination
 import uuid
 
 logger = structlog.get_logger(__name__)
@@ -356,6 +357,10 @@ class DataWarehouseSavedQuerySerializer(serializers.ModelSerializer):
         return name
 
 
+class DataWarehouseSavedQueryPagination(PageNumberPagination):
+    page_size = 1000
+
+
 class DataWarehouseSavedQueryViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     """
     Create, Read, Update and Delete Warehouse Tables.
@@ -364,6 +369,7 @@ class DataWarehouseSavedQueryViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewS
     scope_object = "warehouse_view"
     queryset = DataWarehouseSavedQuery.objects.all()
     serializer_class = DataWarehouseSavedQuerySerializer
+    pagination_class = DataWarehouseSavedQueryPagination
     filter_backends = [filters.SearchFilter]
     search_fields = ["name"]
     ordering = "-created_at"

--- a/posthog/warehouse/api/test/test_saved_query.py
+++ b/posthog/warehouse/api/test/test_saved_query.py
@@ -170,6 +170,27 @@ class TestSavedQuery(APIBaseTest):
 
         assert json["count"] == 1
 
+    def test_listing_many_queries(self):
+        for i in range(150):
+            DataWarehouseSavedQuery.objects.create(
+                team=self.team,
+                name=f"saved_query_{i}",
+                query={
+                    "kind": "HogQLQuery",
+                    "query": "select event as event from events LIMIT 100",
+                },
+            )
+
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/warehouse_saved_queries/",
+        )
+
+        assert response.status_code == 200
+        json = response.json()
+
+        assert json["count"] == 150
+        assert len(json["results"]) == 150
+
     def test_get_deleted_query(self):
         query = DataWarehouseSavedQuery.objects.create(
             team=self.team,


### PR DESCRIPTION
## Problem
- If you have more than 100 saved views, the rest dont get returned to the frontend
- Increase the page limit to 1000 instead 
