### PR TITLE
fix(flags): Validate feature flag key on the server

### DIFF
--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,4 +1,4 @@
-import api from 'lib/api'
+import api, { ApiRequest } from 'lib/api'
 import posthog from 'posthog-js'
 
 import { PropertyFilterType, PropertyOperator } from '~/types'
@@ -112,6 +112,22 @@ describe('API helper', () => {
         await expect(api.get('/api/projects/null/dings')).rejects.toStrictEqual({
             detail: 'Cannot make request - project ID is unknown.',
             status: 0,
+        })
+    })
+
+    describe('organizationFeatureFlags', () => {
+        it('builds correct URL for organization feature flags', () => {
+            const apiRequest = new ApiRequest()
+            const request = apiRequest.organizationFeatureFlags('123', 'my-feature-flag')
+            expect(request.assembleEndpointUrl()).toEqual('organizations/123/feature_flags/my-feature-flag')
+        })
+
+        it('builds correct URL for organization feature flags with special characters', () => {
+            const apiRequest = new ApiRequest()
+            const request = apiRequest.organizationFeatureFlags('123', 'my-feature-flag/foo/bar?baz=qux')
+            expect(request.assembleEndpointUrl()).toEqual(
+                'organizations/123/feature_flags/my-feature-flag%2Ffoo%2Fbar%3Fbaz%3Dqux'
+            )
         })
     })
 })

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -296,11 +296,11 @@ export class ApiConfig {
     }
 }
 
-class ApiRequest {
+export class ApiRequest {
     private pathComponents: string[]
     private queryString: string | undefined
 
-    constructor() {
+    public constructor() {
         this.pathComponents = []
     }
 
@@ -325,6 +325,11 @@ class ApiRequest {
 
     private addPathComponent(component: string | number): ApiRequest {
         this.pathComponents.push(component.toString())
+        return this
+    }
+
+    private addEncodedPathComponent(component: string | number): ApiRequest {
+        this.pathComponents.push(encodeURIComponent(component.toString()))
         return this
     }
 
@@ -365,7 +370,7 @@ class ApiRequest {
         return this.organizations()
             .addPathComponent(orgId)
             .addPathComponent('feature_flags')
-            .addPathComponent(featureFlagKey)
+            .addEncodedPathComponent(featureFlagKey) // Never trust user input.
     }
 
     public copyOrganizationFeatureFlags(orgId: OrganizationType['id']): ApiRequest {

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -133,7 +133,7 @@ const EMPTY_MULTIVARIATE_OPTIONS: MultivariateFlagOptions = {
 export function validateFeatureFlagKey(key: string): string | undefined {
     return !key
         ? 'Please set a key'
-        : !key.match?.(/^([A-z]|[a-z]|[0-9]|-|_)+$/)
+        : !key.match?.(/^[a-zA-Z0-9_-]+$/)
         ? 'Only letters, numbers, hyphens (-) & underscores (_) are allowed.'
         : undefined
 }

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -133,6 +133,8 @@ const EMPTY_MULTIVARIATE_OPTIONS: MultivariateFlagOptions = {
 export function validateFeatureFlagKey(key: string): string | undefined {
     return !key
         ? 'Please set a key'
+        : key.length > 400
+        ? 'Key must be 400 characters or less.'
         : !key.match?.(/^[a-zA-Z0-9_-]+$/)
         ? 'Only letters, numbers, hyphens (-) & underscores (_) are allowed.'
         : undefined

--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -1,4 +1,5 @@
 import json
+import re
 import time
 import logging
 from typing import Any, Optional, cast
@@ -241,6 +242,11 @@ class FeatureFlagSerializer(
             .exists()
         ):
             raise serializers.ValidationError("There is already a feature flag with this key.", code="unique")
+
+        if not re.match(r"^[a-zA-Z0-9_-]+$", value):
+            raise serializers.ValidationError(
+                "Only letters, numbers, hyphens (-) & underscores (_) are allowed.", code="invalid_key"
+            )
 
         return value
 

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -10,6 +10,7 @@ from django.test import TransactionTestCase
 from django.test.client import RequestFactory
 from django.utils.timezone import now
 from freezegun.api import freeze_time
+from parameterized import parameterized
 from rest_framework import status
 
 from posthog import redis
@@ -124,6 +125,35 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
                 "type": "validation_error",
                 "code": "unique",
                 "detail": "There is already a feature flag with this key.",
+                "attr": "key",
+            },
+        )
+        self.assertEqual(FeatureFlag.objects.count(), count)
+
+    @parameterized.expand(
+        [
+            ("foo?bar=baz",),
+            ("foo/bar",),
+            ("foo\\bar",),
+            ("foo.bar",),
+            ("foo bar",),
+        ]
+    )
+    def test_cant_create_flag_with_invalid_key(self, key):
+        FeatureFlag.objects.create(team=self.team, created_by=self.user, key="red_button")
+        count = FeatureFlag.objects.count()
+        # Make sure the endpoint works with and without the trailing slash
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags",
+            {"name": "Beta feature", "key": key},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            {
+                "type": "validation_error",
+                "code": "invalid_key",
+                "detail": "Only letters, numbers, hyphens (-) & underscores (_) are allowed.",
                 "attr": "key",
             },
         )


### PR DESCRIPTION
## Problem

The feature flag create/edit page validates the feature flag key on the client, but not the server. This allows a bad actor to create feature flag keys with invalid characters.

## Changes

Use the same regex on the client and server to validate the feature flag key. This also simplifies the client regex as it was needlessly complex.

Also ensured that when creating a URL with feature flag key, we URL encode the feature flag key as it's part of a path component. This isn't strictly necessary any longer, but provides defense in depth.

## Did you write or update any docs for this change?

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Manually. Added unit tests.