### PR TITLE
feat(cdp): Only load sparkline if in view

### DIFF
--- a/frontend/src/scenes/hog-functions/metrics/HogFunctionMetricsSparkline.tsx
+++ b/frontend/src/scenes/hog-functions/metrics/HogFunctionMetricsSparkline.tsx
@@ -32,6 +32,12 @@ export function HogFunctionMetricSparkLine({ id }: HogFunctionMetricsLogicProps)
         },
     ]
 
+    const isInStorybook = document.body.classList.contains('storybook-test-runner')
+
+    if (isInStorybook) {
+        return <div className="h-8 max-w-24 bg-surface-secondary" />
+    }
+
     return (
         <div ref={inViewRef}>
             {!inView || !appMetrics || appMetricsLoading ? (

--- a/frontend/src/scenes/hog-functions/metrics/HogFunctionMetricsSparkline.tsx
+++ b/frontend/src/scenes/hog-functions/metrics/HogFunctionMetricsSparkline.tsx
@@ -38,7 +38,7 @@ export function HogFunctionMetricSparkLine({ id }: HogFunctionMetricsLogicProps)
                 <LemonSkeleton className="h-8 max-w-24" />
             ) : (
                 <Sparkline
-                    labels={appMetrics?.labels}
+                    labels={appMetrics.labels}
                     data={displayData}
                     className="h-8 max-w-24"
                     maximumIndicator={false}

--- a/frontend/src/scenes/hog-functions/metrics/HogFunctionMetricsSparkline.tsx
+++ b/frontend/src/scenes/hog-functions/metrics/HogFunctionMetricsSparkline.tsx
@@ -10,14 +10,14 @@ export function HogFunctionMetricSparkLine({ id }: HogFunctionMetricsLogicProps)
     const logic = hogFunctionMetricsLogic({ id })
     const { appMetrics, appMetricsLoading } = useValues(logic)
     const { loadMetrics } = useActions(logic)
-
     const { ref: inViewRef, inView } = useInView()
+    const isInStorybook = document.body.classList.contains('storybook-test-runner')
 
     useEffect(() => {
-        if (inView && !appMetrics && !appMetricsLoading) {
+        if (isInStorybook || (inView && !appMetrics && !appMetricsLoading)) {
             loadMetrics()
         }
-    }, [inView])
+    }, [inView, isInStorybook])
 
     const displayData: SparklineTimeSeries[] = [
         {
@@ -31,12 +31,6 @@ export function HogFunctionMetricSparkLine({ id }: HogFunctionMetricsLogicProps)
             values: appMetrics?.series.find((s) => s.name === 'failed')?.values || [],
         },
     ]
-
-    const isInStorybook = document.body.classList.contains('storybook-test-runner')
-
-    if (isInStorybook) {
-        return <div className="h-8 max-w-24 bg-surface-secondary" />
-    }
 
     return (
         <div ref={inViewRef}>

--- a/frontend/src/scenes/hog-functions/metrics/HogFunctionMetricsSparkline.tsx
+++ b/frontend/src/scenes/hog-functions/metrics/HogFunctionMetricsSparkline.tsx
@@ -38,7 +38,6 @@ export function HogFunctionMetricSparkLine({ id }: HogFunctionMetricsLogicProps)
                 <LemonSkeleton className="h-8 max-w-24" />
             ) : (
                 <Sparkline
-                    loading={appMetricsLoading}
                     labels={appMetrics?.labels}
                     data={displayData}
                     className="h-8 max-w-24"

--- a/frontend/src/scenes/hog-functions/metrics/HogFunctionMetricsSparkline.tsx
+++ b/frontend/src/scenes/hog-functions/metrics/HogFunctionMetricsSparkline.tsx
@@ -1,6 +1,7 @@
 import { LemonSkeleton } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { Sparkline, SparklineTimeSeries } from 'lib/components/Sparkline'
+import { inStorybookTestRunner } from 'lib/utils'
 import { useEffect } from 'react'
 import { useInView } from 'react-intersection-observer'
 
@@ -11,13 +12,12 @@ export function HogFunctionMetricSparkLine({ id }: HogFunctionMetricsLogicProps)
     const { appMetrics, appMetricsLoading } = useValues(logic)
     const { loadMetrics } = useActions(logic)
     const { ref: inViewRef, inView } = useInView()
-    const isInStorybook = document.body.classList.contains('storybook-test-runner')
 
     useEffect(() => {
-        if (isInStorybook || (inView && !appMetrics && !appMetricsLoading)) {
+        if (inStorybookTestRunner() || (inView && !appMetrics && !appMetricsLoading)) {
             loadMetrics()
         }
-    }, [inView, isInStorybook])
+    }, [inView])
 
     const displayData: SparklineTimeSeries[] = [
         {

--- a/frontend/src/scenes/pipeline/AppMetricSparkLine.tsx
+++ b/frontend/src/scenes/pipeline/AppMetricSparkLine.tsx
@@ -1,12 +1,22 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { Sparkline, SparklineTimeSeries } from 'lib/components/Sparkline'
+import { useEffect } from 'react'
+import { useInView } from 'react-intersection-observer'
 
 import { pipelineNodeMetricsLogic } from './pipelineNodeMetricsLogic'
 import { PipelineNode } from './types'
 
 export function AppMetricSparkLine({ pipelineNode }: { pipelineNode: PipelineNode }): JSX.Element {
     const logic = pipelineNodeMetricsLogic({ id: pipelineNode.id })
-    const { appMetricsResponse } = useValues(logic)
+    const { appMetricsResponse, appMetricsResponseLoading } = useValues(logic)
+    const { loadMetrics } = useActions(logic)
+    const { ref: inViewRef, inView } = useInView()
+
+    useEffect(() => {
+        if (inView && !appMetricsResponse && !appMetricsResponseLoading) {
+            loadMetrics()
+        }
+    }, [inView])
 
     // The metrics response has last 7 days time wise, we're showing the
     // sparkline graph by day, so ignore the potential 8th day
@@ -31,12 +41,14 @@ export function AppMetricSparkLine({ pipelineNode }: { pipelineNode: PipelineNod
     }
 
     return (
-        <Sparkline
-            loading={appMetricsResponse === null}
-            labels={dates}
-            data={displayData}
-            className="max-w-24 h-8"
-            maximumIndicator={false}
-        />
+        <div ref={inViewRef}>
+            <Sparkline
+                loading={appMetricsResponse === null}
+                labels={dates}
+                data={displayData}
+                className="h-8 max-w-24"
+                maximumIndicator={false}
+            />
+        </div>
     )
 }

--- a/frontend/src/scenes/pipeline/pipelineNodeMetricsLogic.tsx
+++ b/frontend/src/scenes/pipeline/pipelineNodeMetricsLogic.tsx
@@ -1,4 +1,4 @@
-import { actions, afterMount, connect, kea, key, listeners, path, props, reducers } from 'kea'
+import { actions, connect, kea, key, listeners, path, props, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 import { toParams } from 'lib/utils'
@@ -104,7 +104,4 @@ export const pipelineNodeMetricsLogic = kea<pipelineNodeMetricsLogicType>([
             actions.loadMetrics()
         },
     })),
-    afterMount(({ actions }) => {
-        actions.loadMetrics()
-    }),
 ])

--- a/frontend/src/scenes/pipeline/pipelineNodeMetricsLogic.tsx
+++ b/frontend/src/scenes/pipeline/pipelineNodeMetricsLogic.tsx
@@ -1,4 +1,4 @@
-import { actions, connect, kea, key, listeners, path, props, reducers } from 'kea'
+import { actions, afterMount, connect, kea, key, listeners, path, props, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 import { toParams } from 'lib/utils'
@@ -104,4 +104,8 @@ export const pipelineNodeMetricsLogic = kea<pipelineNodeMetricsLogicType>([
             actions.loadMetrics()
         },
     })),
+
+    afterMount(({ actions }) => {
+        actions.loadMetrics()
+    }),
 ])


### PR DESCRIPTION
## Problem

We have a lot of destinations. Loading metrics for them all is silly if they aren't in view

## Changes

* Only trigger the loading if in view

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
