### PR TITLE
fix: possible leak source

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerFrame.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerFrame.tsx
@@ -33,6 +33,7 @@ export const PlayerFrame = (): JSX.Element => {
         window.addEventListener('resize', windowResize)
 
         return () => {
+            player.replayer.off('resize', updatePlayerDimensions as Handler)
             window.removeEventListener('resize', windowResize)
         }
     }, [player?.replayer])


### PR DESCRIPTION
in my continuing journey into learning how bad the tooling to investigate web app memory usage is

this is a possible source of memory leak I saw in a heap snapshot

where we could be keeping references to the replayer - and so to its snapshots

🤷 

Related to #32479
