### PR TITLE
fix(data-warehouse): Dont sync tables with duplicate primary keys

### DIFF
--- a/posthog/temporal/data_imports/external_data_job.py
+++ b/posthog/temporal/data_imports/external_data_job.py
@@ -47,6 +47,7 @@ from posthog.warehouse.models.external_data_schema import update_should_sync
 Any_Source_Errors: list[str] = [
     "Could not establish session to SSH gateway",
     "Primary key required for incremental syncs",
+    "The primary keys for this table are not unique",
 ]
 
 Non_Retryable_Schema_Errors: dict[ExternalDataSource.Type, list[str]] = {

--- a/posthog/temporal/data_imports/pipelines/bigquery/source.py
+++ b/posthog/temporal/data_imports/pipelines/bigquery/source.py
@@ -256,7 +256,7 @@ def has_duplicate_primary_keys(table: bigquery.Table, client: bigquery.Client, p
         query = f"""
             SELECT {", ".join(primary_keys)}
             FROM `{table.dataset_id}`.`{table.table_id}`
-            GROUP BY {", ".join([str(i + 1) for i, _ in enumerate(primary_keys)])}
+            GROUP BY {", ".join(primary_keys)}
             HAVING COUNT(*) > 1
         """
 

--- a/posthog/temporal/data_imports/pipelines/pipeline/typings.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/typings.py
@@ -23,6 +23,8 @@ class SourceResponse:
     """Override partition mode at a source level"""
     partition_format: Optional[PartitionFormat] = None
     """Override partition format at a source level"""
-    # our source typically return data in ascending timestamp order, but some (eg Stripe) do not
     sort_mode: Optional[SortMode] = "asc"
+    """our source typically return data in ascending timestamp order, but some (eg Stripe) do not"""
     rows_to_sync: Optional[int] = None
+    """Whether incremental tables have non-unique primary keys"""
+    has_duplicate_primary_keys: Optional[bool] = None

--- a/posthog/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/utils.py
@@ -44,6 +44,10 @@ DEFAULT_NUMERIC_SCALE = 32
 DEFAULT_PARTITION_TARGET_SIZE_IN_BYTES = 200 * 1024 * 1024  # 200 MB
 
 
+class DuplicatePrimaryKeysException(Exception):
+    pass
+
+
 def normalize_column_name(column_name: str) -> str:
     return NamingConvention().normalize_identifier(column_name)
 

--- a/posthog/temporal/data_imports/pipelines/postgres/postgres.py
+++ b/posthog/temporal/data_imports/pipelines/postgres/postgres.py
@@ -187,15 +187,16 @@ def _has_duplicate_primary_keys(
             FROM {{}}.{{}}
             GROUP BY {", ".join([str(i + 1) for i, _ in enumerate(primary_keys)])}
             HAVING COUNT(*) > 1
+            LIMIT 1
         """,
         )
         query = sql.SQL(sql_query).format(
             *[sql.Identifier(key) for key in primary_keys], sql.Identifier(schema), sql.Identifier(table_name)
         )
         cursor.execute(query)
-        rows = cursor.fetchall()
+        row = cursor.fetchone()
 
-        return len(rows) > 0
+        return row is not None
     except Exception as e:
         capture_exception(e)
         return False
@@ -468,12 +469,12 @@ def postgres_source(
             chunk_size = _get_table_chunk_size(cursor, inner_query_with_limit, logger)
             rows_to_sync = _get_rows_to_sync(cursor, inner_query_without_limit, logger)
             partition_settings = _get_partition_settings(cursor, schema, table_name) if is_incremental else None
+            has_duplicate_primary_keys = False
 
             # Fallback on checking for an `id` field on the table
             if primary_keys is None and "id" in table:
                 primary_keys = ["id"]
-
-            has_duplicate_primary_keys = _has_duplicate_primary_keys(cursor, schema, table_name, primary_keys)
+                has_duplicate_primary_keys = _has_duplicate_primary_keys(cursor, schema, table_name, primary_keys)
 
     def get_rows(chunk_size: int) -> Iterator[Any]:
         arrow_schema = table.to_arrow_schema()

--- a/posthog/temporal/data_imports/pipelines/postgres/postgres.py
+++ b/posthog/temporal/data_imports/pipelines/postgres/postgres.py
@@ -173,9 +173,35 @@ def _get_primary_keys(cursor: psycopg.Cursor, schema: str, table_name: str) -> l
     return None
 
 
-def _get_table_chunk_size(
-    cursor: psycopg.Cursor, inner_query: sql.Composed, schema: str, table_name: str, logger: FilteringBoundLogger
-) -> int:
+def _has_duplicate_primary_keys(
+    cursor: psycopg.Cursor, schema: str, table_name: str, primary_keys: list[str] | None
+) -> bool:
+    if not primary_keys or len(primary_keys) == 0:
+        return False
+
+    try:
+        sql_query = cast(
+            LiteralString,
+            f"""
+            SELECT {", ".join(["{}" for _ in primary_keys])}
+            FROM {{}}.{{}}
+            GROUP BY {", ".join([str(i + 1) for i, _ in enumerate(primary_keys)])}
+            HAVING COUNT(*) > 1
+        """,
+        )
+        query = sql.SQL(sql_query).format(
+            *[sql.Identifier(key) for key in primary_keys], sql.Identifier(schema), sql.Identifier(table_name)
+        )
+        cursor.execute(query)
+        rows = cursor.fetchall()
+
+        return len(rows) > 0
+    except Exception as e:
+        capture_exception(e)
+        return False
+
+
+def _get_table_chunk_size(cursor: psycopg.Cursor, inner_query: sql.Composed, logger: FilteringBoundLogger) -> int:
     try:
         query = sql.SQL("""
             SELECT SUM(pg_column_size(t.*)) / COUNT(t.*) FROM ({}) as t
@@ -439,13 +465,15 @@ def postgres_source(
 
             primary_keys = _get_primary_keys(cursor, schema, table_name)
             table = _get_table(cursor, schema, table_name)
-            chunk_size = _get_table_chunk_size(cursor, inner_query_with_limit, schema, table_name, logger)
+            chunk_size = _get_table_chunk_size(cursor, inner_query_with_limit, logger)
             rows_to_sync = _get_rows_to_sync(cursor, inner_query_without_limit, logger)
             partition_settings = _get_partition_settings(cursor, schema, table_name) if is_incremental else None
 
             # Fallback on checking for an `id` field on the table
             if primary_keys is None and "id" in table:
                 primary_keys = ["id"]
+
+            has_duplicate_primary_keys = _has_duplicate_primary_keys(cursor, schema, table_name, primary_keys)
 
     def get_rows(chunk_size: int) -> Iterator[Any]:
         arrow_schema = table.to_arrow_schema()
@@ -503,4 +531,5 @@ def postgres_source(
         partition_count=partition_settings.partition_count if partition_settings else None,
         partition_size=partition_settings.partition_size if partition_settings else None,
         rows_to_sync=rows_to_sync,
+        has_duplicate_primary_keys=has_duplicate_primary_keys,
     )

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -1966,3 +1966,67 @@ async def test_row_tracking_incrementing(team, postgres_config, postgres_connect
     assert columns is not None
     assert len(columns) == 1
     assert any(x == "id" for x in columns)
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_postgres_duplicate_primary_key(team, postgres_config, postgres_connection):
+    await postgres_connection.execute(
+        "CREATE TABLE IF NOT EXISTS {schema}.duplicate_primary_key (id integer)".format(
+            schema=postgres_config["schema"]
+        )
+    )
+    await postgres_connection.execute(
+        "INSERT INTO {schema}.duplicate_primary_key (id) VALUES (1)".format(schema=postgres_config["schema"])
+    )
+    await postgres_connection.execute(
+        "INSERT INTO {schema}.duplicate_primary_key (id) VALUES (1)".format(schema=postgres_config["schema"])
+    )
+    await postgres_connection.execute(
+        "INSERT INTO {schema}.duplicate_primary_key (id) VALUES (2)".format(schema=postgres_config["schema"])
+    )
+    await postgres_connection.commit()
+
+    with (
+        pytest.raises(Exception),
+        mock.patch("posthog.temporal.data_imports.external_data_job.update_should_sync") as mock_update_should_sync,
+    ):
+        await _run(
+            team=team,
+            schema_name="duplicate_primary_key",
+            table_name="postgres_duplicate_primary_key",
+            source_type="Postgres",
+            job_inputs={
+                "host": postgres_config["host"],
+                "port": postgres_config["port"],
+                "database": postgres_config["database"],
+                "user": postgres_config["user"],
+                "password": postgres_config["password"],
+                "schema": postgres_config["schema"],
+                "ssh_tunnel_enabled": "False",
+            },
+            mock_data_response=[],
+            sync_type=ExternalDataSchema.SyncType.INCREMENTAL,
+            sync_type_config={"incremental_field": "id", "incremental_field_type": "integer"},
+        )
+
+    job: ExternalDataJob = await sync_to_async(ExternalDataJob.objects.get)(
+        team_id=team.id, schema__name="duplicate_primary_key"
+    )
+
+    assert job.status == ExternalDataJob.Status.FAILED
+    assert job.latest_error is not None
+    assert (
+        "The primary keys for this table are not unique. We can't sync incrementally until the table has a unique primary key"
+        in job.latest_error
+    )
+
+    with pytest.raises(Exception):
+        await sync_to_async(execute_hogql_query)(f"SELECT * FROM postgres_duplicate_primary_key", team)
+
+    schema: ExternalDataSchema = await sync_to_async(ExternalDataSchema.objects.get)(id=job.schema_id)
+    mock_update_should_sync.assert_called_once_with(
+        schema_id=str(schema.id),
+        team_id=team.id,
+        should_sync=False,
+    )


### PR DESCRIPTION
## Problem
- Duplicate primary keys cause delta memory to blow up during merging
- See here https://posthog.slack.com/archives/C019RAX2XBN/p1748867552418579

## Changes
- For postgres and bigquery sources, check whether there are duplicate primary keys ahead of time - both of these db systems dont enforce uniqueness here and account for the majority of our `heartbeat timeout` errors in the pipeline
- If the table is incremental and has duplicate keys, then we raise an error and turn off the sync

## How did you test this code?
- Added test