### PR TITLE
fix: use client callable instead of string

### DIFF
--- a/dags/web_preaggregated_hourly.py
+++ b/dags/web_preaggregated_hourly.py
@@ -114,7 +114,11 @@ def web_bounces_hourly(
     """
     Hourly bounce rate data for web analytics with 24h TTL. Updates every 5 minutes.
     """
-    cluster.map_all_hosts("TRUNCATE TABLE web_bounces_hourly SYNC")
+
+    def truncate(client: Client):
+        client.execute("TRUNCATE TABLE web_bounces_hourly SYNC")
+
+    cluster.map_all_hosts(truncate).result()
 
     return pre_aggregate_web_analytics_hourly_data(
         context=context, table_name="web_bounces_hourly", sql_generator=WEB_BOUNCES_INSERT_SQL
@@ -136,7 +140,11 @@ def web_stats_hourly(
     """
     Hourly aggregated dimensional data with pageviews and unique user counts with 24h TTL. Updates every 5 minutes.
     """
-    cluster.map_all_hosts("TRUNCATE TABLE web_stats_hourly SYNC")
+
+    def truncate(client: Client):
+        client.execute("TRUNCATE TABLE web_stats_hourly SYNC")
+
+    cluster.map_all_hosts(truncate).result()
 
     return pre_aggregate_web_analytics_hourly_data(
         context=context,


### PR DESCRIPTION
## Problem

Fixes https://github.com/PostHog/posthog/pull/33095 retryable behaviour, it needs to be a callable and we need to run for every host since the table is replicated.

## Changes

- Use the standard way of creating ch callables on dagster

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

Manually
