### PR TITLE
fix: Revert "chore: do not cancel queries for now (#32170)"

### DIFF
--- a/posthog/clickhouse/cancel.py
+++ b/posthog/clickhouse/cancel.py
@@ -27,7 +27,7 @@ def cancel_query_on_cluster(team_id: int, client_query_id: str) -> None:
         statsd.incr("clickhouse.query.cancellation.no_initiator_host", tags={"team_id": team_id})
 
     if initiator_host:
-        logger.debug("Found initiator host for query %s, cancelling query on host", initiator_host, client_query_id)
+        logger.debug("Found initiator host %s for query %s, cancelling query on host", initiator_host, client_query_id)
         with default_client(host=initiator_host) as client:
             result = sync_execute(
                 "KILL QUERY WHERE query_id=%(query_id)s SETTINGS max_execution_time = 5",

--- a/posthog/clickhouse/cancel.py
+++ b/posthog/clickhouse/cancel.py
@@ -21,7 +21,7 @@ def cancel_query_on_cluster(team_id: int, client_query_id: str) -> None:
             """,
             {"client_query_id": f"{team_id}_{client_query_id}%"},
         )
-        initiator_host, query_id = result[0] if result else (None, None)
+        initiator_host, query_id = result[0] if (result and len(result[0]) == 2) else (None, None)
     except Exception as e:
         logger.info("Failed to find initiator host for query %s: %s", client_query_id, e)
         statsd.incr("clickhouse.query.cancellation.no_initiator_host", tags={"team_id": team_id})

--- a/posthog/clickhouse/cancel.py
+++ b/posthog/clickhouse/cancel.py
@@ -1,38 +1,46 @@
+from statshog.defaults.django import statsd
+
+from posthog import settings
+from posthog.api.services.query import logger
+from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.client.connection import default_client
+from posthog.settings import CLICKHOUSE_CLUSTER
+
+
 def cancel_query_on_cluster(team_id: int, client_query_id: str) -> None:
-    pass
-    # initiator_host = None
+    initiator_host = None
 
-    # statsd.incr("clickhouse.query.cancellation.requested", tags={"team_id": team_id})
-    # try:
-    #     result = sync_execute(
-    #         """
-    #         SELECT hostname(), query_id
-    #         FROM distributed_system_processes
-    #         WHERE query_id LIKE %(client_query_id)s
-    #         SETTINGS max_execution_time = 2
-    #         """,
-    #         {"client_query_id": f"{team_id}_{client_query_id}%"},
-    #     )
-    #     initiator_host, query_id = result[0] if result else (None, None)
-    # except Exception as e:
-    #     logger.info("Failed to find initiator host for query %s: %s", client_query_id, e)
-    #     statsd.incr("clickhouse.query.cancellation.no_initiator_host", tags={"team_id": team_id})
+    statsd.incr("clickhouse.query.cancellation.requested", tags={"team_id": team_id})
+    try:
+        result = sync_execute(
+            """
+            SELECT hostname(), query_id
+            FROM distributed_system_processes
+            WHERE query_id LIKE %(client_query_id)s
+            SETTINGS max_execution_time = 2
+            """,
+            {"client_query_id": f"{team_id}_{client_query_id}%"},
+        )
+        initiator_host, query_id = result[0] if result else (None, None)
+    except Exception as e:
+        logger.info("Failed to find initiator host for query %s: %s", client_query_id, e)
+        statsd.incr("clickhouse.query.cancellation.no_initiator_host", tags={"team_id": team_id})
 
-    # if initiator_host:
-    #     logger.debug("Found initiator host for query %s, cancelling query on host", initiator_host, client_query_id)
-    #     with default_client(host=initiator_host) as client:
-    #         result = sync_execute(
-    #             "KILL QUERY WHERE query_id=%(query_id)s SETTINGS max_execution_time = 5",
-    #             {"query_id": query_id},
-    #             sync_client=client,
-    #         )
-    #     logger.info("Cancelled query %s for team %s, result: %s", client_query_id, team_id, result)
-    #     statsd.incr("clickhouse.query.cancellation.ok", tags={"team_id": team_id})
-    # elif settings.CLICKHOUSE_FALLBACK_CANCEL_QUERY_ON_CLUSTER:
-    #     logger.debug("No initiator host found for query %s, cancelling query on cluster", client_query_id)
-    #     result = sync_execute(
-    #         f"KILL QUERY ON CLUSTER '{CLICKHOUSE_CLUSTER}' WHERE query_id LIKE %(client_query_id)s SETTINGS max_execution_time = 10, skip_unavailable_shards=1",
-    #         {"client_query_id": f"{team_id}_{client_query_id}%"},
-    #     )
-    #     logger.info("Cancelled query %s for team %s, result: %s", client_query_id, team_id, result)
-    #     statsd.incr("clickhouse.query.cancellation.on_cluster", tags={"team_id": team_id})
+    if initiator_host:
+        logger.debug("Found initiator host for query %s, cancelling query on host", initiator_host, client_query_id)
+        with default_client(host=initiator_host) as client:
+            result = sync_execute(
+                "KILL QUERY WHERE query_id=%(query_id)s SETTINGS max_execution_time = 5",
+                {"query_id": query_id},
+                sync_client=client,
+            )
+        logger.info("Cancelled query %s for team %s, result: %s", client_query_id, team_id, result)
+        statsd.incr("clickhouse.query.cancellation.ok", tags={"team_id": team_id})
+    elif settings.CLICKHOUSE_FALLBACK_CANCEL_QUERY_ON_CLUSTER:
+        logger.debug("No initiator host found for query %s, cancelling query on cluster", client_query_id)
+        result = sync_execute(
+            f"KILL QUERY ON CLUSTER '{CLICKHOUSE_CLUSTER}' WHERE query_id LIKE %(client_query_id)s SETTINGS max_execution_time = 10, skip_unavailable_shards=1",
+            {"client_query_id": f"{team_id}_{client_query_id}%"},
+        )
+        logger.info("Cancelled query %s for team %s, result: %s", client_query_id, team_id, result)
+        statsd.incr("clickhouse.query.cancellation.on_cluster", tags={"team_id": team_id})

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -179,7 +179,7 @@ CLICKHOUSE_VERIFY: bool = get_from_env("CLICKHOUSE_VERIFY", True, type_cast=str_
 CLICKHOUSE_ENABLE_STORAGE_POLICY: bool = get_from_env("CLICKHOUSE_ENABLE_STORAGE_POLICY", False, type_cast=str_to_bool)
 CLICKHOUSE_SINGLE_SHARD_CLUSTER: str = os.getenv("CLICKHOUSE_SINGLE_SHARD_CLUSTER", "posthog_single_shard")
 CLICKHOUSE_FALLBACK_CANCEL_QUERY_ON_CLUSTER = get_from_env(
-    "CLICKHOUSE_FALLBACK_CANCEL_QUERY_ON_CLUSTER", default=True, type_cast=str_to_bool
+    "CLICKHOUSE_FALLBACK_CANCEL_QUERY_ON_CLUSTER", default=False, type_cast=str_to_bool
 )
 
 CLICKHOUSE_USE_HTTP: str = get_from_env("CLICKHOUSE_USE_HTTP", False, type_cast=str_to_bool)


### PR DESCRIPTION
This reverts commit bf08d06e8d6f31812bbd0ce4545ac26eb4fb1429.

The clusters are quite hot right now and I'd like to bring this back. I may disable the `CLICKHOUSE_FALLBACK_CANCEL_QUERY_ON_CLUSTER` default set to true which is probably where most of the cluster heartburn was coming from before.