### PR TITLE
fix: in cohort filter hanging 

### DIFF
--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -390,7 +390,8 @@ def _recalculate_cohortpeople_for_team_hogql(
             "optimize_on_insert": 0,
             "max_ast_elements": hogql_global_settings.max_ast_elements,
             "max_expanded_ast_elements": hogql_global_settings.max_expanded_ast_elements,
-            "max_bytes_before_external_group_by": hogql_global_settings.max_bytes_before_external_group_by,
+            "max_bytes_ratio_before_external_group_by": 0.5,
+            "max_bytes_ratio_before_external_sort": 0.5,
         },
         workload=Workload.OFFLINE,
     )


### PR DESCRIPTION
> [!IMPORTANT]
> 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Cohort calculations are falling with OOM errors: 

```
posthog.errors.CHQueryErrorMemoryLimitExceeded: Query exceeds memory limits. Try reducing its scope by changing the time range.
```
or

```
>>> command terminated with exit code 137
```

I got these errors when trying to manually restart a calculation for a customer with a large cohort query: https://posthoghelp.zendesk.com/agent/tickets/30719 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/33476)

There is some prior art using this parameter in this PR: https://github.com/PostHog/posthog/pull/23022
I wasn't really able to test this so I'm going to test in prod with the impacted customer 

https://github.com/PostHog/posthog/issues/32449

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

I want to offload some of the query to the filesystem by using `max_bytes_ratio_before_external_group_by` and `max_bytes_ratio_before_external_sort`

ClickHouse docs reccommend a value of 0.5
> we recommend that you set max_memory_usage about twice as high (or max_bytes_ratio_before_external_group_by=0.5).

From: https://clickhouse.com/docs/sql-reference/statements/select/group-by#group-by-in-external-memory

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
