### PR TITLE
feat: don't include unnamed playlists in the digests

### DIFF
--- a/posthog/tasks/periodic_digest/playlist_digests.py
+++ b/posthog/tasks/periodic_digest/playlist_digests.py
@@ -138,6 +138,7 @@ def get_teams_with_interesting_playlists(end: datetime) -> list[CountedPlaylist]
         )
         .exclude(deleted=True)
         .exclude(name__in=DEFAULT_PLAYLIST_NAMES)
+        .exclude(name="Unnamed")
         .annotate(
             pinned_item_count=Count("playlist_items"),
             # count views in the last 4 weeks

--- a/posthog/tasks/periodic_digest/playlist_digests.py
+++ b/posthog/tasks/periodic_digest/playlist_digests.py
@@ -128,17 +128,17 @@ def _prepare_counted_playlists(qs: QuerySet) -> list[CountedPlaylist]:
 
 def get_teams_with_interesting_playlists(end: datetime) -> list[CountedPlaylist]:
     qs = (
-        SessionRecordingPlaylist.objects.exclude(
-            name__isnull=True,
-            derived_name__isnull=True,
-        )
-        .exclude(
-            name="",
-            derived_name=None,
-        )
-        .exclude(deleted=True)
+        SessionRecordingPlaylist.objects.exclude(deleted=True)
         .exclude(name__in=DEFAULT_PLAYLIST_NAMES)
-        .exclude(name="Unnamed")
+        .exclude(
+            (Q(name__isnull=True) | Q(name="Unnamed") | Q(name=""))
+            & (
+                Q(derived_name__isnull=True)
+                | Q(derived_name="(Untitled)")
+                | Q(derived_name="Unnamed")
+                | Q(derived_name="")
+            )
+        )
         .annotate(
             pinned_item_count=Count("playlist_items"),
             # count views in the last 4 weeks
@@ -166,12 +166,13 @@ def get_teams_with_new_playlists(end: datetime, begin: datetime) -> list[Counted
             created_at__lte=end,
         )
         .exclude(
-            name__isnull=True,
-            derived_name__isnull=True,
-        )
-        .exclude(
-            name="",
-            derived_name=None,
+            (Q(name__isnull=True) | Q(name="Unnamed") | Q(name=""))
+            & (
+                Q(derived_name__isnull=True)
+                | Q(derived_name="(Untitled)")
+                | Q(derived_name="Unnamed")
+                | Q(derived_name="")
+            )
         )
         .exclude(deleted=True)
         .exclude(name__in=DEFAULT_PLAYLIST_NAMES)


### PR DESCRIPTION
## Problem
![Arc 2025-06-03 17 20 55](https://github.com/user-attachments/assets/4d4e3813-93fb-4126-ba49-f43ac2fac650)

Digest emails included "Unnamed" playlists

## Changes

Excludes them from "interesting" ones 🤷‍♀️ 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Did you write or update any docs for this change?

<!-- Engineers are responsible for doing the first pass at documenting their features and/or code.  -->

- [ ] I've [added or updated the docs](https://posthog.com/handbook/engineering/writing-docs)
- [ ] I've reached out for help from the docs team
- [x] No docs needed for this change

## How did you test this code?

I didn't 😅 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
