### PR TITLE
fix(navigation): Flag "User interviews" in new nav

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -571,6 +571,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         path: 'User interviews',
         href: urls.userInterviews(),
         type: 'user_interview',
+        flag: FEATURE_FLAGS.USER_INTERVIEWS,
         visualOrder: PRODUCT_VISUAL_ORDER.userInterviews,
         tags: ['alpha'],
     },

--- a/products/user_interviews/manifest.tsx
+++ b/products/user_interviews/manifest.tsx
@@ -43,6 +43,7 @@ export const manifest: ProductManifest = {
             path: 'User interviews',
             href: urls.userInterviews(),
             type: 'user_interview',
+            flag: FEATURE_FLAGS.USER_INTERVIEWS,
             visualOrder: PRODUCT_VISUAL_ORDER.userInterviews,
             tags: ['alpha'],
         },


### PR DESCRIPTION
## Problem

Didn't think to flag the alpha User interviews product in the new nav, leading to tickets like ZEN-31788.

## Changes

User interviews now flagged.