### PR TITLE
fix(max): Fix race condition between auto-run and conversation history

### DIFF
--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -317,7 +317,13 @@ export const maxLogic = kea<maxLogicType>([
             // the current chat is not a chat with ID
             // the current chat is a temp chat
             // we have explicitly marked
-            if (!values.conversationId || isTempId(values.conversationId) || payload?.doNotUpdateCurrentThread) {
+            // we're in an autorun conversation
+            if (
+                !values.conversationId ||
+                values.autoRun ||
+                isTempId(values.conversationId) ||
+                payload?.doNotUpdateCurrentThread
+            ) {
                 return
             }
 
@@ -327,14 +333,13 @@ export const maxLogic = kea<maxLogicType>([
             // after the history has been loaded.
             if (conversation) {
                 actions.scrollThreadToBottom('instant')
-            }
-
-            if (!conversation) {
+                if (conversation.status === ConversationStatus.InProgress) {
+                    // If the conversation is in progress, poll the conversation status.
+                    actions.pollConversation(values.conversationId)
+                }
+            } else {
                 // If the conversation is not found, retrieve once the conversation status and reset if 404.
                 actions.pollConversation(values.conversationId, 0, 0)
-            } else if (conversation.status === ConversationStatus.InProgress) {
-                // If the conversation is in progress, poll the conversation status.
-                actions.pollConversation(values.conversationId)
             }
         },
 


### PR DESCRIPTION
## Problem

Some of the time running Max via an auto-run link like https://localhost:8010/#panel=max%3A!Hi! results in this:

<img src="https://github.com/user-attachments/assets/a1982fb3-e982-4502-87c9-b4430d3b6519" width="300" alt="Failing">

Discovered while reviewing https://github.com/PostHog/posthog.com/pull/11538.

It seems that the problem is that with auto-run links, `loadConversationHistorySuccess()` can fire just before the `POST /conversations/` creates the new `Conversation`, calling `pollConversation()` for a conversation ID which isn't present in the database yet. This results in a 404 on which `pollConversation()` resets the conversation, as for genuinely non-existent conversations we have nothing to show.

## Changes

Avoiding the issue by skipping `loadConversationHistorySuccess()` if `autoRun` is true.

## How did you test this code?

Time-consuming to write automated tests for a race condition like this, so just manual testing.