### PR TITLE
fix: set os['home'] for chromium exports, remove extra settings added for debugging

### DIFF
--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -58,13 +58,6 @@ def get_driver() -> webdriver.Chrome:
         "excludeSwitches", ["enable-automation"]
     )  # Removes the "Chrome is being controlled by automated test software" bar
 
-    # Ensure completely fresh profile
-    options.add_argument("--incognito")
-    options.add_argument("--no-first-run")
-    options.add_argument("--no-default-browser-check")
-    options.add_argument("--disable-extensions")
-    options.add_argument("--disable-sync")
-
     # Create a unique prefix for the temporary directory
     pid = os.getpid()
     timestamp = int(time.time() * 1000)
@@ -73,6 +66,9 @@ def get_driver() -> webdriver.Chrome:
     # Use TemporaryDirectory which will automatically clean up when the context manager exits
     temp_dir = tempfile.TemporaryDirectory(prefix=unique_prefix)
     options.add_argument(f"--user-data-dir={temp_dir.name}")
+
+    # Necessary to let the nobody user run chromium
+    os.environ["HOME"] = temp_dir.name
 
     if os.environ.get("CHROMEDRIVER_BIN"):
         service = webdriver.ChromeService(executable_path=os.environ["CHROMEDRIVER_BIN"])


### PR DESCRIPTION
chromium needs a home set to run, nobody user doesn't have a home set, the error message it shows in this case is super unhelpful

will look into creating a test for this after this goes out and I verify it actually fixed it on prod