### PR TITLE
fix: truncate tables to avoid duplications

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -587,4 +587,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
 export const getTreeItemsGames = (): FileSystemImport[] => [{ path: '368 Hedgehogs', href: urls.game368hedgehogs() }]
 
 /** This const is auto-generated, as is the whole file */
-export const getTreeItemsDataManagement = (): FileSystemImport[] => []
+export const getTreeItemsMetadata = (): FileSystemImport[] => [
+    { path: 'Actions', iconType: 'rocket', href: urls.actions() },
+    { path: 'Revenue settings', iconType: 'handMoney', href: urls.revenueSettings() },
+]

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -587,7 +587,4 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
 export const getTreeItemsGames = (): FileSystemImport[] => [{ path: '368 Hedgehogs', href: urls.game368hedgehogs() }]
 
 /** This const is auto-generated, as is the whole file */
-export const getTreeItemsMetadata = (): FileSystemImport[] => [
-    { path: 'Actions', iconType: 'rocket', href: urls.actions() },
-    { path: 'Revenue settings', iconType: 'handMoney', href: urls.revenueSettings() },
-]
+export const getTreeItemsDataManagement = (): FileSystemImport[] => []


### PR DESCRIPTION
## Problem

This is a temporary workaround to test the pre-aggregation integration. The actual problem is that the sorting key for the `ReplacingMergeTree` is not allowing deduplication to work correctly due to the dimensions we have there.

## Changes

- Truncate the hourly tables, as it is the cheapest way to remove data and regenerate the current-day data (it is a cheap query right now).

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Manually