### PR TITLE
fix(sql-insights): Handle missing types when rendering sql insights

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -179,7 +179,11 @@ export const convertTableValue = (
     return value
 }
 
-const toFriendlyClickhouseTypeName = (type: string): ColumnScalar => {
+const toFriendlyClickhouseTypeName = (type: string | undefined): ColumnScalar => {
+    if (!type) {
+        return 'UNKNOWN'
+    }
+
     if (type.indexOf('Array') !== -1) {
         return 'ARRAY'
     }

--- a/frontend/src/queries/nodes/DataVisualization/types.ts
+++ b/frontend/src/queries/nodes/DataVisualization/types.ts
@@ -8,6 +8,7 @@ export type ColumnScalar =
     | 'STRING'
     | 'TUPLE'
     | 'ARRAY'
+    | 'UNKNOWN'
 
 export interface FormattingTemplate {
     id: string


### PR DESCRIPTION
## Problem
- Sometimes `types` can be missing from the insight request due to some changes on the backend
- https://posthog.slack.com/archives/C019RAX2XBN/p1748958014201369

## Changes
- Guard against having no types returned to the browser
