### PR TITLE
chore(capture-rs): minor chatter reduction

### DIFF
--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -537,7 +537,7 @@ pub async fn event(
                 };
                 report_dropped_events(cause, events.len() as u64);
                 report_internal_error_metrics(err.to_metric_tag(), "processing");
-                tracing::log::warn!("rejected invalid payload: {}", err);
+                warn!("rejected invalid payload: {}", err);
                 return Err(err);
             }
 
@@ -729,14 +729,10 @@ pub async fn process_events<'a>(
         }
     });
 
-    if context.is_mirror_deploy {
-        warn!(
-            event_count = events.len(),
-            "process_event: batch successful"
-        )
-    }
-    // TODO(eli): post-migration, land on something appropriately chatty (this is too much!)
-    debug!(events=?events, "processed {} events", events.len());
+    debug!(
+        event_count = events.len(),
+        "process_event: batch successful"
+    );
 
     if events.len() == 1 {
         sink.send(events[0].clone()).await

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -134,20 +134,12 @@ impl RawRequest {
         Span::current().record("path", path.clone());
         Span::current().record("request_id", request_id);
 
-        debug!(
-            path = &path,
-            payload_len = bytes.len(),
-            "from_bytes: decoding new event"
-        );
+        debug!(payload_len = bytes.len(), "from_bytes: decoding new event");
 
         let mut payload = if cmp_hint == Compression::Gzip || bytes.starts_with(&GZIP_MAGIC_NUMBERS)
         {
             let len = bytes.len();
-            debug!(
-                path = &path,
-                payload_len = len,
-                "from_bytes: matched GZIP compression"
-            );
+            debug!(payload_len = len, "from_bytes: matched GZIP compression");
 
             let mut zipstream = GzDecoder::new(bytes.reader());
             let chunk = &mut [0; 1024];
@@ -191,7 +183,6 @@ impl RawRequest {
             }
         } else if cmp_hint == Compression::LZString {
             debug!(
-                path = &path,
                 payload_len = bytes.len(),
                 "from_bytes: matched LZ64 compression"
             );
@@ -238,8 +229,7 @@ impl RawRequest {
                             Ok(unwrapped_payload) => {
                                 let unwrapped_size = unwrapped_payload.len();
                                 if unwrapped_size > limit {
-                                    error!(path = &path,
-                                        unwrapped_size,
+                                    error!(unwrapped_size,
                                         "from_bytes: request size limit exceeded after post-decode base64 unwrap");
                                     report_dropped_events("event_too_big", 1);
                                     return Err(CaptureError::EventTooBig(format!(
@@ -250,7 +240,7 @@ impl RawRequest {
                                 unwrapped_payload
                             }
                             Err(e) => {
-                                error!(path = &path, "from_bytes: failed UTF8 conversion after post-decode base64: {}", e);
+                                error!("from_bytes: failed UTF8 conversion after post-decode base64: {}", e);
                                 payload
                             }
                         }
@@ -264,10 +254,7 @@ impl RawRequest {
                     }
                 }
             } else {
-                warn!(
-                    path = &path,
-                    "from_bytes: payload may be LZ64 or other after decoding step"
-                );
+                debug!("from_bytes: payload may be LZ64 or other after decoding step");
             }
         }
 


### PR DESCRIPTION
## Problem
Now that we're serving legacy capture endpoints from `capture-rs` in `dev` I'd like to reduce the chattiness of the debug logging just a tad more, prior to prod testing.

## Changes
* Reduce log level on a couple more chatty warnings
* Remove redundant log tag
* Don't log event details in final batch-success dbg log

Once the smoke testing is done, expect more drastic refactors to follow 👍 

## Did you write or update any docs for this change?


- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?
Locally and in CI. Deploy test to follow