### PR TITLE
feat(project-tree): rename "metadata" to "data warehouse"

### DIFF
--- a/frontend/src/layout/panel-layout/PanelLayout.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayout.tsx
@@ -162,8 +162,8 @@ export function PanelLayout({ mainRef }: { mainRef: React.RefObject<HTMLElement>
                     {activePanelIdentifier === 'Shortcuts' && (
                         <ProjectTree root="shortcuts://" searchPlaceholder="Search your shortcuts" />
                     )}
-                    {activePanelIdentifier === 'Metadata' && (
-                        <ProjectTree root="metadata://" searchPlaceholder="Search metadata" />
+                    {activePanelIdentifier === 'DataWarehouse' && (
+                        <ProjectTree root="data-warehouse://" searchPlaceholder="Search products" />
                     )}
                     {activePanelIdentifier === 'People' && (
                         <ProjectTree root="persons://" searchPlaceholder="Search persons" />

--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -197,7 +197,7 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
         },
         {
             identifier: 'Metadata',
-            id: 'Metadata',
+            id: 'Data warehouse',
             icon: <IconDatabase />,
             onClick: (e?: React.KeyboardEvent) => {
                 if (!e || e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowRight') {

--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -196,12 +196,12 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
             },
         },
         {
-            identifier: 'Metadata',
+            identifier: 'DataWarehouse',
             id: 'Data warehouse',
             icon: <IconDatabase />,
             onClick: (e?: React.KeyboardEvent) => {
                 if (!e || e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowRight') {
-                    handlePanelTriggerClick('Metadata')
+                    handlePanelTriggerClick('DataWarehouse')
                 }
             },
             showChevron: true,

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -617,7 +617,7 @@ export function ProjectTree({
             renderItemTooltip={(item) => {
                 const user = item.record?.user as UserBasicType | undefined
                 const nameNode: JSX.Element = <span className="font-semibold">{item.displayName}</span>
-                if (root === 'products://' || root === 'metadata://' || root === 'persons://') {
+                if (root === 'products://' || root === 'data-warehouse://' || root === 'persons://') {
                     return <>View {nameNode}</>
                 }
                 if (root === 'new://') {

--- a/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
@@ -250,12 +250,6 @@ export const getDefaultTreeMetadata = (): FileSystemImport[] => [
         iconType: 'plug',
         href: urls.pipeline(PipelineTab.Destinations),
     } as FileSystemImport,
-    {
-        path: `Site apps`,
-        type: 'hog_function/site_app',
-        iconType: 'plug',
-        href: urls.pipeline(PipelineTab.SiteApps),
-    } as FileSystemImport,
 ]
 
 export const getDefaultTreeProducts = (): FileSystemImport[] =>

--- a/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
@@ -228,11 +228,6 @@ export const getDefaultTreeMetadata = (): FileSystemImport[] => [
         flag: FEATURE_FLAGS.INGESTION_WARNINGS_ENABLED,
     },
     {
-        path: `SQL editor`,
-        type: 'sql',
-        href: urls.sqlEditor(),
-    } as FileSystemImport,
-    {
         path: `Sources`,
         type: 'hog_function/source',
         iconType: 'plug',
@@ -261,6 +256,12 @@ export const getDefaultTreeProducts = (): FileSystemImport[] =>
             iconType: 'plug',
             href: urls.pipeline(),
             visualOrder: PRODUCT_VISUAL_ORDER.dataPipeline,
+        } as FileSystemImport,
+        {
+            path: `SQL editor`,
+            type: 'sql',
+            href: urls.sqlEditor(),
+            visualOrder: PRODUCT_VISUAL_ORDER.sqlEditor,
         } as FileSystemImport,
         {
             path: 'Error tracking',

--- a/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
@@ -204,7 +204,7 @@ export const getDefaultTreeNew = (): FileSystemImport[] =>
         },
     ].sort((a, b) => a.path.localeCompare(b.path, undefined, { sensitivity: 'accent' }))
 
-export const getDefaultTreeMetadata = (): FileSystemImport[] => [
+export const getDefaultTreeDataWarehouse = (): FileSystemImport[] => [
     ...getTreeItemsMetadata(),
     {
         path: 'Event definitions',

--- a/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
@@ -33,7 +33,7 @@ import {
     getTreeItemsProducts,
 } from '~/products'
 import { FileSystemImport } from '~/queries/schema/schema-general'
-import { FileSystemIconColor, PipelineStage } from '~/types'
+import { FileSystemIconColor, PipelineStage, PipelineTab } from '~/types'
 
 const iconTypes: Record<string, { icon: JSX.Element; iconColor?: FileSystemIconColor }> = {
     ai: {
@@ -227,6 +227,35 @@ export const getDefaultTreeMetadata = (): FileSystemImport[] => [
         href: urls.ingestionWarnings(),
         flag: FEATURE_FLAGS.INGESTION_WARNINGS_ENABLED,
     },
+    {
+        path: `SQL editor`,
+        type: 'sql',
+        href: urls.sqlEditor(),
+    } as FileSystemImport,
+    {
+        path: `Sources`,
+        type: 'hog_function/source',
+        iconType: 'plug',
+        href: urls.pipeline(PipelineTab.Sources),
+    } as FileSystemImport,
+    {
+        path: `Transformations`,
+        type: 'hog_function/transformation',
+        iconType: 'plug',
+        href: urls.pipeline(PipelineTab.Transformations),
+    } as FileSystemImport,
+    {
+        path: `Destinations`,
+        type: 'hog_function/destination',
+        iconType: 'plug',
+        href: urls.pipeline(PipelineTab.Destinations),
+    } as FileSystemImport,
+    {
+        path: `Site apps`,
+        type: 'hog_function/site_app',
+        iconType: 'plug',
+        href: urls.pipeline(PipelineTab.SiteApps),
+    } as FileSystemImport,
 ]
 
 export const getDefaultTreeProducts = (): FileSystemImport[] =>
@@ -238,12 +267,6 @@ export const getDefaultTreeProducts = (): FileSystemImport[] =>
             iconType: 'plug',
             href: urls.pipeline(),
             visualOrder: PRODUCT_VISUAL_ORDER.dataPipeline,
-        } as FileSystemImport,
-        {
-            path: `SQL editor`,
-            type: 'sql',
-            href: urls.sqlEditor(),
-            visualOrder: PRODUCT_VISUAL_ORDER.sqlEditor,
         } as FileSystemImport,
         {
             path: 'Error tracking',

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
@@ -10,7 +10,7 @@ import { urls } from 'scenes/urls'
 
 import { breadcrumbsLogic } from '~/layout/navigation/Breadcrumbs/breadcrumbsLogic'
 import {
-    getDefaultTreeMetadata,
+    getDefaultTreeDataWarehouse,
     getDefaultTreeNew,
     getDefaultTreePersons,
     getDefaultTreeProducts,
@@ -592,7 +592,7 @@ export const projectTreeDataLogic = kea<projectTreeDataLogicType>([
                 return function getStaticItems(searchTerm: string, onlyFolders: boolean): TreeDataItem[] {
                     const data: [string, FileSystemImport[]][] = [
                         ['products://', getDefaultTreeProducts()],
-                        ['metadata://', getDefaultTreeMetadata()],
+                        ['data-warehouse://', getDefaultTreeDataWarehouse()],
                         ['persons://', [...getDefaultTreePersons(), ...groupItems]],
                         ['new://', getDefaultTreeNew()],
                         ['shortcuts://', shortcutData],

--- a/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
+++ b/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
@@ -4,7 +4,7 @@ import { LemonTreeRef } from 'lib/lemon-ui/LemonTree/LemonTree'
 import { navigation3000Logic } from '../navigation-3000/navigationLogic'
 import type { panelLayoutLogicType } from './panelLayoutLogicType'
 
-export type PanelLayoutNavIdentifier = 'Project' | 'Products' | 'People' | 'Games' | 'Shortcuts' | 'Metadata'
+export type PanelLayoutNavIdentifier = 'Project' | 'Products' | 'People' | 'Games' | 'Shortcuts' | 'DataWarehouse'
 export type PanelLayoutTreeRef = React.RefObject<LemonTreeRef> | null
 export type PanelLayoutMainContentRef = React.RefObject<HTMLElement> | null
 export const PANEL_LAYOUT_DEFAULT_WIDTH: number = 320

--- a/frontend/src/scenes/data-management/DataManagementScene.tsx
+++ b/frontend/src/scenes/data-management/DataManagementScene.tsx
@@ -198,6 +198,7 @@ const dataManagementSceneLogic = kea<dataManagementSceneLogicType>([
 export function DataManagementScene(): JSX.Element {
     const { enabledTabs, tab } = useValues(dataManagementSceneLogic)
     const { setTab } = useActions(dataManagementSceneLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     const lemonTabs: LemonTab<DataManagementTab>[] = enabledTabs.map((key) => ({
         key: key as DataManagementTab,
@@ -205,6 +206,12 @@ export function DataManagementScene(): JSX.Element {
         content: tabs[key].content,
         tooltipDocLink: tabs[key].tooltipDocLink,
     }))
+
+    if (featureFlags[FEATURE_FLAGS.TREE_VIEW] || featureFlags[FEATURE_FLAGS.TREE_VIEW_RELEASE]) {
+        if (enabledTabs.includes(tab)) {
+            return tabs[tab || DataManagementTab.Actions].content
+        }
+    }
 
     return (
         <>


### PR DESCRIPTION
## Problem

Naming things is hard.

## Changes

When discussing how to call the "Data" panel, we (credit to Cory) came to the realization that actually... PostHog _is_ a Data Warehouse, and all the tools under "Data"... are actually all tools you can use to manage your data warehouse.

Hence the idea was born to rename "Data" (and/or "Metadata", "Data management") directly into "Data warehouse" and keep that as a top level panel.

All changes:

- Rename "Data" / "Metadata" / "Data management" into -------> "Data warehouse"
- Explode the "Sources", "Destinations" and "Transformations" tabs out of data pipelines and into "Data warehouse"
- Remove 2nd set of tabs for old "data management" pages if the tree view flag is on.

This is what it looks like now:

![2025-06-03 17 03 45](https://github.com/user-attachments/assets/ffde82c2-a55c-40d0-bc02-6cc6a450ae2b)

## How did you test this code?

👀