### PR TITLE
fix(googleads): Use fully qualified field names

### DIFF
--- a/posthog/temporal/data_imports/pipelines/google_ads/source.py
+++ b/posthog/temporal/data_imports/pipelines/google_ads/source.py
@@ -227,7 +227,7 @@ def google_ads_source(config: GoogleAdsSourceConfig) -> SourceResponse:
     table = get_schemas(config)[config.resource_name]
 
     def get_rows() -> collections.abc.Iterator[pa.Table]:
-        query = f"SELECT {','.join(f'{field.name}' for field in table)} FROM {table.name}"
+        query = f"SELECT {','.join(f'{table.name}.{field.name}' for field in table)} FROM {table.name}"
 
         client = google_ads_client(config)
         service = client.get_service("GoogleAdsService", version="v19")


### PR DESCRIPTION
## Problem

Google ads requires fully qualified fields.

## Changes

Use fully qualified fields.

## Testing

Manually tested.