### PR TITLE
fix(project-tree): panel button fix, clean up

### DIFF
--- a/frontend/src/layout/panel-layout/PanelLayout.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayout.tsx
@@ -177,7 +177,7 @@ export function PanelLayout({ mainRef }: { mainRef: React.RefObject<HTMLElement>
                         showLayoutPanel(false)
                         clearActivePanelIdentifier()
                     }}
-                    className="z-[var(--z-layout-panel-under)] fixed inset-0 w-screen h-screen bg-[var(--bg-fill-highlight-200)]"
+                    className="z-[var(--z-layout-panel-under)] fixed inset-0 w-screen h-screen bg-fill-highlight-200"
                 />
             )}
 
@@ -187,7 +187,7 @@ export function PanelLayout({ mainRef }: { mainRef: React.RefObject<HTMLElement>
                         // Return to tree mode when clicking outside the table view
                         setProjectTreeMode('tree')
                     }}
-                    className="z-[var(--z-layout-navbar-under)] fixed inset-0 w-screen h-screen bg-[var(--bg-fill-highlight-200)]"
+                    className="z-[var(--z-layout-navbar-under)] fixed inset-0 w-screen h-screen bg-fill-highlight-200"
                 />
             )}
         </>

--- a/frontend/src/layout/panel-layout/PanelLayout.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayout.tsx
@@ -177,7 +177,7 @@ export function PanelLayout({ mainRef }: { mainRef: React.RefObject<HTMLElement>
                         showLayoutPanel(false)
                         clearActivePanelIdentifier()
                     }}
-                    className="z-[var(--z-layout-panel-under)] fixed inset-0 w-screen h-screen"
+                    className="z-[var(--z-layout-panel-under)] fixed inset-0 w-screen h-screen bg-[var(--bg-fill-highlight-200)]"
                 />
             )}
 
@@ -187,7 +187,7 @@ export function PanelLayout({ mainRef }: { mainRef: React.RefObject<HTMLElement>
                         // Return to tree mode when clicking outside the table view
                         setProjectTreeMode('tree')
                     }}
-                    className="z-[var(--z-layout-navbar-under)] fixed inset-0 w-screen h-screen"
+                    className="z-[var(--z-layout-navbar-under)] fixed inset-0 w-screen h-screen bg-[var(--bg-fill-highlight-200)]"
                 />
             )}
         </>

--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -94,15 +94,12 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
     const { isDev } = useValues(preflightLogic)
 
     function handlePanelTriggerClick(item: PanelLayoutNavIdentifier): void {
-        if (!isLayoutPanelVisible) {
-            showLayoutPanel(true)
-        } else {
-            showLayoutPanel(false)
-            clearActivePanelIdentifier()
-        }
-
         if (activePanelIdentifier !== item) {
             setActivePanelIdentifier(item)
+            showLayoutPanel(true)
+        } else if (activePanelIdentifier === item) {
+            clearActivePanelIdentifier()
+            showLayoutPanel(false)
         }
     }
 

--- a/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutNavBar.tsx
@@ -554,7 +554,7 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
                             showLayoutNavBar(false)
                             clearActivePanelIdentifier()
                         }}
-                        className="z-[var(--z-layout-navbar-under)] fixed inset-0 w-screen h-screen bg-[var(--bg-fill-highlight-200)] lg:bg-transparent"
+                        className="z-[var(--z-layout-navbar-under)] fixed inset-0 w-screen h-screen bg-fill-highlight-200 lg:bg-transparent"
                     />
                 )}
 
@@ -564,7 +564,7 @@ export function PanelLayoutNavBar({ children }: { children: React.ReactNode }): 
                             showLayoutPanel(false)
                             clearActivePanelIdentifier()
                         }}
-                        className="z-[var(--z-layout-navbar-over)] fixed inset-0 w-screen h-screen bg-[var(--bg-fill-highlight-200)] lg:bg-transparent"
+                        className="z-[var(--z-layout-navbar-over)] fixed inset-0 w-screen h-screen bg-fill-highlight-200 lg:bg-transparent"
                     />
                 )}
             </div>

--- a/frontend/src/layout/panel-layout/PanelLayoutPanel.tsx
+++ b/frontend/src/layout/panel-layout/PanelLayoutPanel.tsx
@@ -24,6 +24,10 @@ interface PanelLayoutPanelProps {
 const panelLayoutPanelVariants = cva({
     base: 'w-full flex flex-col max-h-screen min-h-screen relative border-r border-primary transition-[width] duration-100 prefers-reduced-motion:transition-none',
     variants: {
+        isLayoutPanelPinned: {
+            true: 'relative',
+            false: 'absolute',
+        },
         projectTreeMode: {
             tree: '',
             table: 'absolute top-0 left-0 bottom-0',
@@ -93,6 +97,7 @@ export function PanelLayoutPanel({
                     isLayoutNavCollapsed,
                     isMobileLayout,
                     panelWillHide,
+                    isLayoutPanelPinned,
                 })
             )}
             ref={containerRef}
@@ -140,6 +145,10 @@ export function PanelLayoutPanel({
 
     return (
         <ResizableElement
+            className={cn({
+                relative: isLayoutPanelPinned,
+                'absolute left-full h-full': !isLayoutPanelPinned,
+            })}
             key="panel-layout-panel"
             defaultWidth={computedPanelWidth}
             onResize={(width) => {

--- a/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
+++ b/frontend/src/layout/panel-layout/panelLayoutLogic.tsx
@@ -69,7 +69,7 @@ export const panelLayoutLogic = kea<panelLayoutLogicType>([
             },
         ],
         isLayoutPanelPinned: [
-            true,
+            false,
             { persist: true },
             {
                 toggleLayoutPanelPinned: (_, { pinned }) => pinned,


### PR DESCRIPTION
## Problem
* Switching panels (project open and want to open "products" would result in a strange edge case where "pinned" panels would seem unpinned etc. What's actually happening is the logic to toggle a new panel was incorrect. 
* Positioning of the panel is strange and hacky
* Pinned/Unpinned panel state is not very clear
* Pinned (by default) is probably not what most users want
* 
![2025-06-03 15 00 55](https://github.com/user-attachments/assets/4bce740e-2d66-4140-91fc-10c91d75c802)

## Changes
* Fixed bug
* Fixed up panel positioning 
* Added background color to overlays (unpinned panel overlay) to indicate you will dismiss something before interacting. This is particularly helpful for the mobile experience.
* Pinned is now NOT default

## How did you test this code?
Manually