### PR TITLE
feat(marketing-analytics): enhance data source configurations and schema

### DIFF
--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -3111,15 +3111,17 @@ export interface EventsHeatMapStructuredResult {
 export type MarketingAnalyticsSchemaField = {
     type: string[]
     required: boolean
+    default?: string
 }
 
 export const MARKETING_ANALYTICS_SCHEMA: Record<string, MarketingAnalyticsSchemaField> = {
     campaign_name: { type: ['string'], required: true },
     total_cost: { type: ['float', 'integer'], required: true },
-    clicks: { type: ['integer', 'number', 'float'], required: true },
-    impressions: { type: ['integer', 'number', 'float'], required: true },
-    date: { type: ['datetime', 'date'], required: true },
+    clicks: { type: ['integer', 'number', 'float'], required: false },
+    impressions: { type: ['integer', 'number', 'float'], required: false },
+    date: { type: ['datetime', 'date', 'string'], required: true },
     source_name: { type: ['string'], required: false },
+    base_currency: { type: ['currency'], required: false, default: 'USD' },
 }
 
 export type MarketingAnalyticsSchema = keyof typeof MARKETING_ANALYTICS_SCHEMA

--- a/frontend/src/scenes/data-warehouse/settings/DataWarehouseSourceIcon.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/DataWarehouseSourceIcon.tsx
@@ -47,6 +47,19 @@ export function mapUrlToProvider(url: string): string {
     return 'BlushingHog'
 }
 
+export function mapUrlToSourceName(url: string): string {
+    if (url.includes('amazonaws.com')) {
+        return 'AWS'
+    } else if (url.startsWith('https://storage.googleapis.com')) {
+        return 'GCS'
+    } else if (url.includes('.blob.')) {
+        return 'Azure'
+    } else if (url.includes('.r2.cloudflarestorage.com')) {
+        return 'Cloudflare'
+    }
+    return 'BlushingHog'
+}
+
 const SIZE_PX_MAP = {
     xsmall: 16,
     small: 30,

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -25,6 +25,7 @@ import { SessionsV2JoinModeSettings } from 'scenes/settings/environment/Sessions
 import { urls } from 'scenes/urls'
 import { BaseCurrency } from 'scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/BaseCurrency'
 import { NonNativeExternalDataSourceConfiguration } from 'scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/NonNativeExternalDataSourceConfiguration'
+import { SelfManagedExternalDataSourceConfiguration } from 'scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/SelfManagedExternalDataSourceConfiguration'
 
 import { Realm } from '~/types'
 
@@ -283,6 +284,11 @@ export const SETTINGS_MAP: SettingSection[] = [
                 id: 'marketing-analytics-external-data-sources',
                 title: 'External data sources',
                 component: <NonNativeExternalDataSourceConfiguration />,
+            },
+            {
+                id: 'marketing-analytics-self-managed-external-data-sources',
+                title: 'Self-managed external data sources',
+                component: <SelfManagedExternalDataSourceConfiguration />,
             },
         ],
     },

--- a/frontend/src/scenes/settings/types.ts
+++ b/frontend/src/scenes/settings/types.ts
@@ -143,6 +143,7 @@ export type SettingId =
     | 'csp-reporting'
     | 'marketing-base-currency'
     | 'marketing-analytics-external-data-sources'
+    | 'marketing-analytics-self-managed-external-data-sources'
 
 type FeatureFlagKey = keyof typeof FEATURE_FLAGS
 

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/CurrencyDropdown.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/CurrencyDropdown.tsx
@@ -1,11 +1,8 @@
-import { LemonSelect, LemonSelectOption, LemonSelectProps } from '@posthog/lemon-ui'
-import {
-    CURRENCY_SYMBOL_TO_EMOJI_MAP,
-    CURRENCY_SYMBOL_TO_NAME_MAP,
-    DISABLED_CURRENCIES,
-} from 'lib/utils/geography/currency'
+import { LemonSelect, LemonSelectProps } from '@posthog/lemon-ui'
 
 import { CurrencyCode } from '~/queries/schema/schema-general'
+
+import { OPTIONS_FOR_IMPORTANT_CURRENCIES, OPTIONS_FOR_OTHER_CURRENCIES } from './utils'
 
 type CurrencyDropdownProps = {
     value: CurrencyCode | null
@@ -13,43 +10,6 @@ type CurrencyDropdownProps = {
     size?: LemonSelectProps<any>['size']
     visible?: boolean // Useful for stories to display the dropdown content
 }
-
-// These are the currencies that are most important to show first because they're used by the most customers.
-// Check our web analytics dashboard for the most popular countries from our visitors.
-const IMPORTANT_CURRENCIES: CurrencyCode[] = [
-    CurrencyCode.USD,
-    CurrencyCode.EUR,
-    CurrencyCode.GBP,
-    CurrencyCode.CAD,
-    CurrencyCode.INR,
-    CurrencyCode.CNY,
-    CurrencyCode.BRL,
-]
-
-// All the other currencies, sorted by their "long name" in alphabetical order.
-const OTHER_CURRENCIES: CurrencyCode[] = (
-    Object.keys(CurrencyCode).filter(
-        (currency) => !IMPORTANT_CURRENCIES.includes(currency as CurrencyCode)
-    ) as CurrencyCode[]
-).sort((a, b) => {
-    return CURRENCY_SYMBOL_TO_NAME_MAP[a].localeCompare(CURRENCY_SYMBOL_TO_NAME_MAP[b])
-})
-
-const optionFromCurrency = (currency: CurrencyCode): LemonSelectOption<CurrencyCode> => {
-    return {
-        value: currency,
-        disabledReason: DISABLED_CURRENCIES[currency],
-        label: (
-            <span>
-                {CURRENCY_SYMBOL_TO_EMOJI_MAP[currency]} {CURRENCY_SYMBOL_TO_NAME_MAP[currency]} ({currency})
-            </span>
-        ),
-    }
-}
-
-// Computing these before hand is more efficient than computing them on the fly.
-const OPTIONS_FOR_IMPORTANT_CURRENCIES: LemonSelectOption<CurrencyCode>[] = IMPORTANT_CURRENCIES.map(optionFromCurrency)
-const OPTIONS_FOR_OTHER_CURRENCIES: LemonSelectOption<CurrencyCode>[] = OTHER_CURRENCIES.map(optionFromCurrency)
 
 export const CurrencyDropdown = ({ value, onChange, visible, size }: CurrencyDropdownProps): JSX.Element => {
     return (

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/MarketingAnalyticsSettings.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/MarketingAnalyticsSettings.tsx
@@ -2,14 +2,17 @@ import { useRef } from 'react'
 
 import { BaseCurrency } from './BaseCurrency'
 import { NonNativeExternalDataSourceConfiguration } from './NonNativeExternalDataSourceConfiguration'
+import { SelfManagedExternalDataSourceConfiguration } from './SelfManagedExternalDataSourceConfiguration'
 
 export function MarketingAnalyticsSettings(): JSX.Element {
     const dataWarehouseTablesButtonRef = useRef<HTMLButtonElement>(null)
+    const selfManagedExternalDataSourceButtonRef = useRef<HTMLButtonElement>(null)
 
     return (
         <div className="flex flex-col gap-8 mb-10">
             <BaseCurrency />
             <NonNativeExternalDataSourceConfiguration buttonRef={dataWarehouseTablesButtonRef} />
+            <SelfManagedExternalDataSourceConfiguration buttonRef={selfManagedExternalDataSourceButtonRef} />
         </div>
     )
 }

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/NonNativeExternalDataSourceConfiguration.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/NonNativeExternalDataSourceConfiguration.tsx
@@ -1,27 +1,15 @@
-import { IconCheck, IconTrash, IconWarning, IconX } from '@posthog/icons'
-import { LemonButton, LemonSelect, Link } from '@posthog/lemon-ui'
-import { useActions, useValues } from 'kea'
-import { router } from 'kea-router'
-import { LemonTable } from 'lib/lemon-ui/LemonTable'
-import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { useValues } from 'kea'
 import { DataWarehouseSourceIcon } from 'scenes/data-warehouse/settings/DataWarehouseSourceIcon'
-import { urls } from 'scenes/urls'
 
-import { MARKETING_ANALYTICS_SCHEMA } from '~/queries/schema/schema-general'
-import { ExternalDataSource, PipelineNodeTab, PipelineStage } from '~/types'
+import { ExternalDataSource } from '~/types'
 
 import { marketingAnalyticsSettingsLogic } from '../../logic/marketingAnalyticsSettingsLogic'
+import {
+    SharedExternalDataSourceConfiguration,
+    SimpleDataWarehouseTable,
+} from './SharedExternalDataSourceConfiguration'
 
 const VALID_MARKETING_SOURCES: ExternalDataSource['source_type'][] = ['BigQuery']
-
-type SimpleDataWarehouseTable = {
-    name: string
-    source_type: ExternalDataSource['source_type']
-    id: string
-    source_id: string
-    source_prefix: string
-    columns?: { name: string; type: string }[]
-}
 
 // This is to map tables that are not natively integrated with PostHog.
 // It's a workaround to allow users to map columns to the correct fields in the Marketing Analytics product.
@@ -31,12 +19,12 @@ export function NonNativeExternalDataSourceConfiguration({
 }: {
     buttonRef?: React.RefObject<HTMLButtonElement>
 }): JSX.Element {
-    const { dataWarehouseSources, sources_map } = useValues(marketingAnalyticsSettingsLogic)
-    const { updateSourceMapping } = useActions(marketingAnalyticsSettingsLogic)
+    const { dataWarehouseSources } = useValues(marketingAnalyticsSettingsLogic)
+
     const marketingSources =
         dataWarehouseSources?.results.filter((source) => VALID_MARKETING_SOURCES.includes(source.source_type)) ?? []
 
-    const tables = marketingSources
+    const tables: SimpleDataWarehouseTable[] = marketingSources
         .map((source) =>
             source.schemas.map((schema) => ({
                 ...schema,
@@ -48,210 +36,18 @@ export function NonNativeExternalDataSourceConfiguration({
         )
         .flat()
 
-    const isColumnTypeCompatible = (
-        columnType: string,
-        schemaField: { required: boolean; type: string[] }
-    ): boolean => {
-        return schemaField.type.includes(columnType)
-    }
-
-    const renderColumnMappingDropdown = (
-        table: SimpleDataWarehouseTable,
-        fieldName: keyof typeof MARKETING_ANALYTICS_SCHEMA
-    ): JSX.Element => {
-        const sourceMapping = sources_map?.[table.id]
-        const currentValue = sourceMapping?.[fieldName]
-        const expectedTypes = MARKETING_ANALYTICS_SCHEMA[fieldName]
-        const compatibleColumns = table.columns?.filter((col) => isColumnTypeCompatible(col.type, expectedTypes)) || []
-
-        const columnOptions = [
-            { label: 'None', value: null as string | null },
-            ...compatibleColumns.map((col) => ({
-                label: `${col.name} (${col.type})`,
-                value: col.name as string | null,
-            })),
-        ]
-
-        return (
-            <LemonSelect
-                value={currentValue || null}
-                onChange={(value) => updateSourceMapping(table.id, fieldName, value)}
-                options={columnOptions}
-                placeholder="Select column..."
-                size="small"
-            />
-        )
-    }
-
-    const removeTableMapping = (tableId: string): void => {
-        // Remove all field mappings for this table by setting each to undefined
-        const sourceMapping = sources_map?.[tableId]
-
-        if (sourceMapping) {
-            Object.keys(sourceMapping).forEach((fieldName) => {
-                updateSourceMapping(tableId, fieldName, null)
-            })
-        }
-    }
-
-    const hasAnyMapping = (tableId: string): boolean => {
-        const sourceMapping = sources_map?.[tableId]
-        return sourceMapping && Object.keys(sourceMapping).length > 0
-    }
-
-    const isTableFullyConfigured = (tableId: string): boolean => {
-        const sourceMapping = sources_map?.[tableId]
-        if (!sourceMapping) {
-            return false
-        }
-
-        // Check if all required fields from the schema are mapped
-        const requiredFields = Object.keys(MARKETING_ANALYTICS_SCHEMA).filter(
-            (field) => MARKETING_ANALYTICS_SCHEMA[field].required
-        )
-        return requiredFields.every((fieldName: string) => {
-            const mapping = sourceMapping[fieldName]
-            return mapping && mapping.trim() !== ''
-        })
-    }
-
-    const getTableStatus = (tableId: string): { isConfigured: boolean; message: string } => {
-        const sourceMapping = sources_map?.[tableId]
-        if (!sourceMapping || Object.keys(sourceMapping).length === 0) {
-            return { isConfigured: false, message: 'No fields mapped' }
-        }
-
-        if (isTableFullyConfigured(tableId)) {
-            return { isConfigured: true, message: 'Ready to use! All fields mapped correctly.' }
-        }
-        const requiredFields = Object.keys(MARKETING_ANALYTICS_SCHEMA)
-        const mappedFields = requiredFields.filter((fieldName) => {
-            const mapping = sourceMapping[fieldName]
-            return mapping && mapping.trim() !== ''
-        })
-
-        const missingCount = requiredFields.length - mappedFields.length
-        return {
-            isConfigured: false,
-            message: `${missingCount} field${missingCount > 1 ? 's' : ''} still need mapping`,
-        }
-    }
-
     return (
-        <div>
-            <h3 className="mb-2">Non Native Data Warehouse Sources Configuration</h3>
-            <p className="mb-4">
-                PostHog can display marketing data in our Marketing Analytics product from the following data warehouse
-                sources.
-            </p>
-            <LemonTable
-                rowKey={(item) => item.id}
-                loading={dataWarehouseSources === null}
-                dataSource={tables}
-                columns={[
-                    {
-                        key: 'source_icon',
-                        title: '',
-                        width: 0,
-                        render: (_, item: any) => {
-                            return <DataWarehouseSourceIcon type={item.source_type} />
-                        },
-                    },
-                    {
-                        key: 'source',
-                        title: 'Source',
-                        width: 0,
-                        render: (_, item: any) => {
-                            return (
-                                <Link
-                                    to={urls.pipelineNode(
-                                        PipelineStage.Source,
-                                        `managed-${item.source_id}`,
-                                        PipelineNodeTab.Schemas
-                                    )}
-                                >
-                                    {item.source_type} {item.source_prefix}
-                                </Link>
-                            )
-                        },
-                    },
-                    {
-                        key: 'prefix',
-                        title: 'Table',
-                        render: (_, item: any) => item.name,
-                    },
-                    {
-                        key: 'status',
-                        title: 'Status',
-                        width: 80,
-                        render: (_, item: any) => {
-                            const { isConfigured, message } = getTableStatus(item.id)
-                            const sourceMapping = sources_map?.[item.id]
-                            const hasAnyMapping = sourceMapping && Object.keys(sourceMapping).length > 0
-
-                            if (isConfigured) {
-                                return (
-                                    <Tooltip title={message}>
-                                        <div className="flex justify-center">
-                                            <IconCheck className="text-success text-lg" />
-                                        </div>
-                                    </Tooltip>
-                                )
-                            } else if (hasAnyMapping) {
-                                return (
-                                    <Tooltip title={message}>
-                                        <div className="flex justify-center">
-                                            <IconWarning className="text-warning text-lg" />
-                                        </div>
-                                    </Tooltip>
-                                )
-                            }
-                            return (
-                                <Tooltip title={message}>
-                                    <div className="flex justify-center">
-                                        <IconX className="text-muted text-lg" />
-                                    </div>
-                                </Tooltip>
-                            )
-                        },
-                    },
-                    ...Object.keys(MARKETING_ANALYTICS_SCHEMA).map((column) => ({
-                        key: column,
-                        title: `${column.replace(/_/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase())}${
-                            MARKETING_ANALYTICS_SCHEMA[column].required ? ' (*)' : ''
-                        }`,
-                        render: (_: any, item: any) => renderColumnMappingDropdown(item, column),
-                    })),
-                    {
-                        key: 'actions',
-                        width: 0,
-                        title: (
-                            <LemonButton
-                                className="my-1"
-                                ref={buttonRef}
-                                type="primary"
-                                onClick={() => {
-                                    router.actions.push(urls.pipelineNodeNew(PipelineStage.Source))
-                                }}
-                            >
-                                Add new source
-                            </LemonButton>
-                        ),
-                        render: (_, item: any) => {
-                            const tableHasMapping = hasAnyMapping(item.id)
-                            return tableHasMapping ? (
-                                <LemonButton
-                                    icon={<IconTrash />}
-                                    size="small"
-                                    status="danger"
-                                    onClick={() => removeTableMapping(item.id)}
-                                    tooltip="Remove all mappings for this table"
-                                />
-                            ) : null
-                        },
-                    },
-                ]}
-            />
-        </div>
+        <SharedExternalDataSourceConfiguration
+            title="Non Native Data Warehouse Sources Configuration"
+            description="PostHog can display marketing data in our Marketing Analytics product from the following data warehouse sources."
+            tables={tables}
+            loading={dataWarehouseSources === null}
+            buttonRef={buttonRef}
+            renderSourceIcon={renderSourceIcon}
+        />
     )
 }
+
+const renderSourceIcon = (item: SimpleDataWarehouseTable): JSX.Element => (
+    <DataWarehouseSourceIcon type={item.source_type} />
+)

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/SelfManagedExternalDataSourceConfiguration.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/SelfManagedExternalDataSourceConfiguration.tsx
@@ -1,0 +1,56 @@
+import { useValues } from 'kea'
+import {
+    DataWarehouseSourceIcon,
+    mapUrlToProvider,
+    mapUrlToSourceName,
+} from 'scenes/data-warehouse/settings/DataWarehouseSourceIcon'
+
+import { ExternalDataSource } from '~/types'
+
+import { marketingAnalyticsSettingsLogic } from '../../logic/marketingAnalyticsSettingsLogic'
+import {
+    SharedExternalDataSourceConfiguration,
+    SimpleDataWarehouseTable,
+} from './SharedExternalDataSourceConfiguration'
+
+// This is to map tables that are self-managed by the user.
+// It's a workaround to allow users to map columns to the correct fields in the Marketing Analytics product.
+export function SelfManagedExternalDataSourceConfiguration({
+    buttonRef,
+}: {
+    buttonRef?: React.RefObject<HTMLButtonElement>
+}): JSX.Element {
+    const { dataWarehouseSources, selfManagedTables } = useValues(marketingAnalyticsSettingsLogic)
+    const marketingSources = selfManagedTables ?? []
+
+    const tables: SimpleDataWarehouseTable[] = marketingSources
+        .map((source) => ({
+            ...source,
+            id: source.id,
+            source_type: mapUrlToSourceName(source.url_pattern) as ExternalDataSource['source_type'],
+            source_id: source.id,
+            source_prefix: '',
+            name: source.name,
+            columns: Object.keys(source.fields).map((field) => ({
+                name: source.fields[field].hogql_value,
+                type: source.fields[field].type,
+            })),
+            url_pattern: source.url_pattern,
+        }))
+        .flat()
+
+    return (
+        <SharedExternalDataSourceConfiguration
+            title="Self-managed Data Warehouse Sources Configuration"
+            description="PostHog can display marketing data in our Marketing Analytics product from the following self-managed data warehouse sources."
+            tables={tables}
+            loading={dataWarehouseSources === null}
+            buttonRef={buttonRef}
+            renderSourceIcon={renderSourceIcon}
+        />
+    )
+}
+
+const renderSourceIcon = (item: SimpleDataWarehouseTable): JSX.Element => (
+    <DataWarehouseSourceIcon type={mapUrlToProvider(item.url_pattern!)} />
+)

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/SharedExternalDataSourceConfiguration.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/SharedExternalDataSourceConfiguration.tsx
@@ -1,0 +1,276 @@
+import { IconCheck, IconTrash, IconWarning, IconX } from '@posthog/icons'
+import { LemonButton, LemonSelect, LemonSelectSection, Link } from '@posthog/lemon-ui'
+import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
+import { LemonTable } from 'lib/lemon-ui/LemonTable'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { urls } from 'scenes/urls'
+
+import { MARKETING_ANALYTICS_SCHEMA } from '~/queries/schema/schema-general'
+import { ExternalDataSource, PipelineNodeTab, PipelineStage } from '~/types'
+
+import { marketingAnalyticsSettingsLogic } from '../../logic/marketingAnalyticsSettingsLogic'
+import { OPTIONS_FOR_IMPORTANT_CURRENCIES_ABBREVIATED, OPTIONS_FOR_OTHER_CURRENCIES_ABBREVIATED } from './utils'
+
+export type SimpleDataWarehouseTable = {
+    name: string
+    source_type: ExternalDataSource['source_type']
+    id: string
+    source_id: string
+    source_prefix: string
+    columns?: { name: string; type: string }[]
+    url_pattern?: string
+}
+
+interface SharedExternalDataSourceConfigurationProps {
+    title: string
+    description: string
+    tables: SimpleDataWarehouseTable[]
+    loading: boolean
+    buttonRef?: React.RefObject<HTMLButtonElement>
+    renderSourceIcon: (item: SimpleDataWarehouseTable) => JSX.Element
+}
+
+export function SharedExternalDataSourceConfiguration({
+    title,
+    description,
+    tables,
+    loading,
+    buttonRef,
+    renderSourceIcon,
+}: SharedExternalDataSourceConfigurationProps): JSX.Element {
+    const { sources_map } = useValues(marketingAnalyticsSettingsLogic)
+    const { updateSourceMapping } = useActions(marketingAnalyticsSettingsLogic)
+
+    const isColumnTypeCompatible = (
+        columnType: string,
+        schemaField: { required: boolean; type: string[] }
+    ): boolean => {
+        return schemaField.type.includes(columnType)
+    }
+
+    const renderColumnMappingDropdown = (
+        table: SimpleDataWarehouseTable,
+        fieldName: keyof typeof MARKETING_ANALYTICS_SCHEMA
+    ): JSX.Element => {
+        const sourceMapping = sources_map?.[table.id]
+        const currentValue = sourceMapping?.[fieldName]
+        const expectedTypes = MARKETING_ANALYTICS_SCHEMA[fieldName]
+        const compatibleColumns = table.columns?.filter((col) => isColumnTypeCompatible(col.type, expectedTypes)) || []
+
+        const columnOptions: LemonSelectSection<string | null>[] = [
+            {
+                options: [
+                    {
+                        label: 'None',
+                        value: null,
+                    },
+                ],
+            },
+            {
+                options: compatibleColumns.map((col) => ({
+                    label: `${col.name} (${col.type})`,
+                    value: col.name,
+                })),
+            },
+        ]
+
+        if (expectedTypes.type.includes('currency')) {
+            columnOptions.push(
+                ...[
+                    { options: OPTIONS_FOR_IMPORTANT_CURRENCIES_ABBREVIATED, title: 'Most Popular' },
+                    { options: OPTIONS_FOR_OTHER_CURRENCIES_ABBREVIATED, title: 'Other currencies' },
+                ]
+            )
+        }
+
+        return (
+            <LemonSelect
+                value={currentValue || null}
+                onChange={(value) => updateSourceMapping(table.id, fieldName, value)}
+                options={columnOptions}
+                placeholder="Select..."
+                size="small"
+            />
+        )
+    }
+
+    const removeTableMapping = (tableId: string): void => {
+        // Remove all field mappings for this table by setting each to undefined
+        const sourceMapping = sources_map?.[tableId]
+
+        if (sourceMapping) {
+            Object.keys(sourceMapping).forEach((fieldName) => {
+                updateSourceMapping(tableId, fieldName, null)
+            })
+        }
+    }
+
+    const hasAnyMapping = (tableId: string): boolean => {
+        const sourceMapping = sources_map?.[tableId]
+        return sourceMapping && Object.keys(sourceMapping).length > 0
+    }
+
+    const isTableFullyConfigured = (tableId: string): boolean => {
+        const sourceMapping = sources_map?.[tableId]
+        if (!sourceMapping) {
+            return false
+        }
+
+        // Check if all required fields from the schema are mapped
+        const requiredFields = Object.keys(MARKETING_ANALYTICS_SCHEMA).filter(
+            (field) => MARKETING_ANALYTICS_SCHEMA[field].required
+        )
+        return requiredFields.every((fieldName: string) => {
+            const mapping = sourceMapping[fieldName]
+            return mapping && mapping.trim() !== ''
+        })
+    }
+
+    const getTableStatus = (tableId: string): { isConfigured: boolean; message: string } => {
+        const sourceMapping = sources_map?.[tableId]
+        if (!sourceMapping || Object.keys(sourceMapping).length === 0) {
+            return { isConfigured: false, message: 'No fields mapped' }
+        }
+
+        if (isTableFullyConfigured(tableId)) {
+            return { isConfigured: true, message: 'Ready to use! All fields mapped correctly.' }
+        }
+        const requiredFields = Object.keys(MARKETING_ANALYTICS_SCHEMA)
+        const mappedFields = requiredFields.filter((fieldName) => {
+            const mapping = sourceMapping[fieldName]
+            return mapping && mapping.trim() !== ''
+        })
+
+        const missingCount = requiredFields.length - mappedFields.length
+        return {
+            isConfigured: false,
+            message: `${missingCount} field${missingCount > 1 ? 's' : ''} still need mapping`,
+        }
+    }
+
+    return (
+        <div>
+            <h3 className="mb-2">{title}</h3>
+            <p className="mb-4">{description}</p>
+            <LemonTable
+                rowKey={(item) => item.id}
+                loading={loading}
+                dataSource={tables}
+                columns={[
+                    {
+                        key: 'source_icon',
+                        title: '',
+                        width: 0,
+                        render: (_, item: SimpleDataWarehouseTable) => renderSourceIcon(item),
+                    },
+                    {
+                        key: 'source',
+                        title: 'Source',
+                        width: 0,
+                        render: (_, item: SimpleDataWarehouseTable) => {
+                            return (
+                                <Link
+                                    to={urls.pipelineNode(
+                                        PipelineStage.Source,
+                                        `managed-${item.source_id}`,
+                                        PipelineNodeTab.Schemas
+                                    )}
+                                >
+                                    {item.source_type} {item.source_prefix}
+                                </Link>
+                            )
+                        },
+                    },
+                    {
+                        key: 'prefix',
+                        title: 'Table',
+                        render: (_, item: SimpleDataWarehouseTable) => item.name,
+                    },
+                    {
+                        key: 'status',
+                        title: 'Status',
+                        width: 80,
+                        render: (_, item: SimpleDataWarehouseTable) => {
+                            const { isConfigured, message } = getTableStatus(item.id)
+                            const sourceMapping = sources_map?.[item.id]
+                            const hasAnyMapping = sourceMapping && Object.keys(sourceMapping).length > 0
+
+                            if (isConfigured) {
+                                return (
+                                    <Tooltip title={message}>
+                                        <div className="flex justify-center">
+                                            <IconCheck className="text-success text-lg" />
+                                        </div>
+                                    </Tooltip>
+                                )
+                            } else if (hasAnyMapping) {
+                                return (
+                                    <Tooltip title={message}>
+                                        <div className="flex justify-center">
+                                            <IconWarning className="text-warning text-lg" />
+                                        </div>
+                                    </Tooltip>
+                                )
+                            }
+                            return (
+                                <Tooltip title={message}>
+                                    <div className="flex justify-center">
+                                        <IconX className="text-muted text-lg" />
+                                    </div>
+                                </Tooltip>
+                            )
+                        },
+                    },
+                    // Required fields first
+                    ...Object.keys(MARKETING_ANALYTICS_SCHEMA)
+                        .filter((column) => MARKETING_ANALYTICS_SCHEMA[column].required)
+                        .sort()
+                        .map((column) => ({
+                            key: column,
+                            title: `${column.replace(/_/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase())} (*)`,
+                            render: (_: any, item: SimpleDataWarehouseTable) =>
+                                renderColumnMappingDropdown(item, column),
+                        })),
+                    ...Object.keys(MARKETING_ANALYTICS_SCHEMA)
+                        .filter((column) => !MARKETING_ANALYTICS_SCHEMA[column].required)
+                        .sort()
+                        .map((column) => ({
+                            key: column,
+                            title: `${column.replace(/_/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase())}`,
+                            render: (_: any, item: SimpleDataWarehouseTable) =>
+                                renderColumnMappingDropdown(item, column),
+                        })),
+                    {
+                        key: 'actions',
+                        width: 0,
+                        title: (
+                            <LemonButton
+                                className="my-1"
+                                ref={buttonRef}
+                                type="primary"
+                                onClick={() => {
+                                    router.actions.push(urls.pipelineNodeNew(PipelineStage.Source))
+                                }}
+                            >
+                                Add new source
+                            </LemonButton>
+                        ),
+                        render: (_, item: SimpleDataWarehouseTable) => {
+                            const tableHasMapping = hasAnyMapping(item.id)
+                            return tableHasMapping ? (
+                                <LemonButton
+                                    icon={<IconTrash />}
+                                    size="small"
+                                    status="danger"
+                                    onClick={() => removeTableMapping(item.id)}
+                                    tooltip="Remove all mappings for this table"
+                                />
+                            ) : null
+                        },
+                    },
+                ]}
+            />
+        </div>
+    )
+}

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/utils.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/settings/utils.tsx
@@ -1,0 +1,63 @@
+// These are the currencies that are most important to show first because they're used by the most customers.
+
+import { LemonSelectOption } from '@posthog/lemon-ui'
+import {
+    CURRENCY_SYMBOL_TO_EMOJI_MAP,
+    CURRENCY_SYMBOL_TO_NAME_MAP,
+    DISABLED_CURRENCIES,
+} from 'lib/utils/geography/currency'
+
+import { CurrencyCode } from '~/queries/schema/schema-general'
+
+const optionFromCurrency = (currency: CurrencyCode): LemonSelectOption<CurrencyCode> => {
+    return {
+        value: currency,
+        disabledReason: DISABLED_CURRENCIES[currency],
+        label: (
+            <span>
+                {CURRENCY_SYMBOL_TO_EMOJI_MAP[currency]} {`${CURRENCY_SYMBOL_TO_NAME_MAP[currency]} (${currency})`}
+            </span>
+        ),
+    }
+}
+
+const optionFromCurrencyAbbreviated = (currency: CurrencyCode): LemonSelectOption<CurrencyCode> => {
+    return {
+        value: currency,
+        disabledReason: DISABLED_CURRENCIES[currency],
+        label: (
+            <span>
+                {CURRENCY_SYMBOL_TO_EMOJI_MAP[currency]} {currency}
+            </span>
+        ),
+    }
+}
+
+// Check our web analytics dashboard for the most popular countries from our visitors.
+const IMPORTANT_CURRENCIES: CurrencyCode[] = [
+    CurrencyCode.USD,
+    CurrencyCode.EUR,
+    CurrencyCode.GBP,
+    CurrencyCode.CAD,
+    CurrencyCode.INR,
+    CurrencyCode.CNY,
+    CurrencyCode.BRL,
+]
+
+// All the other currencies, sorted by their "long name" in alphabetical order.
+const OTHER_CURRENCIES: CurrencyCode[] = (
+    Object.keys(CurrencyCode).filter(
+        (currency) => !IMPORTANT_CURRENCIES.includes(currency as CurrencyCode)
+    ) as CurrencyCode[]
+).sort((a, b) => {
+    return CURRENCY_SYMBOL_TO_NAME_MAP[a].localeCompare(CURRENCY_SYMBOL_TO_NAME_MAP[b])
+})
+
+// Computing these before hand is more efficient than computing them on the fly.
+export const OPTIONS_FOR_IMPORTANT_CURRENCIES: LemonSelectOption<CurrencyCode>[] =
+    IMPORTANT_CURRENCIES.map(optionFromCurrency)
+export const OPTIONS_FOR_OTHER_CURRENCIES: LemonSelectOption<CurrencyCode>[] = OTHER_CURRENCIES.map(optionFromCurrency)
+export const OPTIONS_FOR_IMPORTANT_CURRENCIES_ABBREVIATED: LemonSelectOption<CurrencyCode>[] =
+    IMPORTANT_CURRENCIES.map(optionFromCurrencyAbbreviated)
+export const OPTIONS_FOR_OTHER_CURRENCIES_ABBREVIATED: LemonSelectOption<CurrencyCode>[] =
+    OTHER_CURRENCIES.map(optionFromCurrencyAbbreviated)

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsSettingsLogic.ts
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/logic/marketingAnalyticsSettingsLogic.ts
@@ -30,7 +30,7 @@ export const marketingAnalyticsSettingsLogic = kea<marketingAnalyticsSettingsLog
             preflightLogic,
             ['preflight'],
             dataWarehouseSettingsLogic,
-            ['dataWarehouseSources'],
+            ['dataWarehouseSources', 'selfManagedTables'],
         ],
         actions: [teamLogic, ['updateCurrentTeam'], dataWarehouseSettingsLogic, ['updateSource']],
     })),

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -12,7 +12,7 @@ import { Link, PostHogComDocsURL } from 'lib/lemon-ui/Link/Link'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { getDefaultInterval, isNotNil, objectsEqual, UnexpectedNeverError, updateDatesWithInterval } from 'lib/utils'
 import { isDefinitionStale } from 'lib/utils/definitions'
-import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
+import { dataWarehouseSettingsLogic } from 'scenes/data-warehouse/settings/dataWarehouseSettingsLogic'
 import { errorTrackingQuery } from 'scenes/error-tracking/queries'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { Scene } from 'scenes/sceneTypes'
@@ -32,7 +32,6 @@ import {
     CustomEventConversionGoal,
     DatabaseSchemaDataWarehouseTable,
     DataTableNode,
-    DataWarehouseNode,
     EventsNode,
     InsightVizNode,
     MARKETING_ANALYTICS_SCHEMA,
@@ -424,9 +423,9 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
             authorizedUrlListLogic({ type: AuthorizedUrlListType.WEB_ANALYTICS, actionId: null, experimentId: null }),
             ['authorizedUrls'],
             marketingAnalyticsSettingsLogic,
-            ['sources_map'],
-            databaseTableListLogic,
-            ['dataWarehouseTables'],
+            ['sources_map', 'baseCurrency'],
+            dataWarehouseSettingsLogic,
+            ['dataWarehouseTables', 'selfManagedTables'],
         ],
     })),
     actions({
@@ -758,16 +757,17 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
     selectors(({ actions, values }) => ({
         // Helper functions for dynamic marketing analytics
         createMarketingDataWarehouseNodes: [
-            (s) => [s.sources_map, s.dataWarehouseTables],
+            (s) => [s.sources_map, s.dataWarehouseTables, s.selfManagedTables],
             (
                 sources_map: { [key: string]: SourceMap },
-                dataWarehouseTables: DatabaseSchemaDataWarehouseTable[]
+                dataWarehouseTables: DatabaseSchemaDataWarehouseTable[],
+                selfManagedTables: DatabaseSchemaDataWarehouseTable[]
             ): AnyEntityNode[] => {
                 if (
                     !sources_map ||
                     Object.keys(sources_map).length === 0 ||
-                    !dataWarehouseTables ||
-                    dataWarehouseTables.length === 0
+                    ((!dataWarehouseTables || dataWarehouseTables.length === 0) &&
+                        (!selfManagedTables || selfManagedTables.length === 0))
                 ) {
                     return []
                 }
@@ -788,45 +788,50 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     return []
                 }
 
-                const mappedNodes = Object.entries(validSourcesMap).map(([tableId, fieldMapping]: [string, any]) => {
-                    const table = dataWarehouseTables.find((table) => table.schema?.id === tableId)
-                    const table_name = table?.name
-                    const schema_name = table?.schema?.name
-                    if (!table_name) {
-                        return null
-                    }
+                const nodeList: AnyEntityNode[] = Object.entries(validSourcesMap)
+                    .map(([tableId, fieldMapping]: [string, any]) => {
+                        const dataWarehouseTable = dataWarehouseTables.find((table) => table.schema?.id === tableId)
+                        const selfManagedTable = selfManagedTables.find((table) => table.id === tableId)
+                        const tableName = dataWarehouseTable?.name || selfManagedTable?.name
+                        const schema = dataWarehouseTable?.schema?.name || selfManagedTable?.name
 
-                    const returning: AnyEntityNode = {
-                        kind: NodeKind.DataWarehouseNode,
-                        id: tableId,
-                        name: schema_name,
-                        custom_name: `${schema_name} Cost`,
-                        id_field: 'id',
-                        distinct_id_field: 'id',
-                        timestamp_field: fieldMapping.date,
-                        table_name: table_name,
-                        math: PropertyMathType.Sum,
-                        math_property: fieldMapping.total_cost,
-                    }
-                    return returning
-                })
+                        if (!tableName) {
+                            return null
+                        }
 
-                const nodeList: AnyEntityNode[] = mappedNodes.filter((node): node is DataWarehouseNode => node !== null)
+                        const returning: AnyEntityNode = {
+                            kind: NodeKind.DataWarehouseNode,
+                            id: tableId,
+                            name: schema,
+                            custom_name: `${schema} Cost`,
+                            id_field: 'id',
+                            distinct_id_field: 'id',
+                            timestamp_field: fieldMapping.date,
+                            table_name: tableName,
+                            math: PropertyMathType.Sum,
+                            math_property: fieldMapping.total_cost,
+                        }
+                        return returning
+                    })
+                    .filter((node) => node !== null)
+
                 return nodeList
             },
         ],
 
         createDynamicCampaignQuery: [
-            (s) => [s.sources_map, s.dataWarehouseTables],
+            (s) => [s.sources_map, s.dataWarehouseTables, s.selfManagedTables, s.baseCurrency],
             (
                 sources_map: { [key: string]: SourceMap },
-                dataWarehouseTables: DatabaseSchemaDataWarehouseTable[]
+                dataWarehouseTables: DatabaseSchemaDataWarehouseTable[],
+                selfManagedTables: DatabaseSchemaDataWarehouseTable[],
+                baseCurrency: string
             ): string | null => {
                 if (
                     !sources_map ||
                     Object.keys(sources_map).length === 0 ||
-                    !dataWarehouseTables ||
-                    dataWarehouseTables.length === 0
+                    ((!dataWarehouseTables || dataWarehouseTables.length === 0) &&
+                        (!selfManagedTables || selfManagedTables.length === 0))
                 ) {
                     return null
                 }
@@ -849,25 +854,29 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
 
                 const unionQueries = Object.entries(validSourcesMap)
                     .map(([tableId, fieldMapping]: [string, any]) => {
-                        const table = dataWarehouseTables.find((table) => table.schema?.id === tableId)
-                        const table_name = table?.name
-                        if (!table_name) {
+                        const dataWarehouseTable = dataWarehouseTables.find((table) => table.schema?.id === tableId)
+                        const selfManagedTable = selfManagedTables.find((table) => table.id === tableId)
+                        const tableName = dataWarehouseTable?.name || selfManagedTable?.name
+                        const schemaName = dataWarehouseTable?.schema?.name || selfManagedTable?.name
+                        if (!tableName) {
                             return null
                         }
 
+                        // TODO: we should replicate this logic for the area charts once we build the query runner
                         return `
                         SELECT 
                             ${fieldMapping.campaign_name} as campaignname,
-                            ${fieldMapping.total_cost} as cost,
-                            ${fieldMapping.clicks || '0'} as clicks,
-                            ${fieldMapping.impressions || '0'} as impressions,
-                            ${fieldMapping.source_name || `'${table.schema?.name || tableId}'`} as source_name
-                        FROM ${table_name}
+                            convertCurrency('${
+                                fieldMapping.base_currency || MARKETING_ANALYTICS_SCHEMA.base_currency.default
+                            }', '${baseCurrency}', toFloat(coalesce(${fieldMapping.total_cost}, 0))) as cost,
+                            toFloat(coalesce(${fieldMapping.clicks}, 0)) as clicks,
+                            toFloat(coalesce(${fieldMapping.impressions}, 0)) as impressions,
+                            ${fieldMapping.source_name || `'${schemaName}'`} as source_name
+                        FROM ${tableName}
                         WHERE ${fieldMapping.date} >= '2025-01-01'
                     `.trim()
                     })
                     .filter(Boolean)
-
                 if (unionQueries.length === 0) {
                     return `SELECT 'No valid sources_map configured' as message`
                 }
@@ -912,6 +921,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     ORDER BY cc.total_cost DESC
                     LIMIT 20
                 `.trim()
+
                 return query
             },
         ],


### PR DESCRIPTION
- Added support for self-managed external data sources with new configuration component.
- Updated Marketing Analytics schema to include default values and optional fields for clicks, impressions, and base currency.
- Enhanced web analytics logic to accommodate self-managed tables and improved query generation.
- Refactored currency dropdown options for better performance and clarity.
- Introduced shared configuration component for external data sources to reduce code duplication.

> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [ ] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
